### PR TITLE
Add Docker file for automated images to allow for easier testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,71 @@
+FROM ubuntu:latest
+
+RUN apt-get update; \
+    apt-get install -y --no-install-recommends \
+    autoconf \
+    automake \
+    bzip2\
+    dpkg-dev \
+    file \
+    wget \
+    curl \
+    build-essential \
+    imagemagick \
+    libbz2-dev \
+    libc6-dev \
+    libcurl4-openssl-dev \
+    libdb-dev \
+    libevent-dev \
+    libffi-dev \
+    libgdbm-dev \
+    libglib2.0-dev \
+    libgmp-dev \
+    libjpeg-dev \
+    libkrb5-dev \
+    liblzma-dev \
+    libmagickcore-dev \
+    libmagickwand-dev \
+    libmaxminddb-dev \
+    libncurses5-dev \
+    libncursesw5-dev \
+    libpng-dev \
+    libpq-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    libssl-dev \
+    libtool \
+    libwebp-dev \
+    libxml2-dev \
+    libxslt-dev \
+    libyaml-dev \
+    make \
+    patch \
+    unzip \
+    xz-utils \
+    zlib1g-dev \
+    flex \
+    bison
+
+ADD . /usr/src/gcc
+RUN /bin/sh -c set -ex; \
+    cd /usr/src/gcc; \
+    ./contrib/download_prerequisites; 	{ rm *.tar.* || true; }; \
+    mkdir -p /usr/src/gcc/gcc-build; \
+    cd /usr/src/gcc/gcc-build; \
+    /usr/src/gcc/configure --disable-bootstrap --disable-multilib --enable-languages=c,c++,rust; \
+    make -j "$(nproc)"; \
+    make install-strip; \
+    cd /root; \
+    rm -rf /usr/src/gcc
+
+RUN /bin/sh -c set -ex; \
+    echo '/usr/local/lib64' > /etc/ld.so.conf.d/local-lib64.conf; \
+    ldconfig -v
+
+RUN /bin/sh -c set -ex; \
+    dpkg-divert --divert /usr/bin/gcc.orig --rename /usr/bin/gcc; \
+    dpkg-divert --divert /usr/bin/g++.orig --rename /usr/bin/g++; \
+    update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 999
+
+
+CMD ["bash"]


### PR DESCRIPTION
This allows for easy testing via docker:

```
sudo docker build . -t gccrs-dev
sudo docker run --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp gccrs-dev:latest gccrs -g -O2 -c gcc/testsuite/rust.test/compilable/type_infer1.rs -o type_infer1.o
```