### PR TITLE
Turn on make check-rust

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -43,4 +43,5 @@ jobs:
     - name: Build
       run: |
            cd gccrs-build; \
-           make
+           make; \
+           make check-rust


### PR DESCRIPTION
This will turn on the test-suite which does have a currently failing test
lets see what happens the workflow in github.

Eventually it would be ideal to have a junit.xml or equivalent archive artefact to compare with each PR.