### PR TITLE
Add Type resolution to Array expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ make
 Running the compiler itself without make install we can simply imvoke the compiler proper:
 
 ```
-$ gdb --args ./gcc/rust1 test1.rs -frust-dump-parse -dumpbase test.rs -mtune=generic -march=x86-64 -auxbase-strip test.s -O0 -version -fdump-tree-gimple -o test.s -L/lib/x86_64-linux-gnu -L/lib/../lib64 -L/usr/lib/x86_64-linux-gnu -L/usr/lib/../lib64
+$ gdb --args ./gcc/rust1 test.rs -frust-dump-parse -dumpbase test.rs -mtune=generic -march=x86-64 test.s -O0 -version -fdump-tree-gimple -o test.s -L/lib/x86_64-linux-gnu -L/lib/../lib64 -L/usr/lib/x86_64-linux-gnu -L/usr/lib/../lib64
 ```
 
 Invoking the compiler driver we need to:

--- a/gcc/rust/analysis/rust-type-resolution.cc
+++ b/gcc/rust/analysis/rust-type-resolution.cc
@@ -445,6 +445,7 @@ TypeResolution::visit (AST::ArrayElemsValues &elems)
   if (failed)
     return;
 
+  // FIXME This will leak
   auto capacity
     = new AST::LiteralExpr (std::to_string (elems.get_num_values ()),
 			    AST::Literal::INT,

--- a/gcc/rust/analysis/rust-type-resolution.cc
+++ b/gcc/rust/analysis/rust-type-resolution.cc
@@ -496,7 +496,15 @@ TypeResolution::visit (AST::ArrayIndexExpr &expr)
 
   // check the index_type should be an i32 which should really be
   // more permissive
-  // TODO
+  AST::Type *i32 = nullptr;
+  scope.LookupType ("i32", &i32);
+  rust_assert (i32 != nullptr);
+
+  if (!typesAreCompatible (array_index_type, i32,
+			   expr.get_index_expr ()->get_locus_slow ()))
+    {
+      return;
+    }
 
   // the the element type from the array_expr_type and it _must_ be an array
   AST::ArrayType *resolved = ArrayTypeVisitor::Resolve (array_expr_type);

--- a/gcc/rust/analysis/rust-type-resolution.cc
+++ b/gcc/rust/analysis/rust-type-resolution.cc
@@ -466,7 +466,17 @@ void
 TypeResolution::visit (AST::ArrayExpr &expr)
 {
   auto elements = expr.get_internal_elements ();
+
+  auto before = typeBuffer.size ();
   elements->accept_vis (*this);
+  if (typeBuffer.size () <= before)
+    {
+      rust_error_at (expr.get_locus_slow (),
+		     "unable to determine type for ArrayExpr");
+      return;
+    }
+
+  expr.set_inferred_type (typeBuffer.back ());
 }
 
 void

--- a/gcc/rust/analysis/rust-type-resolution.h
+++ b/gcc/rust/analysis/rust-type-resolution.h
@@ -1,3 +1,20 @@
+// Copyright (C) 2020 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
 #pragma once
 
 #include "rust-resolution.h"

--- a/gcc/rust/analysis/rust-type-visitor.h
+++ b/gcc/rust/analysis/rust-type-visitor.h
@@ -1,0 +1,261 @@
+// rust-type-visitor.h -- Rust AST Visitor to AST::Type specific
+// Copyright (C) 2020 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_TYPE_VISITOR_H
+#define RUST_TYPE_VISITOR_H
+
+#include "rust-system.h"
+#include "rust-ast-full.h"
+#include "rust-ast-visitor.h"
+#include "rust-scan.h"
+
+namespace Rust {
+namespace Analysis {
+
+class BaseTypeVisitor : public AST::ASTVisitor
+{
+public:
+  // visitor impl
+  // rust-ast.h
+  //  virtual void visit(AttrInput& attr_input);
+  //  virtual void visit(TokenTree& token_tree);
+  //  virtual void visit(MacroMatch& macro_match);
+  virtual void visit (AST::Token &tok) override {}
+  virtual void visit (AST::DelimTokenTree &delim_tok_tree) override {}
+  virtual void visit (AST::AttrInputMetaItemContainer &input) override {}
+  //  virtual void visit(MetaItem& meta_item) override {}
+  //  void vsit(Stmt& stmt) override {}
+  //  virtual void visit(Expr& expr) override {}
+  virtual void visit (AST::IdentifierExpr &ident_expr) override {}
+  //  virtual void visit(Pattern& pattern) override {}
+  //  virtual void visit(Type& type) override {}
+  //  virtual void visit(TypeParamBound& type_param_bound) override {}
+  virtual void visit (AST::Lifetime &lifetime) override {}
+  //  virtual void visit(GenericParam& generic_param) override {}
+  virtual void visit (AST::LifetimeParam &lifetime_param) override {}
+  //  virtual void visit(TraitItem& trait_item) override {}
+  //  virtual void visit(InherentImplItem& inherent_impl_item) override {}
+  //  virtual void visit(TraitImplItem& trait_impl_item) override {}
+  virtual void visit (AST::MacroInvocationSemi &macro) override {}
+
+  // rust-path.h
+  virtual void visit (AST::PathInExpression &path) override {}
+  virtual void visit (AST::TypePathSegment &segment) override {}
+  virtual void visit (AST::TypePathSegmentGeneric &segment) override {}
+  virtual void visit (AST::TypePathSegmentFunction &segment) override {}
+  virtual void visit (AST::TypePath &path) override {}
+  virtual void visit (AST::QualifiedPathInExpression &path) override {}
+  virtual void visit (AST::QualifiedPathInType &path) override {}
+
+  // rust-expr.h
+  virtual void visit (AST::LiteralExpr &expr) override {}
+  virtual void visit (AST::AttrInputLiteral &attr_input) override {}
+  virtual void visit (AST::MetaItemLitExpr &meta_item) override {}
+  virtual void visit (AST::MetaItemPathLit &meta_item) override {}
+  virtual void visit (AST::BorrowExpr &expr) override {}
+  virtual void visit (AST::DereferenceExpr &expr) override {}
+  virtual void visit (AST::ErrorPropagationExpr &expr) override {}
+  virtual void visit (AST::NegationExpr &expr) override {}
+  virtual void visit (AST::ArithmeticOrLogicalExpr &expr) override {}
+  virtual void visit (AST::ComparisonExpr &expr) override {}
+  virtual void visit (AST::LazyBooleanExpr &expr) override {}
+  virtual void visit (AST::TypeCastExpr &expr) override {}
+  virtual void visit (AST::AssignmentExpr &expr) override {}
+  virtual void visit (AST::CompoundAssignmentExpr &expr) override {}
+  virtual void visit (AST::GroupedExpr &expr) override {}
+  //  virtual void visit(ArrayElems& elems) override {}
+  virtual void visit (AST::ArrayElemsValues &elems) override {}
+  virtual void visit (AST::ArrayElemsCopied &elems) override {}
+  virtual void visit (AST::ArrayExpr &expr) override {}
+  virtual void visit (AST::ArrayIndexExpr &expr) override {}
+  virtual void visit (AST::TupleExpr &expr) override {}
+  virtual void visit (AST::TupleIndexExpr &expr) override {}
+  virtual void visit (AST::StructExprStruct &expr) override {}
+  //  virtual void visit(StructExprField& field) override {}
+  virtual void visit (AST::StructExprFieldIdentifier &field) override {}
+  virtual void visit (AST::StructExprFieldIdentifierValue &field) override {}
+  virtual void visit (AST::StructExprFieldIndexValue &field) override {}
+  virtual void visit (AST::StructExprStructFields &expr) override {}
+  virtual void visit (AST::StructExprStructBase &expr) override {}
+  virtual void visit (AST::StructExprTuple &expr) override {}
+  virtual void visit (AST::StructExprUnit &expr) override {}
+  //  virtual void visit(EnumExprField& field) override {}
+  virtual void visit (AST::EnumExprFieldIdentifier &field) override {}
+  virtual void visit (AST::EnumExprFieldIdentifierValue &field) override {}
+  virtual void visit (AST::EnumExprFieldIndexValue &field) override {}
+  virtual void visit (AST::EnumExprStruct &expr) override {}
+  virtual void visit (AST::EnumExprTuple &expr) override {}
+  virtual void visit (AST::EnumExprFieldless &expr) override {}
+  virtual void visit (AST::CallExpr &expr) override {}
+  virtual void visit (AST::MethodCallExpr &expr) override {}
+  virtual void visit (AST::FieldAccessExpr &expr) override {}
+  virtual void visit (AST::ClosureExprInner &expr) override {}
+  virtual void visit (AST::BlockExpr &expr) override {}
+  virtual void visit (AST::ClosureExprInnerTyped &expr) override {}
+  virtual void visit (AST::ContinueExpr &expr) override {}
+  virtual void visit (AST::BreakExpr &expr) override {}
+  virtual void visit (AST::RangeFromToExpr &expr) override {}
+  virtual void visit (AST::RangeFromExpr &expr) override {}
+  virtual void visit (AST::RangeToExpr &expr) override {}
+  virtual void visit (AST::RangeFullExpr &expr) override {}
+  virtual void visit (AST::RangeFromToInclExpr &expr) override {}
+  virtual void visit (AST::RangeToInclExpr &expr) override {}
+  virtual void visit (AST::ReturnExpr &expr) override {}
+  virtual void visit (AST::UnsafeBlockExpr &expr) override {}
+  virtual void visit (AST::LoopExpr &expr) override {}
+  virtual void visit (AST::WhileLoopExpr &expr) override {}
+  virtual void visit (AST::WhileLetLoopExpr &expr) override {}
+  virtual void visit (AST::ForLoopExpr &expr) override {}
+  virtual void visit (AST::IfExpr &expr) override {}
+  virtual void visit (AST::IfExprConseqElse &expr) override {}
+  virtual void visit (AST::IfExprConseqIf &expr) override {}
+  virtual void visit (AST::IfExprConseqIfLet &expr) override {}
+  virtual void visit (AST::IfLetExpr &expr) override {}
+  virtual void visit (AST::IfLetExprConseqElse &expr) override {}
+  virtual void visit (AST::IfLetExprConseqIf &expr) override {}
+  virtual void visit (AST::IfLetExprConseqIfLet &expr) override {}
+  //  virtual void visit(MatchCase& match_case) override {}
+  // virtual void visit (AST::MatchCaseBlockExpr &match_case) override {}
+  // virtual void visit (AST::MatchCaseExpr &match_case) override {}
+  virtual void visit (AST::MatchExpr &expr) override {}
+  virtual void visit (AST::AwaitExpr &expr) override {}
+  virtual void visit (AST::AsyncBlockExpr &expr) override {}
+
+  // rust-item.h
+  virtual void visit (AST::TypeParam &param) override {}
+  //  virtual void visit(WhereClauseItem& item) override {}
+  virtual void visit (AST::LifetimeWhereClauseItem &item) override {}
+  virtual void visit (AST::TypeBoundWhereClauseItem &item) override {}
+  virtual void visit (AST::Method &method) override {}
+  virtual void visit (AST::ModuleBodied &module) override {}
+  virtual void visit (AST::ModuleNoBody &module) override {}
+  virtual void visit (AST::ExternCrate &crate) override {}
+  //  virtual void visit(UseTree& use_tree) override {}
+  virtual void visit (AST::UseTreeGlob &use_tree) override {}
+  virtual void visit (AST::UseTreeList &use_tree) override {}
+  virtual void visit (AST::UseTreeRebind &use_tree) override {}
+  virtual void visit (AST::UseDeclaration &use_decl) override {}
+  virtual void visit (AST::Function &function) override {}
+  virtual void visit (AST::TypeAlias &type_alias) override {}
+  virtual void visit (AST::StructStruct &struct_item) override {}
+  virtual void visit (AST::TupleStruct &tuple_struct) override {}
+  virtual void visit (AST::EnumItem &item) override {}
+  virtual void visit (AST::EnumItemTuple &item) override {}
+  virtual void visit (AST::EnumItemStruct &item) override {}
+  virtual void visit (AST::EnumItemDiscriminant &item) override {}
+  virtual void visit (AST::Enum &enum_item) override {}
+  virtual void visit (AST::Union &union_item) override {}
+  virtual void visit (AST::ConstantItem &const_item) override {}
+  virtual void visit (AST::StaticItem &static_item) override {}
+  virtual void visit (AST::TraitItemFunc &item) override {}
+  virtual void visit (AST::TraitItemMethod &item) override {}
+  virtual void visit (AST::TraitItemConst &item) override {}
+  virtual void visit (AST::TraitItemType &item) override {}
+  virtual void visit (AST::Trait &trait) override {}
+  virtual void visit (AST::InherentImpl &impl) override {}
+  virtual void visit (AST::TraitImpl &impl) override {}
+  //  virtual void visit(ExternalItem& item) override {}
+  virtual void visit (AST::ExternalStaticItem &item) override {}
+  virtual void visit (AST::ExternalFunctionItem &item) override {}
+  virtual void visit (AST::ExternBlock &block) override {}
+
+  // rust-macro.h
+  virtual void visit (AST::MacroMatchFragment &match) override {}
+  virtual void visit (AST::MacroMatchRepetition &match) override {}
+  virtual void visit (AST::MacroMatcher &matcher) override {}
+  virtual void visit (AST::MacroRulesDefinition &rules_def) override {}
+  virtual void visit (AST::MacroInvocation &macro_invoc) override {}
+  virtual void visit (AST::MetaItemPath &meta_item) override {}
+  virtual void visit (AST::MetaItemSeq &meta_item) override {}
+  virtual void visit (AST::MetaWord &meta_item) override {}
+  virtual void visit (AST::MetaNameValueStr &meta_item) override {}
+  virtual void visit (AST::MetaListPaths &meta_item) override {}
+  virtual void visit (AST::MetaListNameValueStr &meta_item) override {}
+
+  // rust-pattern.h
+  virtual void visit (AST::LiteralPattern &pattern) override {}
+  virtual void visit (AST::IdentifierPattern &pattern) override {}
+  virtual void visit (AST::WildcardPattern &pattern) override {}
+  //  virtual void visit(RangePatternBound& bound) override {}
+  virtual void visit (AST::RangePatternBoundLiteral &bound) override {}
+  virtual void visit (AST::RangePatternBoundPath &bound) override {}
+  virtual void visit (AST::RangePatternBoundQualPath &bound) override {}
+  virtual void visit (AST::RangePattern &pattern) override {}
+  virtual void visit (AST::ReferencePattern &pattern) override {}
+  //  virtual void visit(StructPatternField& field) override {}
+  virtual void visit (AST::StructPatternFieldTuplePat &field) override {}
+  virtual void visit (AST::StructPatternFieldIdentPat &field) override {}
+  virtual void visit (AST::StructPatternFieldIdent &field) override {}
+  virtual void visit (AST::StructPattern &pattern) override {}
+  //  virtual void visit(TupleStructItems& tuple_items) override {}
+  virtual void visit (AST::TupleStructItemsNoRange &tuple_items) override {}
+  virtual void visit (AST::TupleStructItemsRange &tuple_items) override {}
+  virtual void visit (AST::TupleStructPattern &pattern) override {}
+  //  virtual void visit(TuplePatternItems& tuple_items) override {}
+  virtual void visit (AST::TuplePatternItemsMultiple &tuple_items) override {}
+  virtual void visit (AST::TuplePatternItemsRanged &tuple_items) override {}
+  virtual void visit (AST::TuplePattern &pattern) override {}
+  virtual void visit (AST::GroupedPattern &pattern) override {}
+  virtual void visit (AST::SlicePattern &pattern) override {}
+
+  // rust-stmt.h
+  virtual void visit (AST::EmptyStmt &stmt) override {}
+  virtual void visit (AST::LetStmt &stmt) override {}
+  virtual void visit (AST::ExprStmtWithoutBlock &stmt) override {}
+  virtual void visit (AST::ExprStmtWithBlock &stmt) override {}
+
+  // rust-type.h
+  virtual void visit (AST::TraitBound &bound) override {}
+  virtual void visit (AST::ImplTraitType &type) override {}
+  virtual void visit (AST::TraitObjectType &type) override {}
+  virtual void visit (AST::ParenthesisedType &type) override {}
+  virtual void visit (AST::ImplTraitTypeOneBound &type) override {}
+  virtual void visit (AST::TraitObjectTypeOneBound &type) override {}
+  virtual void visit (AST::TupleType &type) override {}
+  virtual void visit (AST::NeverType &type) override {}
+  virtual void visit (AST::RawPointerType &type) override {}
+  virtual void visit (AST::ReferenceType &type) override {}
+  virtual void visit (AST::ArrayType &type) override {}
+  virtual void visit (AST::SliceType &type) override {}
+  virtual void visit (AST::InferredType &type) override {}
+  virtual void visit (AST::BareFunctionType &type) override {}
+};
+
+class ArrayTypeVisitor : public BaseTypeVisitor
+{
+public:
+  static AST::ArrayType *Resolve (AST::Type *type)
+  {
+    ArrayTypeVisitor vis;
+    type->accept_vis (vis);
+    return vis.resolved;
+  }
+
+  virtual void visit (AST::ArrayType &type) override { resolved = &type; };
+
+private:
+  ArrayTypeVisitor () : resolved (nullptr) {}
+
+  AST::ArrayType *resolved;
+};
+
+} // namespace Analysis
+} // namespace Rust
+
+#endif // RUST_TYPE_VISITOR_H

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -1000,6 +1000,10 @@ class ArrayExpr : public ExprWithoutBlock
 
   Location locus;
 
+  // this is a reference to what the inferred type is based on
+  // this init expression
+  Type *inferredType;
+
 public:
   std::string as_string () const override;
 
@@ -1049,6 +1053,9 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   ArrayElems *get_internal_elements () { return internal_elements.get (); };
+
+  Type *get_inferred_type () { return inferredType; }
+  void set_inferred_type (Type *type) { inferredType = type; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -928,6 +928,17 @@ public:
 
   void accept_vis (ASTVisitor &vis) override;
 
+  size_t get_num_values () const { return values.size (); }
+
+  void iterate (std::function<bool (Expr *)> cb)
+  {
+    for (auto it = values.begin (); it != values.end (); it++)
+      {
+	if (!cb ((*it).get ()))
+	  return;
+      }
+  }
+
 protected:
   ArrayElemsValues *clone_array_elems_impl () const override
   {
@@ -1037,6 +1048,8 @@ public:
 
   void accept_vis (ASTVisitor &vis) override;
 
+  ArrayElems *get_internal_elements () { return internal_elements.get (); };
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */
@@ -1099,6 +1112,9 @@ public:
   Location get_locus_slow () const override { return get_locus (); }
 
   void accept_vis (ASTVisitor &vis) override;
+
+  Expr *get_array_expr () { return array_expr.get (); }
+  Expr *get_index_expr () { return index_expr.get (); }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather

--- a/gcc/rust/ast/rust-type.h
+++ b/gcc/rust/ast/rust-type.h
@@ -576,6 +576,10 @@ public:
 
   Type *get_element_type () { return elem_type.get (); }
 
+  Expr *get_size_expr () { return size.get (); }
+
+  Location &get_locus () { return locus; }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */

--- a/gcc/rust/ast/rust-type.h
+++ b/gcc/rust/ast/rust-type.h
@@ -60,7 +60,7 @@ class ImplTraitType : public Type
 {
   // TypeParamBounds type_param_bounds;
   // inlined form
-  std::vector<std::unique_ptr<TypeParamBound>> type_param_bounds;
+  std::vector<std::unique_ptr<TypeParamBound> > type_param_bounds;
 
   Location locus;
 
@@ -74,7 +74,7 @@ protected:
 
 public:
   ImplTraitType (
-    std::vector<std::unique_ptr<TypeParamBound>> type_param_bounds,
+    std::vector<std::unique_ptr<TypeParamBound> > type_param_bounds,
     Location locus)
     : type_param_bounds (std::move (type_param_bounds)), locus (locus)
   {}
@@ -115,7 +115,7 @@ class TraitObjectType : public Type
 {
   bool has_dyn;
   // TypeParamBounds type_param_bounds;
-  std::vector<std::unique_ptr<TypeParamBound>>
+  std::vector<std::unique_ptr<TypeParamBound> >
     type_param_bounds; // inlined form
 
   Location locus;
@@ -130,7 +130,7 @@ protected:
 
 public:
   TraitObjectType (
-    std::vector<std::unique_ptr<TypeParamBound>> type_param_bounds,
+    std::vector<std::unique_ptr<TypeParamBound> > type_param_bounds,
     Location locus, bool is_dyn_dispatch = false)
     : has_dyn (is_dyn_dispatch),
       type_param_bounds (std::move (type_param_bounds)), locus (locus)
@@ -318,14 +318,14 @@ class TypePath; // definition moved to "rust-path.h"
  * specific order */
 class TupleType : public TypeNoBounds
 {
-  std::vector<std::unique_ptr<Type>> elems;
+  std::vector<std::unique_ptr<Type> > elems;
   Location locus;
 
 public:
   // Returns whether the tuple type is the unit type, i.e. has no elements.
   bool is_unit_type () const { return elems.empty (); }
 
-  TupleType (std::vector<std::unique_ptr<Type>> elems, Location locus)
+  TupleType (std::vector<std::unique_ptr<Type> > elems, Location locus)
     : elems (std::move (elems)), locus (locus)
   {}
 
@@ -573,6 +573,8 @@ public:
   Location get_locus () const { return locus; }
 
   void accept_vis (ASTVisitor &vis) override;
+
+  Type *get_element_type () { return elem_type.get (); }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather

--- a/gcc/rust/backend/rust-compile.h
+++ b/gcc/rust/backend/rust-compile.h
@@ -243,7 +243,8 @@ private:
   std::vector< ::Bexpression *> exprs;
   std::vector< ::Bstatement *> stmts;
   std::vector< ::Bvariable *> varBuffer;
-  std::vector<AST::StructStruct*> structBuffer;
+  std::vector<AST::StructStruct *> structBuffer;
+  std::vector<std::vector< ::Bexpression *> > arrayConsStack;
 
   // careful these are the vectors we pass into the GCC middle-end
   std::vector< ::Btype *> type_decls;

--- a/gcc/testsuite/rust.test/compilable/arrays1.rs
+++ b/gcc/testsuite/rust.test/compilable/arrays1.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let xs: [i32; 5] = [1, 2, 3, 4, 5];
+    let xy = [6, 7, 8];
+
+    let a = xs[0];
+    let b = xy[2];
+}


### PR DESCRIPTION
This adds type inferencing and validation for arrays such as:

  let x: [i32, 5] = [1,2,3,4,5]
  ley y = [1,2,3];

It checks that each element is of a valid type and they line up correctly.
There needs to be some refactoring of the type resolution to handle the
array index expressions so this is a good save point for now.

Addresses: #27 #55