### PR TITLE
We cannot lookup types to ensure they are known as AST::Type differs

### DIFF
--- a/gcc/rust/analysis/rust-type-resolution.cc
+++ b/gcc/rust/analysis/rust-type-resolution.cc
@@ -1181,13 +1181,13 @@ TypeResolution::visit (AST::LetStmt &stmt)
       auto typeString = typeComparisonBuffer.back ();
       typeComparisonBuffer.pop_back ();
 
-      AST::Type *val = NULL;
-      if (!scope.LookupType (typeString, &val))
-	{
-	  rust_error_at (stmt.locus, "LetStmt has unknown type: %s",
-			 stmt.type->as_string ().c_str ());
-	  return;
-	}
+      // AST::Type *val = NULL;
+      // if (!scope.LookupType (typeString, &val))
+      //   {
+      //     rust_error_at (stmt.locus, "LetStmt has unknown type: %s",
+      //   		 stmt.type->as_string ().c_str ());
+      //     return;
+      //   }
     }
   else if (inferedType != nullptr)
     {
@@ -1201,13 +1201,13 @@ TypeResolution::visit (AST::LetStmt &stmt)
       auto typeString = typeComparisonBuffer.back ();
       typeComparisonBuffer.pop_back ();
 
-      AST::Type *val = NULL;
-      if (!scope.LookupType (typeString, &val))
-	{
-	  rust_error_at (stmt.locus, "Inferred unknown type: %s",
-			 inferedType->as_string ().c_str ());
-	  return;
-	}
+      // AST::Type *val = NULL;
+      // if (!scope.LookupType (typeString, &val))
+      //   {
+      //     rust_error_at (stmt.locus, "Inferred unknown type: %s",
+      //   		 inferedType->as_string ().c_str ());
+      //     return;
+      //   }
     }
   else
     {


### PR DESCRIPTION
to how struct AST Types. We need to move to HIR to avoid this issue via
name resolution.

This was a regression from the arrays work breaking inferencing of structs we need the move to hir to handle this better.