### PR TITLE
Type Resolve ReturnExpr's to ensure they match the function type.

### DIFF
--- a/gcc/rust/analysis/rust-type-resolution.h
+++ b/gcc/rust/analysis/rust-type-resolution.h
@@ -55,6 +55,12 @@ public:
     return functionScope.Lookup (ident, fn);
   }
 
+  void PushFunction (AST::Function *fn) { functionStack.push_back (fn); }
+
+  void PopFunction () { functionStack.pop_back (); }
+
+  AST::Function *CurrentFunction () { return functionStack.back (); }
+
   void InsertLocal (std::string ident, AST::LetStmt *let)
   {
     localsPerBlock.Insert (ident, let);
@@ -91,6 +97,8 @@ public:
   }
 
 private:
+  std::vector<AST::Function *> functionStack;
+
   Scope<AST::Function *> functionScope;
   Scope<AST::LetStmt *> localsPerBlock;
   Scope<AST::StructStruct *> structsPerBlock;

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -3012,11 +3012,11 @@ protected:
 // Return expression AST node representation
 class ReturnExpr : public ExprWithoutBlock
 {
-public:
   std::unique_ptr<Expr> return_expr;
 
   Location locus;
 
+public:
   std::string as_string () const override;
 
   /* Returns whether the object has an expression returned (i.e. not void return
@@ -3058,6 +3058,8 @@ public:
   Location get_locus_slow () const override { return get_locus (); }
 
   void accept_vis (ASTVisitor &vis) override;
+
+  Expr *get_expr () { return return_expr.get (); }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -805,10 +805,10 @@ void
 Compilation::visit (AST::ReturnExpr &expr)
 {
   Bexpression *ret = NULL;
-  VISIT_POP (expr.return_expr->get_locus_slow (), expr.return_expr, ret, exprs);
+  VISIT_POP (expr.get_expr ()->get_locus_slow (), expr.get_expr (), ret, exprs);
   if (ret == NULL)
     {
-      rust_fatal_error (expr.return_expr->get_locus_slow (),
+      rust_fatal_error (expr.get_expr ()->get_locus_slow (),
 			"failed to compile");
       return;
     }
@@ -816,7 +816,7 @@ Compilation::visit (AST::ReturnExpr &expr)
   std::vector<Bexpression *> retstmts;
   retstmts.push_back (ret);
   auto s = backend->return_statement (scope.GetCurrentFndecl (), retstmts,
-				      expr.locus);
+				      expr.get_locus ());
   scope.AddStatement (s);
 }
 


### PR DESCRIPTION
This an implementation to check return types for functions it needs work
to handle structs and other data structures later on.