### PR TITLE
Phil/build changes

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -36,7 +36,7 @@ jobs:
            mkdir -p gccrs-build;
            cd gccrs-build;
            ../configure \
-               --enable-languages=c,c++,rust \
+               --enable-languages=rust \
                --disable-bootstrap \
                --enable-multilib
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN /bin/sh -c set -ex; \
     ./contrib/download_prerequisites; 	{ rm *.tar.* || true; }; \
     mkdir -p /usr/src/gcc/gcc-build; \
     cd /usr/src/gcc/gcc-build; \
-    /usr/src/gcc/configure --disable-bootstrap --disable-multilib --enable-languages=c,c++,rust; \
+    /usr/src/gcc/configure --disable-bootstrap --disable-multilib --enable-languages=rust; \
     make -j "$(nproc)"; \
     make install-strip; \
     cd /root; \

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ this is why a build directory is created.
 ```bash
 $ mkdir gccrs-build
 $ cd gccrs-build
-$ ../gccrs/configure --prefix=$HOME/gccrs-install --disable-bootstrap --enable-multilib --enable-languages=c,c++,rust
+$ ../gccrs/configure --prefix=$HOME/gccrs-install --disable-bootstrap --enable-multilib --enable-languages=rust
 $ make
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ ../gccrs/configure --prefix=$HOME/gccrs-install --disable-bootstrap --enable-m
 $ make
 ```
 
-Running the compiler itself without make install we can simply imvoke the compiler proper:
+Running the compiler itself without make install we can simply invoke the compiler proper:
 
 ```
 $ gdb --args ./gcc/rust1 test.rs -frust-dump-parse -Warray-bounds -dumpbase test.rs -mtune=generic -march=x86-64 -O0 -version -fdump-tree-gimple -o test.s -L/lib/x86_64-linux-gnu -L/lib/../lib64 -L/usr/lib/x86_64-linux-gnu -L/usr/lib/../lib64

--- a/README.md
+++ b/README.md
@@ -88,4 +88,4 @@ Not all contributions must be code, we would love to see new test cases or bugs 
 We can be found on all usual Rust channels such as Zulip but we also have our own channels:
 
  * GCC Rust Zulip: https://gcc-rust.zulipchat.com/
- * Twitter: comming-soon
+ * Twitter: https://twitter.com/gcc_rust

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ make
 Running the compiler itself without make install we can simply imvoke the compiler proper:
 
 ```
-$ gdb --args ./gcc/rust1 test.rs -frust-dump-parse -dumpbase test.rs -mtune=generic -march=x86-64 test.s -O0 -version -fdump-tree-gimple -o test.s -L/lib/x86_64-linux-gnu -L/lib/../lib64 -L/usr/lib/x86_64-linux-gnu -L/usr/lib/../lib64
+$ gdb --args ./gcc/rust1 test.rs -frust-dump-parse -Warray-bounds -dumpbase test.rs -mtune=generic -march=x86-64 -O0 -version -fdump-tree-gimple -o test.s -L/lib/x86_64-linux-gnu -L/lib/../lib64 -L/usr/lib/x86_64-linux-gnu -L/usr/lib/../lib64
 ```
 
 Invoking the compiler driver we need to:


### PR DESCRIPTION
This updates the README and removes C/C++ from the enabled languages as simply building rust seems to work since the rebase against GCC