### PR TITLE
When compiling a block it might reference a GIMPLE node that is not

### DIFF
--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -48,11 +48,7 @@ public:
       {
 	// has this been added to the list then it must be finished
 	if (ctx->function_completed (lookup))
-	  {
-	    printf ("returning early the function [%s] is completed!\n",
-		    function.as_string ().c_str ());
-	    return;
-	  }
+	  return;
       }
 
     TyTy::TyBase *fnType;
@@ -123,9 +119,12 @@ public:
       return true;
     });
 
-    Bblock *enclosing_scope = ctx->peek_enclosing_scope ();
-    HIR::BlockExpr *function_body = function.function_body.get ();
+    bool toplevel_item
+      = function.get_mappings ().get_local_defid () != UNKNOWN_LOCAL_DEFID;
+    Bblock *enclosing_scope
+      = toplevel_item ? NULL : ctx->peek_enclosing_scope ();
 
+    HIR::BlockExpr *function_body = function.function_body.get ();
     Location start_location = function_body->get_locus ();
     Location end_location = function_body->get_closing_locus ();
 

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -36,10 +36,6 @@ ResolvePath::visit (HIR::PathInExpression &expr)
       return;
     }
 
-  printf ("PATHIN have ast node id %u ref %u for expr [%s]\n",
-	  expr.get_mappings ().get_nodeid (), ref_node_id,
-	  expr.as_string ().c_str ());
-
   HirId ref;
   if (!ctx->get_mappings ()->lookup_node_to_hir (
 	expr.get_mappings ().get_crate_num (), ref_node_id, &ref))
@@ -52,9 +48,6 @@ ResolvePath::visit (HIR::PathInExpression &expr)
   Bfunction *fn;
   if (!ctx->lookup_function_decl (ref, &fn))
     {
-      printf (
-	"path failed to lookup function attempting to forward resolve!\n");
-
       // this might fail because its a forward decl so we can attempt to
       // resolve it now
       HIR::Item *resolved_item = ctx->get_mappings ()->lookup_hir_item (

--- a/gcc/testsuite/rust.test/compilable/forward_decl_1.rs
+++ b/gcc/testsuite/rust.test/compilable/forward_decl_1.rs
@@ -1,0 +1,10 @@
+fn main() {
+    let mut an_integer = 5;
+    an_integer = test(1) + 3;
+
+    let call_test = test(1);
+}
+
+fn test(x: i32) -> i32 {
+    return x + 1;
+}


### PR DESCRIPTION
resolved yet. Such as:

fn main() -> i32 { call() }
fn call() -> i32 { return 1; }

The compilation pass acts on the first function main and detects the other
node call is not compiled yet we can go resolve it. This is a toplevel
item since it has a local_def_id and therefore it has a NULL enclosing
scope for the block.

Fixes #72