### PR TITLE
This brings arrays back into the new framework. It resolves ArrayType

### DIFF
--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -952,9 +952,15 @@ public:
 
   virtual void accept_vis (ASTVisitor &vis) = 0;
 
+  NodeId get_node_id () const { return node_id; }
+
 protected:
+  ArrayElems () : node_id (Analysis::Mappings::get ()->get_next_node_id ()) {}
+
   // pure virtual clone implementation
   virtual ArrayElems *clone_array_elems_impl () const = 0;
+
+  NodeId node_id;
 };
 
 // Value array elements
@@ -966,7 +972,7 @@ class ArrayElemsValues : public ArrayElems
 
 public:
   ArrayElemsValues (std::vector<std::unique_ptr<Expr> > elems)
-    : values (std::move (elems))
+    : ArrayElems (), values (std::move (elems))
   {}
 
   // copy constructor with vector clone
@@ -1032,7 +1038,7 @@ public:
   // Constructor requires pointers for polymorphism
   ArrayElemsCopied (std::unique_ptr<Expr> copied_elem,
 		    std::unique_ptr<Expr> copy_amount)
-    : elem_to_copy (std::move (copied_elem)),
+    : ArrayElems (), elem_to_copy (std::move (copied_elem)),
       num_copies (std::move (copy_amount))
   {}
 
@@ -1090,10 +1096,6 @@ class ArrayExpr : public ExprWithoutBlock
 
   // TODO: find another way to store this to save memory?
   bool marked_for_strip = false;
-
-  // this is a reference to what the inferred type is based on
-  // this init expression
-  Type *inferredType;
 
 public:
   std::string as_string () const override;
@@ -1158,9 +1160,6 @@ public:
     rust_assert (internal_elements != nullptr);
     return internal_elements;
   }
-
-  Type *get_inferred_type () { return inferredType; }
-  void set_inferred_type (Type *type) { inferredType = type; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -211,6 +211,19 @@ public:
 
   void visit (TyTy::FnType &type) override { gcc_unreachable (); }
 
+  void visit (TyTy::ArrayType &type) override
+  {
+    mpz_t ival;
+    mpz_init_set_ui (ival, type.get_capacity ());
+
+    Btype *capacity_type = ctx->get_backend ()->integer_type (true, 32);
+    Bexpression *length
+      = ctx->get_backend ()->integer_constant_expression (capacity_type, ival);
+
+    Btype *element_type = TyTyResolveCompile::compile (ctx, type.get_type ());
+    translated = ctx->get_backend ()->array_type (element_type, length);
+  }
+
   void visit (TyTy::BoolType &type) override
   {
     ::Btype *compiled_type = nullptr;
@@ -221,9 +234,6 @@ public:
 
   void visit (TyTy::IntType &type) override
   {
-    printf ("type [%s] has ref: %u\n", type.as_string ().c_str (),
-	    type.get_ref ());
-
     ::Btype *compiled_type = nullptr;
     bool ok = ctx->lookup_compiled_types (type.get_ref (), &compiled_type);
     rust_assert (ok);

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -211,6 +211,15 @@ public:
     });
   }
 
+  void visit (HIR::ArrayElemsCopied &elems)
+  {
+    Bexpression *translated_expr
+      = CompileExpr::Compile (elems.get_elem_to_copy (), ctx);
+
+    for (size_t i = 0; i < elems.get_num_elements (); ++i)
+      constructor.push_back (translated_expr);
+  }
+
   void visit (HIR::ArithmeticOrLogicalExpr &expr)
   {
     Operator op;

--- a/gcc/rust/hir/rust-ast-lower-type.h
+++ b/gcc/rust/hir/rust-ast-lower-type.h
@@ -21,6 +21,7 @@
 
 #include "rust-ast-lower-base.h"
 #include "rust-diagnostics.h"
+#include "rust-ast-lower-expr.h"
 
 namespace Rust {
 namespace HIR {
@@ -73,6 +74,27 @@ public:
       = new HIR::TypePath (std::move (mapping), std::move (translated_segments),
 			   path.get_locus (),
 			   path.has_opening_scope_resolution_op ());
+    mappings->insert_hir_type (mapping.get_crate_num (), mapping.get_hirid (),
+			       translated);
+  }
+
+  void visit (AST::ArrayType &type)
+  {
+    HIR::Type *translated_type
+      = ASTLoweringType::translate (type.get_elem_type ().get ());
+    HIR::Expr *array_size
+      = ASTLoweringExpr::translate (type.get_size_expr ().get ());
+
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, type.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   mappings->get_next_localdef_id (crate_num));
+
+    translated
+      = new HIR::ArrayType (mapping,
+			    std::unique_ptr<HIR::Type> (translated_type),
+			    std::unique_ptr<HIR::Expr> (array_size),
+			    type.get_locus ());
     mappings->insert_hir_type (mapping.get_crate_num (), mapping.get_hirid (),
 			       translated);
   }

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -980,21 +980,25 @@ class ArrayElemsCopied : public ArrayElems
 {
   std::unique_ptr<Expr> elem_to_copy;
   std::unique_ptr<Expr> num_copies;
+  size_t folded_copy_amount;
 
   // TODO: should this store location data?
 
 public:
   // Constructor requires pointers for polymorphism
   ArrayElemsCopied (std::unique_ptr<Expr> copied_elem,
-		    std::unique_ptr<Expr> copy_amount)
+		    std::unique_ptr<Expr> copy_amount,
+		    size_t folded_copy_amount)
     : elem_to_copy (std::move (copied_elem)),
-      num_copies (std::move (copy_amount))
+      num_copies (std::move (copy_amount)),
+      folded_copy_amount (folded_copy_amount)
   {}
 
   // Copy constructor required due to unique_ptr - uses custom clone
   ArrayElemsCopied (ArrayElemsCopied const &other)
     : elem_to_copy (other.elem_to_copy->clone_expr ()),
-      num_copies (other.num_copies->clone_expr ())
+      num_copies (other.num_copies->clone_expr ()),
+      folded_copy_amount (other.folded_copy_amount)
   {}
 
   // Overloaded assignment operator for deep copying
@@ -1002,6 +1006,7 @@ public:
   {
     elem_to_copy = other.elem_to_copy->clone_expr ();
     num_copies = other.num_copies->clone_expr ();
+    folded_copy_amount = other.folded_copy_amount;
 
     return *this;
   }
@@ -1014,7 +1019,9 @@ public:
 
   void accept_vis (HIRVisitor &vis) override;
 
-  size_t get_num_elements () const override { return 0; }
+  size_t get_num_elements () const override { return folded_copy_amount; }
+
+  Expr *get_elem_to_copy () { return elem_to_copy.get (); }
 
 protected:
   ArrayElemsCopied *clone_array_elems_impl () const override

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -912,6 +912,8 @@ public:
 
   virtual void accept_vis (HIRVisitor &vis) = 0;
 
+  virtual size_t get_num_elements () const = 0;
+
 protected:
   // pure virtual clone implementation
   virtual ArrayElems *clone_array_elems_impl () const = 0;
@@ -955,7 +957,7 @@ public:
 
   void accept_vis (HIRVisitor &vis) override;
 
-  size_t get_num_values () const { return values.size (); }
+  size_t get_num_elements () const override { return values.size (); }
 
   void iterate (std::function<bool (Expr *)> cb)
   {
@@ -1012,6 +1014,8 @@ public:
 
   void accept_vis (HIRVisitor &vis) override;
 
+  size_t get_num_elements () const override { return 0; }
+
 protected:
   ArrayElemsCopied *clone_array_elems_impl () const override
   {
@@ -1026,10 +1030,6 @@ class ArrayExpr : public ExprWithoutBlock
   std::unique_ptr<ArrayElems> internal_elements;
 
   Location locus;
-
-  // this is a reference to what the inferred type is based on
-  // this init expression
-  Type *inferredType;
 
 public:
   std::string as_string () const override;
@@ -1081,9 +1081,6 @@ public:
   void accept_vis (HIRVisitor &vis) override;
 
   ArrayElems *get_internal_elements () { return internal_elements.get (); };
-
-  Type *get_inferred_type () { return inferredType; }
-  void set_inferred_type (Type *type) { inferredType = type; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather

--- a/gcc/rust/resolve/rust-ast-resolve-expr.h
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.h
@@ -129,6 +129,31 @@ public:
 
   void visit (AST::BlockExpr &expr);
 
+  void visit (AST::ArrayElemsValues &elems)
+  {
+    elems.iterate ([&] (AST::Expr *elem) mutable -> bool {
+      ResolveExpr::go (elem, elems.get_node_id ());
+      return true;
+    });
+  }
+
+  void visit (AST::ArrayExpr &expr)
+  {
+    expr.get_array_elems ()->accept_vis (*this);
+  }
+
+  void visit (AST::ArrayIndexExpr &expr)
+  {
+    ResolveExpr::go (expr.get_array_expr ().get (), expr.get_node_id ());
+    ResolveExpr::go (expr.get_index_expr ().get (), expr.get_node_id ());
+  }
+
+  void visit (AST::ArrayElemsCopied &elems)
+  {
+    // TODO
+    gcc_unreachable ();
+  }
+
 private:
   ResolveExpr (NodeId parent) : ResolverBase (parent) {}
 };

--- a/gcc/rust/resolve/rust-ast-resolve-expr.h
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.h
@@ -150,8 +150,8 @@ public:
 
   void visit (AST::ArrayElemsCopied &elems)
   {
-    // TODO
-    gcc_unreachable ();
+    ResolveExpr::go (elems.get_num_copies ().get (), elems.get_node_id ());
+    ResolveExpr::go (elems.get_elem_to_copy ().get (), elems.get_node_id ());
   }
 
 private:

--- a/gcc/rust/resolve/rust-ast-resolve-type.h
+++ b/gcc/rust/resolve/rust-ast-resolve-type.h
@@ -42,7 +42,7 @@ public:
 
   ~ResolveType () {}
 
-  virtual void visit (AST::TypePath &path)
+  void visit (AST::TypePath &path)
   {
     // this will need changed to handle mod/crate/use globs and look
     // at the segments in granularity
@@ -54,6 +54,11 @@ public:
 					 Definition{path.get_node_id (),
 						    parent});
       }
+  }
+
+  void visit (AST::ArrayType &type)
+  {
+    type.get_elem_type ()->accept_vis (*this);
   }
 
 private:

--- a/gcc/rust/rust-backend.h
+++ b/gcc/rust/rust-backend.h
@@ -23,6 +23,8 @@
 #include <mpfr.h>
 #include <mpc.h>
 
+#include "rust-location.h"
+#include "rust-linemap.h"
 #include "operator.h"
 
 extern bool

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -232,15 +232,9 @@ public:
 
     expr.get_array_expr ()->accept_vis (*this);
     rust_assert (infered != nullptr);
-    printf ("Resolved array-index 1  [%u] -> %s\n",
-	    expr.get_mappings ().get_hirid (), infered->as_string ().c_str ());
+
     // extract the element type out now from the base type
     infered = TyTyExtractorArray::ExtractElementTypeFromArray (infered);
-
-    printf ("Resolved array-index 2  [%u] -> %s\n",
-	    expr.get_mappings ().get_hirid (), infered->as_string ().c_str ());
-    printf ("array-expr node [%u]\n",
-	    expr.get_array_expr ()->get_mappings ().get_hirid ());
   }
 
   void visit (HIR::ArrayExpr &expr)
@@ -268,6 +262,11 @@ public:
       {
 	infered_array_elems = infered_array_elems->combine (types.at (i));
       }
+  }
+
+  void visit (HIR::ArrayElemsCopied &elems)
+  {
+    infered_array_elems = TypeCheckExpr::Resolve (elems.get_elem_to_copy ());
   }
 
 private:

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.h
@@ -59,8 +59,15 @@ public:
     // let x:i32 = 123;
     if (specified_ty != nullptr && init_expr_ty != nullptr)
       {
-	context->insert_type (stmt.get_mappings ().get_hirid (),
-			      specified_ty->combine (init_expr_ty));
+	auto combined = specified_ty->combine (init_expr_ty);
+	if (combined == nullptr)
+	  {
+	    rust_fatal_error (stmt.get_locus (),
+			      "failure in setting up let stmt type");
+	    return;
+	  }
+
+	context->insert_type (stmt.get_mappings ().get_hirid (), combined);
       }
     else
       {

--- a/gcc/rust/typecheck/rust-tyty-visitor.h
+++ b/gcc/rust/typecheck/rust-tyty-visitor.h
@@ -31,6 +31,7 @@ public:
   virtual void visit (InferType &type) {}
   virtual void visit (FnType &type) {}
   virtual void visit (ParamType &type) {}
+  virtual void visit (ArrayType &type) {}
   virtual void visit (BoolType &type) {}
   virtual void visit (IntType &type) {}
   virtual void visit (UintType &type) {}

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -110,6 +110,25 @@ ParamType::combine (TyBase *other)
 }
 
 void
+ArrayType::accept_vis (TyVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+std::string
+ArrayType::as_string () const
+{
+  return "[" + type->as_string () + ":" + std::to_string (capacity) + "]";
+}
+
+TyBase *
+ArrayType::combine (TyBase *other)
+{
+  ArrayRules r (this);
+  return r.combine (other);
+}
+
+void
 BoolType::accept_vis (TyVisitor &vis)
 {
   vis.visit (*this);

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -143,6 +143,28 @@ private:
   TyBase *type;
 };
 
+class ArrayType : public TyBase
+{
+public:
+  ArrayType (HirId ref, size_t capacity, TyBase *type)
+    : TyBase (ref, TypeKind::ARRAY), capacity (capacity), type (type)
+  {}
+
+  void accept_vis (TyVisitor &vis) override;
+
+  std::string as_string () const override;
+
+  TyBase *combine (TyBase *other) override;
+
+  size_t get_capacity () const { return capacity; }
+
+  TyBase *get_type () { return type; }
+
+private:
+  size_t capacity;
+  TyBase *type;
+};
+
 class BoolType : public TyBase
 {
 public:

--- a/gcc/testsuite/rust.test/compilable/arrays2.rs
+++ b/gcc/testsuite/rust.test/compilable/arrays2.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let mut array: [i32; 3] = [0; 3];
+
+    let a = array[0];
+    let mut c;
+    c = array[2];
+}

--- a/gcc/testsuite/rust.test/compilable/arrays_index1.rs
+++ b/gcc/testsuite/rust.test/compilable/arrays_index1.rs
@@ -1,0 +1,8 @@
+fn main() {
+    let mut array: [i32; 3] = [0; 3];
+
+    let a = array[0];
+    let x = 0;
+    let mut c;
+    c = array[x+1];
+}

--- a/gcc/testsuite/rust.test/compilable/type_infer4.rs
+++ b/gcc/testsuite/rust.test/compilable/type_infer4.rs
@@ -1,0 +1,9 @@
+fn main() {
+    let xs: [i32; 5] = [1, 2, 3, 4, 5];
+    let xy = [6, 7, 8];
+
+    let a = xs[0];
+    let b = xy[2];
+    let mut c;
+    c = xs[0];
+}


### PR DESCRIPTION
ArrayExpr, ArrayExprElems and ArrayIndexExpr. Still need to do
ArrayElemsCopied.

I expect there to be some changes to cleanup the rust-tyty-resolver
this code is to resolve all ribs within a scope but its getting a bit
hairy in there now.