### PR TITLE
Bring conditionals back since the HIR change.

### DIFF
--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -550,6 +550,8 @@ public:
     return right_expr;
   }
 
+  ExprType get_kind () { return expr_type; }
+
   /* TODO: implement via a function call to std::cmp::PartialEq::eq(&op1, &op2)
    * maybe? */
 protected:
@@ -627,6 +629,8 @@ public:
     rust_assert (right_expr != nullptr);
     return right_expr;
   }
+
+  ExprType get_kind () { return expr_type; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather

--- a/gcc/rust/backend/rust-compile-block.h
+++ b/gcc/rust/backend/rust-compile-block.h
@@ -1,0 +1,112 @@
+// Copyright (C) 2020 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_COMPILE_BLOCK
+#define RUST_COMPILE_BLOCK
+
+#include "rust-compile-base.h"
+#include "rust-compile-tyty.h"
+
+namespace Rust {
+namespace Compile {
+
+class CompileBlock : public HIRCompileBase
+{
+public:
+  static Bblock *compile (HIR::BlockExpr *expr, Context *ctx)
+  {
+    CompileBlock compiler (ctx);
+    expr->accept_vis (compiler);
+    return compiler.translated;
+  }
+
+  ~CompileBlock () {}
+
+  void visit (HIR::BlockExpr &expr);
+
+private:
+  CompileBlock (Context *ctx) : HIRCompileBase (ctx), translated (nullptr) {}
+
+  Bblock *translated;
+};
+
+class CompileConditionalBlocks : public HIRCompileBase
+{
+public:
+  static Bstatement *compile (HIR::IfExpr *expr, Context *ctx)
+  {
+    CompileConditionalBlocks resolver (ctx);
+    expr->accept_vis (resolver);
+    return resolver.translated;
+  }
+
+  ~CompileConditionalBlocks () {}
+
+  void visit (HIR::IfExpr &expr);
+
+  void visit (HIR::IfExprConseqElse &expr);
+
+  void visit (HIR::IfExprConseqIf &expr);
+
+private:
+  CompileConditionalBlocks (Context *ctx)
+    : HIRCompileBase (ctx), translated (nullptr)
+  {}
+
+  Bstatement *translated;
+};
+
+class CompileExprWithBlock : public HIRCompileBase
+{
+public:
+  static Bstatement *compile (HIR::ExprWithBlock *expr, Context *ctx)
+  {
+    CompileExprWithBlock resolver (ctx);
+    expr->accept_vis (resolver);
+    return resolver.translated;
+  }
+
+  ~CompileExprWithBlock () {}
+
+  void visit (HIR::IfExpr &expr)
+  {
+    translated = CompileConditionalBlocks::compile (&expr, ctx);
+  }
+
+  void visit (HIR::IfExprConseqElse &expr)
+  {
+    translated = CompileConditionalBlocks::compile (&expr, ctx);
+  }
+
+  void visit (HIR::IfExprConseqIf &expr)
+  {
+    translated = CompileConditionalBlocks::compile (&expr, ctx);
+  }
+
+private:
+  CompileExprWithBlock (Context *ctx)
+    : HIRCompileBase (ctx), translated (nullptr)
+  {}
+
+  Bstatement *translated;
+};
+
+} // namespace Compile
+} // namespace Rust
+
+#endif // RUST_COMPILE_BLOCK

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -22,6 +22,7 @@
 #include "rust-compile-base.h"
 #include "rust-compile-tyty.h"
 #include "rust-compile-resolve-path.h"
+#include "rust-compile-block.h"
 
 namespace Rust {
 namespace Compile {
@@ -271,6 +272,31 @@ public:
 
     translated = ctx->get_backend ()->binary_expression (op, lhs, rhs,
 							 expr.get_locus ());
+  }
+
+  void visit (HIR::IfExpr &expr)
+  {
+    auto stmt = CompileConditionalBlocks::compile (&expr, ctx);
+    ctx->add_statement (stmt);
+  }
+
+  void visit (HIR::IfExprConseqElse &expr)
+  {
+    auto stmt = CompileConditionalBlocks::compile (&expr, ctx);
+    ctx->add_statement (stmt);
+  }
+
+  void visit (HIR::IfExprConseqIf &expr)
+  {
+    auto stmt = CompileConditionalBlocks::compile (&expr, ctx);
+    ctx->add_statement (stmt);
+  }
+
+  void visit (HIR::BlockExpr &expr)
+  {
+    auto code_block = CompileBlock::compile (&expr, ctx);
+    auto block_stmt = ctx->get_backend ()->block_statement (code_block);
+    ctx->add_statement (block_stmt);
   }
 
 private:

--- a/gcc/rust/backend/rust-compile-stmt.h
+++ b/gcc/rust/backend/rust-compile-stmt.h
@@ -38,6 +38,18 @@ public:
 
   virtual ~CompileStmt () {}
 
+  void visit (HIR::ExprStmtWithBlock &stmt)
+  {
+    ok = true;
+    auto translated = CompileExpr::Compile (stmt.get_expr (), ctx);
+
+    // these can be null
+    if (translated == nullptr)
+      return;
+
+    gcc_unreachable ();
+  }
+
   void visit (HIR::ExprStmtWithoutBlock &stmt)
   {
     ok = true;

--- a/gcc/rust/hir/rust-ast-lower-block.h
+++ b/gcc/rust/hir/rust-ast-lower-block.h
@@ -1,0 +1,132 @@
+// Copyright (C) 2020 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_AST_LOWER_BLOCK
+#define RUST_AST_LOWER_BLOCK
+
+#include "rust-diagnostics.h"
+#include "rust-ast-lower-base.h"
+
+namespace Rust {
+namespace HIR {
+
+class ASTLoweringBlock : public ASTLoweringBase
+{
+public:
+  static HIR::BlockExpr *translate (AST::BlockExpr *expr)
+  {
+    ASTLoweringBlock resolver;
+    expr->accept_vis (resolver);
+    if (resolver.translated != nullptr)
+      {
+	resolver.mappings->insert_hir_expr (
+	  resolver.translated->get_mappings ().get_crate_num (),
+	  resolver.translated->get_mappings ().get_hirid (),
+	  resolver.translated);
+      }
+
+    return resolver.translated;
+  }
+
+  ~ASTLoweringBlock () {}
+
+  void visit (AST::BlockExpr &expr);
+
+private:
+  ASTLoweringBlock () : ASTLoweringBase (), translated (nullptr) {}
+
+  HIR::BlockExpr *translated;
+};
+
+class ASTLoweringIfBlock : public ASTLoweringBase
+{
+public:
+  static HIR::IfExpr *translate (AST::IfExpr *expr)
+  {
+    ASTLoweringIfBlock resolver;
+    expr->accept_vis (resolver);
+    if (resolver.translated != nullptr)
+      {
+	resolver.mappings->insert_hir_expr (
+	  resolver.translated->get_mappings ().get_crate_num (),
+	  resolver.translated->get_mappings ().get_hirid (),
+	  resolver.translated);
+      }
+
+    return resolver.translated;
+  }
+
+  ~ASTLoweringIfBlock () {}
+
+  void visit (AST::IfExpr &expr);
+
+  void visit (AST::IfExprConseqElse &expr);
+
+  void visit (AST::IfExprConseqIf &expr);
+
+private:
+  ASTLoweringIfBlock () : ASTLoweringBase (), translated (nullptr) {}
+
+  HIR::IfExpr *translated;
+};
+
+class ASTLoweringExprWithBlock : public ASTLoweringBase
+{
+public:
+  static HIR::ExprWithBlock *translate (AST::ExprWithBlock *expr)
+  {
+    ASTLoweringExprWithBlock resolver;
+    expr->accept_vis (resolver);
+    if (resolver.translated != nullptr)
+      {
+	resolver.mappings->insert_hir_expr (
+	  resolver.translated->get_mappings ().get_crate_num (),
+	  resolver.translated->get_mappings ().get_hirid (),
+	  resolver.translated);
+      }
+
+    return resolver.translated;
+  }
+
+  ~ASTLoweringExprWithBlock () {}
+
+  void visit (AST::IfExpr &expr)
+  {
+    translated = ASTLoweringIfBlock::translate (&expr);
+  }
+
+  void visit (AST::IfExprConseqElse &expr)
+  {
+    translated = ASTLoweringIfBlock::translate (&expr);
+  }
+
+  void visit (AST::IfExprConseqIf &expr)
+  {
+    translated = ASTLoweringIfBlock::translate (&expr);
+  }
+
+private:
+  ASTLoweringExprWithBlock () : ASTLoweringBase (), translated (nullptr) {}
+
+  HIR::ExprWithBlock *translated;
+};
+
+} // namespace HIR
+} // namespace Rust
+
+#endif // RUST_AST_LOWER_BLOCK

--- a/gcc/rust/hir/rust-ast-lower-stmt.h
+++ b/gcc/rust/hir/rust-ast-lower-stmt.h
@@ -23,6 +23,7 @@
 
 #include "rust-ast-lower-base.h"
 #include "rust-ast-lower-type.h"
+#include "rust-ast-lower-block.h"
 #include "rust-ast-lower-expr.h"
 #include "rust-ast-lower-pattern.h"
 
@@ -45,6 +46,24 @@ public:
   }
 
   virtual ~ASTLoweringStmt () {}
+
+  void visit (AST::ExprStmtWithBlock &stmt)
+  {
+    HIR::ExprWithBlock *expr
+      = ASTLoweringExprWithBlock::translate (stmt.get_expr ().get ());
+
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, stmt.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   UNKNOWN_LOCAL_DEFID);
+    translated
+      = new HIR::ExprStmtWithBlock (mapping,
+				    std::unique_ptr<HIR::ExprWithBlock> (expr),
+				    stmt.get_locus ());
+    mappings->insert_location (crate_num, mapping.get_hirid (),
+			       stmt.get_locus ());
+    mappings->insert_hir_stmt (crate_num, mapping.get_hirid (), translated);
+  }
 
   void visit (AST::ExprStmtWithoutBlock &stmt)
   {

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -538,6 +538,8 @@ public:
   Expr *get_lhs () { return main_or_left_expr.get (); }
   Expr *get_rhs () { return right_expr.get (); }
 
+  ExprType get_kind () { return expr_type; }
+
   /* TODO: implement via a function call to std::cmp::PartialEq::eq(&op1, &op2)
    * maybe? */
 protected:
@@ -3647,6 +3649,8 @@ public:
 
   void vis_else_block (HIRVisitor &vis) { else_block->accept_vis (vis); }
 
+  BlockExpr *get_else_block () { return else_block.get (); }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */
@@ -3714,6 +3718,8 @@ public:
   {
     conseq_if_expr->accept_vis (vis);
   }
+
+  IfExpr *get_conseq_if_expr () { return conseq_if_expr.get (); }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather

--- a/gcc/rust/hir/tree/rust-hir-stmt.h
+++ b/gcc/rust/hir/tree/rust-hir-stmt.h
@@ -192,12 +192,10 @@ protected:
 // Statement containing an expression with a block
 class ExprStmtWithBlock : public ExprStmt
 {
-public:
   std::unique_ptr<ExprWithBlock> expr;
 
+public:
   std::string as_string () const override;
-
-  std::vector<LetStmt *> locals;
 
   ExprStmtWithBlock (Analysis::NodeMapping mappings,
 		     std::unique_ptr<ExprWithBlock> expr, Location locus)
@@ -223,6 +221,8 @@ public:
   ExprStmtWithBlock &operator= (ExprStmtWithBlock &&other) = default;
 
   void accept_vis (HIRVisitor &vis) override;
+
+  ExprWithBlock *get_expr () { return expr.get (); }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather

--- a/gcc/rust/resolve/rust-ast-resolve-expr.h
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.h
@@ -95,6 +95,40 @@ public:
     ResolveExpr::go (expr.get_right_expr ().get (), expr.get_node_id ());
   }
 
+  void visit (AST::ComparisonExpr &expr)
+  {
+    ResolveExpr::go (expr.get_left_expr ().get (), expr.get_node_id ());
+    ResolveExpr::go (expr.get_right_expr ().get (), expr.get_node_id ());
+  }
+
+  void visit (AST::LazyBooleanExpr &expr)
+  {
+    ResolveExpr::go (expr.get_left_expr ().get (), expr.get_node_id ());
+    ResolveExpr::go (expr.get_right_expr ().get (), expr.get_node_id ());
+  }
+
+  void visit (AST::IfExpr &expr)
+  {
+    ResolveExpr::go (expr.get_condition_expr ().get (), expr.get_node_id ());
+    ResolveExpr::go (expr.get_if_block ().get (), expr.get_node_id ());
+  }
+
+  void visit (AST::IfExprConseqElse &expr)
+  {
+    ResolveExpr::go (expr.get_condition_expr ().get (), expr.get_node_id ());
+    ResolveExpr::go (expr.get_if_block ().get (), expr.get_node_id ());
+    ResolveExpr::go (expr.get_else_block ().get (), expr.get_node_id ());
+  }
+
+  void visit (AST::IfExprConseqIf &expr)
+  {
+    ResolveExpr::go (expr.get_condition_expr ().get (), expr.get_node_id ());
+    ResolveExpr::go (expr.get_if_block ().get (), expr.get_node_id ());
+    ResolveExpr::go (expr.get_conseq_if_expr ().get (), expr.get_node_id ());
+  }
+
+  void visit (AST::BlockExpr &expr);
+
 private:
   ResolveExpr (NodeId parent) : ResolverBase (parent) {}
 };

--- a/gcc/rust/resolve/rust-ast-resolve-stmt.h
+++ b/gcc/rust/resolve/rust-ast-resolve-stmt.h
@@ -39,6 +39,11 @@ public:
 
   ~ResolveStmt () {}
 
+  void visit (AST::ExprStmtWithBlock &stmt)
+  {
+    ResolveExpr::go (stmt.get_expr ().get (), stmt.get_node_id ());
+  }
+
   void visit (AST::ExprStmtWithoutBlock &stmt)
   {
     ResolveExpr::go (stmt.get_expr ().get (), stmt.get_node_id ());

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -179,6 +179,46 @@ public:
     infered = lhs->combine (rhs);
   }
 
+  void visit (HIR::ComparisonExpr &expr)
+  {
+    auto lhs = TypeCheckExpr::Resolve (expr.get_lhs ());
+    auto rhs = TypeCheckExpr::Resolve (expr.get_rhs ());
+
+    infered = lhs->combine (rhs);
+    // FIXME this will need to turn into bool
+  }
+
+  void visit (HIR::LazyBooleanExpr &expr)
+  {
+    auto lhs = TypeCheckExpr::Resolve (expr.get_lhs ());
+    auto rhs = TypeCheckExpr::Resolve (expr.get_rhs ());
+
+    infered = lhs->combine (rhs);
+    // FIXME this will need to turn into bool
+  }
+
+  void visit (HIR::IfExpr &expr)
+  {
+    TypeCheckExpr::Resolve (expr.get_if_condition ());
+    TypeCheckExpr::Resolve (expr.get_if_block ());
+  }
+
+  void visit (HIR::IfExprConseqElse &expr)
+  {
+    TypeCheckExpr::Resolve (expr.get_if_condition ());
+    TypeCheckExpr::Resolve (expr.get_if_block ());
+    TypeCheckExpr::Resolve (expr.get_else_block ());
+  }
+
+  void visit (HIR::IfExprConseqIf &expr)
+  {
+    TypeCheckExpr::Resolve (expr.get_if_condition ());
+    TypeCheckExpr::Resolve (expr.get_if_block ());
+    TypeCheckExpr::Resolve (expr.get_conseq_if_expr ());
+  }
+
+  void visit (HIR::BlockExpr &expr);
+
 private:
   TypeCheckExpr () : TypeCheckBase (), infered (nullptr) {}
 

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.h
@@ -36,6 +36,11 @@ public:
     stmt->accept_vis (resolver);
   }
 
+  void visit (HIR::ExprStmtWithBlock &stmt)
+  {
+    TypeCheckExpr::Resolve (stmt.get_expr ());
+  }
+
   void visit (HIR::ExprStmtWithoutBlock &stmt)
   {
     TypeCheckExpr::Resolve (stmt.get_expr ());

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -20,6 +20,7 @@
 #include "rust-hir-full.h"
 #include "rust-hir-type-check-toplevel.h"
 #include "rust-hir-type-check-item.h"
+#include "rust-hir-type-check-expr.h"
 
 namespace Rust {
 namespace Resolver {
@@ -32,6 +33,16 @@ TypeResolution::Resolve (HIR::Crate &crate)
 
   for (auto it = crate.items.begin (); it != crate.items.end (); it++)
     TypeCheckItem::Resolve (it->get ());
+}
+
+// RUST_HIR_TYPE_CHECK_EXPR
+void
+TypeCheckExpr::visit (HIR::BlockExpr &expr)
+{
+  expr.iterate_stmts ([&] (HIR::Stmt *s) mutable -> bool {
+    TypeCheckStmt::Resolve (s);
+    return true;
+  });
 }
 
 } // namespace Resolver

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -260,8 +260,6 @@ Mappings::lookup_hir_item (CrateNum crateNum, HirId id)
 void
 Mappings::insert_hir_expr (CrateNum crateNum, HirId id, HIR::Expr *expr)
 {
-  rust_assert (lookup_hir_expr (crateNum, id) == nullptr);
-
   hirExprMappings[crateNum][id] = expr;
   nodeIdToHirMappings[crateNum][expr->get_mappings ().get_nodeid ()] = id;
   insert_location (crateNum, id, expr->get_locus_slow ());


### PR DESCRIPTION
Example:

```
fn main() {
    let mut x = 5;

    if x == 5 {
        x = 1;
    } else if x == 3 {
        x = 2;
    } else {
        x = 3;
    }
}
```

GIMPLE

```
void main ()
{
  i32 mut x;

  mut x = 5;
  if (mut x == 5) goto <D.188>; else goto <D.189>;
  <D.188>:
  {
    mut x = 1;
  }
  goto <D.190>;
  <D.189>:
  {
    if (mut x == 3) goto <D.191>; else goto <D.192>;
    <D.191>:
    {
      mut x = 2;
    }
    goto <D.193>;
    <D.192>:
    {
      mut x = 3;
    }
    <D.193>:
  }
  <D.190>:
}
```