### PR TITLE
Shadowing rules are done as part of name resolution.

### DIFF
--- a/gcc/rust/typecheck/rust-tyty-resolver.h
+++ b/gcc/rust/typecheck/rust-tyty-resolver.h
@@ -87,12 +87,18 @@ public:
 
       auto resolved_tyty = resolved_type;
       for (auto it : gathered_types)
-	resolved_tyty = resolved_tyty->combine (it);
+	{
+	  auto combined = resolved_tyty->combine (it);
+	  if (combined == nullptr)
+	    break;
+
+	  resolved_tyty = combined;
+	}
 
       // something is not inferred we need to look at all references now
       if (resolved_tyty == nullptr || resolved_tyty->is_unit ())
 	{
-	  rust_error_at (decl->get_locus_slow (), "failed to resolve type");
+	  rust_fatal_error (decl->get_locus_slow (), "failed to resolve type");
 	  return false;
 	}
 

--- a/gcc/testsuite/rust.test/compilable/shadow1.rs
+++ b/gcc/testsuite/rust.test/compilable/shadow1.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let mut x = 5;
+    let mut x;
+    x = true;
+}

--- a/gcc/testsuite/rust.test/fail_compilation/shadow1.rs
+++ b/gcc/testsuite/rust.test/fail_compilation/shadow1.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let mut x = 5;
+    let mut x;
+    x = true;
+    x = x + 2;
+}


### PR DESCRIPTION
When a new name is defined the name resolver freezes the previous
declartion such that all new references point to the latest decl.

This patch fixes a crash when we shadow and get a type mismatch and the
combination of types fails. See the failure test case for the crash.

Fixes #82