### PR TITLE
This brings structs back in post HIR changes. 

### DIFF
--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -1746,6 +1746,8 @@ public:
     return where_clause;
   }
 
+  Identifier get_identifier () const { return struct_name; }
+
 protected:
   Struct (Identifier struct_name,
 	  std::vector<std::unique_ptr<GenericParam> > generic_params,
@@ -1801,6 +1803,8 @@ private:
   std::unique_ptr<Type> field_type;
 
   // should this store location info?
+
+  NodeId node_id;
 
 public:
   // Returns whether struct field has any outer attributes.
@@ -1877,6 +1881,8 @@ public:
   }
 
   Visibility get_visibility () const { return visibility; }
+
+  NodeId get_node_id () const { return node_id; }
 };
 
 // Rust struct declaration with true struct type AST node
@@ -1921,6 +1927,15 @@ public:
   // TODO: this mutable getter seems really dodgy. Think up better way.
   std::vector<StructField> &get_fields () { return fields; }
   const std::vector<StructField> &get_fields () const { return fields; }
+
+  void iterate (std::function<bool (StructField &)> cb)
+  {
+    for (auto &field : fields)
+      {
+	if (!cb (field))
+	  return;
+      }
+  }
 
 protected:
   /* Use covariance to implement clone function as returning this object

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -227,6 +227,14 @@ public:
 
   void visit (TyTy::FnType &type) override { gcc_unreachable (); }
 
+  void visit (TyTy::ADTType &type) override
+  {
+    ::Btype *compiled_type = nullptr;
+    bool ok = ctx->lookup_compiled_types (type.get_ref (), &compiled_type);
+    rust_assert (ok);
+    translated = compiled_type;
+  }
+
   void visit (TyTy::ArrayType &type) override
   {
     mpz_t ival;

--- a/gcc/rust/backend/rust-compile-resolve-path.h
+++ b/gcc/rust/backend/rust-compile-resolve-path.h
@@ -25,25 +25,42 @@
 namespace Rust {
 namespace Compile {
 
-class ResolvePath : public HIRCompileBase
+class ResolvePathRef : public HIRCompileBase
 {
 public:
   static Bexpression *Compile (HIR::Expr *expr, Context *ctx)
   {
-    ResolvePath resolver (ctx);
+    ResolvePathRef resolver (ctx);
     expr->accept_vis (resolver);
     rust_assert (resolver.resolved != nullptr);
     return resolver.resolved;
   }
 
-  virtual ~ResolvePath () {}
+  void visit (HIR::PathInExpression &expr);
+
+private:
+  ResolvePathRef (Context *ctx) : HIRCompileBase (ctx), resolved (nullptr) {}
+
+  Bexpression *resolved;
+};
+
+class ResolvePathType : public HIRCompileBase
+{
+public:
+  static Btype *Compile (HIR::Expr *expr, Context *ctx)
+  {
+    ResolvePathType resolver (ctx);
+    expr->accept_vis (resolver);
+    rust_assert (resolver.resolved != nullptr);
+    return resolver.resolved;
+  }
 
   void visit (HIR::PathInExpression &expr);
 
 private:
-  ResolvePath (Context *ctx) : HIRCompileBase (ctx), resolved (nullptr) {}
+  ResolvePathType (Context *ctx) : HIRCompileBase (ctx), resolved (nullptr) {}
 
-  Bexpression *resolved;
+  Btype *resolved;
 };
 
 } // namespace Compile

--- a/gcc/rust/backend/rust-compile-struct-field-expr.h
+++ b/gcc/rust/backend/rust-compile-struct-field-expr.h
@@ -16,30 +16,37 @@
 // along with GCC; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef RUST_TYTY_VISITOR
-#define RUST_TYTY_VISITOR
+#ifndef RUST_COMPILE_STRUCT_FIELD_EXPR
+#define RUST_COMPILE_STRUCT_FIELD_EXPR
 
-#include "rust-tyty.h"
+#include "rust-compile-base.h"
+#include "rust-compile-tyty.h"
 
 namespace Rust {
-namespace TyTy {
+namespace Compile {
 
-class TyVisitor
+class CompileStructExprField : public HIRCompileBase
 {
 public:
-  virtual void visit (UnitType &type) {}
-  virtual void visit (InferType &type) {}
-  virtual void visit (StructFieldType &type) {}
-  virtual void visit (ADTType &type) {}
-  virtual void visit (FnType &type) {}
-  virtual void visit (ParamType &type) {}
-  virtual void visit (ArrayType &type) {}
-  virtual void visit (BoolType &type) {}
-  virtual void visit (IntType &type) {}
-  virtual void visit (UintType &type) {}
+  static Bexpression *Compile (HIR::StructExprField *field, Context *ctx)
+  {
+    CompileStructExprField compiler (ctx);
+    field->accept_vis (compiler);
+    rust_assert (compiler.translated != nullptr);
+    return compiler.translated;
+  }
+
+  void visit (HIR::StructExprFieldIdentifierValue &field);
+
+private:
+  CompileStructExprField (Context *ctx)
+    : HIRCompileBase (ctx), translated (nullptr)
+  {}
+
+  Bexpression *translated;
 };
 
-} // namespace TyTy
+} // namespace Compile
 } // namespace Rust
 
-#endif // RUST_TYTY_VISITOR
+#endif // RUST_COMPILE_STRUCT_FIELD_EXPR

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -19,6 +19,7 @@
 #include "rust-compile.h"
 #include "rust-compile-item.h"
 #include "rust-compile-expr.h"
+#include "rust-compile-struct-field-expr.h"
 
 namespace Rust {
 namespace Compile {
@@ -150,6 +151,14 @@ CompileConditionalBlocks::visit (HIR::IfExprConseqIf &expr)
   translated
     = ctx->get_backend ()->if_statement (fndecl, condition_expr, then_block,
 					 else_block, expr.get_locus ());
+}
+
+// rust-compile-struct-field-expr.h
+
+void
+CompileStructExprField::visit (HIR::StructExprFieldIdentifierValue &field)
+{
+  translated = CompileExpr::Compile (field.get_value (), ctx);
 }
 
 } // namespace Compile

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -22,6 +22,7 @@
 #include "rust-diagnostics.h"
 #include "rust-ast-lower-base.h"
 #include "rust-ast-lower-block.h"
+#include "rust-ast-lower-struct-field-expr.h"
 
 namespace Rust {
 namespace HIR {
@@ -61,6 +62,47 @@ private:
   bool ok;
   size_t result;
 }; // namespace Resolver
+
+class ASTLowerPathInExpression : public ASTLoweringBase
+{
+public:
+  static HIR::PathInExpression *translate (AST::PathInExpression *expr)
+  {
+    ASTLowerPathInExpression compiler;
+    expr->accept_vis (compiler);
+    rust_assert (compiler.translated);
+    return compiler.translated;
+  }
+
+  ~ASTLowerPathInExpression () {}
+
+  void visit (AST::PathInExpression &expr)
+  {
+    std::vector<HIR::PathExprSegment> path_segments;
+    expr.iterate_path_segments ([&] (AST::PathExprSegment &s) mutable -> bool {
+      rust_assert (s.has_generic_args () == false); // TODO
+
+      HIR::PathIdentSegment is (s.get_ident_segment ().as_string ());
+      HIR::PathExprSegment seg (is, s.get_locus ());
+      path_segments.push_back (seg);
+      return true;
+    });
+
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, expr.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   UNKNOWN_LOCAL_DEFID);
+
+    translated = new HIR::PathInExpression (mapping, std::move (path_segments),
+					    expr.get_locus (),
+					    expr.opening_scope_resolution ());
+  }
+
+private:
+  ASTLowerPathInExpression () : translated (nullptr) {}
+
+  HIR::PathInExpression *translated;
+};
 
 class ASTLoweringExpr : public ASTLoweringBase
 {
@@ -107,24 +149,7 @@ public:
 
   void visit (AST::PathInExpression &expr)
   {
-    std::vector<HIR::PathExprSegment> path_segments;
-    expr.iterate_path_segments ([&] (AST::PathExprSegment &s) mutable -> bool {
-      rust_assert (s.has_generic_args () == false); // TODO
-
-      HIR::PathIdentSegment is (s.get_ident_segment ().as_string ());
-      HIR::PathExprSegment seg (is, s.get_locus ());
-      path_segments.push_back (seg);
-      return true;
-    });
-
-    auto crate_num = mappings->get_current_crate ();
-    Analysis::NodeMapping mapping (crate_num, expr.get_node_id (),
-				   mappings->get_next_hir_id (crate_num),
-				   UNKNOWN_LOCAL_DEFID);
-
-    translated = new HIR::PathInExpression (mapping, std::move (path_segments),
-					    expr.get_locus (),
-					    expr.opening_scope_resolution ());
+    translated = ASTLowerPathInExpression::translate (&expr);
   }
 
   void visit (AST::ReturnExpr &expr)
@@ -429,6 +454,46 @@ public:
       = new HIR::LazyBooleanExpr (mapping, std::unique_ptr<HIR::Expr> (lhs),
 				  std::unique_ptr<HIR::Expr> (rhs), kind,
 				  expr.get_locus ());
+  }
+
+  void visit (AST::StructExprStructFields &struct_expr)
+  {
+    std::vector<HIR::Attribute> inner_attribs;
+    std::vector<HIR::Attribute> outer_attribs;
+
+    // bit of a hack for now
+    HIR::PathInExpression *path
+      = ASTLowerPathInExpression::translate (&struct_expr.get_struct_name ());
+    HIR::PathInExpression copied_path (*path);
+    delete path;
+
+    HIR::StructBase *base = nullptr;
+    if (struct_expr.has_struct_base ())
+      {
+	HIR::Expr *translated_base = ASTLoweringExpr::translate (
+	  struct_expr.get_struct_base ().get_base_struct ().get ());
+	base
+	  = new HIR::StructBase (std::unique_ptr<HIR::Expr> (translated_base));
+      }
+
+    std::vector<std::unique_ptr<HIR::StructExprField> > fields;
+    struct_expr.iterate ([&] (AST::StructExprField *field) mutable -> bool {
+      HIR::StructExprField *translated
+	= ASTLowerStructExprField::translate (field);
+      fields.push_back (std::unique_ptr<HIR::StructExprField> (translated));
+      return true;
+    });
+
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, struct_expr.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   UNKNOWN_LOCAL_DEFID);
+
+    translated
+      = new HIR::StructExprStructFields (mapping, copied_path,
+					 std::move (fields),
+					 struct_expr.get_locus (), base,
+					 inner_attribs, outer_attribs);
   }
 
 private:

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -43,6 +43,57 @@ public:
 
   virtual ~ASTLoweringItem () {}
 
+  void visit (AST::StructStruct &struct_decl)
+  {
+    std::vector<std::unique_ptr<HIR::GenericParam> > generic_params;
+    std::vector<std::unique_ptr<HIR::WhereClauseItem> > where_clause_items;
+    HIR::WhereClause where_clause (std::move (where_clause_items));
+    HIR::Visibility vis = HIR::Visibility::create_public ();
+    std::vector<HIR::Attribute> outer_attrs;
+
+    bool is_unit = false;
+    std::vector<HIR::StructField> fields;
+    struct_decl.iterate ([&] (AST::StructField &field) mutable -> bool {
+      std::vector<HIR::Attribute> outer_attrs;
+      HIR::Visibility vis = HIR::Visibility::create_public ();
+      HIR::Type *type
+	= ASTLoweringType::translate (field.get_field_type ().get ());
+
+      auto crate_num = mappings->get_current_crate ();
+      Analysis::NodeMapping mapping (crate_num, field.get_node_id (),
+				     mappings->get_next_hir_id (crate_num),
+				     mappings->get_next_localdef_id (
+				       crate_num));
+
+      // FIXME
+      // AST::StructField is missing Location info
+      Location field_locus;
+      HIR::StructField translated_field (mapping, field.get_field_name (),
+					 std::unique_ptr<HIR::Type> (type), vis,
+					 field_locus, outer_attrs);
+      fields.push_back (std::move (translated_field));
+      return true;
+    });
+
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, struct_decl.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   mappings->get_next_localdef_id (crate_num));
+
+    translated = new HIR::StructStruct (mapping, std::move (fields),
+					struct_decl.get_identifier (),
+					std::move (generic_params),
+					std::move (where_clause), is_unit, vis,
+					std::move (outer_attrs),
+					struct_decl.get_locus ());
+
+    mappings->insert_defid_mapping (mapping.get_defid (), translated);
+    mappings->insert_hir_item (mapping.get_crate_num (), mapping.get_hirid (),
+			       translated);
+    mappings->insert_location (crate_num, mapping.get_hirid (),
+			       struct_decl.get_locus ());
+  }
+
   void visit (AST::ConstantItem &constant)
   {
     std::vector<HIR::Attribute> outer_attrs;

--- a/gcc/rust/hir/rust-ast-lower-struct-field-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-struct-field-expr.h
@@ -1,0 +1,58 @@
+// Copyright (C) 2020 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_AST_LOWER_STRUCT_FIELD_EXPR
+#define RUST_AST_LOWER_STRUCT_FIELD_EXPR
+
+#include "rust-diagnostics.h"
+#include "rust-ast-lower-base.h"
+
+namespace Rust {
+namespace HIR {
+
+class ASTLowerStructExprField : public ASTLoweringBase
+{
+public:
+  static HIR::StructExprField *translate (AST::StructExprField *field)
+  {
+    ASTLowerStructExprField compiler;
+    field->accept_vis (compiler);
+    rust_assert (compiler.translated != nullptr);
+
+    // compiler.mappings->insert_hir_expr (
+    //   compiler.translated->get_mappings ().get_crate_num (),
+    //   compiler.translated->get_mappings ().get_hirid (),
+    //   compiler.translated);
+
+    return compiler.translated;
+  }
+
+  ~ASTLowerStructExprField () {}
+
+  void visit (AST::StructExprFieldIdentifierValue &field);
+
+private:
+  ASTLowerStructExprField () : translated (nullptr) {}
+
+  HIR::StructExprField *translated;
+};
+
+} // namespace HIR
+} // namespace Rust
+
+#endif // RUST_AST_LOWER_STRUCT_FIELD_EXPR

--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -149,5 +149,22 @@ ASTLoweringIfBlock::visit (AST::IfExprConseqIf &expr)
 			       expr.get_locus ());
 }
 
+// rust-ast-lower-struct-field-expr.h
+
+void
+ASTLowerStructExprField::visit (AST::StructExprFieldIdentifierValue &field)
+{
+  HIR::Expr *value = ASTLoweringExpr::translate (field.get_value ().get ());
+
+  auto crate_num = mappings->get_current_crate ();
+  Analysis::NodeMapping mapping (crate_num, field.get_node_id (),
+				 mappings->get_next_hir_id (crate_num),
+				 UNKNOWN_LOCAL_DEFID);
+
+  translated = new HIR::StructExprFieldIdentifierValue (
+    mapping, field.get_field_name (), std::unique_ptr<HIR::Expr> (value),
+    field.get_locus ());
+}
+
 } // namespace HIR
 } // namespace Rust

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -1315,9 +1315,9 @@ protected:
 // Base struct/tuple/union value creator HIR node (abstract)
 class StructExpr : public ExprWithoutBlock
 {
+protected:
   PathInExpression struct_name;
 
-protected:
   // Protected constructor to allow initialising struct_name
   StructExpr (Analysis::NodeMapping mappings, PathInExpression struct_path,
 	      std::vector<Attribute> outer_attribs)
@@ -1326,7 +1326,7 @@ protected:
   {}
 
 public:
-  const PathInExpression &get_struct_name () const { return struct_name; }
+  PathInExpression &get_struct_name () { return struct_name; }
 
   std::string as_string () const override;
 };
@@ -1417,6 +1417,8 @@ public:
   bool is_invalid () const { return base_struct == nullptr; }
 
   std::string as_string () const;
+
+  Expr *get_base () { return base_struct.get (); }
 };
 
 /* Base HIR node for a single struct expression field (in struct instance
@@ -1436,9 +1438,20 @@ public:
 
   virtual void accept_vis (HIRVisitor &vis) = 0;
 
+  Analysis::NodeMapping &get_mappings () { return mappings; }
+
+  Location get_locus () { return locus; }
+
 protected:
   // pure virtual clone implementation
   virtual StructExprField *clone_struct_expr_field_impl () const = 0;
+
+  StructExprField (Analysis::NodeMapping mapping, Location locus)
+    : mappings (mapping), locus (locus)
+  {}
+
+  Analysis::NodeMapping mappings;
+  Location locus;
 };
 
 // Identifier-only variant of StructExprField HIR node
@@ -1449,8 +1462,10 @@ public:
 
   // TODO: should this store location data?
 
-  StructExprFieldIdentifier (Identifier field_identifier)
-    : field_name (std::move (field_identifier))
+  StructExprFieldIdentifier (Analysis::NodeMapping mapping,
+			     Identifier field_identifier, Location locus)
+    : StructExprField (mapping, locus),
+      field_name (std::move (field_identifier))
   {}
 
   std::string as_string () const override { return field_name; }
@@ -1470,23 +1485,26 @@ protected:
  * abstract */
 class StructExprFieldWithVal : public StructExprField
 {
-public:
   std::unique_ptr<Expr> value;
 
 protected:
-  StructExprFieldWithVal (std::unique_ptr<Expr> field_value)
-    : value (std::move (field_value))
+  StructExprFieldWithVal (Analysis::NodeMapping mapping,
+			  std::unique_ptr<Expr> field_value, Location locus)
+    : StructExprField (mapping, locus), value (std::move (field_value))
   {}
 
   // Copy constructor requires clone
   StructExprFieldWithVal (StructExprFieldWithVal const &other)
-    : value (other.value->clone_expr ())
+    : StructExprField (other.mappings, other.locus),
+      value (other.value->clone_expr ())
   {}
 
   // Overload assignment operator to clone unique_ptr
   StructExprFieldWithVal &operator= (StructExprFieldWithVal const &other)
   {
     value = other.value->clone_expr ();
+    mappings = other.mappings;
+    locus = other.locus;
 
     return *this;
   }
@@ -1497,6 +1515,8 @@ protected:
 
 public:
   std::string as_string () const override;
+
+  Expr *get_value () { return value.get (); }
 };
 
 // Identifier and value variant of StructExprField HIR node
@@ -1507,9 +1527,11 @@ public:
 
   // TODO: should this store location data?
 
-  StructExprFieldIdentifierValue (Identifier field_identifier,
-				  std::unique_ptr<Expr> field_value)
-    : StructExprFieldWithVal (std::move (field_value)),
+  StructExprFieldIdentifierValue (Analysis::NodeMapping mapping,
+				  Identifier field_identifier,
+				  std::unique_ptr<Expr> field_value,
+				  Location locus)
+    : StructExprFieldWithVal (mapping, std::move (field_value), locus),
       field_name (std::move (field_identifier))
   {}
 
@@ -1534,9 +1556,11 @@ public:
 
   // TODO: should this store location data?
 
-  StructExprFieldIndexValue (TupleIndex tuple_index,
-			     std::unique_ptr<Expr> field_value)
-    : StructExprFieldWithVal (std::move (field_value)), index (tuple_index)
+  StructExprFieldIndexValue (Analysis::NodeMapping mapping,
+			     TupleIndex tuple_index,
+			     std::unique_ptr<Expr> field_value, Location locus)
+    : StructExprFieldWithVal (mapping, std::move (field_value), locus),
+      index (tuple_index)
   {}
 
   std::string as_string () const override;
@@ -1560,31 +1584,24 @@ public:
   std::vector<std::unique_ptr<StructExprField> > fields;
 
   // bool has_struct_base;
-  StructBase struct_base;
+  // FIXME make unique_ptr
+  StructBase *struct_base;
 
   std::string as_string () const override;
 
-  bool has_struct_base () const { return !struct_base.is_invalid (); }
-
-  /*inline std::vector<std::unique_ptr<StructExprField>> get_fields()
-  const { return fields;
-  }*/
-
-  /*inline StructBase get_struct_base() const {
-      return has_struct_base ? struct_base : StructBase::error();
-  }*/
+  bool has_struct_base () const { return struct_base != nullptr; }
 
   // Constructor for StructExprStructFields when no struct base is used
   StructExprStructFields (
     Analysis::NodeMapping mappings, PathInExpression struct_path,
     std::vector<std::unique_ptr<StructExprField> > expr_fields, Location locus,
-    StructBase base_struct = StructBase::error (),
+    StructBase *base_struct,
     std::vector<Attribute> inner_attribs = std::vector<Attribute> (),
     std::vector<Attribute> outer_attribs = std::vector<Attribute> ())
     : StructExprStruct (std::move (mappings), std::move (struct_path),
 			std::move (inner_attribs), std::move (outer_attribs),
 			locus),
-      fields (std::move (expr_fields)), struct_base (std::move (base_struct))
+      fields (std::move (expr_fields)), struct_base (base_struct)
   {}
 
   // copy constructor with vector clone
@@ -1614,6 +1631,15 @@ public:
   StructExprStructFields &operator= (StructExprStructFields &&other) = default;
 
   void accept_vis (HIRVisitor &vis) override;
+
+  void iterate (std::function<bool (StructExprField *)> cb)
+  {
+    for (auto &field : fields)
+      {
+	if (!cb (field.get ()))
+	  return;
+      }
+  }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather
@@ -1752,11 +1778,7 @@ class StructExprUnit : public StructExpr
   Location locus;
 
 public:
-  std::string as_string () const override
-  {
-    return get_struct_name ().as_string ();
-    // return struct_name.as_string();
-  }
+  std::string as_string () const override { return struct_name.as_string (); }
 
   StructExprUnit (Analysis::NodeMapping mappings, PathInExpression struct_path,
 		  std::vector<Attribute> outer_attribs, Location locus)

--- a/gcc/rust/hir/tree/rust-hir-full-test.cc
+++ b/gcc/rust/hir/tree/rust-hir-full-test.cc
@@ -3683,7 +3683,7 @@ StructExprStruct::as_string () const
 {
   std::string str ("StructExprStruct (or subclass): ");
 
-  str += "\n Path: " + get_struct_name ().as_string ();
+  str += "\n Path: " + struct_name.as_string ();
 
   // inner attributes
   str += "\n inner attributes: ";
@@ -3761,7 +3761,7 @@ StructExprStructFields::as_string () const
     }
   else
     {
-      str += struct_base.as_string ();
+      str += struct_base->as_string ();
     }
 
   return str;

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -1390,7 +1390,7 @@ protected:
 // Rust base struct declaration HIR node - abstract base class
 class Struct : public VisItem
 {
-public:
+protected:
   // protected to enable access by derived classes - allows better as_string
   Identifier struct_name;
 
@@ -1402,6 +1402,9 @@ public:
   WhereClause where_clause;
 
   Location locus;
+
+public:
+  Identifier get_identifier () const { return struct_name; }
 
   // Returns whether struct has generic parameters.
   bool has_generics () const { return !generic_params.empty (); }
@@ -1465,6 +1468,10 @@ public:
   Identifier field_name;
   std::unique_ptr<Type> field_type;
 
+  Analysis::NodeMapping mappings;
+
+  Location locus;
+
   // should this store location info?
 
   // Returns whether struct field has any outer attributes.
@@ -1473,18 +1480,19 @@ public:
   // Returns whether struct field has a non-private (non-default) visibility.
   bool has_visibility () const { return !visibility.is_error (); }
 
-  StructField (Identifier field_name, std::unique_ptr<Type> field_type,
-	       Visibility vis,
+  StructField (Analysis::NodeMapping mappings, Identifier field_name,
+	       std::unique_ptr<Type> field_type, Visibility vis, Location locus,
 	       std::vector<Attribute> outer_attrs = std::vector<Attribute> ())
     : outer_attrs (std::move (outer_attrs)), visibility (std::move (vis)),
-      field_name (std::move (field_name)), field_type (std::move (field_type))
+      field_name (std::move (field_name)), field_type (std::move (field_type)),
+      mappings (mappings), locus (locus)
   {}
 
   // Copy constructor
   StructField (StructField const &other)
     : outer_attrs (other.outer_attrs), visibility (other.visibility),
       field_name (other.field_name),
-      field_type (other.field_type->clone_type ())
+      field_type (other.field_type->clone_type ()), mappings (other.mappings)
   {}
 
   ~StructField () = default;
@@ -1496,6 +1504,7 @@ public:
     field_type = other.field_type->clone_type ();
     visibility = other.visibility;
     outer_attrs = other.outer_attrs;
+    mappings = other.mappings;
 
     return *this;
   }
@@ -1504,20 +1513,19 @@ public:
   StructField (StructField &&other) = default;
   StructField &operator= (StructField &&other) = default;
 
-  // Returns whether struct field is in an error state.
-  bool is_error () const
-  {
-    return field_name.empty () && field_type == nullptr;
-    // this should really be an or since neither are allowed
-  }
-
-  // Creates an error state struct field.
-  static StructField create_error ()
-  {
-    return StructField (std::string (""), nullptr, Visibility::create_error ());
-  }
-
   std::string as_string () const;
+
+  Identifier get_field_name () const { return field_name; }
+
+  std::unique_ptr<Type> &get_field_type ()
+  {
+    rust_assert (field_type != nullptr);
+    return field_type;
+  }
+
+  Analysis::NodeMapping get_mappings () const { return mappings; }
+
+  Location get_locus () { return locus; }
 };
 
 // Rust struct declaration with true struct type HIR node
@@ -1559,6 +1567,15 @@ public:
   bool is_unit_struct () const { return is_unit; }
 
   void accept_vis (HIRVisitor &vis) override;
+
+  void iterate (std::function<bool (StructField &)> cb)
+  {
+    for (auto &field : fields)
+      {
+	if (!cb (field))
+	  return;
+      }
+  }
 
 protected:
   /* Use covariance to implement clone function as returning this object

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -39,6 +39,14 @@ public:
 
   ~ResolveItem () {}
 
+  void visit (AST::StructStruct &struct_decl)
+  {
+    struct_decl.iterate ([&] (AST::StructField &field) mutable -> bool {
+      ResolveType::go (field.get_field_type ().get (), field.get_node_id ());
+      return true;
+    });
+  }
+
   void visit (AST::ConstantItem &constant)
   {
     ResolveType::go (constant.get_type ().get (), constant.get_node_id ());

--- a/gcc/rust/resolve/rust-ast-resolve-struct-expr-field.h
+++ b/gcc/rust/resolve/rust-ast-resolve-struct-expr-field.h
@@ -1,0 +1,53 @@
+// Copyright (C) 2020 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_AST_RESOLVE_STRUCT_EXPR_FIELD
+#define RUST_AST_RESOLVE_STRUCT_EXPR_FIELD
+
+#include "rust-ast-resolve-base.h"
+#include "rust-ast-full.h"
+
+namespace Rust {
+namespace Resolver {
+
+// this resolves values being assigned not that the field actually exists yet.
+// We cant resolve the field to struct until type resolution since the HIR
+// Mappings don't exist yet.
+class ResolveStructExprField : public ResolverBase
+{
+public:
+  static void go (AST::StructExprField *field, NodeId parent)
+  {
+    ResolveStructExprField resolver (parent);
+    field->accept_vis (resolver);
+  }
+
+  virtual ~ResolveStructExprField () {}
+
+  void visit (AST::StructExprFieldIdentifierValue &field);
+
+  // TODO
+
+private:
+  ResolveStructExprField (NodeId parent) : ResolverBase (parent) {}
+};
+
+} // namespace Resolver
+} // namespace Rust
+
+#endif // RUST_AST_RESOLVE_STRUCT_EXPR_FIELD

--- a/gcc/rust/resolve/rust-ast-resolve-toplevel.h
+++ b/gcc/rust/resolve/rust-ast-resolve-toplevel.h
@@ -36,6 +36,12 @@ public:
 
   ~ResolveTopLevel () {}
 
+  void visit (AST::StructStruct &struct_decl)
+  {
+    resolver->get_type_scope ().insert (struct_decl.get_identifier (),
+					struct_decl.get_node_id ());
+  }
+
   void visit (AST::ConstantItem &constant)
   {
     resolver->get_name_scope ().insert (constant.get_identifier (),

--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -271,5 +271,13 @@ ResolveExpr::visit (AST::BlockExpr &expr)
   resolver->get_type_scope ().pop ();
 }
 
+// rust-ast-resolve-struct-expr-field.h
+
+void
+ResolveStructExprField::visit (AST::StructExprFieldIdentifierValue &field)
+{
+  ResolveExpr::go (field.get_value ().get (), field.get_node_id ());
+}
+
 } // namespace Resolver
 } // namespace Rust

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -24,6 +24,7 @@
 #include "rust-tyty.h"
 #include "rust-tyty-call.h"
 #include "rust-tyty-resolver.h"
+#include "rust-hir-type-check-struct-field.h"
 
 namespace Rust {
 namespace Resolver {
@@ -136,9 +137,8 @@ public:
     TyTy::TyBase *lookup;
     if (!context->lookup_type (ref, &lookup))
       {
-	// FIXME we need to be able to lookup the location info for the
-	// reference here
-	rust_error_at (expr.get_locus (), "consider giving this a type: %s",
+	rust_error_at (mappings->lookup_location (ref),
+		       "consider giving this a type: %s",
 		       expr.as_string ().c_str ());
 	return;
       }
@@ -267,6 +267,11 @@ public:
   void visit (HIR::ArrayElemsCopied &elems)
   {
     infered_array_elems = TypeCheckExpr::Resolve (elems.get_elem_to_copy ());
+  }
+
+  void visit (HIR::StructExprStructFields &struct_expr)
+  {
+    infered = TypeCheckStructExpr::Resolve (&struct_expr);
   }
 
 private:

--- a/gcc/rust/typecheck/rust-hir-type-check-struct-field.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-struct-field.h
@@ -1,0 +1,61 @@
+// Copyright (C) 2020 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_HIR_TYPE_CHECK_STRUCT_FIELD
+#define RUST_HIR_TYPE_CHECK_STRUCT_FIELD
+
+#include "rust-hir-type-check-base.h"
+#include "rust-hir-full.h"
+#include "rust-hir-type-check-type.h"
+#include "rust-tyty.h"
+
+namespace Rust {
+namespace Resolver {
+
+class TypeCheckStructExpr : public TypeCheckBase
+{
+public:
+  static TyTy::TyBase *Resolve (HIR::StructExprStructFields *expr)
+  {
+    TypeCheckStructExpr resolver;
+    expr->accept_vis (resolver);
+    rust_assert (resolver.resolved != nullptr);
+    return resolver.resolved;
+  }
+
+  void visit (HIR::StructExprStructFields &struct_expr);
+
+  void visit (HIR::PathInExpression &path);
+
+  void visit (HIR::StructExprFieldIdentifierValue &field);
+
+private:
+  TypeCheckStructExpr ()
+    : TypeCheckBase (), resolved (nullptr), struct_path_resolved (nullptr)
+  {}
+
+  TyTy::TyBase *resolved;
+  TyTy::ADTType *struct_path_resolved;
+  TyTy::TyBase *resolved_field;
+  std::set<std::string> fields_assigned;
+};
+
+} // namespace Resolver
+} // namespace Rust
+
+#endif // RUST_HIR_TYPE_CHECK_STRUCT_FIELD

--- a/gcc/rust/typecheck/rust-tyty-rules.h
+++ b/gcc/rust/typecheck/rust-tyty-rules.h
@@ -134,6 +134,24 @@ private:
   TyBase *resolved;
 };
 
+class StructFieldTypeRules : protected BaseRules
+{
+public:
+  StructFieldTypeRules (StructFieldType *base)
+    : BaseRules (base), base (base), resolved (nullptr)
+  {}
+
+  TyBase *combine (TyBase *other)
+  {
+    other->accept_vis (*this);
+    return resolved;
+  }
+
+private:
+  StructFieldType *base;
+  TyBase *resolved;
+};
+
 class UnitRules : protected BaseRules
 {
 public:

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -64,6 +64,47 @@ InferType::combine (TyBase *other)
 }
 
 void
+StructFieldType::accept_vis (TyVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+std::string
+StructFieldType::as_string () const
+{
+  return name + ":" + ty->as_string ();
+}
+
+TyBase *
+StructFieldType::combine (TyBase *other)
+{
+  StructFieldTypeRules r (this);
+  return r.combine (other);
+}
+
+void
+ADTType::accept_vis (TyVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+std::string
+ADTType::as_string () const
+{
+  std::string fields_buffer;
+  for (auto &field : fields)
+    fields_buffer += field->as_string () + "\n";
+
+  return identifier + "{\n" + fields_buffer + "\n}";
+}
+
+TyBase *
+ADTType::combine (TyBase *other)
+{
+  return nullptr;
+}
+
+void
 FnType::accept_vis (TyVisitor &vis)
 {
   vis.visit (*this);

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -41,6 +41,7 @@ enum TypeKind
   UINT,
   FLOAT,
   UNIT,
+  FIELD,
   // there are more to add...
 };
 
@@ -59,6 +60,8 @@ public:
   virtual TyBase *combine (TyBase *other) = 0;
 
   virtual bool is_unit () const { return kind == TypeKind::UNIT; }
+
+  TypeKind get_kind () const { return kind; }
 
 protected:
   TyBase (HirId ref, TypeKind kind) : kind (kind), ref (ref) {}
@@ -93,6 +96,65 @@ public:
   std::string as_string () const override;
 
   TyBase *combine (TyBase *other) override;
+};
+
+class StructFieldType : public TyBase
+{
+public:
+  StructFieldType (HirId ref, std::string name, TyBase *ty)
+    : TyBase (ref, TypeKind::FIELD), name (name), ty (ty)
+  {}
+
+  void accept_vis (TyVisitor &vis) override;
+
+  bool is_unit () const override { return ty->is_unit (); }
+
+  std::string as_string () const override;
+
+  TyBase *combine (TyBase *other) override;
+
+  std::string get_name () const { return name; }
+
+  TyBase *get_field_type () { return ty; }
+
+private:
+  std::string name;
+  TyBase *ty;
+};
+
+class ADTType : public TyBase
+{
+public:
+  ADTType (HirId ref, std::string identifier,
+	   std::vector<StructFieldType *> fields)
+    : TyBase (ref, TypeKind::ADT), identifier (identifier), fields (fields)
+  {}
+
+  void accept_vis (TyVisitor &vis) override;
+
+  bool is_unit () const override { return false; }
+
+  std::string as_string () const override;
+
+  TyBase *combine (TyBase *other) override;
+
+  size_t num_fields () const { return fields.size (); }
+
+  StructFieldType *get_field (size_t index) { return fields.at (index); }
+
+  StructFieldType *get_field (const std::string &lookup)
+  {
+    for (auto &field : fields)
+      {
+	if (field->get_name ().compare (lookup) == 0)
+	  return field;
+      }
+    return nullptr;
+  }
+
+private:
+  std::string identifier;
+  std::vector<StructFieldType *> fields;
 };
 
 class ParamType : public TyBase


### PR DESCRIPTION
It supports structs where no base struct is referenced and the constructor is in order.

This is a big change to get the basic ADT type implemented. More smaller changes are to come in subsequent PRs to support tuples and base struct references.

With this change the test suite should be fully passing. Such that we can start failing builds if failing tests are popping up in PRs.