### PR TITLE
Change CI to look for any unexpected failures to fail the build.

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -49,4 +49,5 @@ jobs:
     - name: Test
       run: |
            cd gccrs-build; \
-           make check-rust
+           make check-rust | tee results.log; \
+           if [ `grep "# of unexpected failures" results.log | wc -l` != "0" ]; then exit 1; fi


### PR DESCRIPTION
This should fail until the struct PR has been merged. Lets see if it works.