### PR TITLE
Add in support to compile static variables.

### DIFF
--- a/gcc/rust/ast/rust-ast-full-test.cc
+++ b/gcc/rust/ast/rust-ast-full-test.cc
@@ -437,7 +437,7 @@ StaticItem::as_string () const
       str += " mut";
     }
 
-  str += name;
+  str += " " + name;
 
   // DEBUG: null pointer check
   if (type == nullptr)

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -2658,6 +2658,10 @@ public:
     return type;
   }
 
+  bool is_mutable () const { return has_mut; }
+
+  Identifier get_identifier () const { return name; }
+
 protected:
   /* Use covariance to implement clone function as returning this object
    * rather than base */

--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -68,6 +68,34 @@ public:
 			       named_struct);
   }
 
+  void visit (HIR::StaticItem &var)
+  {
+    TyTy::TyBase *resolved_type = nullptr;
+    bool ok = ctx->get_tyctx ()->lookup_type (var.get_mappings ().get_hirid (),
+					      &resolved_type);
+    rust_assert (ok);
+
+    Btype *type = TyTyResolveCompile::compile (ctx, resolved_type);
+    Bexpression *value = CompileExpr::Compile (var.get_expr (), ctx);
+
+    std::string name = var.get_identifier ();
+    // FIXME need name mangling
+    std::string asm_name = "__" + var.get_identifier ();
+
+    bool is_external = false;
+    bool is_hidden = false;
+    bool in_unique_section = true;
+
+    Bvariable *static_global
+      = ctx->get_backend ()->global_variable (name, asm_name, type, is_external,
+					      is_hidden, in_unique_section,
+					      var.get_locus ());
+    ctx->get_backend ()->global_variable_set_init (static_global, value);
+
+    ctx->insert_var_decl (var.get_mappings ().get_hirid (), static_global);
+    ctx->push_var (static_global);
+  }
+
   void visit (HIR::ConstantItem &constant)
   {
     TyTy::TyBase *resolved_type = nullptr;

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -94,6 +94,32 @@ public:
 			       struct_decl.get_locus ());
   }
 
+  void visit (AST::StaticItem &var)
+  {
+    std::vector<HIR::Attribute> outer_attrs;
+    HIR::Visibility vis = HIR::Visibility::create_public ();
+
+    HIR::Type *type = ASTLoweringType::translate (var.get_type ().get ());
+    HIR::Expr *expr = ASTLoweringExpr::translate (var.get_expr ().get ());
+
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, var.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   mappings->get_next_localdef_id (crate_num));
+
+    translated
+      = new HIR::StaticItem (mapping, var.get_identifier (), var.is_mutable (),
+			     std::unique_ptr<HIR::Type> (type),
+			     std::unique_ptr<HIR::Expr> (expr), vis,
+			     outer_attrs, var.get_locus ());
+
+    mappings->insert_defid_mapping (mapping.get_defid (), translated);
+    mappings->insert_hir_item (mapping.get_crate_num (), mapping.get_hirid (),
+			       translated);
+    mappings->insert_location (crate_num, mapping.get_hirid (),
+			       var.get_locus ());
+  }
+
   void visit (AST::ConstantItem &constant)
   {
     std::vector<HIR::Attribute> outer_attrs;

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -2157,6 +2157,14 @@ public:
 
   void accept_vis (HIRVisitor &vis) override;
 
+  Identifier get_identifier () const { return name; }
+
+  bool is_mutable () const { return has_mut; }
+
+  Expr *get_expr () { return expr.get (); }
+
+  Type *get_type () { return type.get (); }
+
 protected:
   /* Use covariance to implement clone function as returning this object
    * rather than base */

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -47,6 +47,12 @@ public:
     });
   }
 
+  void visit (AST::StaticItem &var)
+  {
+    ResolveType::go (var.get_type ().get (), var.get_node_id ());
+    ResolveExpr::go (var.get_expr ().get (), var.get_node_id ());
+  }
+
   void visit (AST::ConstantItem &constant)
   {
     ResolveType::go (constant.get_type ().get (), constant.get_node_id ());

--- a/gcc/rust/resolve/rust-ast-resolve-toplevel.h
+++ b/gcc/rust/resolve/rust-ast-resolve-toplevel.h
@@ -42,6 +42,15 @@ public:
 					struct_decl.get_node_id ());
   }
 
+  void visit (AST::StaticItem &var)
+  {
+    resolver->get_name_scope ().insert (var.get_identifier (),
+					var.get_node_id ());
+    resolver->insert_new_definition (var.get_node_id (),
+				     Definition{var.get_node_id (),
+						var.get_node_id ()});
+  }
+
   void visit (AST::ConstantItem &constant)
   {
     resolver->get_name_scope ().insert (constant.get_identifier (),

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -2527,7 +2527,7 @@ Gcc_backend::global_variable_set_init (Bvariable *var, Bexpression *expr)
     return;
   DECL_INITIAL (var_decl) = expr_tree;
 
-  // If this variable rustes in a unique section, it may need to rust into
+  // If this variable goes in a unique section, it may need to go into
   // a different one now that DECL_INITIAL is set.
   if (symtab_node::get (var_decl)
       && symtab_node::get (var_decl)->implicit_section)

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
@@ -59,6 +59,15 @@ public:
     context->insert_type (struct_decl.get_mappings ().get_hirid (), type);
   }
 
+  void visit (HIR::StaticItem &var)
+  {
+    TyTy::TyBase *type = TypeCheckType::Resolve (var.get_type ());
+    TyTy::TyBase *expr_type = TypeCheckExpr::Resolve (var.get_expr ());
+
+    context->insert_type (var.get_mappings ().get_hirid (),
+			  type->combine (expr_type));
+  }
+
   void visit (HIR::ConstantItem &constant)
   {
     TyTy::TyBase *type = TypeCheckType::Resolve (constant.get_type ());

--- a/gcc/testsuite/rust.test/compilable/static_var1.rs
+++ b/gcc/testsuite/rust.test/compilable/static_var1.rs
@@ -1,0 +1,5 @@
+static x:i32 = 3;
+
+fn main() {
+    let y = x +1;
+}

--- a/gcc/testsuite/rust.test/fail_compilation/static_var1.rs
+++ b/gcc/testsuite/rust.test/fail_compilation/static_var1.rs
@@ -1,0 +1,5 @@
+static x = 3;
+
+fn main() {
+    let y = x +1;
+}


### PR DESCRIPTION
Still requires name mangling for the ASM name similar to functions.

```
static x:i32 = 3;

fn main() {
    let y = x +1;
}
```

```
        .file   "test.rs"
        .text
        .globl  __x
        .section        .data.__x,"aw"
        .align 4
        .type   __x, @object
        .size   __x, 4
__x:
        .long   3
        .text
        .type   main, @function
main:
.LFB0:
        .cfi_startproc
        pushq   %rbp
        .cfi_def_cfa_offset 16
        .cfi_offset 6, -16
        movq    %rsp, %rbp
        .cfi_def_cfa_register 6
        movl    __x(%rip), %eax
        addl    $1, %eax
        movl    %eax, -4(%rbp)
        popq    %rbp
        .cfi_def_cfa 7, 8
        ret
        .cfi_endproc
.LFE0:
        .size   main, .-main
        .ident  "GCC: (GNU) 11.0.0 20201127 (experimental)"
        .section        .note.GNU-stack,"",@progbits
```