### PR TITLE
Add in F32 and F64 types builtin types.

### DIFF
--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -272,6 +272,14 @@ public:
     translated = compiled_type;
   }
 
+  void visit (TyTy::FloatType &type) override
+  {
+    ::Btype *compiled_type = nullptr;
+    bool ok = ctx->lookup_compiled_types (type.get_ref (), &compiled_type);
+    rust_assert (ok);
+    translated = compiled_type;
+  }
+
 private:
   TyTyResolveCompile (Context *ctx) : ctx (ctx) {}
 

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -155,6 +155,36 @@ public:
 	}
 	return;
 
+	case HIR::Literal::FLOAT: {
+	  printf ("FLOATY BOYO: [%s]\n", expr.as_string ().c_str ());
+
+	  mpfr_t fval;
+	  if (mpfr_init_set_str (fval, expr.as_string ().c_str (), 10,
+				 MPFR_RNDN)
+	      != 0)
+	    {
+	      rust_fatal_error (expr.get_locus (),
+				"bad float number in literal");
+	      return;
+	    }
+
+	  TyTy::TyBase *tyty = nullptr;
+	  if (!ctx->get_tyctx ()->lookup_type (
+		expr.get_mappings ().get_hirid (), &tyty))
+	    {
+	      rust_fatal_error (expr.get_locus (),
+				"did not resolve type for this literal expr");
+	      return;
+	    }
+
+	  printf ("tyty float is [%s]\n", tyty->as_string ().c_str ());
+
+	  Btype *type = TyTyResolveCompile::compile (ctx, tyty);
+	  translated
+	    = ctx->get_backend ()->float_constant_expression (type, fval);
+	}
+	return;
+
       default:
 	rust_fatal_error (expr.get_locus (), "unknown literal");
 	return;

--- a/gcc/rust/backend/rust-compile-tyty.h
+++ b/gcc/rust/backend/rust-compile-tyty.h
@@ -163,6 +163,24 @@ public:
     gcc_unreachable ();
   }
 
+  void visit (TyTy::FloatType &type) override
+  {
+    switch (type.get_kind ())
+      {
+      case TyTy::FloatType::F32:
+	translated = backend->named_type ("f32", backend->float_type (32),
+					  Linemap::predeclared_location ());
+	return;
+
+      case TyTy::FloatType::F64:
+	translated = backend->named_type ("f32", backend->float_type (64),
+					  Linemap::predeclared_location ());
+	return;
+      }
+
+    gcc_unreachable ();
+  }
+
 private:
   TyTyCompile (::Backend *backend)
     : backend (backend), translated (nullptr),

--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -140,6 +140,10 @@ Resolver::generate_builtins ()
   auto i128
     = new TyTy::IntType (mappings->get_next_hir_id (), TyTy::IntType::I128);
   auto rbool = new TyTy::BoolType (mappings->get_next_hir_id ());
+  auto f32
+    = new TyTy::FloatType (mappings->get_next_hir_id (), TyTy::FloatType::F32);
+  auto f64
+    = new TyTy::FloatType (mappings->get_next_hir_id (), TyTy::FloatType::F64);
 
   MKBUILTIN_TYPE ("u8", builtins, u8);
   MKBUILTIN_TYPE ("u16", builtins, u16);
@@ -152,6 +156,8 @@ Resolver::generate_builtins ()
   MKBUILTIN_TYPE ("i64", builtins, i64);
   MKBUILTIN_TYPE ("i128", builtins, i128);
   MKBUILTIN_TYPE ("bool", builtins, rbool);
+  MKBUILTIN_TYPE ("f32", builtins, f32);
+  MKBUILTIN_TYPE ("f64", builtins, f64);
 }
 
 void

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -196,6 +196,13 @@ public:
 	}
 	break;
 
+	case HIR::Literal::LitType::FLOAT: {
+	  // FIXME need to respect the suffix if applicable
+	  auto ok = context->lookup_builtin ("f32", &infered);
+	  rust_assert (ok);
+	}
+	break;
+
 	case HIR::Literal::LitType::BOOL: {
 	  auto ok = context->lookup_builtin ("bool", &infered);
 	  rust_assert (ok);

--- a/gcc/rust/typecheck/rust-tyty-rules.h
+++ b/gcc/rust/typecheck/rust-tyty-rules.h
@@ -316,6 +316,31 @@ private:
   TyBase *resolved;
 };
 
+class FloatRules : protected BaseRules
+{
+public:
+  FloatRules (FloatType *base)
+    : BaseRules (base), base (base), resolved (nullptr)
+  {}
+  ~FloatRules () {}
+
+  TyBase *combine (TyBase *other)
+  {
+    other->accept_vis (*this);
+    return resolved;
+  }
+
+  void visit (FloatType &type) override
+  {
+    // FIXME we should look at the FloatKind and respect it
+    resolved = new FloatType (type.get_ref (), type.get_kind ());
+  }
+
+private:
+  FloatType *base;
+  TyBase *resolved;
+};
+
 } // namespace TyTy
 } // namespace Rust
 

--- a/gcc/rust/typecheck/rust-tyty-visitor.h
+++ b/gcc/rust/typecheck/rust-tyty-visitor.h
@@ -37,6 +37,7 @@ public:
   virtual void visit (BoolType &type) {}
   virtual void visit (IntType &type) {}
   virtual void visit (UintType &type) {}
+  virtual void visit (FloatType &type) {}
 };
 
 } // namespace TyTy

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -255,6 +255,33 @@ UintType::combine (TyBase *other)
 }
 
 void
+FloatType::accept_vis (TyVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+std::string
+FloatType::as_string () const
+{
+  switch (float_kind)
+    {
+    case F32:
+      return "f32";
+    case F64:
+      return "f64";
+    }
+  gcc_unreachable ();
+  return "__unknown_float_type";
+}
+
+TyBase *
+FloatType::combine (TyBase *other)
+{
+  FloatRules r (this);
+  return r.combine (other);
+}
+
+void
 TypeCheckCallExpr::visit (FnType &type)
 {
   if (call.num_params () != type.num_params ())

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -295,6 +295,31 @@ private:
   UintKind uint_kind;
 };
 
+class FloatType : public TyBase
+{
+public:
+  enum FloatKind
+  {
+    F32,
+    F64
+  };
+
+  FloatType (HirId ref, FloatKind kind)
+    : TyBase (ref, TypeKind::FLOAT), float_kind (kind)
+  {}
+
+  void accept_vis (TyVisitor &vis) override;
+
+  std::string as_string () const override;
+
+  TyBase *combine (TyBase *other) override;
+
+  FloatKind get_kind () const { return float_kind; }
+
+private:
+  FloatKind float_kind;
+};
+
 } // namespace TyTy
 } // namespace Rust
 

--- a/gcc/testsuite/rust.test/compilable/float1.rs
+++ b/gcc/testsuite/rust.test/compilable/float1.rs
@@ -1,0 +1,8 @@
+fn test(x: f32) -> f32 {
+    return x + 1.0;
+}
+
+fn main() {
+    let a_float = 5.123;
+    let call_test = test(a_float + 1.0);
+}


### PR DESCRIPTION
We need to ensure all suffix of literals are handled in a subsequent PR.

```
f32 test (f32 x)
{
  f32 D.199;

  D.199 = x + 1.0e+0;
  return D.199;
}


void main ()
{
  f32 a_float;
  f32 call_test;

  a_float = 5.12300014495849609375e+0;
  _1 = a_float + 1.0e+0;
  call_test = test (_1);
}
```