### PR TITLE
Examine the Suffix hint on integers to apply apropriate TyTy type.

### DIFF
--- a/gcc/rust/ast/rust-ast-full-test.cc
+++ b/gcc/rust/ast/rust-ast-full-test.cc
@@ -4940,28 +4940,30 @@ MacroParser::parse_literal ()
     {
     case CHAR_LITERAL:
       skip_token ();
-      return Literal (tok->as_string (), Literal::CHAR);
+      return Literal (tok->as_string (), Literal::CHAR, tok->get_type_hint ());
     case STRING_LITERAL:
       skip_token ();
-      return Literal (tok->as_string (), Literal::STRING);
+      return Literal (tok->as_string (), Literal::STRING,
+		      tok->get_type_hint ());
     case BYTE_CHAR_LITERAL:
       skip_token ();
-      return Literal (tok->as_string (), Literal::BYTE);
+      return Literal (tok->as_string (), Literal::BYTE, tok->get_type_hint ());
     case BYTE_STRING_LITERAL:
       skip_token ();
-      return Literal (tok->as_string (), Literal::BYTE_STRING);
+      return Literal (tok->as_string (), Literal::BYTE_STRING,
+		      tok->get_type_hint ());
     case INT_LITERAL:
       skip_token ();
-      return Literal (tok->as_string (), Literal::INT);
+      return Literal (tok->as_string (), Literal::INT, tok->get_type_hint ());
     case FLOAT_LITERAL:
       skip_token ();
-      return Literal (tok->as_string (), Literal::FLOAT);
+      return Literal (tok->as_string (), Literal::FLOAT, tok->get_type_hint ());
     case TRUE_LITERAL:
       skip_token ();
-      return Literal ("true", Literal::BOOL);
+      return Literal ("true", Literal::BOOL, tok->get_type_hint ());
     case FALSE_LITERAL:
       skip_token ();
-      return Literal ("false", Literal::BOOL);
+      return Literal ("false", Literal::BOOL, tok->get_type_hint ());
     default:
       rust_error_at (tok->get_locus (), "expected literal - found '%s'",
 		     get_token_description (tok->get_id ()));
@@ -5284,7 +5286,8 @@ Token::to_token_stream () const
 Attribute
 MetaNameValueStr::to_attribute () const
 {
-  LiteralExpr lit_expr (str, Literal::LitType::STRING, Location ());
+  LiteralExpr lit_expr (str, Literal::LitType::STRING,
+			PrimitiveCoreType::CORETYPE_UNKNOWN, Location ());
   return Attribute (SimplePath::from_str (ident),
 		    std::unique_ptr<AttrInputLiteral> (
 		      new AttrInputLiteral (std::move (lit_expr))));

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -212,6 +212,8 @@ public:
 
   Location get_locus () const { return locus; }
 
+  PrimitiveCoreType get_type_hint () const { return type_hint; }
+
 protected:
   // No virtual for now as not polymorphic but can be in future
   /*virtual*/ Token *clone_token_impl () const { return new Token (*this); }
@@ -250,17 +252,25 @@ private:
    * (or generics) */
   std::string value_as_string;
   LitType type;
+  PrimitiveCoreType type_hint;
 
 public:
   std::string as_string () const { return value_as_string; }
 
   LitType get_lit_type () const { return type; }
 
-  Literal (std::string value_as_string, LitType type)
-    : value_as_string (std::move (value_as_string)), type (type)
+  PrimitiveCoreType get_type_hint () const { return type_hint; }
+
+  Literal (std::string value_as_string, LitType type,
+	   PrimitiveCoreType type_hint)
+    : value_as_string (std::move (value_as_string)), type (type),
+      type_hint (type_hint)
   {}
 
-  static Literal create_error () { return Literal ("", CHAR); }
+  static Literal create_error ()
+  {
+    return Literal ("", CHAR, PrimitiveCoreType::CORETYPE_UNKNOWN);
+  }
 
   // Returns whether literal is in an invalid state.
   bool is_error () const { return value_as_string == ""; }

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -50,10 +50,10 @@ public:
   Literal::LitType get_lit_type () const { return literal.get_lit_type (); }
 
   LiteralExpr (std::string value_as_string, Literal::LitType type,
-	       Location locus,
+	       PrimitiveCoreType type_hint, Location locus,
 	       std::vector<Attribute> outer_attrs = std::vector<Attribute> ())
     : ExprWithoutBlock (std::move (outer_attrs)),
-      literal (std::move (value_as_string), type), locus (locus)
+      literal (std::move (value_as_string), type, type_hint), locus (locus)
   {}
 
   LiteralExpr (Literal literal, Location locus,

--- a/gcc/rust/ast/rust-pattern.h
+++ b/gcc/rust/ast/rust-pattern.h
@@ -47,8 +47,8 @@ public:
 
   LiteralPattern (std::string val, Literal::LitType type, Location locus,
 		  bool has_minus = false)
-    : lit (Literal (std::move (val), type)), has_minus (has_minus),
-      locus (locus)
+    : lit (Literal (std::move (val), type, PrimitiveCoreType::CORETYPE_STR)),
+      has_minus (has_minus), locus (locus)
   {}
 
   Location get_locus () const { return locus; }

--- a/gcc/rust/backend/rust-compile-tyty.h
+++ b/gcc/rust/backend/rust-compile-tyty.h
@@ -111,6 +111,18 @@ public:
 	  = backend->named_type ("i32", backend->integer_type (false, 32),
 				 Linemap::predeclared_location ());
 	return;
+
+      case TyTy::IntType::I64:
+	translated
+	  = backend->named_type ("i64", backend->integer_type (false, 64),
+				 Linemap::predeclared_location ());
+	return;
+
+      case TyTy::IntType::I128:
+	translated
+	  = backend->named_type ("i128", backend->integer_type (false, 128),
+				 Linemap::predeclared_location ());
+	return;
       }
     gcc_unreachable ();
   }
@@ -133,6 +145,18 @@ public:
       case TyTy::UintType::U32:
 	translated
 	  = backend->named_type ("i32", backend->integer_type (true, 32),
+				 Linemap::predeclared_location ());
+	return;
+
+      case TyTy::UintType::U64:
+	translated
+	  = backend->named_type ("u64", backend->integer_type (true, 64),
+				 Linemap::predeclared_location ());
+	return;
+
+      case TyTy::UintType::U128:
+	translated
+	  = backend->named_type ("u128", backend->integer_type (true, 128),
 				 Linemap::predeclared_location ());
 	return;
       }

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -303,6 +303,7 @@ public:
 				   UNKNOWN_LOCAL_DEFID);
 
     translated = new HIR::LiteralExpr (mapping, expr.as_string (), type,
+				       expr.get_literal ().get_type_hint (),
 				       expr.get_locus ());
   }
 

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -66,10 +66,11 @@ public:
   Literal::LitType get_lit_type () const { return literal.get_lit_type (); }
 
   LiteralExpr (Analysis::NodeMapping mappings, std::string value_as_string,
-	       Literal::LitType type, Location locus,
+	       Literal::LitType type, PrimitiveCoreType type_hint,
+	       Location locus,
 	       std::vector<Attribute> outer_attrs = std::vector<Attribute> ())
     : ExprWithoutBlock (std::move (mappings), std::move (outer_attrs)),
-      literal (std::move (value_as_string), type), locus (locus)
+      literal (std::move (value_as_string), type, type_hint), locus (locus)
   {}
 
   LiteralExpr (Analysis::NodeMapping mappings, Literal literal, Location locus,

--- a/gcc/rust/hir/tree/rust-hir-full-test.cc
+++ b/gcc/rust/hir/tree/rust-hir-full-test.cc
@@ -4904,38 +4904,8 @@ DelimTokenTree::to_token_stream () const
 Literal
 MacroParser::parse_literal ()
 {
-  const std::unique_ptr<Token> &tok = peek_token ();
-  switch (tok->get_id ())
-    {
-    case CHAR_LITERAL:
-      skip_token ();
-      return Literal (tok->as_string (), Literal::CHAR);
-    case STRING_LITERAL:
-      skip_token ();
-      return Literal (tok->as_string (), Literal::STRING);
-    case BYTE_CHAR_LITERAL:
-      skip_token ();
-      return Literal (tok->as_string (), Literal::BYTE);
-    case BYTE_STRING_LITERAL:
-      skip_token ();
-      return Literal (tok->as_string (), Literal::BYTE_STRING);
-    case INT_LITERAL:
-      skip_token ();
-      return Literal (tok->as_string (), Literal::INT);
-    case FLOAT_LITERAL:
-      skip_token ();
-      return Literal (tok->as_string (), Literal::FLOAT);
-    case TRUE_LITERAL:
-      skip_token ();
-      return Literal ("true", Literal::BOOL);
-    case FALSE_LITERAL:
-      skip_token ();
-      return Literal ("false", Literal::BOOL);
-    default:
-      rust_error_at (tok->get_locus (), "expected literal - found '%s'",
-		     get_token_description (tok->get_id ()));
-      return Literal::create_error ();
-    }
+  // marcos need to be removed from HIR
+  gcc_unreachable ();
 }
 
 SimplePath
@@ -5037,7 +5007,8 @@ Attribute
 MetaNameValueStr::to_attribute () const
 {
   LiteralExpr lit_expr (Analysis::NodeMapping::get_error (), str,
-			Literal::LitType::STRING, Location ());
+			Literal::LitType::STRING,
+			PrimitiveCoreType::CORETYPE_STR, Location ());
   return Attribute (SimplePath::from_str (ident),
 		    std::unique_ptr<AttrInputLiteral> (
 		      new AttrInputLiteral (std::move (lit_expr))));

--- a/gcc/rust/hir/tree/rust-hir-pattern.h
+++ b/gcc/rust/hir/tree/rust-hir-pattern.h
@@ -47,8 +47,8 @@ public:
 
   LiteralPattern (std::string val, Literal::LitType type, Location locus,
 		  bool has_minus = false)
-    : lit (Literal (std::move (val), type)), has_minus (has_minus),
-      locus (locus)
+    : lit (Literal (std::move (val), type, PrimitiveCoreType::CORETYPE_STR)),
+      has_minus (has_minus), locus (locus)
   {}
 
   Location get_locus () const { return locus; }

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -235,21 +235,27 @@ public:
   };
 
 private:
-  /* TODO: maybe make subclasses of each type of literal with their typed values
-   * (or generics) */
   std::string value_as_string;
   LitType type;
+  PrimitiveCoreType type_hint;
 
 public:
   std::string as_string () const { return value_as_string; }
 
   LitType get_lit_type () const { return type; }
 
-  Literal (std::string value_as_string, LitType type)
-    : value_as_string (std::move (value_as_string)), type (type)
+  PrimitiveCoreType get_type_hint () const { return type_hint; }
+
+  Literal (std::string value_as_string, LitType type,
+	   PrimitiveCoreType type_hint)
+    : value_as_string (std::move (value_as_string)), type (type),
+      type_hint (type_hint)
   {}
 
-  static Literal create_error () { return Literal ("", CHAR); }
+  static Literal create_error ()
+  {
+    return Literal ("", CHAR, PrimitiveCoreType::CORETYPE_UNKNOWN);
+  }
 
   // Returns whether literal is in an invalid state.
   bool is_error () const { return value_as_string == ""; }

--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -126,19 +126,31 @@ Resolver::generate_builtins ()
     = new TyTy::UintType (mappings->get_next_hir_id (), TyTy::UintType::U16);
   auto u32
     = new TyTy::UintType (mappings->get_next_hir_id (), TyTy::UintType::U32);
+  auto u64
+    = new TyTy::UintType (mappings->get_next_hir_id (), TyTy::UintType::U64);
+  auto u128
+    = new TyTy::UintType (mappings->get_next_hir_id (), TyTy::UintType::U128);
   auto i8 = new TyTy::IntType (mappings->get_next_hir_id (), TyTy::IntType::I8);
   auto i16
     = new TyTy::IntType (mappings->get_next_hir_id (), TyTy::IntType::I16);
   auto i32
     = new TyTy::IntType (mappings->get_next_hir_id (), TyTy::IntType::I32);
+  auto i64
+    = new TyTy::IntType (mappings->get_next_hir_id (), TyTy::IntType::I64);
+  auto i128
+    = new TyTy::IntType (mappings->get_next_hir_id (), TyTy::IntType::I128);
   auto rbool = new TyTy::BoolType (mappings->get_next_hir_id ());
 
   MKBUILTIN_TYPE ("u8", builtins, u8);
   MKBUILTIN_TYPE ("u16", builtins, u16);
   MKBUILTIN_TYPE ("u32", builtins, u32);
+  MKBUILTIN_TYPE ("u64", builtins, u64);
+  MKBUILTIN_TYPE ("u128", builtins, u128);
   MKBUILTIN_TYPE ("i8", builtins, i8);
   MKBUILTIN_TYPE ("i16", builtins, i16);
   MKBUILTIN_TYPE ("i32", builtins, i32);
+  MKBUILTIN_TYPE ("i64", builtins, i64);
+  MKBUILTIN_TYPE ("i128", builtins, i128);
   MKBUILTIN_TYPE ("bool", builtins, rbool);
 }
 

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -359,9 +359,10 @@ Session::enable_dump (std::string arg)
    * created */
   if (arg == "all")
     {
-      rust_error_at (Location (),
-		     "dumping all is not supported as of now. choose %<lex%>, %<parse%>, "
-         "or %<target_options%>");
+      rust_error_at (
+	Location (),
+	"dumping all is not supported as of now. choose %<lex%>, %<parse%>, "
+	"or %<target_options%>");
       return false;
     }
   else if (arg == "lex")
@@ -409,10 +410,11 @@ Session::enable_dump (std::string arg)
     }
   else
     {
-      rust_error_at (Location (),
-		     "dump option %qs was unrecognised. choose %<lex%>, %<parse%>, or "
-         "%<target_options%>",
-		     arg.c_str ());
+      rust_error_at (
+	Location (),
+	"dump option %qs was unrecognised. choose %<lex%>, %<parse%>, or "
+	"%<target_options%>",
+	arg.c_str ());
       return false;
     }
   return true;

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -152,10 +152,46 @@ public:
     switch (expr.get_lit_type ())
       {
 	case HIR::Literal::LitType::INT: {
-	  // FIXME:
-	  // assume i32 let the combiner functions figure it out
-	  // this should look at the suffix of the literal value to check
-	  auto ok = context->lookup_builtin ("i32", &infered);
+	  bool ok = false;
+
+	  switch (expr.get_literal ()->get_type_hint ())
+	    {
+	    case CORETYPE_I8:
+	      ok = context->lookup_builtin ("i8", &infered);
+	      break;
+	    case CORETYPE_I16:
+	      ok = context->lookup_builtin ("i16", &infered);
+	      break;
+	    case CORETYPE_I32:
+	      ok = context->lookup_builtin ("i32", &infered);
+	      break;
+	    case CORETYPE_I64:
+	      ok = context->lookup_builtin ("i64", &infered);
+	      break;
+	    case CORETYPE_I128:
+	      ok = context->lookup_builtin ("i128", &infered);
+	      break;
+
+	    case CORETYPE_U8:
+	      ok = context->lookup_builtin ("u8", &infered);
+	      break;
+	    case CORETYPE_U16:
+	      ok = context->lookup_builtin ("u16", &infered);
+	      break;
+	    case CORETYPE_U32:
+	      ok = context->lookup_builtin ("u32", &infered);
+	      break;
+	    case CORETYPE_U64:
+	      ok = context->lookup_builtin ("u64", &infered);
+	      break;
+	    case CORETYPE_U128:
+	      ok = context->lookup_builtin ("u128", &infered);
+	      break;
+
+	    default:
+	      ok = context->lookup_builtin ("i32", &infered);
+	      break;
+	    }
 	  rust_assert (ok);
 	}
 	break;

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -164,6 +164,10 @@ IntType::as_string () const
       return "i16";
     case I32:
       return "i32";
+    case I64:
+      return "i64";
+    case I128:
+      return "i128";
     }
   gcc_unreachable ();
   return "__unknown_int_type";
@@ -193,6 +197,10 @@ UintType::as_string () const
       return "u16";
     case U32:
       return "u32";
+    case U64:
+      return "u64";
+    case U128:
+      return "u128";
     }
   gcc_unreachable ();
   return "__unknown_uint_type";

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -185,6 +185,8 @@ public:
     I8,
     I16,
     I32,
+    I64,
+    I128
   };
 
   IntType (HirId ref, IntKind kind)
@@ -211,6 +213,8 @@ public:
     U8,
     U16,
     U32,
+    U64,
+    U128
   };
 
   UintType (HirId ref, UintKind kind)

--- a/gcc/testsuite/rust.test/compilable/integer_types.rs
+++ b/gcc/testsuite/rust.test/compilable/integer_types.rs
@@ -1,0 +1,25 @@
+fn main() {
+    let a1: i8 = 1i8;
+    let a2: i16 = 2i16;
+    let a3: i32 = 3i32;
+    let a4: i64 = 4i64;
+    let a5: i128 = 5i128;
+
+    let b1 = 1i8;
+    let b2 = 2i16;
+    let b3 = 3i32;
+    let b4 = 4i64;
+    let b5 = 5i128;
+
+    let c1: u8 = 1u8;
+    let c2: u16 = 2u16;
+    let c3: u32 = 3u32;
+    let c4: u64 = 4u64;
+    let c5: u128 = 5u128;
+
+    let d1 = 1u8;
+    let d2 = 2u16;
+    let d3 = 3u32;
+    let d4 = 4u64;
+    let d5 = 5u128;
+}


### PR DESCRIPTION
This change propagates the PrimitiveCoreType to AST and HIR so the suffix can be examined.

```
fn main() {
    let a1: i8 = 1i8;
    let a2: i16 = 2i16;
    let a3: i32 = 3i32;
    let a4: i64 = 4i64;
    let a5: i128 = 5i128;

    let b1 = 1i8;
    let b2 = 2i16;
    let b3 = 3i32;
    let b4 = 4i64;
    let b5 = 5i128;

    let c1: u8 = 1u8;
    let c2: u16 = 2u16;
    let c3: u32 = 3u32;
    let c4: u64 = 4u64;
    let c5: u128 = 5u128;

    let d1 = 1u8;
    let d2 = 2u16;
    let d3 = 3u32;
    let d4 = 4u64;
    let d5 = 5u128;
}
```

```
void main ()
{
  i8 a1;
  i16 a2;
  i32 a3;
  i64 a4;
  i128 a5;
  i8 b1;
  i16 b2;
  i32 b3;
  i64 b4;
  i128 b5;
  i8 c1;
  i16 c2;
  i32 c3;
  u64 c4;
  u128 c5;
  i8 d1;
  i16 d2;
  i32 d3;
  u64 d4;
  u128 d5;

  a1 = 1;
  a2 = 2;
  a3 = 3;
  a4 = 4;
  a5 = 5;
  b1 = 1;
  b2 = 2;
  b3 = 3;
  b4 = 4;
  b5 = 5;
  c1 = 1;
  c2 = 2;
  c3 = 3;
  c4 = 4;
  c5 = 5;
  d1 = 1;
  d2 = 2;
  d3 = 3;
  d4 = 4;
  d5 = 5;
}

```