### PR TITLE
Respect the f32 and f64 suffix on literals

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -156,8 +156,6 @@ public:
 	return;
 
 	case HIR::Literal::FLOAT: {
-	  printf ("FLOATY BOYO: [%s]\n", expr.as_string ().c_str ());
-
 	  mpfr_t fval;
 	  if (mpfr_init_set_str (fval, expr.as_string ().c_str (), 10,
 				 MPFR_RNDN)
@@ -176,8 +174,6 @@ public:
 				"did not resolve type for this literal expr");
 	      return;
 	    }
-
-	  printf ("tyty float is [%s]\n", tyty->as_string ().c_str ());
 
 	  Btype *type = TyTyResolveCompile::compile (ctx, tyty);
 	  translated

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -257,6 +257,8 @@ public:
     return Literal ("", CHAR, PrimitiveCoreType::CORETYPE_UNKNOWN);
   }
 
+  void set_lit_type (LitType lt) { type = lt; }
+
   // Returns whether literal is in an invalid state.
   bool is_error () const { return value_as_string == ""; }
 };

--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -1938,16 +1938,6 @@ Lexer::parse_decimal_int_or_float (Location loc)
       PrimitiveCoreType type_hint = type_suffix_pair.first;
       length += type_suffix_pair.second;
 
-      if (type_hint == CORETYPE_F32 || type_hint == CORETYPE_F64)
-	{
-	  rust_error_at (
-	    get_current_location (),
-	    "invalid type suffix %qs for integer (decimal) literal",
-	    get_type_hint_string (type_hint));
-	  // ignore invalid type suffix as everything else seems fine
-	  type_hint = CORETYPE_UNKNOWN;
-	}
-
       current_column += length;
 
       str.shrink_to_fit ();

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -188,6 +188,15 @@ public:
 	      ok = context->lookup_builtin ("u128", &infered);
 	      break;
 
+	    case CORETYPE_F32:
+	      expr.get_literal ()->set_lit_type (HIR::Literal::LitType::FLOAT);
+	      ok = context->lookup_builtin ("f32", &infered);
+	      break;
+	    case CORETYPE_F64:
+	      expr.get_literal ()->set_lit_type (HIR::Literal::LitType::FLOAT);
+	      ok = context->lookup_builtin ("f64", &infered);
+	      break;
+
 	    default:
 	      ok = context->lookup_builtin ("i32", &infered);
 	      break;
@@ -197,8 +206,20 @@ public:
 	break;
 
 	case HIR::Literal::LitType::FLOAT: {
-	  // FIXME need to respect the suffix if applicable
-	  auto ok = context->lookup_builtin ("f32", &infered);
+	  bool ok = false;
+
+	  switch (expr.get_literal ()->get_type_hint ())
+	    {
+	    case CORETYPE_F32:
+	      ok = context->lookup_builtin ("f32", &infered);
+	      break;
+	    case CORETYPE_F64:
+	      ok = context->lookup_builtin ("f64", &infered);
+	      break;
+	    default:
+	      ok = context->lookup_builtin ("f32", &infered);
+	      break;
+	    }
 	  rust_assert (ok);
 	}
 	break;

--- a/gcc/testsuite/rust.test/compilable/float_types.rs
+++ b/gcc/testsuite/rust.test/compilable/float_types.rs
@@ -1,0 +1,11 @@
+fn main() {
+    let a1: f32 = 1.0f32;
+    let a2: f64 = 2.0f64;
+    let a3: f32 = 3f32;
+    let a4: f64 = 4f64;
+
+    let b1 = 1.0f32;
+    let b2 = 2.0f64;
+    let b3 = 3f32;
+    let b4 = 4f64;
+}


### PR DESCRIPTION
Rust is permissive for integers being marked as floats so the check in the lexer can be removed here.