### PR TITLE
Add test to cover handling hex, binary and octal number literals.

### DIFF
--- a/gcc/rust/backend/rust-compile-tyty.h
+++ b/gcc/rust/backend/rust-compile-tyty.h
@@ -132,19 +132,19 @@ public:
     switch (type.get_kind ())
       {
       case TyTy::UintType::U8:
-	translated = backend->named_type ("i8", backend->integer_type (true, 8),
+	translated = backend->named_type ("u8", backend->integer_type (true, 8),
 					  Linemap::predeclared_location ());
 	return;
 
       case TyTy::UintType::U16:
 	translated
-	  = backend->named_type ("i16", backend->integer_type (true, 16),
+	  = backend->named_type ("u16", backend->integer_type (true, 16),
 				 Linemap::predeclared_location ());
 	return;
 
       case TyTy::UintType::U32:
 	translated
-	  = backend->named_type ("i32", backend->integer_type (true, 32),
+	  = backend->named_type ("u32", backend->integer_type (true, 32),
 				 Linemap::predeclared_location ());
 	return;
 

--- a/gcc/testsuite/rust.test/compilable/literals1.rs
+++ b/gcc/testsuite/rust.test/compilable/literals1.rs
@@ -1,0 +1,9 @@
+fn main() {
+    let hex: i32 = 0xFF;
+    let binary: i32 = 0b11110000;
+    let oct: i32 = 0o70;
+
+    let hex_u8: u8 = 0xFF_u8;
+    let bin_u16: u16 = 0b1111000011110000_u16;
+    let oct: u32 = 0o70_u32;
+}


### PR DESCRIPTION
This also ensure the type suffix is respected against the number.