### PR TITLE
Implicit Returns support.

### DIFF
--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -2838,6 +2838,8 @@ public:
       }
   }
 
+  size_t num_statements () const { return statements.size (); }
+
   // TODO: this mutable getter seems really dodgy. Think up better way.
   const std::vector<Attribute> &get_inner_attrs () const { return inner_attrs; }
   std::vector<Attribute> &get_inner_attrs () { return inner_attrs; }

--- a/gcc/rust/ast/rust-stmt.h
+++ b/gcc/rust/ast/rust-stmt.h
@@ -184,6 +184,8 @@ class ExprStmt : public Stmt
   Location locus;
 
 public:
+  Location get_locus_slow () const final override { return get_locus (); }
+
   Location get_locus () const { return locus; }
 
 protected:

--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -232,6 +232,23 @@ public:
       return true;
     });
 
+    if (function_body->has_expr ())
+      {
+	// the previous passes will ensure this is a valid return
+	// dead code elimination should remove any bad trailing expressions
+	Bexpression *compiled_expr
+	  = CompileExpr::Compile (function_body->expr.get (), ctx);
+	rust_assert (compiled_expr != nullptr);
+
+	auto fncontext = ctx->peek_fn ();
+
+	std::vector<Bexpression *> retstmts;
+	retstmts.push_back (compiled_expr);
+	auto s = ctx->get_backend ()->return_statement (
+	  fncontext.fndecl, retstmts, function_body->expr->get_locus_slow ());
+	ctx->add_statement (s);
+      }
+
     ctx->pop_block ();
     auto body = ctx->get_backend ()->block_statement (code_block);
     if (!ctx->get_backend ()->function_set_body (fndecl, body))

--- a/gcc/rust/hir/rust-ast-lower-block.h
+++ b/gcc/rust/hir/rust-ast-lower-block.h
@@ -28,7 +28,7 @@ namespace HIR {
 class ASTLoweringBlock : public ASTLoweringBase
 {
 public:
-  static HIR::BlockExpr *translate (AST::BlockExpr *expr)
+  static HIR::BlockExpr *translate (AST::BlockExpr *expr, bool *terminated)
   {
     ASTLoweringBlock resolver;
     expr->accept_vis (resolver);
@@ -40,6 +40,7 @@ public:
 	  resolver.translated);
       }
 
+    *terminated = resolver.terminated;
     return resolver.translated;
   }
 
@@ -48,15 +49,18 @@ public:
   void visit (AST::BlockExpr &expr);
 
 private:
-  ASTLoweringBlock () : ASTLoweringBase (), translated (nullptr) {}
+  ASTLoweringBlock ()
+    : ASTLoweringBase (), translated (nullptr), terminated (false)
+  {}
 
   HIR::BlockExpr *translated;
+  bool terminated;
 };
 
 class ASTLoweringIfBlock : public ASTLoweringBase
 {
 public:
-  static HIR::IfExpr *translate (AST::IfExpr *expr)
+  static HIR::IfExpr *translate (AST::IfExpr *expr, bool *terminated)
   {
     ASTLoweringIfBlock resolver;
     expr->accept_vis (resolver);
@@ -67,7 +71,7 @@ public:
 	  resolver.translated->get_mappings ().get_hirid (),
 	  resolver.translated);
       }
-
+    *terminated = resolver.terminated;
     return resolver.translated;
   }
 
@@ -80,15 +84,19 @@ public:
   void visit (AST::IfExprConseqIf &expr);
 
 private:
-  ASTLoweringIfBlock () : ASTLoweringBase (), translated (nullptr) {}
+  ASTLoweringIfBlock ()
+    : ASTLoweringBase (), translated (nullptr), terminated (false)
+  {}
 
   HIR::IfExpr *translated;
+  bool terminated;
 };
 
 class ASTLoweringExprWithBlock : public ASTLoweringBase
 {
 public:
-  static HIR::ExprWithBlock *translate (AST::ExprWithBlock *expr)
+  static HIR::ExprWithBlock *translate (AST::ExprWithBlock *expr,
+					bool *terminated)
   {
     ASTLoweringExprWithBlock resolver;
     expr->accept_vis (resolver);
@@ -100,6 +108,7 @@ public:
 	  resolver.translated);
       }
 
+    *terminated = resolver.terminated;
     return resolver.translated;
   }
 
@@ -107,23 +116,26 @@ public:
 
   void visit (AST::IfExpr &expr)
   {
-    translated = ASTLoweringIfBlock::translate (&expr);
+    translated = ASTLoweringIfBlock::translate (&expr, &terminated);
   }
 
   void visit (AST::IfExprConseqElse &expr)
   {
-    translated = ASTLoweringIfBlock::translate (&expr);
+    translated = ASTLoweringIfBlock::translate (&expr, &terminated);
   }
 
   void visit (AST::IfExprConseqIf &expr)
   {
-    translated = ASTLoweringIfBlock::translate (&expr);
+    translated = ASTLoweringIfBlock::translate (&expr, &terminated);
   }
 
 private:
-  ASTLoweringExprWithBlock () : ASTLoweringBase (), translated (nullptr) {}
+  ASTLoweringExprWithBlock ()
+    : ASTLoweringBase (), translated (nullptr), terminated (false)
+  {}
 
   HIR::ExprWithBlock *translated;
+  bool terminated;
 };
 
 } // namespace HIR

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -185,9 +185,14 @@ public:
 	function_params.push_back (hir_param);
       }
 
+    bool terminated = false;
     std::unique_ptr<HIR::BlockExpr> function_body
       = std::unique_ptr<HIR::BlockExpr> (
-	ASTLoweringBlock::translate (function.get_definition ().get ()));
+	ASTLoweringBlock::translate (function.get_definition ().get (),
+				     &terminated));
+    if (!terminated && function.has_return_type ())
+      rust_error_at (function.get_definition ()->get_locus (),
+		     "missing return");
 
     auto crate_num = mappings->get_current_crate ();
     Analysis::NodeMapping mapping (crate_num, function.get_node_id (),

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -2594,6 +2594,8 @@ public:
       }
   }
 
+  bool is_final_stmt (Stmt *stmt) { return statements.back ().get () == stmt; }
+
   Location get_closing_locus ()
   {
     if (statements.size () == 0)

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -85,6 +85,10 @@ public:
 	return true;
       });
 
+    if (function.get_definition ()->has_tail_expr ())
+      ResolveExpr::go (function.get_definition ()->get_tail_expr ().get (),
+		       function.get_node_id ());
+
     resolver->get_name_scope ().pop ();
     resolver->get_type_scope ().pop ();
   }

--- a/gcc/rust/typecheck/rust-hir-type-check-item.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.h
@@ -72,25 +72,7 @@ public:
     ResolveFnType resolve_fn_type (fnType);
     context->push_return_type (resolve_fn_type.go ());
 
-    // walk statements to make sure they are all typed correctly and they match
-    // up
-    function.function_body->iterate_stmts ([&] (HIR::Stmt *s) mutable -> bool {
-      TypeCheckStmt::Resolve (s);
-      return true;
-    });
-
-    // now that the stmts have been resolved we must resolve the block of locals
-    // and make sure the variables have been resolved
-    auto body_mappings = function.function_body->get_mappings ();
-    Rib *rib = nullptr;
-    if (!resolver->find_name_rib (body_mappings.get_nodeid (), &rib))
-      {
-	rust_fatal_error (function.get_locus (),
-			  "failed to lookup locals per block");
-	return;
-      }
-
-    TyTyResolver::Resolve (rib, mappings, resolver, context);
+    TypeCheckExpr::Resolve (function.function_body.get ());
 
     context->pop_return_type ();
   }

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.h
@@ -30,27 +30,29 @@ namespace Resolver {
 class TypeCheckStmt : public TypeCheckBase
 {
 public:
-  static void Resolve (HIR::Stmt *stmt)
+  static TyTy::TyBase *Resolve (HIR::Stmt *stmt, bool is_final_stmt)
   {
-    TypeCheckStmt resolver;
+    TypeCheckStmt resolver (is_final_stmt);
     stmt->accept_vis (resolver);
+    return resolver.infered;
   }
 
   void visit (HIR::ExprStmtWithBlock &stmt)
   {
-    TypeCheckExpr::Resolve (stmt.get_expr ());
+    infered = TypeCheckExpr::Resolve (stmt.get_expr (), is_final_stmt);
   }
 
   void visit (HIR::ExprStmtWithoutBlock &stmt)
   {
-    TypeCheckExpr::Resolve (stmt.get_expr ());
+    infered = TypeCheckExpr::Resolve (stmt.get_expr (), is_final_stmt);
   }
 
   void visit (HIR::LetStmt &stmt)
   {
     TyTy::TyBase *init_expr_ty = nullptr;
     if (stmt.has_init_expr ())
-      init_expr_ty = TypeCheckExpr::Resolve (stmt.get_init_expr ());
+      init_expr_ty
+	= TypeCheckExpr::Resolve (stmt.get_init_expr (), is_final_stmt);
 
     TyTy::TyBase *specified_ty = nullptr;
     if (stmt.has_type ())
@@ -94,7 +96,12 @@ public:
   }
 
 private:
-  TypeCheckStmt () : TypeCheckBase () {}
+  TypeCheckStmt (bool is_final_stmt)
+    : TypeCheckBase (), is_final_stmt (is_final_stmt)
+  {}
+
+  TyTy::TyBase *infered;
+  bool is_final_stmt;
 }; // namespace Resolver
 
 } // namespace Resolver

--- a/gcc/rust/typecheck/rust-tyty-resolver.h
+++ b/gcc/rust/typecheck/rust-tyty-resolver.h
@@ -73,8 +73,6 @@ public:
 						 d.parent, &hir_node_ref);
 	      rust_assert (ok);
 
-	      printf ("failed lets try [%u]\n", hir_node_ref);
-
 	      if (!context->lookup_type (hir_node_ref, &resolved))
 		{
 		  rust_fatal_error (
@@ -102,10 +100,8 @@ public:
 				 &resolved_type);
       rust_assert (ok);
 
-      if (!resolved_type->is_unit ())
-	{
-	  return true;
-	}
+      if (resolved_type->get_kind () != TyTy::TypeKind::INFER)
+	return true;
 
       auto resolved_tyty = resolved_type;
       for (auto it : gathered_types)

--- a/gcc/rust/typecheck/rust-tyty-rules.h
+++ b/gcc/rust/typecheck/rust-tyty-rules.h
@@ -34,58 +34,83 @@ public:
 
   virtual void visit (UnitType &type) override
   {
-    Location locus = mappings->lookup_location (type.get_ref ());
-    rust_error_at (locus, "expected [%s] got [%s]", base->as_string ().c_str (),
-		   type.as_string ().c_str ());
+    Location ref_locus = mappings->lookup_location (type.get_ref ());
+    Location def_locus = mappings->lookup_location (base->get_ref ());
+    rust_error_at (ref_locus, "expected [%s] got [%s]",
+		   base->as_string ().c_str (), type.as_string ().c_str ());
+    rust_fatal_error (def_locus, "declared here");
+  }
+
+  virtual void visit (ADTType &type) override
+  {
+    Location ref_locus = mappings->lookup_location (type.get_ref ());
+    Location def_locus = mappings->lookup_location (base->get_ref ());
+    rust_error_at (ref_locus, "expected [%s] got [%s]",
+		   base->as_string ().c_str (), type.as_string ().c_str ());
+    rust_fatal_error (def_locus, "declared here");
   }
 
   virtual void visit (InferType &type) override
   {
-    Location locus = mappings->lookup_location (type.get_ref ());
-    rust_error_at (locus, "expected [%s] got [%s]", base->as_string ().c_str (),
-		   type.as_string ().c_str ());
+    Location ref_locus = mappings->lookup_location (type.get_ref ());
+    Location def_locus = mappings->lookup_location (base->get_ref ());
+    rust_error_at (ref_locus, "expected [%s] got [%s]",
+		   base->as_string ().c_str (), type.as_string ().c_str ());
+    rust_fatal_error (def_locus, "declared here");
   }
 
   virtual void visit (FnType &type) override
   {
-    Location locus = mappings->lookup_location (type.get_ref ());
-    rust_error_at (locus, "expected [%s] got [%s]", base->as_string ().c_str (),
-		   type.as_string ().c_str ());
+    Location ref_locus = mappings->lookup_location (type.get_ref ());
+    Location def_locus = mappings->lookup_location (base->get_ref ());
+    rust_error_at (ref_locus, "expected [%s] got [%s]",
+		   base->as_string ().c_str (), type.as_string ().c_str ());
+    rust_fatal_error (def_locus, "declared here");
   }
 
   virtual void visit (ParamType &type) override
   {
-    Location locus = mappings->lookup_location (type.get_ref ());
-    rust_error_at (locus, "expected [%s] got [%s]", base->as_string ().c_str (),
-		   type.as_string ().c_str ());
+    Location ref_locus = mappings->lookup_location (type.get_ref ());
+    Location def_locus = mappings->lookup_location (base->get_ref ());
+    rust_error_at (ref_locus, "expected [%s] got [%s]",
+		   base->as_string ().c_str (), type.as_string ().c_str ());
+    rust_fatal_error (def_locus, "declared here");
   }
 
   virtual void visit (ArrayType &type) override
   {
-    Location locus = mappings->lookup_location (type.get_ref ());
-    rust_error_at (locus, "expected [%s] got [%s]", base->as_string ().c_str (),
-		   type.as_string ().c_str ());
+    Location ref_locus = mappings->lookup_location (type.get_ref ());
+    Location def_locus = mappings->lookup_location (base->get_ref ());
+    rust_error_at (ref_locus, "expected [%s] got [%s]",
+		   base->as_string ().c_str (), type.as_string ().c_str ());
+    rust_fatal_error (def_locus, "declared here");
   }
 
   virtual void visit (BoolType &type) override
   {
-    Location locus = mappings->lookup_location (type.get_ref ());
-    rust_error_at (locus, "expected [%s] got [%s]", base->as_string ().c_str (),
-		   type.as_string ().c_str ());
+    Location ref_locus = mappings->lookup_location (type.get_ref ());
+    Location def_locus = mappings->lookup_location (base->get_ref ());
+    rust_error_at (ref_locus, "expected [%s] got [%s]",
+		   base->as_string ().c_str (), type.as_string ().c_str ());
+    rust_fatal_error (def_locus, "declared here");
   }
 
   virtual void visit (IntType &type) override
   {
-    Location locus = mappings->lookup_location (type.get_ref ());
-    rust_error_at (locus, "expected [%s] got [%s]", base->as_string ().c_str (),
-		   type.as_string ().c_str ());
+    Location ref_locus = mappings->lookup_location (type.get_ref ());
+    Location def_locus = mappings->lookup_location (base->get_ref ());
+    rust_error_at (ref_locus, "expected [%s] got [%s]",
+		   base->as_string ().c_str (), type.as_string ().c_str ());
+    rust_fatal_error (def_locus, "declared here");
   }
 
   virtual void visit (UintType &type) override
   {
-    Location locus = mappings->lookup_location (type.get_ref ());
-    rust_error_at (locus, "expected [%s] got [%s]", base->as_string ().c_str (),
-		   type.as_string ().c_str ());
+    Location ref_locus = mappings->lookup_location (type.get_ref ());
+    Location def_locus = mappings->lookup_location (base->get_ref ());
+    rust_error_at (ref_locus, "expected [%s] got [%s]",
+		   base->as_string ().c_str (), type.as_string ().c_str ());
+    rust_fatal_error (def_locus, "declared here");
   }
 
 protected:
@@ -114,6 +139,11 @@ public:
 
   // we are an inference variable so this means we can take the other as the
   // type
+  virtual void visit (UnitType &type) override
+  {
+    resolved = new UnitType (type.get_ref ());
+  }
+
   virtual void visit (BoolType &type) override
   {
     resolved = new BoolType (type.get_ref ());
@@ -164,6 +194,8 @@ public:
     other->accept_vis (*this);
     return resolved;
   }
+
+  void visit (IntType &type) override { rust_assert (false); }
 
 private:
   UnitType *base;

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -49,7 +49,7 @@ class TyVisitor;
 class TyBase
 {
 public:
-  ~TyBase () {}
+  virtual ~TyBase () {}
 
   HirId get_ref () const { return ref; }
 

--- a/gcc/testsuite/rust.test/compilable/deadcode1.rs
+++ b/gcc/testsuite/rust.test/compilable/deadcode1.rs
@@ -1,0 +1,18 @@
+fn test1() -> i32 {
+    return 2;
+    1
+}
+
+fn test2(x: i32) -> i32 {
+    if x > 1 {
+        return 5;
+    } else {
+        return 0;
+    }
+    return 1;
+}
+
+fn main() {
+    let call1 = test1();
+    let call2 = test2(2);
+}

--- a/gcc/testsuite/rust.test/compilable/implicit_returns1.rs
+++ b/gcc/testsuite/rust.test/compilable/implicit_returns1.rs
@@ -1,0 +1,65 @@
+fn test1() -> i32 {
+    1
+}
+
+fn test2() -> i32 {
+    return 2;
+}
+
+fn test3(x: i32) -> i32 {
+    if x > 1 {
+        5
+    } else {
+        0
+    }
+}
+
+fn test4(x: i32) -> i32 {
+    if x > 1 {
+        return 1;
+    }
+    0
+}
+
+fn test5(x: i32) -> i32 {
+    if x > 1 {
+        if x == 5 {
+            7
+        } else {
+            9
+        }
+    } else {
+        0
+    }
+}
+
+fn test6(x: i32) -> i32 {
+    if x > 1 {
+        return 5;
+    } else {
+        return 0;
+    }
+}
+
+fn test7(x: i32) -> i32 {
+    if x > 1 {
+        return 5;
+    } else {
+        return 0;
+    }
+}
+
+fn test8() -> i32 {
+    return 1;
+}
+
+fn main() {
+    let call1 = test1();
+    let call2 = test2();
+    let call3 = test3(3);
+    let call4 = test4(4);
+    let call5 = test5(5);
+    let call6 = test6(6);
+    let call7 = test7(7);
+    let call8 = test8();
+}

--- a/gcc/testsuite/rust.test/fail_compilation/missing_return1.rs
+++ b/gcc/testsuite/rust.test/fail_compilation/missing_return1.rs
@@ -1,0 +1,5 @@
+fn test1() -> i32 {}
+
+fn main() {
+    let call1 = test1();
+}


### PR DESCRIPTION
For implict returns we must consider cases with a block having multiple
returns:

 HIR::BlockExpr Stmts {
   ...
   return x
 }
 HIR::BlockExpr final_expression {
   x + 1
 }

Although the code above is bad this is valid rust code and the rust
compiler correctly identifies the final_expression as unreachable.

This dead code eliminiation is done as part of AST to HIR lowering.
Type resolution examines all blocks to identifiy if they terminate
a function with a return/final expression it must correspond accordngly.

If the block is the final block the resulting termination of the block
must match the return type of the function, else the block must conform
to unit type.