### PR TITLE
Make TyTyVisitor a pure abstract class

### DIFF
--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -221,11 +221,17 @@ public:
 
   virtual ~TyTyResolveCompile () {}
 
+  void visit (TyTy::ErrorType &type) override { gcc_unreachable (); }
+
   void visit (TyTy::UnitType &type) override { gcc_unreachable (); }
 
   void visit (TyTy::InferType &type) override { gcc_unreachable (); }
 
   void visit (TyTy::FnType &type) override { gcc_unreachable (); }
+
+  void visit (TyTy::StructFieldType &type) override { gcc_unreachable (); }
+
+  void visit (TyTy::ParamType &type) override { gcc_unreachable (); }
 
   void visit (TyTy::ADTType &type) override
   {

--- a/gcc/rust/backend/rust-compile-tyty.h
+++ b/gcc/rust/backend/rust-compile-tyty.h
@@ -43,13 +43,19 @@ public:
 
   ~TyTyCompile () {}
 
-  void visit (TyTy::InferType &type) override
-  {
-    // there shouldn't be any of these left
-    gcc_unreachable ();
-  }
+  void visit (TyTy::ErrorType &type) override { gcc_unreachable (); }
 
-  void visit (TyTy::UnitType &type) override {}
+  void visit (TyTy::UnitType &type) override { gcc_unreachable (); }
+
+  void visit (TyTy::InferType &type) override { gcc_unreachable (); }
+
+  void visit (TyTy::StructFieldType &type) override { gcc_unreachable (); }
+
+  void visit (TyTy::ParamType &type) override { gcc_unreachable (); }
+
+  void visit (TyTy::ADTType &type) override { gcc_unreachable (); }
+
+  void visit (TyTy::ArrayType &type) override { gcc_unreachable (); }
 
   void visit (TyTy::FnType &type) override
   {
@@ -81,8 +87,6 @@ public:
       = backend->function_type (receiver, parameters, results, NULL,
 				mappings->lookup_location (type.get_ref ()));
   }
-
-  void visit (TyTy::ParamType &type) override {}
 
   void visit (TyTy::BoolType &type) override
   {
@@ -205,6 +209,18 @@ public:
 
   ~TyTyExtractParamsFromFnType () {}
 
+  void visit (TyTy::UnitType &type) override { gcc_unreachable (); }
+  void visit (TyTy::InferType &type) override { gcc_unreachable (); }
+  void visit (TyTy::StructFieldType &type) override { gcc_unreachable (); }
+  void visit (TyTy::ADTType &type) override { gcc_unreachable (); }
+  void visit (TyTy::ParamType &type) override { gcc_unreachable (); }
+  void visit (TyTy::ArrayType &type) override { gcc_unreachable (); }
+  void visit (TyTy::BoolType &type) override { gcc_unreachable (); }
+  void visit (TyTy::IntType &type) override { gcc_unreachable (); }
+  void visit (TyTy::UintType &type) override { gcc_unreachable (); }
+  void visit (TyTy::FloatType &type) override { gcc_unreachable (); }
+  void visit (TyTy::ErrorType &type) override { gcc_unreachable (); }
+
   void visit (TyTy::FnType &type) override
   {
     ok = true;
@@ -234,6 +250,18 @@ public:
 
   ~TyTyExtractRetFromFnType () {}
 
+  void visit (TyTy::UnitType &type) override { gcc_unreachable (); }
+  void visit (TyTy::InferType &type) override { gcc_unreachable (); }
+  void visit (TyTy::StructFieldType &type) override { gcc_unreachable (); }
+  void visit (TyTy::ADTType &type) override { gcc_unreachable (); }
+  void visit (TyTy::ParamType &type) override { gcc_unreachable (); }
+  void visit (TyTy::ArrayType &type) override { gcc_unreachable (); }
+  void visit (TyTy::BoolType &type) override { gcc_unreachable (); }
+  void visit (TyTy::IntType &type) override { gcc_unreachable (); }
+  void visit (TyTy::UintType &type) override { gcc_unreachable (); }
+  void visit (TyTy::FloatType &type) override { gcc_unreachable (); }
+  void visit (TyTy::ErrorType &type) override { gcc_unreachable (); }
+
   void visit (TyTy::FnType &type) override
   {
     ok = true;
@@ -260,6 +288,18 @@ public:
   }
 
   ~TyTyCompileParam () {}
+
+  void visit (TyTy::UnitType &type) override { gcc_unreachable (); }
+  void visit (TyTy::InferType &type) override { gcc_unreachable (); }
+  void visit (TyTy::StructFieldType &type) override { gcc_unreachable (); }
+  void visit (TyTy::ADTType &type) override { gcc_unreachable (); }
+  void visit (TyTy::FnType &type) override { gcc_unreachable (); }
+  void visit (TyTy::ArrayType &type) override { gcc_unreachable (); }
+  void visit (TyTy::BoolType &type) override { gcc_unreachable (); }
+  void visit (TyTy::IntType &type) override { gcc_unreachable (); }
+  void visit (TyTy::UintType &type) override { gcc_unreachable (); }
+  void visit (TyTy::FloatType &type) override { gcc_unreachable (); }
+  void visit (TyTy::ErrorType &type) override { gcc_unreachable (); }
 
   void visit (TyTy::ParamType &type) override
   {

--- a/gcc/rust/typecheck/rust-hir-type-check-item.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.h
@@ -43,6 +43,18 @@ public:
     return state;
   }
 
+  void visit (TyTy::UnitType &type) override { gcc_unreachable (); }
+  void visit (TyTy::InferType &type) override { gcc_unreachable (); }
+  void visit (TyTy::StructFieldType &type) override { gcc_unreachable (); }
+  void visit (TyTy::ADTType &type) override { gcc_unreachable (); }
+  void visit (TyTy::ParamType &type) override { gcc_unreachable (); }
+  void visit (TyTy::ArrayType &type) override { gcc_unreachable (); }
+  void visit (TyTy::BoolType &type) override { gcc_unreachable (); }
+  void visit (TyTy::IntType &type) override { gcc_unreachable (); }
+  void visit (TyTy::UintType &type) override { gcc_unreachable (); }
+  void visit (TyTy::FloatType &type) override { gcc_unreachable (); }
+  void visit (TyTy::ErrorType &type) override { gcc_unreachable (); }
+
   void visit (TyTy::FnType &type) override { state = type.return_type (); }
 
 private:

--- a/gcc/rust/typecheck/rust-tyctx.cc
+++ b/gcc/rust/typecheck/rust-tyctx.cc
@@ -69,7 +69,10 @@ TypeCheckContext::lookup_type (HirId id, TyTy::TyBase **type)
 {
   auto it = resolved.find (id);
   if (it == resolved.end ())
-    return false;
+    {
+      *type = new TyTy::ErrorType (id);
+      return false;
+    }
 
   *type = it->second;
   return true;

--- a/gcc/rust/typecheck/rust-tyty-call.h
+++ b/gcc/rust/typecheck/rust-tyty-call.h
@@ -38,6 +38,18 @@ public:
   }
   ~TypeCheckCallExpr () {}
 
+  void visit (UnitType &type) override { gcc_unreachable (); }
+  void visit (InferType &type) override { gcc_unreachable (); }
+  void visit (StructFieldType &type) override { gcc_unreachable (); }
+  void visit (ADTType &type) override { gcc_unreachable (); }
+  void visit (ParamType &type) override { gcc_unreachable (); }
+  void visit (ArrayType &type) override { gcc_unreachable (); }
+  void visit (BoolType &type) override { gcc_unreachable (); }
+  void visit (IntType &type) override { gcc_unreachable (); }
+  void visit (UintType &type) override { gcc_unreachable (); }
+  void visit (FloatType &type) override { gcc_unreachable (); }
+  void visit (ErrorType &type) override { gcc_unreachable (); }
+
   void visit (FnType &type) override;
 
 private:

--- a/gcc/rust/typecheck/rust-tyty-resolver.h
+++ b/gcc/rust/typecheck/rust-tyty-resolver.h
@@ -151,6 +151,18 @@ public:
 
   virtual ~TyTyExtractorArray () {}
 
+  void visit (TyTy::UnitType &type) override { gcc_unreachable (); }
+  void visit (TyTy::InferType &type) override { gcc_unreachable (); }
+  void visit (TyTy::StructFieldType &type) override { gcc_unreachable (); }
+  void visit (TyTy::ADTType &type) override { gcc_unreachable (); }
+  void visit (TyTy::ParamType &type) override { gcc_unreachable (); }
+  void visit (TyTy::FnType &type) override { gcc_unreachable (); }
+  void visit (TyTy::BoolType &type) override { gcc_unreachable (); }
+  void visit (TyTy::IntType &type) override { gcc_unreachable (); }
+  void visit (TyTy::UintType &type) override { gcc_unreachable (); }
+  void visit (TyTy::FloatType &type) override { gcc_unreachable (); }
+  void visit (TyTy::ErrorType &type) override { gcc_unreachable (); }
+
   void visit (TyTy::ArrayType &type) override { extracted = type.get_type (); }
 
 private:

--- a/gcc/rust/typecheck/rust-tyty-visitor.h
+++ b/gcc/rust/typecheck/rust-tyty-visitor.h
@@ -27,17 +27,18 @@ namespace TyTy {
 class TyVisitor
 {
 public:
-  virtual void visit (UnitType &type) {}
-  virtual void visit (InferType &type) {}
-  virtual void visit (StructFieldType &type) {}
-  virtual void visit (ADTType &type) {}
-  virtual void visit (FnType &type) {}
-  virtual void visit (ParamType &type) {}
-  virtual void visit (ArrayType &type) {}
-  virtual void visit (BoolType &type) {}
-  virtual void visit (IntType &type) {}
-  virtual void visit (UintType &type) {}
-  virtual void visit (FloatType &type) {}
+  virtual void visit (UnitType &type) = 0;
+  virtual void visit (InferType &type) = 0;
+  virtual void visit (StructFieldType &type) = 0;
+  virtual void visit (ADTType &type) = 0;
+  virtual void visit (FnType &type) = 0;
+  virtual void visit (ParamType &type) = 0;
+  virtual void visit (ArrayType &type) = 0;
+  virtual void visit (BoolType &type) = 0;
+  virtual void visit (IntType &type) = 0;
+  virtual void visit (UintType &type) = 0;
+  virtual void visit (FloatType &type) = 0;
+  virtual void visit (ErrorType &type) = 0;
 };
 
 } // namespace TyTy

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -64,6 +64,25 @@ InferType::combine (TyBase *other)
 }
 
 void
+ErrorType::accept_vis (TyVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+std::string
+ErrorType::as_string () const
+{
+  return "<tyty::error>";
+}
+
+TyBase *
+ErrorType::combine (TyBase *other)
+{
+  // rust_error_at ();
+  return this;
+}
+
+void
 StructFieldType::accept_vis (TyVisitor &vis)
 {
   vis.visit (*this);

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -43,6 +43,7 @@ enum TypeKind
   UNIT,
   FIELD,
   // there are more to add...
+  ERROR
 };
 
 class TyVisitor;
@@ -74,6 +75,20 @@ class InferType : public TyBase
 {
 public:
   InferType (HirId ref) : TyBase (ref, TypeKind::INFER) {}
+
+  void accept_vis (TyVisitor &vis) override;
+
+  bool is_unit () const override { return true; }
+
+  std::string as_string () const override;
+
+  TyBase *combine (TyBase *other) override;
+};
+
+class ErrorType : public TyBase
+{
+public:
+  ErrorType (HirId ref) : TyBase (ref, TypeKind::ERROR) {}
 
   void accept_vis (TyVisitor &vis) override;
 


### PR DESCRIPTION
This is a code cleanup as there are some inconsistencies with type inferencing rules and making the class force implementing the visitors will help fix these later on.