### PR TITLE
Ensure scoping rules are enforced correctly for BlockExpr's

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-block.h
+++ b/gcc/rust/hir/rust-ast-lower-block.h
@@ -129,6 +129,11 @@ public:
     translated = ASTLoweringIfBlock::translate (&expr, &terminated);
   }
 
+  void visit (AST::BlockExpr &expr)
+  {
+    translated = ASTLoweringBlock::translate (&expr, &terminated);
+  }
+
 private:
   ASTLoweringExprWithBlock ()
     : ASTLoweringBase (), translated (nullptr), terminated (false)

--- a/gcc/rust/resolve/rust-ast-resolve-stmt.h
+++ b/gcc/rust/resolve/rust-ast-resolve-stmt.h
@@ -51,12 +51,12 @@ public:
 
   void visit (AST::LetStmt &stmt)
   {
+    if (stmt.has_init_expr ())
+      ResolveExpr::go (stmt.get_init_expr ().get (), stmt.get_node_id ());
+
     PatternDeclaration::go (stmt.get_pattern ().get (), stmt.get_node_id ());
     if (stmt.has_type ())
       ResolveType::go (stmt.get_type ().get (), stmt.get_node_id ());
-
-    if (stmt.has_init_expr ())
-      ResolveExpr::go (stmt.get_init_expr ().get (), stmt.get_node_id ());
   }
 
 private:

--- a/gcc/testsuite/rust.test/compilable/scoping1.rs
+++ b/gcc/testsuite/rust.test/compilable/scoping1.rs
@@ -1,0 +1,10 @@
+fn main() {
+    let x = 1;
+    {
+        let x = true;
+        {
+            x = false;
+        }
+    }
+    let x = x + 1;
+}

--- a/gcc/testsuite/rust.test/compilable/shadow2.rs
+++ b/gcc/testsuite/rust.test/compilable/shadow2.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let x = 1;
+    let x = x + 1;
+}


### PR DESCRIPTION
There was a bug with LetStmts where we name resolved the identifier
pattern first before the init expression. This lead to a situation
where shadowing rules were broken.

Example:

let x = 1;
let x = x + 1;

In this example the code was referencing the 2nd LetStmt as the resolved
name for the Identifier reference.

Fixes #80 