### PR TITLE
Add in a check for unused decls within ribs.

### DIFF
--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -180,7 +180,7 @@ public:
       }
 
     std::vector<Bvariable *> locals;
-    rib->iterate_decls ([&] (NodeId n) mutable -> bool {
+    rib->iterate_decls ([&] (NodeId n, Location) mutable -> bool {
       Resolver::Definition d;
       bool ok = ctx->get_resolver ()->lookup_definition (n, &d);
       rust_assert (ok);

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -75,7 +75,7 @@ ResolvePathType::visit (HIR::PathInExpression &expr)
 {
   // need to look up the reference for this identifier
   NodeId ref_node_id;
-  if (!ctx->get_resolver ()->lookup_resolved_name (
+  if (!ctx->get_resolver ()->lookup_resolved_type (
 	expr.get_mappings ().get_nodeid (), &ref_node_id))
     {
       rust_fatal_error (expr.get_locus (), "failed to look up resolved name");

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -64,7 +64,7 @@ CompileBlock::visit (HIR::BlockExpr &expr)
     }
 
   std::vector<Bvariable *> locals;
-  rib->iterate_decls ([&] (NodeId n) mutable -> bool {
+  rib->iterate_decls ([&] (NodeId n, Location) mutable -> bool {
     Resolver::Definition d;
     bool ok = ctx->get_resolver ()->lookup_definition (n, &d);
     rust_assert (ok);

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -24,6 +24,7 @@
 #include "rust-ast-resolve-type.h"
 #include "rust-ast-resolve-pattern.h"
 #include "rust-ast-resolve-stmt.h"
+#include "rust-ast-resolve-unused.h"
 
 namespace Rust {
 namespace Resolver {
@@ -83,6 +84,9 @@ public:
     // resolve the function body
     ResolveExpr::go (function.get_definition ().get (),
 		     function.get_node_id ());
+
+    ScanUnused::Scan (resolver->get_name_scope ().peek ());
+    ScanUnused::Scan (resolver->get_type_scope ().peek ());
 
     resolver->get_name_scope ().pop ();
     resolver->get_type_scope ().pop ();

--- a/gcc/rust/resolve/rust-ast-resolve-pattern.h
+++ b/gcc/rust/resolve/rust-ast-resolve-pattern.h
@@ -81,7 +81,8 @@ public:
     // if we have a duplicate id this then allows for shadowing correctly
     // as new refs to this decl will match back here so it is ok to overwrite
     resolver->get_name_scope ().insert (pattern.get_ident (),
-					pattern.get_node_id ());
+					pattern.get_node_id (),
+					pattern.get_locus ());
     resolver->insert_new_definition (pattern.get_node_id (),
 				     Definition{pattern.get_node_id (),
 						parent});

--- a/gcc/rust/resolve/rust-ast-resolve-toplevel.h
+++ b/gcc/rust/resolve/rust-ast-resolve-toplevel.h
@@ -39,13 +39,14 @@ public:
   void visit (AST::StructStruct &struct_decl)
   {
     resolver->get_type_scope ().insert (struct_decl.get_identifier (),
-					struct_decl.get_node_id ());
+					struct_decl.get_node_id (),
+					struct_decl.get_locus ());
   }
 
   void visit (AST::StaticItem &var)
   {
     resolver->get_name_scope ().insert (var.get_identifier (),
-					var.get_node_id ());
+					var.get_node_id (), var.get_locus ());
     resolver->insert_new_definition (var.get_node_id (),
 				     Definition{var.get_node_id (),
 						var.get_node_id ()});
@@ -54,7 +55,8 @@ public:
   void visit (AST::ConstantItem &constant)
   {
     resolver->get_name_scope ().insert (constant.get_identifier (),
-					constant.get_node_id ());
+					constant.get_node_id (),
+					constant.get_locus ());
     resolver->insert_new_definition (constant.get_node_id (),
 				     Definition{constant.get_node_id (),
 						constant.get_node_id ()});
@@ -62,10 +64,17 @@ public:
 
   void visit (AST::Function &function)
   {
-    // function_names are simple std::String identifiers so this can be a
-    // NodeId mapping to the Function node
     resolver->get_name_scope ().insert (function.get_function_name (),
+					function.get_node_id (),
+					function.get_locus ());
+
+    // if this does not get a reference it will be determined to be unused
+    // lets give it a fake reference to itself
+    if (function.get_function_name ().compare ("main") == 0)
+      {
+	resolver->insert_resolved_name (function.get_node_id (),
 					function.get_node_id ());
+      }
   }
 
 private:

--- a/gcc/rust/resolve/rust-ast-resolve-type.h
+++ b/gcc/rust/resolve/rust-ast-resolve-type.h
@@ -46,7 +46,6 @@ public:
   {
     // this will need changed to handle mod/crate/use globs and look
     // at the segments in granularity
-    locus = path.get_locus ();
     if (resolver->get_type_scope ().lookup (path.as_string (), &resolved_node))
       {
 	resolver->insert_resolved_type (path.get_node_id (), resolved_node);

--- a/gcc/rust/resolve/rust-ast-resolve-unused.h
+++ b/gcc/rust/resolve/rust-ast-resolve-unused.h
@@ -1,0 +1,45 @@
+// Copyright (C) 2020 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_AST_RESOLVE_UNUSED_H
+#define RUST_AST_RESOLVE_UNUSED_H
+
+#include "rust-ast-resolve-base.h"
+
+namespace Rust {
+namespace Resolver {
+
+class ScanUnused : public ResolverBase
+{
+public:
+  static void Scan (Rib *r)
+  {
+    r->iterate_decls ([&] (NodeId decl_node_id, Location locus) -> bool {
+      if (!r->have_references_for_node (decl_node_id))
+	{
+	  rust_warning_at (locus, 0, "unused name");
+	}
+      return true;
+    });
+  }
+};
+
+} // namespace Resolver
+} // namespace Rust
+
+#endif // RUST_AST_RESOLVE_UNUSED_H

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -140,10 +140,13 @@ TypeCheckStructExpr::visit (HIR::PathInExpression &expr)
   NodeId ref_node_id;
   if (!resolver->lookup_resolved_name (ast_node_id, &ref_node_id))
     {
-      rust_error_at (expr.get_locus (),
-		     "Failed to lookup reference for node: %s",
-		     expr.as_string ().c_str ());
-      return;
+      if (!resolver->lookup_resolved_type (ast_node_id, &ref_node_id))
+	{
+	  rust_error_at (expr.get_locus (),
+			 "Failed to lookup reference for node: %s",
+			 expr.as_string ().c_str ());
+	  return;
+	}
     }
 
   // node back to HIR

--- a/gcc/rust/typecheck/rust-tyty-resolver.h
+++ b/gcc/rust/typecheck/rust-tyty-resolver.h
@@ -44,7 +44,7 @@ public:
 
   void go (Rib *rib)
   {
-    rib->iterate_decls ([&] (NodeId decl_node_id) mutable -> bool {
+    rib->iterate_decls ([&] (NodeId decl_node_id, Location) mutable -> bool {
       // type inference in rust means we need to gather and examine all
       // references of this decl and combine each to make sure the type is
       // correctly inferred. Consider the example:

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -331,8 +331,6 @@ Mappings::insert_hir_param (CrateNum crateNum, HirId id,
 {
   rust_assert (lookup_hir_stmt (crateNum, id) == nullptr);
 
-  printf ("inserting param with node id %u hir id: %u\n",
-	  param->get_mappings ()->get_nodeid (), id);
   hirParamMappings[crateNum][id] = param;
   nodeIdToHirMappings[crateNum][param->get_mappings ()->get_nodeid ()] = id;
 }

--- a/gcc/testsuite/rust.test/compilable/unused1.rs
+++ b/gcc/testsuite/rust.test/compilable/unused1.rs
@@ -1,0 +1,12 @@
+fn test() -> i32 {
+    1
+}
+
+fn unused() -> i32 {
+    2
+}
+
+fn main() {
+    let a = 1;
+    let b = test();
+}


### PR DESCRIPTION
This lead to cleanup of the name resolver as the usage of mappings means that in a given rib if there are no references to a decl NodeId that means it was not used.

To get on par with the offical rust compiler it should be allowed to have a reference where the name was assigned but not used but this might be a separate pass.

This gives us warnings for example:

```
test.rs:10:9: warning: unused name
   10 |     let a = 1;
      |         ^
test.rs:11:9: warning: unused name
   11 |     let b = test();
      |         ^
test.rs:5:1: warning: unused name
    5 | fn unused() -> i32 {
      | ^
```

test

```
fn test() -> i32 {
    1
}

fn unused() -> i32 {
    2
}

fn main() {
    let a = 1;
    let b = test();
}
```

The check is very generic since it is based on node id mappings so it should work as more rust is supported over time.
