### PR TITLE
Fix link to build status shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![C/C++ CI](https://github.com/philberty/gccrs/workflows/C/C++%20CI/badge.svg)
+![C/C++ CI](https://github.com/Rust-GCC/gccrs/workflows/C/C++%20CI/badge.svg)
 ![Docker Build](https://img.shields.io/docker/cloud/build/philberty/gccrs)
 ![Docker Pulls](https://img.shields.io/docker/pulls/philberty/gccrs)
 [![project chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://gcc-rust.zulipchat.com/)


### PR DESCRIPTION
The repository was moved into the Rust-GCC organization from philberty