### PR TITLE
Enforce type checking on implicit returns

### DIFF
--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -239,7 +239,7 @@ public:
   void visit (TyTy::ADTType &type) override
   {
     ::Btype *compiled_type = nullptr;
-    bool ok = ctx->lookup_compiled_types (type.get_ref (), &compiled_type);
+    bool ok = ctx->lookup_compiled_types (type.get_ty_ref (), &compiled_type);
     rust_assert (ok);
     translated = compiled_type;
   }
@@ -260,7 +260,7 @@ public:
   void visit (TyTy::BoolType &type) override
   {
     ::Btype *compiled_type = nullptr;
-    bool ok = ctx->lookup_compiled_types (type.get_ref (), &compiled_type);
+    bool ok = ctx->lookup_compiled_types (type.get_ty_ref (), &compiled_type);
     rust_assert (ok);
     translated = compiled_type;
   }
@@ -268,7 +268,7 @@ public:
   void visit (TyTy::IntType &type) override
   {
     ::Btype *compiled_type = nullptr;
-    bool ok = ctx->lookup_compiled_types (type.get_ref (), &compiled_type);
+    bool ok = ctx->lookup_compiled_types (type.get_ty_ref (), &compiled_type);
     rust_assert (ok);
     translated = compiled_type;
   }
@@ -276,7 +276,7 @@ public:
   void visit (TyTy::UintType &type) override
   {
     ::Btype *compiled_type = nullptr;
-    bool ok = ctx->lookup_compiled_types (type.get_ref (), &compiled_type);
+    bool ok = ctx->lookup_compiled_types (type.get_ty_ref (), &compiled_type);
     rust_assert (ok);
     translated = compiled_type;
   }
@@ -284,7 +284,7 @@ public:
   void visit (TyTy::FloatType &type) override
   {
     ::Btype *compiled_type = nullptr;
-    bool ok = ctx->lookup_compiled_types (type.get_ref (), &compiled_type);
+    bool ok = ctx->lookup_compiled_types (type.get_ty_ref (), &compiled_type);
     rust_assert (ok);
     translated = compiled_type;
   }

--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -246,7 +246,7 @@ public:
       return true;
     });
 
-    if (function_body->has_expr ())
+    if (function_body->has_expr () && function_body->tail_expr_reachable ())
       {
 	// the previous passes will ensure this is a valid return
 	// dead code elimination should remove any bad trailing expressions

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -90,7 +90,7 @@ CompileBlock::visit (HIR::BlockExpr &expr)
     return true;
   });
 
-  if (expr.has_expr ())
+  if (expr.has_expr () && expr.tail_expr_reachable ())
     {
       // the previous passes will ensure this is a valid return
       // dead code elimination should remove any bad trailing expressions

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -190,14 +190,15 @@ public:
       = std::unique_ptr<HIR::BlockExpr> (
 	ASTLoweringBlock::translate (function.get_definition ().get (),
 				     &terminated));
-    if (!terminated && function.has_return_type ())
-      rust_error_at (function.get_definition ()->get_locus (),
-		     "missing return");
 
     auto crate_num = mappings->get_current_crate ();
     Analysis::NodeMapping mapping (crate_num, function.get_node_id (),
 				   mappings->get_next_hir_id (crate_num),
 				   mappings->get_next_localdef_id (crate_num));
+
+    mappings->insert_location (crate_num,
+			       function_body->get_mappings ().get_hirid (),
+			       function.get_locus ());
 
     auto fn
       = new HIR::Function (mapping, std::move (function_name),

--- a/gcc/rust/hir/rust-ast-lower-type.h
+++ b/gcc/rust/hir/rust-ast-lower-type.h
@@ -122,10 +122,9 @@ public:
   }
 
 private:
-  ASTLoweringType () : translated (nullptr) {}
+  ASTLoweringType () : translated (nullptr), translated_segment (nullptr) {}
 
   HIR::Type *translated;
-
   HIR::TypePathSegment *translated_segment;
 };
 

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -2524,11 +2524,10 @@ class BlockExpr : public ExprWithBlock
 public:
   std::vector<Attribute> inner_attrs;
 
-  // bool has_statements;
   std::vector<std::unique_ptr<Stmt> > statements;
-  // bool has_expr;
   std::unique_ptr<ExprWithoutBlock> expr; // inlined from Statements
 
+  bool tail_reachable;
   Location locus;
 
   std::string as_string () const override;
@@ -2539,15 +2538,17 @@ public:
   // Returns whether the block contains an expression
   bool has_expr () const { return expr != nullptr; }
 
+  bool tail_expr_reachable () const { return tail_reachable; }
+
   BlockExpr (Analysis::NodeMapping mappings,
 	     std::vector<std::unique_ptr<Stmt> > block_statements,
-	     std::unique_ptr<ExprWithoutBlock> block_expr,
+	     std::unique_ptr<ExprWithoutBlock> block_expr, bool tail_reachable,
 	     std::vector<Attribute> inner_attribs,
 	     std::vector<Attribute> outer_attribs, Location locus)
     : ExprWithBlock (std::move (mappings), std::move (outer_attribs)),
       inner_attrs (std::move (inner_attribs)),
       statements (std::move (block_statements)), expr (std::move (block_expr)),
-      locus (locus)
+      tail_reachable (tail_reachable), locus (locus)
   {}
 
   // Copy constructor with clone

--- a/gcc/rust/typecheck/rust-hir-type-check-item.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.h
@@ -85,6 +85,12 @@ public:
     context->push_return_type (resolve_fn_type.go ());
 
     TypeCheckExpr::Resolve (function.function_body.get ());
+    if (function.function_body->has_expr ())
+      {
+	auto resolved
+	  = TypeCheckExpr::Resolve (function.function_body->expr.get ());
+	context->peek_return_type ()->combine (resolved);
+      }
 
     context->pop_return_type ();
   }

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
@@ -83,7 +83,12 @@ public:
     if (!function.has_function_return_type ())
       ret_type = new TyTy::UnitType (function.get_mappings ().get_hirid ());
     else
-      ret_type = TypeCheckType::Resolve (function.return_type.get ());
+      {
+	TyTy::InferType infer (function.get_mappings ().get_hirid ());
+	auto resolved = TypeCheckType::Resolve (function.return_type.get ());
+	ret_type = infer.combine (resolved);
+	ret_type->set_ref (function.return_type->get_mappings ().get_hirid ());
+      }
 
     std::vector<TyTy::ParamType *> params;
     for (auto &param : function.function_params)

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -119,7 +119,6 @@ public:
 
     // this might be a struct type (TyTy::ADT) reference
     // TODO
-    printf ("UNREACHABLE %s\n", path.as_string ().c_str ());
     gcc_unreachable ();
   }
 

--- a/gcc/rust/typecheck/rust-tyty-rules.h
+++ b/gcc/rust/typecheck/rust-tyty-rules.h
@@ -38,7 +38,7 @@ public:
     Location def_locus = mappings->lookup_location (base->get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
 		   base->as_string ().c_str (), type.as_string ().c_str ());
-    rust_fatal_error (def_locus, "declared here");
+    rust_error_at (def_locus, "declared here");
   }
 
   virtual void visit (ADTType &type) override
@@ -47,7 +47,7 @@ public:
     Location def_locus = mappings->lookup_location (base->get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
 		   base->as_string ().c_str (), type.as_string ().c_str ());
-    rust_fatal_error (def_locus, "declared here");
+    rust_error_at (def_locus, "declared here");
   }
 
   virtual void visit (InferType &type) override
@@ -56,7 +56,7 @@ public:
     Location def_locus = mappings->lookup_location (base->get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
 		   base->as_string ().c_str (), type.as_string ().c_str ());
-    rust_fatal_error (def_locus, "declared here");
+    rust_error_at (def_locus, "declared here");
   }
 
   virtual void visit (FnType &type) override
@@ -65,7 +65,7 @@ public:
     Location def_locus = mappings->lookup_location (base->get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
 		   base->as_string ().c_str (), type.as_string ().c_str ());
-    rust_fatal_error (def_locus, "declared here");
+    rust_error_at (def_locus, "declared here");
   }
 
   virtual void visit (ParamType &type) override
@@ -74,7 +74,7 @@ public:
     Location def_locus = mappings->lookup_location (base->get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
 		   base->as_string ().c_str (), type.as_string ().c_str ());
-    rust_fatal_error (def_locus, "declared here");
+    rust_error_at (def_locus, "declared here");
   }
 
   virtual void visit (ArrayType &type) override
@@ -83,7 +83,7 @@ public:
     Location def_locus = mappings->lookup_location (base->get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
 		   base->as_string ().c_str (), type.as_string ().c_str ());
-    rust_fatal_error (def_locus, "declared here");
+    rust_error_at (def_locus, "declared here");
   }
 
   virtual void visit (BoolType &type) override
@@ -92,7 +92,7 @@ public:
     Location def_locus = mappings->lookup_location (base->get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
 		   base->as_string ().c_str (), type.as_string ().c_str ());
-    rust_fatal_error (def_locus, "declared here");
+    rust_error_at (def_locus, "declared here");
   }
 
   virtual void visit (IntType &type) override
@@ -101,7 +101,7 @@ public:
     Location def_locus = mappings->lookup_location (base->get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
 		   base->as_string ().c_str (), type.as_string ().c_str ());
-    rust_fatal_error (def_locus, "declared here");
+    rust_error_at (def_locus, "declared here");
   }
 
   virtual void visit (UintType &type) override
@@ -110,7 +110,7 @@ public:
     Location def_locus = mappings->lookup_location (base->get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
 		   base->as_string ().c_str (), type.as_string ().c_str ());
-    rust_fatal_error (def_locus, "declared here");
+    rust_error_at (def_locus, "declared here");
   }
 
   virtual void visit (FloatType &type) override
@@ -119,7 +119,7 @@ public:
     Location def_locus = mappings->lookup_location (base->get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
 		   base->as_string ().c_str (), type.as_string ().c_str ());
-    rust_fatal_error (def_locus, "declared here");
+    rust_error_at (def_locus, "declared here");
   }
 
   virtual void visit (ErrorType &type) override
@@ -128,7 +128,7 @@ public:
     Location def_locus = mappings->lookup_location (base->get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
 		   base->as_string ().c_str (), type.as_string ().c_str ());
-    rust_fatal_error (def_locus, "declared here");
+    rust_error_at (def_locus, "declared here");
   }
 
   virtual void visit (StructFieldType &type) override
@@ -137,13 +137,13 @@ public:
     Location def_locus = mappings->lookup_location (base->get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
 		   base->as_string ().c_str (), type.as_string ().c_str ());
-    rust_fatal_error (def_locus, "declared here");
+    rust_error_at (def_locus, "declared here");
   }
 
 protected:
   BaseRules (TyBase *base)
     : mappings (Analysis::Mappings::get ()), base (base),
-      resolved (new ErrorType (base->get_ref ()))
+      resolved (new ErrorType (base->get_ref (), base->get_ref ()))
   {}
 
   Analysis::Mappings *mappings;
@@ -164,25 +164,23 @@ public:
 
   // we are an inference variable so this means we can take the other as the
   // type
-  void visit (UnitType &type) override
-  {
-    resolved = new UnitType (type.get_ref ());
-  }
+  void visit (InferType &type) override { resolved = type.clone (); }
 
-  void visit (BoolType &type) override
-  {
-    resolved = new BoolType (type.get_ref ());
-  }
+  void visit (UnitType &type) override { resolved = type.clone (); }
 
-  void visit (IntType &type) override
-  {
-    resolved = new IntType (type.get_ref (), type.get_kind ());
-  }
+  void visit (BoolType &type) override { resolved = type.clone (); }
 
-  void visit (UintType &type) override
-  {
-    resolved = new UintType (type.get_ref (), type.get_kind ());
-  }
+  void visit (IntType &type) override { resolved = type.clone (); }
+
+  void visit (UintType &type) override { resolved = type.clone (); }
+
+  void visit (FloatType &type) override { resolved = type.clone (); }
+
+  void visit (ParamType &type) override { resolved = type.clone (); }
+
+  void visit (ArrayType &type) override { resolved = type.clone (); }
+
+  void visit (ADTType &type) override { resolved = type.clone (); }
 
 private:
   InferType *base;
@@ -217,7 +215,7 @@ public:
 
   void visit (UnitType &type) override
   {
-    resolved = new UnitType (type.get_ref ());
+    resolved = new UnitType (type.get_ref (), type.get_ty_ref ());
   }
 
 private:
@@ -280,8 +278,8 @@ public:
 	return;
       }
 
-    resolved
-      = new ArrayType (type.get_ref (), type.get_capacity (), base_resolved);
+    resolved = new ArrayType (type.get_ref (), type.get_ty_ref (),
+			      type.get_capacity (), base_resolved);
   }
 
 private:
@@ -301,7 +299,7 @@ public:
 
   void visit (BoolType &type) override
   {
-    resolved = new BoolType (type.get_ref ());
+    resolved = new BoolType (type.get_ref (), type.get_ty_ref ());
   }
 
 private:
@@ -321,8 +319,14 @@ public:
 
   void visit (IntType &type) override
   {
-    // FIXME we should look at the IntTypeKind and check if i8 vs i16 etc..
-    resolved = new IntType (type.get_ref (), type.get_kind ());
+    if (type.get_kind () != base->get_kind ())
+      {
+	BaseRules::visit (type);
+	return;
+      }
+
+    resolved
+      = new IntType (type.get_ref (), type.get_ty_ref (), type.get_kind ());
   }
 
 private:
@@ -342,8 +346,14 @@ public:
 
   void visit (UintType &type) override
   {
-    // FIXME we should look at the IntTypeKind and check if u8 vs u16 etc..
-    resolved = new UintType (type.get_ref (), type.get_kind ());
+    if (type.get_kind () != base->get_kind ())
+      {
+	BaseRules::visit (type);
+	return;
+      }
+
+    resolved
+      = new UintType (type.get_ref (), type.get_ty_ref (), type.get_kind ());
   }
 
 private:
@@ -363,8 +373,14 @@ public:
 
   void visit (FloatType &type) override
   {
-    // FIXME we should look at the FloatKind and respect it
-    resolved = new FloatType (type.get_ref (), type.get_kind ());
+    if (type.get_kind () != base->get_kind ())
+      {
+	BaseRules::visit (type);
+	return;
+      }
+
+    resolved
+      = new FloatType (type.get_ref (), type.get_ty_ref (), type.get_kind ());
   }
 
 private:

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -44,6 +44,12 @@ UnitType::combine (TyBase *other)
   return r.combine (other);
 }
 
+TyBase *
+UnitType::clone ()
+{
+  return new UnitType (get_ref (), get_ty_ref ());
+}
+
 void
 InferType::accept_vis (TyVisitor &vis)
 {
@@ -53,7 +59,7 @@ InferType::accept_vis (TyVisitor &vis)
 std::string
 InferType::as_string () const
 {
-  return "[_]";
+  return "?";
 }
 
 TyBase *
@@ -61,6 +67,12 @@ InferType::combine (TyBase *other)
 {
   InferRules r (this);
   return r.combine (other);
+}
+
+TyBase *
+InferType::clone ()
+{
+  return new InferType (get_ref (), get_ty_ref ());
 }
 
 void
@@ -78,8 +90,15 @@ ErrorType::as_string () const
 TyBase *
 ErrorType::combine (TyBase *other)
 {
+  // FIXME
   // rust_error_at ();
   return this;
+}
+
+TyBase *
+ErrorType::clone ()
+{
+  return new ErrorType (get_ref ());
 }
 
 void
@@ -99,6 +118,13 @@ StructFieldType::combine (TyBase *other)
 {
   StructFieldTypeRules r (this);
   return r.combine (other);
+}
+
+TyBase *
+StructFieldType::clone ()
+{
+  return new StructFieldType (get_ref (), get_ty_ref (), get_name (),
+			      get_field_type ()->clone ());
 }
 
 void
@@ -121,6 +147,16 @@ TyBase *
 ADTType::combine (TyBase *other)
 {
   return nullptr;
+}
+
+TyBase *
+ADTType::clone ()
+{
+  std::vector<StructFieldType *> cloned_fields;
+  for (auto &f : fields)
+    cloned_fields.push_back ((StructFieldType *) f->clone ());
+
+  return new ADTType (get_ref (), get_ty_ref (), get_name (), cloned_fields);
 }
 
 void
@@ -150,6 +186,17 @@ FnType::combine (TyBase *other)
   return r.combine (other);
 }
 
+TyBase *
+FnType::clone ()
+{
+  std::vector<ParamType *> cloned_params;
+  for (auto &p : params)
+    cloned_params.push_back ((ParamType *) p->clone ());
+
+  return new FnType (get_ref (), get_ty_ref (), cloned_params,
+		     get_return_type ()->clone ());
+}
+
 void
 ParamType::accept_vis (TyVisitor &vis)
 {
@@ -167,6 +214,13 @@ ParamType::combine (TyBase *other)
 {
   ParamRules r (this);
   return r.combine (other);
+}
+
+TyBase *
+ParamType::clone ()
+{
+  return new ParamType (get_ref (), get_ty_ref (), get_identifier (),
+			get_base_type ()->clone ());
 }
 
 void
@@ -188,6 +242,13 @@ ArrayType::combine (TyBase *other)
   return r.combine (other);
 }
 
+TyBase *
+ArrayType::clone ()
+{
+  return new ArrayType (get_ref (), get_ty_ref (), get_capacity (),
+			get_type ()->clone ());
+}
+
 void
 BoolType::accept_vis (TyVisitor &vis)
 {
@@ -205,6 +266,12 @@ BoolType::combine (TyBase *other)
 {
   BoolRules r (this);
   return r.combine (other);
+}
+
+TyBase *
+BoolType::clone ()
+{
+  return new BoolType (get_ref (), get_ty_ref ());
 }
 
 void
@@ -240,6 +307,12 @@ IntType::combine (TyBase *other)
   return r.combine (other);
 }
 
+TyBase *
+IntType::clone ()
+{
+  return new IntType (get_ref (), get_ty_ref (), get_kind ());
+}
+
 void
 UintType::accept_vis (TyVisitor &vis)
 {
@@ -273,6 +346,12 @@ UintType::combine (TyBase *other)
   return r.combine (other);
 }
 
+TyBase *
+UintType::clone ()
+{
+  return new UintType (get_ref (), get_ty_ref (), get_kind ());
+}
+
 void
 FloatType::accept_vis (TyVisitor &vis)
 {
@@ -298,6 +377,12 @@ FloatType::combine (TyBase *other)
 {
   FloatRules r (this);
   return r.combine (other);
+}
+
+TyBase *
+FloatType::clone ()
+{
+  return new FloatType (get_ref (), get_ty_ref (), get_kind ());
 }
 
 void

--- a/gcc/testsuite/rust.test/fail_compilation/implicit_returns_err1.rs
+++ b/gcc/testsuite/rust.test/fail_compilation/implicit_returns_err1.rs
@@ -1,0 +1,12 @@
+fn test(x: i32) -> i32 {
+    if x > 1 {
+        1
+    } else {
+        2
+    }
+    3
+}
+
+fn main() {
+    let a = test(1);
+}

--- a/gcc/testsuite/rust.test/fail_compilation/implicit_returns_err2.rs
+++ b/gcc/testsuite/rust.test/fail_compilation/implicit_returns_err2.rs
@@ -1,0 +1,8 @@
+fn test(x: i32) -> i32 {
+    return 1;
+    true
+}
+
+fn main() {
+    let a = test(1);
+}

--- a/gcc/testsuite/rust.test/fail_compilation/implicit_returns_err3.rs
+++ b/gcc/testsuite/rust.test/fail_compilation/implicit_returns_err3.rs
@@ -1,0 +1,9 @@
+fn test(x: i32) -> i32 {
+    if x > 1 {
+        1
+    }
+}
+
+fn main() {
+    let a = test(9);
+}


### PR DESCRIPTION
This change enforces strict type checkon on all ExprWithBlock. This includes unreachable tail expressions. Specific test cases have been added for context to ensure the failure cases are hit accordingly.

This change also improves the diagnostic errors for mismatched types where the reference HirId was lost leading to default locations.

There is a general hardening of the typechecker in this patch which will be used for further changes later on. 