### PR TITLE
Handle forward references in backend compilation

### DIFF
--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -31,9 +31,9 @@ namespace Compile {
 class CompileItem : public HIRCompileBase
 {
 public:
-  static void compile (HIR::Item *item, Context *ctx)
+  static void compile (HIR::Item *item, Context *ctx, bool compile_fns = true)
   {
-    CompileItem compiler (ctx);
+    CompileItem compiler (ctx, compile_fns);
     item->accept_vis (compiler);
   }
 
@@ -116,6 +116,9 @@ public:
 
   void visit (HIR::Function &function)
   {
+    if (!compile_fns)
+      return;
+
     // items can be forward compiled which means we may not need to invoke this
     // code
     Bfunction *lookup = nullptr;
@@ -277,7 +280,11 @@ public:
   }
 
 private:
-  CompileItem (Context *ctx) : HIRCompileBase (ctx) {}
+  CompileItem (Context *ctx, bool compile_fns)
+    : HIRCompileBase (ctx), compile_fns (compile_fns)
+  {}
+
+  bool compile_fns;
 };
 
 } // namespace Compile

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -41,8 +41,11 @@ CompileCrate::Compile (HIR::Crate &crate, Context *ctx)
 void
 CompileCrate::go ()
 {
-  for (auto it = crate.items.begin (); it != crate.items.end (); it++)
-    CompileItem::compile (it->get (), ctx);
+  for (auto &item : crate.items)
+    CompileItem::compile (item.get (), ctx, false);
+
+  for (auto &item : crate.items)
+    CompileItem::compile (item.get (), ctx, true);
 }
 
 // rust-compile-block.h

--- a/gcc/testsuite/rust.test/compilable/forward_decl_2.rs
+++ b/gcc/testsuite/rust.test/compilable/forward_decl_2.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let y = x + 1;
+}
+
+static x: i32 = 3;

--- a/gcc/testsuite/rust.test/compilable/forward_decl_3.rs
+++ b/gcc/testsuite/rust.test/compilable/forward_decl_3.rs
@@ -1,0 +1,8 @@
+fn main() {
+    let struct_test = Foo { one: 1, two: 2 };
+}
+
+struct Foo {
+    one: i32,
+    two: i32,
+}

--- a/gcc/testsuite/rust.test/compilable/forward_decl_4.rs
+++ b/gcc/testsuite/rust.test/compilable/forward_decl_4.rs
@@ -1,0 +1,8 @@
+fn main() {
+    let mut x = TEST_CONST;
+    x = x + 1;
+
+    let mut y = x + TEST_CONST;
+}
+
+const TEST_CONST: i32 = 10;


### PR DESCRIPTION
We must ensure the backend can support compilation of things declared
lexically after they are referenced. This scans the toplevel except
functions which are handled as we reference them. To make that generic
enough for all toplevel items will be a move to query based compilation
which still needs planning.