### PR TITLE
Fix the naming of VAR_DECLS within gimple nodes.

### DIFF
--- a/gcc/rust/backend/rust-compile-var-decl.h
+++ b/gcc/rust/backend/rust-compile-var-decl.h
@@ -42,24 +42,33 @@ public:
 
   void visit (HIR::LetStmt &stmt)
   {
+    locus = stmt.get_locus ();
     TyTy::TyBase *resolved_type = nullptr;
     bool ok = ctx->get_tyctx ()->lookup_type (stmt.get_mappings ().get_hirid (),
 					      &resolved_type);
     rust_assert (ok);
 
-    ::Btype *translated_type = TyTyResolveCompile::compile (ctx, resolved_type);
+    translated_type = TyTyResolveCompile::compile (ctx, resolved_type);
+    stmt.get_pattern ()->accept_vis (*this);
+  }
 
-    translated = ctx->get_backend ()->local_variable (
-      fndecl, stmt.get_pattern ()->as_string (), translated_type,
-      NULL /*decl_var*/, false /*address_taken*/, stmt.get_locus ());
+  void visit (HIR::IdentifierPattern &pattern)
+  {
+    translated
+      = ctx->get_backend ()->local_variable (fndecl, pattern.variable_ident,
+					     translated_type, NULL /*decl_var*/,
+					     false /*address_taken*/, locus);
   }
 
 private:
   CompileVarDecl (Context *ctx, ::Bfunction *fndecl)
-    : HIRCompileBase (ctx), fndecl (fndecl), translated (nullptr)
+    : HIRCompileBase (ctx), fndecl (fndecl), translated_type (nullptr),
+      translated (nullptr)
   {}
 
   ::Bfunction *fndecl;
+  ::Btype *translated_type;
+  Location locus;
   ::Bvariable *translated;
 };
 


### PR DESCRIPTION
This was using LetStmt->Pattern.as_string which included mut in the string
dump. This makes the gimple nodes harder to debug as the name is (mut a)
instead of a for example.

Addresses: #77 