### PR TITLE
Expressions within parentheses

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -406,6 +406,11 @@ public:
 						     struct_expr.get_locus ());
   }
 
+  void visit (HIR::GroupedExpr &expr)
+  {
+    translated = CompileExpr::Compile (expr.get_expr_in_parens ().get (), ctx);
+  }
+
 private:
   CompileExpr (Context *ctx) : HIRCompileBase (ctx), translated (nullptr) {}
 

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -525,6 +525,25 @@ public:
 					 inner_attribs, outer_attribs);
   }
 
+  void visit (AST::GroupedExpr &expr)
+  {
+    std::vector<HIR::Attribute> inner_attribs;
+    std::vector<HIR::Attribute> outer_attribs;
+
+    HIR::Expr *paren_expr
+      = ASTLoweringExpr::translate (expr.get_expr_in_parens ().get ());
+
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, expr.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   UNKNOWN_LOCAL_DEFID);
+
+    translated
+      = new HIR::GroupedExpr (mapping, std::unique_ptr<HIR::Expr> (paren_expr),
+			      std::move (inner_attribs),
+			      std::move (outer_attribs), expr.get_locus ());
+  }
+
 private:
   ASTLoweringExpr ()
     : translated (nullptr), translated_array_elems (nullptr), terminated (false)

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -880,6 +880,12 @@ public:
 
   void accept_vis (HIRVisitor &vis) override;
 
+  std::unique_ptr<Expr> &get_expr_in_parens ()
+  {
+    rust_assert (expr_in_parens != nullptr);
+    return expr_in_parens;
+  }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */

--- a/gcc/rust/resolve/rust-ast-resolve-expr.h
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.h
@@ -181,6 +181,11 @@ public:
       });
   }
 
+  void visit (AST::GroupedExpr &expr)
+  {
+    ResolveExpr::go (expr.get_expr_in_parens ().get (), expr.get_node_id ());
+  }
+
 private:
   ResolveExpr (NodeId parent) : ResolverBase (parent) {}
 };

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -417,6 +417,11 @@ public:
     infered = TypeCheckStructExpr::Resolve (&struct_expr);
   }
 
+  void visit (HIR::GroupedExpr &expr)
+  {
+    infered = TypeCheckExpr::Resolve (expr.get_expr_in_parens ().get ());
+  }
+
 private:
   TypeCheckExpr (bool is_final_expr)
     : TypeCheckBase (), infered (nullptr), infered_array_elems (nullptr),

--- a/gcc/testsuite/rust.test/compilable/parens1.rs
+++ b/gcc/testsuite/rust.test/compilable/parens1.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let a = 123;
+    let b = a + (a * 2);
+}


### PR DESCRIPTION
This makes the expression handling support exprs within parens. Such as:
      x = (2*a) + 3;