### PR TITLE
Fix '#include <algorithm>'

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -22,8 +22,6 @@ along with GCC; see the file COPYING3.  If not see
 
 #include "rust-diagnostics.h"
 
-#include <algorithm> // for std::find
-
 namespace Rust {
 // Left binding powers of operations.
 enum binding_powers

--- a/gcc/rust/parse/rust-parse.cc
+++ b/gcc/rust/parse/rust-parse.cc
@@ -41,8 +41,6 @@ along with GCC; see the file COPYING3.  If not see
 #endif
 // maybe put these back in if compiling no longer works
 
-#include <algorithm> // for std::find
-
 /* TODO: move non-essential stuff back here from rust-parse-impl.h after
  * confirming that it works */
 

--- a/gcc/rust/rust-system.h
+++ b/gcc/rust/rust-system.h
@@ -20,6 +20,7 @@
 #ifndef RUST_SYSTEM_H
 #define RUST_SYSTEM_H
 
+#define INCLUDE_ALGORITHM
 #include "config.h"
 
 /* Define this so that inttypes.h defines the PRI?64 macros even
@@ -30,7 +31,6 @@
 
 // These must be included before the #poison declarations in system.h.
 
-#include <algorithm>
 #include <string>
 #include <list>
 #include <map>


### PR DESCRIPTION
GCC doesn't like that:

    In file included from [...]
    ./mm_malloc.h:42:12: error: attempt to use poisoned "malloc"
         return malloc (__size);
            ^

See commit e7b3f654f2ab0400c95c0517387a9ad645a5c4cd, for example.