### PR TITLE
Turn brace-enclosed initializer list into actual assignments

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -12241,10 +12241,9 @@ Parser<ManagedTokenSource>::null_denotation (
 
 	// HACK: as struct expressions should always be value expressions,
 	// cannot be referenced
-	ParseRestrictions entered_from_unary
-	  = {/* can_be_struct_expr = */ false, /* entered_from_unary = */ true};
-	/*entered_from_unary.entered_from_unary = true;
-	entered_from_unary.can_be_struct_expr = false;*/
+	ParseRestrictions entered_from_unary;
+	entered_from_unary.entered_from_unary = true;
+	entered_from_unary.can_be_struct_expr = false;
 
 	if (lexer.peek_token ()->get_id () == MUT)
 	  {


### PR DESCRIPTION
... as used otherwise, in this file.  And, this avoids:

    [...]/source-gcc/gcc/rust/parse/rust-parse-impl.h:12243:72: error: could not convert '{false, true}' from '<brace-enclosed initializer list>' to 'Rust::ParseRestrictions'
        = {/* can_be_struct_expr = */ false, /* entered_from_unary = */ true};
                                                                            ^