### PR TITLE
Struct constructors

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -882,6 +882,8 @@ public:
 
   virtual NodeId get_node_id () const { return node_id; }
 
+  virtual void set_node_id (NodeId id) { node_id = id; }
+
 protected:
   // Constructor
   Expr (std::vector<Attribute> outer_attribs = std::vector<Attribute> ())

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -1604,6 +1604,8 @@ public:
 
   void accept_vis (ASTVisitor &vis) override;
 
+  Identifier get_field_name () const { return field_name; }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -225,11 +225,42 @@ public:
 
   void visit (TyTy::InferType &type) override { gcc_unreachable (); }
 
-  void visit (TyTy::FnType &type) override { gcc_unreachable (); }
-
   void visit (TyTy::StructFieldType &type) override { gcc_unreachable (); }
 
   void visit (TyTy::ParamType &type) override { gcc_unreachable (); }
+
+  void visit (TyTy::FnType &type) override
+  {
+    Backend::Btyped_identifier receiver;
+    std::vector<Backend::Btyped_identifier> parameters;
+    std::vector<Backend::Btyped_identifier> results;
+
+    if (!type.get_return_type ()->is_unit ())
+      {
+	auto hir_type = type.get_return_type ();
+	auto ret = TyTyResolveCompile::compile (ctx, hir_type);
+	results.push_back (Backend::Btyped_identifier (
+	  "_", ret,
+	  ctx->get_mappings ()->lookup_location (hir_type->get_ref ())));
+      }
+
+    for (size_t i = 0; i < type.num_params (); i++)
+      {
+	auto param_tyty = type.param_at (i);
+	auto compiled_param_type
+	  = TyTyResolveCompile::compile (ctx, param_tyty->get_base_type ());
+
+	auto compiled_param = Backend::Btyped_identifier (
+	  param_tyty->get_identifier (), compiled_param_type,
+	  ctx->get_mappings ()->lookup_location (param_tyty->get_ref ()));
+
+	parameters.push_back (compiled_param);
+      }
+
+    translated = ctx->get_backend ()->function_type (
+      receiver, parameters, results, NULL,
+      ctx->get_mappings ()->lookup_location (type.get_ref ()));
+  }
 
   void visit (TyTy::UnitType &type) override
   {
@@ -318,6 +349,51 @@ private:
 
   Context *ctx;
   ::Btype *translated;
+};
+
+class TyTyCompileParam : public TyTy::TyVisitor
+{
+public:
+  static ::Bvariable *compile (Context *ctx, Bfunction *fndecl,
+			       TyTy::TyBase *ty)
+  {
+    TyTyCompileParam compiler (ctx, fndecl);
+    ty->accept_vis (compiler);
+    rust_assert (compiler.translated != nullptr);
+    return compiler.translated;
+  }
+
+  ~TyTyCompileParam () {}
+
+  void visit (TyTy::UnitType &type) override { gcc_unreachable (); }
+  void visit (TyTy::InferType &type) override { gcc_unreachable (); }
+  void visit (TyTy::StructFieldType &type) override { gcc_unreachable (); }
+  void visit (TyTy::ADTType &type) override { gcc_unreachable (); }
+  void visit (TyTy::FnType &type) override { gcc_unreachable (); }
+  void visit (TyTy::ArrayType &type) override { gcc_unreachable (); }
+  void visit (TyTy::BoolType &type) override { gcc_unreachable (); }
+  void visit (TyTy::IntType &type) override { gcc_unreachable (); }
+  void visit (TyTy::UintType &type) override { gcc_unreachable (); }
+  void visit (TyTy::FloatType &type) override { gcc_unreachable (); }
+  void visit (TyTy::ErrorType &type) override { gcc_unreachable (); }
+
+  void visit (TyTy::ParamType &type) override
+  {
+    auto btype = TyTyResolveCompile::compile (ctx, type.get_base_type ());
+    bool tree_addressable = false;
+    translated = ctx->get_backend ()->parameter_variable (
+      fndecl, type.get_identifier (), btype, tree_addressable,
+      ctx->get_mappings ()->lookup_location (type.get_ref ()));
+  }
+
+private:
+  TyTyCompileParam (Context *ctx, ::Bfunction *fndecl)
+    : ctx (ctx), fndecl (fndecl), translated (nullptr)
+  {}
+
+  Context *ctx;
+  ::Bfunction *fndecl;
+  ::Bvariable *translated;
 };
 
 } // namespace Compile

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -86,24 +86,7 @@ public:
     ctx->add_statement (s);
   }
 
-  void visit (HIR::CallExpr &expr)
-  {
-    Bexpression *fn = ResolvePathRef::Compile (expr.get_fnexpr (), ctx);
-    rust_assert (fn != nullptr);
-
-    std::vector<Bexpression *> args;
-    expr.iterate_params ([&] (HIR::Expr *p) mutable -> bool {
-      Bexpression *compiled_expr = CompileExpr::Compile (p, ctx);
-      rust_assert (compiled_expr != nullptr);
-      args.push_back (compiled_expr);
-      return true;
-    });
-
-    auto fncontext = ctx->peek_fn ();
-    translated
-      = ctx->get_backend ()->call_expression (fncontext.fndecl, fn, args,
-					      nullptr, expr.get_locus ());
-  }
+  void visit (HIR::CallExpr &expr);
 
   void visit (HIR::IdentifierExpr &expr)
   {

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -38,6 +38,17 @@ public:
     return compiler.translated;
   }
 
+  void visit (HIR::TupleIndexExpr &expr)
+  {
+    HIR::Expr *tuple_expr = expr.get_tuple_expr ().get ();
+    TupleIndex index = expr.get_tuple_index ();
+
+    Bexpression *receiver_ref = CompileExpr::Compile (tuple_expr, ctx);
+    translated
+      = ctx->get_backend ()->struct_field_expression (receiver_ref, index,
+						      expr.get_locus ());
+  }
+
   void visit (HIR::TupleExpr &expr)
   {
     if (expr.is_unit ())

--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -127,16 +127,16 @@ public:
 	  return;
       }
 
-    TyTy::TyBase *fnType;
+    TyTy::TyBase *fntype;
     if (!ctx->get_tyctx ()->lookup_type (function.get_mappings ().get_hirid (),
-					 &fnType))
+					 &fntype))
       {
 	rust_fatal_error (function.locus, "failed to lookup function type");
 	return;
       }
 
     // convert to the actual function type
-    auto compiled_fn_type = TyTyCompile::compile (ctx->get_backend (), fnType);
+    ::Btype *compiled_fn_type = TyTyResolveCompile::compile (ctx, fntype);
 
     unsigned int flags = 0;
     bool is_main_fn = function.function_name.compare ("main") == 0;
@@ -159,15 +159,14 @@ public:
     ctx->insert_function_decl (function.get_mappings ().get_hirid (), fndecl);
 
     // setup the params
-    TyTy::TyBase *tyret = TyTyExtractRetFromFnType::compile (fnType);
+    TyTy::TyBase *tyret = TyTyExtractRetFromFnType::compile (fntype);
     std::vector<TyTy::ParamType *> typarams
-      = TyTyExtractParamsFromFnType::compile (fnType);
+      = TyTyExtractParamsFromFnType::compile (fntype);
     std::vector<Bvariable *> param_vars;
 
     for (auto &it : typarams)
       {
-	auto compiled_param
-	  = TyTyCompileParam::compile (ctx->get_backend (), fndecl, it);
+	auto compiled_param = TyTyCompileParam::compile (ctx, fndecl, it);
 	param_vars.push_back (compiled_param);
 
 	ctx->insert_var_decl (it->get_ref (), compiled_param);
@@ -226,7 +225,7 @@ public:
     Bvariable *return_address = nullptr;
     if (function.has_function_return_type ())
       {
-	Btype *return_type = TyTyCompile::compile (ctx->get_backend (), tyret);
+	Btype *return_type = TyTyResolveCompile::compile (ctx, tyret);
 
 	bool address_is_taken = false;
 	Bstatement *ret_var_stmt = nullptr;

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -32,7 +32,6 @@ ResolvePathRef::visit (HIR::PathInExpression &expr)
   if (!ctx->get_resolver ()->lookup_resolved_name (
 	expr.get_mappings ().get_nodeid (), &ref_node_id))
     {
-      rust_fatal_error (expr.get_locus (), "failed to look up resolved name");
       return;
     }
 
@@ -40,7 +39,7 @@ ResolvePathRef::visit (HIR::PathInExpression &expr)
   if (!ctx->get_mappings ()->lookup_node_to_hir (
 	expr.get_mappings ().get_crate_num (), ref_node_id, &ref))
     {
-      rust_fatal_error (expr.get_locus (), "reverse lookup failure");
+      rust_error_at (expr.get_locus (), "reverse lookup failure");
       return;
     }
 
@@ -54,14 +53,14 @@ ResolvePathRef::visit (HIR::PathInExpression &expr)
 	expr.get_mappings ().get_crate_num (), ref);
       if (resolved_item == nullptr)
 	{
-	  rust_fatal_error (expr.get_locus (), "failed to lookup forward decl");
+	  rust_error_at (expr.get_locus (), "failed to lookup forward decl");
 	  return;
 	}
 
       CompileItem::compile (resolved_item, ctx);
       if (!ctx->lookup_function_decl (ref, &fn))
 	{
-	  rust_fatal_error (expr.get_locus (), "forward decl was not compiled");
+	  rust_error_at (expr.get_locus (), "forward decl was not compiled");
 	  return;
 	}
     }
@@ -78,7 +77,6 @@ ResolvePathType::visit (HIR::PathInExpression &expr)
   if (!ctx->get_resolver ()->lookup_resolved_type (
 	expr.get_mappings ().get_nodeid (), &ref_node_id))
     {
-      rust_fatal_error (expr.get_locus (), "failed to look up resolved name");
       return;
     }
 
@@ -86,14 +84,14 @@ ResolvePathType::visit (HIR::PathInExpression &expr)
   if (!ctx->get_mappings ()->lookup_node_to_hir (
 	expr.get_mappings ().get_crate_num (), ref_node_id, &ref))
     {
-      rust_fatal_error (expr.get_locus (), "reverse lookup failure");
+      rust_error_at (expr.get_locus (), "reverse lookup failure");
       return;
     }
 
   // assumes paths are functions for now
   if (!ctx->lookup_compiled_types (ref, &resolved))
     {
-      rust_fatal_error (expr.get_locus (), "forward decl was not compiled");
+      rust_error_at (expr.get_locus (), "forward decl was not compiled");
       return;
     }
 }

--- a/gcc/rust/backend/rust-compile-resolve-path.h
+++ b/gcc/rust/backend/rust-compile-resolve-path.h
@@ -32,7 +32,6 @@ public:
   {
     ResolvePathRef resolver (ctx);
     expr->accept_vis (resolver);
-    rust_assert (resolver.resolved != nullptr);
     return resolver.resolved;
   }
 
@@ -51,7 +50,6 @@ public:
   {
     ResolvePathType resolver (ctx);
     expr->accept_vis (resolver);
-    rust_assert (resolver.resolved != nullptr);
     return resolver.resolved;
   }
 

--- a/gcc/rust/backend/rust-compile-struct-field-expr.h
+++ b/gcc/rust/backend/rust-compile-struct-field-expr.h
@@ -38,6 +38,8 @@ public:
 
   void visit (HIR::StructExprFieldIdentifierValue &field);
 
+  void visit (HIR::StructExprFieldIndexValue &field);
+
 private:
   CompileStructExprField (Context *ctx)
     : HIRCompileBase (ctx), translated (nullptr)

--- a/gcc/rust/backend/rust-compile-struct-field-expr.h
+++ b/gcc/rust/backend/rust-compile-struct-field-expr.h
@@ -40,6 +40,8 @@ public:
 
   void visit (HIR::StructExprFieldIndexValue &field);
 
+  void visit (HIR::StructExprFieldIdentifier &field);
+
 private:
   CompileStructExprField (Context *ctx)
     : HIRCompileBase (ctx), translated (nullptr)

--- a/gcc/rust/backend/rust-compile-tyty.h
+++ b/gcc/rust/backend/rust-compile-tyty.h
@@ -278,54 +278,6 @@ private:
   TyTy::TyBase *translated;
 };
 
-class TyTyCompileParam : public TyTy::TyVisitor
-{
-public:
-  static ::Bvariable *compile (::Backend *backend, Bfunction *fndecl,
-			       TyTy::TyBase *ty)
-  {
-    TyTyCompileParam compiler (backend, fndecl);
-    ty->accept_vis (compiler);
-    rust_assert (compiler.translated != nullptr);
-    return compiler.translated;
-  }
-
-  ~TyTyCompileParam () {}
-
-  void visit (TyTy::UnitType &type) override { gcc_unreachable (); }
-  void visit (TyTy::InferType &type) override { gcc_unreachable (); }
-  void visit (TyTy::StructFieldType &type) override { gcc_unreachable (); }
-  void visit (TyTy::ADTType &type) override { gcc_unreachable (); }
-  void visit (TyTy::FnType &type) override { gcc_unreachable (); }
-  void visit (TyTy::ArrayType &type) override { gcc_unreachable (); }
-  void visit (TyTy::BoolType &type) override { gcc_unreachable (); }
-  void visit (TyTy::IntType &type) override { gcc_unreachable (); }
-  void visit (TyTy::UintType &type) override { gcc_unreachable (); }
-  void visit (TyTy::FloatType &type) override { gcc_unreachable (); }
-  void visit (TyTy::ErrorType &type) override { gcc_unreachable (); }
-
-  void visit (TyTy::ParamType &type) override
-  {
-    auto btype = TyTyCompile::compile (backend, type.get_base_type ());
-    bool tree_addressable = false;
-    translated = backend->parameter_variable (fndecl, type.get_identifier (),
-					      btype, tree_addressable,
-					      mappings->lookup_location (
-						type.get_ref ()));
-  }
-
-private:
-  TyTyCompileParam (::Backend *backend, ::Bfunction *fndecl)
-    : backend (backend), translated (nullptr), fndecl (fndecl),
-      mappings (Analysis::Mappings::get ())
-  {}
-
-  ::Backend *backend;
-  ::Bvariable *translated;
-  ::Bfunction *fndecl;
-  Analysis::Mappings *mappings;
-};
-
 } // namespace Compile
 } // namespace Rust
 

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -48,6 +48,53 @@ CompileCrate::go ()
     CompileItem::compile (item.get (), ctx, true);
 }
 
+// rust-compile-expr.h
+
+void
+CompileExpr::visit (HIR::CallExpr &expr)
+{
+  // this can be a function call or it can be a constructor for a tuple struct
+  Bexpression *fn = ResolvePathRef::Compile (expr.get_fnexpr (), ctx);
+  if (fn != nullptr)
+    {
+      std::vector<Bexpression *> args;
+      expr.iterate_params ([&] (HIR::Expr *p) mutable -> bool {
+	Bexpression *compiled_expr = CompileExpr::Compile (p, ctx);
+	rust_assert (compiled_expr != nullptr);
+	args.push_back (compiled_expr);
+	return true;
+      });
+
+      auto fncontext = ctx->peek_fn ();
+      translated
+	= ctx->get_backend ()->call_expression (fncontext.fndecl, fn, args,
+						nullptr, expr.get_locus ());
+    }
+  else
+    {
+      Btype *type = ResolvePathType::Compile (expr.get_fnexpr (), ctx);
+      if (type == nullptr)
+	{
+	  rust_fatal_error (expr.get_locus (),
+			    "failed to lookup type associated with call");
+	  return;
+	}
+
+      // this assumes all fields are in order from type resolution and if a base
+      // struct was specified those fields are filed via accesors
+      std::vector<Bexpression *> vals;
+      expr.iterate_params ([&] (HIR::Expr *argument) mutable -> bool {
+	Bexpression *e = CompileExpr::Compile (argument, ctx);
+	vals.push_back (e);
+	return true;
+      });
+
+      translated
+	= ctx->get_backend ()->constructor_expression (type, vals,
+						       expr.get_locus ());
+    }
+}
+
 // rust-compile-block.h
 
 void

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -234,5 +234,15 @@ CompileStructExprField::visit (HIR::StructExprFieldIndexValue &field)
   translated = CompileExpr::Compile (field.get_value (), ctx);
 }
 
+void
+CompileStructExprField::visit (HIR::StructExprFieldIdentifier &field)
+{
+  // we can make the field look like an identifier expr to take advantage of
+  // existing code
+  HIR::IdentifierExpr expr (field.get_mappings (), field.get_field_name (),
+			    field.get_locus ());
+  translated = CompileExpr::Compile (&expr, ctx);
+}
+
 } // namespace Compile
 } // namespace Rust

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -228,5 +228,11 @@ CompileStructExprField::visit (HIR::StructExprFieldIdentifierValue &field)
   translated = CompileExpr::Compile (field.get_value (), ctx);
 }
 
+void
+CompileStructExprField::visit (HIR::StructExprFieldIndexValue &field)
+{
+  translated = CompileExpr::Compile (field.get_value (), ctx);
+}
+
 } // namespace Compile
 } // namespace Rust

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -132,6 +132,25 @@ public:
     return resolver.translated;
   }
 
+  void visit (AST::TupleIndexExpr &expr)
+  {
+    std::vector<HIR::Attribute> outer_attribs;
+
+    HIR::Expr *tuple_expr
+      = ASTLoweringExpr::translate (expr.get_tuple_expr ().get (), &terminated);
+
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, expr.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   UNKNOWN_LOCAL_DEFID);
+
+    translated
+      = new HIR::TupleIndexExpr (mapping,
+				 std::unique_ptr<HIR::Expr> (tuple_expr),
+				 expr.get_tuple_index (),
+				 std::move (outer_attribs), expr.get_locus ());
+  }
+
   void visit (AST::TupleExpr &expr)
   {
     std::vector<HIR::Attribute> inner_attribs;

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -274,8 +274,7 @@ public:
     for (auto &param : fn->function_params)
       {
 	mappings->insert_hir_param (mapping.get_crate_num (),
-				    param.get_mappings ()->get_hirid (),
-				    &param);
+				    param.get_mappings ().get_hirid (), &param);
 	mappings->insert_location (crate_num, mapping.get_hirid (),
 				   param.get_locus ());
       }

--- a/gcc/rust/hir/rust-ast-lower-struct-field-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-struct-field-expr.h
@@ -46,6 +46,8 @@ public:
 
   void visit (AST::StructExprFieldIdentifierValue &field);
 
+  void visit (AST::StructExprFieldIndexValue &field);
+
 private:
   ASTLowerStructExprField () : translated (nullptr) {}
 

--- a/gcc/rust/hir/rust-ast-lower-struct-field-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-struct-field-expr.h
@@ -34,10 +34,13 @@ public:
     field->accept_vis (compiler);
     rust_assert (compiler.translated != nullptr);
 
-    // compiler.mappings->insert_hir_expr (
-    //   compiler.translated->get_mappings ().get_crate_num (),
-    //   compiler.translated->get_mappings ().get_hirid (),
-    //   compiler.translated);
+    compiler.mappings->insert_hir_struct_field (
+      compiler.translated->get_mappings ().get_crate_num (),
+      compiler.translated->get_mappings ().get_hirid (), compiler.translated);
+    compiler.mappings->insert_location (
+      compiler.translated->get_mappings ().get_crate_num (),
+      compiler.translated->get_mappings ().get_hirid (),
+      field->get_locus_slow ());
 
     return compiler.translated;
   }
@@ -47,6 +50,8 @@ public:
   void visit (AST::StructExprFieldIdentifierValue &field);
 
   void visit (AST::StructExprFieldIndexValue &field);
+
+  void visit (AST::StructExprFieldIdentifier &field);
 
 private:
   ASTLowerStructExprField () : translated (nullptr) {}

--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -228,5 +228,18 @@ ASTLowerStructExprField::visit (AST::StructExprFieldIndexValue &field)
 					  field.get_locus ());
 }
 
+void
+ASTLowerStructExprField::visit (AST::StructExprFieldIdentifier &field)
+{
+  auto crate_num = mappings->get_current_crate ();
+  Analysis::NodeMapping mapping (crate_num, field.get_node_id (),
+				 mappings->get_next_hir_id (crate_num),
+				 UNKNOWN_LOCAL_DEFID);
+
+  translated
+    = new HIR::StructExprFieldIdentifier (mapping, field.get_field_name (),
+					  field.get_locus ());
+}
+
 } // namespace HIR
 } // namespace Rust

--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -212,5 +212,21 @@ ASTLowerStructExprField::visit (AST::StructExprFieldIdentifierValue &field)
     field.get_locus ());
 }
 
+void
+ASTLowerStructExprField::visit (AST::StructExprFieldIndexValue &field)
+{
+  HIR::Expr *value = ASTLoweringExpr::translate (field.get_value ().get ());
+
+  auto crate_num = mappings->get_current_crate ();
+  Analysis::NodeMapping mapping (crate_num, field.get_node_id (),
+				 mappings->get_next_hir_id (crate_num),
+				 UNKNOWN_LOCAL_DEFID);
+
+  translated
+    = new HIR::StructExprFieldIndexValue (mapping, field.get_index (),
+					  std::unique_ptr<HIR::Expr> (value),
+					  field.get_locus ());
+}
+
 } // namespace HIR
 } // namespace Rust

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -1669,6 +1669,16 @@ public:
       }
   }
 
+  std::vector<std::unique_ptr<StructExprField> > &get_fields ()
+  {
+    return fields;
+  };
+
+  const std::vector<std::unique_ptr<StructExprField> > &get_fields () const
+  {
+    return fields;
+  };
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -1314,6 +1314,12 @@ public:
 
   void accept_vis (HIRVisitor &vis) override;
 
+  std::unique_ptr<Expr> &get_tuple_expr ()
+  {
+    rust_assert (tuple_expr != nullptr);
+    return tuple_expr;
+  }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -1496,6 +1496,8 @@ public:
 
   void accept_vis (HIRVisitor &vis) override;
 
+  Identifier get_field_name () const { return field_name; }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -1679,6 +1679,17 @@ public:
     return fields;
   };
 
+  std::vector<std::unique_ptr<StructExprField> > get_fields_as_owner ()
+  {
+    return std::move (fields);
+  };
+
+  void set_fields_as_owner (
+    std::vector<std::unique_ptr<StructExprField> > new_fields)
+  {
+    fields = std::move (new_fields);
+  }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -1591,6 +1591,8 @@ public:
 
   void accept_vis (HIRVisitor &vis) override;
 
+  TupleIndex get_tuple_index () const { return index; };
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -448,7 +448,7 @@ public:
 
   Type *get_type () { return type.get (); }
 
-  Analysis::NodeMapping *get_mappings () { return &mappings; }
+  Analysis::NodeMapping &get_mappings () { return mappings; }
 };
 
 // Visibility of item - if the item has it, then it is some form of public

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -1604,7 +1604,9 @@ private:
 
   std::unique_ptr<Type> field_type;
 
-  // should this store location info?
+  Location locus;
+
+  Analysis::NodeMapping mappings;
 
 public:
   // Returns whether tuple field has outer attributes.
@@ -1615,16 +1617,18 @@ public:
   bool has_visibility () const { return !visibility.is_error (); }
 
   // Complete constructor
-  TupleField (std::unique_ptr<Type> field_type, Visibility vis,
+  TupleField (Analysis::NodeMapping mapping, std::unique_ptr<Type> field_type,
+	      Visibility vis, Location locus,
 	      std::vector<Attribute> outer_attrs = std::vector<Attribute> ())
     : outer_attrs (std::move (outer_attrs)), visibility (std::move (vis)),
-      field_type (std::move (field_type))
+      field_type (std::move (field_type)), locus (locus), mappings (mapping)
   {}
 
   // Copy constructor with clone
   TupleField (TupleField const &other)
     : outer_attrs (other.outer_attrs), visibility (other.visibility),
-      field_type (other.field_type->clone_type ())
+      field_type (other.field_type->clone_type ()), locus (other.locus),
+      mappings (other.mappings)
   {}
 
   ~TupleField () = default;
@@ -1635,6 +1639,8 @@ public:
     field_type = other.field_type->clone_type ();
     visibility = other.visibility;
     outer_attrs = other.outer_attrs;
+    locus = other.locus;
+    mappings = other.mappings;
 
     return *this;
   }
@@ -1646,13 +1652,13 @@ public:
   // Returns whether tuple field is in an error state.
   bool is_error () const { return field_type == nullptr; }
 
-  // Creates an error state tuple field.
-  static TupleField create_error ()
-  {
-    return TupleField (nullptr, Visibility::create_error ());
-  }
-
   std::string as_string () const;
+
+  Analysis::NodeMapping get_mappings () { return mappings; }
+
+  Location get_locus () const { return locus; }
+
+  std::unique_ptr<HIR::Type> &get_field_type () { return field_type; }
 };
 
 // Rust tuple declared using struct keyword HIR node
@@ -1676,6 +1682,18 @@ public:
   {}
 
   void accept_vis (HIRVisitor &vis) override;
+
+  std::vector<TupleField> &get_fields () { return fields; }
+  const std::vector<TupleField> &get_fields () const { return fields; }
+
+  void iterate (std::function<bool (TupleField &)> cb)
+  {
+    for (auto &field : fields)
+      {
+	if (!cb (field))
+	  return;
+      }
+  }
 
 protected:
   /* Use covariance to implement clone function as returning this object

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -819,15 +819,15 @@ public:
 
   const Analysis::NodeMapping &get_mappings () const { return mappings; }
 
+  // Clone function implementation as pure virtual method
+  virtual Expr *clone_expr_impl () const = 0;
+
 protected:
   // Constructor
   Expr (Analysis::NodeMapping mappings,
 	std::vector<Attribute> outer_attribs = std::vector<Attribute> ())
     : outer_attrs (std::move (outer_attribs)), mappings (std::move (mappings))
   {}
-
-  // Clone function implementation as pure virtual method
-  virtual Expr *clone_expr_impl () const = 0;
 
   // TODO: think of less hacky way to implement this kind of thing
   // Sets outer attributes.

--- a/gcc/rust/resolve/rust-ast-resolve-expr.h
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.h
@@ -83,7 +83,6 @@ public:
       ResolveExpr::go (p, expr.get_node_id ());
       return true;
     });
-    // resolver->insert_resolved_name(NodeId refId,NodeId defId)
   }
 
   void visit (AST::AssignmentExpr &expr)

--- a/gcc/rust/resolve/rust-ast-resolve-expr.h
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.h
@@ -179,6 +179,14 @@ public:
   {
     ResolveExpr::go (&struct_expr.get_struct_name (),
 		     struct_expr.get_node_id ());
+
+    if (struct_expr.has_struct_base ())
+      {
+	AST::StructBase &base = struct_expr.get_struct_base ();
+	ResolveExpr::go (base.get_base_struct ().get (),
+			 struct_expr.get_node_id ());
+      }
+
     struct_expr.iterate (
       [&] (AST::StructExprField *struct_field) mutable -> bool {
 	ResolveStructExprField::go (struct_field, struct_expr.get_node_id ());

--- a/gcc/rust/resolve/rust-ast-resolve-expr.h
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.h
@@ -35,6 +35,11 @@ public:
     expr->accept_vis (resolver);
   };
 
+  void visit (AST::TupleIndexExpr &expr)
+  {
+    ResolveExpr::go (expr.get_tuple_expr ().get (), expr.get_node_id ());
+  }
+
   void visit (AST::TupleExpr &expr)
   {
     if (expr.is_unit ())

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -40,10 +40,20 @@ public:
 
   ~ResolveItem () {}
 
+  void visit (AST::TupleStruct &struct_decl)
+  {
+    struct_decl.iterate ([&] (AST::TupleField &field) mutable -> bool {
+      ResolveType::go (field.get_field_type ().get (),
+		       struct_decl.get_node_id ());
+      return true;
+    });
+  }
+
   void visit (AST::StructStruct &struct_decl)
   {
     struct_decl.iterate ([&] (AST::StructField &field) mutable -> bool {
-      ResolveType::go (field.get_field_type ().get (), field.get_node_id ());
+      ResolveType::go (field.get_field_type ().get (),
+		       struct_decl.get_node_id ());
       return true;
     });
   }

--- a/gcc/rust/resolve/rust-ast-resolve-struct-expr-field.h
+++ b/gcc/rust/resolve/rust-ast-resolve-struct-expr-field.h
@@ -26,8 +26,7 @@ namespace Rust {
 namespace Resolver {
 
 // this resolves values being assigned not that the field actually exists yet.
-// We cant resolve the field to struct until type resolution since the HIR
-// Mappings don't exist yet.
+
 class ResolveStructExprField : public ResolverBase
 {
 public:
@@ -42,6 +41,8 @@ public:
   void visit (AST::StructExprFieldIdentifierValue &field);
 
   void visit (AST::StructExprFieldIndexValue &field);
+
+  void visit (AST::StructExprFieldIdentifier &field);
 
 private:
   ResolveStructExprField (NodeId parent) : ResolverBase (parent) {}

--- a/gcc/rust/resolve/rust-ast-resolve-struct-expr-field.h
+++ b/gcc/rust/resolve/rust-ast-resolve-struct-expr-field.h
@@ -41,7 +41,7 @@ public:
 
   void visit (AST::StructExprFieldIdentifierValue &field);
 
-  // TODO
+  void visit (AST::StructExprFieldIndexValue &field);
 
 private:
   ResolveStructExprField (NodeId parent) : ResolverBase (parent) {}

--- a/gcc/rust/resolve/rust-ast-resolve-toplevel.h
+++ b/gcc/rust/resolve/rust-ast-resolve-toplevel.h
@@ -36,6 +36,13 @@ public:
 
   ~ResolveTopLevel () {}
 
+  void visit (AST::TupleStruct &struct_decl)
+  {
+    resolver->get_type_scope ().insert (struct_decl.get_identifier (),
+					struct_decl.get_node_id (),
+					struct_decl.get_locus ());
+  }
+
   void visit (AST::StructStruct &struct_decl)
   {
     resolver->get_type_scope ().insert (struct_decl.get_identifier (),

--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -324,5 +324,14 @@ ResolveStructExprField::visit (AST::StructExprFieldIndexValue &field)
   ResolveExpr::go (field.get_value ().get (), field.get_node_id ());
 }
 
+void
+ResolveStructExprField::visit (AST::StructExprFieldIdentifier &field)
+{
+  AST::IdentifierExpr expr (field.get_field_name (), field.get_locus ());
+  expr.set_node_id (field.get_node_id ());
+
+  ResolveExpr::go (&expr, field.get_node_id ());
+}
+
 } // namespace Resolver
 } // namespace Rust

--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -318,5 +318,11 @@ ResolveStructExprField::visit (AST::StructExprFieldIdentifierValue &field)
   ResolveExpr::go (field.get_value ().get (), field.get_node_id ());
 }
 
+void
+ResolveStructExprField::visit (AST::StructExprFieldIndexValue &field)
+{
+  ResolveExpr::go (field.get_value ().get (), field.get_node_id ());
+}
+
 } // namespace Resolver
 } // namespace Rust

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -41,8 +41,7 @@ public:
       resolver.infered
 	= new TyTy::UnitType (expr->get_mappings ().get_hirid ());
 
-    resolver.context->insert_type (expr->get_mappings ().get_hirid (),
-				   resolver.infered);
+    resolver.context->insert_type (expr->get_mappings (), resolver.infered);
     return resolver.infered;
   }
 
@@ -183,8 +182,7 @@ public:
 
     infered = lhs->combine (rhs);
     // need to overrite the lhs type with this combination
-    context->insert_type (expr.get_lhs ()->get_mappings ().get_hirid (),
-			  infered);
+    context->insert_type (expr.get_lhs ()->get_mappings (), infered);
   }
 
   void visit (HIR::IdentifierExpr &expr)

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.h
@@ -69,26 +69,24 @@ public:
 	    return;
 	  }
 
-	context->insert_type (stmt.get_mappings ().get_hirid (), combined);
+	context->insert_type (stmt.get_mappings (), combined);
       }
     else
       {
 	// let x:i32;
 	if (specified_ty != nullptr)
 	  {
-	    context->insert_type (stmt.get_mappings ().get_hirid (),
-				  specified_ty);
+	    context->insert_type (stmt.get_mappings (), specified_ty);
 	  }
 	// let x = 123;
 	else if (init_expr_ty != nullptr)
 	  {
-	    context->insert_type (stmt.get_mappings ().get_hirid (),
-				  init_expr_ty);
+	    context->insert_type (stmt.get_mappings (), init_expr_ty);
 	  }
 	// let x;
 	else
 	  {
-	    context->insert_type (stmt.get_mappings ().get_hirid (),
+	    context->insert_type (stmt.get_mappings (),
 				  new TyTy::InferType (
 				    stmt.get_mappings ().get_hirid ()));
 	  }

--- a/gcc/rust/typecheck/rust-hir-type-check-struct-field.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-struct-field.h
@@ -46,6 +46,8 @@ public:
 
   void visit (HIR::StructExprFieldIndexValue &field);
 
+  void visit (HIR::StructExprFieldIdentifier &field);
+
 private:
   TypeCheckStructExpr ()
     : TypeCheckBase (), resolved (nullptr), struct_path_resolved (nullptr)

--- a/gcc/rust/typecheck/rust-hir-type-check-struct-field.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-struct-field.h
@@ -44,6 +44,8 @@ public:
 
   void visit (HIR::StructExprFieldIdentifierValue &field);
 
+  void visit (HIR::StructExprFieldIndexValue &field);
+
 private:
   TypeCheckStructExpr ()
     : TypeCheckBase (), resolved (nullptr), struct_path_resolved (nullptr)

--- a/gcc/rust/typecheck/rust-hir-type-check-struct-field.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-struct-field.h
@@ -57,6 +57,7 @@ private:
   TyTy::ADTType *struct_path_resolved;
   TyTy::TyBase *resolved_field;
   std::set<std::string> fields_assigned;
+  std::map<size_t, HIR::StructExprField *> adtFieldIndexToField;
 };
 
 } // namespace Resolver

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
@@ -49,8 +49,7 @@ public:
 	= new TyTy::StructFieldType (field.get_mappings ().get_hirid (),
 				     std::to_string (idx), field_type);
       fields.push_back (ty_field);
-      context->insert_type (field.get_mappings ().get_hirid (),
-			    ty_field->get_field_type ());
+      context->insert_type (field.get_mappings (), ty_field->get_field_type ());
       idx++;
       return true;
     });
@@ -60,7 +59,7 @@ public:
 			   struct_decl.get_identifier (), true,
 			   std::move (fields));
 
-    context->insert_type (struct_decl.get_mappings ().get_hirid (), type);
+    context->insert_type (struct_decl.get_mappings (), type);
   }
 
   void visit (HIR::StructStruct &struct_decl)
@@ -73,8 +72,7 @@ public:
 	= new TyTy::StructFieldType (field.get_mappings ().get_hirid (),
 				     field.get_field_name (), field_type);
       fields.push_back (ty_field);
-      context->insert_type (field.get_mappings ().get_hirid (),
-			    ty_field->get_field_type ());
+      context->insert_type (field.get_mappings (), ty_field->get_field_type ());
       return true;
     });
 
@@ -83,7 +81,7 @@ public:
 			   struct_decl.get_identifier (), false,
 			   std::move (fields));
 
-    context->insert_type (struct_decl.get_mappings ().get_hirid (), type);
+    context->insert_type (struct_decl.get_mappings (), type);
   }
 
   void visit (HIR::StaticItem &var)
@@ -91,8 +89,7 @@ public:
     TyTy::TyBase *type = TypeCheckType::Resolve (var.get_type ());
     TyTy::TyBase *expr_type = TypeCheckExpr::Resolve (var.get_expr ());
 
-    context->insert_type (var.get_mappings ().get_hirid (),
-			  type->combine (expr_type));
+    context->insert_type (var.get_mappings (), type->combine (expr_type));
   }
 
   void visit (HIR::ConstantItem &constant)
@@ -100,8 +97,7 @@ public:
     TyTy::TyBase *type = TypeCheckType::Resolve (constant.get_type ());
     TyTy::TyBase *expr_type = TypeCheckExpr::Resolve (constant.get_expr ());
 
-    context->insert_type (constant.get_mappings ().get_hirid (),
-			  type->combine (expr_type));
+    context->insert_type (constant.get_mappings (), type->combine (expr_type));
   }
 
   void visit (HIR::Function &function)
@@ -123,16 +119,16 @@ public:
 	// get the name as well required for later on
 	auto param_type = TypeCheckType::Resolve (param.type.get ());
 	auto param_tyty
-	  = new TyTy::ParamType (param.get_mappings ()->get_hirid (),
+	  = new TyTy::ParamType (param.get_mappings ().get_hirid (),
 				 param.param_name->as_string (), param_type);
 	params.push_back (param_tyty);
 
-	context->insert_type (param.get_mappings ()->get_hirid (), param_tyty);
+	context->insert_type (param.get_mappings (), param_tyty);
       }
 
     auto fnType = new TyTy::FnType (function.get_mappings ().get_hirid (),
 				    params, ret_type);
-    context->insert_type (function.get_mappings ().get_hirid (), fnType);
+    context->insert_type (function.get_mappings (), fnType);
   }
 
 private:

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -107,7 +107,7 @@ public:
       }
     identifier += ")";
     translated = new TyTy::ADTType (tuple.get_mappings ().get_hirid (),
-				    identifier, fields);
+				    identifier, true, fields);
   }
 
   void visit (HIR::TypePath &path)

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -70,7 +70,7 @@ public:
     type->accept_vis (resolver);
 
     if (resolver.translated != nullptr)
-      resolver.context->insert_type (type->get_mappings ().get_hirid (),
+      resolver.context->insert_type (type->get_mappings (),
 				     resolver.translated);
 
     return resolver.translated;
@@ -112,10 +112,6 @@ public:
 
   void visit (HIR::TypePath &path)
   {
-    // check if this is already defined or not
-    if (context->lookup_type (path.get_mappings ().get_hirid (), &translated))
-      return;
-
     // lookup the Node this resolves to
     NodeId ref;
     if (!resolver->lookup_resolved_type (path.get_mappings ().get_nodeid (),
@@ -132,11 +128,10 @@ public:
       {
 	// we got an HIR node
 	if (context->lookup_type (hir_lookup, &translated))
-	  return;
+	  {
+	    return;
+	  }
       }
-
-    // this might be a struct type (TyTy::ADT) reference
-    // TODO
     gcc_unreachable ();
   }
 

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -116,7 +116,7 @@ TypeCheckStructExpr::visit (HIR::StructExprStructFields &struct_expr)
 	return false;
       }
 
-    context->insert_type (field->get_mappings ().get_hirid (), resolved_field);
+    context->insert_type (field->get_mappings (), resolved_field);
     return true;
   });
 

--- a/gcc/rust/typecheck/rust-hir-type-check.h
+++ b/gcc/rust/typecheck/rust-hir-type-check.h
@@ -37,7 +37,7 @@ public:
   bool lookup_builtin (std::string name, TyTy::TyBase **type);
   void insert_builtin (HirId id, NodeId ref, TyTy::TyBase *type);
 
-  void insert_type (HirId id, TyTy::TyBase *type);
+  void insert_type (const Analysis::NodeMapping &mappings, TyTy::TyBase *type);
   bool lookup_type (HirId id, TyTy::TyBase **type);
 
   void insert_type_by_node_id (NodeId ref, HirId id);

--- a/gcc/rust/typecheck/rust-tyctx.cc
+++ b/gcc/rust/typecheck/rust-tyctx.cc
@@ -73,9 +73,13 @@ TypeCheckContext::insert_builtin (HirId id, NodeId ref, TyTy::TyBase *type)
 }
 
 void
-TypeCheckContext::insert_type (HirId id, TyTy::TyBase *type)
+TypeCheckContext::insert_type (const Analysis::NodeMapping &mappings,
+			       TyTy::TyBase *type)
 {
   rust_assert (type != nullptr);
+  NodeId ref = mappings.get_nodeid ();
+  HirId id = mappings.get_hirid ();
+  node_id_refs[ref] = id;
   resolved[id] = type;
 }
 

--- a/gcc/rust/typecheck/rust-tyty-call.h
+++ b/gcc/rust/typecheck/rust-tyty-call.h
@@ -41,7 +41,6 @@ public:
   void visit (UnitType &type) override { gcc_unreachable (); }
   void visit (InferType &type) override { gcc_unreachable (); }
   void visit (StructFieldType &type) override { gcc_unreachable (); }
-  void visit (ADTType &type) override { gcc_unreachable (); }
   void visit (ParamType &type) override { gcc_unreachable (); }
   void visit (ArrayType &type) override { gcc_unreachable (); }
   void visit (BoolType &type) override { gcc_unreachable (); }
@@ -50,6 +49,10 @@ public:
   void visit (FloatType &type) override { gcc_unreachable (); }
   void visit (ErrorType &type) override { gcc_unreachable (); }
 
+  // tuple-structs
+  void visit (ADTType &type) override;
+
+  // call fns
   void visit (FnType &type) override;
 
 private:

--- a/gcc/rust/typecheck/rust-tyty-resolver.h
+++ b/gcc/rust/typecheck/rust-tyty-resolver.h
@@ -159,7 +159,7 @@ public:
 	}
 
       // insert the new resolved definition
-      context->insert_type (decl->get_mappings ().get_hirid (), resolved_tyty);
+      context->insert_type (decl->get_mappings (), resolved_tyty);
       return true;
     });
   }

--- a/gcc/rust/typecheck/rust-tyty-rules.h
+++ b/gcc/rust/typecheck/rust-tyty-rules.h
@@ -438,8 +438,9 @@ public:
 	fields.push_back ((TyTy::StructFieldType *) combined);
       }
 
-    resolved = new TyTy::ADTType (type.get_ref (), type.get_ty_ref (),
-				  type.get_name (), fields);
+    resolved
+      = new TyTy::ADTType (type.get_ref (), type.get_ty_ref (),
+			   type.get_name (), type.is_tuple_struct (), fields);
   }
 
 private:

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -169,15 +169,16 @@ private:
 class ADTType : public TyBase
 {
 public:
-  ADTType (HirId ref, std::string identifier,
+  ADTType (HirId ref, std::string identifier, bool is_tuple,
 	   std::vector<StructFieldType *> fields)
-    : TyBase (ref, ref, TypeKind::ADT), identifier (identifier), fields (fields)
+    : TyBase (ref, ref, TypeKind::ADT), identifier (identifier),
+      is_tuple (is_tuple), fields (fields)
   {}
 
-  ADTType (HirId ref, HirId ty_ref, std::string identifier,
+  ADTType (HirId ref, HirId ty_ref, std::string identifier, bool is_tuple,
 	   std::vector<StructFieldType *> fields)
     : TyBase (ref, ty_ref, TypeKind::ADT), identifier (identifier),
-      fields (fields)
+      is_tuple (is_tuple), fields (fields)
   {}
 
   void accept_vis (TyVisitor &vis) override;
@@ -191,6 +192,8 @@ public:
   size_t num_fields () const { return fields.size (); }
 
   std::string get_name () const { return identifier; }
+
+  bool is_tuple_struct () const { return is_tuple; }
 
   StructFieldType *get_field (size_t index) { return fields.at (index); }
 
@@ -218,6 +221,7 @@ public:
 
 private:
   std::string identifier;
+  bool is_tuple;
   std::vector<StructFieldType *> fields;
 };
 

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -219,6 +219,15 @@ public:
   std::vector<StructFieldType *> &get_fields () { return fields; }
   const std::vector<StructFieldType *> &get_fields () const { return fields; }
 
+  void iterate_fields (std::function<bool (StructFieldType *)> cb)
+  {
+    for (auto &f : fields)
+      {
+	if (!cb (f))
+	  return;
+      }
+  }
+
 private:
   std::string identifier;
   bool is_tuple;

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -350,6 +350,30 @@ Mappings::lookup_hir_param (CrateNum crateNum, HirId id)
 }
 
 void
+Mappings::insert_hir_struct_field (CrateNum crateNum, HirId id,
+				   HIR::StructExprField *field)
+{
+  rust_assert (lookup_hir_stmt (crateNum, id) == nullptr);
+
+  hirStructFieldMappings[crateNum][id] = field;
+  nodeIdToHirMappings[crateNum][field->get_mappings ().get_nodeid ()] = id;
+}
+
+HIR::StructExprField *
+Mappings::lookup_hir_struct_field (CrateNum crateNum, HirId id)
+{
+  auto it = hirStructFieldMappings.find (crateNum);
+  if (it == hirStructFieldMappings.end ())
+    return nullptr;
+
+  auto iy = it->second.find (id);
+  if (iy == it->second.end ())
+    return nullptr;
+
+  return iy->second;
+}
+
+void
 Mappings::insert_local_defid_mapping (CrateNum crateNum, LocalDefId id,
 				      HIR::Item *item)
 {

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -332,7 +332,7 @@ Mappings::insert_hir_param (CrateNum crateNum, HirId id,
   rust_assert (lookup_hir_stmt (crateNum, id) == nullptr);
 
   hirParamMappings[crateNum][id] = param;
-  nodeIdToHirMappings[crateNum][param->get_mappings ()->get_nodeid ()] = id;
+  nodeIdToHirMappings[crateNum][param->get_mappings ().get_nodeid ()] = id;
 }
 
 HIR::FunctionParam *

--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -121,6 +121,10 @@ public:
   void insert_hir_param (CrateNum crateNum, HirId id, HIR::FunctionParam *type);
   HIR::FunctionParam *lookup_hir_param (CrateNum crateNum, HirId id);
 
+  void insert_hir_struct_field (CrateNum crateNum, HirId id,
+				HIR::StructExprField *type);
+  HIR::StructExprField *lookup_hir_struct_field (CrateNum crateNum, HirId id);
+
   void walk_local_defids_for_crate (CrateNum crateNum,
 				    std::function<bool (HIR::Item *)> cb);
 
@@ -159,6 +163,8 @@ private:
   std::map<CrateNum, std::map<HirId, HIR::Expr *> > hirExprMappings;
   std::map<CrateNum, std::map<HirId, HIR::Stmt *> > hirStmtMappings;
   std::map<CrateNum, std::map<HirId, HIR::FunctionParam *> > hirParamMappings;
+  std::map<CrateNum, std::map<HirId, HIR::StructExprField *> >
+    hirStructFieldMappings;
 
   // location info
   std::map<CrateNum, std::map<NodeId, Location> > locations;

--- a/gcc/testsuite/rust.test/compilable/struct_base_init_1.rs
+++ b/gcc/testsuite/rust.test/compilable/struct_base_init_1.rs
@@ -1,0 +1,12 @@
+struct Foo {
+    a: i32,
+    b: i32,
+}
+
+fn foo() -> Foo {
+    Foo { a: 42, b: 32 }
+}
+
+fn main() {
+    let _f = Foo { a: 10, ..foo() };
+}

--- a/gcc/testsuite/rust.test/compilable/struct_init_2.rs
+++ b/gcc/testsuite/rust.test/compilable/struct_init_2.rs
@@ -1,0 +1,5 @@
+struct Foo(f32, f32);
+
+fn main() {
+    let a = Foo { 0: 10.0, 1: 20.0 };
+}

--- a/gcc/testsuite/rust.test/compilable/struct_init_3.rs
+++ b/gcc/testsuite/rust.test/compilable/struct_init_3.rs
@@ -1,0 +1,10 @@
+struct Foo {
+    a: i32,
+    b: i32,
+}
+
+fn main() {
+    let a = 1;
+    let b = 2;
+    let c = Foo { a, b };
+}

--- a/gcc/testsuite/rust.test/compilable/struct_init_4.rs
+++ b/gcc/testsuite/rust.test/compilable/struct_init_4.rs
@@ -1,0 +1,9 @@
+struct Foo {
+    a: i32,
+    b: i32,
+}
+
+fn main() {
+    let a = Foo { a: 1, b: 2 };
+    let b = Foo { a: 3, b: 4, ..a };
+}

--- a/gcc/testsuite/rust.test/compilable/struct_init_5.rs
+++ b/gcc/testsuite/rust.test/compilable/struct_init_5.rs
@@ -1,0 +1,9 @@
+struct Foo {
+    a: i32,
+    b: i32,
+}
+
+fn main() {
+    let a = Foo { a: 1, b: 2 };
+    let b = Foo { ..a };
+}

--- a/gcc/testsuite/rust.test/compilable/struct_init_6.rs
+++ b/gcc/testsuite/rust.test/compilable/struct_init_6.rs
@@ -1,0 +1,9 @@
+struct Foo {
+    a: i32,
+    b: i32,
+}
+
+fn main() {
+    let a = Foo { a: 1, b: 2 };
+    let b = Foo { a: 1, ..a };
+}

--- a/gcc/testsuite/rust.test/compilable/struct_init_7.rs
+++ b/gcc/testsuite/rust.test/compilable/struct_init_7.rs
@@ -1,0 +1,9 @@
+struct Foo {
+    a: i32,
+    b: f32,
+}
+
+fn main() {
+    let a = Foo { a: 1, b: 2f32 };
+    let b = Foo { b: 4f32, ..a };
+}

--- a/gcc/testsuite/rust.test/compilable/struct_init_8.rs
+++ b/gcc/testsuite/rust.test/compilable/struct_init_8.rs
@@ -1,0 +1,6 @@
+struct Foo(f32, i32);
+
+fn main() {
+    let a = Foo { 1: 1, 0: 2f32 };
+    let b = Foo { ..a };
+}

--- a/gcc/testsuite/rust.test/compilable/tuple3.rs
+++ b/gcc/testsuite/rust.test/compilable/tuple3.rs
@@ -1,0 +1,9 @@
+fn main() {
+    let a = (1, true);
+
+    let b;
+    let c;
+
+    b = a.0;
+    c = a.1;
+}

--- a/gcc/testsuite/rust.test/compilable/tuple_struct1.rs
+++ b/gcc/testsuite/rust.test/compilable/tuple_struct1.rs
@@ -1,0 +1,5 @@
+struct Foo(i32, i32, bool);
+
+fn main() {
+    let a = Foo(1, 2, true);
+}

--- a/gcc/testsuite/rust.test/compilable/tuple_struct2.rs
+++ b/gcc/testsuite/rust.test/compilable/tuple_struct2.rs
@@ -1,0 +1,11 @@
+struct Foo(i32, bool);
+
+fn main() {
+    let a = Foo(1, true);
+
+    let b;
+    let c;
+
+    b = a.0;
+    c = a.1;
+}

--- a/gcc/testsuite/rust.test/fail_compilation/func2.rs
+++ b/gcc/testsuite/rust.test/fail_compilation/func2.rs
@@ -1,0 +1,7 @@
+fn test(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+fn main() {
+    let a = test(1);
+}

--- a/gcc/testsuite/rust.test/fail_compilation/func3.rs
+++ b/gcc/testsuite/rust.test/fail_compilation/func3.rs
@@ -1,0 +1,7 @@
+fn test(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+fn main() {
+    let a = test(1, true);
+}

--- a/gcc/testsuite/rust.test/fail_compilation/struct_init1.rs
+++ b/gcc/testsuite/rust.test/fail_compilation/struct_init1.rs
@@ -1,0 +1,8 @@
+struct Foo {
+    a: f32,
+    b: f32,
+}
+
+fn main() {
+    let a = Foo { 0: 10.0, 1: 20.0 };
+}

--- a/gcc/testsuite/rust.test/fail_compilation/tuple_struct1.rs
+++ b/gcc/testsuite/rust.test/fail_compilation/tuple_struct1.rs
@@ -1,0 +1,8 @@
+struct Foo {
+    one: i32,
+    two: i32,
+}
+
+fn main() {
+    let a = Foo(1, 2);
+}

--- a/gcc/testsuite/rust.test/fail_compilation/tuple_struct2.rs
+++ b/gcc/testsuite/rust.test/fail_compilation/tuple_struct2.rs
@@ -1,0 +1,5 @@
+struct Bar(i32, i32, bool);
+
+fn main() {
+    let a = Bar(1, 2);
+}

--- a/gcc/testsuite/rust.test/fail_compilation/tuple_struct3.rs
+++ b/gcc/testsuite/rust.test/fail_compilation/tuple_struct3.rs
@@ -1,0 +1,5 @@
+struct Foo(i32, i32, bool);
+
+fn main() {
+    let c = Foo(1, 2f32, true);
+}


### PR DESCRIPTION
This covers:

1. TupleStructs
2. TupleIndexExpressions such as tuple_reference.0
3. StructFieldIndexField such as Foo{0: 123, 1: b }
4. Struct Identifier constructors example Foo {a, b}
5. Struct base references Foo {a: 1, ..b}

Addresses #154 #78 #76 