### PR TITLE
ComparisonExprs and LazyBoolExprs are bools

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -327,7 +327,12 @@ public:
     auto lhs = TypeCheckExpr::Resolve (expr.get_lhs ());
     auto rhs = TypeCheckExpr::Resolve (expr.get_rhs ());
 
-    infered = lhs->combine (rhs);
+    auto result = lhs->combine (rhs);
+    if (result == nullptr || result->get_kind () == TyTy::TypeKind::ERROR)
+      return;
+
+    // we expect this to be
+    infered = new TyTy::BoolType (expr.get_mappings ().get_hirid ());
   }
 
   void visit (HIR::LazyBooleanExpr &expr)
@@ -335,8 +340,18 @@ public:
     auto lhs = TypeCheckExpr::Resolve (expr.get_lhs ());
     auto rhs = TypeCheckExpr::Resolve (expr.get_rhs ());
 
+    // we expect the lhs and rhs must be bools at this point
+    TyTy::BoolType elhs (expr.get_mappings ().get_hirid ());
+    lhs = elhs.combine (lhs);
+    if (lhs == nullptr || lhs->get_kind () == TyTy::TypeKind::ERROR)
+      return;
+
+    TyTy::BoolType rlhs (expr.get_mappings ().get_hirid ());
+    rhs = elhs.combine (rhs);
+    if (lhs == nullptr || lhs->get_kind () == TyTy::TypeKind::ERROR)
+      return;
+
     infered = lhs->combine (rhs);
-    // FIXME this will need to turn into bool
   }
 
   void visit (HIR::IfExpr &expr)

--- a/gcc/testsuite/rust.test/compilable/comparison_expr1.rs
+++ b/gcc/testsuite/rust.test/compilable/comparison_expr1.rs
@@ -1,0 +1,34 @@
+fn is_zero(x: i32) -> bool {
+    x == 0
+}
+
+fn is_not_zero(x: i32) -> bool {
+    x != 0
+}
+
+fn is_positive(x: i32) -> bool {
+    x > 0
+}
+
+fn is_negative(x: i32) -> bool {
+    x < 0
+}
+
+fn is_positive_or_zero(x: i32) -> bool {
+    x >= 0
+}
+
+fn is_negative_or_zero(x: i32) -> bool {
+    x <= 0
+}
+
+fn main() {
+    let a: bool = is_zero(1);
+    let b: bool = is_not_zero(2);
+    let c: bool = is_positive(3);
+    let d: bool = is_negative(4);
+    let e: bool = is_positive_or_zero(5);
+    let f: bool = is_negative_or_zero(6);
+    let g: bool = a || b;
+    let h: bool = c && d;
+}


### PR DESCRIPTION
This fixes the expression type resolution to coerce these into bools. For
LazyBoolExprs && and || the lhs and rhs are bools.

Fixes: #172 #171 