### PR TITLE
Fixes the ^= and %= compound expression parsing.

### DIFF
--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -466,7 +466,9 @@ Lexer::build_token ()
 	  if (peek_input () == '=')
 	    {
 	      // modulo-assign
+	      skip_input ();
 	      current_column += 2;
+
 	      return Token::make (PERCENT_EQ, loc);
 	    }
 	  else
@@ -479,7 +481,9 @@ Lexer::build_token ()
 	  if (peek_input () == '=')
 	    {
 	      // xor-assign?
+	      skip_input ();
 	      current_column += 2;
+
 	      return Token::make (CARET_EQ, loc);
 	    }
 	  else


### PR DESCRIPTION
The input needed to be skipped once the operator was parsed to ensure
the lexer did not duplicate the operator. |= still fails but this looks
to be a parser problem.

The output for |= shows:

```
beginning null denotation identifier handling
current peek token when starting path pratt parse: '|='
current token (just about to return path to null denotation): '|='
finished null denotation identifier path parsing - next is branching 
test.rs:24:7: error: expecting ‘}’ but ‘|=’ found
   24 |     g |= 7;
      |       ^
test.rs:24:5: error: error may be from having an expression (as opposed to statement) in the body of the function but not last
   24 |     g |= 7;
      |     ^

```

I am unsure what the bug is there yet

Addresses #173 