### PR TITLE
Add backend support to create immutable types

### DIFF
--- a/gcc/rust/rust-backend.h
+++ b/gcc/rust/rust-backend.h
@@ -112,6 +112,9 @@ public:
   // Get a pointer type.
   virtual Btype *pointer_type (Btype *to_type) = 0;
 
+  // make type immutable
+  virtual Btype *immutable_type (Btype *base) = 0;
+
   // Get a function type.  The receiver, parameter, and results are
   // generated from the types in the Function_type.  The Function_type
   // is provided so that the names are available.  This should return

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -173,6 +173,8 @@ public:
 
   Btype *pointer_type (Btype *);
 
+  Btype *immutable_type (Btype *);
+
   Btype *function_type (const Btyped_identifier &,
 			const std::vector<Btyped_identifier> &,
 			const std::vector<Btyped_identifier> &, Btype *,
@@ -846,6 +848,18 @@ Gcc_backend::pointer_type (Btype *to_type)
     return this->error_type ();
   tree type = build_pointer_type (to_type_tree);
   return this->make_type (type);
+}
+
+// Get immutable type
+
+Btype *
+Gcc_backend::immutable_type (Btype *base)
+{
+  tree type_tree = base->get_tree ();
+  if (type_tree == error_mark_node)
+    return this->error_type ();
+  tree constified = build_qualified_type (type_tree, TYPE_QUAL_CONST);
+  return this->make_type (constified);
 }
 
 // Make a function type.


### PR DESCRIPTION
GCC uses qualified types to create const immutability.

This is a building block for #77 