### PR TITLE
Support binding functions to LetStmts.

### DIFF
--- a/gcc/rust/ast/rust-type.h
+++ b/gcc/rust/ast/rust-type.h
@@ -816,6 +816,10 @@ public:
     rust_assert (param_type != nullptr);
     return param_type;
   }
+
+  ParamKind get_param_kind () const { return param_kind; }
+
+  Identifier get_name () const { return name; }
 };
 
 /* A function pointer type - can be created via coercion from function items and

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -127,20 +127,28 @@ public:
 	return;
       }
 
-    // this could be a constant reference
-    if (ctx->lookup_const_decl (ref, &translated))
-      return;
-
-    // must be an identifier
+    Bfunction *fn = nullptr;
     Bvariable *var = nullptr;
-    if (!ctx->lookup_var_decl (ref, &var))
+    if (ctx->lookup_const_decl (ref, &translated))
       {
-	rust_fatal_error (expr.get_locus (),
-			  "failed to lookup compiled variable");
 	return;
       }
-
-    translated = ctx->get_backend ()->var_expression (var, expr.get_locus ());
+    else if (ctx->lookup_function_decl (ref, &fn))
+      {
+	translated
+	  = ctx->get_backend ()->function_code_expression (fn,
+							   expr.get_locus ());
+      }
+    else if (ctx->lookup_var_decl (ref, &var))
+      {
+	translated
+	  = ctx->get_backend ()->var_expression (var, expr.get_locus ());
+      }
+    else
+      {
+	rust_fatal_error (expr.get_locus (),
+			  "failed to lookup compiled reference");
+      }
   }
 
   void visit (HIR::LiteralExpr &expr)

--- a/gcc/rust/hir/tree/rust-hir-type.h
+++ b/gcc/rust/hir/tree/rust-hir-type.h
@@ -791,6 +791,16 @@ public:
   }
 
   Location get_locus () const { return locus; }
+
+  std::unique_ptr<Type> &get_type ()
+  {
+    rust_assert (param_type != nullptr);
+    return param_type;
+  }
+
+  ParamKind get_param_kind () const { return param_kind; }
+
+  Identifier get_name () const { return name; }
 };
 
 /* A function pointer type - can be created via coercion from function items and
@@ -805,9 +815,7 @@ class BareFunctionType : public TypeNoBounds
   std::vector<MaybeNamedParam> params;
   bool is_variadic;
 
-  // bool has_return_type;
-  // BareFunctionReturnType return_type;
-  std::unique_ptr<TypeNoBounds> return_type; // inlined version
+  std::unique_ptr<Type> return_type; // inlined version
 
   Location locus;
 
@@ -822,7 +830,7 @@ public:
 		    std::vector<LifetimeParam> lifetime_params,
 		    FunctionQualifiers qualifiers,
 		    std::vector<MaybeNamedParam> named_params, bool is_variadic,
-		    std::unique_ptr<TypeNoBounds> type, Location locus)
+		    std::unique_ptr<Type> type, Location locus)
     : TypeNoBounds (mappings), for_lifetimes (std::move (lifetime_params)),
       function_qualifiers (std::move (qualifiers)),
       params (std::move (named_params)), is_variadic (is_variadic),
@@ -834,8 +842,7 @@ public:
     : TypeNoBounds (other.mappings), for_lifetimes (other.for_lifetimes),
       function_qualifiers (other.function_qualifiers), params (other.params),
       is_variadic (other.is_variadic),
-      return_type (other.return_type->clone_type_no_bounds ()),
-      locus (other.locus)
+      return_type (other.return_type->clone_type ()), locus (other.locus)
   {}
 
   // Overload assignment operator to deep copy
@@ -846,7 +853,7 @@ public:
     function_qualifiers = other.function_qualifiers;
     params = other.params;
     is_variadic = other.is_variadic;
-    return_type = other.return_type->clone_type_no_bounds ();
+    return_type = other.return_type->clone_type ();
     locus = other.locus;
 
     return *this;
@@ -861,6 +868,19 @@ public:
   Location get_locus () const { return locus; }
 
   void accept_vis (HIRVisitor &vis) override;
+
+  std::vector<MaybeNamedParam> &get_function_params () { return params; }
+  const std::vector<MaybeNamedParam> &get_function_params () const
+  {
+    return params;
+  }
+
+  // TODO: would a "vis_type" be better?
+  std::unique_ptr<Type> &get_return_type ()
+  {
+    rust_assert (has_return_type ());
+    return return_type;
+  }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather

--- a/gcc/rust/resolve/rust-ast-resolve-expr.h
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.h
@@ -98,16 +98,26 @@ public:
 
   void visit (AST::IdentifierExpr &expr)
   {
-    if (!resolver->get_name_scope ().lookup (expr.as_string (), &resolved_node))
+    if (resolver->get_name_scope ().lookup (expr.as_string (), &resolved_node))
+      {
+	resolver->insert_resolved_name (expr.get_node_id (), resolved_node);
+	resolver->insert_new_definition (expr.get_node_id (),
+					 Definition{expr.get_node_id (),
+						    parent});
+      }
+    else if (resolver->get_type_scope ().lookup (expr.as_string (),
+						 &resolved_node))
+      {
+	resolver->insert_resolved_type (expr.get_node_id (), resolved_node);
+	resolver->insert_new_definition (expr.get_node_id (),
+					 Definition{expr.get_node_id (),
+						    parent});
+      }
+    else
       {
 	rust_error_at (expr.get_locus (), "failed to find name: %s",
 		       expr.as_string ().c_str ());
-	return;
       }
-
-    resolver->insert_resolved_name (expr.get_node_id (), resolved_node);
-    resolver->insert_new_definition (expr.get_node_id (),
-				     Definition{expr.get_node_id (), parent});
   }
 
   void visit (AST::ArithmeticOrLogicalExpr &expr)

--- a/gcc/rust/resolve/rust-ast-resolve-toplevel.h
+++ b/gcc/rust/resolve/rust-ast-resolve-toplevel.h
@@ -74,6 +74,9 @@ public:
     resolver->get_name_scope ().insert (function.get_function_name (),
 					function.get_node_id (),
 					function.get_locus ());
+    resolver->insert_new_definition (function.get_node_id (),
+				     Definition{function.get_node_id (),
+						function.get_node_id ()});
 
     // if this does not get a reference it will be determined to be unused
     // lets give it a fake reference to itself

--- a/gcc/rust/resolve/rust-ast-resolve-type.h
+++ b/gcc/rust/resolve/rust-ast-resolve-type.h
@@ -34,6 +34,15 @@ public:
     type->accept_vis (resolver);
   };
 
+  void visit (AST::BareFunctionType &fntype)
+  {
+    for (auto &param : fntype.get_function_params ())
+      ResolveType::go (param.get_type ().get (), fntype.get_node_id ());
+
+    if (fntype.has_return_type ())
+      ResolveType::go (fntype.get_return_type ().get (), fntype.get_node_id ());
+  }
+
   void visit (AST::TupleType &tuple)
   {
     if (tuple.is_unit_type ())

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -550,8 +550,8 @@ Session::parse_file (const char *filename)
   type_resolution (hir);
 
   // FIXME this needs an option of itself
-  // auto buf = Resolver::TypeResolverDump::go (hir);
-  // fprintf (stderr, "%s\n", buf.c_str ());
+  auto buf = Resolver::TypeResolverDump::go (hir);
+  fprintf (stderr, "%s\n", buf.c_str ());
 
   if (saw_errors ())
     return;

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -147,11 +147,14 @@ ADTType::accept_vis (TyVisitor &vis)
 std::string
 ADTType::as_string () const
 {
+  if (num_fields () == 0)
+    return identifier;
+
   std::string fields_buffer;
   for (auto &field : fields)
-    fields_buffer += field->as_string () + "\n";
+    fields_buffer += field->as_string () + ", ";
 
-  return identifier + "{\n" + fields_buffer + "\n}";
+  return identifier + "{" + fields_buffer + "}";
 }
 
 TyBase *

--- a/gcc/testsuite/rust.test/compilable/function_reference1.rs
+++ b/gcc/testsuite/rust.test/compilable/function_reference1.rs
@@ -1,0 +1,8 @@
+fn test(a: i32) -> i32 {
+    a + 1
+}
+
+fn main() {
+    let a = test;
+    let b = a(1);
+}

--- a/gcc/testsuite/rust.test/compilable/function_reference2.rs
+++ b/gcc/testsuite/rust.test/compilable/function_reference2.rs
@@ -1,0 +1,8 @@
+fn test(a: i32) -> i32 {
+    a + 1
+}
+
+fn main() {
+    let a: fn(i32) -> i32 = test;
+    let b = a(1);
+}


### PR DESCRIPTION
This supports basic function pointers in rust most of the code was already
there to infer this but this has now helped tidy it up and make it work.

Fixes #184