### PR TITLE
Move scan for unused names to be after type resolution

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -24,7 +24,6 @@
 #include "rust-ast-resolve-type.h"
 #include "rust-ast-resolve-pattern.h"
 #include "rust-ast-resolve-stmt.h"
-#include "rust-ast-resolve-unused.h"
 
 namespace Rust {
 namespace Resolver {
@@ -109,9 +108,6 @@ public:
     // resolve the function body
     ResolveExpr::go (function.get_definition ().get (),
 		     function.get_node_id ());
-
-    ScanUnused::Scan (resolver->get_name_scope ().peek ());
-    ScanUnused::Scan (resolver->get_type_scope ().peek ());
 
     resolver->get_name_scope ().pop ();
     resolver->get_type_scope ().pop ();

--- a/gcc/rust/resolve/rust-ast-resolve-unused.h
+++ b/gcc/rust/resolve/rust-ast-resolve-unused.h
@@ -24,10 +24,10 @@
 namespace Rust {
 namespace Resolver {
 
-class ScanUnused : public ResolverBase
+class ScanUnused
 {
 public:
-  static void Scan (Rib *r)
+  static void ScanRib (Rib *r)
   {
     r->iterate_decls ([&] (NodeId decl_node_id, Location locus) -> bool {
       if (!r->have_references_for_node (decl_node_id))
@@ -36,6 +36,13 @@ public:
 	}
       return true;
     });
+  }
+
+  static void Scan ()
+  {
+    auto resolver = Resolver::get ();
+    resolver->iterate_name_ribs ([&] (Rib *r) -> void { ScanRib (r); });
+    resolver->iterate_type_ribs ([&] (Rib *r) -> void { ScanRib (r); });
   }
 };
 

--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -22,7 +22,6 @@
 #include "rust-ast-resolve-toplevel.h"
 #include "rust-ast-resolve-item.h"
 #include "rust-ast-resolve-expr.h"
-#include "rust-ast-resolve-unused.h"
 
 #define MKBUILTIN_TYPE(_X, _R, _TY)                                            \
   do                                                                           \
@@ -284,9 +283,6 @@ NameResolution::go (AST::Crate &crate)
   // next we can drill down into the items and their scopes
   for (auto it = crate.items.begin (); it != crate.items.end (); it++)
     ResolveItem::go (it->get ());
-
-  ScanUnused::Scan (resolver->get_name_scope ().peek ());
-  ScanUnused::Scan (resolver->get_type_scope ().peek ());
 }
 
 // rust-ast-resolve-expr.h
@@ -307,9 +303,6 @@ ResolveExpr::visit (AST::BlockExpr &expr)
 
   if (expr.has_tail_expr ())
     ResolveExpr::go (expr.get_tail_expr ().get (), expr.get_node_id ());
-
-  ScanUnused::Scan (resolver->get_name_scope ().peek ());
-  ScanUnused::Scan (resolver->get_type_scope ().peek ());
 
   resolver->get_name_scope ().pop ();
   resolver->get_type_scope ().pop ();

--- a/gcc/rust/resolve/rust-name-resolver.h
+++ b/gcc/rust/resolve/rust-name-resolver.h
@@ -290,6 +290,23 @@ public:
     return it->second.size ();
   }
 
+  void iterate_name_ribs (std::function<void (Rib *)> cb)
+  {
+    for (auto it = name_ribs.begin (); it != name_ribs.end (); it++)
+      cb (it->second);
+  }
+
+  void iterate_type_ribs (std::function<void (Rib *)> cb)
+  {
+    for (auto it = type_ribs.begin (); it != type_ribs.end (); it++)
+      {
+	if (it->first == global_type_node_id)
+	  continue;
+
+	cb (it->second);
+      }
+  }
+
 private:
   Resolver ();
 

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -35,6 +35,7 @@
 #include "rust-ast-lower.h"
 #include "rust-hir-type-check.h"
 #include "rust-tycheck-dump.h"
+#include "rust-ast-resolve-unused.h"
 #include "rust-compile.h"
 
 extern Linemap *
@@ -524,9 +525,7 @@ Session::parse_file (const char *filename)
     }
 
   // resolution pipeline stage
-  resolution (parsed_crate);
-  fprintf (stderr, "\033[0;31mSUCCESSFULLY FINISHED RESOLUTION \n\033[0m");
-
+  Resolver::NameResolution::Resolve (parsed_crate);
   if (options.dump_option == CompileOptions::RESOLUTION_DUMP)
     {
       // TODO: what do I dump here? resolved names? AST with resolved names?
@@ -536,7 +535,7 @@ Session::parse_file (const char *filename)
     return;
 
   // lower AST to HIR
-  HIR::Crate hir = lower_ast (parsed_crate);
+  HIR::Crate hir = HIR::ASTLowering::Resolve (parsed_crate);
   if (options.dump_option == CompileOptions::HIR_DUMP)
     {
       fprintf (stderr, "%s", hir.as_string ().c_str ());
@@ -547,11 +546,17 @@ Session::parse_file (const char *filename)
     return;
 
   // type resolve
-  type_resolution (hir);
+  Resolver::TypeResolution::Resolve (hir);
+  if (options.dump_option == CompileOptions::TYPE_RESOLUTION_DUMP)
+    {
+      auto buf = Resolver::TypeResolverDump::go (hir);
+      fprintf (stderr, "%s\n", buf.c_str ());
+      return;
+    }
 
-  // FIXME this needs an option of itself
-  // auto buf = Resolver::TypeResolverDump::go (hir);
-  // fprintf (stderr, "%s\n", buf.c_str ());
+  // scan unused has to be done after type resolution since methods are resolved
+  // at that point
+  Resolver::ScanUnused::Scan ();
 
   if (saw_errors ())
     return;
@@ -786,31 +791,6 @@ Session::expansion (AST::Crate &crate)
   // maybe create macro crate if not rustdoc
 
   fprintf (stderr, "finished expansion\n");
-}
-
-void
-Session::resolution (AST::Crate &crate)
-{
-  fprintf (stderr, "started name resolution\n");
-  Resolver::NameResolution::Resolve (crate);
-  fprintf (stderr, "finished name resolution\n");
-}
-
-HIR::Crate
-Session::lower_ast (AST::Crate &crate)
-{
-  fprintf (stderr, "started lowering AST\n");
-  auto hir = HIR::ASTLowering::Resolve (crate);
-  fprintf (stderr, "finished lowering AST\n");
-  return hir;
-}
-
-void
-Session::type_resolution (HIR::Crate &crate)
-{
-  fprintf (stderr, "started type resolution\n");
-  Resolver::TypeResolution::Resolve (crate);
-  fprintf (stderr, "finished type resolution\n");
 }
 
 void

--- a/gcc/rust/rust-session-manager.h
+++ b/gcc/rust/rust-session-manager.h
@@ -177,7 +177,8 @@ struct CompileOptions
     RESOLUTION_DUMP,
     TARGET_OPTION_DUMP,
     HIR_DUMP,
-    // TODO: add more?
+    TYPE_RESOLUTION_DUMP,
+
   } dump_option;
 
   /* configuration options - actually useful for conditional compilation and
@@ -204,8 +205,6 @@ struct Session
   // backend linemap
   Linemap *linemap;
 
-  // TODO: replace raw pointers with smart pointers?
-
 public:
   /* Initialise compiler session. Corresponds to langhook grs_langhook_init().
    * Note that this is called after option handling. */
@@ -217,7 +216,6 @@ public:
   void init_options ();
 
 private:
-  // TODO: should this be private or public?
   void parse_file (const char *filename);
   bool enable_dump (std::string arg);
 
@@ -232,23 +230,16 @@ private:
    * (top-level inner attribute creation from command line arguments), setting
    * options maybe, registering lints maybe, loading plugins maybe. */
   void register_plugins (AST::Crate &crate);
+
   /* Injection pipeline stage. TODO maybe move to another object? Maybe have
    * some lint checks (in future, obviously), register builtin macros, crate
    * injection. */
   void injection (AST::Crate &crate);
+
   /* Expansion pipeline stage. TODO maybe move to another object? Expands all
    * macros, maybe build test harness in future, AST validation, maybe create
    * macro crate (if not rustdoc).*/
   void expansion (AST::Crate &crate);
-  /* Resolution pipeline stage. TODO maybe move to another object.
-   * Performs name resolution and type resolution, maybe complete gated
-   * feature checking, maybe create buffered lints in future. */
-  void resolution (AST::Crate &crate);
-  /* This lowers the AST down to HIR and assigns all mappings from AST
-   * NodeIds back to HirIds */
-  HIR::Crate lower_ast (AST::Crate &crate);
-  /* This adds the type resolution process */
-  void type_resolution (HIR::Crate &crate);
 };
 } // namespace Rust
 


### PR DESCRIPTION
Methods are resolved as part of type resolution so scanning ribs early
on will results in false warnings about unused methods.