### PR TITLE
Enforce Duplicate definition rules

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-implitem.h
+++ b/gcc/rust/resolve/rust-ast-resolve-implitem.h
@@ -39,8 +39,12 @@ public:
   {
     std::string identifier
       = base->as_string () + "::" + constant.get_identifier ();
-    resolver->get_name_scope ().insert (identifier, constant.get_node_id (),
-					constant.get_locus ());
+    resolver->get_name_scope ().insert (
+      identifier, constant.get_node_id (), constant.get_locus (), false,
+      [&] (std::string, NodeId, Location locus) -> void {
+	rust_error_at (constant.get_locus (), "redefined multiple times");
+	rust_error_at (locus, "was defined here");
+      });
     resolver->insert_new_definition (constant.get_node_id (),
 				     Definition{constant.get_node_id (),
 						constant.get_node_id ()});
@@ -50,8 +54,12 @@ public:
   {
     std::string identifier
       = base->as_string () + "::" + function.get_function_name ();
-    resolver->get_name_scope ().insert (identifier, function.get_node_id (),
-					function.get_locus ());
+    resolver->get_name_scope ().insert (
+      identifier, function.get_node_id (), function.get_locus (), false,
+      [&] (std::string, NodeId, Location locus) -> void {
+	rust_error_at (function.get_locus (), "redefined multiple times");
+	rust_error_at (locus, "was defined here");
+      });
     resolver->insert_new_definition (function.get_node_id (),
 				     Definition{function.get_node_id (),
 						function.get_node_id ()});
@@ -61,8 +69,12 @@ public:
   {
     std::string identifier
       = base->as_string () + "::" + method.get_method_name ();
-    resolver->get_name_scope ().insert (identifier, method.get_node_id (),
-					method.get_locus ());
+    resolver->get_name_scope ().insert (
+      identifier, method.get_node_id (), method.get_locus (), false,
+      [&] (std::string, NodeId, Location locus) -> void {
+	rust_error_at (method.get_locus (), "redefined multiple times");
+	rust_error_at (locus, "was defined here");
+      });
     resolver->insert_new_definition (method.get_node_id (),
 				     Definition{method.get_node_id (),
 						method.get_node_id ()});

--- a/gcc/rust/resolve/rust-ast-resolve-toplevel.h
+++ b/gcc/rust/resolve/rust-ast-resolve-toplevel.h
@@ -38,22 +38,34 @@ public:
 
   void visit (AST::TupleStruct &struct_decl)
   {
-    resolver->get_type_scope ().insert (struct_decl.get_identifier (),
-					struct_decl.get_node_id (),
-					struct_decl.get_locus ());
+    resolver->get_type_scope ().insert (
+      struct_decl.get_identifier (), struct_decl.get_node_id (),
+      struct_decl.get_locus (), false,
+      [&] (std::string, NodeId, Location locus) -> void {
+	rust_error_at (struct_decl.get_locus (), "redefined multiple times");
+	rust_error_at (locus, "was defined here");
+      });
   }
 
   void visit (AST::StructStruct &struct_decl)
   {
-    resolver->get_type_scope ().insert (struct_decl.get_identifier (),
-					struct_decl.get_node_id (),
-					struct_decl.get_locus ());
+    resolver->get_type_scope ().insert (
+      struct_decl.get_identifier (), struct_decl.get_node_id (),
+      struct_decl.get_locus (), false,
+      [&] (std::string, NodeId, Location locus) -> void {
+	rust_error_at (struct_decl.get_locus (), "redefined multiple times");
+	rust_error_at (locus, "was defined here");
+      });
   }
 
   void visit (AST::StaticItem &var)
   {
-    resolver->get_name_scope ().insert (var.get_identifier (),
-					var.get_node_id (), var.get_locus ());
+    resolver->get_name_scope ().insert (
+      var.get_identifier (), var.get_node_id (), var.get_locus (), false,
+      [&] (std::string, NodeId, Location locus) -> void {
+	rust_error_at (var.get_locus (), "redefined multiple times");
+	rust_error_at (locus, "was defined here");
+      });
     resolver->insert_new_definition (var.get_node_id (),
 				     Definition{var.get_node_id (),
 						var.get_node_id ()});
@@ -62,9 +74,13 @@ public:
 
   void visit (AST::ConstantItem &constant)
   {
-    resolver->get_name_scope ().insert (constant.get_identifier (),
-					constant.get_node_id (),
-					constant.get_locus ());
+    resolver->get_name_scope ().insert (
+      constant.get_identifier (), constant.get_node_id (),
+      constant.get_locus (), false,
+      [&] (std::string, NodeId, Location locus) -> void {
+	rust_error_at (constant.get_locus (), "redefined multiple times");
+	rust_error_at (locus, "was defined here");
+      });
     resolver->insert_new_definition (constant.get_node_id (),
 				     Definition{constant.get_node_id (),
 						constant.get_node_id ()});
@@ -72,9 +88,13 @@ public:
 
   void visit (AST::Function &function)
   {
-    resolver->get_name_scope ().insert (function.get_function_name (),
-					function.get_node_id (),
-					function.get_locus ());
+    resolver->get_name_scope ().insert (
+      function.get_function_name (), function.get_node_id (),
+      function.get_locus (), false,
+      [&] (std::string, NodeId, Location locus) -> void {
+	rust_error_at (function.get_locus (), "redefined multiple times");
+	rust_error_at (locus, "was defined here");
+      });
     resolver->insert_new_definition (function.get_node_id (),
 				     Definition{function.get_node_id (),
 						function.get_node_id ()});

--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -110,7 +110,8 @@ Resolver::insert_builtin_types (Rib *r)
   auto builtins = get_builtin_types ();
   for (auto &builtin : builtins)
     r->insert_name (builtin->as_string (), builtin->get_node_id (),
-		    Linemap::predeclared_location ());
+		    Linemap::predeclared_location (), false,
+		    [] (std::string, NodeId, Location) -> void {});
 }
 
 std::vector<AST::Type *> &

--- a/gcc/testsuite/rust.test/compilable/name_resolve1.rs
+++ b/gcc/testsuite/rust.test/compilable/name_resolve1.rs
@@ -1,0 +1,23 @@
+struct Foo(i32, bool);
+
+impl Foo {
+    fn new(a: i32, b: bool) -> Foo {
+        Foo(a, b)
+    }
+
+    fn test() -> i32 {
+        test()
+    }
+}
+
+fn test() -> i32 {
+    123
+}
+
+fn main() {
+    let a;
+    a = Foo::new(1, true);
+
+    let b;
+    b = Foo::test();
+}

--- a/gcc/testsuite/rust.test/fail_compilation/redef_error1.rs
+++ b/gcc/testsuite/rust.test/fail_compilation/redef_error1.rs
@@ -1,0 +1,8 @@
+struct S1 {
+    x: f64,
+    y: f64,
+}
+
+struct S1(i32, bool);
+
+fn main() {}

--- a/gcc/testsuite/rust.test/fail_compilation/redef_error2.rs
+++ b/gcc/testsuite/rust.test/fail_compilation/redef_error2.rs
@@ -1,0 +1,4 @@
+const TEST: i32 = 2;
+const TEST: f32 = 3.0;
+
+fn main() {}

--- a/gcc/testsuite/rust.test/fail_compilation/redef_error3.rs
+++ b/gcc/testsuite/rust.test/fail_compilation/redef_error3.rs
@@ -1,0 +1,9 @@
+fn test() -> bool {
+    true
+}
+
+fn test() -> i32 {
+    123
+}
+
+fn main() {}

--- a/gcc/testsuite/rust.test/fail_compilation/redef_error4.rs
+++ b/gcc/testsuite/rust.test/fail_compilation/redef_error4.rs
@@ -1,0 +1,27 @@
+struct Foo(i32, bool);
+
+impl Foo {
+    fn new(a: i32, b: bool) -> Foo {
+        Foo(a, b)
+    }
+
+    fn test() -> i32 {
+        test()
+    }
+
+    fn test() -> bool {
+        true
+    }
+}
+
+fn test() -> i32 {
+    123
+}
+
+fn main() {
+    let a;
+    a = Foo::new(1, true);
+
+    let b;
+    b = Foo::test();
+}

--- a/gcc/testsuite/rust.test/fail_compilation/redef_error5.rs
+++ b/gcc/testsuite/rust.test/fail_compilation/redef_error5.rs
@@ -1,0 +1,8 @@
+struct Foo(i32, bool);
+
+impl Foo {
+    const TEST: i32 = 123;
+    const TEST: bool = false;
+}
+
+fn main() {}


### PR DESCRIPTION
Rust does not allow functions/methods/constants/static definitions to
shadow otherwise you end up with unusable items.

Fixes #208 