### PR TITLE
This adds support for basic BlockExpressions

### DIFF
--- a/gcc/rust/backend/rust-compile-base.h
+++ b/gcc/rust/backend/rust-compile-base.h
@@ -237,9 +237,13 @@ public:
 protected:
   HIRCompileBase (Context *ctx) : ctx (ctx) {}
 
+  Context *ctx;
+
   Context *get_context () { return ctx; }
 
-  Context *ctx;
+  void compile_function_body (Bfunction *fndecl,
+			      std::unique_ptr<HIR::BlockExpr> &function_body,
+			      bool has_return_type);
 };
 
 } // namespace Compile

--- a/gcc/rust/backend/rust-compile-block.h
+++ b/gcc/rust/backend/rust-compile-block.h
@@ -28,34 +28,34 @@ namespace Compile {
 class CompileBlock : public HIRCompileBase
 {
 public:
-  static Bblock *compile (HIR::BlockExpr *expr, Context *ctx)
+  static Bblock *compile (HIR::BlockExpr *expr, Context *ctx, Bvariable *result)
   {
-    CompileBlock compiler (ctx);
+    CompileBlock compiler (ctx, result);
     expr->accept_vis (compiler);
     return compiler.translated;
   }
 
-  ~CompileBlock () {}
-
   void visit (HIR::BlockExpr &expr);
 
 private:
-  CompileBlock (Context *ctx) : HIRCompileBase (ctx), translated (nullptr) {}
+  CompileBlock (Context *ctx, Bvariable *result)
+    : HIRCompileBase (ctx), translated (nullptr), result (result)
+  {}
 
   Bblock *translated;
+  Bvariable *result;
 };
 
 class CompileConditionalBlocks : public HIRCompileBase
 {
 public:
-  static Bstatement *compile (HIR::IfExpr *expr, Context *ctx)
+  static Bstatement *compile (HIR::IfExpr *expr, Context *ctx,
+			      Bvariable *result)
   {
-    CompileConditionalBlocks resolver (ctx);
+    CompileConditionalBlocks resolver (ctx, result);
     expr->accept_vis (resolver);
     return resolver.translated;
   }
-
-  ~CompileConditionalBlocks () {}
 
   void visit (HIR::IfExpr &expr);
 
@@ -64,46 +64,47 @@ public:
   void visit (HIR::IfExprConseqIf &expr);
 
 private:
-  CompileConditionalBlocks (Context *ctx)
-    : HIRCompileBase (ctx), translated (nullptr)
+  CompileConditionalBlocks (Context *ctx, Bvariable *result)
+    : HIRCompileBase (ctx), translated (nullptr), result (result)
   {}
 
   Bstatement *translated;
+  Bvariable *result;
 };
 
 class CompileExprWithBlock : public HIRCompileBase
 {
 public:
-  static Bstatement *compile (HIR::ExprWithBlock *expr, Context *ctx)
+  static Bstatement *compile (HIR::ExprWithBlock *expr, Context *ctx,
+			      Bvariable *result)
   {
-    CompileExprWithBlock resolver (ctx);
+    CompileExprWithBlock resolver (ctx, result);
     expr->accept_vis (resolver);
     return resolver.translated;
   }
 
-  ~CompileExprWithBlock () {}
-
   void visit (HIR::IfExpr &expr)
   {
-    translated = CompileConditionalBlocks::compile (&expr, ctx);
+    translated = CompileConditionalBlocks::compile (&expr, ctx, result);
   }
 
   void visit (HIR::IfExprConseqElse &expr)
   {
-    translated = CompileConditionalBlocks::compile (&expr, ctx);
+    translated = CompileConditionalBlocks::compile (&expr, ctx, result);
   }
 
   void visit (HIR::IfExprConseqIf &expr)
   {
-    translated = CompileConditionalBlocks::compile (&expr, ctx);
+    translated = CompileConditionalBlocks::compile (&expr, ctx, result);
   }
 
 private:
-  CompileExprWithBlock (Context *ctx)
-    : HIRCompileBase (ctx), translated (nullptr)
+  CompileExprWithBlock (Context *ctx, Bvariable *result)
+    : HIRCompileBase (ctx), translated (nullptr), result (result)
   {}
 
   Bstatement *translated;
+  Bvariable *result;
 };
 
 } // namespace Compile

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -110,6 +110,11 @@ public:
     return scope_stack.back ();
   }
 
+  void add_statement_to_enclosing_scope (Bstatement *stmt)
+  {
+    statements.at (statements.size () - 2).push_back (stmt);
+  }
+
   void add_statement (Bstatement *stmt) { statements.back ().push_back (stmt); }
 
   void insert_var_decl (HirId id, ::Bvariable *decl)

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -409,27 +409,71 @@ public:
 
   void visit (HIR::IfExpr &expr)
   {
-    auto stmt = CompileConditionalBlocks::compile (&expr, ctx);
+    auto stmt = CompileConditionalBlocks::compile (&expr, ctx, nullptr);
     ctx->add_statement (stmt);
   }
 
   void visit (HIR::IfExprConseqElse &expr)
   {
-    auto stmt = CompileConditionalBlocks::compile (&expr, ctx);
+    // this can be a return expression
+    TyTy::TyBase *if_type = nullptr;
+    if (!ctx->get_tyctx ()->lookup_type (expr.get_mappings ().get_hirid (),
+					 &if_type))
+      {
+	rust_error_at (expr.get_locus (),
+		       "failed to lookup type of IfExprConseqElse");
+	return;
+      }
+
+    fncontext fnctx = ctx->peek_fn ();
+    Bblock *enclosing_scope = ctx->peek_enclosing_scope ();
+    Btype *block_type = TyTyResolveCompile::compile (ctx, if_type);
+
+    bool is_address_taken = false;
+    Bstatement *ret_var_stmt = nullptr;
+    Bvariable *tmp = ctx->get_backend ()->temporary_variable (
+      fnctx.fndecl, enclosing_scope, block_type, NULL, is_address_taken,
+      expr.get_locus (), &ret_var_stmt);
+    ctx->add_statement (ret_var_stmt);
+
+    auto stmt = CompileConditionalBlocks::compile (&expr, ctx, tmp);
     ctx->add_statement (stmt);
+
+    translated = ctx->get_backend ()->var_expression (tmp, expr.get_locus ());
   }
 
   void visit (HIR::IfExprConseqIf &expr)
   {
-    auto stmt = CompileConditionalBlocks::compile (&expr, ctx);
+    auto stmt = CompileConditionalBlocks::compile (&expr, ctx, nullptr);
     ctx->add_statement (stmt);
   }
 
   void visit (HIR::BlockExpr &expr)
   {
-    auto code_block = CompileBlock::compile (&expr, ctx);
+    TyTy::TyBase *block_tyty = nullptr;
+    if (!ctx->get_tyctx ()->lookup_type (expr.get_mappings ().get_hirid (),
+					 &block_tyty))
+      {
+	rust_error_at (expr.get_locus (), "failed to lookup type of BlockExpr");
+	return;
+      }
+
+    fncontext fnctx = ctx->peek_fn ();
+    Bblock *enclosing_scope = ctx->peek_enclosing_scope ();
+    Btype *block_type = TyTyResolveCompile::compile (ctx, block_tyty);
+
+    bool is_address_taken = false;
+    Bstatement *ret_var_stmt = nullptr;
+    Bvariable *tmp = ctx->get_backend ()->temporary_variable (
+      fnctx.fndecl, enclosing_scope, block_type, NULL, is_address_taken,
+      expr.get_locus (), &ret_var_stmt);
+    ctx->add_statement (ret_var_stmt);
+
+    auto code_block = CompileBlock::compile (&expr, ctx, tmp);
     auto block_stmt = ctx->get_backend ()->block_statement (code_block);
     ctx->add_statement (block_stmt);
+
+    translated = ctx->get_backend ()->var_expression (tmp, expr.get_locus ());
   }
 
   void visit (HIR::StructExprStructFields &struct_expr)

--- a/gcc/rust/backend/rust-compile-implitem.h
+++ b/gcc/rust/backend/rust-compile-implitem.h
@@ -213,28 +213,8 @@ public:
 
     ctx->push_fn (fndecl, return_address);
 
-    // compile the block
-    function_body->iterate_stmts ([&] (HIR::Stmt *s) mutable -> bool {
-      CompileStmt::Compile (s, ctx);
-      return true;
-    });
-
-    if (function_body->has_expr () && function_body->tail_expr_reachable ())
-      {
-	// the previous passes will ensure this is a valid return
-	// dead code elimination should remove any bad trailing expressions
-	Bexpression *compiled_expr
-	  = CompileExpr::Compile (function_body->expr.get (), ctx);
-	rust_assert (compiled_expr != nullptr);
-
-	auto fncontext = ctx->peek_fn ();
-
-	std::vector<Bexpression *> retstmts;
-	retstmts.push_back (compiled_expr);
-	auto s = ctx->get_backend ()->return_statement (
-	  fncontext.fndecl, retstmts, function_body->expr->get_locus_slow ());
-	ctx->add_statement (s);
-      }
+    compile_function_body (fndecl, function.function_body,
+			   function.has_function_return_type ());
 
     ctx->pop_block ();
     auto body = ctx->get_backend ()->block_statement (code_block);

--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -265,28 +265,8 @@ public:
 
     ctx->push_fn (fndecl, return_address);
 
-    // compile the block
-    function_body->iterate_stmts ([&] (HIR::Stmt *s) mutable -> bool {
-      CompileStmt::Compile (s, ctx);
-      return true;
-    });
-
-    if (function_body->has_expr () && function_body->tail_expr_reachable ())
-      {
-	// the previous passes will ensure this is a valid return
-	// dead code elimination should remove any bad trailing expressions
-	Bexpression *compiled_expr
-	  = CompileExpr::Compile (function_body->expr.get (), ctx);
-	rust_assert (compiled_expr != nullptr);
-
-	auto fncontext = ctx->peek_fn ();
-
-	std::vector<Bexpression *> retstmts;
-	retstmts.push_back (compiled_expr);
-	auto s = ctx->get_backend ()->return_statement (
-	  fncontext.fndecl, retstmts, function_body->expr->get_locus_slow ());
-	ctx->add_statement (s);
-      }
+    compile_function_body (fndecl, function.function_body,
+			   function.has_function_return_type ());
 
     ctx->pop_block ();
     auto body = ctx->get_backend ()->block_statement (code_block);
@@ -297,7 +277,6 @@ public:
       }
 
     ctx->pop_fn ();
-
     ctx->push_function (fndecl);
   }
 

--- a/gcc/rust/backend/rust-compile-stmt.h
+++ b/gcc/rust/backend/rust-compile-stmt.h
@@ -29,37 +29,24 @@ namespace Compile {
 class CompileStmt : public HIRCompileBase
 {
 public:
-  static void Compile (HIR::Stmt *stmt, Context *ctx)
+  static Bexpression *Compile (HIR::Stmt *stmt, Context *ctx)
   {
     CompileStmt compiler (ctx);
     stmt->accept_vis (compiler);
     rust_assert (compiler.ok);
+    return compiler.translated;
   }
-
-  virtual ~CompileStmt () {}
 
   void visit (HIR::ExprStmtWithBlock &stmt)
   {
     ok = true;
-    auto translated = CompileExpr::Compile (stmt.get_expr (), ctx);
-
-    // these can be null
-    if (translated == nullptr)
-      return;
-
-    gcc_unreachable ();
+    translated = CompileExpr::Compile (stmt.get_expr (), ctx);
   }
 
   void visit (HIR::ExprStmtWithoutBlock &stmt)
   {
     ok = true;
-    auto translated = CompileExpr::Compile (stmt.get_expr (), ctx);
-
-    // these can be null
-    if (translated == nullptr)
-      return;
-
-    gcc_unreachable ();
+    translated = CompileExpr::Compile (stmt.get_expr (), ctx);
   }
 
   void visit (HIR::LetStmt &stmt)
@@ -99,9 +86,12 @@ public:
   }
 
 private:
-  CompileStmt (Context *ctx) : HIRCompileBase (ctx), ok (false) {}
+  CompileStmt (Context *ctx)
+    : HIRCompileBase (ctx), ok (false), translated (nullptr)
+  {}
 
   bool ok;
+  Bexpression *translated;
 };
 
 } // namespace Compile

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -2585,6 +2585,10 @@ public:
     return statements[statements.size () - 1]->get_locus_slow ();
   }
 
+  std::unique_ptr<ExprWithoutBlock> &get_final_expr () { return expr; }
+
+  std::vector<std::unique_ptr<Stmt> > &get_statements () { return statements; }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -127,19 +127,12 @@ TypeCheckExpr::visit (HIR::BlockExpr &expr)
     return true;
   });
 
-  // tail expression must be checked as part of the caller since
-  // the result of this is very dependant on what we expect it to be
+  if (expr.has_expr ())
+    {
+      delete block_tyty;
 
-  // now that the stmts have been resolved we must resolve the block of locals
-  // and make sure the variables have been resolved
-  // auto body_mappings = expr.get_mappings ();
-  // Rib *rib = nullptr;
-  // if (!resolver->find_name_rib (body_mappings.get_nodeid (), &rib))
-  //   {
-  //     rust_fatal_error (expr.get_locus (), "failed to lookup locals per
-  //     block"); return;
-  //   }
-  // TyTyResolver::Resolve (rib, mappings, resolver, context);
+      block_tyty = TypeCheckExpr::Resolve (expr.get_final_expr ().get (), true);
+    }
 
   infered = block_tyty->clone ();
 }

--- a/gcc/testsuite/rust.test/compilable/block_expr1.rs
+++ b/gcc/testsuite/rust.test/compilable/block_expr1.rs
@@ -1,0 +1,27 @@
+fn test3(x: i32) -> i32 {
+    if x > 1 {
+        5
+    } else {
+        0
+    }
+}
+
+fn test5(x: i32) -> i32 {
+    if x > 1 {
+        if x == 5 {
+            7
+        } else {
+            9
+        }
+    } else {
+        0
+    }
+}
+
+fn main() {
+    let call3: i32 = { test3(3) + 2 };
+    let call5 = {
+        let a = test5(5);
+        a + 1
+    };
+}


### PR DESCRIPTION
We keep temporary's for each block in order for the result to be
referenced. For example:

  let x = { test() + 1 };

This can be resolved into:

  {
    let x:i32;

    _tmp1:i32;
    {
      _tmp2:i32 = test();
      _tmp1 = _tmp2 + 1;
    }

    x = _tmp1;
  }

Fixes #189

Depending on the order of merging PRs the method resolution one will need an amendment to use this shared function block code.