### PR TITLE
With the merge of BlockExprs

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -170,23 +170,12 @@ public:
     auto expected_ret_tyty = resolve_fn_type->return_type ();
     context->push_return_type (expected_ret_tyty);
 
-    TypeCheckExpr::Resolve (function.function_body.get ());
-    if (function.function_body->has_expr ())
-      {
-	auto resolved
-	  = TypeCheckExpr::Resolve (function.function_body->expr.get ());
+    auto result = TypeCheckExpr::Resolve (function.function_body.get ());
+    auto ret_resolved = expected_ret_tyty->combine (result);
+    if (ret_resolved == nullptr)
+      return;
 
-	auto ret_resolved = expected_ret_tyty->combine (resolved);
-	if (ret_resolved == nullptr)
-	  {
-	    rust_error_at (function.function_body->expr->get_locus_slow (),
-			   "failed to resolve final expression");
-	    return;
-	  }
-
-	context->peek_return_type ()->append_reference (
-	  ret_resolved->get_ref ());
-      }
+    context->peek_return_type ()->append_reference (ret_resolved->get_ref ());
 
     context->pop_return_type ();
   }
@@ -213,23 +202,12 @@ public:
     auto expected_ret_tyty = resolve_fn_type->return_type ();
     context->push_return_type (expected_ret_tyty);
 
-    TypeCheckExpr::Resolve (method.get_function_body ().get ());
-    if (method.get_function_body ()->has_expr ())
-      {
-	auto resolved
-	  = TypeCheckExpr::Resolve (method.get_function_body ()->expr.get ());
+    auto result = TypeCheckExpr::Resolve (method.get_function_body ().get ());
+    auto ret_resolved = expected_ret_tyty->combine (result);
+    if (ret_resolved == nullptr)
+      return;
 
-	auto ret_resolved = expected_ret_tyty->combine (resolved);
-	if (ret_resolved == nullptr)
-	  {
-	    rust_error_at (method.get_function_body ()->expr->get_locus_slow (),
-			   "failed to resolve final expression");
-	    return;
-	  }
-
-	context->peek_return_type ()->append_reference (
-	  ret_resolved->get_ref ());
-      }
+    context->peek_return_type ()->append_reference (ret_resolved->get_ref ());
 
     context->pop_return_type ();
   }

--- a/gcc/rust/typecheck/rust-hir-type-check-item.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.h
@@ -75,23 +75,12 @@ public:
     auto expected_ret_tyty = resolve_fn_type->return_type ();
     context->push_return_type (expected_ret_tyty);
 
-    TypeCheckExpr::Resolve (function.function_body.get ());
-    if (function.function_body->has_expr ())
-      {
-	auto resolved
-	  = TypeCheckExpr::Resolve (function.function_body->expr.get ());
+    auto result = TypeCheckExpr::Resolve (function.function_body.get ());
+    auto ret_resolved = expected_ret_tyty->combine (result);
+    if (ret_resolved == nullptr)
+      return;
 
-	auto ret_resolved = expected_ret_tyty->combine (resolved);
-	if (ret_resolved == nullptr)
-	  {
-	    rust_error_at (function.function_body->expr->get_locus_slow (),
-			   "failed to resolve final expression");
-	    return;
-	  }
-
-	context->peek_return_type ()->append_reference (
-	  ret_resolved->get_ref ());
-      }
+    context->peek_return_type ()->append_reference (ret_resolved->get_ref ());
 
     context->pop_return_type ();
   }

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.h
@@ -30,21 +30,21 @@ namespace Resolver {
 class TypeCheckStmt : public TypeCheckBase
 {
 public:
-  static TyTy::TyBase *Resolve (HIR::Stmt *stmt, bool is_final_stmt)
+  static TyTy::TyBase *Resolve (HIR::Stmt *stmt)
   {
-    TypeCheckStmt resolver (is_final_stmt);
+    TypeCheckStmt resolver;
     stmt->accept_vis (resolver);
     return resolver.infered;
   }
 
   void visit (HIR::ExprStmtWithBlock &stmt)
   {
-    infered = TypeCheckExpr::Resolve (stmt.get_expr (), is_final_stmt);
+    infered = TypeCheckExpr::Resolve (stmt.get_expr ());
   }
 
   void visit (HIR::ExprStmtWithoutBlock &stmt)
   {
-    infered = TypeCheckExpr::Resolve (stmt.get_expr (), is_final_stmt);
+    infered = TypeCheckExpr::Resolve (stmt.get_expr ());
   }
 
   void visit (HIR::LetStmt &stmt)
@@ -54,8 +54,7 @@ public:
     TyTy::TyBase *init_expr_ty = nullptr;
     if (stmt.has_init_expr ())
       {
-	init_expr_ty
-	  = TypeCheckExpr::Resolve (stmt.get_init_expr (), is_final_stmt);
+	init_expr_ty = TypeCheckExpr::Resolve (stmt.get_init_expr ());
 	if (init_expr_ty == nullptr)
 	  return;
 
@@ -106,13 +105,10 @@ public:
   }
 
 private:
-  TypeCheckStmt (bool is_final_stmt)
-    : TypeCheckBase (), infered (nullptr), is_final_stmt (is_final_stmt)
-  {}
+  TypeCheckStmt () : TypeCheckBase (), infered (nullptr) {}
 
   TyTy::TyBase *infered;
-  bool is_final_stmt;
-}; // namespace Resolver
+};
 
 } // namespace Resolver
 } // namespace Rust

--- a/gcc/testsuite/rust.test/compilable/block_expr2.rs
+++ b/gcc/testsuite/rust.test/compilable/block_expr2.rs
@@ -1,0 +1,14 @@
+fn test() -> i32 {
+    123
+}
+
+fn main() {
+    let a = { test() };
+    let b = {
+        if a > 10 {
+            a - 1
+        } else {
+            a + 1
+        }
+    };
+}


### PR DESCRIPTION
Further testing found regressions with implicit returns and type
resolution.

This unifies the type resolution in block expressions to be more strict
and ensure everything bar the final statement should be UnitType.

It also gets rid of the is_final_expr hack used for implicit returns before

#212 if fixed would have picked this up