### PR TITLE
Fixes parsing if expressions as part of an expression.

### DIFF
--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -480,10 +480,12 @@ private:
 		    bool pratt_parse = false);
   std::unique_ptr<AST::IfExpr>
   parse_if_expr (std::vector<AST::Attribute> outer_attrs
-		 = std::vector<AST::Attribute> ());
+		 = std::vector<AST::Attribute> (),
+		 bool pratt_parse = false);
   std::unique_ptr<AST::IfLetExpr>
   parse_if_let_expr (std::vector<AST::Attribute> outer_attrs
-		     = std::vector<AST::Attribute> ());
+		     = std::vector<AST::Attribute> (),
+		     bool pratt_parse = false);
   std::unique_ptr<AST::LoopExpr>
   parse_loop_expr (std::vector<AST::Attribute> outer_attrs
 		   = std::vector<AST::Attribute> (),

--- a/gcc/testsuite/rust.test/compilable/block_expr_parser_bug.rs
+++ b/gcc/testsuite/rust.test/compilable/block_expr_parser_bug.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let a = 123;
+    let b = if a > 10 { a - 1 } else { a + 1 };
+}


### PR DESCRIPTION
This allows for rust style ternery expressions.

Fixes #214