### PR TITLE
Fix bad type resolution for CallExpr when fn is not simply PathInExpression

### DIFF
--- a/gcc/testsuite/rust.test/compilable/function_reference3.rs
+++ b/gcc/testsuite/rust.test/compilable/function_reference3.rs
@@ -1,0 +1,18 @@
+struct Foo {
+    a: fn(i32) -> i32,
+    b: i32,
+}
+
+fn test(a: i32) -> i32 {
+    a + 1
+}
+
+fn main() {
+    let a = test(1);
+
+    let b: fn(i32) -> i32 = test;
+    let c = b(1);
+
+    let d = Foo { a: test, b: c };
+    let e = (d.a)(d.b);
+}


### PR DESCRIPTION
When we have a test case that is, for example, a FieldAccessExpression the
compiler must resolve and compile that field into a reference which can be
called. This is not a simple direct call to a function in that scenario.

Fixes #217