### PR TITLE
Fix parsing |= as a compound assignment expression.

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -386,6 +386,8 @@ Parser<ManagedTokenSource>::left_binding_power (const_TokenPtr token)
       return LBP_MOD_ASSIG;
     case AMP_EQ:
       return LBP_AMP_ASSIG;
+    case PIPE_EQ:
+      return LBP_PIPE_ASSIG;
     case CARET_EQ:
       return LBP_CARET_ASSIG;
     case LEFT_SHIFT_EQ:

--- a/gcc/testsuite/rust.test/compilable/compound_assignment_expr1.rs
+++ b/gcc/testsuite/rust.test/compilable/compound_assignment_expr1.rs
@@ -16,8 +16,7 @@ fn main() {
     d /= 4;
     e %= 5;
     f &= 6;
-    // https://github.com/Rust-GCC/gccrs/issues/173
-    // g |= 7;
+    g |= 7;
     h ^= 8;
     i <<= 9;
     j >>= 10;


### PR DESCRIPTION
Fixes #173