### PR TITLE
Enable -frust-dump-all option for debugging

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -14457,7 +14457,7 @@ Parser<ManagedTokenSource>::done_end ()
 // Dumps lexer output to stderr.
 template <typename ManagedTokenSource>
 void
-Parser<ManagedTokenSource>::debug_dump_lex_output ()
+Parser<ManagedTokenSource>::debug_dump_lex_output (std::ostream &out)
 {
   /* TODO: a better implementation of "lexer dump" (as in dump what was actually
    * tokenised) would actually be to "write" a token to a file every time
@@ -14468,6 +14468,9 @@ Parser<ManagedTokenSource>::debug_dump_lex_output ()
 
   while (true)
     {
+      if (tok->get_id () == Rust::END_OF_FILE)
+	break;
+
       bool has_text = tok->get_id () == Rust::IDENTIFIER
 		      || tok->get_id () == Rust::INT_LITERAL
 		      || tok->get_id () == Rust::FLOAT_LITERAL
@@ -14478,16 +14481,13 @@ Parser<ManagedTokenSource>::debug_dump_lex_output ()
 
       Location loc = tok->get_locus ();
 
-      fprintf (stderr, "<id=%s%s, %s\n", tok->token_id_to_str (),
-	       has_text ? (std::string (", text=") + tok->get_str ()
-			   + std::string (", typehint=")
-			   + std::string (tok->get_type_hint_str ()))
-			    .c_str ()
-			: "",
-	       lexer.get_line_map ()->to_string (loc).c_str ());
-
-      if (tok->get_id () == Rust::END_OF_FILE)
-	break;
+      out << "<id=";
+      out << tok->token_id_to_str ();
+      out << has_text ? (std::string (", text=") + tok->get_str ()
+			 + std::string (", typehint=")
+			 + std::string (tok->get_type_hint_str ()))
+		      : "";
+      out << lexer.get_line_map ()->to_string (loc);
 
       lexer.skip_token ();
       tok = lexer.peek_token ();
@@ -14497,9 +14497,9 @@ Parser<ManagedTokenSource>::debug_dump_lex_output ()
 // Parses crate and dumps AST to stderr, recursively.
 template <typename ManagedTokenSource>
 void
-Parser<ManagedTokenSource>::debug_dump_ast_output (AST::Crate &crate)
+Parser<ManagedTokenSource>::debug_dump_ast_output (AST::Crate &crate,
+						   std::ostream &out)
 {
-  // print crate "as string", which then calls each item as string, etc.
-  fprintf (stderr, "%s", crate.as_string ().c_str ());
+  out << crate.as_string ();
 }
 } // namespace Rust

--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -166,22 +166,30 @@ private:
   parse_generic_params_in_angles ();
   std::vector<std::unique_ptr<AST::GenericParam> > parse_generic_params ();
   template <typename EndTokenPred>
-  std::vector<std::unique_ptr<AST::GenericParam> > parse_generic_params (EndTokenPred is_end_token);
+  std::vector<std::unique_ptr<AST::GenericParam> >
+  parse_generic_params (EndTokenPred is_end_token);
   std::vector<std::unique_ptr<AST::LifetimeParam> > parse_lifetime_params ();
   template <typename EndTokenPred>
-  std::vector<std::unique_ptr<AST::LifetimeParam> > parse_lifetime_params (EndTokenPred is_end_token);
+  std::vector<std::unique_ptr<AST::LifetimeParam> >
+  parse_lifetime_params (EndTokenPred is_end_token);
   std::vector<AST::LifetimeParam> parse_lifetime_params_objs ();
   template <typename EndTokenPred>
-  std::vector<AST::LifetimeParam> parse_lifetime_params_objs (EndTokenPred is_end_token);
+  std::vector<AST::LifetimeParam>
+  parse_lifetime_params_objs (EndTokenPred is_end_token);
   template <typename ParseFunction, typename EndTokenPred>
-  auto parse_non_ptr_sequence (ParseFunction parsing_function, EndTokenPred is_end_token, std::string error_msg = "failed to parse generic param in generic params") -> std::vector<decltype(parsing_function ())>;
+  auto parse_non_ptr_sequence (
+    ParseFunction parsing_function, EndTokenPred is_end_token,
+    std::string error_msg = "failed to parse generic param in generic params")
+    -> std::vector<decltype (parsing_function ())>;
   AST::LifetimeParam parse_lifetime_param ();
   std::vector<std::unique_ptr<AST::TypeParam> > parse_type_params ();
   template <typename EndTokenPred>
-  std::vector<std::unique_ptr<AST::TypeParam> > parse_type_params (EndTokenPred is_end_token);
+  std::vector<std::unique_ptr<AST::TypeParam> >
+  parse_type_params (EndTokenPred is_end_token);
   std::unique_ptr<AST::TypeParam> parse_type_param ();
   template <typename EndTokenPred>
-  std::vector<AST::FunctionParam> parse_function_params (EndTokenPred is_end_token);
+  std::vector<AST::FunctionParam>
+  parse_function_params (EndTokenPred is_end_token);
   AST::FunctionParam parse_function_param ();
   std::unique_ptr<AST::Type> parse_function_return_type ();
   AST::WhereClause parse_where_clause ();
@@ -192,7 +200,8 @@ private:
   parse_type_bound_where_clause_item ();
   std::vector<AST::LifetimeParam> parse_for_lifetimes ();
   template <typename EndTokenPred>
-  std::vector<std::unique_ptr<AST::TypeParamBound> > parse_type_param_bounds (EndTokenPred is_end_token);
+  std::vector<std::unique_ptr<AST::TypeParamBound> >
+  parse_type_param_bounds (EndTokenPred is_end_token);
   std::vector<std::unique_ptr<AST::TypeParamBound> > parse_type_param_bounds ();
   std::unique_ptr<AST::TypeParamBound> parse_type_param_bound ();
   std::unique_ptr<AST::TraitBound> parse_trait_bound ();
@@ -215,7 +224,8 @@ private:
   parse_enum (AST::Visibility vis, std::vector<AST::Attribute> outer_attrs);
   std::vector<std::unique_ptr<AST::EnumItem> > parse_enum_items ();
   template <typename EndTokenPred>
-  std::vector<std::unique_ptr<AST::EnumItem> > parse_enum_items (EndTokenPred is_end_token);
+  std::vector<std::unique_ptr<AST::EnumItem> >
+  parse_enum_items (EndTokenPred is_end_token);
   std::unique_ptr<AST::EnumItem> parse_enum_item ();
   std::unique_ptr<AST::Union>
   parse_union (AST::Visibility vis, std::vector<AST::Attribute> outer_attrs);
@@ -247,8 +257,9 @@ private:
   parse_extern_block (AST::Visibility vis,
 		      std::vector<AST::Attribute> outer_attrs);
   std::unique_ptr<AST::ExternalItem> parse_external_item ();
-  AST::NamedFunctionParam parse_named_function_param (
-    std::vector<AST::Attribute> outer_attrs = std::vector<AST::Attribute> ());
+  AST::NamedFunctionParam
+  parse_named_function_param (std::vector<AST::Attribute> outer_attrs
+			      = std::vector<AST::Attribute> ());
   AST::Method parse_method ();
 
   // Expression-related (Pratt parsed)
@@ -272,9 +283,11 @@ private:
 		   = std::vector<AST::Attribute> (),
 		   ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::ArithmeticOrLogicalExpr>
-  parse_arithmetic_or_logical_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-			  std::vector<AST::Attribute> outer_attrs, AST::ArithmeticOrLogicalExpr::ExprType expr_type,
-			  ParseRestrictions restrictions = ParseRestrictions ());
+  parse_arithmetic_or_logical_expr (
+    const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
+    std::vector<AST::Attribute> outer_attrs,
+    AST::ArithmeticOrLogicalExpr::ExprType expr_type,
+    ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::ArithmeticOrLogicalExpr>
   parse_binary_plus_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
 			  std::vector<AST::Attribute> outer_attrs,
@@ -368,10 +381,11 @@ private:
   parse_assig_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
 		    std::vector<AST::Attribute> outer_attrs,
 		    ParseRestrictions restrictions = ParseRestrictions ());
-  std::unique_ptr<AST::CompoundAssignmentExpr>
-  parse_compound_assignment_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-			 std::vector<AST::Attribute> outer_attrs, AST::CompoundAssignmentExpr::ExprType expr_type,
-			 ParseRestrictions restrictions = ParseRestrictions ());
+  std::unique_ptr<AST::CompoundAssignmentExpr> parse_compound_assignment_expr (
+    const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
+    std::vector<AST::Attribute> outer_attrs,
+    AST::CompoundAssignmentExpr::ExprType expr_type,
+    ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::CompoundAssignmentExpr>
   parse_plus_assig_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
 			 std::vector<AST::Attribute> outer_attrs,
@@ -563,7 +577,8 @@ private:
   std::unique_ptr<AST::Type> parse_paren_prefixed_type ();
   std::unique_ptr<AST::TypeNoBounds> parse_paren_prefixed_type_no_bounds ();
   std::unique_ptr<AST::Type> parse_for_prefixed_type ();
-  AST::MaybeNamedParam parse_maybe_named_param (std::vector<AST::Attribute> outer_attrs);
+  AST::MaybeNamedParam
+  parse_maybe_named_param (std::vector<AST::Attribute> outer_attrs);
 
   // Statement-related
   std::unique_ptr<AST::Stmt> parse_stmt ();
@@ -593,7 +608,8 @@ private:
   std::unique_ptr<AST::TupleStructItems> parse_tuple_struct_items ();
   AST::StructPatternElements parse_struct_pattern_elems ();
   std::unique_ptr<AST::StructPatternField> parse_struct_pattern_field ();
-  std::unique_ptr<AST::StructPatternField> parse_struct_pattern_field_partial (std::vector<AST::Attribute> outer_attrs);
+  std::unique_ptr<AST::StructPatternField>
+  parse_struct_pattern_field_partial (std::vector<AST::Attribute> outer_attrs);
 
   int left_binding_power (const_TokenPtr token);
 
@@ -609,8 +625,8 @@ public:
   AST::Crate parse_crate ();
 
   // Dumps all lexer output.
-  void debug_dump_lex_output ();
-  void debug_dump_ast_output (AST::Crate &crate);
+  void debug_dump_lex_output (std::ostream &out);
+  void debug_dump_ast_output (AST::Crate &crate, std::ostream &out);
 
 private:
   // The token source (usually lexer) associated with the parser.

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -21,6 +21,8 @@
 #include "rust-diagnostics.h"
 #include "diagnostic.h"
 #include "input.h"
+#include <fstream>
+#include <sstream>
 
 #include "target.h"
 #include "tm.h"
@@ -45,6 +47,13 @@ extern Backend *
 rust_get_backend ();
 
 namespace Rust {
+
+const char *kLexDumpFile = "gccrs.lex.dump";
+const char *kASTDumpFile = "gccrs.ast.dump";
+const char *kASTExpandedDumpFile = "gccrs.ast-expanded.dump";
+const char *kHIRDumpFile = "gccrs.hir.dump";
+const char *kHIRTypeResolutionDumpFile = "gccrs.type-resolution.dump";
+const char *kTargetOptionsDumpFile = "gccrs.target-options.dump";
 
 // Implicitly enable a target_feature (and recursively enable dependencies).
 void
@@ -309,9 +318,7 @@ Session::init ()
  * itself. */
 void
 Session::init_options ()
-{
-  options.dump_option = CompileOptions::NO_DUMP;
-}
+{}
 
 // Handle option selection.
 bool
@@ -357,39 +364,40 @@ Session::handle_option (
 bool
 Session::enable_dump (std::string arg)
 {
-  /* FIXME: change dumping algorithm when new non-inhibiting dump system is
-   * created */
+  if (arg.empty ())
+    {
+      rust_error_at (Location (), "dump option was not given a name. choose "
+				  "%<lex%>, %<parse%>, or %<target_options%>");
+      return false;
+    }
+
   if (arg == "all")
     {
-      rust_error_at (
-	Location (),
-	"dumping all is not supported as of now. choose %<lex%>, %<parse%>, "
-	"or %<target_options%>");
-      return false;
+      options.enable_all_dump_options ();
     }
   else if (arg == "lex")
     {
-      options.dump_option = CompileOptions::LEXER_DUMP;
+      options.enable_dump_option (CompileOptions::LEXER_DUMP);
     }
   else if (arg == "parse")
     {
-      options.dump_option = CompileOptions::PARSER_AST_DUMP;
+      options.enable_dump_option (CompileOptions::PARSER_AST_DUMP);
     }
   else if (arg == "register_plugins")
     {
-      options.dump_option = CompileOptions::REGISTER_PLUGINS_DUMP;
+      options.enable_dump_option (CompileOptions::REGISTER_PLUGINS_DUMP);
     }
   else if (arg == "injection")
     {
-      options.dump_option = CompileOptions::INJECTION_DUMP;
+      options.enable_dump_option (CompileOptions::INJECTION_DUMP);
     }
   else if (arg == "expansion")
     {
-      options.dump_option = CompileOptions::EXPANSION_DUMP;
+      options.enable_dump_option (CompileOptions::EXPANSION_DUMP);
     }
   else if (arg == "resolution")
     {
-      options.dump_option = CompileOptions::RESOLUTION_DUMP;
+      options.enable_dump_option (CompileOptions::RESOLUTION_DUMP);
     }
   else if (arg == "target_options")
     {
@@ -398,17 +406,11 @@ Session::enable_dump (std::string arg)
       // actual compile option
       // options.target_data.dump_target_options();
       // return false;
-      options.dump_option = CompileOptions::TARGET_OPTION_DUMP;
+      options.enable_dump_option (CompileOptions::TARGET_OPTION_DUMP);
     }
   else if (arg == "hir")
     {
-      options.dump_option = CompileOptions::HIR_DUMP;
-    }
-  else if (arg == "")
-    {
-      rust_error_at (Location (), "dump option was not given a name. choose "
-				  "%<lex%>, %<parse%>, or %<target_options%>");
-      return false;
+      options.enable_dump_option (CompileOptions::HIR_DUMP);
     }
   else
     {
@@ -460,23 +462,21 @@ Session::parse_file (const char *filename)
   auto mappings = Analysis::Mappings::get ();
   mappings->insert_ast_crate (&parsed_crate);
 
-  // give a chance to give some debug
-  switch (options.dump_option)
+  if (options.dump_option_enabled (CompileOptions::LEXER_DUMP))
     {
-    case CompileOptions::LEXER_DUMP:
-      parser.debug_dump_lex_output ();
-      // TODO: rewrite lexer dump or something so that it allows for the crate
-      // to already be parsed
-      break;
-    case CompileOptions::PARSER_AST_DUMP:
-      parser.debug_dump_ast_output (parsed_crate);
-      break;
-    case CompileOptions::TARGET_OPTION_DUMP:
-      options.target_data.dump_target_options ();
-      return;
-    default:
-      break;
+      dump_lex (parser);
     }
+  if (options.dump_option_enabled (CompileOptions::PARSER_AST_DUMP))
+    {
+      dump_ast (parser, parsed_crate);
+    }
+  if (options.dump_option_enabled (CompileOptions::TARGET_OPTION_DUMP))
+    {
+      options.target_data.dump_target_options ();
+    }
+
+  if (saw_errors ())
+    return;
 
   /* basic pipeline:
    *  - lex
@@ -497,8 +497,7 @@ Session::parse_file (const char *filename)
   // register plugins pipeline stage
   register_plugins (parsed_crate);
   fprintf (stderr, "\033[0;31mSUCCESSFULLY REGISTERED PLUGINS \n\033[0m");
-
-  if (options.dump_option == CompileOptions::REGISTER_PLUGINS_DUMP)
+  if (options.dump_option_enabled (CompileOptions::REGISTER_PLUGINS_DUMP))
     {
       // TODO: what do I dump here?
     }
@@ -506,8 +505,7 @@ Session::parse_file (const char *filename)
   // injection pipeline stage
   injection (parsed_crate);
   fprintf (stderr, "\033[0;31mSUCCESSFULLY FINISHED INJECTION \n\033[0m");
-
-  if (options.dump_option == CompileOptions::INJECTION_DUMP)
+  if (options.dump_option_enabled (CompileOptions::INJECTION_DUMP))
     {
       // TODO: what do I dump here? injected crate names?
     }
@@ -515,18 +513,17 @@ Session::parse_file (const char *filename)
   // expansion pipeline stage
   expansion (parsed_crate);
   fprintf (stderr, "\033[0;31mSUCCESSFULLY FINISHED EXPANSION \n\033[0m");
-
-  if (options.dump_option == CompileOptions::EXPANSION_DUMP)
+  if (options.dump_option_enabled (CompileOptions::EXPANSION_DUMP))
     {
       // dump AST with expanded stuff
       fprintf (stderr, "BEGIN POST-EXPANSION AST DUMP\n");
-      parser.debug_dump_ast_output (parsed_crate);
+      dump_ast_expanded (parser, parsed_crate);
       fprintf (stderr, "END POST-EXPANSION AST DUMP\n");
     }
 
   // resolution pipeline stage
   Resolver::NameResolution::Resolve (parsed_crate);
-  if (options.dump_option == CompileOptions::RESOLUTION_DUMP)
+  if (options.dump_option_enabled (CompileOptions::RESOLUTION_DUMP))
     {
       // TODO: what do I dump here? resolved names? AST with resolved names?
     }
@@ -536,10 +533,9 @@ Session::parse_file (const char *filename)
 
   // lower AST to HIR
   HIR::Crate hir = HIR::ASTLowering::Resolve (parsed_crate);
-  if (options.dump_option == CompileOptions::HIR_DUMP)
+  if (options.dump_option_enabled (CompileOptions::HIR_DUMP))
     {
-      fprintf (stderr, "%s", hir.as_string ().c_str ());
-      return;
+      dump_hir (hir);
     }
 
   if (saw_errors ())
@@ -547,11 +543,9 @@ Session::parse_file (const char *filename)
 
   // type resolve
   Resolver::TypeResolution::Resolve (hir);
-  if (options.dump_option == CompileOptions::TYPE_RESOLUTION_DUMP)
+  if (options.dump_option_enabled (CompileOptions::TYPE_RESOLUTION_DUMP))
     {
-      auto buf = Resolver::TypeResolverDump::go (hir);
-      fprintf (stderr, "%s\n", buf.c_str ());
-      return;
+      dump_type_resolution (hir);
     }
 
   // scan unused has to be done after type resolution since methods are resolved
@@ -794,22 +788,114 @@ Session::expansion (AST::Crate &crate)
 }
 
 void
+Session::dump_lex (Parser<Lexer> &parser) const
+{
+  std::ofstream out;
+  out.open (kLexDumpFile);
+  if (out.fail ())
+    {
+      rust_error_at (Linemap::unknown_location (), "cannot open %s:%m; ignored",
+		     kLexDumpFile);
+      return;
+    }
+
+  // TODO: rewrite lexer dump or something so that it allows for the crate
+  // to already be parsed
+  parser.debug_dump_lex_output (out);
+  out.close ();
+}
+
+void
+Session::dump_ast (Parser<Lexer> &parser, AST::Crate &crate) const
+{
+  std::ofstream out;
+  out.open (kASTDumpFile);
+  if (out.fail ())
+    {
+      rust_error_at (Linemap::unknown_location (), "cannot open %s:%m; ignored",
+		     kASTDumpFile);
+      return;
+    }
+
+  parser.debug_dump_ast_output (crate, out);
+  out.close ();
+}
+
+void
+Session::dump_ast_expanded (Parser<Lexer> &parser, AST::Crate &crate) const
+{
+  std::ofstream out;
+  out.open (kASTExpandedDumpFile);
+  if (out.fail ())
+    {
+      rust_error_at (Linemap::unknown_location (), "cannot open %s:%m; ignored",
+		     kASTExpandedDumpFile);
+      return;
+    }
+
+  parser.debug_dump_ast_output (crate, out);
+  out.close ();
+}
+
+void
+Session::dump_hir (HIR::Crate &hir) const
+{
+  std::ofstream out;
+  out.open (kHIRDumpFile);
+  if (out.fail ())
+    {
+      rust_error_at (Linemap::unknown_location (), "cannot open %s:%m; ignored",
+		     kHIRDumpFile);
+      return;
+    }
+
+  out << hir.as_string ();
+  out.close ();
+}
+
+void
+Session::dump_type_resolution (HIR::Crate &hir) const
+{
+  std::ofstream out;
+  out.open (kHIRTypeResolutionDumpFile);
+  if (out.fail ())
+    {
+      rust_error_at (Linemap::unknown_location (), "cannot open %s:%m; ignored",
+		     kHIRTypeResolutionDumpFile);
+      return;
+    }
+
+  Resolver::TypeResolverDump::go (hir, out);
+  out.close ();
+}
+
+void
 TargetOptions::dump_target_options () const
 {
-  fprintf (stderr,
-	   "\033[0;31m--PREPARING TO DUMP ALL TARGET OPTIONS--\n\033[0m");
+  std::ofstream out;
+  out.open (kTargetOptionsDumpFile);
+  if (out.fail ())
+    {
+      rust_error_at (Linemap::unknown_location (), "cannot open %s:%m; ignored",
+		     kTargetOptionsDumpFile);
+      return;
+    }
+
+  if (features.empty ())
+    {
+      out << "No target options available!\n";
+    }
+
   for (const auto &pairs : features)
     {
       for (const auto &value : pairs.second)
-	fprintf (stderr, "%s: \"%s\"\n", pairs.first.c_str (), value.c_str ());
+	out << pairs.first + ": \"" + value + "\"\n";
 
       if (pairs.second.empty ())
-	fprintf (stderr, "%s\n", pairs.first.c_str ());
+	out << pairs.first + "\n";
     }
-  if (features.empty ())
-    fprintf (stderr, "No target options available!\n");
 
-  fprintf (stderr, "\033[0;31m--END OF TARGET OPTION DUMP--\n\033[0m");
+  out.close ();
 }
 
 void

--- a/gcc/rust/rust-session-manager.h
+++ b/gcc/rust/rust-session-manager.h
@@ -116,8 +116,8 @@ public:
   // Dump all target options to stderr.
   void dump_target_options () const;
 
-  /* Creates derived values and implicit enables after all target info is added
-   * (e.g. "unix"). */
+  /* Creates derived values and implicit enables after all target info is
+   * added (e.g. "unix"). */
   void init_derived_values ();
 
   /* Enables all requirements for the feature given, and will enable feature
@@ -162,13 +162,8 @@ public:
 // Defines compiler options (e.g. dump, etc.).
 struct CompileOptions
 {
-  // TODO: use bitfield for smaller memory requirements?
-
-  /* FIXME: this is set up for "instead of" dumping - in future, dumps should
-   * not inhibit compilation */
-  enum DumpOptions
+  enum DumpOption
   {
-    NO_DUMP,
     LEXER_DUMP,
     PARSER_AST_DUMP,
     REGISTER_PLUGINS_DUMP,
@@ -178,8 +173,9 @@ struct CompileOptions
     TARGET_OPTION_DUMP,
     HIR_DUMP,
     TYPE_RESOLUTION_DUMP,
+  };
 
-  } dump_option;
+  std::set<DumpOption> dump_options;
 
   /* configuration options - actually useful for conditional compilation and
    * whatever data related to target arch, features, os, family, env, endian,
@@ -188,6 +184,26 @@ struct CompileOptions
   bool enable_test = false;
   bool debug_assertions = false;
   bool proc_macro = false;
+
+  bool dump_option_enabled (DumpOption option) const
+  {
+    return dump_options.find (option) != dump_options.end ();
+  }
+
+  void enable_dump_option (DumpOption option) { dump_options.insert (option); }
+
+  void enable_all_dump_options ()
+  {
+    enable_dump_option (DumpOption::LEXER_DUMP);
+    enable_dump_option (DumpOption::PARSER_AST_DUMP);
+    enable_dump_option (DumpOption::REGISTER_PLUGINS_DUMP);
+    enable_dump_option (DumpOption::INJECTION_DUMP);
+    enable_dump_option (DumpOption::EXPANSION_DUMP);
+    enable_dump_option (DumpOption::RESOLUTION_DUMP);
+    enable_dump_option (DumpOption::TARGET_OPTION_DUMP);
+    enable_dump_option (DumpOption::HIR_DUMP);
+    enable_dump_option (DumpOption::TYPE_RESOLUTION_DUMP);
+  }
 };
 
 /* Defines a compiler session. This is for a single compiler invocation, so
@@ -218,6 +234,12 @@ public:
 private:
   void parse_file (const char *filename);
   bool enable_dump (std::string arg);
+
+  void dump_lex (Parser<Lexer> &parser) const;
+  void dump_ast (Parser<Lexer> &parser, AST::Crate &crate) const;
+  void dump_ast_expanded (Parser<Lexer> &parser, AST::Crate &crate) const;
+  void dump_hir (HIR::Crate &crate) const;
+  void dump_type_resolution (HIR::Crate &crate) const;
 
   void debug_dump_load_crates (Parser<Lexer> &parser);
 

--- a/gcc/rust/typecheck/rust-tycheck-dump.h
+++ b/gcc/rust/typecheck/rust-tycheck-dump.h
@@ -28,13 +28,13 @@ namespace Resolver {
 class TypeResolverDump : public TypeCheckBase
 {
 public:
-  static std::string go (HIR::Crate &crate)
+  static void go (HIR::Crate &crate, std::ofstream &out)
   {
     TypeResolverDump dumper;
     for (auto &item : crate.items)
       item->accept_vis (dumper);
 
-    return dumper.dump;
+    out << dumper.dump;
   }
 
   void visit (HIR::InherentImpl &impl_block) override


### PR DESCRIPTION
We output each debug IR to file which makes it easier to debug larger
test cases. Be aware not all dumps are complete such as name resolution
is not implemented yet, HIR is badly formatted and type resolution dump is
not finished.

We get the following outputs:

```
-rw-rw-r--  1 philbert philbert    4012 Feb  9 14:04 gccrs.ast.dump
-rw-rw-r--  1 philbert philbert    4082 Feb  9 14:04 gccrs.ast-expanded.dump
-rw-rw-r--  1 philbert philbert    5445 Feb  9 14:04 gccrs.hir.dump
-rw-rw-r--  1 philbert philbert       0 Feb  9 14:04 gccrs.lex.dump
-rw-rw-r--  1 philbert philbert     604 Feb  9 14:04 gccrs.target-options.dump
-rw-rw-r--  1 philbert philbert    1214 Feb  9 14:04 gccrs.type-resolution.dump
```