### PR TITLE
Simple Loops

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -1139,11 +1139,14 @@ private:
 
   Location locus;
 
+  NodeId node_id;
+
 public:
   // Constructor
   Lifetime (LifetimeType type, std::string name = std::string (),
 	    Location locus = Location ())
-    : lifetime_type (type), lifetime_name (std::move (name)), locus (locus)
+    : lifetime_type (type), lifetime_name (std::move (name)), locus (locus),
+      node_id (Analysis::Mappings::get ()->get_next_node_id ())
   {}
 
   // Creates an "error" lifetime.
@@ -1158,6 +1161,14 @@ public:
   std::string as_string () const override;
 
   void accept_vis (ASTVisitor &vis) override;
+
+  LifetimeType get_lifetime_type () { return lifetime_type; }
+
+  Location get_locus () { return locus; }
+
+  std::string get_lifetime_name () const { return lifetime_name; }
+
+  NodeId get_node_id () const { return node_id; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -3103,6 +3103,8 @@ public:
     return break_expr;
   }
 
+  Lifetime &get_label () { return label; }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */
@@ -3670,11 +3672,14 @@ class LoopLabel /*: public Node*/
   Lifetime label; // or type LIFETIME_OR_LABEL
   Location locus;
 
+  NodeId node_id;
+
 public:
   std::string as_string () const;
 
   LoopLabel (Lifetime loop_label, Location locus = Location ())
-    : label (std::move (loop_label)), locus (locus)
+    : label (std::move (loop_label)), locus (locus),
+      node_id (Analysis::Mappings::get ()->get_next_node_id ())
   {}
 
   // Returns whether the LoopLabel is in an error state.
@@ -3684,6 +3689,10 @@ public:
   static LoopLabel error () { return LoopLabel (Lifetime::error ()); }
 
   Location get_locus () const { return locus; }
+
+  Lifetime &get_lifetime () { return label; }
+
+  NodeId get_node_id () const { return node_id; }
 };
 
 // Base loop expression AST node - aka LoopExpr
@@ -3742,6 +3751,8 @@ protected:
 
 public:
   bool has_loop_label () const { return !loop_label.is_error (); }
+
+  LoopLabel &get_loop_label () { return loop_label; }
 
   Location get_locus () const { return locus; }
   Location get_locus_slow () const override { return get_locus (); }

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -162,6 +162,21 @@ public:
     return true;
   }
 
+  void insert_label_decl (HirId id, ::Blabel *label)
+  {
+    compiled_labels[id] = label;
+  }
+
+  bool lookup_label_decl (HirId id, ::Blabel **label)
+  {
+    auto it = compiled_labels.find (id);
+    if (it == compiled_labels.end ())
+      return false;
+
+    *label = it->second;
+    return true;
+  }
+
   void push_fn (::Bfunction *fn, ::Bvariable *ret_addr)
   {
     fn_stack.push_back (fncontext{fn, ret_addr});
@@ -205,6 +220,7 @@ private:
   std::map<HirId, ::Btype *> compiled_type_map;
   std::map<HirId, ::Bfunction *> compiled_fn_map;
   std::map<HirId, ::Bexpression *> compiled_consts;
+  std::map<HirId, ::Blabel *> compiled_labels;
   std::vector< ::std::vector<Bstatement *> > statements;
   std::vector< ::Bblock *> scope_stack;
 

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -208,6 +208,17 @@ public:
     return false;
   }
 
+  void push_loop_context (Bvariable *var) { loop_value_stack.push_back (var); }
+
+  Bvariable *peek_loop_context () { return loop_value_stack.back (); }
+
+  Bvariable *pop_loop_context ()
+  {
+    auto back = loop_value_stack.back ();
+    loop_value_stack.pop_back ();
+    return back;
+  }
+
 private:
   ::Backend *backend;
   Resolver::Resolver *resolver;
@@ -223,6 +234,7 @@ private:
   std::map<HirId, ::Blabel *> compiled_labels;
   std::vector< ::std::vector<Bstatement *> > statements;
   std::vector< ::Bblock *> scope_stack;
+  std::vector< ::Bvariable *> loop_value_stack;
 
   // To GCC middle-end
   std::vector< ::Btype *> type_decls;

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -84,14 +84,18 @@ public:
 
   void visit (HIR::ReturnExpr &expr)
   {
-    Bexpression *compiled_expr
-      = CompileExpr::Compile (expr.return_expr.get (), ctx);
-    rust_assert (compiled_expr != nullptr);
-
     auto fncontext = ctx->peek_fn ();
 
     std::vector<Bexpression *> retstmts;
-    retstmts.push_back (compiled_expr);
+    if (expr.has_return_expr ())
+      {
+	Bexpression *compiled_expr
+	  = CompileExpr::Compile (expr.return_expr.get (), ctx);
+	rust_assert (compiled_expr != nullptr);
+
+	retstmts.push_back (compiled_expr);
+      }
+
     auto s = ctx->get_backend ()->return_statement (fncontext.fndecl, retstmts,
 						    expr.get_locus ());
     ctx->add_statement (s);

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -580,6 +580,25 @@ public:
     translated = ResolvePathRef::Compile (&expr, ctx);
   }
 
+  void visit (HIR::LoopExpr &expr)
+  {
+    // loop_start:
+    //      <loop_body>
+    //   goto loop_start;
+    fncontext fnctx = ctx->peek_fn ();
+    Blabel *loop_start
+      = ctx->get_backend ()->label (fnctx.fndecl, "", expr.get_locus ());
+    Bstatement *label_decl_stmt
+      = ctx->get_backend ()->label_definition_statement (loop_start);
+    ctx->add_statement (label_decl_stmt);
+
+    translated = CompileExpr::Compile (expr.get_loop_block ().get (), ctx);
+
+    Bstatement *goto_loop_start_stmt
+      = ctx->get_backend ()->goto_statement (loop_start, Location ());
+    ctx->add_statement (goto_loop_start_stmt);
+  }
+
 private:
   CompileExpr (Context *ctx) : HIRCompileBase (ctx), translated (nullptr) {}
 

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -236,23 +236,28 @@ CompileBlock::visit (HIR::BlockExpr &expr)
       // the previous passes will ensure this is a valid return
       // dead code elimination should remove any bad trailing expressions
       Bexpression *compiled_expr = CompileExpr::Compile (expr.expr.get (), ctx);
-      rust_assert (compiled_expr != nullptr);
-
-      if (result == nullptr)
+      if (compiled_expr != nullptr)
 	{
-	  Bstatement *final_stmt
-	    = ctx->get_backend ()->expression_statement (fnctx.fndecl,
-							 compiled_expr);
-	  ctx->add_statement (final_stmt);
-	}
-      else
-	{
-	  Bexpression *result_reference = ctx->get_backend ()->var_expression (
-	    result, expr.get_final_expr ()->get_locus_slow ());
+	  if (result == nullptr)
+	    {
+	      Bstatement *final_stmt
+		= ctx->get_backend ()->expression_statement (fnctx.fndecl,
+							     compiled_expr);
+	      ctx->add_statement (final_stmt);
+	    }
+	  else
+	    {
+	      Bexpression *result_reference
+		= ctx->get_backend ()->var_expression (
+		  result, expr.get_final_expr ()->get_locus_slow ());
 
-	  Bstatement *assignment = ctx->get_backend ()->assignment_statement (
-	    fnctx.fndecl, result_reference, compiled_expr, expr.get_locus ());
-	  ctx->add_statement (assignment);
+	      Bstatement *assignment
+		= ctx->get_backend ()->assignment_statement (fnctx.fndecl,
+							     result_reference,
+							     compiled_expr,
+							     expr.get_locus ());
+	      ctx->add_statement (assignment);
+	    }
 	}
     }
 

--- a/gcc/rust/hir/rust-ast-lower-base.h
+++ b/gcc/rust/hir/rust-ast-lower-base.h
@@ -264,6 +264,8 @@ protected:
     Analysis::NodeMapping mapping (crate_num, lifetime.get_node_id (),
 				   mappings->get_next_hir_id (crate_num),
 				   UNKNOWN_LOCAL_DEFID);
+    mappings->insert_node_to_hir (mapping.get_crate_num (),
+				  mapping.get_nodeid (), mapping.get_hirid ());
 
     return HIR::Lifetime (mapping, type, lifetime.get_lifetime_name (),
 			  lifetime.get_locus ());
@@ -277,6 +279,8 @@ protected:
     Analysis::NodeMapping mapping (crate_num, loop_label.get_node_id (),
 				   mappings->get_next_hir_id (crate_num),
 				   UNKNOWN_LOCAL_DEFID);
+    mappings->insert_node_to_hir (mapping.get_crate_num (),
+				  mapping.get_nodeid (), mapping.get_hirid ());
 
     return HIR::LoopLabel (mapping, std::move (life), loop_label.get_locus ());
   }

--- a/gcc/rust/hir/rust-ast-lower-base.h
+++ b/gcc/rust/hir/rust-ast-lower-base.h
@@ -243,6 +243,43 @@ protected:
   ASTLoweringBase () : mappings (Analysis::Mappings::get ()) {}
 
   Analysis::Mappings *mappings;
+
+  HIR::Lifetime lower_lifetime (AST::Lifetime &lifetime)
+  {
+    HIR::Lifetime::LifetimeType type = HIR::Lifetime::LifetimeType::NAMED;
+    switch (lifetime.get_lifetime_type ())
+      {
+      case AST::Lifetime::LifetimeType::NAMED:
+	type = HIR::Lifetime::LifetimeType::NAMED;
+	break;
+      case AST::Lifetime::LifetimeType::STATIC:
+	type = HIR::Lifetime::LifetimeType::STATIC;
+	break;
+      case AST::Lifetime::LifetimeType::WILDCARD:
+	type = HIR::Lifetime::LifetimeType::WILDCARD;
+	break;
+      }
+
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, lifetime.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   UNKNOWN_LOCAL_DEFID);
+
+    return HIR::Lifetime (mapping, type, lifetime.get_lifetime_name (),
+			  lifetime.get_locus ());
+  }
+
+  HIR::LoopLabel lower_loop_label (AST::LoopLabel &loop_label)
+  {
+    HIR::Lifetime life = lower_lifetime (loop_label.get_lifetime ());
+
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, loop_label.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   UNKNOWN_LOCAL_DEFID);
+
+    return HIR::LoopLabel (mapping, std::move (life), loop_label.get_locus ());
+  }
 };
 
 } // namespace HIR

--- a/gcc/rust/hir/rust-ast-lower-block.h
+++ b/gcc/rust/hir/rust-ast-lower-block.h
@@ -141,6 +141,8 @@ public:
       = ASTLoweringBlock::translate (expr.get_loop_block ().get (),
 				     &terminated);
 
+    HIR::LoopLabel loop_label = lower_loop_label (expr.get_loop_label ());
+
     auto crate_num = mappings->get_current_crate ();
     Analysis::NodeMapping mapping (crate_num, expr.get_node_id (),
 				   mappings->get_next_hir_id (crate_num),
@@ -149,7 +151,7 @@ public:
     translated
       = new HIR::LoopExpr (mapping,
 			   std::unique_ptr<HIR::BlockExpr> (loop_block),
-			   expr.get_locus (), HIR::LoopLabel::error (),
+			   expr.get_locus (), std::move (loop_label),
 			   std::move (outer_attribs));
   }
 

--- a/gcc/rust/hir/rust-ast-lower-block.h
+++ b/gcc/rust/hir/rust-ast-lower-block.h
@@ -134,6 +134,25 @@ public:
     translated = ASTLoweringBlock::translate (&expr, &terminated);
   }
 
+  void visit (AST::LoopExpr &expr)
+  {
+    std::vector<HIR::Attribute> outer_attribs;
+    HIR::BlockExpr *loop_block
+      = ASTLoweringBlock::translate (expr.get_loop_block ().get (),
+				     &terminated);
+
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, expr.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   UNKNOWN_LOCAL_DEFID);
+
+    translated
+      = new HIR::LoopExpr (mapping,
+			   std::unique_ptr<HIR::BlockExpr> (loop_block),
+			   expr.get_locus (), HIR::LoopLabel::error (),
+			   std::move (outer_attribs));
+  }
+
 private:
   ASTLoweringExprWithBlock ()
     : ASTLoweringBase (), translated (nullptr), terminated (false)

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -697,6 +697,11 @@ public:
 				  std::move (outer_attribs), expr.get_locus ());
   }
 
+  void visit (AST::LoopExpr &expr)
+  {
+    translated = ASTLoweringExprWithBlock::translate (&expr, &terminated);
+  }
+
 private:
   ASTLoweringExpr ()
     : translated (nullptr), translated_array_elems (nullptr), terminated (false)

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -74,8 +74,6 @@ public:
     return compiler.translated;
   }
 
-  ~ASTLowerPathInExpression () {}
-
   void visit (AST::PathInExpression &expr)
   {
     std::vector<HIR::PathExprSegment> path_segments;
@@ -702,9 +700,30 @@ public:
     translated = ASTLoweringExprWithBlock::translate (&expr, &terminated);
   }
 
+  void visit (AST::BreakExpr &expr)
+  {
+    std::vector<HIR::Attribute> outer_attribs;
+    HIR::Lifetime break_label = lower_lifetime (expr.get_label ());
+    HIR::Expr *break_expr
+      = expr.has_break_expr ()
+	  ? ASTLoweringExpr::translate (expr.get_break_expr ().get ())
+	  : nullptr;
+
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, expr.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   UNKNOWN_LOCAL_DEFID);
+
+    translated = new HIR::BreakExpr (mapping, expr.get_locus (),
+				     std ::move (break_label),
+				     std::unique_ptr<HIR::Expr> (break_expr),
+				     std::move (outer_attribs));
+  }
+
 private:
   ASTLoweringExpr ()
-    : translated (nullptr), translated_array_elems (nullptr), terminated (false)
+    : ASTLoweringBase (), translated (nullptr),
+      translated_array_elems (nullptr), terminated (false)
   {}
 
   HIR::Expr *translated;

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -3334,6 +3334,8 @@ public:
 
   Location get_locus () const { return locus; }
   Location get_locus_slow () const override { return get_locus (); }
+
+  std::unique_ptr<HIR::BlockExpr> &get_loop_block () { return loop_block; };
 };
 
 // 'Loop' expression (i.e. the infinite loop) HIR node

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -2712,8 +2712,7 @@ public:
   bool has_label () const { return !label.is_error (); }
 
   // Constructor for a ContinueExpr with a label.
-  ContinueExpr (Analysis::NodeMapping mappings, Location locus,
-		Lifetime label = Lifetime::error (),
+  ContinueExpr (Analysis::NodeMapping mappings, Location locus, Lifetime label,
 		std::vector<Attribute> outer_attribs
 		= std::vector<Attribute> ())
     : ExprWithoutBlock (std::move (mappings), std::move (outer_attribs)),
@@ -2765,7 +2764,7 @@ public:
 
   // Constructor for a break expression
   BreakExpr (Analysis::NodeMapping mappings, Location locus,
-	     Lifetime break_label = Lifetime::error (),
+	     Lifetime break_label,
 	     std::unique_ptr<Expr> expr_in_break = nullptr,
 	     std::vector<Attribute> outer_attribs = std::vector<Attribute> ())
     : ExprWithoutBlock (std::move (mappings), std::move (outer_attribs)),
@@ -2802,6 +2801,10 @@ public:
   Location get_locus_slow () const override { return get_locus (); }
 
   void accept_vis (HIRVisitor &vis) override;
+
+  Lifetime &get_label () { return label; }
+
+  std::unique_ptr<Expr> &get_expr () { return break_expr; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather
@@ -3266,20 +3269,21 @@ class LoopLabel /*: public Node*/
 
   Location locus;
 
+  Analysis::NodeMapping mappings;
+
 public:
   std::string as_string () const;
 
-  LoopLabel (Lifetime loop_label, Location locus = Location ())
-    : label (std::move (loop_label)), locus (locus)
+  LoopLabel (Analysis::NodeMapping mapping, Lifetime loop_label, Location locus)
+    : label (std::move (loop_label)), locus (locus), mappings (mapping)
   {}
 
   // Returns whether the LoopLabel is in an error state.
   bool is_error () const { return label.is_error (); }
 
-  // Creates an error state LoopLabel.
-  static LoopLabel error () { return LoopLabel (Lifetime::error ()); }
-
   Location get_locus () const { return locus; }
+
+  Analysis::NodeMapping &get_mappings () { return mappings; }
 };
 
 // Base loop expression HIR node - aka LoopExpr
@@ -3299,7 +3303,7 @@ protected:
   // Constructor for BaseLoopExpr
   BaseLoopExpr (Analysis::NodeMapping mappings,
 		std::unique_ptr<BlockExpr> loop_block, Location locus,
-		LoopLabel loop_label = LoopLabel::error (),
+		LoopLabel loop_label,
 		std::vector<Attribute> outer_attribs
 		= std::vector<Attribute> ())
     : ExprWithBlock (std::move (mappings), std::move (outer_attribs)),
@@ -3347,7 +3351,7 @@ public:
   // Constructor for LoopExpr
   LoopExpr (Analysis::NodeMapping mappings,
 	    std::unique_ptr<BlockExpr> loop_block, Location locus,
-	    LoopLabel loop_label = LoopLabel::error (),
+	    LoopLabel loop_label,
 	    std::vector<Attribute> outer_attribs = std::vector<Attribute> ())
     : BaseLoopExpr (std::move (mappings), std::move (loop_block), locus,
 		    std::move (loop_label), std::move (outer_attribs))
@@ -3380,7 +3384,7 @@ public:
   WhileLoopExpr (Analysis::NodeMapping mappings,
 		 std::unique_ptr<Expr> loop_condition,
 		 std::unique_ptr<BlockExpr> loop_block, Location locus,
-		 LoopLabel loop_label = LoopLabel::error (),
+		 LoopLabel loop_label,
 		 std::vector<Attribute> outer_attribs
 		 = std::vector<Attribute> ())
     : BaseLoopExpr (std::move (mappings), std::move (loop_block), locus,
@@ -3442,7 +3446,7 @@ public:
 		    std::vector<std::unique_ptr<Pattern> > match_arm_patterns,
 		    std::unique_ptr<Expr> condition,
 		    std::unique_ptr<BlockExpr> loop_block, Location locus,
-		    LoopLabel loop_label = LoopLabel::error (),
+		    LoopLabel loop_label,
 		    std::vector<Attribute> outer_attribs
 		    = std::vector<Attribute> ())
     : BaseLoopExpr (std::move (mappings), std::move (loop_block), locus,
@@ -3515,7 +3519,7 @@ public:
 	       std::unique_ptr<Pattern> loop_pattern,
 	       std::unique_ptr<Expr> iterator_expr,
 	       std::unique_ptr<BlockExpr> loop_body, Location locus,
-	       LoopLabel loop_label = LoopLabel::error (),
+	       LoopLabel loop_label,
 	       std::vector<Attribute> outer_attribs = std::vector<Attribute> ())
     : BaseLoopExpr (std::move (mappings), std::move (loop_body), locus,
 		    std::move (loop_label), std::move (outer_attribs)),

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -3284,6 +3284,8 @@ public:
   Location get_locus () const { return locus; }
 
   Analysis::NodeMapping &get_mappings () { return mappings; }
+
+  Lifetime &get_lifetime () { return label; }
 };
 
 // Base loop expression HIR node - aka LoopExpr
@@ -3340,6 +3342,8 @@ public:
   Location get_locus_slow () const override { return get_locus (); }
 
   std::unique_ptr<HIR::BlockExpr> &get_loop_block () { return loop_block; };
+
+  LoopLabel &get_loop_label () { return loop_label; }
 };
 
 // 'Loop' expression (i.e. the infinite loop) HIR node

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -324,7 +324,8 @@ public:
   // Type-based self parameter (not ref, no lifetime)
   SelfParam (Analysis::NodeMapping mappings, std::unique_ptr<Type> type,
 	     bool is_mut, Location locus)
-    : has_ref (false), is_mut (is_mut), lifetime (Lifetime::error ()),
+    : has_ref (false), is_mut (is_mut),
+      lifetime (Lifetime (mappings, Lifetime::LifetimeType::NAMED, "", locus)),
       type (std::move (type)), locus (locus), mappings (mappings)
   {}
 

--- a/gcc/rust/hir/tree/rust-hir-type.h
+++ b/gcc/rust/hir/tree/rust-hir-type.h
@@ -531,7 +531,7 @@ public:
   // Constructor
   ReferenceType (Analysis::NodeMapping mappings, bool is_mut,
 		 std::unique_ptr<TypeNoBounds> type_no_bounds, Location locus,
-		 Lifetime lifetime = Lifetime::error ())
+		 Lifetime lifetime)
     : TypeNoBounds (mappings), lifetime (std::move (lifetime)),
       has_mut (is_mut), type (std::move (type_no_bounds)), locus (locus)
   {}

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -1060,15 +1060,15 @@ private:
 
   Location locus;
 
+  Analysis::NodeMapping mappings;
+
 public:
   // Constructor
-  Lifetime (LifetimeType type, std::string name = std::string (),
-	    Location locus = Location ())
-    : lifetime_type (type), lifetime_name (std::move (name)), locus (locus)
+  Lifetime (Analysis::NodeMapping mapping, LifetimeType type, std::string name,
+	    Location locus)
+    : lifetime_type (type), lifetime_name (std::move (name)), locus (locus),
+      mappings (mapping)
   {}
-
-  // Creates an "error" lifetime.
-  static Lifetime error () { return Lifetime (NAMED, std::string ("")); }
 
   // Returns true if the lifetime is in an error state.
   bool is_error () const
@@ -1079,6 +1079,14 @@ public:
   std::string as_string () const override;
 
   void accept_vis (HIRVisitor &vis) override;
+
+  std::string get_name () const { return lifetime_name; }
+
+  LifetimeType get_lifetime_type () const { return lifetime_type; }
+
+  Location get_locus () const { return locus; }
+
+  Analysis::NodeMapping get_mappings () const { return mappings; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather
@@ -1132,12 +1140,6 @@ public:
 
   // Returns whether the lifetime param has an outer attribute.
   bool has_outer_attribute () const { return !outer_attr.is_empty (); }
-
-  // Creates an error state lifetime param.
-  static LifetimeParam create_error ()
-  {
-    return LifetimeParam (Lifetime::error ());
-  }
 
   // Returns whether the lifetime param is in an error state.
   bool is_error () const { return lifetime.is_error (); }

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -7437,7 +7437,10 @@ Parser<ManagedTokenSource>::parse_break_expr (
     }
 
   // parse break return expression if it exists
-  std::unique_ptr<AST::Expr> return_expr = parse_expr ();
+  ParseRestrictions restrictions;
+  restrictions.expr_can_be_null = true;
+  std::unique_ptr<AST::Expr> return_expr
+    = parse_expr (std::vector<AST::Attribute> (), restrictions);
 
   return std::unique_ptr<AST::BreakExpr> (
     new AST::BreakExpr (locus, std::move (label), std::move (return_expr),
@@ -12461,9 +12464,10 @@ Parser<ManagedTokenSource>::null_denotation (
       // array definition expr (not indexing)
       return parse_array_expr (std::move (outer_attrs), true);
     default:
-      rust_error_at (tok->get_locus (),
-		     "found unexpected token %qs in null denotation",
-		     tok->get_token_description ());
+      if (!restrictions.expr_can_be_null)
+	rust_error_at (tok->get_locus (),
+		       "found unexpected token %qs in null denotation",
+		       tok->get_token_description ());
       return nullptr;
     }
 }

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -7400,8 +7400,10 @@ Parser<ManagedTokenSource>::parse_return_expr (
     }
 
   // parse expression to return, if it exists
-  std::unique_ptr<AST::Expr> returned_expr = parse_expr ();
-  // FIXME: ensure this doesn't ruin the middle of any expressions or anything
+  ParseRestrictions restrictions;
+  restrictions.expr_can_be_null = true;
+  std::unique_ptr<AST::Expr> returned_expr
+    = parse_expr (std::vector<AST::Attribute> (), restrictions);
 
   return std::unique_ptr<AST::ReturnExpr> (
     new AST::ReturnExpr (locus, std::move (returned_expr),

--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -82,6 +82,7 @@ struct ParseRestrictions
   /* Whether the expression was entered from a unary expression - prevents stuff
    * like struct exprs being parsed from a dereference. */
   bool entered_from_unary = false;
+  bool expr_can_be_null = false;
 };
 
 // Parser implementation for gccrs.

--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -500,10 +500,9 @@ private:
   parse_if_let_expr (std::vector<AST::Attribute> outer_attrs
 		     = std::vector<AST::Attribute> (),
 		     bool pratt_parse = false);
-  std::unique_ptr<AST::LoopExpr>
-  parse_loop_expr (std::vector<AST::Attribute> outer_attrs
-		   = std::vector<AST::Attribute> (),
-		   AST::LoopLabel label = AST::LoopLabel::error ());
+  std::unique_ptr<AST::LoopExpr> parse_loop_expr (
+    std::vector<AST::Attribute> outer_attrs = std::vector<AST::Attribute> (),
+    AST::LoopLabel label = AST::LoopLabel::error (), bool pratt_parse = false);
   std::unique_ptr<AST::WhileLoopExpr>
   parse_while_loop_expr (std::vector<AST::Attribute> outer_attrs
 			 = std::vector<AST::Attribute> (),

--- a/gcc/rust/resolve/rust-ast-resolve-expr.h
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.h
@@ -241,6 +241,11 @@ public:
     ResolveExpr::go (expr.get_receiver_expr ().get (), expr.get_node_id ());
   }
 
+  void visit (AST::LoopExpr &expr)
+  {
+    ResolveExpr::go (expr.get_loop_block ().get (), expr.get_node_id ());
+  }
+
 private:
   ResolveExpr (NodeId parent) : ResolverBase (parent) {}
 };

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -88,8 +88,10 @@ public:
     NodeId scope_node_id = function.get_node_id ();
     resolver->get_name_scope ().push (scope_node_id);
     resolver->get_type_scope ().push (scope_node_id);
+    resolver->get_label_scope ().push (scope_node_id);
     resolver->push_new_name_rib (resolver->get_name_scope ().peek ());
     resolver->push_new_type_rib (resolver->get_type_scope ().peek ());
+    resolver->push_new_label_rib (resolver->get_type_scope ().peek ());
 
     // we make a new scope so the names of parameters are resolved and shadowed
     // correctly
@@ -111,6 +113,7 @@ public:
 
     resolver->get_name_scope ().pop ();
     resolver->get_type_scope ().pop ();
+    resolver->get_label_scope ().pop ();
   }
 
   void visit (AST::InherentImpl &impl_block)

--- a/gcc/rust/resolve/rust-ast-resolve-unused.h
+++ b/gcc/rust/resolve/rust-ast-resolve-unused.h
@@ -43,6 +43,7 @@ public:
     auto resolver = Resolver::get ();
     resolver->iterate_name_ribs ([&] (Rib *r) -> void { ScanRib (r); });
     resolver->iterate_type_ribs ([&] (Rib *r) -> void { ScanRib (r); });
+    resolver->iterate_label_ribs ([&] (Rib *r) -> void { ScanRib (r); });
   }
 };
 

--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -252,7 +252,7 @@ Resolver::insert_resolved_label (NodeId refId, NodeId defId)
   auto it = resolved_labels.find (refId);
   rust_assert (it == resolved_labels.end ());
 
-  resolved_types[refId] = defId;
+  resolved_labels[refId] = defId;
   get_label_scope ().append_reference_for_def (refId, defId);
 }
 

--- a/gcc/rust/resolve/rust-name-resolver.h
+++ b/gcc/rust/resolve/rust-name-resolver.h
@@ -250,9 +250,11 @@ public:
 
   void push_new_name_rib (Rib *r);
   void push_new_type_rib (Rib *r);
+  void push_new_label_rib (Rib *r);
 
   bool find_name_rib (NodeId id, Rib **rib);
   bool find_type_rib (NodeId id, Rib **rib);
+  bool find_label_rib (NodeId id, Rib **rib);
 
   void insert_new_definition (NodeId id, Definition def);
   bool lookup_definition (NodeId id, Definition *def);
@@ -263,9 +265,13 @@ public:
   void insert_resolved_type (NodeId refId, NodeId defId);
   bool lookup_resolved_type (NodeId refId, NodeId *defId);
 
+  void insert_resolved_label (NodeId refId, NodeId defId);
+  bool lookup_resolved_label (NodeId refId, NodeId *defId);
+
   // proxy for scoping
   Scope &get_name_scope () { return name_scope; }
   Scope &get_type_scope () { return type_scope; }
+  Scope &get_label_scope () { return label_scope; }
 
   NodeId get_global_type_node_id () { return global_type_node_id; }
 
@@ -320,6 +326,12 @@ public:
       }
   }
 
+  void iterate_label_ribs (std::function<void (Rib *)> cb)
+  {
+    for (auto it = label_ribs.begin (); it != label_ribs.end (); it++)
+      cb (it->second);
+  }
+
 private:
   Resolver ();
 
@@ -332,6 +344,7 @@ private:
 
   Scope name_scope;
   Scope type_scope;
+  Scope label_scope;
 
   NodeId global_type_node_id;
   NodeId unit_ty_node_id;
@@ -339,6 +352,7 @@ private:
   // map a AST Node to a Rib
   std::map<NodeId, Rib *> name_ribs;
   std::map<NodeId, Rib *> type_ribs;
+  std::map<NodeId, Rib *> label_ribs;
 
   // map any Node to its Definition
   // ie any name or type usage
@@ -354,6 +368,7 @@ private:
   // we need two namespaces one for names and ones for types
   std::map<NodeId, NodeId> resolved_names;
   std::map<NodeId, NodeId> resolved_types;
+  std::map<NodeId, NodeId> resolved_labels;
 
   // map of resolved names mutability flag
   std::map<NodeId, bool> decl_mutability;

--- a/gcc/rust/rust-backend.h
+++ b/gcc/rust/rust-backend.h
@@ -425,6 +425,12 @@ public:
 				    Location)
     = 0;
 
+  // infinite loop expressions
+  virtual Bexpression *loop_expression (Bblock *body, Location);
+
+  // exit expressions
+  virtual Bexpression *exit_expression (Bexpression *condition, Location);
+
   // Create a switch statement where the case values are constants.
   // CASES and STATEMENTS must have the same number of entries.  If
   // VALUE matches any of the list in CASES[i], which will all be

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -326,6 +326,10 @@ public:
 					   Bstatement *except_stmt,
 					   Bstatement *finally_stmt, Location);
 
+  Bexpression *loop_expression (Bblock *body, Location);
+
+  Bexpression *exit_expression (Bexpression *condition, Location);
+
   // Blocks.
 
   Bblock *block (Bfunction *, Bblock *, const std::vector<Bvariable *> &,
@@ -2199,6 +2203,25 @@ Gcc_backend::if_statement (Bfunction *, Bexpression *condition,
   tree ret = build3_loc (location.gcc_location (), COND_EXPR, void_type_node,
 			 cond_tree, then_tree, else_tree);
   return this->make_statement (ret);
+}
+
+// Loops
+
+Bexpression *
+Gcc_backend::loop_expression (Bblock *body, Location locus)
+{
+  tree loop_expr_tree = fold_build1_loc (locus.gcc_location (), LOOP_EXPR,
+					 void_type_node, body->get_tree ());
+  return this->make_expression (loop_expr_tree);
+}
+
+Bexpression *
+Gcc_backend::exit_expression (Bexpression *condition, Location locus)
+{
+  tree cond_tree = condition->get_tree ();
+  tree exit_expr_tree = fold_build1_loc (locus.gcc_location (), EXIT_EXPR,
+					 void_type_node, cond_tree);
+  return this->make_expression (exit_expr_tree);
 }
 
 // Switch.

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -39,7 +39,8 @@ public:
 
     if (resolver.infered == nullptr)
       {
-	rust_error_at (expr->get_locus_slow (), "failed to resolve expression");
+	rust_error_at (expr->get_locus_slow (),
+		       "failed to type resolve expression");
 	return new TyTy::ErrorType (expr->get_mappings ().get_hirid ());
       }
 
@@ -744,6 +745,13 @@ public:
   void visit (HIR::LoopExpr &expr)
   {
     infered = TypeCheckExpr::Resolve (expr.get_loop_block ().get ());
+  }
+
+  void visit (HIR::BreakExpr &expr)
+  {
+    infered = expr.has_break_expr ()
+		? TypeCheckExpr::Resolve (expr.get_expr ().get ())
+		: new TyTy::UnitType (expr.get_mappings ().get_hirid ());
   }
 
 private:

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -137,6 +137,12 @@ public:
 
   void visit (HIR::ReturnExpr &expr)
   {
+    if (!expr.has_return_expr ())
+      {
+	infered = new TyTy::UnitType (expr.get_mappings ().get_hirid ());
+	return;
+      }
+
     auto fn_return_tyty = context->peek_return_type ();
     rust_assert (fn_return_tyty != nullptr);
 

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -741,6 +741,11 @@ public:
       }
   }
 
+  void visit (HIR::LoopExpr &expr)
+  {
+    infered = TypeCheckExpr::Resolve (expr.get_loop_block ().get ());
+  }
+
 private:
   TypeCheckExpr ()
     : TypeCheckBase (), infered (nullptr), infered_array_elems (nullptr)

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -40,7 +40,8 @@ public:
   void visit (HIR::ConstantItem &constant)
   {
     TyTy::TyBase *type = TypeCheckType::Resolve (constant.get_type ());
-    TyTy::TyBase *expr_type = TypeCheckExpr::Resolve (constant.get_expr ());
+    TyTy::TyBase *expr_type
+      = TypeCheckExpr::Resolve (constant.get_expr (), false);
 
     context->insert_type (constant.get_mappings (), type->combine (expr_type));
   }
@@ -170,7 +171,7 @@ public:
     auto expected_ret_tyty = resolve_fn_type->return_type ();
     context->push_return_type (expected_ret_tyty);
 
-    auto result = TypeCheckExpr::Resolve (function.function_body.get ());
+    auto result = TypeCheckExpr::Resolve (function.function_body.get (), false);
     auto ret_resolved = expected_ret_tyty->combine (result);
     if (ret_resolved == nullptr)
       return;
@@ -202,7 +203,8 @@ public:
     auto expected_ret_tyty = resolve_fn_type->return_type ();
     context->push_return_type (expected_ret_tyty);
 
-    auto result = TypeCheckExpr::Resolve (method.get_function_body ().get ());
+    auto result
+      = TypeCheckExpr::Resolve (method.get_function_body ().get (), false);
     auto ret_resolved = expected_ret_tyty->combine (result);
     if (ret_resolved == nullptr)
       return;

--- a/gcc/rust/typecheck/rust-hir-type-check-item.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.h
@@ -75,7 +75,7 @@ public:
     auto expected_ret_tyty = resolve_fn_type->return_type ();
     context->push_return_type (expected_ret_tyty);
 
-    auto result = TypeCheckExpr::Resolve (function.function_body.get ());
+    auto result = TypeCheckExpr::Resolve (function.function_body.get (), false);
     auto ret_resolved = expected_ret_tyty->combine (result);
     if (ret_resolved == nullptr)
       return;

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.h
@@ -30,21 +30,21 @@ namespace Resolver {
 class TypeCheckStmt : public TypeCheckBase
 {
 public:
-  static TyTy::TyBase *Resolve (HIR::Stmt *stmt)
+  static TyTy::TyBase *Resolve (HIR::Stmt *stmt, bool inside_loop)
   {
-    TypeCheckStmt resolver;
+    TypeCheckStmt resolver (inside_loop);
     stmt->accept_vis (resolver);
     return resolver.infered;
   }
 
   void visit (HIR::ExprStmtWithBlock &stmt)
   {
-    infered = TypeCheckExpr::Resolve (stmt.get_expr ());
+    infered = TypeCheckExpr::Resolve (stmt.get_expr (), inside_loop);
   }
 
   void visit (HIR::ExprStmtWithoutBlock &stmt)
   {
-    infered = TypeCheckExpr::Resolve (stmt.get_expr ());
+    infered = TypeCheckExpr::Resolve (stmt.get_expr (), inside_loop);
   }
 
   void visit (HIR::LetStmt &stmt)
@@ -54,7 +54,8 @@ public:
     TyTy::TyBase *init_expr_ty = nullptr;
     if (stmt.has_init_expr ())
       {
-	init_expr_ty = TypeCheckExpr::Resolve (stmt.get_init_expr ());
+	init_expr_ty
+	  = TypeCheckExpr::Resolve (stmt.get_init_expr (), inside_loop);
 	if (init_expr_ty == nullptr)
 	  return;
 
@@ -105,9 +106,12 @@ public:
   }
 
 private:
-  TypeCheckStmt () : TypeCheckBase (), infered (nullptr) {}
+  TypeCheckStmt (bool inside_loop)
+    : TypeCheckBase (), infered (nullptr), inside_loop (inside_loop)
+  {}
 
   TyTy::TyBase *infered;
+  bool inside_loop;
 };
 
 } // namespace Resolver

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
@@ -86,7 +86,7 @@ public:
   void visit (HIR::StaticItem &var)
   {
     TyTy::TyBase *type = TypeCheckType::Resolve (var.get_type ());
-    TyTy::TyBase *expr_type = TypeCheckExpr::Resolve (var.get_expr ());
+    TyTy::TyBase *expr_type = TypeCheckExpr::Resolve (var.get_expr (), false);
 
     context->insert_type (var.get_mappings (), type->combine (expr_type));
   }
@@ -94,7 +94,8 @@ public:
   void visit (HIR::ConstantItem &constant)
   {
     TyTy::TyBase *type = TypeCheckType::Resolve (constant.get_type ());
-    TyTy::TyBase *expr_type = TypeCheckExpr::Resolve (constant.get_expr ());
+    TyTy::TyBase *expr_type
+      = TypeCheckExpr::Resolve (constant.get_expr (), false);
 
     context->insert_type (constant.get_mappings (), type->combine (expr_type));
   }

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -112,7 +112,7 @@ TypeCheckExpr::visit (HIR::BlockExpr &expr)
     bool is_final_expr
       = is_final_stmt && (!expr.has_expr () || !expr.tail_expr_reachable ());
 
-    auto resolved = TypeCheckStmt::Resolve (s);
+    auto resolved = TypeCheckStmt::Resolve (s, inside_loop);
     if (resolved == nullptr)
       {
 	rust_error_at (s->get_locus_slow (), "failure to resolve type");
@@ -137,7 +137,8 @@ TypeCheckExpr::visit (HIR::BlockExpr &expr)
     {
       delete block_tyty;
 
-      block_tyty = TypeCheckExpr::Resolve (expr.get_final_expr ().get ());
+      block_tyty
+	= TypeCheckExpr::Resolve (expr.get_final_expr ().get (), inside_loop);
     }
 
   infered = block_tyty->clone ();
@@ -160,7 +161,8 @@ TypeCheckStructExpr::visit (HIR::StructExprStructFields &struct_expr)
   if (struct_expr.has_struct_base ())
     {
       TyTy::TyBase *base_resolved
-	= TypeCheckExpr::Resolve (struct_expr.struct_base->base_struct.get ());
+	= TypeCheckExpr::Resolve (struct_expr.struct_base->base_struct.get (),
+				  false);
       resolved = struct_path_resolved->combine (base_resolved);
       if (resolved == nullptr)
 	{
@@ -326,7 +328,7 @@ TypeCheckStructExpr::visit (HIR::StructExprFieldIdentifierValue &field)
     }
 
   size_t field_index;
-  TyTy::TyBase *value = TypeCheckExpr::Resolve (field.get_value ());
+  TyTy::TyBase *value = TypeCheckExpr::Resolve (field.get_value (), false);
   TyTy::StructFieldType *field_type
     = struct_path_resolved->get_field (field.field_name, &field_index);
   if (field_type == nullptr)
@@ -355,7 +357,7 @@ TypeCheckStructExpr::visit (HIR::StructExprFieldIndexValue &field)
     }
 
   size_t field_index;
-  TyTy::TyBase *value = TypeCheckExpr::Resolve (field.get_value ());
+  TyTy::TyBase *value = TypeCheckExpr::Resolve (field.get_value (), false);
   TyTy::StructFieldType *field_type
     = struct_path_resolved->get_field (field_name, &field_index);
   if (field_type == nullptr)
@@ -395,7 +397,7 @@ TypeCheckStructExpr::visit (HIR::StructExprFieldIdentifier &field)
   // existing code to figure out the type
   HIR::IdentifierExpr expr (field.get_mappings (), field.get_field_name (),
 			    field.get_locus ());
-  TyTy::TyBase *value = TypeCheckExpr::Resolve (&expr);
+  TyTy::TyBase *value = TypeCheckExpr::Resolve (&expr, false);
 
   resolved_field = field_type->get_field_type ()->combine (value);
   if (resolved_field != nullptr)

--- a/gcc/rust/typecheck/rust-hir-type-check.h
+++ b/gcc/rust/typecheck/rust-hir-type-check.h
@@ -56,6 +56,28 @@ public:
       }
   }
 
+  void push_new_loop_context (HirId id)
+  {
+    TyTy::TyBase *infer_var
+      = new TyTy::InferType (id, TyTy::InferType::InferTypeKind::GENERAL);
+    loop_type_stack.push_back (infer_var);
+  }
+
+  TyTy::TyBase *peek_loop_context () { return loop_type_stack.back (); }
+
+  TyTy::TyBase *pop_loop_context ()
+  {
+    auto back = peek_loop_context ();
+    loop_type_stack.pop_back ();
+    return back;
+  }
+
+  void swap_head_loop_context (TyTy::TyBase *val)
+  {
+    loop_type_stack.pop_back ();
+    loop_type_stack.push_back (val);
+  }
+
 private:
   TypeCheckContext ();
 
@@ -63,6 +85,7 @@ private:
   std::map<HirId, TyTy::TyBase *> resolved;
   std::vector<std::unique_ptr<TyTy::TyBase> > builtins;
   std::vector<TyTy::TyBase *> return_type_stack;
+  std::vector<TyTy::TyBase *> loop_type_stack;
 };
 
 class TypeResolution

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -501,7 +501,7 @@ TypeCheckCallExpr::visit (ADTType &type)
     StructFieldType *field = type.get_field (i);
     TyBase *field_tyty = field->get_field_type ();
 
-    TyBase *arg = Resolver::TypeCheckExpr::Resolve (p);
+    TyBase *arg = Resolver::TypeCheckExpr::Resolve (p, false);
     if (arg == nullptr)
       {
 	rust_error_at (p->get_locus_slow (), "failed to resolve argument type");
@@ -542,7 +542,7 @@ TypeCheckCallExpr::visit (FnType &type)
   size_t i = 0;
   call.iterate_params ([&] (HIR::Expr *param) mutable -> bool {
     auto fnparam = type.param_at (i);
-    auto argument_expr_tyty = Resolver::TypeCheckExpr::Resolve (param);
+    auto argument_expr_tyty = Resolver::TypeCheckExpr::Resolve (param, false);
     if (argument_expr_tyty == nullptr)
       {
 	rust_error_at (param->get_locus_slow (),
@@ -593,7 +593,7 @@ TypeCheckMethodCallExpr::visit (FnType &type)
   size_t i = 1;
   call.iterate_params ([&] (HIR::Expr *param) mutable -> bool {
     auto fnparam = type.param_at (i);
-    auto argument_expr_tyty = Resolver::TypeCheckExpr::Resolve (param);
+    auto argument_expr_tyty = Resolver::TypeCheckExpr::Resolve (param, false);
     if (argument_expr_tyty == nullptr)
       {
 	rust_error_at (param->get_locus_slow (),

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -460,6 +460,12 @@ Mappings::walk_local_defids_for_crate (CrateNum crateNum,
     }
 }
 
+void
+Mappings::insert_node_to_hir (CrateNum crate, NodeId id, HirId ref)
+{
+  nodeIdToHirMappings[crate][id] = ref;
+}
+
 bool
 Mappings::lookup_node_to_hir (CrateNum crate, NodeId id, HirId *ref)
 {

--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -136,6 +136,7 @@ public:
   void walk_local_defids_for_crate (CrateNum crateNum,
 				    std::function<bool (HIR::Item *)> cb);
 
+  void insert_node_to_hir (CrateNum crate, NodeId id, HirId ref);
   bool lookup_node_to_hir (CrateNum crate, NodeId id, HirId *ref);
 
   void insert_location (CrateNum crate, HirId id, Location locus);

--- a/gcc/testsuite/rust.test/compilable/loop1.rs
+++ b/gcc/testsuite/rust.test/compilable/loop1.rs
@@ -1,0 +1,10 @@
+fn main() {
+    let mut a = 1;
+    let mut b = 1;
+
+    loop {
+        let c = a + b;
+        a = b;
+        b = c;
+    }
+}

--- a/gcc/testsuite/rust.test/compilable/loop2.rs
+++ b/gcc/testsuite/rust.test/compilable/loop2.rs
@@ -1,0 +1,14 @@
+fn main() {
+    let mut a = 1;
+    let mut b = 1;
+
+    // first number in Fibonacci sequence over 10:
+    loop {
+        if b > 10 {
+            break;
+        }
+        let c = a + b;
+        a = b;
+        b = c;
+    }
+}

--- a/gcc/testsuite/rust.test/compilable/loop3.rs
+++ b/gcc/testsuite/rust.test/compilable/loop3.rs
@@ -1,0 +1,14 @@
+fn main() {
+    let mut a = 1;
+    let mut b = 1;
+
+    // first number in Fibonacci sequence over 10:
+    loop {
+        if b > 10 {
+            return;
+        }
+        let c = a + b;
+        a = b;
+        b = c;
+    }
+}

--- a/gcc/testsuite/rust.test/compilable/loop4.rs
+++ b/gcc/testsuite/rust.test/compilable/loop4.rs
@@ -1,0 +1,7 @@
+fn main() {
+    'outer: loop {
+        'inner: loop {
+            break 'outer;
+        }
+    }
+}

--- a/gcc/testsuite/rust.test/compilable/loop5.rs
+++ b/gcc/testsuite/rust.test/compilable/loop5.rs
@@ -1,0 +1,14 @@
+fn main() {
+    let mut a = 1;
+    let mut b = 1;
+
+    // first number in Fibonacci sequence over 10:
+    let _fib = loop {
+        if b > 10 {
+            break b;
+        }
+        let c = a + b;
+        a = b;
+        b = c;
+    };
+}

--- a/gcc/testsuite/rust.test/fail_compilation/break1.rs
+++ b/gcc/testsuite/rust.test/fail_compilation/break1.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let a;
+    a = 1;
+    break a;
+}


### PR DESCRIPTION
    Support Simple LoopExpr
    
    This is the building block for the rest of loops where we have a basic
    infinite loop. Break/Continue reliest on the resolution of labels and
    breaks can also make a loop into a BlockExpr
    
    Fixes #106

    Fix parse of LoopExpr as part of a normal expression
    
    For example this fixes the form of: let x = loop { ... };
    
    Fixes #219
