### PR TITLE
Add ReferenceType with BorrowExpr and DereferenceExpr

### DIFF
--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -288,6 +288,10 @@ public:
     return main_or_left_expr;
   }
 
+  bool get_is_mut () const { return is_mut; }
+
+  bool get_is_double_borrow () const { return double_borrow; }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */

--- a/gcc/rust/ast/rust-type.h
+++ b/gcc/rust/ast/rust-type.h
@@ -576,6 +576,12 @@ public:
     return type;
   }
 
+  bool get_has_mut () const { return has_mut; }
+
+  Lifetime &get_lifetime () { return lifetime; }
+
+  std::unique_ptr<TypeNoBounds> &get_base_type () { return type; }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -445,6 +445,13 @@ public:
     translated = compiled_type;
   }
 
+  void visit (TyTy::ReferenceType &type) override
+  {
+    Btype *base_compiled_type
+      = TyTyResolveCompile::compile (ctx, type.get_base ());
+    translated = ctx->get_backend ()->reference_type (base_compiled_type);
+  }
+
 private:
   TyTyResolveCompile (Context *ctx) : ctx (ctx) {}
 

--- a/gcc/rust/backend/rust-compile-tyty.h
+++ b/gcc/rust/backend/rust-compile-tyty.h
@@ -56,6 +56,8 @@ public:
 
   void visit (TyTy::ArrayType &) override { gcc_unreachable (); }
 
+  void visit (TyTy::ReferenceType &) override { gcc_unreachable (); }
+
   void visit (TyTy::UnitType &) override { translated = backend->void_type (); }
 
   void visit (TyTy::FnType &type) override

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -740,6 +740,43 @@ public:
 					std::move (outer_attribs));
   }
 
+  void visit (AST::BorrowExpr &expr)
+  {
+    std::vector<HIR::Attribute> outer_attribs;
+
+    HIR::Expr *borrow_lvalue
+      = ASTLoweringExpr::translate (expr.get_borrowed_expr ().get ());
+
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, expr.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   UNKNOWN_LOCAL_DEFID);
+
+    translated
+      = new HIR::BorrowExpr (mapping,
+			     std::unique_ptr<HIR::Expr> (borrow_lvalue),
+			     expr.get_is_mut (), expr.get_is_double_borrow (),
+			     std::move (outer_attribs), expr.get_locus ());
+  }
+
+  void visit (AST::DereferenceExpr &expr)
+  {
+    std::vector<HIR::Attribute> outer_attribs;
+
+    HIR::Expr *dref_lvalue
+      = ASTLoweringExpr::translate (expr.get_dereferenced_expr ().get ());
+
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, expr.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   UNKNOWN_LOCAL_DEFID);
+
+    translated
+      = new HIR::DereferenceExpr (mapping,
+				  std::unique_ptr<HIR::Expr> (dref_lvalue),
+				  std::move (outer_attribs), expr.get_locus ());
+  }
+
 private:
   ASTLoweringExpr ()
     : ASTLoweringBase (), translated (nullptr),

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -244,6 +244,8 @@ protected:
 public:
   Location get_locus () const { return locus; }
   Location get_locus_slow () const override { return get_locus (); }
+
+  std::unique_ptr<Expr> &get_expr () { return main_or_left_expr; }
 };
 
 /* Unary prefix & or &mut (or && and &&mut) borrow operator. Cannot be
@@ -266,6 +268,9 @@ public:
   {}
 
   void accept_vis (HIRVisitor &vis) override;
+
+  bool get_is_mut () const { return is_mut; }
+  bool get_is_double_borrow () const { return double_borrow; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather

--- a/gcc/rust/hir/tree/rust-hir-type.h
+++ b/gcc/rust/hir/tree/rust-hir-type.h
@@ -518,7 +518,7 @@ class ReferenceType : public TypeNoBounds
   Lifetime lifetime;
 
   bool has_mut;
-  std::unique_ptr<TypeNoBounds> type;
+  std::unique_ptr<Type> type;
   Location locus;
 
 public:
@@ -530,7 +530,7 @@ public:
 
   // Constructor
   ReferenceType (Analysis::NodeMapping mappings, bool is_mut,
-		 std::unique_ptr<TypeNoBounds> type_no_bounds, Location locus,
+		 std::unique_ptr<Type> type_no_bounds, Location locus,
 		 Lifetime lifetime)
     : TypeNoBounds (mappings), lifetime (std::move (lifetime)),
       has_mut (is_mut), type (std::move (type_no_bounds)), locus (locus)
@@ -539,7 +539,7 @@ public:
   // Copy constructor with custom clone method
   ReferenceType (ReferenceType const &other)
     : TypeNoBounds (other.mappings), lifetime (other.lifetime),
-      has_mut (other.has_mut), type (other.type->clone_type_no_bounds ()),
+      has_mut (other.has_mut), type (other.type->clone_type ()),
       locus (other.locus)
   {}
 
@@ -549,7 +549,7 @@ public:
     mappings = other.mappings;
     lifetime = other.lifetime;
     has_mut = other.has_mut;
-    type = other.type->clone_type_no_bounds ();
+    type = other.type->clone_type ();
     locus = other.locus;
 
     return *this;
@@ -564,6 +564,12 @@ public:
   Location get_locus () const { return locus; }
 
   void accept_vis (HIRVisitor &vis) override;
+
+  Lifetime &get_lifetime () { return lifetime; }
+
+  bool get_has_mut () const { return has_mut; }
+
+  std::unique_ptr<Type> &get_base_type () { return type; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather

--- a/gcc/rust/resolve/rust-ast-resolve-expr.h
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.h
@@ -351,6 +351,16 @@ public:
       }
   }
 
+  void visit (AST::BorrowExpr &expr)
+  {
+    ResolveExpr::go (expr.get_borrowed_expr ().get (), expr.get_node_id ());
+  }
+
+  void visit (AST::DereferenceExpr &expr)
+  {
+    ResolveExpr::go (expr.get_dereferenced_expr ().get (), expr.get_node_id ());
+  }
+
 private:
   ResolveExpr (NodeId parent) : ResolverBase (parent) {}
 };

--- a/gcc/rust/resolve/rust-ast-resolve-type.h
+++ b/gcc/rust/resolve/rust-ast-resolve-type.h
@@ -83,6 +83,14 @@ public:
     type.get_elem_type ()->accept_vis (*this);
   }
 
+  void visit (AST::ReferenceType &type)
+  {
+    type.get_type_referenced ()->accept_vis (*this);
+  }
+
+  // nothing to do for inferred types
+  void visit (AST::InferredType &type) { ok = true; }
+
 private:
   ResolveType (NodeId parent) : ResolverBase (parent), ok (false) {}
 

--- a/gcc/rust/rust-backend.h
+++ b/gcc/rust/rust-backend.h
@@ -121,6 +121,9 @@ public:
   // Get a pointer type.
   virtual Btype *pointer_type (Btype *to_type) = 0;
 
+  // Get a reference type.
+  virtual Btype *reference_type (Btype *to_type) = 0;
+
   // make type immutable
   virtual Btype *immutable_type (Btype *base) = 0;
 

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -43,6 +43,7 @@
 #include "output.h"
 #include "realmpfr.h"
 #include "builtins.h"
+#include "print-tree.h"
 
 #include "rust-location.h"
 #include "rust-linemap.h"
@@ -185,6 +186,8 @@ public:
   Btype *complex_type (int);
 
   Btype *pointer_type (Btype *);
+
+  Btype *reference_type (Btype *);
 
   Btype *immutable_type (Btype *);
 
@@ -872,6 +875,18 @@ Gcc_backend::pointer_type (Btype *to_type)
   if (to_type_tree == error_mark_node)
     return this->error_type ();
   tree type = build_pointer_type (to_type_tree);
+  return this->make_type (type);
+}
+
+// Get a reference type.
+
+Btype *
+Gcc_backend::reference_type (Btype *to_type)
+{
+  tree to_type_tree = to_type->get_tree ();
+  if (to_type_tree == error_mark_node)
+    return this->error_type ();
+  tree type = build_reference_type (to_type_tree);
   return this->make_type (type);
 }
 
@@ -2517,7 +2532,6 @@ Gcc_backend::convert_tree (tree type_tree, tree expr_tree, Location location)
       || TREE_TYPE (expr_tree) == error_mark_node)
     return error_mark_node;
 
-  gcc_assert (TREE_CODE (type_tree) == TREE_CODE (TREE_TYPE (expr_tree)));
   if (POINTER_TYPE_P (type_tree) || INTEGRAL_TYPE_P (type_tree)
       || SCALAR_FLOAT_TYPE_P (type_tree) || COMPLEX_FLOAT_TYPE_P (type_tree))
     return fold_convert_loc (location.gcc_location (), type_tree, expr_tree);

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.h
@@ -73,7 +73,7 @@ public:
     if (specified_ty != nullptr && init_expr_ty != nullptr)
       {
 	auto combined = specified_ty->combine (init_expr_ty);
-	if (combined == nullptr)
+	if (combined->get_kind () == TyTy::TypeKind::ERROR)
 	  {
 	    rust_fatal_error (stmt.get_locus (),
 			      "failure in setting up let stmt type");

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -51,7 +51,7 @@ TypeResolution::Resolve (HIR::Crate &crate)
     if (ty->get_kind () == TyTy::TypeKind::ERROR)
       {
 	rust_error_at (mappings->lookup_location (id),
-		       "failure in type resolution");
+		       "failure in type resolution for %u", id);
 	return false;
       }
 
@@ -64,7 +64,8 @@ TypeResolution::Resolve (HIR::Crate &crate)
       {
       case TyTy::InferType::GENERAL:
 	rust_error_at (mappings->lookup_location (id),
-		       "unable to determine type: %u", id);
+		       "unable to determine type: please give this a type: %u",
+		       id);
 	break;
 
 	case TyTy::InferType::INTEGRAL: {

--- a/gcc/rust/typecheck/rust-tyctx.cc
+++ b/gcc/rust/typecheck/rust-tyctx.cc
@@ -88,10 +88,7 @@ TypeCheckContext::lookup_type (HirId id, TyTy::TyBase **type)
 {
   auto it = resolved.find (id);
   if (it == resolved.end ())
-    {
-      *type = new TyTy::ErrorType (id);
-      return false;
-    }
+    return false;
 
   *type = it->second;
   return true;

--- a/gcc/rust/typecheck/rust-tyty-call.h
+++ b/gcc/rust/typecheck/rust-tyty-call.h
@@ -52,6 +52,7 @@ public:
   void visit (ISizeType &type) override { gcc_unreachable (); }
   void visit (ErrorType &type) override { gcc_unreachable (); }
   void visit (CharType &type) override { gcc_unreachable (); }
+  void visit (ReferenceType &type) override { gcc_unreachable (); }
 
   // tuple-structs
   void visit (ADTType &type) override;
@@ -96,6 +97,7 @@ public:
   void visit (ErrorType &type) override { gcc_unreachable (); }
   void visit (ADTType &type) override { gcc_unreachable (); };
   void visit (CharType &type) override { gcc_unreachable (); }
+  void visit (ReferenceType &type) override { gcc_unreachable (); }
 
   // call fns
   void visit (FnType &type) override;

--- a/gcc/rust/typecheck/rust-tyty-visitor.h
+++ b/gcc/rust/typecheck/rust-tyty-visitor.h
@@ -42,6 +42,7 @@ public:
   virtual void visit (ISizeType &type) = 0;
   virtual void visit (ErrorType &type) = 0;
   virtual void visit (CharType &type) = 0;
+  virtual void visit (ReferenceType &type) = 0;
 };
 
 } // namespace TyTy

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -510,6 +510,52 @@ CharType::clone ()
   return new CharType (get_ref (), get_ty_ref (), get_combined_refs ());
 }
 
+void
+ReferenceType::accept_vis (TyVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+std::string
+ReferenceType::as_string () const
+{
+  return "&" + get_base ()->as_string ();
+}
+
+TyBase *
+ReferenceType::combine (TyBase *other)
+{
+  ReferenceRules r (this);
+  return r.combine (other);
+}
+
+const TyBase *
+ReferenceType::get_base () const
+{
+  auto context = Resolver::TypeCheckContext::get ();
+  TyBase *lookup = nullptr;
+  bool ok = context->lookup_type (base, &lookup);
+  rust_assert (ok);
+  return lookup;
+}
+
+TyBase *
+ReferenceType::get_base ()
+{
+  auto context = Resolver::TypeCheckContext::get ();
+  TyBase *lookup = nullptr;
+  bool ok = context->lookup_type (base, &lookup);
+  rust_assert (ok);
+  return lookup;
+}
+
+TyBase *
+ReferenceType::clone ()
+{
+  return new ReferenceType (get_ref (), get_ty_ref (), base,
+			    get_combined_refs ());
+}
+
 // rust-tyty-call.h
 
 void

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -561,6 +561,7 @@ public:
 
   CharType (HirId ref, HirId ty_ref, std::set<HirId> refs = std::set<HirId> ())
     : TyBase (ref, ty_ref, TypeKind::CHAR)
+
   {}
 
   void accept_vis (TyVisitor &vis) override;
@@ -570,6 +571,35 @@ public:
   TyBase *combine (TyBase *other) override;
 
   TyBase *clone () final override;
+};
+
+class ReferenceType : public TyBase
+{
+public:
+  ReferenceType (HirId ref, HirId base,
+		 std::set<HirId> refs = std::set<HirId> ())
+    : TyBase (ref, ref, TypeKind::REF), base (base)
+  {}
+
+  ReferenceType (HirId ref, HirId ty_ref, HirId base,
+		 std::set<HirId> refs = std::set<HirId> ())
+    : TyBase (ref, ty_ref, TypeKind::REF), base (base)
+  {}
+
+  const TyTy::TyBase *get_base () const;
+
+  TyTy::TyBase *get_base ();
+
+  void accept_vis (TyVisitor &vis) override;
+
+  std::string as_string () const override;
+
+  TyBase *combine (TyBase *other) override;
+
+  TyBase *clone () final override;
+
+private:
+  HirId base;
 };
 
 } // namespace TyTy

--- a/gcc/testsuite/rust.test/compilable/borrow1.rs
+++ b/gcc/testsuite/rust.test/compilable/borrow1.rs
@@ -1,0 +1,17 @@
+fn main() {
+    let a: i32;
+    a = 123;
+
+    let b: &i32;
+    b = &a;
+
+    let aa;
+    aa = 456;
+    let bb: &_;
+    bb = &a;
+
+    let aaa;
+    aaa = 123;
+    let bbb;
+    bbb = &aaa;
+}

--- a/gcc/testsuite/rust.test/compilable/deref1.rs
+++ b/gcc/testsuite/rust.test/compilable/deref1.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let a = 123;
+    let b = &a;
+    let c = *b;
+}


### PR DESCRIPTION
This also adds in the mising InferenceType _ which was mostly implemented
before as part of Data Structures 1.

We create GENERIC REFERENCE_TYPES for these this is the building block
to finish work on mutability rules and pointers.

Fixes: #196
Addresses: #169 #170

Note more work is needed here for mutable references and double references.