### PR TITLE
Cleanup tyty

### DIFF
--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -53,7 +53,7 @@ public:
 	rust_assert (
 	  tyctx->lookup_type_by_node_id ((*it)->get_node_id (), &ref));
 
-	TyTy::TyBase *lookup;
+	TyTy::BaseType *lookup;
 	rust_assert (tyctx->lookup_type (ref, &lookup));
 
 	auto compiled = TyTyCompile::compile (backend, lookup);
@@ -261,7 +261,7 @@ private:
 class TyTyResolveCompile : public TyTy::TyVisitor
 {
 public:
-  static ::Btype *compile (Context *ctx, TyTy::TyBase *ty)
+  static ::Btype *compile (Context *ctx, TyTy::BaseType *ty)
   {
     TyTyResolveCompile compiler (ctx);
     ty->accept_vis (compiler);
@@ -355,7 +355,7 @@ public:
     std::vector<Backend::Btyped_identifier> fields;
     for (size_t i = 0; i < type.num_fields (); i++)
       {
-	TyTy::TyBase *field = type.get_field (i);
+	TyTy::BaseType *field = type.get_field (i);
 	Btype *compiled_field_ty
 	  = TyTyCompile::compile (ctx->get_backend (), field);
 

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -57,7 +57,7 @@ public:
 	return;
       }
 
-    TyTy::TyBase *tyty = nullptr;
+    TyTy::BaseType *tyty = nullptr;
     if (!ctx->get_tyctx ()->lookup_type (expr.get_mappings ().get_hirid (),
 					 &tyty))
       {
@@ -177,7 +177,7 @@ public:
 	      return;
 	    }
 
-	  TyTy::TyBase *tyty = nullptr;
+	  TyTy::BaseType *tyty = nullptr;
 	  if (!ctx->get_tyctx ()->lookup_type (
 		expr.get_mappings ().get_hirid (), &tyty))
 	    {
@@ -203,7 +203,7 @@ public:
 	      return;
 	    }
 
-	  TyTy::TyBase *tyty = nullptr;
+	  TyTy::BaseType *tyty = nullptr;
 	  if (!ctx->get_tyctx ()->lookup_type (
 		expr.get_mappings ().get_hirid (), &tyty))
 	    {
@@ -256,7 +256,7 @@ public:
 
   void visit (HIR::ArrayExpr &expr)
   {
-    TyTy::TyBase *tyty = nullptr;
+    TyTy::BaseType *tyty = nullptr;
     if (!ctx->get_tyctx ()->lookup_type (expr.get_mappings ().get_hirid (),
 					 &tyty))
       {
@@ -428,7 +428,7 @@ public:
 
   void visit (HIR::IfExprConseqElse &expr)
   {
-    TyTy::TyBase *if_type = nullptr;
+    TyTy::BaseType *if_type = nullptr;
     if (!ctx->get_tyctx ()->lookup_type (expr.get_mappings ().get_hirid (),
 					 &if_type))
       {
@@ -465,7 +465,7 @@ public:
 
   void visit (HIR::IfExprConseqIf &expr)
   {
-    TyTy::TyBase *if_type = nullptr;
+    TyTy::BaseType *if_type = nullptr;
     if (!ctx->get_tyctx ()->lookup_type (expr.get_mappings ().get_hirid (),
 					 &if_type))
       {
@@ -502,7 +502,7 @@ public:
 
   void visit (HIR::BlockExpr &expr)
   {
-    TyTy::TyBase *block_tyty = nullptr;
+    TyTy::BaseType *block_tyty = nullptr;
     if (!ctx->get_tyctx ()->lookup_type (expr.get_mappings ().get_hirid (),
 					 &block_tyty))
       {
@@ -564,7 +564,7 @@ public:
   void visit (HIR::FieldAccessExpr &expr)
   {
     // resolve the receiver back to ADT type
-    TyTy::TyBase *receiver = nullptr;
+    TyTy::BaseType *receiver = nullptr;
     if (!ctx->get_tyctx ()->lookup_type (
 	  expr.get_receiver_expr ()->get_mappings ().get_hirid (), &receiver))
       {
@@ -593,7 +593,7 @@ public:
 
   void visit (HIR::LoopExpr &expr)
   {
-    TyTy::TyBase *block_tyty = nullptr;
+    TyTy::BaseType *block_tyty = nullptr;
     if (!ctx->get_tyctx ()->lookup_type (expr.get_mappings ().get_hirid (),
 					 &block_tyty))
       {
@@ -830,7 +830,7 @@ public:
     Bexpression *main_expr
       = CompileExpr::Compile (expr.get_expr ().get (), ctx);
 
-    TyTy::TyBase *tyty = nullptr;
+    TyTy::BaseType *tyty = nullptr;
     if (!ctx->get_tyctx ()->lookup_type (expr.get_mappings ().get_hirid (),
 					 &tyty))
       {

--- a/gcc/rust/backend/rust-compile-implitem.h
+++ b/gcc/rust/backend/rust-compile-implitem.h
@@ -32,7 +32,7 @@ namespace Compile {
 class CompileInherentImplItem : public HIRCompileBase
 {
 public:
-  static void Compile (TyTy::TyBase *self, HIR::InherentImplItem *item,
+  static void Compile (TyTy::BaseType *self, HIR::InherentImplItem *item,
 		       Context *ctx, bool compile_fns)
   {
     CompileInherentImplItem compiler (self, ctx, compile_fns);
@@ -41,7 +41,7 @@ public:
 
   void visit (HIR::ConstantItem &constant)
   {
-    TyTy::TyBase *resolved_type = nullptr;
+    TyTy::BaseType *resolved_type = nullptr;
     bool ok
       = ctx->get_tyctx ()->lookup_type (constant.get_mappings ().get_hirid (),
 					&resolved_type);
@@ -74,7 +74,7 @@ public:
 	  return;
       }
 
-    TyTy::TyBase *fntype_tyty;
+    TyTy::BaseType *fntype_tyty;
     if (!ctx->get_tyctx ()->lookup_type (function.get_mappings ().get_hirid (),
 					 &fntype_tyty))
       {
@@ -110,7 +110,7 @@ public:
 
     // setup the params
 
-    TyTy::TyBase *tyret = fntype->return_type ();
+    TyTy::BaseType *tyret = fntype->return_type ();
     std::vector<Bvariable *> param_vars;
 
     size_t i = 0;
@@ -238,7 +238,7 @@ public:
 	  return;
       }
 
-    TyTy::TyBase *fntype_tyty;
+    TyTy::BaseType *fntype_tyty;
     if (!ctx->get_tyctx ()->lookup_type (method.get_mappings ().get_hirid (),
 					 &fntype_tyty))
       {
@@ -273,11 +273,11 @@ public:
     ctx->insert_function_decl (method.get_mappings ().get_hirid (), fndecl);
 
     // setup the params
-    TyTy::TyBase *tyret = fntype->return_type ();
+    TyTy::BaseType *tyret = fntype->return_type ();
     std::vector<Bvariable *> param_vars;
 
     // insert self
-    TyTy::TyBase *self_tyty_lookup = nullptr;
+    TyTy::BaseType *self_tyty_lookup = nullptr;
     if (!ctx->get_tyctx ()->lookup_type (
 	  method.get_self_param ().get_mappings ().get_hirid (),
 	  &self_tyty_lookup))
@@ -428,11 +428,11 @@ public:
   }
 
 private:
-  CompileInherentImplItem (TyTy::TyBase *self, Context *ctx, bool compile_fns)
+  CompileInherentImplItem (TyTy::BaseType *self, Context *ctx, bool compile_fns)
     : HIRCompileBase (ctx), self (self), compile_fns (compile_fns)
   {}
 
-  TyTy::TyBase *self;
+  TyTy::BaseType *self;
   bool compile_fns;
 };
 

--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -41,7 +41,7 @@ public:
 
   void visit (HIR::TupleStruct &struct_decl)
   {
-    TyTy::TyBase *resolved = nullptr;
+    TyTy::BaseType *resolved = nullptr;
     if (!ctx->get_tyctx ()->lookup_type (
 	  struct_decl.get_mappings ().get_hirid (), &resolved))
       {
@@ -55,7 +55,7 @@ public:
 
   void visit (HIR::StructStruct &struct_decl)
   {
-    TyTy::TyBase *resolved = nullptr;
+    TyTy::BaseType *resolved = nullptr;
     if (!ctx->get_tyctx ()->lookup_type (
 	  struct_decl.get_mappings ().get_hirid (), &resolved))
       {
@@ -69,7 +69,7 @@ public:
 
   void visit (HIR::StaticItem &var)
   {
-    TyTy::TyBase *resolved_type = nullptr;
+    TyTy::BaseType *resolved_type = nullptr;
     bool ok = ctx->get_tyctx ()->lookup_type (var.get_mappings ().get_hirid (),
 					      &resolved_type);
     rust_assert (ok);
@@ -97,7 +97,7 @@ public:
 
   void visit (HIR::ConstantItem &constant)
   {
-    TyTy::TyBase *resolved_type = nullptr;
+    TyTy::BaseType *resolved_type = nullptr;
     bool ok
       = ctx->get_tyctx ()->lookup_type (constant.get_mappings ().get_hirid (),
 					&resolved_type);
@@ -129,7 +129,7 @@ public:
 	  return;
       }
 
-    TyTy::TyBase *fntype_tyty;
+    TyTy::BaseType *fntype_tyty;
     if (!ctx->get_tyctx ()->lookup_type (function.get_mappings ().get_hirid (),
 					 &fntype_tyty))
       {
@@ -169,7 +169,7 @@ public:
 
     // setup the params
 
-    TyTy::TyBase *tyret = fntype->return_type ();
+    TyTy::BaseType *tyret = fntype->return_type ();
     std::vector<Bvariable *> param_vars;
 
     size_t i = 0;
@@ -282,7 +282,7 @@ public:
 
   void visit (HIR::InherentImpl &impl_block)
   {
-    TyTy::TyBase *self_lookup = nullptr;
+    TyTy::BaseType *self_lookup = nullptr;
     if (!ctx->get_tyctx ()->lookup_type (
 	  impl_block.get_type ()->get_mappings ().get_hirid (), &self_lookup))
       {

--- a/gcc/rust/backend/rust-compile-stmt.h
+++ b/gcc/rust/backend/rust-compile-stmt.h
@@ -58,7 +58,7 @@ public:
     if (!stmt.has_init_expr ())
       return;
 
-    TyTy::TyBase *ty = nullptr;
+    TyTy::BaseType *ty = nullptr;
     if (!ctx->get_tyctx ()->lookup_type (stmt.get_mappings ().get_hirid (),
 					 &ty))
       {

--- a/gcc/rust/backend/rust-compile-tyty.h
+++ b/gcc/rust/backend/rust-compile-tyty.h
@@ -34,7 +34,7 @@ namespace Compile {
 class TyTyCompile : public TyTy::TyVisitor
 {
 public:
-  static ::Btype *compile (::Backend *backend, TyTy::TyBase *ty)
+  static ::Btype *compile (::Backend *backend, TyTy::BaseType *ty)
   {
     TyTyCompile compiler (backend);
     ty->accept_vis (compiler);

--- a/gcc/rust/backend/rust-compile-var-decl.h
+++ b/gcc/rust/backend/rust-compile-var-decl.h
@@ -41,7 +41,7 @@ public:
   void visit (HIR::LetStmt &stmt)
   {
     locus = stmt.get_locus ();
-    TyTy::TyBase *resolved_type = nullptr;
+    TyTy::BaseType *resolved_type = nullptr;
     bool ok = ctx->get_tyctx ()->lookup_type (stmt.get_mappings ().get_hirid (),
 					      &resolved_type);
     rust_assert (ok);

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -125,7 +125,7 @@ CompileExpr::visit (HIR::MethodCallExpr &expr)
 	  return;
 	}
 
-      TyTy::TyBase *self_type = nullptr;
+      TyTy::BaseType *self_type = nullptr;
       if (!ctx->get_tyctx ()->lookup_type (
 	    expr.get_receiver ()->get_mappings ().get_hirid (), &self_type))
 	{

--- a/gcc/rust/typecheck/rust-hir-method-resolve.h
+++ b/gcc/rust/typecheck/rust-hir-method-resolve.h
@@ -66,14 +66,14 @@ public:
 
     // FIXME this can be simplified with
     // https://github.com/Rust-GCC/gccrs/issues/187
-    auto combined = receiver->combine (self_lookup);
-    if (combined == nullptr)
+    auto unified_ty = receiver->unify (self_lookup);
+    if (unified_ty == nullptr)
       {
 	// incompatible self argument then this is not a valid method for this
 	// receiver
 	return;
       }
-    delete combined;
+    delete unified_ty;
 
     probed.push_back (&method);
   }

--- a/gcc/rust/typecheck/rust-hir-method-resolve.h
+++ b/gcc/rust/typecheck/rust-hir-method-resolve.h
@@ -29,7 +29,7 @@ namespace Resolver {
 class MethodResolution : public TypeCheckBase
 {
 public:
-  static std::vector<HIR::Method *> Probe (TyTy::TyBase *receiver,
+  static std::vector<HIR::Method *> Probe (TyTy::BaseType *receiver,
 					   HIR::PathExprSegment method_name)
   {
     MethodResolution probe (receiver, method_name);
@@ -47,7 +47,7 @@ public:
 
   void visit (HIR::Method &method)
   {
-    TyTy::TyBase *self_lookup = nullptr;
+    TyTy::BaseType *self_lookup = nullptr;
     if (!context->lookup_type (
 	  method.get_self_param ().get_mappings ().get_hirid (), &self_lookup))
       {
@@ -79,11 +79,11 @@ public:
   }
 
 private:
-  MethodResolution (TyTy::TyBase *receiver, HIR::PathExprSegment method_name)
+  MethodResolution (TyTy::BaseType *receiver, HIR::PathExprSegment method_name)
     : TypeCheckBase (), receiver (receiver), method_name (method_name)
   {}
 
-  TyTy::TyBase *receiver;
+  TyTy::BaseType *receiver;
   HIR::PathExprSegment method_name;
 
   std::vector<HIR::Method *> probed;

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -32,7 +32,7 @@ namespace Resolver {
 class TypeCheckExpr : public TypeCheckBase
 {
 public:
-  static TyTy::TyBase *Resolve (HIR::Expr *expr, bool inside_loop)
+  static TyTy::BaseType *Resolve (HIR::Expr *expr, bool inside_loop)
   {
     TypeCheckExpr resolver (inside_loop);
     expr->accept_vis (resolver);
@@ -163,7 +163,7 @@ public:
 
   void visit (HIR::CallExpr &expr)
   {
-    TyTy::TyBase *function_tyty
+    TyTy::BaseType *function_tyty
       = TypeCheckExpr::Resolve (expr.get_fnexpr (), false);
     if (function_tyty == nullptr)
       return;
@@ -212,7 +212,7 @@ public:
       }
 
     auto resolved_method = probes.at (0);
-    TyTy::TyBase *lookup;
+    TyTy::BaseType *lookup;
     if (!context->lookup_type (resolved_method->get_mappings ().get_hirid (),
 			       &lookup))
       {
@@ -335,7 +335,7 @@ public:
       }
 
     // the base reference for this name _must_ have a type set
-    TyTy::TyBase *lookup;
+    TyTy::BaseType *lookup;
     if (!context->lookup_type (ref, &lookup))
       {
 	rust_error_at (mappings->lookup_location (ref),
@@ -592,7 +592,7 @@ public:
 
   void visit (HIR::ArrayIndexExpr &expr)
   {
-    TyTy::TyBase *size_ty;
+    TyTy::BaseType *size_ty;
     if (!context->lookup_builtin ("usize", &size_ty))
       {
 	rust_error_at (
@@ -647,7 +647,7 @@ public:
 
   void visit (HIR::ArrayElemsValues &elems)
   {
-    std::vector<TyTy::TyBase *> types;
+    std::vector<TyTy::BaseType *> types;
     elems.iterate ([&] (HIR::Expr *e) mutable -> bool {
       types.push_back (TypeCheckExpr::Resolve (e, false));
       return true;
@@ -760,7 +760,7 @@ public:
   void visit (HIR::LoopExpr &expr)
   {
     context->push_new_loop_context (expr.get_mappings ().get_hirid ());
-    TyTy::TyBase *block_expr
+    TyTy::BaseType *block_expr
       = TypeCheckExpr::Resolve (expr.get_loop_block ().get (), true);
     if (block_expr->get_kind () != TyTy::TypeKind::UNIT)
       {
@@ -769,7 +769,7 @@ public:
 	return;
       }
 
-    TyTy::TyBase *loop_context_type = context->pop_loop_context ();
+    TyTy::BaseType *loop_context_type = context->pop_loop_context ();
 
     bool loop_context_type_infered
       = (loop_context_type->get_kind () != TyTy::TypeKind::INFER)
@@ -787,7 +787,7 @@ public:
     context->push_new_while_loop_context (expr.get_mappings ().get_hirid ());
 
     TypeCheckExpr::Resolve (expr.get_predicate_expr ().get (), false);
-    TyTy::TyBase *block_expr
+    TyTy::BaseType *block_expr
       = TypeCheckExpr::Resolve (expr.get_loop_block ().get (), true);
 
     if (block_expr->get_kind () != TyTy::TypeKind::UNIT)
@@ -811,10 +811,10 @@ public:
 
     if (expr.has_break_expr ())
       {
-	TyTy::TyBase *break_expr_tyty
+	TyTy::BaseType *break_expr_tyty
 	  = TypeCheckExpr::Resolve (expr.get_expr ().get (), false);
 
-	TyTy::TyBase *loop_context = context->peek_loop_context ();
+	TyTy::BaseType *loop_context = context->peek_loop_context ();
 	if (loop_context->get_kind () == TyTy::TypeKind::ERROR)
 	  {
 	    rust_error_at (expr.get_locus (),
@@ -822,7 +822,7 @@ public:
 	    return;
 	  }
 
-	TyTy::TyBase *combined = loop_context->combine (break_expr_tyty);
+	TyTy::BaseType *combined = loop_context->combine (break_expr_tyty);
 	context->swap_head_loop_context (combined);
       }
 
@@ -843,7 +843,7 @@ public:
 
   void visit (HIR::BorrowExpr &expr)
   {
-    TyTy::TyBase *resolved_base
+    TyTy::BaseType *resolved_base
       = TypeCheckExpr::Resolve (expr.get_expr ().get (), false);
 
     // FIXME double_reference
@@ -854,7 +854,7 @@ public:
 
   void visit (HIR::DereferenceExpr &expr)
   {
-    TyTy::TyBase *resolved_base
+    TyTy::BaseType *resolved_base
       = TypeCheckExpr::Resolve (expr.get_expr ().get (), false);
     if (resolved_base->get_kind () != TyTy::TypeKind::REF)
       {
@@ -874,7 +874,7 @@ private:
   {}
 
   bool
-  validate_arithmetic_type (TyTy::TyBase *type,
+  validate_arithmetic_type (TyTy::BaseType *type,
 			    HIR::ArithmeticOrLogicalExpr::ExprType expr_type)
   {
     // https://doc.rust-lang.org/reference/expressions/operator-expr.html#arithmetic-and-logical-binary-operators
@@ -919,8 +919,8 @@ private:
     gcc_unreachable ();
   }
 
-  TyTy::TyBase *infered;
-  TyTy::TyBase *infered_array_elems;
+  TyTy::BaseType *infered;
+  TyTy::BaseType *infered_array_elems;
 
   bool inside_loop;
 };

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -155,7 +155,7 @@ public:
 	return;
       }
 
-    infered = fn_return_tyty->combine (expr_ty);
+    infered = fn_return_tyty->unify (expr_ty);
     fn_return_tyty->append_reference (expr_ty->get_ref ());
     for (auto &ref : infered->get_combined_refs ())
       fn_return_tyty->append_reference (ref);
@@ -245,7 +245,7 @@ public:
     auto lhs = TypeCheckExpr::Resolve (expr.get_lhs (), false);
     auto rhs = TypeCheckExpr::Resolve (expr.get_rhs (), false);
 
-    auto result = lhs->combine (rhs);
+    auto result = lhs->unify (rhs);
     if (result->get_kind () == TyTy::TypeKind::ERROR)
       {
 	rust_error_at (expr.get_locus (),
@@ -469,7 +469,7 @@ public:
 	return;
       }
 
-    infered = lhs->combine (rhs);
+    infered = lhs->unify (rhs);
     infered->append_reference (lhs->get_ref ());
     infered->append_reference (rhs->get_ref ());
   }
@@ -479,7 +479,7 @@ public:
     auto lhs = TypeCheckExpr::Resolve (expr.get_lhs (), false);
     auto rhs = TypeCheckExpr::Resolve (expr.get_rhs (), false);
 
-    auto result = lhs->combine (rhs);
+    auto result = lhs->unify (rhs);
     if (result == nullptr || result->get_kind () == TyTy::TypeKind::ERROR)
       return;
 
@@ -496,16 +496,16 @@ public:
 
     // we expect the lhs and rhs must be bools at this point
     TyTy::BoolType elhs (expr.get_mappings ().get_hirid ());
-    lhs = elhs.combine (lhs);
+    lhs = elhs.unify (lhs);
     if (lhs == nullptr || lhs->get_kind () == TyTy::TypeKind::ERROR)
       return;
 
     TyTy::BoolType rlhs (expr.get_mappings ().get_hirid ());
-    rhs = elhs.combine (rhs);
+    rhs = elhs.unify (rhs);
     if (lhs == nullptr || lhs->get_kind () == TyTy::TypeKind::ERROR)
       return;
 
-    infered = lhs->combine (rhs);
+    infered = lhs->unify (rhs);
     infered->append_reference (lhs->get_ref ());
     infered->append_reference (rhs->get_ref ());
   }
@@ -575,7 +575,7 @@ public:
     auto else_blk_resolved
       = TypeCheckExpr::Resolve (expr.get_else_block (), inside_loop);
 
-    infered = if_blk_resolved->combine (else_blk_resolved);
+    infered = if_blk_resolved->unify (else_blk_resolved);
   }
 
   void visit (HIR::IfExprConseqIf &expr)
@@ -585,7 +585,7 @@ public:
     auto else_blk
       = TypeCheckExpr::Resolve (expr.get_conseq_if_expr (), inside_loop);
 
-    infered = if_blk->combine (else_blk);
+    infered = if_blk->unify (else_blk);
   }
 
   void visit (HIR::BlockExpr &expr);
@@ -601,7 +601,7 @@ public:
 	return;
       }
 
-    auto resolved_index_expr = size_ty->combine (
+    auto resolved_index_expr = size_ty->unify (
       TypeCheckExpr::Resolve (expr.get_index_expr (), false));
     if (resolved_index_expr == nullptr)
       {
@@ -656,7 +656,7 @@ public:
     infered_array_elems = types[0];
     for (size_t i = 1; i < types.size (); i++)
       {
-	infered_array_elems = infered_array_elems->combine (types.at (i));
+	infered_array_elems = infered_array_elems->unify (types.at (i));
       }
 
     for (auto &elem : types)
@@ -822,8 +822,8 @@ public:
 	    return;
 	  }
 
-	TyTy::BaseType *combined = loop_context->combine (break_expr_tyty);
-	context->swap_head_loop_context (combined);
+	TyTy::BaseType *unified_ty = loop_context->unify (break_expr_tyty);
+	context->swap_head_loop_context (unified_ty);
       }
 
     infered = new TyTy::UnitType (expr.get_mappings ().get_hirid ());

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -31,7 +31,7 @@ namespace Resolver {
 class TypeCheckTopLevelImplItem : public TypeCheckBase
 {
 public:
-  static void Resolve (HIR::InherentImplItem *item, TyTy::TyBase *self)
+  static void Resolve (HIR::InherentImplItem *item, TyTy::BaseType *self)
   {
     TypeCheckTopLevelImplItem resolver (self);
     item->accept_vis (resolver);
@@ -39,8 +39,8 @@ public:
 
   void visit (HIR::ConstantItem &constant)
   {
-    TyTy::TyBase *type = TypeCheckType::Resolve (constant.get_type ());
-    TyTy::TyBase *expr_type
+    TyTy::BaseType *type = TypeCheckType::Resolve (constant.get_type ());
+    TyTy::BaseType *expr_type
       = TypeCheckExpr::Resolve (constant.get_expr (), false);
 
     context->insert_type (constant.get_mappings (), type->combine (expr_type));
@@ -48,7 +48,7 @@ public:
 
   void visit (HIR::Function &function)
   {
-    TyTy::TyBase *ret_type = nullptr;
+    TyTy::BaseType *ret_type = nullptr;
     if (!function.has_function_return_type ())
       ret_type = new TyTy::UnitType (function.get_mappings ().get_hirid ());
     else
@@ -65,13 +65,13 @@ public:
 	ret_type->set_ref (function.return_type->get_mappings ().get_hirid ());
       }
 
-    std::vector<std::pair<HIR::Pattern *, TyTy::TyBase *> > params;
+    std::vector<std::pair<HIR::Pattern *, TyTy::BaseType *> > params;
     for (auto &param : function.function_params)
       {
 	// get the name as well required for later on
 	auto param_tyty = TypeCheckType::Resolve (param.get_type ());
 	params.push_back (
-	  std::pair<HIR::Pattern *, TyTy::TyBase *> (param.get_param_name (),
+	  std::pair<HIR::Pattern *, TyTy::BaseType *> (param.get_param_name (),
 						     param_tyty));
 
 	context->insert_type (param.get_mappings (), param_tyty);
@@ -84,7 +84,7 @@ public:
 
   void visit (HIR::Method &method)
   {
-    TyTy::TyBase *ret_type = nullptr;
+    TyTy::BaseType *ret_type = nullptr;
     if (!method.has_function_return_type ())
       ret_type = new TyTy::UnitType (method.get_mappings ().get_hirid ());
     else
@@ -104,7 +104,7 @@ public:
       }
 
     // hold all the params to the fndef
-    std::vector<std::pair<HIR::Pattern *, TyTy::TyBase *> > params;
+    std::vector<std::pair<HIR::Pattern *, TyTy::BaseType *> > params;
 
     // add the self param at the front
     HIR::SelfParam &self_param = method.get_self_param ();
@@ -115,14 +115,14 @@ public:
 				    std::unique_ptr<HIR::Pattern> (nullptr));
     context->insert_type (self_param.get_mappings (), self->clone ());
     params.push_back (
-      std::pair<HIR::Pattern *, TyTy::TyBase *> (self_pattern, self->clone ()));
+      std::pair<HIR::Pattern *, TyTy::BaseType *> (self_pattern, self->clone ()));
 
     for (auto &param : method.get_function_params ())
       {
 	// get the name as well required for later on
 	auto param_tyty = TypeCheckType::Resolve (param.get_type ());
 	params.push_back (
-	  std::pair<HIR::Pattern *, TyTy::TyBase *> (param.get_param_name (),
+	  std::pair<HIR::Pattern *, TyTy::BaseType *> (param.get_param_name (),
 						     param_tyty));
 
 	context->insert_type (param.get_mappings (), param_tyty);
@@ -134,16 +134,16 @@ public:
   }
 
 private:
-  TypeCheckTopLevelImplItem (TyTy::TyBase *self) : TypeCheckBase (), self (self)
+  TypeCheckTopLevelImplItem (TyTy::BaseType *self) : TypeCheckBase (), self (self)
   {}
 
-  TyTy::TyBase *self;
+  TyTy::BaseType *self;
 };
 
 class TypeCheckImplItem : public TypeCheckBase
 {
 public:
-  static void Resolve (HIR::InherentImplItem *item, TyTy::TyBase *self)
+  static void Resolve (HIR::InherentImplItem *item, TyTy::BaseType *self)
   {
     TypeCheckImplItem resolver (self);
     item->accept_vis (resolver);
@@ -151,7 +151,7 @@ public:
 
   void visit (HIR::Function &function)
   {
-    TyTy::TyBase *lookup;
+    TyTy::BaseType *lookup;
     if (!context->lookup_type (function.get_mappings ().get_hirid (), &lookup))
       {
 	rust_error_at (function.get_locus (), "failed to lookup function type");
@@ -183,7 +183,7 @@ public:
 
   void visit (HIR::Method &method)
   {
-    TyTy::TyBase *lookup;
+    TyTy::BaseType *lookup;
     if (!context->lookup_type (method.get_mappings ().get_hirid (), &lookup))
       {
 	rust_error_at (method.get_locus (), "failed to lookup function type");
@@ -215,9 +215,9 @@ public:
   }
 
 private:
-  TypeCheckImplItem (TyTy::TyBase *self) : TypeCheckBase (), self (self) {}
+  TypeCheckImplItem (TyTy::BaseType *self) : TypeCheckBase (), self (self) {}
 
-  TyTy::TyBase *self;
+  TyTy::BaseType *self;
 };
 
 } // namespace Resolver

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -43,7 +43,7 @@ public:
     TyTy::BaseType *expr_type
       = TypeCheckExpr::Resolve (constant.get_expr (), false);
 
-    context->insert_type (constant.get_mappings (), type->combine (expr_type));
+    context->insert_type (constant.get_mappings (), type->unify (expr_type));
   }
 
   void visit (HIR::Function &function)
@@ -172,7 +172,7 @@ public:
     context->push_return_type (expected_ret_tyty);
 
     auto result = TypeCheckExpr::Resolve (function.function_body.get (), false);
-    auto ret_resolved = expected_ret_tyty->combine (result);
+    auto ret_resolved = expected_ret_tyty->unify (result);
     if (ret_resolved == nullptr)
       return;
 
@@ -205,7 +205,7 @@ public:
 
     auto result
       = TypeCheckExpr::Resolve (method.get_function_body ().get (), false);
-    auto ret_resolved = expected_ret_tyty->combine (result);
+    auto ret_resolved = expected_ret_tyty->unify (result);
     if (ret_resolved == nullptr)
       return;
 

--- a/gcc/rust/typecheck/rust-hir-type-check-item.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.h
@@ -76,7 +76,7 @@ public:
     context->push_return_type (expected_ret_tyty);
 
     auto result = TypeCheckExpr::Resolve (function.function_body.get (), false);
-    auto ret_resolved = expected_ret_tyty->combine (result);
+    auto ret_resolved = expected_ret_tyty->unify (result);
     if (ret_resolved == nullptr)
       return;
 

--- a/gcc/rust/typecheck/rust-hir-type-check-item.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.h
@@ -40,7 +40,7 @@ public:
 
   void visit (HIR::InherentImpl &impl_block) override
   {
-    TyTy::TyBase *self = nullptr;
+    TyTy::BaseType *self = nullptr;
     if (!context->lookup_type (
 	  impl_block.get_type ()->get_mappings ().get_hirid (), &self))
       {
@@ -55,7 +55,7 @@ public:
 
   void visit (HIR::Function &function) override
   {
-    TyTy::TyBase *lookup;
+    TyTy::BaseType *lookup;
     if (!context->lookup_type (function.get_mappings ().get_hirid (), &lookup))
       {
 	rust_error_at (function.locus, "failed to lookup function type");

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.h
@@ -30,7 +30,7 @@ namespace Resolver {
 class TypeCheckStmt : public TypeCheckBase
 {
 public:
-  static TyTy::TyBase *Resolve (HIR::Stmt *stmt, bool inside_loop)
+  static TyTy::BaseType *Resolve (HIR::Stmt *stmt, bool inside_loop)
   {
     TypeCheckStmt resolver (inside_loop);
     stmt->accept_vis (resolver);
@@ -51,7 +51,7 @@ public:
   {
     infered = new TyTy::UnitType (stmt.get_mappings ().get_hirid ());
 
-    TyTy::TyBase *init_expr_ty = nullptr;
+    TyTy::BaseType *init_expr_ty = nullptr;
     if (stmt.has_init_expr ())
       {
 	init_expr_ty
@@ -65,7 +65,7 @@ public:
 	init_expr_ty->append_reference (ref);
       }
 
-    TyTy::TyBase *specified_ty = nullptr;
+    TyTy::BaseType *specified_ty = nullptr;
     if (stmt.has_type ())
       specified_ty = TypeCheckType::Resolve (stmt.get_type ());
 
@@ -110,7 +110,7 @@ private:
     : TypeCheckBase (), infered (nullptr), inside_loop (inside_loop)
   {}
 
-  TyTy::TyBase *infered;
+  TyTy::BaseType *infered;
   bool inside_loop;
 };
 

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.h
@@ -72,15 +72,15 @@ public:
     // let x:i32 = 123;
     if (specified_ty != nullptr && init_expr_ty != nullptr)
       {
-	auto combined = specified_ty->combine (init_expr_ty);
-	if (combined->get_kind () == TyTy::TypeKind::ERROR)
+	auto unified_ty = specified_ty->unify (init_expr_ty);
+	if (unified_ty->get_kind () == TyTy::TypeKind::ERROR)
 	  {
 	    rust_fatal_error (stmt.get_locus (),
 			      "failure in setting up let stmt type");
 	    return;
 	  }
 
-	context->insert_type (stmt.get_mappings (), combined);
+	context->insert_type (stmt.get_mappings (), unified_ty);
       }
     else
       {

--- a/gcc/rust/typecheck/rust-hir-type-check-struct-field.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-struct-field.h
@@ -30,7 +30,7 @@ namespace Resolver {
 class TypeCheckStructExpr : public TypeCheckBase
 {
 public:
-  static TyTy::TyBase *Resolve (HIR::StructExprStructFields *expr)
+  static TyTy::BaseType *Resolve (HIR::StructExprStructFields *expr)
   {
     TypeCheckStructExpr resolver;
     expr->accept_vis (resolver);
@@ -53,9 +53,9 @@ private:
     : TypeCheckBase (), resolved (nullptr), struct_path_resolved (nullptr)
   {}
 
-  TyTy::TyBase *resolved;
+  TyTy::BaseType *resolved;
   TyTy::ADTType *struct_path_resolved;
-  TyTy::TyBase *resolved_field;
+  TyTy::BaseType *resolved_field;
   std::set<std::string> fields_assigned;
   std::map<size_t, HIR::StructExprField *> adtFieldIndexToField;
 };

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
@@ -44,7 +44,7 @@ public:
 
     size_t idx = 0;
     struct_decl.iterate ([&] (HIR::TupleField &field) mutable -> bool {
-      TyTy::TyBase *field_type
+      TyTy::BaseType *field_type
 	= TypeCheckType::Resolve (field.get_field_type ().get ());
       TyTy::StructFieldType *ty_field
 	= new TyTy::StructFieldType (field.get_mappings ().get_hirid (),
@@ -55,7 +55,7 @@ public:
       return true;
     });
 
-    TyTy::TyBase *type
+    TyTy::BaseType *type
       = new TyTy::ADTType (struct_decl.get_mappings ().get_hirid (),
 			   struct_decl.get_identifier (), std::move (fields));
 
@@ -66,7 +66,7 @@ public:
   {
     std::vector<TyTy::StructFieldType *> fields;
     struct_decl.iterate ([&] (HIR::StructField &field) mutable -> bool {
-      TyTy::TyBase *field_type
+      TyTy::BaseType *field_type
 	= TypeCheckType::Resolve (field.get_field_type ().get ());
       TyTy::StructFieldType *ty_field
 	= new TyTy::StructFieldType (field.get_mappings ().get_hirid (),
@@ -76,7 +76,7 @@ public:
       return true;
     });
 
-    TyTy::TyBase *type
+    TyTy::BaseType *type
       = new TyTy::ADTType (struct_decl.get_mappings ().get_hirid (),
 			   struct_decl.get_identifier (), std::move (fields));
 
@@ -85,16 +85,16 @@ public:
 
   void visit (HIR::StaticItem &var)
   {
-    TyTy::TyBase *type = TypeCheckType::Resolve (var.get_type ());
-    TyTy::TyBase *expr_type = TypeCheckExpr::Resolve (var.get_expr (), false);
+    TyTy::BaseType *type = TypeCheckType::Resolve (var.get_type ());
+    TyTy::BaseType *expr_type = TypeCheckExpr::Resolve (var.get_expr (), false);
 
     context->insert_type (var.get_mappings (), type->combine (expr_type));
   }
 
   void visit (HIR::ConstantItem &constant)
   {
-    TyTy::TyBase *type = TypeCheckType::Resolve (constant.get_type ());
-    TyTy::TyBase *expr_type
+    TyTy::BaseType *type = TypeCheckType::Resolve (constant.get_type ());
+    TyTy::BaseType *expr_type
       = TypeCheckExpr::Resolve (constant.get_expr (), false);
 
     context->insert_type (constant.get_mappings (), type->combine (expr_type));
@@ -102,7 +102,7 @@ public:
 
   void visit (HIR::Function &function)
   {
-    TyTy::TyBase *ret_type = nullptr;
+    TyTy::BaseType *ret_type = nullptr;
     if (!function.has_function_return_type ())
       ret_type = new TyTy::UnitType (function.get_mappings ().get_hirid ());
     else
@@ -119,13 +119,13 @@ public:
 	ret_type->set_ref (function.return_type->get_mappings ().get_hirid ());
       }
 
-    std::vector<std::pair<HIR::Pattern *, TyTy::TyBase *> > params;
+    std::vector<std::pair<HIR::Pattern *, TyTy::BaseType *> > params;
     for (auto &param : function.function_params)
       {
 	// get the name as well required for later on
 	auto param_tyty = TypeCheckType::Resolve (param.get_type ());
 	params.push_back (
-	  std::pair<HIR::Pattern *, TyTy::TyBase *> (param.get_param_name (),
+	  std::pair<HIR::Pattern *, TyTy::BaseType *> (param.get_param_name (),
 						     param_tyty));
 
 	context->insert_type (param.get_mappings (), param_tyty);

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
@@ -88,7 +88,7 @@ public:
     TyTy::BaseType *type = TypeCheckType::Resolve (var.get_type ());
     TyTy::BaseType *expr_type = TypeCheckExpr::Resolve (var.get_expr (), false);
 
-    context->insert_type (var.get_mappings (), type->combine (expr_type));
+    context->insert_type (var.get_mappings (), type->unify (expr_type));
   }
 
   void visit (HIR::ConstantItem &constant)
@@ -97,7 +97,7 @@ public:
     TyTy::BaseType *expr_type
       = TypeCheckExpr::Resolve (constant.get_expr (), false);
 
-    context->insert_type (constant.get_mappings (), type->combine (expr_type));
+    context->insert_type (constant.get_mappings (), type->unify (expr_type));
   }
 
   void visit (HIR::Function &function)

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -65,7 +65,7 @@ private:
 class TypeCheckType : public TypeCheckBase
 {
 public:
-  static TyTy::TyBase *Resolve (HIR::Type *type)
+  static TyTy::BaseType *Resolve (HIR::Type *type)
   {
     TypeCheckType resolver;
     type->accept_vis (resolver);
@@ -83,12 +83,12 @@ public:
 
   void visit (HIR::BareFunctionType &fntype)
   {
-    TyTy::TyBase *return_type
+    TyTy::BaseType *return_type
       = fntype.has_return_type ()
 	  ? TypeCheckType::Resolve (fntype.get_return_type ().get ())
 	  : new TyTy::UnitType (fntype.get_mappings ().get_hirid ());
 
-    std::vector<std::pair<HIR::Pattern *, TyTy::TyBase *> > params;
+    std::vector<std::pair<HIR::Pattern *, TyTy::BaseType *> > params;
     for (auto &param : fntype.get_function_params ())
       {
 	std::unique_ptr<HIR::Pattern> to_bind;
@@ -100,9 +100,9 @@ public:
 	  = new HIR::IdentifierPattern (param.get_name (), param.get_locus (),
 					is_ref, is_mut, std::move (to_bind));
 
-	TyTy::TyBase *ptype = TypeCheckType::Resolve (param.get_type ().get ());
+	TyTy::BaseType *ptype = TypeCheckType::Resolve (param.get_type ().get ());
 	params.push_back (
-	  std::pair<HIR::Pattern *, TyTy::TyBase *> (pattern, ptype));
+	  std::pair<HIR::Pattern *, TyTy::BaseType *> (pattern, ptype));
       }
 
     translated = new TyTy::FnType (fntype.get_mappings ().get_hirid (),
@@ -171,14 +171,14 @@ public:
 	return;
       }
 
-    TyTy::TyBase *base = TypeCheckType::Resolve (type.get_element_type ());
+    TyTy::BaseType *base = TypeCheckType::Resolve (type.get_element_type ());
     translated
       = new TyTy::ArrayType (type.get_mappings ().get_hirid (), capacity, base);
   }
 
   void visit (HIR::ReferenceType &type)
   {
-    TyTy::TyBase *base = TypeCheckType::Resolve (type.get_base_type ().get ());
+    TyTy::BaseType *base = TypeCheckType::Resolve (type.get_base_type ().get ());
     translated = new TyTy::ReferenceType (type.get_mappings ().get_hirid (),
 					  base->get_ref ());
   }
@@ -192,7 +192,7 @@ public:
 private:
   TypeCheckType () : TypeCheckBase (), translated (nullptr) {}
 
-  TyTy::TyBase *translated;
+  TyTy::BaseType *translated;
 };
 
 } // namespace Resolver

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -47,7 +47,7 @@ TypeResolution::Resolve (HIR::Crate &crate)
   auto mappings = Analysis::Mappings::get ();
   auto context = TypeCheckContext::get ();
 
-  context->iterate ([&] (HirId id, TyTy::TyBase *ty) mutable -> bool {
+  context->iterate ([&] (HirId id, TyTy::BaseType *ty) mutable -> bool {
     if (ty->get_kind () == TyTy::TypeKind::ERROR)
       {
 	rust_error_at (mappings->lookup_location (id),
@@ -69,7 +69,7 @@ TypeResolution::Resolve (HIR::Crate &crate)
 	break;
 
 	case TyTy::InferType::INTEGRAL: {
-	  TyTy::TyBase *default_integer;
+	  TyTy::BaseType *default_integer;
 	  bool ok = context->lookup_builtin ("i32", &default_integer);
 	  rust_assert (ok);
 
@@ -83,7 +83,7 @@ TypeResolution::Resolve (HIR::Crate &crate)
 	break;
 
 	case TyTy::InferType::FLOAT: {
-	  TyTy::TyBase *default_float;
+	  TyTy::BaseType *default_float;
 	  bool ok = context->lookup_builtin ("f32", &default_float);
 	  rust_assert (ok);
 
@@ -105,7 +105,7 @@ TypeResolution::Resolve (HIR::Crate &crate)
 void
 TypeCheckExpr::visit (HIR::BlockExpr &expr)
 {
-  TyTy::TyBase *block_tyty
+  TyTy::BaseType *block_tyty
     = new TyTy::UnitType (expr.get_mappings ().get_hirid ());
 
   expr.iterate_stmts ([&] (HIR::Stmt *s) mutable -> bool {
@@ -161,7 +161,7 @@ TypeCheckStructExpr::visit (HIR::StructExprStructFields &struct_expr)
   resolved = struct_path_resolved;
   if (struct_expr.has_struct_base ())
     {
-      TyTy::TyBase *base_resolved
+      TyTy::BaseType *base_resolved
 	= TypeCheckExpr::Resolve (struct_expr.struct_base->base_struct.get (),
 				  false);
       resolved = struct_path_resolved->combine (base_resolved);
@@ -300,7 +300,7 @@ TypeCheckStructExpr::visit (HIR::PathInExpression &expr)
     }
 
   // the base reference for this name _must_ have a type set
-  TyTy::TyBase *lookup;
+  TyTy::BaseType *lookup;
   if (!context->lookup_type (ref, &lookup))
     {
       rust_error_at (mappings->lookup_location (ref),
@@ -329,7 +329,7 @@ TypeCheckStructExpr::visit (HIR::StructExprFieldIdentifierValue &field)
     }
 
   size_t field_index;
-  TyTy::TyBase *value = TypeCheckExpr::Resolve (field.get_value (), false);
+  TyTy::BaseType *value = TypeCheckExpr::Resolve (field.get_value (), false);
   TyTy::StructFieldType *field_type
     = struct_path_resolved->get_field (field.field_name, &field_index);
   if (field_type == nullptr)
@@ -358,7 +358,7 @@ TypeCheckStructExpr::visit (HIR::StructExprFieldIndexValue &field)
     }
 
   size_t field_index;
-  TyTy::TyBase *value = TypeCheckExpr::Resolve (field.get_value (), false);
+  TyTy::BaseType *value = TypeCheckExpr::Resolve (field.get_value (), false);
   TyTy::StructFieldType *field_type
     = struct_path_resolved->get_field (field_name, &field_index);
   if (field_type == nullptr)
@@ -398,7 +398,7 @@ TypeCheckStructExpr::visit (HIR::StructExprFieldIdentifier &field)
   // existing code to figure out the type
   HIR::IdentifierExpr expr (field.get_mappings (), field.get_field_name (),
 			    field.get_locus ());
-  TyTy::TyBase *value = TypeCheckExpr::Resolve (&expr, false);
+  TyTy::BaseType *value = TypeCheckExpr::Resolve (&expr, false);
 
   resolved_field = field_type->get_field_type ()->combine (value);
   if (resolved_field != nullptr)

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -73,7 +73,7 @@ TypeResolution::Resolve (HIR::Crate &crate)
 	  bool ok = context->lookup_builtin ("i32", &default_integer);
 	  rust_assert (ok);
 
-	  auto result = ty->combine (default_integer);
+	  auto result = ty->unify (default_integer);
 	  result->set_ref (id);
 	  context->insert_type (
 	    Analysis::NodeMapping (mappings->get_current_crate (), 0, id,
@@ -87,7 +87,7 @@ TypeResolution::Resolve (HIR::Crate &crate)
 	  bool ok = context->lookup_builtin ("f32", &default_float);
 	  rust_assert (ok);
 
-	  auto result = ty->combine (default_float);
+	  auto result = ty->unify (default_float);
 	  result->set_ref (id);
 	  context->insert_type (
 	    Analysis::NodeMapping (mappings->get_current_crate (), 0, id,
@@ -164,7 +164,7 @@ TypeCheckStructExpr::visit (HIR::StructExprStructFields &struct_expr)
       TyTy::BaseType *base_resolved
 	= TypeCheckExpr::Resolve (struct_expr.struct_base->base_struct.get (),
 				  false);
-      resolved = struct_path_resolved->combine (base_resolved);
+      resolved = struct_path_resolved->unify (base_resolved);
       if (resolved == nullptr)
 	{
 	  rust_fatal_error (
@@ -338,7 +338,7 @@ TypeCheckStructExpr::visit (HIR::StructExprFieldIdentifierValue &field)
       return;
     }
 
-  resolved_field = field_type->get_field_type ()->combine (value);
+  resolved_field = field_type->get_field_type ()->unify (value);
   if (resolved_field != nullptr)
     {
       fields_assigned.insert (field.field_name);
@@ -367,7 +367,7 @@ TypeCheckStructExpr::visit (HIR::StructExprFieldIndexValue &field)
       return;
     }
 
-  resolved_field = field_type->get_field_type ()->combine (value);
+  resolved_field = field_type->get_field_type ()->unify (value);
   if (resolved_field != nullptr)
     {
       fields_assigned.insert (field_name);
@@ -400,7 +400,7 @@ TypeCheckStructExpr::visit (HIR::StructExprFieldIdentifier &field)
 			    field.get_locus ());
   TyTy::BaseType *value = TypeCheckExpr::Resolve (&expr, false);
 
-  resolved_field = field_type->get_field_type ()->combine (value);
+  resolved_field = field_type->get_field_type ()->unify (value);
   if (resolved_field != nullptr)
     {
       fields_assigned.insert (field.field_name);

--- a/gcc/rust/typecheck/rust-hir-type-check.h
+++ b/gcc/rust/typecheck/rust-hir-type-check.h
@@ -33,21 +33,21 @@ public:
 
   ~TypeCheckContext ();
 
-  bool lookup_builtin (NodeId id, TyTy::TyBase **type);
-  bool lookup_builtin (std::string name, TyTy::TyBase **type);
-  void insert_builtin (HirId id, NodeId ref, TyTy::TyBase *type);
+  bool lookup_builtin (NodeId id, TyTy::BaseType **type);
+  bool lookup_builtin (std::string name, TyTy::BaseType **type);
+  void insert_builtin (HirId id, NodeId ref, TyTy::BaseType *type);
 
-  void insert_type (const Analysis::NodeMapping &mappings, TyTy::TyBase *type);
-  bool lookup_type (HirId id, TyTy::TyBase **type);
+  void insert_type (const Analysis::NodeMapping &mappings, TyTy::BaseType *type);
+  bool lookup_type (HirId id, TyTy::BaseType **type);
 
   void insert_type_by_node_id (NodeId ref, HirId id);
   bool lookup_type_by_node_id (NodeId ref, HirId *id);
 
-  TyTy::TyBase *peek_return_type ();
-  void push_return_type (TyTy::TyBase *return_type);
+  TyTy::BaseType *peek_return_type ();
+  void push_return_type (TyTy::BaseType *return_type);
   void pop_return_type ();
 
-  void iterate (std::function<bool (HirId, TyTy::TyBase *)> cb)
+  void iterate (std::function<bool (HirId, TyTy::BaseType *)> cb)
   {
     for (auto it = resolved.begin (); it != resolved.end (); it++)
       {
@@ -58,27 +58,27 @@ public:
 
   void push_new_loop_context (HirId id)
   {
-    TyTy::TyBase *infer_var
+    TyTy::BaseType *infer_var
       = new TyTy::InferType (id, TyTy::InferType::InferTypeKind::GENERAL);
     loop_type_stack.push_back (infer_var);
   }
 
   void push_new_while_loop_context (HirId id)
   {
-    TyTy::TyBase *infer_var = new TyTy::ErrorType (id);
+    TyTy::BaseType *infer_var = new TyTy::ErrorType (id);
     loop_type_stack.push_back (infer_var);
   }
 
-  TyTy::TyBase *peek_loop_context () { return loop_type_stack.back (); }
+  TyTy::BaseType *peek_loop_context () { return loop_type_stack.back (); }
 
-  TyTy::TyBase *pop_loop_context ()
+  TyTy::BaseType *pop_loop_context ()
   {
     auto back = peek_loop_context ();
     loop_type_stack.pop_back ();
     return back;
   }
 
-  void swap_head_loop_context (TyTy::TyBase *val)
+  void swap_head_loop_context (TyTy::BaseType *val)
   {
     loop_type_stack.pop_back ();
     loop_type_stack.push_back (val);
@@ -88,10 +88,10 @@ private:
   TypeCheckContext ();
 
   std::map<NodeId, HirId> node_id_refs;
-  std::map<HirId, TyTy::TyBase *> resolved;
-  std::vector<std::unique_ptr<TyTy::TyBase> > builtins;
-  std::vector<TyTy::TyBase *> return_type_stack;
-  std::vector<TyTy::TyBase *> loop_type_stack;
+  std::map<HirId, TyTy::BaseType *> resolved;
+  std::vector<std::unique_ptr<TyTy::BaseType> > builtins;
+  std::vector<TyTy::BaseType *> return_type_stack;
+  std::vector<TyTy::BaseType *> loop_type_stack;
 };
 
 class TypeResolution

--- a/gcc/rust/typecheck/rust-tycheck-dump.h
+++ b/gcc/rust/typecheck/rust-tycheck-dump.h
@@ -180,7 +180,7 @@ public:
 protected:
   std::string type_string (const Analysis::NodeMapping &mappings)
   {
-    TyTy::TyBase *lookup = nullptr;
+    TyTy::BaseType *lookup = nullptr;
     if (!context->lookup_type (mappings.get_hirid (), &lookup))
       return "<error>";
 

--- a/gcc/rust/typecheck/rust-tyctx.cc
+++ b/gcc/rust/typecheck/rust-tyctx.cc
@@ -36,7 +36,7 @@ TypeCheckContext::TypeCheckContext () {}
 TypeCheckContext::~TypeCheckContext () {}
 
 bool
-TypeCheckContext::lookup_builtin (NodeId id, TyTy::TyBase **type)
+TypeCheckContext::lookup_builtin (NodeId id, TyTy::BaseType **type)
 {
   auto ref_it = node_id_refs.find (id);
   if (ref_it == node_id_refs.end ())
@@ -51,7 +51,7 @@ TypeCheckContext::lookup_builtin (NodeId id, TyTy::TyBase **type)
 }
 
 bool
-TypeCheckContext::lookup_builtin (std::string name, TyTy::TyBase **type)
+TypeCheckContext::lookup_builtin (std::string name, TyTy::BaseType **type)
 {
   for (auto &builtin : builtins)
     {
@@ -65,16 +65,16 @@ TypeCheckContext::lookup_builtin (std::string name, TyTy::TyBase **type)
 }
 
 void
-TypeCheckContext::insert_builtin (HirId id, NodeId ref, TyTy::TyBase *type)
+TypeCheckContext::insert_builtin (HirId id, NodeId ref, TyTy::BaseType *type)
 {
   node_id_refs[ref] = id;
   resolved[id] = type;
-  builtins.push_back (std::unique_ptr<TyTy::TyBase> (type));
+  builtins.push_back (std::unique_ptr<TyTy::BaseType> (type));
 }
 
 void
 TypeCheckContext::insert_type (const Analysis::NodeMapping &mappings,
-			       TyTy::TyBase *type)
+			       TyTy::BaseType *type)
 {
   rust_assert (type != nullptr);
   NodeId ref = mappings.get_nodeid ();
@@ -84,7 +84,7 @@ TypeCheckContext::insert_type (const Analysis::NodeMapping &mappings,
 }
 
 bool
-TypeCheckContext::lookup_type (HirId id, TyTy::TyBase **type)
+TypeCheckContext::lookup_type (HirId id, TyTy::BaseType **type)
 {
   auto it = resolved.find (id);
   if (it == resolved.end ())
@@ -112,14 +112,14 @@ TypeCheckContext::lookup_type_by_node_id (NodeId ref, HirId *id)
   return true;
 }
 
-TyTy::TyBase *
+TyTy::BaseType *
 TypeCheckContext::peek_return_type ()
 {
   return return_type_stack.back ();
 }
 
 void
-TypeCheckContext::push_return_type (TyTy::TyBase *return_type)
+TypeCheckContext::push_return_type (TyTy::BaseType *return_type)
 {
   return_type_stack.push_back (return_type);
 }

--- a/gcc/rust/typecheck/rust-tyty-call.h
+++ b/gcc/rust/typecheck/rust-tyty-call.h
@@ -31,7 +31,7 @@ namespace TyTy {
 class TypeCheckCallExpr : private TyVisitor
 {
 public:
-  static TyBase *go (TyBase *ref, HIR::CallExpr &call,
+  static BaseType *go (BaseType *ref, HIR::CallExpr &call,
 		     Resolver::TypeCheckContext *context)
   {
     TypeCheckCallExpr checker (call, context);
@@ -66,7 +66,7 @@ private:
       mappings (Analysis::Mappings::get ())
   {}
 
-  TyBase *resolved;
+  BaseType *resolved;
   HIR::CallExpr &call;
   Resolver::TypeCheckContext *context;
   Analysis::Mappings *mappings;
@@ -75,7 +75,7 @@ private:
 class TypeCheckMethodCallExpr : private TyVisitor
 {
 public:
-  static TyBase *go (TyBase *ref, HIR::MethodCallExpr &call,
+  static BaseType *go (BaseType *ref, HIR::MethodCallExpr &call,
 		     Resolver::TypeCheckContext *context)
   {
     TypeCheckMethodCallExpr checker (call, context);
@@ -109,7 +109,7 @@ private:
       mappings (Analysis::Mappings::get ())
   {}
 
-  TyBase *resolved;
+  BaseType *resolved;
   HIR::MethodCallExpr &call;
   Resolver::TypeCheckContext *context;
   Analysis::Mappings *mappings;

--- a/gcc/rust/typecheck/rust-tyty-rules.h
+++ b/gcc/rust/typecheck/rust-tyty-rules.h
@@ -33,7 +33,7 @@ class BaseRules : public TyVisitor
 public:
   virtual ~BaseRules () {}
 
-  TyBase *combine (TyBase *other)
+  BaseType *combine (BaseType *other)
   {
     other->accept_vis (*this);
     if (resolved != nullptr)
@@ -50,7 +50,7 @@ public:
 	  {
 	    for (auto &ref : resolved->get_combined_refs ())
 	      {
-		TyTy::TyBase *ref_tyty = nullptr;
+		TyTy::BaseType *ref_tyty = nullptr;
 		bool ok = context->lookup_type (ref, &ref_tyty);
 		if (!ok)
 		  continue;
@@ -185,7 +185,7 @@ public:
   }
 
 protected:
-  BaseRules (TyBase *base)
+  BaseRules (BaseType *base)
     : mappings (Analysis::Mappings::get ()),
       context (Resolver::TypeCheckContext::get ()), base (base),
       resolved (new ErrorType (base->get_ref (), base->get_ref ()))
@@ -194,8 +194,8 @@ protected:
   Analysis::Mappings *mappings;
   Resolver::TypeCheckContext *context;
 
-  TyBase *base;
-  TyBase *resolved;
+  BaseType *base;
+  BaseType *resolved;
 };
 
 class InferRules : public BaseRules
@@ -423,7 +423,7 @@ public:
 
   void visit (StructFieldType &type)
   {
-    TyBase *ty = base->get_field_type ()->combine (type.get_field_type ());
+    BaseType *ty = base->get_field_type ()->combine (type.get_field_type ());
     if (ty == nullptr)
       return;
 
@@ -474,7 +474,7 @@ public:
 	return;
       }
 
-    // FIXME add an abstract method for is_equal on TyBase
+    // FIXME add an abstract method for is_equal on BaseType
     for (size_t i = 0; i < base->num_params (); i++)
       {
 	auto a = base->param_at (i).second;
@@ -670,7 +670,7 @@ public:
 	TyTy::StructFieldType *base_field = base->get_field (i);
 	TyTy::StructFieldType *other_field = type.get_field (i);
 
-	TyBase *combined = base_field->combine (other_field);
+	BaseType *combined = base_field->combine (other_field);
 	if (combined == nullptr)
 	  {
 	    BaseRules::visit (type);
@@ -704,10 +704,10 @@ public:
     std::vector<HirId> fields;
     for (size_t i = 0; i < base->num_fields (); i++)
       {
-	TyBase *bo = base->get_field (i);
-	TyBase *fo = type.get_field (i);
+	BaseType *bo = base->get_field (i);
+	BaseType *fo = type.get_field (i);
 
-	TyBase *combined = bo->combine (fo);
+	BaseType *combined = bo->combine (fo);
 	if (combined == nullptr)
 	  {
 	    BaseRules::visit (type);
@@ -806,7 +806,7 @@ public:
     auto base_type = base->get_base ();
     auto other_base_type = type.get_base ();
 
-    TyTy::TyBase *base_resolved = base_type->combine (other_base_type);
+    TyTy::BaseType *base_resolved = base_type->combine (other_base_type);
     resolved = new ReferenceType (base->get_ref (), base->get_ty_ref (),
 				  base_resolved->get_ref ());
   }

--- a/gcc/rust/typecheck/rust-tyty-rules.h
+++ b/gcc/rust/typecheck/rust-tyty-rules.h
@@ -33,7 +33,7 @@ class BaseRules : public TyVisitor
 public:
   virtual ~BaseRules () {}
 
-  BaseType *combine (BaseType *other)
+  BaseType *unify (BaseType *other)
   {
     other->accept_vis (*this);
     if (resolved != nullptr)
@@ -423,7 +423,7 @@ public:
 
   void visit (StructFieldType &type)
   {
-    BaseType *ty = base->get_field_type ()->combine (type.get_field_type ());
+    BaseType *ty = base->get_field_type ()->unify (type.get_field_type ());
     if (ty == nullptr)
       return;
 
@@ -480,17 +480,17 @@ public:
 	auto a = base->param_at (i).second;
 	auto b = type.param_at (i).second;
 
-	auto combined_param = a->combine (b);
-	if (combined_param == nullptr)
+	auto unified_param = a->unify (b);
+	if (unified_param == nullptr)
 	  {
 	    BaseRules::visit (type);
 	    return;
 	  }
       }
 
-    auto combined_return
-      = base->get_return_type ()->combine (type.get_return_type ());
-    if (combined_return == nullptr)
+    auto unified_return
+      = base->get_return_type ()->unify (type.get_return_type ());
+    if (unified_return == nullptr)
       {
 	BaseRules::visit (type);
 	return;
@@ -512,7 +512,7 @@ public:
   void visit (ArrayType &type) override
   {
     // check base type
-    auto base_resolved = base->get_type ()->combine (type.get_type ());
+    auto base_resolved = base->get_type ()->unify (type.get_type ());
     if (base_resolved == nullptr)
       {
 	// fixme add error message
@@ -670,14 +670,14 @@ public:
 	TyTy::StructFieldType *base_field = base->get_field (i);
 	TyTy::StructFieldType *other_field = type.get_field (i);
 
-	BaseType *combined = base_field->combine (other_field);
-	if (combined == nullptr)
+	BaseType *unified_ty = base_field->unify (other_field);
+	if (unified_ty == nullptr)
 	  {
 	    BaseRules::visit (type);
 	    return;
 	  }
 
-	fields.push_back ((TyTy::StructFieldType *) combined);
+	fields.push_back ((TyTy::StructFieldType *) unified_ty);
       }
 
     resolved = new TyTy::ADTType (type.get_ref (), type.get_ty_ref (),
@@ -707,14 +707,14 @@ public:
 	BaseType *bo = base->get_field (i);
 	BaseType *fo = type.get_field (i);
 
-	BaseType *combined = bo->combine (fo);
-	if (combined == nullptr)
+	BaseType *unified_ty = bo->unify (fo);
+	if (unified_ty == nullptr)
 	  {
 	    BaseRules::visit (type);
 	    return;
 	  }
 
-	fields.push_back (combined->get_ref ());
+	fields.push_back (unified_ty->get_ref ());
       }
 
     resolved
@@ -806,7 +806,7 @@ public:
     auto base_type = base->get_base ();
     auto other_base_type = type.get_base ();
 
-    TyTy::BaseType *base_resolved = base_type->combine (other_base_type);
+    TyTy::BaseType *base_resolved = base_type->unify (other_base_type);
     resolved = new ReferenceType (base->get_ref (), base->get_ty_ref (),
 				  base_resolved->get_ref ());
   }

--- a/gcc/rust/typecheck/rust-tyty-rules.h
+++ b/gcc/rust/typecheck/rust-tyty-rules.h
@@ -60,9 +60,9 @@ public:
     other->accept_vis (*this);
     if (resolved != nullptr)
       {
-	resolved->append_reference (base->get_ref ());
+	resolved->append_reference (get_base()->get_ref ());
 	resolved->append_reference (other->get_ref ());
-	for (auto ref : base->get_combined_refs ())
+	for (auto ref : get_base()->get_combined_refs ())
 	  resolved->append_reference (ref);
 	for (auto ref : other->get_combined_refs ())
 	  resolved->append_reference (ref);
@@ -97,133 +97,149 @@ public:
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
-		   base->as_string ().c_str (), type.as_string ().c_str ());
+		   get_base ()->as_string ().c_str (),
+		   type.as_string ().c_str ());
   }
 
   virtual void visit (TupleType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
-		   base->as_string ().c_str (), type.as_string ().c_str ());
+		   get_base ()->as_string ().c_str (),
+		   type.as_string ().c_str ());
   }
 
   virtual void visit (ADTType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
-		   base->as_string ().c_str (), type.as_string ().c_str ());
+		   get_base ()->as_string ().c_str (),
+		   type.as_string ().c_str ());
   }
 
   virtual void visit (InferType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
-		   base->as_string ().c_str (), type.as_string ().c_str ());
+		   get_base ()->as_string ().c_str (),
+		   type.as_string ().c_str ());
   }
 
   virtual void visit (FnType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
-		   base->as_string ().c_str (), type.as_string ().c_str ());
+		   get_base ()->as_string ().c_str (),
+		   type.as_string ().c_str ());
   }
 
   virtual void visit (ArrayType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
-		   base->as_string ().c_str (), type.as_string ().c_str ());
+		   get_base ()->as_string ().c_str (),
+		   type.as_string ().c_str ());
   }
 
   virtual void visit (BoolType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
-		   base->as_string ().c_str (), type.as_string ().c_str ());
+		   get_base ()->as_string ().c_str (),
+		   type.as_string ().c_str ());
   }
 
   virtual void visit (IntType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
-		   base->as_string ().c_str (), type.as_string ().c_str ());
+		   get_base ()->as_string ().c_str (),
+		   type.as_string ().c_str ());
   }
 
   virtual void visit (UintType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
-		   base->as_string ().c_str (), type.as_string ().c_str ());
+		   get_base ()->as_string ().c_str (),
+		   type.as_string ().c_str ());
   }
 
   virtual void visit (USizeType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
-		   base->as_string ().c_str (), type.as_string ().c_str ());
+		   get_base ()->as_string ().c_str (),
+		   type.as_string ().c_str ());
   }
 
   virtual void visit (ISizeType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
-		   base->as_string ().c_str (), type.as_string ().c_str ());
+		   get_base ()->as_string ().c_str (),
+		   type.as_string ().c_str ());
   }
 
   virtual void visit (FloatType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
-		   base->as_string ().c_str (), type.as_string ().c_str ());
+		   get_base ()->as_string ().c_str (),
+		   type.as_string ().c_str ());
   }
 
   virtual void visit (ErrorType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
-		   base->as_string ().c_str (), type.as_string ().c_str ());
+		   get_base ()->as_string ().c_str (),
+		   type.as_string ().c_str ());
   }
 
   virtual void visit (StructFieldType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
-		   base->as_string ().c_str (), type.as_string ().c_str ());
+		   get_base ()->as_string ().c_str (),
+		   type.as_string ().c_str ());
   }
 
   virtual void visit (CharType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
-		   base->as_string ().c_str (), type.as_string ().c_str ());
+		   get_base ()->as_string ().c_str (),
+		   type.as_string ().c_str ());
   }
 
   virtual void visit (ReferenceType &type) override
-
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
     rust_error_at (ref_locus, "expected [%s] got [%s]",
-		   base->as_string ().c_str (), type.as_string ().c_str ());
+		   get_base ()->as_string ().c_str (),
+		   type.as_string ().c_str ());
   }
 
 protected:
   BaseRules (BaseType *base)
     : mappings (Analysis::Mappings::get ()),
-      context (Resolver::TypeCheckContext::get ()), base (base),
+      context (Resolver::TypeCheckContext::get ()),
       resolved (new ErrorType (base->get_ref (), base->get_ref ()))
   {}
 
   Analysis::Mappings *mappings;
   Resolver::TypeCheckContext *context;
 
-  /* Pointer to the Ty that created this rule. */
-  BaseType *base;
-
   /* Temporary storage for the result of a unification.
      We could return the result directly instead of storing it in the rule
      object, but that involves modifying the visitor pattern to accommodate
      the return value, which is too complex. */
   BaseType *resolved;
+
+private:
+  /* Returns a pointer to the ty that created this rule. */
+  virtual BaseType *get_base () = 0;
 };
 
 class InferRules : public BaseRules
@@ -440,6 +456,8 @@ public:
   }
 
 private:
+  BaseType *get_base () override { return base; }
+
   InferType *base;
 };
 
@@ -460,6 +478,8 @@ public:
   }
 
 private:
+  BaseType *get_base () override { return base; }
+
   StructFieldType *base;
 };
 
@@ -474,6 +494,8 @@ public:
   }
 
 private:
+  BaseType *get_base () override { return base; }
+
   UnitType *base;
 };
 
@@ -529,6 +551,8 @@ public:
   }
 
 private:
+  BaseType *get_base () override { return base; }
+
   FnType *base;
 };
 
@@ -561,6 +585,8 @@ public:
   }
 
 private:
+  BaseType *get_base () override { return base; }
+
   ArrayType *base;
 };
 
@@ -575,6 +601,8 @@ public:
   }
 
 private:
+  BaseType *get_base () override { return base; }
+
   BoolType *base;
 };
 
@@ -609,6 +637,8 @@ public:
   }
 
 private:
+  BaseType *get_base () override { return base; }
+
   IntType *base;
 };
 
@@ -643,6 +673,8 @@ public:
   }
 
 private:
+  BaseType *get_base () override { return base; }
+
   UintType *base;
 };
 
@@ -676,6 +708,8 @@ public:
   }
 
 private:
+  BaseType *get_base () override { return base; }
+
   FloatType *base;
 };
 
@@ -713,6 +747,8 @@ public:
   }
 
 private:
+  BaseType *get_base () override { return base; }
+
   ADTType *base;
 };
 
@@ -750,6 +786,8 @@ public:
   }
 
 private:
+  BaseType *get_base () override { return base; }
+
   TupleType *base;
 };
 
@@ -774,6 +812,8 @@ public:
   void visit (USizeType &type) override { resolved = type.clone (); }
 
 private:
+  BaseType *get_base () override { return base; }
+
   USizeType *base;
 };
 
@@ -798,6 +838,8 @@ public:
   void visit (ISizeType &type) override { resolved = type.clone (); }
 
 private:
+  BaseType *get_base () override { return base; }
+
   ISizeType *base;
 };
 
@@ -821,6 +863,8 @@ public:
   void visit (CharType &type) override { resolved = type.clone (); }
 
 private:
+  BaseType *get_base () override { return base; }
+
   CharType *base;
 };
 
@@ -840,6 +884,8 @@ public:
   }
 
 private:
+  BaseType *get_base () override { return base; }
+
   ReferenceType *base;
 };
 

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -193,7 +193,7 @@ ADTType::is_equal (const BaseType &other) const
 	{
 	  return false;
 	}
-      for (int i = 0; i < num_fields (); i++)
+      for (size_t i = 0; i < num_fields (); i++)
 	{
 	  if (!get_field (i)->is_equal (*other2.get_field (i)))
 	    {
@@ -264,7 +264,7 @@ TupleType::is_equal (const BaseType &other) const
 	{
 	  return false;
 	}
-      for (int i = 0; i < num_fields (); i++)
+      for (size_t i = 0; i < num_fields (); i++)
 	{
 	  if (!get_field (i)->is_equal (*other2.get_field (i)))
 	    {
@@ -325,7 +325,7 @@ FnType::is_equal (const BaseType &other) const
 	return false;
       if (num_params () != other2.num_params ())
 	return false;
-      for (int i = 0; i < num_params (); i++)
+      for (size_t i = 0; i < num_params (); i++)
 	{
 	  auto lhs = param_at (i).second;
 	  auto rhs = other2.param_at (i).second;

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -37,14 +37,14 @@ UnitType::as_string () const
   return "()";
 }
 
-TyBase *
-UnitType::combine (TyBase *other)
+BaseType *
+UnitType::combine (BaseType *other)
 {
   UnitRules r (this);
   return r.combine (other);
 }
 
-TyBase *
+BaseType *
 UnitType::clone ()
 {
   return new UnitType (get_ref (), get_ty_ref (), get_combined_refs ());
@@ -71,14 +71,14 @@ InferType::as_string () const
   return "<infer::error>";
 }
 
-TyBase *
-InferType::combine (TyBase *other)
+BaseType *
+InferType::combine (BaseType *other)
 {
   InferRules r (this);
   return r.combine (other);
 }
 
-TyBase *
+BaseType *
 InferType::clone ()
 {
   return new InferType (get_ref (), get_ty_ref (), get_infer_kind (),
@@ -97,15 +97,15 @@ ErrorType::as_string () const
   return "<tyty::error>";
 }
 
-TyBase *
-ErrorType::combine (TyBase *other)
+BaseType *
+ErrorType::combine (BaseType *other)
 {
   // FIXME
   // rust_error_at ();
   return this;
 }
 
-TyBase *
+BaseType *
 ErrorType::clone ()
 {
   return new ErrorType (get_ref (), get_ty_ref (), get_combined_refs ());
@@ -123,14 +123,14 @@ StructFieldType::as_string () const
   return name + ":" + ty->as_string ();
 }
 
-TyBase *
-StructFieldType::combine (TyBase *other)
+BaseType *
+StructFieldType::combine (BaseType *other)
 {
   StructFieldTypeRules r (this);
   return r.combine (other);
 }
 
-TyBase *
+BaseType *
 StructFieldType::clone ()
 {
   return new StructFieldType (get_ref (), get_ty_ref (), get_name (),
@@ -158,14 +158,14 @@ ADTType::as_string () const
   return identifier;
 }
 
-TyBase *
-ADTType::combine (TyBase *other)
+BaseType *
+ADTType::combine (BaseType *other)
 {
   ADTRules r (this);
   return r.combine (other);
 }
 
-TyBase *
+BaseType *
 ADTType::clone ()
 {
   std::vector<StructFieldType *> cloned_fields;
@@ -186,7 +186,7 @@ std::string
 TupleType::as_string () const
 {
   std::string fields_buffer;
-  iterate_fields ([&] (TyBase *field) mutable -> bool {
+  iterate_fields ([&] (BaseType *field) mutable -> bool {
     fields_buffer += field->as_string ();
     fields_buffer += ", ";
     return true;
@@ -194,24 +194,24 @@ TupleType::as_string () const
   return "(" + fields_buffer + ")";
 }
 
-TyBase *
+BaseType *
 TupleType::get_field (size_t index) const
 {
   auto context = Resolver::TypeCheckContext::get ();
-  TyBase *lookup = nullptr;
+  BaseType *lookup = nullptr;
   bool ok = context->lookup_type (fields.at (index), &lookup);
   rust_assert (ok);
   return lookup;
 }
 
-TyBase *
-TupleType::combine (TyBase *other)
+BaseType *
+TupleType::combine (BaseType *other)
 {
   TupleRules r (this);
   return r.combine (other);
 }
 
-TyBase *
+BaseType *
 TupleType::clone ()
 {
   return new TupleType (get_ref (), get_ty_ref (), fields,
@@ -240,20 +240,20 @@ FnType::as_string () const
   return "fn (" + params_str + ") -> " + ret_str;
 }
 
-TyBase *
-FnType::combine (TyBase *other)
+BaseType *
+FnType::combine (BaseType *other)
 {
   FnRules r (this);
   return r.combine (other);
 }
 
-TyBase *
+BaseType *
 FnType::clone ()
 {
-  std::vector<std::pair<HIR::Pattern *, TyBase *> > cloned_params;
+  std::vector<std::pair<HIR::Pattern *, BaseType *> > cloned_params;
   for (auto &p : params)
     cloned_params.push_back (
-      std::pair<HIR::Pattern *, TyBase *> (p.first, p.second->clone ()));
+      std::pair<HIR::Pattern *, BaseType *> (p.first, p.second->clone ()));
 
   return new FnType (get_ref (), get_ty_ref (), cloned_params,
 		     get_return_type ()->clone (), get_combined_refs ());
@@ -272,24 +272,24 @@ ArrayType::as_string () const
 	 + "]";
 }
 
-TyBase *
-ArrayType::combine (TyBase *other)
+BaseType *
+ArrayType::combine (BaseType *other)
 {
   ArrayRules r (this);
   return r.combine (other);
 }
 
-TyBase *
+BaseType *
 ArrayType::get_type () const
 {
   auto context = Resolver::TypeCheckContext::get ();
-  TyBase *lookup = nullptr;
+  BaseType *lookup = nullptr;
   bool ok = context->lookup_type (element_type_id, &lookup);
   rust_assert (ok);
   return lookup;
 }
 
-TyBase *
+BaseType *
 ArrayType::clone ()
 {
   return new ArrayType (get_ref (), get_ty_ref (), get_capacity (),
@@ -308,14 +308,14 @@ BoolType::as_string () const
   return "bool";
 }
 
-TyBase *
-BoolType::combine (TyBase *other)
+BaseType *
+BoolType::combine (BaseType *other)
 {
   BoolRules r (this);
   return r.combine (other);
 }
 
-TyBase *
+BaseType *
 BoolType::clone ()
 {
   return new BoolType (get_ref (), get_ty_ref (), get_combined_refs ());
@@ -347,14 +347,14 @@ IntType::as_string () const
   return "__unknown_int_type";
 }
 
-TyBase *
-IntType::combine (TyBase *other)
+BaseType *
+IntType::combine (BaseType *other)
 {
   IntRules r (this);
   return r.combine (other);
 }
 
-TyBase *
+BaseType *
 IntType::clone ()
 {
   return new IntType (get_ref (), get_ty_ref (), get_kind (),
@@ -387,14 +387,14 @@ UintType::as_string () const
   return "__unknown_uint_type";
 }
 
-TyBase *
-UintType::combine (TyBase *other)
+BaseType *
+UintType::combine (BaseType *other)
 {
   UintRules r (this);
   return r.combine (other);
 }
 
-TyBase *
+BaseType *
 UintType::clone ()
 {
   return new UintType (get_ref (), get_ty_ref (), get_kind (),
@@ -421,14 +421,14 @@ FloatType::as_string () const
   return "__unknown_float_type";
 }
 
-TyBase *
-FloatType::combine (TyBase *other)
+BaseType *
+FloatType::combine (BaseType *other)
 {
   FloatRules r (this);
   return r.combine (other);
 }
 
-TyBase *
+BaseType *
 FloatType::clone ()
 {
   return new FloatType (get_ref (), get_ty_ref (), get_kind (),
@@ -447,14 +447,14 @@ USizeType::as_string () const
   return "usize";
 }
 
-TyBase *
-USizeType::combine (TyBase *other)
+BaseType *
+USizeType::combine (BaseType *other)
 {
   USizeRules r (this);
   return r.combine (other);
 }
 
-TyBase *
+BaseType *
 USizeType::clone ()
 {
   return new USizeType (get_ref (), get_ty_ref (), get_combined_refs ());
@@ -472,14 +472,14 @@ ISizeType::as_string () const
   return "isize";
 }
 
-TyBase *
-ISizeType::combine (TyBase *other)
+BaseType *
+ISizeType::combine (BaseType *other)
 {
   ISizeRules r (this);
   return r.combine (other);
 }
 
-TyBase *
+BaseType *
 ISizeType::clone ()
 {
   return new ISizeType (get_ref (), get_ty_ref (), get_combined_refs ());
@@ -497,14 +497,14 @@ CharType::as_string () const
   return "char";
 }
 
-TyBase *
-CharType::combine (TyBase *other)
+BaseType *
+CharType::combine (BaseType *other)
 {
   CharRules r (this);
   return r.combine (other);
 }
 
-TyBase *
+BaseType *
 CharType::clone ()
 {
   return new CharType (get_ref (), get_ty_ref (), get_combined_refs ());
@@ -522,34 +522,34 @@ ReferenceType::as_string () const
   return "&" + get_base ()->as_string ();
 }
 
-TyBase *
-ReferenceType::combine (TyBase *other)
+BaseType *
+ReferenceType::combine (BaseType *other)
 {
   ReferenceRules r (this);
   return r.combine (other);
 }
 
-const TyBase *
+const BaseType *
 ReferenceType::get_base () const
 {
   auto context = Resolver::TypeCheckContext::get ();
-  TyBase *lookup = nullptr;
+  BaseType *lookup = nullptr;
   bool ok = context->lookup_type (base, &lookup);
   rust_assert (ok);
   return lookup;
 }
 
-TyBase *
+BaseType *
 ReferenceType::get_base ()
 {
   auto context = Resolver::TypeCheckContext::get ();
-  TyBase *lookup = nullptr;
+  BaseType *lookup = nullptr;
   bool ok = context->lookup_type (base, &lookup);
   rust_assert (ok);
   return lookup;
 }
 
-TyBase *
+BaseType *
 ReferenceType::clone ()
 {
   return new ReferenceType (get_ref (), get_ty_ref (), base,
@@ -572,9 +572,9 @@ TypeCheckCallExpr::visit (ADTType &type)
   size_t i = 0;
   call.iterate_params ([&] (HIR::Expr *p) mutable -> bool {
     StructFieldType *field = type.get_field (i);
-    TyBase *field_tyty = field->get_field_type ();
+    BaseType *field_tyty = field->get_field_type ();
 
-    TyBase *arg = Resolver::TypeCheckExpr::Resolve (p, false);
+    BaseType *arg = Resolver::TypeCheckExpr::Resolve (p, false);
     if (arg == nullptr)
       {
 	rust_error_at (p->get_locus_slow (), "failed to resolve argument type");

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -130,6 +130,20 @@ StructFieldType::unify (BaseType *other)
   return r.unify (other);
 }
 
+bool
+StructFieldType::equals (const BaseType &other) const
+{
+  if (get_kind () != other.get_kind ())
+    {
+      return false;
+    }
+  else
+    {
+      auto other2 = static_cast<const StructFieldType &> (other);
+      return get_field_type () == other2.get_field_type ();
+    }
+}
+
 BaseType *
 StructFieldType::clone ()
 {
@@ -163,6 +177,31 @@ ADTType::unify (BaseType *other)
 {
   ADTRules r (this);
   return r.unify (other);
+}
+
+bool
+ADTType::equals (const BaseType &other) const
+{
+  if (get_kind () != other.get_kind ())
+    {
+      return false;
+    }
+  else
+    {
+      auto other2 = static_cast<const ADTType &> (other);
+      if (num_fields () != other2.num_fields ())
+	{
+	  return false;
+	}
+      for (int i = 0; i < num_fields (); i++)
+	{
+	  if (!get_field (i)->equals (*other2.get_field (i)))
+	    {
+	      return false;
+	    }
+	}
+      return true;
+    }
 }
 
 BaseType *
@@ -211,6 +250,31 @@ TupleType::unify (BaseType *other)
   return r.unify (other);
 }
 
+bool
+TupleType::equals (const BaseType &other) const
+{
+  if (get_kind () != other.get_kind ())
+    {
+      return false;
+    }
+  else
+    {
+      auto other2 = static_cast<const TupleType &> (other);
+      if (num_fields () != other2.num_fields ())
+	{
+	  return false;
+	}
+      for (int i = 0; i < num_fields (); i++)
+	{
+	  if (!get_field (i)->equals (*other2.get_field (i)))
+	    {
+	      return false;
+	    }
+	}
+      return true;
+    }
+}
+
 BaseType *
 TupleType::clone ()
 {
@@ -247,6 +311,31 @@ FnType::unify (BaseType *other)
   return r.unify (other);
 }
 
+bool
+FnType::equals (const BaseType &other) const
+{
+  if (get_kind () != other.get_kind ())
+    {
+      return false;
+    }
+  else
+    {
+      auto other2 = static_cast<const FnType &> (other);
+      if (!get_return_type ()->equals (*other2.get_return_type ()))
+	return false;
+      if (num_params () != other2.num_params ())
+	return false;
+      for (int i = 0; i < num_params (); i++)
+	{
+	  auto lhs = param_at (i).second;
+	  auto rhs = other2.param_at (i).second;
+	  if (!lhs->equals (*rhs))
+	    return false;
+	}
+      return true;
+    }
+}
+
 BaseType *
 FnType::clone ()
 {
@@ -277,6 +366,21 @@ ArrayType::unify (BaseType *other)
 {
   ArrayRules r (this);
   return r.unify (other);
+}
+
+bool
+ArrayType::equals (const BaseType &other) const
+{
+  if (get_kind () != other.get_kind ())
+    {
+      return false;
+    }
+  else
+    {
+      auto other2 = static_cast<const ArrayType &> (other);
+      return get_type () == other2.get_type ()
+	     && get_capacity () == other2.get_capacity ();
+    }
 }
 
 BaseType *
@@ -527,6 +631,20 @@ ReferenceType::unify (BaseType *other)
 {
   ReferenceRules r (this);
   return r.unify (other);
+}
+
+bool
+ReferenceType::equals (const BaseType &other) const
+{
+  if (get_kind () != other.get_kind ())
+    {
+      return false;
+    }
+  else
+    {
+      auto other2 = static_cast<const ReferenceType &> (other);
+      return get_base () == other2.get_base ();
+    }
 }
 
 const BaseType *

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -131,7 +131,7 @@ StructFieldType::unify (BaseType *other)
 }
 
 bool
-StructFieldType::equals (const BaseType &other) const
+StructFieldType::is_equal (const BaseType &other) const
 {
   if (get_kind () != other.get_kind ())
     {
@@ -180,7 +180,7 @@ ADTType::unify (BaseType *other)
 }
 
 bool
-ADTType::equals (const BaseType &other) const
+ADTType::is_equal (const BaseType &other) const
 {
   if (get_kind () != other.get_kind ())
     {
@@ -195,7 +195,7 @@ ADTType::equals (const BaseType &other) const
 	}
       for (int i = 0; i < num_fields (); i++)
 	{
-	  if (!get_field (i)->equals (*other2.get_field (i)))
+	  if (!get_field (i)->is_equal (*other2.get_field (i)))
 	    {
 	      return false;
 	    }
@@ -251,7 +251,7 @@ TupleType::unify (BaseType *other)
 }
 
 bool
-TupleType::equals (const BaseType &other) const
+TupleType::is_equal (const BaseType &other) const
 {
   if (get_kind () != other.get_kind ())
     {
@@ -266,7 +266,7 @@ TupleType::equals (const BaseType &other) const
 	}
       for (int i = 0; i < num_fields (); i++)
 	{
-	  if (!get_field (i)->equals (*other2.get_field (i)))
+	  if (!get_field (i)->is_equal (*other2.get_field (i)))
 	    {
 	      return false;
 	    }
@@ -312,7 +312,7 @@ FnType::unify (BaseType *other)
 }
 
 bool
-FnType::equals (const BaseType &other) const
+FnType::is_equal (const BaseType &other) const
 {
   if (get_kind () != other.get_kind ())
     {
@@ -321,7 +321,7 @@ FnType::equals (const BaseType &other) const
   else
     {
       auto other2 = static_cast<const FnType &> (other);
-      if (!get_return_type ()->equals (*other2.get_return_type ()))
+      if (!get_return_type ()->is_equal (*other2.get_return_type ()))
 	return false;
       if (num_params () != other2.num_params ())
 	return false;
@@ -329,7 +329,7 @@ FnType::equals (const BaseType &other) const
 	{
 	  auto lhs = param_at (i).second;
 	  auto rhs = other2.param_at (i).second;
-	  if (!lhs->equals (*rhs))
+	  if (!lhs->is_equal (*rhs))
 	    return false;
 	}
       return true;
@@ -369,7 +369,7 @@ ArrayType::unify (BaseType *other)
 }
 
 bool
-ArrayType::equals (const BaseType &other) const
+ArrayType::is_equal (const BaseType &other) const
 {
   if (get_kind () != other.get_kind ())
     {
@@ -634,7 +634,7 @@ ReferenceType::unify (BaseType *other)
 }
 
 bool
-ReferenceType::equals (const BaseType &other) const
+ReferenceType::is_equal (const BaseType &other) const
 {
   if (get_kind () != other.get_kind ())
     {

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -38,10 +38,10 @@ UnitType::as_string () const
 }
 
 BaseType *
-UnitType::combine (BaseType *other)
+UnitType::unify (BaseType *other)
 {
   UnitRules r (this);
-  return r.combine (other);
+  return r.unify (other);
 }
 
 BaseType *
@@ -72,10 +72,10 @@ InferType::as_string () const
 }
 
 BaseType *
-InferType::combine (BaseType *other)
+InferType::unify (BaseType *other)
 {
   InferRules r (this);
-  return r.combine (other);
+  return r.unify (other);
 }
 
 BaseType *
@@ -98,7 +98,7 @@ ErrorType::as_string () const
 }
 
 BaseType *
-ErrorType::combine (BaseType *other)
+ErrorType::unify (BaseType *other)
 {
   // FIXME
   // rust_error_at ();
@@ -124,10 +124,10 @@ StructFieldType::as_string () const
 }
 
 BaseType *
-StructFieldType::combine (BaseType *other)
+StructFieldType::unify (BaseType *other)
 {
   StructFieldTypeRules r (this);
-  return r.combine (other);
+  return r.unify (other);
 }
 
 BaseType *
@@ -159,10 +159,10 @@ ADTType::as_string () const
 }
 
 BaseType *
-ADTType::combine (BaseType *other)
+ADTType::unify (BaseType *other)
 {
   ADTRules r (this);
-  return r.combine (other);
+  return r.unify (other);
 }
 
 BaseType *
@@ -205,10 +205,10 @@ TupleType::get_field (size_t index) const
 }
 
 BaseType *
-TupleType::combine (BaseType *other)
+TupleType::unify (BaseType *other)
 {
   TupleRules r (this);
-  return r.combine (other);
+  return r.unify (other);
 }
 
 BaseType *
@@ -241,10 +241,10 @@ FnType::as_string () const
 }
 
 BaseType *
-FnType::combine (BaseType *other)
+FnType::unify (BaseType *other)
 {
   FnRules r (this);
-  return r.combine (other);
+  return r.unify (other);
 }
 
 BaseType *
@@ -273,10 +273,10 @@ ArrayType::as_string () const
 }
 
 BaseType *
-ArrayType::combine (BaseType *other)
+ArrayType::unify (BaseType *other)
 {
   ArrayRules r (this);
-  return r.combine (other);
+  return r.unify (other);
 }
 
 BaseType *
@@ -309,10 +309,10 @@ BoolType::as_string () const
 }
 
 BaseType *
-BoolType::combine (BaseType *other)
+BoolType::unify (BaseType *other)
 {
   BoolRules r (this);
-  return r.combine (other);
+  return r.unify (other);
 }
 
 BaseType *
@@ -348,10 +348,10 @@ IntType::as_string () const
 }
 
 BaseType *
-IntType::combine (BaseType *other)
+IntType::unify (BaseType *other)
 {
   IntRules r (this);
-  return r.combine (other);
+  return r.unify (other);
 }
 
 BaseType *
@@ -388,10 +388,10 @@ UintType::as_string () const
 }
 
 BaseType *
-UintType::combine (BaseType *other)
+UintType::unify (BaseType *other)
 {
   UintRules r (this);
-  return r.combine (other);
+  return r.unify (other);
 }
 
 BaseType *
@@ -422,10 +422,10 @@ FloatType::as_string () const
 }
 
 BaseType *
-FloatType::combine (BaseType *other)
+FloatType::unify (BaseType *other)
 {
   FloatRules r (this);
-  return r.combine (other);
+  return r.unify (other);
 }
 
 BaseType *
@@ -448,10 +448,10 @@ USizeType::as_string () const
 }
 
 BaseType *
-USizeType::combine (BaseType *other)
+USizeType::unify (BaseType *other)
 {
   USizeRules r (this);
-  return r.combine (other);
+  return r.unify (other);
 }
 
 BaseType *
@@ -473,10 +473,10 @@ ISizeType::as_string () const
 }
 
 BaseType *
-ISizeType::combine (BaseType *other)
+ISizeType::unify (BaseType *other)
 {
   ISizeRules r (this);
-  return r.combine (other);
+  return r.unify (other);
 }
 
 BaseType *
@@ -498,10 +498,10 @@ CharType::as_string () const
 }
 
 BaseType *
-CharType::combine (BaseType *other)
+CharType::unify (BaseType *other)
 {
   CharRules r (this);
-  return r.combine (other);
+  return r.unify (other);
 }
 
 BaseType *
@@ -523,10 +523,10 @@ ReferenceType::as_string () const
 }
 
 BaseType *
-ReferenceType::combine (BaseType *other)
+ReferenceType::unify (BaseType *other)
 {
   ReferenceRules r (this);
-  return r.combine (other);
+  return r.unify (other);
 }
 
 const BaseType *
@@ -581,7 +581,7 @@ TypeCheckCallExpr::visit (ADTType &type)
 	return false;
       }
 
-    auto res = field_tyty->combine (arg);
+    auto res = field_tyty->unify (arg);
     if (res == nullptr)
       return false;
 
@@ -623,7 +623,7 @@ TypeCheckCallExpr::visit (FnType &type)
 	return false;
       }
 
-    auto resolved_argument_type = fnparam.second->combine (argument_expr_tyty);
+    auto resolved_argument_type = fnparam.second->unify (argument_expr_tyty);
     if (resolved_argument_type == nullptr)
       {
 	rust_error_at (param->get_locus_slow (),
@@ -674,7 +674,7 @@ TypeCheckMethodCallExpr::visit (FnType &type)
 	return false;
       }
 
-    auto resolved_argument_type = fnparam.second->combine (argument_expr_tyty);
+    auto resolved_argument_type = fnparam.second->unify (argument_expr_tyty);
     if (resolved_argument_type == nullptr)
       {
 	rust_error_at (param->get_locus_slow (),

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -73,6 +73,15 @@ public:
      releasing the memory of the returned ty. */
   virtual BaseType *unify (BaseType *other) = 0;
 
+  /* Check value equality between two ty. Type inference rules are ignored. Two
+     ty are considered equal if they're of the same kind, and
+       1. (For ADTs, arrays, tuples, refs) have the same underlying ty
+       2. (For functions) have the same signature */
+  virtual bool equals (const BaseType &other) const
+  {
+    return get_kind () == other.get_kind ();
+  }
+
   virtual bool is_unit () const { return kind == TypeKind::UNIT; }
 
   TypeKind get_kind () const { return kind; }
@@ -199,9 +208,11 @@ public:
 
   BaseType *unify (BaseType *other) override;
 
+  virtual bool equals (const BaseType &other) const override;
+
   std::string get_name () const { return name; }
 
-  BaseType *get_field_type () { return ty; }
+  BaseType *get_field_type () const { return ty; }
 
   BaseType *clone () final override;
 
@@ -230,6 +241,8 @@ public:
   std::string as_string () const override;
 
   BaseType *unify (BaseType *other) override;
+
+  virtual bool equals (const BaseType &other) const override;
 
   size_t num_fields () const { return fields.size (); }
 
@@ -275,14 +288,16 @@ public:
 
   BaseType *unify (BaseType *other) override;
 
+  virtual bool equals (const BaseType &other) const override;
+
   size_t num_fields () const { return fields.size (); }
 
   std::string get_name () const { return identifier; }
 
-  StructFieldType *get_field (size_t index) { return fields.at (index); }
+  StructFieldType *get_field (size_t index) const { return fields.at (index); }
 
   StructFieldType *get_field (const std::string &lookup,
-			      size_t *index = nullptr)
+			      size_t *index = nullptr) const
   {
     size_t i = 0;
     for (auto &field : fields)
@@ -341,6 +356,8 @@ public:
 
   BaseType *unify (BaseType *other) override;
 
+  virtual bool equals (const BaseType &other) const override;
+
   size_t num_params () const { return params.size (); }
 
   std::vector<std::pair<HIR::Pattern *, BaseType *> > &get_params ()
@@ -348,12 +365,22 @@ public:
     return params;
   }
 
-  std::pair<HIR::Pattern *, BaseType *> &param_at (size_t idx)
+  const std::vector<std::pair<HIR::Pattern *, BaseType *> > &get_params () const
   {
-    return params[idx];
+    return params;
   }
 
-  BaseType *get_return_type () { return type; }
+  std::pair<HIR::Pattern *, BaseType *> &param_at (size_t idx)
+  {
+    return params.at (idx);
+  }
+
+  const std::pair<HIR::Pattern *, BaseType *> &param_at (size_t idx) const
+  {
+    return params.at (idx);
+  }
+
+  BaseType *get_return_type () const { return type; }
 
   BaseType *clone () final override;
 
@@ -382,6 +409,8 @@ public:
   std::string as_string () const override;
 
   BaseType *unify (BaseType *other) override;
+
+  virtual bool equals (const BaseType &other) const override;
 
   size_t get_capacity () const { return capacity; }
 
@@ -602,6 +631,8 @@ public:
   std::string as_string () const override;
 
   BaseType *unify (BaseType *other) override;
+
+  virtual bool equals (const BaseType &other) const override;
 
   BaseType *clone () final override;
 

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -63,16 +63,22 @@ public:
 
   void set_ty_ref (HirId id) { ty_ref = id; }
 
+  /* Visitor pattern for double dispatch. BaseRules implements TyVisitor. */
   virtual void accept_vis (TyVisitor &vis) = 0;
 
   virtual std::string as_string () const = 0;
 
+  /* Unify two types. Returns a pointer to the newly-created unified ty, or
+     nullptr if the two ty cannot be unified. The caller is responsible for
+     releasing the memory of the returned ty. */
   virtual BaseType *unify (BaseType *other) = 0;
 
   virtual bool is_unit () const { return kind == TypeKind::UNIT; }
 
   TypeKind get_kind () const { return kind; }
 
+  /* Returns a pointer to a clone of this. The caller is responsible for
+   * releasing the memory of the returned ty. */
   virtual BaseType *clone () = 0;
 
   std::set<HirId> get_combined_refs () { return combined; }
@@ -81,7 +87,7 @@ public:
 
 protected:
   BaseType (HirId ref, HirId ty_ref, TypeKind kind,
-	  std::set<HirId> refs = std::set<HirId> ())
+	    std::set<HirId> refs = std::set<HirId> ())
     : kind (kind), ref (ref), ty_ref (ty_ref), combined (refs)
   {}
 
@@ -323,7 +329,8 @@ public:
   FnType (HirId ref, HirId ty_ref,
 	  std::vector<std::pair<HIR::Pattern *, BaseType *> > params,
 	  BaseType *type, std::set<HirId> refs = std::set<HirId> ())
-    : BaseType (ref, ty_ref, TypeKind::FNDEF, refs), params (params), type (type)
+    : BaseType (ref, ty_ref, TypeKind::FNDEF, refs), params (params),
+      type (type)
   {}
 
   void accept_vis (TyVisitor &vis) override;

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -67,7 +67,7 @@ public:
 
   virtual std::string as_string () const = 0;
 
-  virtual BaseType *combine (BaseType *other) = 0;
+  virtual BaseType *unify (BaseType *other) = 0;
 
   virtual bool is_unit () const { return kind == TypeKind::UNIT; }
 
@@ -118,7 +118,7 @@ public:
 
   std::string as_string () const override;
 
-  BaseType *combine (BaseType *other) override;
+  BaseType *unify (BaseType *other) override;
 
   BaseType *clone () final override;
 
@@ -145,7 +145,7 @@ public:
 
   std::string as_string () const override;
 
-  BaseType *combine (BaseType *other) override;
+  BaseType *unify (BaseType *other) override;
 
   BaseType *clone () final override;
 };
@@ -167,7 +167,7 @@ public:
 
   std::string as_string () const override;
 
-  BaseType *combine (BaseType *other) override;
+  BaseType *unify (BaseType *other) override;
 
   BaseType *clone () final override;
 };
@@ -191,7 +191,7 @@ public:
 
   std::string as_string () const override;
 
-  BaseType *combine (BaseType *other) override;
+  BaseType *unify (BaseType *other) override;
 
   std::string get_name () const { return name; }
 
@@ -223,7 +223,7 @@ public:
 
   std::string as_string () const override;
 
-  BaseType *combine (BaseType *other) override;
+  BaseType *unify (BaseType *other) override;
 
   size_t num_fields () const { return fields.size (); }
 
@@ -267,7 +267,7 @@ public:
 
   std::string as_string () const override;
 
-  BaseType *combine (BaseType *other) override;
+  BaseType *unify (BaseType *other) override;
 
   size_t num_fields () const { return fields.size (); }
 
@@ -332,7 +332,7 @@ public:
 
   BaseType *return_type () { return type; }
 
-  BaseType *combine (BaseType *other) override;
+  BaseType *unify (BaseType *other) override;
 
   size_t num_params () const { return params.size (); }
 
@@ -374,7 +374,7 @@ public:
 
   std::string as_string () const override;
 
-  BaseType *combine (BaseType *other) override;
+  BaseType *unify (BaseType *other) override;
 
   size_t get_capacity () const { return capacity; }
 
@@ -404,7 +404,7 @@ public:
 
   std::string as_string () const override;
 
-  BaseType *combine (BaseType *other) override;
+  BaseType *unify (BaseType *other) override;
 
   BaseType *clone () final override;
 };
@@ -434,7 +434,7 @@ public:
 
   std::string as_string () const override;
 
-  BaseType *combine (BaseType *other) override;
+  BaseType *unify (BaseType *other) override;
 
   IntKind get_kind () const { return int_kind; }
 
@@ -469,7 +469,7 @@ public:
 
   std::string as_string () const override;
 
-  BaseType *combine (BaseType *other) override;
+  BaseType *unify (BaseType *other) override;
 
   UintKind get_kind () const { return uint_kind; }
 
@@ -502,7 +502,7 @@ public:
 
   std::string as_string () const override;
 
-  BaseType *combine (BaseType *other) override;
+  BaseType *unify (BaseType *other) override;
 
   FloatKind get_kind () const { return float_kind; }
 
@@ -527,7 +527,7 @@ public:
 
   std::string as_string () const override;
 
-  BaseType *combine (BaseType *other) override;
+  BaseType *unify (BaseType *other) override;
 
   BaseType *clone () final override;
 };
@@ -547,7 +547,7 @@ public:
 
   std::string as_string () const override;
 
-  BaseType *combine (BaseType *other) override;
+  BaseType *unify (BaseType *other) override;
 
   BaseType *clone () final override;
 };
@@ -568,7 +568,7 @@ public:
 
   std::string as_string () const override;
 
-  BaseType *combine (BaseType *other) override;
+  BaseType *unify (BaseType *other) override;
 
   BaseType *clone () final override;
 };
@@ -594,7 +594,7 @@ public:
 
   std::string as_string () const override;
 
-  BaseType *combine (BaseType *other) override;
+  BaseType *unify (BaseType *other) override;
 
   BaseType *clone () final override;
 

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -77,7 +77,7 @@ public:
      ty are considered equal if they're of the same kind, and
        1. (For ADTs, arrays, tuples, refs) have the same underlying ty
        2. (For functions) have the same signature */
-  virtual bool equals (const BaseType &other) const
+  virtual bool is_equal (const BaseType &other) const
   {
     return get_kind () == other.get_kind ();
   }
@@ -208,7 +208,7 @@ public:
 
   BaseType *unify (BaseType *other) override;
 
-  virtual bool equals (const BaseType &other) const override;
+  virtual bool is_equal (const BaseType &other) const override;
 
   std::string get_name () const { return name; }
 
@@ -242,7 +242,7 @@ public:
 
   BaseType *unify (BaseType *other) override;
 
-  virtual bool equals (const BaseType &other) const override;
+  virtual bool is_equal (const BaseType &other) const override;
 
   size_t num_fields () const { return fields.size (); }
 
@@ -288,7 +288,7 @@ public:
 
   BaseType *unify (BaseType *other) override;
 
-  virtual bool equals (const BaseType &other) const override;
+  virtual bool is_equal (const BaseType &other) const override;
 
   size_t num_fields () const { return fields.size (); }
 
@@ -356,7 +356,7 @@ public:
 
   BaseType *unify (BaseType *other) override;
 
-  virtual bool equals (const BaseType &other) const override;
+  virtual bool is_equal (const BaseType &other) const override;
 
   size_t num_params () const { return params.size (); }
 
@@ -410,7 +410,7 @@ public:
 
   BaseType *unify (BaseType *other) override;
 
-  virtual bool equals (const BaseType &other) const override;
+  virtual bool is_equal (const BaseType &other) const override;
 
   size_t get_capacity () const { return capacity; }
 
@@ -632,7 +632,7 @@ public:
 
   BaseType *unify (BaseType *other) override;
 
-  virtual bool equals (const BaseType &other) const override;
+  virtual bool is_equal (const BaseType &other) const override;
 
   BaseType *clone () final override;
 


### PR DESCRIPTION
Todos:
- [x] Rename `TyBase` to `BaseType`
- [x] Rename `combine` to `unify`
- [x] Add `is_equal` method to `BaseType`(Issue #187)
- [ ] Replace `unify` calls with `is_equal` calls where appropriate
- [x] ~~Extract BaseRules::combine as a standalone function~~
- [x] Remove `base` field from `BaseRules`
- [x] Documentation