### PR TITLE
Add debug interface to GCC debug_tree on GENERIC graphs

### DIFF
--- a/gcc/rust/rust-backend.h
+++ b/gcc/rust/rust-backend.h
@@ -84,6 +84,15 @@ public:
     {}
   };
 
+  // debug
+  virtual void debug (Btype *) = 0;
+  virtual void debug (Bexpression *) = 0;
+  virtual void debug (Bstatement *) = 0;
+  virtual void debug (Bfunction *) = 0;
+  virtual void debug (Bblock *) = 0;
+  virtual void debug (Bvariable *) = 0;
+  virtual void debug (Blabel *) = 0;
+
   // Types.
 
   // Produce an error type.  Actually the backend could probably just

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -158,6 +158,14 @@ class Gcc_backend : public Backend
 public:
   Gcc_backend ();
 
+  void debug (Btype *t) { debug_tree (t->get_tree ()); };
+  void debug (Bexpression *t) { debug_tree (t->get_tree ()); };
+  void debug (Bstatement *t) { debug_tree (t->get_tree ()); };
+  void debug (Bfunction *t) { debug_tree (t->get_tree ()); };
+  void debug (Bblock *t) { debug_tree (t->get_tree ()); };
+  void debug (Bvariable *t) { debug_tree (t->get_decl ()); };
+  void debug (Blabel *t) { debug_tree (t->get_tree ()); };
+
   // Types.
 
   Btype *error_type () { return this->make_type (error_mark_node); }


### PR DESCRIPTION
This adds in a debugging interface for the backend IR to help diagnose
issues with the tree.