### PR TITLE
Support Generic arguments to Structs and Tuple Structs

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -1209,9 +1209,18 @@ public:
 
   virtual void accept_vis (ASTVisitor &vis) = 0;
 
+  virtual Location get_locus_slow () const = 0;
+
+  NodeId get_node_id () { return node_id; }
+
 protected:
+  GenericParam () : node_id (Analysis::Mappings::get ()->get_next_node_id ()) {}
+  GenericParam (NodeId node_id) : node_id (node_id) {}
+
   // Clone function implementation as pure virtual method
   virtual GenericParam *clone_generic_param_impl () const = 0;
+
+  NodeId node_id;
 };
 
 // A lifetime generic parameter (as opposed to a type generic parameter)
@@ -1250,6 +1259,10 @@ public:
   std::string as_string () const override;
 
   void accept_vis (ASTVisitor &vis) override;
+
+  Location get_locus () const { return locus; }
+
+  Location get_locus_slow () const override final { return get_locus (); }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather

--- a/gcc/rust/ast/rust-path.h
+++ b/gcc/rust/ast/rust-path.h
@@ -196,6 +196,8 @@ public:
 
   // TODO: is this better? Or is a "vis_pattern" better?
   std::vector<GenericArgsBinding> &get_binding_args () { return binding_args; }
+
+  std::vector<Lifetime> &get_lifetime_args () { return lifetime_args; };
 };
 
 /* A segment of a path in expression, including an identifier aspect and maybe

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -274,7 +274,15 @@ public:
 
   void visit (TyTy::InferType &) override { gcc_unreachable (); }
 
-  void visit (TyTy::StructFieldType &) override { gcc_unreachable (); }
+  void visit (TyTy::ParamType &param) override
+  {
+    rust_assert (param.get_ref () != param.get_ty_ref ());
+
+    TyTy::BaseType *lookup = nullptr;
+    bool ok = ctx->get_tyctx ()->lookup_type (param.get_ty_ref (), &lookup);
+    rust_assert (ok);
+    lookup->accept_vis (*this);
+  }
 
   void visit (TyTy::FnType &type) override
   {
@@ -338,7 +346,7 @@ public:
     Btype *named_struct
       = ctx->get_backend ()->named_type (type.get_name (), struct_type_record,
 					 ctx->get_mappings ()->lookup_location (
-					   type.get_ty_ref ()));
+					   type.get_ref ()));
 
     ctx->push_type (named_struct);
     ctx->insert_compiled_type (type.get_ty_ref (), named_struct);

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -539,8 +539,16 @@ public:
 
   void visit (HIR::StructExprStructFields &struct_expr)
   {
-    Btype *type
-      = ResolvePathType::Compile (&struct_expr.get_struct_name (), ctx);
+    TyTy::BaseType *tyty = nullptr;
+    if (!ctx->get_tyctx ()->lookup_type (
+	  struct_expr.get_mappings ().get_hirid (), &tyty))
+      {
+	rust_error_at (struct_expr.get_locus (), "unknown type");
+	return;
+      }
+
+    Btype *type = TyTyResolveCompile::compile (ctx, tyty);
+    rust_assert (type != nullptr);
 
     // this assumes all fields are in order from type resolution and if a base
     // struct was specified those fields are filed via accesors
@@ -573,8 +581,8 @@ public:
 	return;
       }
     rust_assert (receiver->get_kind () == TyTy::TypeKind::ADT);
+    TyTy::ADTType *adt = static_cast<TyTy::ADTType *> (receiver);
 
-    TyTy::ADTType *adt = (TyTy::ADTType *) receiver;
     size_t index = 0;
     adt->get_field (expr.get_field_name (), &index);
 

--- a/gcc/rust/backend/rust-compile-implitem.h
+++ b/gcc/rust/backend/rust-compile-implitem.h
@@ -50,7 +50,7 @@ public:
     ::Btype *type = TyTyResolveCompile::compile (ctx, resolved_type);
     Bexpression *value = CompileExpr::Compile (constant.get_expr (), ctx);
 
-    std::string ident = self->as_string () + "::" + constant.get_identifier ();
+    std::string ident = self->get_name () + "::" + constant.get_identifier ();
     Bexpression *const_expr = ctx->get_backend ()->named_constant_expression (
       type, constant.get_identifier (), value, constant.get_locus ());
 
@@ -95,7 +95,7 @@ public:
 
     unsigned int flags = 0;
     std::string fn_identifier
-      = self->as_string () + "::" + function.function_name;
+      = self->get_name () + "::" + function.function_name;
 
     // if its the main fn or pub visibility mark its as DECL_PUBLIC
     // please see https://github.com/Rust-GCC/gccrs/pull/137
@@ -259,7 +259,7 @@ public:
 
     unsigned int flags = 0;
     std::string fn_identifier
-      = self->as_string () + "::" + method.get_method_name ();
+      = self->get_name () + "::" + method.get_method_name ();
 
     // if its the main fn or pub visibility mark its as DECL_PUBLIC
     // please see https://github.com/Rust-GCC/gccrs/pull/137

--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -39,34 +39,6 @@ public:
     item->accept_vis (compiler);
   }
 
-  void visit (HIR::TupleStruct &struct_decl)
-  {
-    TyTy::BaseType *resolved = nullptr;
-    if (!ctx->get_tyctx ()->lookup_type (
-	  struct_decl.get_mappings ().get_hirid (), &resolved))
-      {
-	rust_fatal_error (struct_decl.get_locus (),
-			  "Failed to lookup type for struct decl");
-	return;
-      }
-
-    TyTyResolveCompile::compile (ctx, resolved);
-  }
-
-  void visit (HIR::StructStruct &struct_decl)
-  {
-    TyTy::BaseType *resolved = nullptr;
-    if (!ctx->get_tyctx ()->lookup_type (
-	  struct_decl.get_mappings ().get_hirid (), &resolved))
-      {
-	rust_fatal_error (struct_decl.get_locus (),
-			  "Failed to lookup type for struct decl");
-	return;
-      }
-
-    TyTyResolveCompile::compile (ctx, resolved);
-  }
-
   void visit (HIR::StaticItem &var)
   {
     TyTy::BaseType *resolved_type = nullptr;

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -93,34 +93,5 @@ ResolvePathRef::visit (HIR::PathInExpression &expr)
     = ctx->get_backend ()->function_code_expression (fn, expr.get_locus ());
 }
 
-void
-ResolvePathType::visit (HIR::PathInExpression &expr)
-{
-  // need to look up the reference for this identifier
-  NodeId ref_node_id;
-  if (!ctx->get_resolver ()->lookup_resolved_type (
-	expr.get_mappings ().get_nodeid (), &ref_node_id))
-    {
-      return;
-    }
-
-  HirId ref;
-  if (!ctx->get_mappings ()->lookup_node_to_hir (
-	expr.get_mappings ().get_crate_num (), ref_node_id, &ref))
-    {
-      rust_error_at (expr.get_locus (), "reverse lookup failure");
-      return;
-    }
-
-  TyTy::BaseType *tyty = nullptr;
-  if (!ctx->get_tyctx ()->lookup_type (ref, &tyty))
-    {
-      rust_error_at (expr.get_locus (), "unknown type");
-      return;
-    }
-
-  resolved = TyTyResolveCompile::compile (ctx, tyty);
-}
-
 } // namespace Compile
 } // namespace Rust

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -84,7 +84,7 @@ ResolvePathRef::visit (HIR::PathInExpression &expr)
       CompileItem::compile (resolved_item, ctx);
       if (!ctx->lookup_function_decl (ref, &fn))
 	{
-	  rust_error_at (expr.get_locus (), "forward decl was not compiled");
+	  rust_error_at (expr.get_locus (), "forward decl was not compiled 1");
 	  return;
 	}
     }
@@ -112,12 +112,14 @@ ResolvePathType::visit (HIR::PathInExpression &expr)
       return;
     }
 
-  // assumes paths are functions for now
-  if (!ctx->lookup_compiled_types (ref, &resolved))
+  TyTy::BaseType *tyty = nullptr;
+  if (!ctx->get_tyctx ()->lookup_type (ref, &tyty))
     {
-      rust_error_at (expr.get_locus (), "forward decl was not compiled");
+      rust_error_at (expr.get_locus (), "unknown type");
       return;
     }
+
+  resolved = TyTyResolveCompile::compile (ctx, tyty);
 }
 
 } // namespace Compile

--- a/gcc/rust/backend/rust-compile-resolve-path.h
+++ b/gcc/rust/backend/rust-compile-resolve-path.h
@@ -35,30 +35,12 @@ public:
     return resolver.resolved;
   }
 
-  void visit (HIR::PathInExpression &expr);
+  void visit (HIR::PathInExpression &expr) override;
 
 private:
   ResolvePathRef (Context *ctx) : HIRCompileBase (ctx), resolved (nullptr) {}
 
   Bexpression *resolved;
-};
-
-class ResolvePathType : public HIRCompileBase
-{
-public:
-  static Btype *Compile (HIR::Expr *expr, Context *ctx)
-  {
-    ResolvePathType resolver (ctx);
-    expr->accept_vis (resolver);
-    return resolver.resolved;
-  }
-
-  void visit (HIR::PathInExpression &expr);
-
-private:
-  ResolvePathType (Context *ctx) : HIRCompileBase (ctx), resolved (nullptr) {}
-
-  Btype *resolved;
 };
 
 } // namespace Compile

--- a/gcc/rust/backend/rust-compile-tyty.h
+++ b/gcc/rust/backend/rust-compile-tyty.h
@@ -48,8 +48,6 @@ public:
 
   void visit (TyTy::InferType &) override { gcc_unreachable (); }
 
-  void visit (TyTy::StructFieldType &) override { gcc_unreachable (); }
-
   void visit (TyTy::ADTType &) override { gcc_unreachable (); }
 
   void visit (TyTy::TupleType &) override { gcc_unreachable (); }
@@ -57,6 +55,8 @@ public:
   void visit (TyTy::ArrayType &) override { gcc_unreachable (); }
 
   void visit (TyTy::ReferenceType &) override { gcc_unreachable (); }
+
+  void visit (TyTy::ParamType &) override { gcc_unreachable (); }
 
   void visit (TyTy::UnitType &) override { translated = backend->void_type (); }
 

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -74,27 +74,7 @@ public:
     return compiler.translated;
   }
 
-  void visit (AST::PathInExpression &expr)
-  {
-    std::vector<HIR::PathExprSegment> path_segments;
-    expr.iterate_path_segments ([&] (AST::PathExprSegment &s) mutable -> bool {
-      rust_assert (s.has_generic_args () == false); // TODO
-
-      HIR::PathIdentSegment is (s.get_ident_segment ().as_string ());
-      HIR::PathExprSegment seg (is, s.get_locus ());
-      path_segments.push_back (seg);
-      return true;
-    });
-
-    auto crate_num = mappings->get_current_crate ();
-    Analysis::NodeMapping mapping (crate_num, expr.get_node_id (),
-				   mappings->get_next_hir_id (crate_num),
-				   UNKNOWN_LOCAL_DEFID);
-
-    translated = new HIR::PathInExpression (mapping, std::move (path_segments),
-					    expr.get_locus (),
-					    expr.opening_scope_resolution ());
-  }
+  void visit (AST::PathInExpression &expr) override;
 
 private:
   ASTLowerPathInExpression () : translated (nullptr) {}

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -54,6 +54,12 @@ public:
   void visit (AST::TupleStruct &struct_decl)
   {
     std::vector<std::unique_ptr<HIR::GenericParam> > generic_params;
+    if (struct_decl.has_generics ())
+      {
+	generic_params
+	  = lower_generic_params (struct_decl.get_generic_params ());
+      }
+
     std::vector<std::unique_ptr<HIR::WhereClauseItem> > where_clause_items;
     HIR::WhereClause where_clause (std::move (where_clause_items));
     HIR::Visibility vis = HIR::Visibility::create_public ();
@@ -104,6 +110,12 @@ public:
   void visit (AST::StructStruct &struct_decl)
   {
     std::vector<std::unique_ptr<HIR::GenericParam> > generic_params;
+    if (struct_decl.has_generics ())
+      {
+	generic_params
+	  = lower_generic_params (struct_decl.get_generic_params ());
+      }
+
     std::vector<std::unique_ptr<HIR::WhereClauseItem> > where_clause_items;
     HIR::WhereClause where_clause (std::move (where_clause_items));
     HIR::Visibility vis = HIR::Visibility::create_public ();
@@ -324,6 +336,19 @@ public:
   }
 
 private:
+  std::vector<std::unique_ptr<HIR::GenericParam> > lower_generic_params (
+    std::vector<std::unique_ptr<AST::GenericParam> > &params)
+  {
+    std::vector<std::unique_ptr<HIR::GenericParam> > lowered;
+    for (auto &ast_param : params)
+      {
+	auto hir_param = ASTLowerGenericParam::translate (ast_param.get ());
+	lowered.push_back (std::unique_ptr<HIR::GenericParam> (hir_param));
+      }
+
+    return lowered;
+  }
+
   ASTLoweringItem () : translated (nullptr) {}
 
   HIR::Item *translated;

--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -269,5 +269,51 @@ ASTLoweringExprWithBlock::visit (AST::WhileLoopExpr &expr)
 			      std::move (outer_attribs));
 }
 
+// rust-ast-lower-expr.h
+
+void
+ASTLowerPathInExpression::visit (AST::PathInExpression &expr)
+{
+  std::vector<HIR::PathExprSegment> path_segments;
+  expr.iterate_path_segments ([&] (AST::PathExprSegment &s) mutable -> bool {
+    std::vector<HIR::GenericArgsBinding> binding_args; // TODO
+
+    std::vector<HIR::Lifetime> lifetime_args;
+    if (s.has_generic_args ())
+      {
+	for (auto &lifetime : s.get_generic_args ().get_lifetime_args ())
+	  {
+	    HIR::Lifetime l = lower_lifetime (lifetime);
+	    lifetime_args.push_back (std::move (l));
+	  }
+      }
+
+    std::vector<std::unique_ptr<HIR::Type> > type_args;
+    if (s.has_generic_args ())
+      {
+	for (auto &type : s.get_generic_args ().get_type_args ())
+	  {
+	    HIR::Type *t = ASTLoweringType::translate (type.get ());
+	    type_args.push_back (std::unique_ptr<HIR::Type> (t));
+	  }
+      }
+
+    PathExprSegment seg (s.get_ident_segment ().as_string (), s.get_locus (),
+			 std::move (lifetime_args), std::move (type_args),
+			 std::move (binding_args));
+    path_segments.push_back (seg);
+    return true;
+  });
+
+  auto crate_num = mappings->get_current_crate ();
+  Analysis::NodeMapping mapping (crate_num, expr.get_node_id (),
+				 mappings->get_next_hir_id (crate_num),
+				 UNKNOWN_LOCAL_DEFID);
+
+  translated = new HIR::PathInExpression (mapping, std::move (path_segments),
+					  expr.get_locus (),
+					  expr.opening_scope_resolution ());
+}
+
 } // namespace HIR
 } // namespace Rust

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -57,12 +57,13 @@ public:
   // Returns whether the type param has an outer attribute.
   bool has_outer_attribute () const { return !outer_attr.is_empty (); }
 
-  TypeParam (Identifier type_representation, Location locus = Location (),
+  TypeParam (Analysis::NodeMapping mappings, Identifier type_representation,
+	     Location locus = Location (),
 	     std::vector<std::unique_ptr<TypeParamBound> > type_param_bounds
 	     = std::vector<std::unique_ptr<TypeParamBound> > (),
 	     std::unique_ptr<Type> type = nullptr,
 	     Attribute outer_attr = Attribute::create_empty ())
-    : outer_attr (std::move (outer_attr)),
+    : GenericParam (mappings), outer_attr (std::move (outer_attr)),
       type_representation (std::move (type_representation)),
       type_param_bounds (std::move (type_param_bounds)),
       type (std::move (type)), locus (locus)
@@ -70,7 +71,7 @@ public:
 
   // Copy constructor uses clone
   TypeParam (TypeParam const &other)
-    : outer_attr (other.outer_attr),
+    : GenericParam (other.mappings), outer_attr (other.outer_attr),
       type_representation (other.type_representation),
       type (other.type->clone_type ()), locus (other.locus)
   {
@@ -87,6 +88,7 @@ public:
     type = other.type->clone_type ();
     outer_attr = other.outer_attr;
     locus = other.locus;
+    mappings = other.mappings;
 
     type_param_bounds.reserve (other.type_param_bounds.size ());
     for (const auto &e : other.type_param_bounds)
@@ -103,7 +105,11 @@ public:
 
   Location get_locus () const { return locus; }
 
+  Location get_locus_slow () const override final { return get_locus (); }
+
   void accept_vis (HIRVisitor &vis) override;
+
+  Identifier get_type_representation () const { return type_representation; }
 
 protected:
   // Clone function implementation as (not pure) virtual method
@@ -1501,6 +1507,11 @@ public:
   bool has_where_clause () const { return !where_clause.is_empty (); }
 
   Location get_locus () const { return locus; }
+
+  std::vector<std::unique_ptr<GenericParam> > &get_generic_params ()
+  {
+    return generic_params;
+  }
 
 protected:
   Struct (Analysis::NodeMapping mappings, Identifier struct_name,

--- a/gcc/rust/hir/tree/rust-hir-path.h
+++ b/gcc/rust/hir/tree/rust-hir-path.h
@@ -172,7 +172,21 @@ public:
 			std::vector<GenericArgsBinding> ());
   }
 
+  bool is_empty () const
+  {
+    return lifetime_args.size () == 0 && type_args.size () == 0
+	   && binding_args.size () == 0;
+  }
+
   std::string as_string () const;
+
+  std::vector<Lifetime> &get_lifetime_args () { return lifetime_args; }
+
+  std::vector<std::unique_ptr<Type> > &get_type_args () { return type_args; }
+
+  std::vector<GenericArgsBinding> &get_binding_args () { return binding_args; }
+
+  Location get_locus () const { return locus; }
 };
 
 /* A segment of a path in expression, including an identifier aspect and maybe
@@ -230,6 +244,8 @@ public:
   Location get_locus () const { return locus; }
 
   PathIdentSegment get_segment () const { return segment_name; }
+
+  GenericArgs &get_generic_args () { return generic_args; }
 };
 
 // HIR node representing a pattern that involves a "path" - abstract base class
@@ -264,6 +280,8 @@ public:
 	  return;
       }
   }
+
+  PathExprSegment get_final_segment () const { return segments.back (); }
 };
 
 /* HIR node representing a path-in-expression pattern (path that allows generic
@@ -431,6 +449,8 @@ public:
   std::string as_string () const override;
 
   void accept_vis (HIRVisitor &vis) override;
+
+  GenericArgs get_generic_args () { return generic_args; }
 
 protected:
   // Use covariance to override base class method
@@ -653,12 +673,14 @@ public:
 
   void iterate_segments (std::function<bool (TypePathSegment *)> cb)
   {
-    for (auto it = segments.begin (); it != segments.end (); it++)
+    for (auto &seg : segments)
       {
-	if (!cb ((*it).get ()))
+	if (!cb (seg.get ()))
 	  return;
       }
   }
+
+  TypePathSegment *get_final_segment () { return segments.back ().get (); }
 };
 
 struct QualifiedPathType

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -37,8 +37,6 @@ public:
     item->accept_vis (resolver);
   };
 
-  ~ResolveItem () {}
-
   void visit (AST::TupleStruct &struct_decl)
   {
     struct_decl.iterate ([&] (AST::TupleField &field) mutable -> bool {
@@ -50,11 +48,25 @@ public:
 
   void visit (AST::StructStruct &struct_decl)
   {
+    NodeId scope_node_id = struct_decl.get_node_id ();
+    resolver->get_type_scope ().push (scope_node_id);
+
+    if (struct_decl.has_generics ())
+      {
+	for (auto &generic : struct_decl.get_generic_params ())
+	  {
+	    ResolveGenericParam::go (generic.get (),
+				     struct_decl.get_node_id ());
+	  }
+      }
+
     struct_decl.iterate ([&] (AST::StructField &field) mutable -> bool {
       ResolveType::go (field.get_field_type ().get (),
 		       struct_decl.get_node_id ());
       return true;
     });
+
+    resolver->get_type_scope ().pop ();
   }
 
   void visit (AST::StaticItem &var)

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -39,11 +39,25 @@ public:
 
   void visit (AST::TupleStruct &struct_decl)
   {
+    NodeId scope_node_id = struct_decl.get_node_id ();
+    resolver->get_type_scope ().push (scope_node_id);
+
+    if (struct_decl.has_generics ())
+      {
+	for (auto &generic : struct_decl.get_generic_params ())
+	  {
+	    ResolveGenericParam::go (generic.get (),
+				     struct_decl.get_node_id ());
+	  }
+      }
+
     struct_decl.iterate ([&] (AST::TupleField &field) mutable -> bool {
       ResolveType::go (field.get_field_type ().get (),
 		       struct_decl.get_node_id ());
       return true;
     });
+
+    resolver->get_type_scope ().pop ();
   }
 
   void visit (AST::StructStruct &struct_decl)

--- a/gcc/rust/resolve/rust-ast-resolve-type.h
+++ b/gcc/rust/resolve/rust-ast-resolve-type.h
@@ -112,9 +112,13 @@ public:
   {
     resolved_node = ResolveTypePath::go (path, parent);
     ok = resolved_node != UNKNOWN_NODEID;
-    resolver->insert_resolved_type (path.get_node_id (), resolved_node);
-    resolver->insert_new_definition (path.get_node_id (),
-				     Definition{path.get_node_id (), parent});
+    if (ok)
+      {
+	resolver->insert_resolved_type (path.get_node_id (), resolved_node);
+	resolver->insert_new_definition (path.get_node_id (),
+					 Definition{path.get_node_id (),
+						    parent});
+      }
   }
 
   void visit (AST::ArrayType &type)

--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -462,7 +462,7 @@ ResolvePath::resolve_path (AST::PathInExpression *expr)
   else
     {
       rust_error_at (expr->get_locus (), "unknown path %s",
-		     expr->as_string ().c_str (), path_buf.c_str ());
+		     expr->as_string ().c_str ());
     }
 }
 

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -1200,27 +1200,10 @@ Gcc_backend::named_type (const std::string &name, Btype *btype,
   if (type == error_mark_node)
     return this->error_type ();
 
-  // The middle-end expects a basic type to have a name.  In Go every
-  // basic type will have a name.  The first time we see a basic type,
-  // give it whatever Go name we have at this point.
-  if (TYPE_NAME (type) == NULL_TREE
-      && location.gcc_location () == BUILTINS_LOCATION
-      && (TREE_CODE (type) == INTEGER_TYPE || TREE_CODE (type) == REAL_TYPE
-	  || TREE_CODE (type) == COMPLEX_TYPE
-	  || TREE_CODE (type) == BOOLEAN_TYPE))
-    {
-      tree decl = build_decl (BUILTINS_LOCATION, TYPE_DECL,
-			      get_identifier_from_string (name), type);
-      TYPE_NAME (type) = decl;
-      return this->make_type (type);
-    }
-
-  tree copy = build_variant_type_copy (type);
   tree decl = build_decl (location.gcc_location (), TYPE_DECL,
-			  get_identifier_from_string (name), copy);
-  DECL_ORIGINAL_TYPE (decl) = type;
-  TYPE_NAME (copy) = decl;
-  return this->make_type (copy);
+			  get_identifier_from_string (name), type);
+  TYPE_NAME (type) = decl;
+  return this->make_type (type);
 }
 
 // Return a pointer type used as a marker for a circular type.

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -168,6 +168,15 @@ public:
     if (function_tyty == nullptr)
       return;
 
+    bool valid_tyty = function_tyty->get_kind () == TyTy::TypeKind::ADT
+		      || function_tyty->get_kind () == TyTy::TypeKind::FNDEF;
+    if (!valid_tyty)
+      {
+	rust_error_at (expr.get_locus (),
+		       "Failed to resolve expression of function call");
+	return;
+      }
+
     infered = TyTy::TypeCheckCallExpr::go (function_tyty, expr, context);
     if (infered == nullptr)
       {
@@ -778,8 +787,6 @@ public:
 		    ? adt->handle_substitions (seg.get_generic_args ())
 		    : adt->infer_substitions ();
       }
-
-    context->insert_type (expr.get_mappings (), infered->clone ());
   }
 
   void visit (HIR::LoopExpr &expr)

--- a/gcc/rust/typecheck/rust-hir-type-check-struct-field.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-struct-field.h
@@ -32,9 +32,8 @@ class TypeCheckStructExpr : public TypeCheckBase
 public:
   static TyTy::BaseType *Resolve (HIR::StructExprStructFields *expr)
   {
-    TypeCheckStructExpr resolver;
+    TypeCheckStructExpr resolver (expr);
     expr->accept_vis (resolver);
-    rust_assert (resolver.resolved != nullptr);
     return resolver.resolved;
   }
 
@@ -49,13 +48,18 @@ public:
   void visit (HIR::StructExprFieldIdentifier &field);
 
 private:
-  TypeCheckStructExpr ()
-    : TypeCheckBase (), resolved (nullptr), struct_path_resolved (nullptr)
+  TypeCheckStructExpr (HIR::Expr *e)
+    : TypeCheckBase (),
+      resolved (new TyTy::ErrorType (e->get_mappings ().get_hirid ())),
+      struct_path_resolved (nullptr)
   {}
 
+  // result
   TyTy::BaseType *resolved;
+
+  // internal state:
   TyTy::ADTType *struct_path_resolved;
-  TyTy::BaseType *resolved_field;
+  TyTy::BaseType *resolved_field_value_expr;
   std::set<std::string> fields_assigned;
   std::map<size_t, HIR::StructExprField *> adtFieldIndexToField;
 };

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
@@ -40,6 +40,20 @@ public:
 
   void visit (HIR::TupleStruct &struct_decl)
   {
+    std::vector<TyTy::SubstitionMapping> substitions;
+    if (struct_decl.has_generics ())
+      {
+	for (auto &generic_param : struct_decl.get_generic_params ())
+	  {
+	    auto param_type
+	      = TypeResolveGenericParam::Resolve (generic_param.get ());
+	    context->insert_type (generic_param->get_mappings (), param_type);
+
+	    substitions.push_back (
+	      TyTy::SubstitionMapping (generic_param, param_type));
+	  }
+      }
+
     std::vector<TyTy::StructFieldType *> fields;
 
     size_t idx = 0;
@@ -57,13 +71,29 @@ public:
 
     TyTy::BaseType *type
       = new TyTy::ADTType (struct_decl.get_mappings ().get_hirid (),
-			   struct_decl.get_identifier (), std::move (fields));
+			   mappings->get_next_hir_id (),
+			   struct_decl.get_identifier (), std::move (fields),
+			   std::move (substitions));
 
     context->insert_type (struct_decl.get_mappings (), type);
   }
 
   void visit (HIR::StructStruct &struct_decl)
   {
+    std::vector<TyTy::SubstitionMapping> substitions;
+    if (struct_decl.has_generics ())
+      {
+	for (auto &generic_param : struct_decl.get_generic_params ())
+	  {
+	    auto param_type
+	      = TypeResolveGenericParam::Resolve (generic_param.get ());
+	    context->insert_type (generic_param->get_mappings (), param_type);
+
+	    substitions.push_back (
+	      TyTy::SubstitionMapping (generic_param, param_type));
+	  }
+      }
+
     std::vector<TyTy::StructFieldType *> fields;
     struct_decl.iterate ([&] (HIR::StructField &field) mutable -> bool {
       TyTy::BaseType *field_type
@@ -78,7 +108,9 @@ public:
 
     TyTy::BaseType *type
       = new TyTy::ADTType (struct_decl.get_mappings ().get_hirid (),
-			   struct_decl.get_identifier (), std::move (fields));
+			   mappings->get_next_hir_id (),
+			   struct_decl.get_identifier (), std::move (fields),
+			   std::move (substitions));
 
     context->insert_type (struct_decl.get_mappings (), type);
   }

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -232,7 +232,7 @@ public:
 	  }
       }
 
-    rust_error_at (path.get_locus (), "failed to resolve TypePath: %s",
+    rust_error_at (path.get_locus (), "failed to type-resolve TypePath: %s",
 		   path.as_string ().c_str ());
   }
 

--- a/gcc/rust/typecheck/rust-tycheck-dump.h
+++ b/gcc/rust/typecheck/rust-tycheck-dump.h
@@ -32,9 +32,18 @@ public:
   {
     TypeResolverDump dumper;
     for (auto &item : crate.items)
-      item->accept_vis (dumper);
+      {
+	item->accept_vis (dumper);
+	dumper.dump += "\n";
+      }
 
     out << dumper.dump;
+  }
+
+  void visit (HIR::StructStruct &struct_decl) override
+  {
+    dump += indent () + "struct " + type_string (struct_decl.get_mappings ())
+	    + "\n";
   }
 
   void visit (HIR::InherentImpl &impl_block) override
@@ -177,6 +186,11 @@ public:
     dump += type_string (expr.get_mappings ());
   }
 
+  void visit (HIR::StructExprStructFields &expr) override
+  {
+    dump += "ctor: " + type_string (expr.get_mappings ());
+  }
+
 protected:
   std::string type_string (const Analysis::NodeMapping &mappings)
   {
@@ -192,8 +206,8 @@ protected:
       }
     buf += "]";
 
-    return "<" + lookup->as_string ()
-	   + " HIRID: " + std::to_string (mappings.get_hirid ())
+    std::string repr = lookup->as_string ();
+    return "<" + repr + " HIRID: " + std::to_string (mappings.get_hirid ())
 	   + " RF:" + std::to_string (lookup->get_ref ()) + " TF:"
 	   + std::to_string (lookup->get_ty_ref ()) + +" - " + buf + ">";
   }

--- a/gcc/rust/typecheck/rust-tyty-call.h
+++ b/gcc/rust/typecheck/rust-tyty-call.h
@@ -42,7 +42,6 @@ public:
   void visit (UnitType &type) override { gcc_unreachable (); }
   void visit (InferType &type) override { gcc_unreachable (); }
   void visit (TupleType &type) override { gcc_unreachable (); }
-  void visit (StructFieldType &type) override { gcc_unreachable (); }
   void visit (ArrayType &type) override { gcc_unreachable (); }
   void visit (BoolType &type) override { gcc_unreachable (); }
   void visit (IntType &type) override { gcc_unreachable (); }
@@ -53,6 +52,7 @@ public:
   void visit (ErrorType &type) override { gcc_unreachable (); }
   void visit (CharType &type) override { gcc_unreachable (); }
   void visit (ReferenceType &type) override { gcc_unreachable (); }
+  void visit (ParamType &) override { gcc_unreachable (); }
 
   // tuple-structs
   void visit (ADTType &type) override;
@@ -86,7 +86,6 @@ public:
   void visit (UnitType &type) override { gcc_unreachable (); }
   void visit (InferType &type) override { gcc_unreachable (); }
   void visit (TupleType &type) override { gcc_unreachable (); }
-  void visit (StructFieldType &type) override { gcc_unreachable (); }
   void visit (ArrayType &type) override { gcc_unreachable (); }
   void visit (BoolType &type) override { gcc_unreachable (); }
   void visit (IntType &type) override { gcc_unreachable (); }
@@ -98,6 +97,7 @@ public:
   void visit (ADTType &type) override { gcc_unreachable (); };
   void visit (CharType &type) override { gcc_unreachable (); }
   void visit (ReferenceType &type) override { gcc_unreachable (); }
+  void visit (ParamType &) override { gcc_unreachable (); }
 
   // call fns
   void visit (FnType &type) override;

--- a/gcc/rust/typecheck/rust-tyty-visitor.h
+++ b/gcc/rust/typecheck/rust-tyty-visitor.h
@@ -29,7 +29,6 @@ class TyVisitor
 public:
   virtual void visit (UnitType &type) = 0;
   virtual void visit (InferType &type) = 0;
-  virtual void visit (StructFieldType &type) = 0;
   virtual void visit (ADTType &type) = 0;
   virtual void visit (TupleType &type) = 0;
   virtual void visit (FnType &type) = 0;
@@ -43,6 +42,7 @@ public:
   virtual void visit (ErrorType &type) = 0;
   virtual void visit (CharType &type) = 0;
   virtual void visit (ReferenceType &type) = 0;
+  virtual void visit (ParamType &type) = 0;
 };
 
 } // namespace TyTy

--- a/gcc/testsuite/rust.test/compilable/generics1.rs
+++ b/gcc/testsuite/rust.test/compilable/generics1.rs
@@ -1,0 +1,41 @@
+struct Foo {
+    a: f32,
+    b: bool,
+}
+
+struct GenericStruct<T> {
+    a: T,
+    b: usize,
+}
+
+fn main() {
+    let a1;
+    a1 = Foo { a: 1.0, b: false };
+
+    let b1: f32 = a1.a;
+    let c1: bool = a1.b;
+
+    let a2: GenericStruct<i8>;
+    a2 = GenericStruct::<i8> { a: 1, b: 456 };
+
+    let b2: i8 = a2.a;
+    let c2: usize = a2.b;
+
+    let a3;
+    a3 = GenericStruct::<i32> { a: 123, b: 456 };
+
+    let b3: i32 = a3.a;
+    let c3: usize = a3.b;
+
+    let a4;
+    a4 = GenericStruct { a: 1.0, b: 456 };
+
+    let b4: f32 = a4.a;
+    let c4: usize = a4.b;
+
+    let a5;
+    a5 = GenericStruct::<_> { a: true, b: 456 };
+
+    let b5: bool = a5.a;
+    let c5: usize = a5.b;
+}

--- a/gcc/testsuite/rust.test/compilable/generics2.rs
+++ b/gcc/testsuite/rust.test/compilable/generics2.rs
@@ -1,0 +1,35 @@
+struct Foo(f32, bool);
+
+struct GenericStruct<T>(T, usize);
+
+fn main() {
+    let a1;
+    a1 = Foo(1.0, false);
+
+    let b1: f32 = a1.0;
+    let c1: bool = a1.1;
+
+    let a2: GenericStruct<i8>;
+    a2 = GenericStruct::<i8>(1, 456);
+
+    let b2: i8 = a2.0;
+    let c2: usize = a2.1;
+
+    let a3;
+    a3 = GenericStruct::<i32>(123, 456);
+
+    let b3: i32 = a3.0;
+    let c3: usize = a3.1;
+
+    let a4;
+    a4 = GenericStruct(1.0, 456);
+
+    let b4: f32 = a4.0;
+    let c4: usize = a4.1;
+
+    let a5;
+    a5 = GenericStruct::<_>(true, 456);
+
+    let b5: bool = a5.0;
+    let c5: usize = a5.1;
+}

--- a/gcc/testsuite/rust.test/fail_compilation/generics1.rs
+++ b/gcc/testsuite/rust.test/fail_compilation/generics1.rs
@@ -1,0 +1,9 @@
+struct GenericStruct<T>(T, usize);
+
+fn main() {
+    let a2: GenericStruct<i8>;
+    a2 = GenericStruct::<_>(1, 456);
+
+    let b2: i32 = a2.0;
+    let c2: usize = a2.1;
+}

--- a/gcc/testsuite/rust.test/fail_compilation/generics2.rs
+++ b/gcc/testsuite/rust.test/fail_compilation/generics2.rs
@@ -1,0 +1,9 @@
+struct GenericStruct<T>(T, usize);
+
+fn main() {
+    let a2: GenericStruct<i8>;
+    a2 = GenericStruct(1, 456);
+
+    let b2: i32 = a2.0;
+    let c2: usize = a2.1;
+}

--- a/gcc/testsuite/rust.test/fail_compilation/generics3.rs
+++ b/gcc/testsuite/rust.test/fail_compilation/generics3.rs
@@ -1,0 +1,9 @@
+struct GenericStruct<T>(T, usize);
+
+fn main() {
+    let a2;
+    a2 = GenericStruct::<i8>(1, 456);
+
+    let b2: i32 = a2.0;
+    let c2: usize = a2.1;
+}

--- a/gcc/testsuite/rust.test/fail_compilation/generics4.rs
+++ b/gcc/testsuite/rust.test/fail_compilation/generics4.rs
@@ -1,0 +1,9 @@
+struct GenericStruct<T>(T, usize);
+
+fn main() {
+    let a2;
+    a2 = GenericStruct::<i8, i32>(1, 456);
+
+    let b2: i32 = a2.0;
+    let c2: usize = a2.1;
+}

--- a/gcc/testsuite/rust.test/fail_compilation/generics5.rs
+++ b/gcc/testsuite/rust.test/fail_compilation/generics5.rs
@@ -1,0 +1,9 @@
+struct GenericStruct<T>(T, usize);
+
+fn main() {
+    let a2;
+    a2 = GenericStruct::<i8, T>(1, 456);
+
+    let b2: i32 = a2.0;
+    let c2: usize = a2.1;
+}


### PR DESCRIPTION
This removes StructFieldType from the TyTy base as it is not a type that
can be unified against.

It adds in a substition mapper implementation which will likely change
over time when this this support is extended over to Functions.

Note generic argument binding is not supported as part of this yet.
This is the building block needed to move forward with generics.

Fixes #235