### PR TITLE
Add in support for string literals

### DIFF
--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -268,8 +268,6 @@ public:
     return compiler.translated;
   }
 
-  virtual ~TyTyResolveCompile () {}
-
   void visit (TyTy::ErrorType &) override { gcc_unreachable (); }
 
   void visit (TyTy::InferType &) override { gcc_unreachable (); }
@@ -458,6 +456,14 @@ public:
     Btype *base_compiled_type
       = TyTyResolveCompile::compile (ctx, type.get_base ());
     translated = ctx->get_backend ()->reference_type (base_compiled_type);
+  }
+
+  void visit (TyTy::StrType &type) override
+  {
+    ::Btype *compiled_type = nullptr;
+    bool ok = ctx->lookup_compiled_types (type.get_ty_ref (), &compiled_type);
+    rust_assert (ok);
+    translated = compiled_type;
   }
 
 private:

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -225,6 +225,14 @@ public:
 	}
 	return;
 
+	case HIR::Literal::STRING: {
+	  auto base = ctx->get_backend ()->string_constant_expression (
+	    literal_value->as_string ());
+	  translated
+	    = ctx->get_backend ()->address_expression (base, expr.get_locus ());
+	}
+	return;
+
       default:
 	rust_fatal_error (expr.get_locus (), "unknown literal");
 	return;

--- a/gcc/rust/backend/rust-compile-tyty.h
+++ b/gcc/rust/backend/rust-compile-tyty.h
@@ -209,6 +209,13 @@ public:
 				      Linemap::predeclared_location ());
   }
 
+  void visit (TyTy::StrType &) override
+  {
+    Btype *raw_str = backend->raw_str_type ();
+    translated
+      = backend->named_type ("str", raw_str, Linemap::predeclared_location ());
+  }
+
 private:
   TyTyCompile (::Backend *backend)
     : backend (backend), translated (nullptr),

--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -157,6 +157,7 @@ Resolver::generate_builtins ()
   auto usize = new TyTy::USizeType (mappings->get_next_hir_id ());
   auto isize = new TyTy::ISizeType (mappings->get_next_hir_id ());
   auto char_tyty = new TyTy::CharType (mappings->get_next_hir_id ());
+  auto str = new TyTy::StrType (mappings->get_next_hir_id ());
 
   MKBUILTIN_TYPE ("u8", builtins, u8);
   MKBUILTIN_TYPE ("u16", builtins, u16);
@@ -174,6 +175,7 @@ Resolver::generate_builtins ()
   MKBUILTIN_TYPE ("usize", builtins, usize);
   MKBUILTIN_TYPE ("isize", builtins, isize);
   MKBUILTIN_TYPE ("char", builtins, char_tyty);
+  MKBUILTIN_TYPE ("str", builtins, str);
 
   // unit type ()
   TyTy::UnitType *unit_tyty = new TyTy::UnitType (mappings->get_next_hir_id ());

--- a/gcc/rust/rust-backend.h
+++ b/gcc/rust/rust-backend.h
@@ -116,6 +116,9 @@ public:
   // Get the Host pointer size in bits
   virtual int get_pointer_size () = 0;
 
+  // Get the raw str type const char*
+  virtual Btype *raw_str_type () = 0;
+
   // Get an unnamed integer type with the given signedness and number
   // of bits.
   virtual Btype *integer_type (bool is_unsigned, int bits) = 0;

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -187,6 +187,8 @@ public:
 
   int get_pointer_size ();
 
+  Btype *raw_str_type ();
+
   Btype *integer_type (bool, int);
 
   Btype *float_type (int);
@@ -801,6 +803,14 @@ int
 Gcc_backend::get_pointer_size ()
 {
   return POINTER_SIZE;
+}
+
+Btype *
+Gcc_backend::raw_str_type ()
+{
+  tree char_ptr = build_pointer_type (char_type_node);
+  tree const_char_type = build_qualified_type (char_ptr, TYPE_QUAL_CONST);
+  return this->make_type (const_char_type);
 }
 
 Btype *
@@ -1427,8 +1437,7 @@ Bexpression *
 Gcc_backend::string_constant_expression (const std::string &val)
 {
   tree index_type = build_index_type (size_int (val.length ()));
-  tree const_char_type
-    = build_qualified_type (unsigned_char_type_node, TYPE_QUAL_CONST);
+  tree const_char_type = build_qualified_type (char_type_node, TYPE_QUAL_CONST);
   tree string_type = build_array_type (const_char_type, index_type);
   TYPE_STRING_FLAG (string_type) = 1;
   tree string_val = build_string (val.length (), val.data ());

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -454,6 +454,16 @@ public:
 	}
 	break;
 
+	case HIR::Literal::LitType::STRING: {
+	  TyTy::BaseType *base = nullptr;
+	  auto ok = context->lookup_builtin ("str", &base);
+	  rust_assert (ok);
+
+	  infered = new TyTy::ReferenceType (expr.get_mappings ().get_hirid (),
+					     base->get_ref ());
+	}
+	break;
+
       default:
 	gcc_unreachable ();
 	break;

--- a/gcc/rust/typecheck/rust-tyty-call.h
+++ b/gcc/rust/typecheck/rust-tyty-call.h
@@ -53,6 +53,7 @@ public:
   void visit (CharType &type) override { gcc_unreachable (); }
   void visit (ReferenceType &type) override { gcc_unreachable (); }
   void visit (ParamType &) override { gcc_unreachable (); }
+  void visit (StrType &) override { gcc_unreachable (); }
 
   // tuple-structs
   void visit (ADTType &type) override;
@@ -98,6 +99,7 @@ public:
   void visit (CharType &type) override { gcc_unreachable (); }
   void visit (ReferenceType &type) override { gcc_unreachable (); }
   void visit (ParamType &) override { gcc_unreachable (); }
+  void visit (StrType &) override { gcc_unreachable (); }
 
   // call fns
   void visit (FnType &type) override;

--- a/gcc/rust/typecheck/rust-tyty-visitor.h
+++ b/gcc/rust/typecheck/rust-tyty-visitor.h
@@ -43,6 +43,7 @@ public:
   virtual void visit (CharType &type) = 0;
   virtual void visit (ReferenceType &type) = 0;
   virtual void visit (ParamType &type) = 0;
+  virtual void visit (StrType &type) = 0;
 };
 
 } // namespace TyTy

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -799,6 +799,37 @@ ParamType::resolve ()
   return lookup;
 }
 
+BaseType *
+StrType::clone ()
+{
+  return new StrType (get_ref (), get_ty_ref (), get_combined_refs ());
+}
+
+void
+StrType::accept_vis (TyVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+std::string
+StrType::as_string () const
+{
+  return "str";
+}
+
+BaseType *
+StrType::unify (BaseType *other)
+{
+  StrRules r (this);
+  return r.unify (other);
+}
+
+bool
+StrType::is_equal (const BaseType &other) const
+{
+  return get_kind () == other.get_kind ();
+}
+
 // rust-tyty-call.h
 
 void

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -809,12 +809,36 @@ public:
 
   BaseType *unify (BaseType *other) override;
 
-  virtual bool is_equal (const BaseType &other) const override;
+  bool is_equal (const BaseType &other) const override;
 
   BaseType *clone () final override;
 
 private:
   HirId base;
+};
+
+class StrType : public BaseType
+{
+public:
+  StrType (HirId ref, std::set<HirId> refs = std::set<HirId> ())
+    : BaseType (ref, ref, TypeKind::STR)
+  {}
+
+  StrType (HirId ref, HirId ty_ref, std::set<HirId> refs = std::set<HirId> ())
+    : BaseType (ref, ty_ref, TypeKind::STR)
+  {}
+
+  std::string get_name () const override final { return as_string (); }
+
+  void accept_vis (TyVisitor &vis) override;
+
+  std::string as_string () const override;
+
+  BaseType *unify (BaseType *other) override;
+
+  bool is_equal (const BaseType &other) const override;
+
+  BaseType *clone () final override;
 };
 
 } // namespace TyTy

--- a/gcc/testsuite/rust.test/compilable/str1.rs
+++ b/gcc/testsuite/rust.test/compilable/str1.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let a;
+    a = "hello world infer";
+
+    let b: &str;
+    b = "hello world specified";
+}


### PR DESCRIPTION
This gives the apropriate reference type over const char *.

Fixes #85