### PR TITLE
Cleanup operator

### DIFF
--- a/gcc/rust/ast/rust-ast-full-test.cc
+++ b/gcc/rust/ast/rust-ast-full-test.cc
@@ -21,6 +21,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "rust-diagnostics.h"
 #include "rust-ast-visitor.h"
 #include "rust-session-manager.h"
+#include "operator.h"
 
 /* Compilation unit used for various AST-related functions that would make
  * the headers too long if they were defined inline and don't receive any
@@ -1602,12 +1603,12 @@ NegationExpr::as_string () const
   // TODO: rewrite formula to allow outer attributes
   std::string str;
 
-  switch (negation_type)
+  switch (expr_type)
     {
-    case NEGATE:
+    case NegationOperator::NEGATE:
       str = "-";
       break;
-    case NOT:
+    case NegationOperator::NOT:
       str = "!";
       break;
     default:
@@ -1682,22 +1683,22 @@ ComparisonExpr::as_string () const
 
   switch (expr_type)
     {
-    case EQUAL:
+    case ComparisonOperator::EQUAL:
       str += " == ";
       break;
-    case NOT_EQUAL:
+    case ComparisonOperator::NOT_EQUAL:
       str += " != ";
       break;
-    case GREATER_THAN:
+    case ComparisonOperator::GREATER_THAN:
       str += " > ";
       break;
-    case LESS_THAN:
+    case ComparisonOperator::LESS_THAN:
       str += " < ";
       break;
-    case GREATER_OR_EQUAL:
+    case ComparisonOperator::GREATER_OR_EQUAL:
       str += " >= ";
       break;
-    case LESS_OR_EQUAL:
+    case ComparisonOperator::LESS_OR_EQUAL:
       str += " <= ";
       break;
     default:
@@ -1770,10 +1771,10 @@ LazyBooleanExpr::as_string () const
 
   switch (expr_type)
     {
-    case LOGICAL_OR:
+    case LazyBooleanOperator::LOGICAL_OR:
       str += " || ";
       break;
-    case LOGICAL_AND:
+    case LazyBooleanOperator::LOGICAL_AND:
       str += " && ";
       break;
     default:
@@ -1944,34 +1945,34 @@ CompoundAssignmentExpr::as_string () const
   // get operator string
   switch (expr_type)
     {
-    case ADD:
+    case CompoundAssignmentOperator::ADD:
       operator_str = "+";
       break;
-    case SUBTRACT:
+    case CompoundAssignmentOperator::SUBTRACT:
       operator_str = "-";
       break;
-    case MULTIPLY:
+    case CompoundAssignmentOperator::MULTIPLY:
       operator_str = "*";
       break;
-    case DIVIDE:
+    case CompoundAssignmentOperator::DIVIDE:
       operator_str = "/";
       break;
-    case MODULUS:
+    case CompoundAssignmentOperator::MODULUS:
       operator_str = "%";
       break;
-    case BITWISE_AND:
+    case CompoundAssignmentOperator::BITWISE_AND:
       operator_str = "&";
       break;
-    case BITWISE_OR:
+    case CompoundAssignmentOperator::BITWISE_OR:
       operator_str = "|";
       break;
-    case BITWISE_XOR:
+    case CompoundAssignmentOperator::BITWISE_XOR:
       operator_str = "^";
       break;
-    case LEFT_SHIFT:
+    case CompoundAssignmentOperator::LEFT_SHIFT:
       operator_str = "<<";
       break;
-    case RIGHT_SHIFT:
+    case CompoundAssignmentOperator::RIGHT_SHIFT:
       operator_str = ">>";
       break;
     default:
@@ -2005,34 +2006,34 @@ ArithmeticOrLogicalExpr::as_string () const
   // get operator string
   switch (expr_type)
     {
-    case ADD:
+    case ArithmeticOrLogicalOperator::ADD:
       operator_str = "+";
       break;
-    case SUBTRACT:
+    case ArithmeticOrLogicalOperator::SUBTRACT:
       operator_str = "-";
       break;
-    case MULTIPLY:
+    case ArithmeticOrLogicalOperator::MULTIPLY:
       operator_str = "*";
       break;
-    case DIVIDE:
+    case ArithmeticOrLogicalOperator::DIVIDE:
       operator_str = "/";
       break;
-    case MODULUS:
+    case ArithmeticOrLogicalOperator::MODULUS:
       operator_str = "%";
       break;
-    case BITWISE_AND:
+    case ArithmeticOrLogicalOperator::BITWISE_AND:
       operator_str = "&";
       break;
-    case BITWISE_OR:
+    case ArithmeticOrLogicalOperator::BITWISE_OR:
       operator_str = "|";
       break;
-    case BITWISE_XOR:
+    case ArithmeticOrLogicalOperator::BITWISE_XOR:
       operator_str = "^";
       break;
-    case LEFT_SHIFT:
+    case ArithmeticOrLogicalOperator::LEFT_SHIFT:
       operator_str = "<<";
       break;
-    case RIGHT_SHIFT:
+    case ArithmeticOrLogicalOperator::RIGHT_SHIFT:
       operator_str = ">>";
       break;
     default:

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -3,6 +3,7 @@
 
 #include "rust-ast.h"
 #include "rust-path.h"
+#include "operator.h"
 
 namespace Rust {
 namespace AST {
@@ -365,30 +366,25 @@ protected:
 // Unary prefix - or ! negation or NOT operators.
 class NegationExpr : public OperatorExpr
 {
-public:
-  enum NegationType
-  {
-    NEGATE,
-    NOT
-  };
-
 private:
+  using ExprType = NegationOperator;
+
   /* Note: overload negation via std::ops::Neg and not via std::ops::Not
    * Negation only works for signed integer and floating-point types, NOT only
    * works for boolean and integer types (via bitwise NOT) */
-  NegationType negation_type;
+  ExprType expr_type;
 
 public:
   std::string as_string () const override;
 
-  NegationType get_negation_type () const { return negation_type; }
+  ExprType get_expr_type () const { return expr_type; }
 
   // Constructor calls OperatorExpr's protected constructor
-  NegationExpr (std::unique_ptr<Expr> negated_value, NegationType negation_kind,
+  NegationExpr (std::unique_ptr<Expr> negated_value, ExprType expr_kind,
 		std::vector<Attribute> outer_attribs, Location locus)
     : OperatorExpr (std::move (negated_value), std::move (outer_attribs),
 		    locus),
-      negation_type (negation_kind)
+      expr_type (expr_kind)
   {}
 
   void accept_vis (ASTVisitor &vis) override;
@@ -412,22 +408,9 @@ protected:
 // Infix binary operators. +, -, *, /, %, &, |, ^, <<, >>
 class ArithmeticOrLogicalExpr : public OperatorExpr
 {
-public:
-  enum ExprType
-  {
-    ADD,	 // std::ops::Add
-    SUBTRACT,	 // std::ops::Sub
-    MULTIPLY,	 // std::ops::Mul
-    DIVIDE,	 // std::ops::Div
-    MODULUS,	 // std::ops::Rem
-    BITWISE_AND, // std::ops::BitAnd
-    BITWISE_OR,	 // std::ops::BitOr
-    BITWISE_XOR, // std::ops::BitXor
-    LEFT_SHIFT,	 // std::ops::Shl
-    RIGHT_SHIFT	 // std::ops::Shr
-  };
-
 private:
+  using ExprType = ArithmeticOrLogicalOperator;
+
   // Note: overloading trait specified in comments
   ExprType expr_type;
 
@@ -500,18 +483,9 @@ protected:
 // Infix binary comparison operators. ==, !=, <, <=, >, >=
 class ComparisonExpr : public OperatorExpr
 {
-public:
-  enum ExprType
-  {
-    EQUAL,	      // std::cmp::PartialEq::eq
-    NOT_EQUAL,	      // std::cmp::PartialEq::ne
-    GREATER_THAN,     // std::cmp::PartialEq::gt
-    LESS_THAN,	      // std::cmp::PartialEq::lt
-    GREATER_OR_EQUAL, // std::cmp::PartialEq::ge
-    LESS_OR_EQUAL     // std::cmp::PartialEq::le
-  };
-
 private:
+  using ExprType = ComparisionOperator;
+
   // Note: overloading trait specified in comments
   ExprType expr_type;
 
@@ -585,14 +559,9 @@ protected:
 // Infix binary lazy boolean logical operators && and ||.
 class LazyBooleanExpr : public OperatorExpr
 {
-public:
-  enum ExprType
-  {
-    LOGICAL_OR,
-    LOGICAL_AND
-  };
-
 private:
+  using ExprType = LazyBooleanOperator;
+
   ExprType expr_type;
 
   std::unique_ptr<Expr> right_expr;
@@ -791,22 +760,9 @@ protected:
  * expressions. */
 class CompoundAssignmentExpr : public OperatorExpr
 {
-public:
-  enum ExprType
-  {
-    ADD,	 // std::ops::AddAssign
-    SUBTRACT,	 // std::ops::SubAssign
-    MULTIPLY,	 // std::ops::MulAssign
-    DIVIDE,	 // std::ops::DivAssign
-    MODULUS,	 // std::ops::RemAssign
-    BITWISE_AND, // std::ops::BitAndAssign
-    BITWISE_OR,	 // std::ops::BitOrAssign
-    BITWISE_XOR, // std::ops::BitXorAssign
-    LEFT_SHIFT,	 // std::ops::ShlAssign
-    RIGHT_SHIFT	 // std::ops::ShrAssign
-  };
-
 private:
+  using ExprType = CompoundAssignmentOperator;
+
   // Note: overloading trait specified in comments
   ExprType expr_type;
   std::unique_ptr<Expr> right_expr;

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -366,9 +366,10 @@ protected:
 // Unary prefix - or ! negation or NOT operators.
 class NegationExpr : public OperatorExpr
 {
-private:
+public:
   using ExprType = NegationOperator;
 
+private:
   /* Note: overload negation via std::ops::Neg and not via std::ops::Not
    * Negation only works for signed integer and floating-point types, NOT only
    * works for boolean and integer types (via bitwise NOT) */
@@ -408,9 +409,10 @@ protected:
 // Infix binary operators. +, -, *, /, %, &, |, ^, <<, >>
 class ArithmeticOrLogicalExpr : public OperatorExpr
 {
-private:
+public:
   using ExprType = ArithmeticOrLogicalOperator;
 
+private:
   // Note: overloading trait specified in comments
   ExprType expr_type;
 
@@ -483,9 +485,10 @@ protected:
 // Infix binary comparison operators. ==, !=, <, <=, >, >=
 class ComparisonExpr : public OperatorExpr
 {
-private:
-  using ExprType = ComparisionOperator;
+public:
+  using ExprType = ComparisonOperator;
 
+private:
   // Note: overloading trait specified in comments
   ExprType expr_type;
 
@@ -559,9 +562,10 @@ protected:
 // Infix binary lazy boolean logical operators && and ||.
 class LazyBooleanExpr : public OperatorExpr
 {
-private:
+public:
   using ExprType = LazyBooleanOperator;
 
+private:
   ExprType expr_type;
 
   std::unique_ptr<Expr> right_expr;
@@ -760,9 +764,10 @@ protected:
  * expressions. */
 class CompoundAssignmentExpr : public OperatorExpr
 {
-private:
+public:
   using ExprType = CompoundAssignmentOperator;
 
+private:
   // Note: overloading trait specified in comments
   ExprType expr_type;
   std::unique_ptr<Expr> right_expr;

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -316,7 +316,7 @@ public:
     auto location = expr.get_locus ();
 
     translated
-      = ctx->get_backend ()->comparision_expression (op, lhs, rhs, location);
+      = ctx->get_backend ()->comparison_expression (op, lhs, rhs, location);
   }
 
   void visit (HIR::LazyBooleanExpr &expr)

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -298,107 +298,36 @@ public:
 
   void visit (HIR::ArithmeticOrLogicalExpr &expr)
   {
-    Operator op;
-    switch (expr.get_expr_type ())
-      {
-      case HIR::ArithmeticOrLogicalExpr::ADD:
-	op = OPERATOR_PLUS;
-	break;
-      case HIR::ArithmeticOrLogicalExpr::SUBTRACT:
-	op = OPERATOR_MINUS;
-	break;
-      case HIR::ArithmeticOrLogicalExpr::MULTIPLY:
-	op = OPERATOR_MULT;
-	break;
-      case HIR::ArithmeticOrLogicalExpr::DIVIDE:
-	op = OPERATOR_DIV;
-	break;
-      case HIR::ArithmeticOrLogicalExpr::MODULUS:
-	op = OPERATOR_MOD;
-	break;
-      case HIR::ArithmeticOrLogicalExpr::BITWISE_AND:
-	op = OPERATOR_AND;
-	break;
-      case HIR::ArithmeticOrLogicalExpr::BITWISE_OR:
-	op = OPERATOR_OR;
-	break;
-      case HIR::ArithmeticOrLogicalExpr::BITWISE_XOR:
-	op = OPERATOR_XOR;
-	break;
-      case HIR::ArithmeticOrLogicalExpr::LEFT_SHIFT:
-	op = OPERATOR_LSHIFT;
-	break;
-      case HIR::ArithmeticOrLogicalExpr::RIGHT_SHIFT:
-	op = OPERATOR_RSHIFT;
-	break;
-      default:
-	rust_fatal_error (expr.get_locus (), "failed to compile operator");
-	return;
-      }
-
+    auto op = expr.get_expr_type ();
     auto lhs = CompileExpr::Compile (expr.get_lhs (), ctx);
     auto rhs = CompileExpr::Compile (expr.get_rhs (), ctx);
+    auto location = expr.get_locus ();
 
-    translated = ctx->get_backend ()->binary_expression (op, lhs, rhs,
-							 expr.get_locus ());
+    translated
+      = ctx->get_backend ()->arithmetic_or_logical_expression (op, lhs, rhs,
+							       location);
   }
 
   void visit (HIR::ComparisonExpr &expr)
   {
-    Operator op;
-    switch (expr.get_expr_type ())
-      {
-      case HIR::ComparisonExpr::EQUAL:
-	op = OPERATOR_EQEQ;
-	break;
-      case HIR::ComparisonExpr::NOT_EQUAL:
-	op = OPERATOR_NOTEQ;
-	break;
-      case HIR::ComparisonExpr::GREATER_THAN:
-	op = OPERATOR_GT;
-	break;
-      case HIR::ComparisonExpr::LESS_THAN:
-	op = OPERATOR_LT;
-	break;
-      case HIR::ComparisonExpr::GREATER_OR_EQUAL:
-	op = OPERATOR_GE;
-	break;
-      case HIR::ComparisonExpr::LESS_OR_EQUAL:
-	op = OPERATOR_LE;
-	break;
-      default:
-	rust_fatal_error (expr.get_locus (), "failed to compile operator");
-	return;
-      }
-
+    auto op = expr.get_expr_type ();
     auto lhs = CompileExpr::Compile (expr.get_lhs (), ctx);
     auto rhs = CompileExpr::Compile (expr.get_rhs (), ctx);
+    auto location = expr.get_locus ();
 
-    translated = ctx->get_backend ()->binary_expression (op, lhs, rhs,
-							 expr.get_locus ());
+    translated
+      = ctx->get_backend ()->comparision_expression (op, lhs, rhs, location);
   }
 
   void visit (HIR::LazyBooleanExpr &expr)
   {
-    Operator op;
-    switch (expr.get_expr_type ())
-      {
-      case HIR::LazyBooleanExpr::LOGICAL_OR:
-	op = OPERATOR_OROR;
-	break;
-      case HIR::LazyBooleanExpr::LOGICAL_AND:
-	op = OPERATOR_ANDAND;
-	break;
-      default:
-	rust_fatal_error (expr.get_locus (), "failed to compile operator");
-	return;
-      }
-
+    auto op = expr.get_expr_type ();
     auto lhs = CompileExpr::Compile (expr.get_lhs (), ctx);
     auto rhs = CompileExpr::Compile (expr.get_rhs (), ctx);
+    auto location = expr.get_locus ();
 
-    translated = ctx->get_backend ()->binary_expression (op, lhs, rhs,
-							 expr.get_locus ());
+    translated
+      = ctx->get_backend ()->lazy_boolean_expression (op, lhs, rhs, location);
   }
 
   void visit (HIR::NegationExpr &expr)
@@ -415,9 +344,12 @@ public:
 	break;
       }
 
-    Bexpression *negated_expr = CompileExpr::Compile (expr.get_expr (), ctx);
-    translated = ctx->get_backend ()->unary_expression (op, negated_expr,
-							expr.get_locus ());
+    auto op = expr.get_expr_type ();
+    auto negated_expr = CompileExpr::Compile (expr.get_expr (), ctx);
+    auto location = expr.get_locus ();
+
+    translated
+      = ctx->get_backend ()->negation_expression (op, negated_expr, location);
   }
 
   void visit (HIR::IfExpr &expr)

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -332,18 +332,6 @@ public:
 
   void visit (HIR::NegationExpr &expr)
   {
-    Operator op (OPERATOR_INVALID);
-    switch (expr.get_negation_type ())
-      {
-      case HIR::NegationExpr::NegationType::NEGATE:
-	op = OPERATOR_MINUS;
-	break;
-
-      case HIR::NegationExpr::NegationType::NOT:
-	op = OPERATOR_NOT;
-	break;
-      }
-
     auto op = expr.get_expr_type ();
     auto negated_expr = CompileExpr::Compile (expr.get_expr (), ctx);
     auto location = expr.get_locus ();

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -422,7 +422,8 @@ public:
       = new HIR::ArithmeticOrLogicalExpr (mapping,
 					  std::unique_ptr<HIR::Expr> (lhs),
 					  std::unique_ptr<HIR::Expr> (rhs),
-					  expr.get_expr_type(), expr.get_locus ());
+					  expr.get_expr_type (),
+					  expr.get_locus ());
   }
 
   void visit (AST::ComparisonExpr &expr)
@@ -439,8 +440,8 @@ public:
 
     translated
       = new HIR::ComparisonExpr (mapping, std::unique_ptr<HIR::Expr> (lhs),
-				 std::unique_ptr<HIR::Expr> (rhs), expr.get_expr_type(),
-				 expr.get_locus ());
+				 std::unique_ptr<HIR::Expr> (rhs),
+				 expr.get_expr_type (), expr.get_locus ());
   }
 
   void visit (AST::LazyBooleanExpr &expr)
@@ -457,8 +458,8 @@ public:
 
     translated
       = new HIR::LazyBooleanExpr (mapping, std::unique_ptr<HIR::Expr> (lhs),
-				  std::unique_ptr<HIR::Expr> (rhs), expr.get_expr_type(),
-				  expr.get_locus ());
+				  std::unique_ptr<HIR::Expr> (rhs),
+				  expr.get_expr_type (), expr.get_locus ());
   }
 
   void visit (AST::NegationExpr &expr)
@@ -474,14 +475,16 @@ public:
 				   UNKNOWN_LOCAL_DEFID);
     translated
       = new HIR::NegationExpr (mapping,
-			       std::unique_ptr<HIR::Expr> (negated_value), expr.get_expr_type(),
-			       std::move (outer_attribs), expr.get_locus ());
+			       std::unique_ptr<HIR::Expr> (negated_value),
+			       expr.get_expr_type (), std::move (outer_attribs),
+			       expr.get_locus ());
   }
 
   /* Compound assignment expression is compiled away. */
   void visit (AST::CompoundAssignmentExpr &expr)
   {
-      /* First we need to find the corresponding arithmetic or logical operator. */
+    /* First we need to find the corresponding arithmetic or logical operator.
+     */
     ArithmeticOrLogicalOperator op;
     switch (expr.get_expr_type ())
       {

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -408,42 +408,6 @@ public:
 
   void visit (AST::ArithmeticOrLogicalExpr &expr)
   {
-    HIR::ArithmeticOrLogicalExpr::ExprType kind
-      = HIR::ArithmeticOrLogicalExpr::ExprType::ADD;
-    switch (expr.get_expr_type ())
-      {
-      case AST::ArithmeticOrLogicalExpr::ExprType::ADD:
-	kind = HIR::ArithmeticOrLogicalExpr::ExprType::ADD;
-	break;
-      case AST::ArithmeticOrLogicalExpr::ExprType::SUBTRACT:
-	kind = HIR::ArithmeticOrLogicalExpr::ExprType::SUBTRACT;
-	break;
-      case AST::ArithmeticOrLogicalExpr::ExprType::MULTIPLY:
-	kind = HIR::ArithmeticOrLogicalExpr::ExprType::MULTIPLY;
-	break;
-      case AST::ArithmeticOrLogicalExpr::ExprType::DIVIDE:
-	kind = HIR::ArithmeticOrLogicalExpr::ExprType::DIVIDE;
-	break;
-      case AST::ArithmeticOrLogicalExpr::ExprType::MODULUS:
-	kind = HIR::ArithmeticOrLogicalExpr::ExprType::MODULUS;
-	break;
-      case AST::ArithmeticOrLogicalExpr::ExprType::BITWISE_AND:
-	kind = HIR::ArithmeticOrLogicalExpr::ExprType::BITWISE_AND;
-	break;
-      case AST::ArithmeticOrLogicalExpr::ExprType::BITWISE_OR:
-	kind = HIR::ArithmeticOrLogicalExpr::ExprType::BITWISE_OR;
-	break;
-      case AST::ArithmeticOrLogicalExpr::ExprType::BITWISE_XOR:
-	kind = HIR::ArithmeticOrLogicalExpr::ExprType::BITWISE_XOR;
-	break;
-      case AST::ArithmeticOrLogicalExpr::ExprType::LEFT_SHIFT:
-	kind = HIR::ArithmeticOrLogicalExpr::ExprType::LEFT_SHIFT;
-	break;
-      case AST::ArithmeticOrLogicalExpr::ExprType::RIGHT_SHIFT:
-	kind = HIR::ArithmeticOrLogicalExpr::ExprType::RIGHT_SHIFT;
-	break;
-      }
-
     HIR::Expr *lhs = ASTLoweringExpr::translate (expr.get_left_expr ().get ());
     rust_assert (lhs != nullptr);
     HIR::Expr *rhs = ASTLoweringExpr::translate (expr.get_right_expr ().get ());
@@ -458,34 +422,11 @@ public:
       = new HIR::ArithmeticOrLogicalExpr (mapping,
 					  std::unique_ptr<HIR::Expr> (lhs),
 					  std::unique_ptr<HIR::Expr> (rhs),
-					  kind, expr.get_locus ());
+					  expr.get_expr_type(), expr.get_locus ());
   }
 
   void visit (AST::ComparisonExpr &expr)
   {
-    HIR::ComparisonExpr::ExprType kind;
-    switch (expr.get_kind ())
-      {
-      case AST::ComparisonExpr::ExprType::EQUAL:
-	kind = HIR::ComparisonExpr::ExprType::EQUAL;
-	break;
-      case AST::ComparisonExpr::ExprType::NOT_EQUAL:
-	kind = HIR::ComparisonExpr::ExprType::NOT_EQUAL;
-	break;
-      case AST::ComparisonExpr::ExprType::GREATER_THAN:
-	kind = HIR::ComparisonExpr::ExprType::GREATER_THAN;
-	break;
-      case AST::ComparisonExpr::ExprType::LESS_THAN:
-	kind = HIR::ComparisonExpr::ExprType::LESS_THAN;
-	break;
-      case AST::ComparisonExpr::ExprType::GREATER_OR_EQUAL:
-	kind = HIR::ComparisonExpr::ExprType::GREATER_OR_EQUAL;
-	break;
-      case AST::ComparisonExpr::ExprType::LESS_OR_EQUAL:
-	kind = HIR::ComparisonExpr::ExprType::LESS_OR_EQUAL;
-	break;
-      }
-
     HIR::Expr *lhs = ASTLoweringExpr::translate (expr.get_left_expr ().get ());
     rust_assert (lhs != nullptr);
     HIR::Expr *rhs = ASTLoweringExpr::translate (expr.get_right_expr ().get ());
@@ -498,23 +439,12 @@ public:
 
     translated
       = new HIR::ComparisonExpr (mapping, std::unique_ptr<HIR::Expr> (lhs),
-				 std::unique_ptr<HIR::Expr> (rhs), kind,
+				 std::unique_ptr<HIR::Expr> (rhs), expr.get_expr_type(),
 				 expr.get_locus ());
   }
 
   void visit (AST::LazyBooleanExpr &expr)
   {
-    HIR::LazyBooleanExpr::ExprType kind;
-    switch (expr.get_kind ())
-      {
-      case AST::LazyBooleanExpr::ExprType::LOGICAL_AND:
-	kind = HIR::LazyBooleanExpr::ExprType::LOGICAL_AND;
-	break;
-      case AST::LazyBooleanExpr::ExprType::LOGICAL_OR:
-	kind = HIR::LazyBooleanExpr::ExprType::LOGICAL_OR;
-	break;
-      }
-
     HIR::Expr *lhs = ASTLoweringExpr::translate (expr.get_left_expr ().get ());
     rust_assert (lhs != nullptr);
     HIR::Expr *rhs = ASTLoweringExpr::translate (expr.get_right_expr ().get ());
@@ -527,24 +457,13 @@ public:
 
     translated
       = new HIR::LazyBooleanExpr (mapping, std::unique_ptr<HIR::Expr> (lhs),
-				  std::unique_ptr<HIR::Expr> (rhs), kind,
+				  std::unique_ptr<HIR::Expr> (rhs), expr.get_expr_type(),
 				  expr.get_locus ());
   }
 
   void visit (AST::NegationExpr &expr)
   {
     std::vector<HIR::Attribute> outer_attribs;
-
-    HIR::NegationExpr::NegationType type;
-    switch (expr.get_negation_type ())
-      {
-      case AST::NegationExpr::NegationType::NEGATE:
-	type = HIR::NegationExpr::NegationType::NEGATE;
-	break;
-      case AST::NegationExpr::NegationType::NOT:
-	type = HIR::NegationExpr::NegationType::NOT;
-	break;
-      }
 
     HIR::Expr *negated_value
       = ASTLoweringExpr::translate (expr.get_negated_expr ().get ());
@@ -555,45 +474,46 @@ public:
 				   UNKNOWN_LOCAL_DEFID);
     translated
       = new HIR::NegationExpr (mapping,
-			       std::unique_ptr<HIR::Expr> (negated_value), type,
+			       std::unique_ptr<HIR::Expr> (negated_value), expr.get_expr_type(),
 			       std::move (outer_attribs), expr.get_locus ());
   }
 
+  /* Compound assignment expression is compiled away. */
   void visit (AST::CompoundAssignmentExpr &expr)
   {
-    HIR::ArithmeticOrLogicalExpr::ExprType kind
-      = HIR::ArithmeticOrLogicalExpr::ExprType::ADD;
+      /* First we need to find the corresponding arithmetic or logical operator. */
+    ArithmeticOrLogicalOperator op;
     switch (expr.get_expr_type ())
       {
-      case AST::CompoundAssignmentExpr::ExprType::ADD:
-	kind = HIR::ArithmeticOrLogicalExpr::ExprType::ADD;
+      case CompoundAssignmentOperator::ADD:
+	op = ArithmeticOrLogicalOperator::ADD;
 	break;
-      case AST::CompoundAssignmentExpr::ExprType::SUBTRACT:
-	kind = HIR::ArithmeticOrLogicalExpr::ExprType::SUBTRACT;
+      case CompoundAssignmentOperator::SUBTRACT:
+	op = ArithmeticOrLogicalOperator::SUBTRACT;
 	break;
-      case AST::CompoundAssignmentExpr::ExprType::MULTIPLY:
-	kind = HIR::ArithmeticOrLogicalExpr::ExprType::MULTIPLY;
+      case CompoundAssignmentOperator::MULTIPLY:
+	op = ArithmeticOrLogicalOperator::MULTIPLY;
 	break;
-      case AST::CompoundAssignmentExpr::ExprType::DIVIDE:
-	kind = HIR::ArithmeticOrLogicalExpr::ExprType::DIVIDE;
+      case CompoundAssignmentOperator::DIVIDE:
+	op = ArithmeticOrLogicalOperator::DIVIDE;
 	break;
-      case AST::CompoundAssignmentExpr::ExprType::MODULUS:
-	kind = HIR::ArithmeticOrLogicalExpr::ExprType::MODULUS;
+      case CompoundAssignmentOperator::MODULUS:
+	op = ArithmeticOrLogicalOperator::MODULUS;
 	break;
-      case AST::CompoundAssignmentExpr::ExprType::BITWISE_AND:
-	kind = HIR::ArithmeticOrLogicalExpr::ExprType::BITWISE_AND;
+      case CompoundAssignmentOperator::BITWISE_AND:
+	op = ArithmeticOrLogicalOperator::BITWISE_AND;
 	break;
-      case AST::CompoundAssignmentExpr::ExprType::BITWISE_OR:
-	kind = HIR::ArithmeticOrLogicalExpr::ExprType::BITWISE_OR;
+      case CompoundAssignmentOperator::BITWISE_OR:
+	op = ArithmeticOrLogicalOperator::BITWISE_OR;
 	break;
-      case AST::CompoundAssignmentExpr::ExprType::BITWISE_XOR:
-	kind = HIR::ArithmeticOrLogicalExpr::ExprType::BITWISE_XOR;
+      case CompoundAssignmentOperator::BITWISE_XOR:
+	op = ArithmeticOrLogicalOperator::BITWISE_XOR;
 	break;
-      case AST::CompoundAssignmentExpr::ExprType::LEFT_SHIFT:
-	kind = HIR::ArithmeticOrLogicalExpr::ExprType::LEFT_SHIFT;
+      case CompoundAssignmentOperator::LEFT_SHIFT:
+	op = ArithmeticOrLogicalOperator::LEFT_SHIFT;
 	break;
-      case AST::CompoundAssignmentExpr::ExprType::RIGHT_SHIFT:
-	kind = HIR::ArithmeticOrLogicalExpr::ExprType::RIGHT_SHIFT;
+      case CompoundAssignmentOperator::RIGHT_SHIFT:
+	op = ArithmeticOrLogicalOperator::RIGHT_SHIFT;
 	break;
       }
 
@@ -609,7 +529,7 @@ public:
     HIR::Expr *operator_expr
       = new HIR::ArithmeticOrLogicalExpr (mapping, asignee_expr->clone_expr (),
 					  std::unique_ptr<HIR::Expr> (value),
-					  kind, expr.get_locus ());
+					  op, expr.get_locus ());
     translated
       = new HIR::AssignmentExpr (mapping,
 				 std::unique_ptr<HIR::Expr> (asignee_expr),

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -356,9 +356,10 @@ protected:
 // Unary prefix - or ! negation or NOT operators.
 class NegationExpr : public OperatorExpr
 {
-private:
+public:
   using ExprType = NegationOperator;
 
+private:
   /* Note: overload negation via std::ops::Neg and not via std::ops::Not
    * Negation only works for signed integer and floating-point types, NOT only
    * works for boolean and integer types (via bitwise NOT) */
@@ -401,9 +402,10 @@ protected:
 // Infix binary operators. +, -, *, /, %, &, |, ^, <<, >>
 class ArithmeticOrLogicalExpr : public OperatorExpr
 {
-private:
+public:
   using ExprType = ArithmeticOrLogicalOperator;
 
+private:
   // Note: overloading trait specified in comments
   ExprType expr_type;
 
@@ -474,9 +476,10 @@ protected:
 // Infix binary comparison operators. ==, !=, <, <=, >, >=
 class ComparisonExpr : public OperatorExpr
 {
-private:
+public:
   using ExprType = ComparisonOperator;
 
+private:
   // Note: overloading trait specified in comments
   ExprType expr_type;
 
@@ -548,9 +551,10 @@ protected:
 // Infix binary lazy boolean logical operators && and ||.
 class LazyBooleanExpr : public OperatorExpr
 {
-private:
+public:
   using ExprType = LazyBooleanOperator;
 
+private:
   ExprType expr_type;
 
   std::unique_ptr<Expr> right_expr;

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -21,6 +21,7 @@
 
 #include "rust-hir.h"
 #include "rust-hir-path.h"
+#include "operator.h"
 
 namespace Rust {
 namespace HIR {
@@ -355,30 +356,26 @@ protected:
 // Unary prefix - or ! negation or NOT operators.
 class NegationExpr : public OperatorExpr
 {
-public:
-  enum NegationType
-  {
-    NEGATE,
-    NOT
-  };
+private:
+  using ExprType = NegationOperator;
 
   /* Note: overload negation via std::ops::Neg and not via std::ops::Not
    * Negation only works for signed integer and floating-point types, NOT only
    * works for boolean and integer types (via bitwise NOT) */
-  NegationType negation_type;
+  ExprType expr_type;
 
 public:
   std::string as_string () const override;
 
-  NegationType get_negation_type () const { return negation_type; }
+  ExprType get_expr_type () const { return expr_type; }
 
   // Constructor calls OperatorExpr's protected constructor
   NegationExpr (Analysis::NodeMapping mappings,
-		std::unique_ptr<Expr> negated_value, NegationType negation_kind,
+		std::unique_ptr<Expr> negated_value, ExprType expr_kind,
 		std::vector<Attribute> outer_attribs, Location locus)
     : OperatorExpr (std::move (mappings), std::move (negated_value),
 		    std::move (outer_attribs), locus),
-      negation_type (negation_kind)
+      expr_type (expr_kind)
   {}
 
   void accept_vis (HIRVisitor &vis) override;
@@ -404,20 +401,8 @@ protected:
 // Infix binary operators. +, -, *, /, %, &, |, ^, <<, >>
 class ArithmeticOrLogicalExpr : public OperatorExpr
 {
-public:
-  enum ExprType
-  {
-    ADD,	 // std::ops::Add
-    SUBTRACT,	 // std::ops::Sub
-    MULTIPLY,	 // std::ops::Mul
-    DIVIDE,	 // std::ops::Div
-    MODULUS,	 // std::ops::Rem
-    BITWISE_AND, // std::ops::BitAnd
-    BITWISE_OR,	 // std::ops::BitOr
-    BITWISE_XOR, // std::ops::BitXor
-    LEFT_SHIFT,	 // std::ops::Shl
-    RIGHT_SHIFT	 // std::ops::Shr
-  };
+private:
+  using ExprType = ArithmeticOrLogicalOperator;
 
   // Note: overloading trait specified in comments
   ExprType expr_type;
@@ -489,16 +474,8 @@ protected:
 // Infix binary comparison operators. ==, !=, <, <=, >, >=
 class ComparisonExpr : public OperatorExpr
 {
-public:
-  enum ExprType
-  {
-    EQUAL,	      // std::cmp::PartialEq::eq
-    NOT_EQUAL,	      // std::cmp::PartialEq::ne
-    GREATER_THAN,     // std::cmp::PartialEq::gt
-    LESS_THAN,	      // std::cmp::PartialEq::lt
-    GREATER_OR_EQUAL, // std::cmp::PartialEq::ge
-    LESS_OR_EQUAL     // std::cmp::PartialEq::le
-  };
+private:
+  using ExprType = ComparisionOperator;
 
   // Note: overloading trait specified in comments
   ExprType expr_type;
@@ -571,12 +548,8 @@ protected:
 // Infix binary lazy boolean logical operators && and ||.
 class LazyBooleanExpr : public OperatorExpr
 {
-public:
-  enum ExprType
-  {
-    LOGICAL_OR,
-    LOGICAL_AND
-  };
+private:
+  using ExprType = LazyBooleanOperator;
 
   ExprType expr_type;
 

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -475,7 +475,7 @@ protected:
 class ComparisonExpr : public OperatorExpr
 {
 private:
-  using ExprType = ComparisionOperator;
+  using ExprType = ComparisonOperator;
 
   // Note: overloading trait specified in comments
   ExprType expr_type;

--- a/gcc/rust/hir/tree/rust-hir-full-test.cc
+++ b/gcc/rust/hir/tree/rust-hir-full-test.cc
@@ -1687,10 +1687,10 @@ NegationExpr::as_string () const
 
   switch (expr_type)
     {
-        case NegationOperator::NEGATE:
+    case NegationOperator::NEGATE:
       str = "-";
       break;
-        case NegationOperator::NOT:
+    case NegationOperator::NOT:
       str = "!";
       break;
     default:
@@ -1748,22 +1748,22 @@ ComparisonExpr::as_string () const
 
   switch (expr_type)
     {
-        case ComparisonOperator::EQUAL:
+    case ComparisonOperator::EQUAL:
       str += " == ";
       break;
-        case ComparisonOperator::NOT_EQUAL:
+    case ComparisonOperator::NOT_EQUAL:
       str += " != ";
       break;
-        case ComparisonOperator::GREATER_THAN:
+    case ComparisonOperator::GREATER_THAN:
       str += " > ";
       break;
-        case ComparisonOperator::LESS_THAN:
+    case ComparisonOperator::LESS_THAN:
       str += " < ";
       break;
-        case ComparisonOperator::GREATER_OR_EQUAL:
+    case ComparisonOperator::GREATER_OR_EQUAL:
       str += " >= ";
       break;
-        case ComparisonOperator::LESS_OR_EQUAL:
+    case ComparisonOperator::LESS_OR_EQUAL:
       str += " <= ";
       break;
     default:
@@ -1832,10 +1832,10 @@ LazyBooleanExpr::as_string () const
 
   switch (expr_type)
     {
-        case LazyBooleanOperator::LOGICAL_OR:
+    case LazyBooleanOperator::LOGICAL_OR:
       str += " || ";
       break;
-        case LazyBooleanOperator::LOGICAL_AND:
+    case LazyBooleanOperator::LOGICAL_AND:
       str += " && ";
       break;
     default:
@@ -2000,34 +2000,34 @@ ArithmeticOrLogicalExpr::as_string () const
   // get operator string
   switch (expr_type)
     {
-        case ArithmeticOrLogicalOperator::ADD:
+    case ArithmeticOrLogicalOperator::ADD:
       operator_str = "+";
       break;
-        case ArithmeticOrLogicalOperator::SUBTRACT:
+    case ArithmeticOrLogicalOperator::SUBTRACT:
       operator_str = "-";
       break;
-        case ArithmeticOrLogicalOperator::MULTIPLY:
+    case ArithmeticOrLogicalOperator::MULTIPLY:
       operator_str = "*";
       break;
-        case ArithmeticOrLogicalOperator::DIVIDE:
+    case ArithmeticOrLogicalOperator::DIVIDE:
       operator_str = "/";
       break;
-        case ArithmeticOrLogicalOperator::MODULUS:
+    case ArithmeticOrLogicalOperator::MODULUS:
       operator_str = "%";
       break;
-        case ArithmeticOrLogicalOperator::BITWISE_AND:
+    case ArithmeticOrLogicalOperator::BITWISE_AND:
       operator_str = "&";
       break;
-        case ArithmeticOrLogicalOperator::BITWISE_OR:
+    case ArithmeticOrLogicalOperator::BITWISE_OR:
       operator_str = "|";
       break;
-        case ArithmeticOrLogicalOperator::BITWISE_XOR:
+    case ArithmeticOrLogicalOperator::BITWISE_XOR:
       operator_str = "^";
       break;
-        case ArithmeticOrLogicalOperator::LEFT_SHIFT:
+    case ArithmeticOrLogicalOperator::LEFT_SHIFT:
       operator_str = "<<";
       break;
-        case ArithmeticOrLogicalOperator::RIGHT_SHIFT:
+    case ArithmeticOrLogicalOperator::RIGHT_SHIFT:
       operator_str = ">>";
       break;
     default:

--- a/gcc/rust/hir/tree/rust-hir-full-test.cc
+++ b/gcc/rust/hir/tree/rust-hir-full-test.cc
@@ -1685,12 +1685,12 @@ NegationExpr::as_string () const
 {
   std::string str;
 
-  switch (negation_type)
+  switch (expr_type)
     {
-    case NEGATE:
+        case NegationOperator::NEGATE:
       str = "-";
       break;
-    case NOT:
+        case NegationOperator::NOT:
       str = "!";
       break;
     default:
@@ -1748,22 +1748,22 @@ ComparisonExpr::as_string () const
 
   switch (expr_type)
     {
-    case EQUAL:
+        case ComparisonOperator::EQUAL:
       str += " == ";
       break;
-    case NOT_EQUAL:
+        case ComparisonOperator::NOT_EQUAL:
       str += " != ";
       break;
-    case GREATER_THAN:
+        case ComparisonOperator::GREATER_THAN:
       str += " > ";
       break;
-    case LESS_THAN:
+        case ComparisonOperator::LESS_THAN:
       str += " < ";
       break;
-    case GREATER_OR_EQUAL:
+        case ComparisonOperator::GREATER_OR_EQUAL:
       str += " >= ";
       break;
-    case LESS_OR_EQUAL:
+        case ComparisonOperator::LESS_OR_EQUAL:
       str += " <= ";
       break;
     default:
@@ -1832,10 +1832,10 @@ LazyBooleanExpr::as_string () const
 
   switch (expr_type)
     {
-    case LOGICAL_OR:
+        case LazyBooleanOperator::LOGICAL_OR:
       str += " || ";
       break;
-    case LOGICAL_AND:
+        case LazyBooleanOperator::LOGICAL_AND:
       str += " && ";
       break;
     default:
@@ -2000,34 +2000,34 @@ ArithmeticOrLogicalExpr::as_string () const
   // get operator string
   switch (expr_type)
     {
-    case ADD:
+        case ArithmeticOrLogicalOperator::ADD:
       operator_str = "+";
       break;
-    case SUBTRACT:
+        case ArithmeticOrLogicalOperator::SUBTRACT:
       operator_str = "-";
       break;
-    case MULTIPLY:
+        case ArithmeticOrLogicalOperator::MULTIPLY:
       operator_str = "*";
       break;
-    case DIVIDE:
+        case ArithmeticOrLogicalOperator::DIVIDE:
       operator_str = "/";
       break;
-    case MODULUS:
+        case ArithmeticOrLogicalOperator::MODULUS:
       operator_str = "%";
       break;
-    case BITWISE_AND:
+        case ArithmeticOrLogicalOperator::BITWISE_AND:
       operator_str = "&";
       break;
-    case BITWISE_OR:
+        case ArithmeticOrLogicalOperator::BITWISE_OR:
       operator_str = "|";
       break;
-    case BITWISE_XOR:
+        case ArithmeticOrLogicalOperator::BITWISE_XOR:
       operator_str = "^";
       break;
-    case LEFT_SHIFT:
+        case ArithmeticOrLogicalOperator::LEFT_SHIFT:
       operator_str = "<<";
       break;
-    case RIGHT_SHIFT:
+        case ArithmeticOrLogicalOperator::RIGHT_SHIFT:
       operator_str = ">>";
       break;
     default:

--- a/gcc/rust/operator.h
+++ b/gcc/rust/operator.h
@@ -1,8 +1,6 @@
 #ifndef OPERATOR_H
 #define OPERATOR_H
 
-enum Operator {};
-
 enum class NegationOperator
 {
   NEGATE,

--- a/gcc/rust/operator.h
+++ b/gcc/rust/operator.h
@@ -23,7 +23,7 @@ enum class ArithmeticOrLogicalOperator
   RIGHT_SHIFT  // std::ops::Shr
 };
 
-enum class ComparisionOperator
+enum class ComparisonOperator
 {
   EQUAL,	    // std::cmp::PartialEq::eq
   NOT_EQUAL,	    // std::cmp::PartialEq::ne

--- a/gcc/rust/operator.h
+++ b/gcc/rust/operator.h
@@ -1,69 +1,56 @@
-// operator.h -- Go frontend operators.     -*- C++ -*-
+#ifndef OPERATOR_H
+#define OPERATOR_H
 
-// Copyright 2009 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+enum Operator {};
 
-#ifndef GO_OPERATOR_H
-#define GO_OPERATOR_H
-
-// The operators.
-
-// TODO: Will have to be significantly modified to work with Rust and current
-// setup of gccrs
-
-enum Operator
+enum class NegationOperator
 {
-  OPERATOR_INVALID,
-  OPERATOR_OROR,     // ||
-  OPERATOR_ANDAND,   // &&
-  OPERATOR_EQEQ,     // ==
-  OPERATOR_NOTEQ,    // !=
-  OPERATOR_LT,	     // <
-  OPERATOR_LE,	     // <=
-  OPERATOR_GT,	     // >
-  OPERATOR_GE,	     // >=
-  OPERATOR_PLUS,     // +
-  OPERATOR_MINUS,    // -
-  OPERATOR_OR,	     // |
-  OPERATOR_XOR,	     // ^
-  OPERATOR_MULT,     // *
-  OPERATOR_DIV,	     // /
-  OPERATOR_MOD,	     // %
-  OPERATOR_LSHIFT,   // <<
-  OPERATOR_RSHIFT,   // >>
-  OPERATOR_AND,	     // &
-  OPERATOR_NOT,	     // !
-  OPERATOR_BITCLEAR, // &^
-  OPERATOR_CHANOP,   // <-
-
-  OPERATOR_EQ,	       // =
-  OPERATOR_PLUSEQ,     // +=
-  OPERATOR_MINUSEQ,    // -=
-  OPERATOR_OREQ,       // |=
-  OPERATOR_XOREQ,      // ^=
-  OPERATOR_MULTEQ,     // *=
-  OPERATOR_DIVEQ,      // /=
-  OPERATOR_MODEQ,      // %=
-  OPERATOR_LSHIFTEQ,   // <<=
-  OPERATOR_RSHIFTEQ,   // >>=
-  OPERATOR_ANDEQ,      // &=
-  OPERATOR_BITCLEAREQ, // &^=
-  OPERATOR_PLUSPLUS,   // ++
-  OPERATOR_MINUSMINUS, // --
-
-  OPERATOR_COLON,     // :
-  OPERATOR_COLONEQ,   // :=
-  OPERATOR_SEMICOLON, // ;
-  OPERATOR_DOT,	      // .
-  OPERATOR_ELLIPSIS,  // ...
-  OPERATOR_COMMA,     // ,
-  OPERATOR_LPAREN,    // (
-  OPERATOR_RPAREN,    // )
-  OPERATOR_LCURLY,    // {
-  OPERATOR_RCURLY,    // }
-  OPERATOR_LSQUARE,   // [
-  OPERATOR_RSQUARE    // ]
+  NEGATE,
+  NOT
 };
 
-#endif // !defined(GO_OPERATOR_H)
+enum class ArithmeticOrLogicalOperator
+{
+  ADD,	       // std::ops::Add
+  SUBTRACT,    // std::ops::Sub
+  MULTIPLY,    // std::ops::Mul
+  DIVIDE,      // std::ops::Div
+  MODULUS,     // std::ops::Rem
+  BITWISE_AND, // std::ops::BitAnd
+  BITWISE_OR,  // std::ops::BitOr
+  BITWISE_XOR, // std::ops::BitXor
+  LEFT_SHIFT,  // std::ops::Shl
+  RIGHT_SHIFT  // std::ops::Shr
+};
+
+enum class ComparisionOperator
+{
+  EQUAL,	    // std::cmp::PartialEq::eq
+  NOT_EQUAL,	    // std::cmp::PartialEq::ne
+  GREATER_THAN,	    // std::cmp::PartialEq::gt
+  LESS_THAN,	    // std::cmp::PartialEq::lt
+  GREATER_OR_EQUAL, // std::cmp::PartialEq::ge
+  LESS_OR_EQUAL	    // std::cmp::PartialEq::le
+};
+
+enum class LazyBooleanOperator
+{
+  LOGICAL_OR,
+  LOGICAL_AND
+};
+
+enum class CompoundAssignmentOperator
+{
+  ADD,	       // std::ops::AddAssign
+  SUBTRACT,    // std::ops::SubAssign
+  MULTIPLY,    // std::ops::MulAssign
+  DIVIDE,      // std::ops::DivAssign
+  MODULUS,     // std::ops::RemAssign
+  BITWISE_AND, // std::ops::BitAndAssign
+  BITWISE_OR,  // std::ops::BitOrAssign
+  BITWISE_XOR, // std::ops::BitXorAssign
+  LEFT_SHIFT,  // std::ops::ShlAssign
+  RIGHT_SHIFT  // std::ops::ShrAssign
+};
+
+#endif

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -12516,9 +12516,10 @@ Parser<ManagedTokenSource>::left_denotation (
       // sum expression - binary infix
       /*return parse_binary_plus_expr (tok, std::move (left),
 				     std::move (outer_attrs), restrictions);*/
-      return parse_arithmetic_or_logical_expr (
-	tok, std::move (left), std::move (outer_attrs),
-	ArithmeticOrLogicalOperator::ADD, restrictions);
+      return parse_arithmetic_or_logical_expr (tok, std::move (left),
+					       std::move (outer_attrs),
+					       ArithmeticOrLogicalOperator::ADD,
+					       restrictions);
     case MINUS:
       // difference expression - binary infix
       /*return parse_binary_minus_expr (tok, std::move (left),
@@ -12588,8 +12589,7 @@ Parser<ManagedTokenSource>::left_denotation (
 				      std::move (outer_attrs), restrictions);*/
       return parse_comparison_expr (tok, std::move (left),
 				    std::move (outer_attrs),
-				    ComparisonOperator::EQUAL,
-				    restrictions);
+				    ComparisonOperator::EQUAL, restrictions);
     case NOT_EQUAL:
       // not equal to expression - binary infix (no associativity)
       /*return parse_binary_not_equal_expr (tok, std::move (left),
@@ -12622,17 +12622,19 @@ Parser<ManagedTokenSource>::left_denotation (
       /*return parse_binary_greater_equal_expr (tok, std::move (left),
 					      std::move (outer_attrs),
 					      restrictions);*/
-      return parse_comparison_expr (
-	tok, std::move (left), std::move (outer_attrs),
-	ComparisonOperator::GREATER_OR_EQUAL, restrictions);
+      return parse_comparison_expr (tok, std::move (left),
+				    std::move (outer_attrs),
+				    ComparisonOperator::GREATER_OR_EQUAL,
+				    restrictions);
     case LESS_OR_EQUAL:
       // less than or equal to expression - binary infix (no associativity)
       /*return parse_binary_less_equal_expr (tok, std::move (left),
 					   std::move (outer_attrs),
 					   restrictions);*/
-      return parse_comparison_expr (
-	tok, std::move (left), std::move (outer_attrs),
-	ComparisonOperator::LESS_OR_EQUAL, restrictions);
+      return parse_comparison_expr (tok, std::move (left),
+				    std::move (outer_attrs),
+				    ComparisonOperator::LESS_OR_EQUAL,
+				    restrictions);
     case OR:
       // lazy logical or expression - binary infix
       return parse_lazy_or_expr (tok, std::move (left), std::move (outer_attrs),
@@ -12680,9 +12682,10 @@ Parser<ManagedTokenSource>::left_denotation (
        * associativity) */
       /*return parse_div_assig_expr (tok, std::move (left),
 				   std::move (outer_attrs), restrictions);*/
-      return parse_compound_assignment_expr (
-	tok, std::move (left), std::move (outer_attrs),
-	CompoundAssignmentOperator::DIVIDE, restrictions);
+      return parse_compound_assignment_expr (tok, std::move (left),
+					     std::move (outer_attrs),
+					     CompoundAssignmentOperator::DIVIDE,
+					     restrictions);
     case PERCENT_EQ:
       /* modulo-assignment expression - binary infix (note right-to-left
        * associativity) */
@@ -12889,8 +12892,7 @@ Parser<ManagedTokenSource>::parse_binary_plus_expr (
 
   return std::unique_ptr<AST::ArithmeticOrLogicalExpr> (
     new AST::ArithmeticOrLogicalExpr (std::move (left), std::move (right),
-				      ArithmeticOrLogicalOperator::ADD,
-				      locus));
+				      ArithmeticOrLogicalOperator::ADD, locus));
 }
 
 // Parses a binary subtraction expression (with Pratt parsing).

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -12259,7 +12259,7 @@ Parser<ManagedTokenSource>::null_denotation (
 	/* FIXME: allow outer attributes on these expressions by having an outer
 	 * attrs parameter in function*/
 	return std::unique_ptr<AST::NegationExpr> (
-	  new AST::NegationExpr (std::move (expr), AST::NegationExpr::NEGATE,
+	  new AST::NegationExpr (std::move (expr), NegationOperator::NEGATE,
 				 std::move (outer_attrs), tok->get_locus ()));
       }
       case EXCLAM: { // logical or bitwise not
@@ -12282,7 +12282,7 @@ Parser<ManagedTokenSource>::null_denotation (
 
 	// FIXME: allow outer attributes on these expressions
 	return std::unique_ptr<AST::NegationExpr> (
-	  new AST::NegationExpr (std::move (expr), AST::NegationExpr::NOT,
+	  new AST::NegationExpr (std::move (expr), NegationOperator::NOT,
 				 std::move (outer_attrs), tok->get_locus ()));
       }
       case ASTERISK: {
@@ -12518,77 +12518,77 @@ Parser<ManagedTokenSource>::left_denotation (
 				     std::move (outer_attrs), restrictions);*/
       return parse_arithmetic_or_logical_expr (
 	tok, std::move (left), std::move (outer_attrs),
-	AST::ArithmeticOrLogicalExpr::ADD, restrictions);
+	ArithmeticOrLogicalOperator::ADD, restrictions);
     case MINUS:
       // difference expression - binary infix
       /*return parse_binary_minus_expr (tok, std::move (left),
 				      std::move (outer_attrs), restrictions);*/
       return parse_arithmetic_or_logical_expr (
 	tok, std::move (left), std::move (outer_attrs),
-	AST::ArithmeticOrLogicalExpr::SUBTRACT, restrictions);
+	ArithmeticOrLogicalOperator::SUBTRACT, restrictions);
     case ASTERISK:
       // product expression - binary infix
       /*return parse_binary_mult_expr (tok, std::move (left),
 				     std::move (outer_attrs), restrictions);*/
       return parse_arithmetic_or_logical_expr (
 	tok, std::move (left), std::move (outer_attrs),
-	AST::ArithmeticOrLogicalExpr::MULTIPLY, restrictions);
+	ArithmeticOrLogicalOperator::MULTIPLY, restrictions);
     case DIV:
       // quotient expression - binary infix
       /*return parse_binary_div_expr (tok, std::move (left),
 				    std::move (outer_attrs), restrictions);*/
       return parse_arithmetic_or_logical_expr (
 	tok, std::move (left), std::move (outer_attrs),
-	AST::ArithmeticOrLogicalExpr::DIVIDE, restrictions);
+	ArithmeticOrLogicalOperator::DIVIDE, restrictions);
     case PERCENT:
       // modulo expression - binary infix
       /*return parse_binary_mod_expr (tok, std::move (left),
 				    std::move (outer_attrs), restrictions);*/
       return parse_arithmetic_or_logical_expr (
 	tok, std::move (left), std::move (outer_attrs),
-	AST::ArithmeticOrLogicalExpr::MODULUS, restrictions);
+	ArithmeticOrLogicalOperator::MODULUS, restrictions);
     case AMP:
       // logical or bitwise and expression - binary infix
       /*return parse_bitwise_and_expr (tok, std::move (left),
 				     std::move (outer_attrs), restrictions);*/
       return parse_arithmetic_or_logical_expr (
 	tok, std::move (left), std::move (outer_attrs),
-	AST::ArithmeticOrLogicalExpr::BITWISE_AND, restrictions);
+	ArithmeticOrLogicalOperator::BITWISE_AND, restrictions);
     case PIPE:
       // logical or bitwise or expression - binary infix
       /*return parse_bitwise_or_expr (tok, std::move (left),
 				    std::move (outer_attrs), restrictions);*/
       return parse_arithmetic_or_logical_expr (
 	tok, std::move (left), std::move (outer_attrs),
-	AST::ArithmeticOrLogicalExpr::BITWISE_OR, restrictions);
+	ArithmeticOrLogicalOperator::BITWISE_OR, restrictions);
     case CARET:
       // logical or bitwise xor expression - binary infix
       /*return parse_bitwise_xor_expr (tok, std::move (left),
 				     std::move (outer_attrs), restrictions);*/
       return parse_arithmetic_or_logical_expr (
 	tok, std::move (left), std::move (outer_attrs),
-	AST::ArithmeticOrLogicalExpr::BITWISE_XOR, restrictions);
+	ArithmeticOrLogicalOperator::BITWISE_XOR, restrictions);
     case LEFT_SHIFT:
       // left shift expression - binary infix
       /*return parse_left_shift_expr (tok, std::move (left),
 				    std::move (outer_attrs), restrictions);*/
       return parse_arithmetic_or_logical_expr (
 	tok, std::move (left), std::move (outer_attrs),
-	AST::ArithmeticOrLogicalExpr::LEFT_SHIFT, restrictions);
+	ArithmeticOrLogicalOperator::LEFT_SHIFT, restrictions);
     case RIGHT_SHIFT:
       // right shift expression - binary infix
       /*return parse_right_shift_expr (tok, std::move (left),
 				     std::move (outer_attrs), restrictions);*/
       return parse_arithmetic_or_logical_expr (
 	tok, std::move (left), std::move (outer_attrs),
-	AST::ArithmeticOrLogicalExpr::RIGHT_SHIFT, restrictions);
+	ArithmeticOrLogicalOperator::RIGHT_SHIFT, restrictions);
     case EQUAL_EQUAL:
       // equal to expression - binary infix (no associativity)
       /*return parse_binary_equal_expr (tok, std::move (left),
 				      std::move (outer_attrs), restrictions);*/
       return parse_comparison_expr (tok, std::move (left),
 				    std::move (outer_attrs),
-				    AST::ComparisonExpr::ExprType::EQUAL,
+				    ComparisonOperator::EQUAL,
 				    restrictions);
     case NOT_EQUAL:
       // not equal to expression - binary infix (no associativity)
@@ -12597,7 +12597,7 @@ Parser<ManagedTokenSource>::left_denotation (
 					  restrictions);*/
       return parse_comparison_expr (tok, std::move (left),
 				    std::move (outer_attrs),
-				    AST::ComparisonExpr::ExprType::NOT_EQUAL,
+				    ComparisonOperator::NOT_EQUAL,
 				    restrictions);
     case RIGHT_ANGLE:
       // greater than expression - binary infix (no associativity)
@@ -12606,7 +12606,7 @@ Parser<ManagedTokenSource>::left_denotation (
 					     restrictions);*/
       return parse_comparison_expr (tok, std::move (left),
 				    std::move (outer_attrs),
-				    AST::ComparisonExpr::ExprType::GREATER_THAN,
+				    ComparisonOperator::GREATER_THAN,
 				    restrictions);
     case LEFT_ANGLE:
       // less than expression - binary infix (no associativity)
@@ -12615,7 +12615,7 @@ Parser<ManagedTokenSource>::left_denotation (
 					  restrictions);*/
       return parse_comparison_expr (tok, std::move (left),
 				    std::move (outer_attrs),
-				    AST::ComparisonExpr::ExprType::LESS_THAN,
+				    ComparisonOperator::LESS_THAN,
 				    restrictions);
     case GREATER_OR_EQUAL:
       // greater than or equal to expression - binary infix (no associativity)
@@ -12624,7 +12624,7 @@ Parser<ManagedTokenSource>::left_denotation (
 					      restrictions);*/
       return parse_comparison_expr (
 	tok, std::move (left), std::move (outer_attrs),
-	AST::ComparisonExpr::ExprType::GREATER_OR_EQUAL, restrictions);
+	ComparisonOperator::GREATER_OR_EQUAL, restrictions);
     case LESS_OR_EQUAL:
       // less than or equal to expression - binary infix (no associativity)
       /*return parse_binary_less_equal_expr (tok, std::move (left),
@@ -12632,7 +12632,7 @@ Parser<ManagedTokenSource>::left_denotation (
 					   restrictions);*/
       return parse_comparison_expr (
 	tok, std::move (left), std::move (outer_attrs),
-	AST::ComparisonExpr::ExprType::LESS_OR_EQUAL, restrictions);
+	ComparisonOperator::LESS_OR_EQUAL, restrictions);
     case OR:
       // lazy logical or expression - binary infix
       return parse_lazy_or_expr (tok, std::move (left), std::move (outer_attrs),
@@ -12657,7 +12657,7 @@ Parser<ManagedTokenSource>::left_denotation (
 				    std::move (outer_attrs), restrictions);*/
       return parse_compound_assignment_expr (tok, std::move (left),
 					     std::move (outer_attrs),
-					     AST::CompoundAssignmentExpr::ADD,
+					     CompoundAssignmentOperator::ADD,
 					     restrictions);
     case MINUS_EQ:
       /* minus-assignment expression - binary infix (note right-to-left
@@ -12666,7 +12666,7 @@ Parser<ManagedTokenSource>::left_denotation (
 				     std::move (outer_attrs), restrictions);*/
       return parse_compound_assignment_expr (
 	tok, std::move (left), std::move (outer_attrs),
-	AST::CompoundAssignmentExpr::SUBTRACT, restrictions);
+	CompoundAssignmentOperator::SUBTRACT, restrictions);
     case ASTERISK_EQ:
       /* multiply-assignment expression - binary infix (note right-to-left
        * associativity) */
@@ -12674,7 +12674,7 @@ Parser<ManagedTokenSource>::left_denotation (
 				    std::move (outer_attrs), restrictions);*/
       return parse_compound_assignment_expr (
 	tok, std::move (left), std::move (outer_attrs),
-	AST::CompoundAssignmentExpr::MULTIPLY, restrictions);
+	CompoundAssignmentOperator::MULTIPLY, restrictions);
     case DIV_EQ:
       /* division-assignment expression - binary infix (note right-to-left
        * associativity) */
@@ -12682,7 +12682,7 @@ Parser<ManagedTokenSource>::left_denotation (
 				   std::move (outer_attrs), restrictions);*/
       return parse_compound_assignment_expr (
 	tok, std::move (left), std::move (outer_attrs),
-	AST::CompoundAssignmentExpr::DIVIDE, restrictions);
+	CompoundAssignmentOperator::DIVIDE, restrictions);
     case PERCENT_EQ:
       /* modulo-assignment expression - binary infix (note right-to-left
        * associativity) */
@@ -12690,7 +12690,7 @@ Parser<ManagedTokenSource>::left_denotation (
 				   std::move (outer_attrs), restrictions);*/
       return parse_compound_assignment_expr (
 	tok, std::move (left), std::move (outer_attrs),
-	AST::CompoundAssignmentExpr::MODULUS, restrictions);
+	CompoundAssignmentOperator::MODULUS, restrictions);
     case AMP_EQ:
       /* bitwise and-assignment expression - binary infix (note right-to-left
        * associativity) */
@@ -12698,7 +12698,7 @@ Parser<ManagedTokenSource>::left_denotation (
 				   std::move (outer_attrs), restrictions);*/
       return parse_compound_assignment_expr (
 	tok, std::move (left), std::move (outer_attrs),
-	AST::CompoundAssignmentExpr::BITWISE_AND, restrictions);
+	CompoundAssignmentOperator::BITWISE_AND, restrictions);
     case PIPE_EQ:
       /* bitwise or-assignment expression - binary infix (note right-to-left
        * associativity) */
@@ -12706,7 +12706,7 @@ Parser<ManagedTokenSource>::left_denotation (
 				  std::move (outer_attrs), restrictions);*/
       return parse_compound_assignment_expr (
 	tok, std::move (left), std::move (outer_attrs),
-	AST::CompoundAssignmentExpr::BITWISE_OR, restrictions);
+	CompoundAssignmentOperator::BITWISE_OR, restrictions);
     case CARET_EQ:
       /* bitwise xor-assignment expression - binary infix (note right-to-left
        * associativity) */
@@ -12714,7 +12714,7 @@ Parser<ManagedTokenSource>::left_denotation (
 				   std::move (outer_attrs), restrictions);*/
       return parse_compound_assignment_expr (
 	tok, std::move (left), std::move (outer_attrs),
-	AST::CompoundAssignmentExpr::BITWISE_XOR, restrictions);
+	CompoundAssignmentOperator::BITWISE_XOR, restrictions);
     case LEFT_SHIFT_EQ:
       /* left shift-assignment expression - binary infix (note right-to-left
        * associativity) */
@@ -12723,7 +12723,7 @@ Parser<ManagedTokenSource>::left_denotation (
 					  restrictions);*/
       return parse_compound_assignment_expr (
 	tok, std::move (left), std::move (outer_attrs),
-	AST::CompoundAssignmentExpr::LEFT_SHIFT, restrictions);
+	CompoundAssignmentOperator::LEFT_SHIFT, restrictions);
     case RIGHT_SHIFT_EQ:
       /* right shift-assignment expression - binary infix (note right-to-left
        * associativity) */
@@ -12732,7 +12732,7 @@ Parser<ManagedTokenSource>::left_denotation (
 					   restrictions);*/
       return parse_compound_assignment_expr (
 	tok, std::move (left), std::move (outer_attrs),
-	AST::CompoundAssignmentExpr::RIGHT_SHIFT, restrictions);
+	CompoundAssignmentOperator::RIGHT_SHIFT, restrictions);
     case DOT_DOT:
       /* range exclusive expression - binary infix (no associativity)
        * either "range" or "range from" */
@@ -12818,25 +12818,25 @@ get_lbp_for_arithmetic_or_logical_expr (
 {
   switch (expr_type)
     {
-    case AST::ArithmeticOrLogicalExpr::ADD:
+    case ArithmeticOrLogicalOperator::ADD:
       return LBP_PLUS;
-    case AST::ArithmeticOrLogicalExpr::SUBTRACT:
+    case ArithmeticOrLogicalOperator::SUBTRACT:
       return LBP_MINUS;
-    case AST::ArithmeticOrLogicalExpr::MULTIPLY:
+    case ArithmeticOrLogicalOperator::MULTIPLY:
       return LBP_MUL;
-    case AST::ArithmeticOrLogicalExpr::DIVIDE:
+    case ArithmeticOrLogicalOperator::DIVIDE:
       return LBP_DIV;
-    case AST::ArithmeticOrLogicalExpr::MODULUS:
+    case ArithmeticOrLogicalOperator::MODULUS:
       return LBP_MOD;
-    case AST::ArithmeticOrLogicalExpr::BITWISE_AND:
+    case ArithmeticOrLogicalOperator::BITWISE_AND:
       return LBP_AMP;
-    case AST::ArithmeticOrLogicalExpr::BITWISE_OR:
+    case ArithmeticOrLogicalOperator::BITWISE_OR:
       return LBP_PIPE;
-    case AST::ArithmeticOrLogicalExpr::BITWISE_XOR:
+    case ArithmeticOrLogicalOperator::BITWISE_XOR:
       return LBP_CARET;
-    case AST::ArithmeticOrLogicalExpr::LEFT_SHIFT:
+    case ArithmeticOrLogicalOperator::LEFT_SHIFT:
       return LBP_L_SHIFT;
-    case AST::ArithmeticOrLogicalExpr::RIGHT_SHIFT:
+    case ArithmeticOrLogicalOperator::RIGHT_SHIFT:
       return LBP_R_SHIFT;
     default:
       // WTF? should not happen, this is an error
@@ -12889,7 +12889,7 @@ Parser<ManagedTokenSource>::parse_binary_plus_expr (
 
   return std::unique_ptr<AST::ArithmeticOrLogicalExpr> (
     new AST::ArithmeticOrLogicalExpr (std::move (left), std::move (right),
-				      AST::ArithmeticOrLogicalExpr::ADD,
+				      ArithmeticOrLogicalOperator::ADD,
 				      locus));
 }
 
@@ -12912,7 +12912,7 @@ Parser<ManagedTokenSource>::parse_binary_minus_expr (
 
   return std::unique_ptr<AST::ArithmeticOrLogicalExpr> (
     new AST::ArithmeticOrLogicalExpr (std::move (left), std::move (right),
-				      AST::ArithmeticOrLogicalExpr::SUBTRACT,
+				      ArithmeticOrLogicalOperator::SUBTRACT,
 				      locus));
 }
 
@@ -12935,7 +12935,7 @@ Parser<ManagedTokenSource>::parse_binary_mult_expr (
 
   return std::unique_ptr<AST::ArithmeticOrLogicalExpr> (
     new AST::ArithmeticOrLogicalExpr (std::move (left), std::move (right),
-				      AST::ArithmeticOrLogicalExpr::MULTIPLY,
+				      ArithmeticOrLogicalOperator::MULTIPLY,
 				      locus));
 }
 
@@ -12958,7 +12958,7 @@ Parser<ManagedTokenSource>::parse_binary_div_expr (
 
   return std::unique_ptr<AST::ArithmeticOrLogicalExpr> (
     new AST::ArithmeticOrLogicalExpr (std::move (left), std::move (right),
-				      AST::ArithmeticOrLogicalExpr::DIVIDE,
+				      ArithmeticOrLogicalOperator::DIVIDE,
 				      locus));
 }
 
@@ -12981,7 +12981,7 @@ Parser<ManagedTokenSource>::parse_binary_mod_expr (
 
   return std::unique_ptr<AST::ArithmeticOrLogicalExpr> (
     new AST::ArithmeticOrLogicalExpr (std::move (left), std::move (right),
-				      AST::ArithmeticOrLogicalExpr::MODULUS,
+				      ArithmeticOrLogicalOperator::MODULUS,
 				      locus));
 }
 
@@ -13005,7 +13005,7 @@ Parser<ManagedTokenSource>::parse_bitwise_and_expr (
 
   return std::unique_ptr<AST::ArithmeticOrLogicalExpr> (
     new AST::ArithmeticOrLogicalExpr (std::move (left), std::move (right),
-				      AST::ArithmeticOrLogicalExpr::BITWISE_AND,
+				      ArithmeticOrLogicalOperator::BITWISE_AND,
 				      locus));
 }
 
@@ -13029,7 +13029,7 @@ Parser<ManagedTokenSource>::parse_bitwise_or_expr (
 
   return std::unique_ptr<AST::ArithmeticOrLogicalExpr> (
     new AST::ArithmeticOrLogicalExpr (std::move (left), std::move (right),
-				      AST::ArithmeticOrLogicalExpr::BITWISE_OR,
+				      ArithmeticOrLogicalOperator::BITWISE_OR,
 				      locus));
 }
 
@@ -13053,7 +13053,7 @@ Parser<ManagedTokenSource>::parse_bitwise_xor_expr (
 
   return std::unique_ptr<AST::ArithmeticOrLogicalExpr> (
     new AST::ArithmeticOrLogicalExpr (std::move (left), std::move (right),
-				      AST::ArithmeticOrLogicalExpr::BITWISE_XOR,
+				      ArithmeticOrLogicalOperator::BITWISE_XOR,
 				      locus));
 }
 
@@ -13076,7 +13076,7 @@ Parser<ManagedTokenSource>::parse_left_shift_expr (
 
   return std::unique_ptr<AST::ArithmeticOrLogicalExpr> (
     new AST::ArithmeticOrLogicalExpr (std::move (left), std::move (right),
-				      AST::ArithmeticOrLogicalExpr::LEFT_SHIFT,
+				      ArithmeticOrLogicalOperator::LEFT_SHIFT,
 				      locus));
 }
 
@@ -13099,7 +13099,7 @@ Parser<ManagedTokenSource>::parse_right_shift_expr (
 
   return std::unique_ptr<AST::ArithmeticOrLogicalExpr> (
     new AST::ArithmeticOrLogicalExpr (std::move (left), std::move (right),
-				      AST::ArithmeticOrLogicalExpr::RIGHT_SHIFT,
+				      ArithmeticOrLogicalOperator::RIGHT_SHIFT,
 				      locus));
 }
 
@@ -13110,17 +13110,17 @@ get_lbp_for_comparison_expr (AST::ComparisonExpr::ExprType expr_type)
 {
   switch (expr_type)
     {
-    case AST::ComparisonExpr::EQUAL:
+    case ComparisonOperator::EQUAL:
       return LBP_EQUAL;
-    case AST::ComparisonExpr::NOT_EQUAL:
+    case ComparisonOperator::NOT_EQUAL:
       return LBP_NOT_EQUAL;
-    case AST::ComparisonExpr::GREATER_THAN:
+    case ComparisonOperator::GREATER_THAN:
       return LBP_GREATER_THAN;
-    case AST::ComparisonExpr::LESS_THAN:
+    case ComparisonOperator::LESS_THAN:
       return LBP_SMALLER_THAN;
-    case AST::ComparisonExpr::GREATER_OR_EQUAL:
+    case ComparisonOperator::GREATER_OR_EQUAL:
       return LBP_GREATER_EQUAL;
-    case AST::ComparisonExpr::LESS_OR_EQUAL:
+    case ComparisonOperator::LESS_OR_EQUAL:
       return LBP_SMALLER_EQUAL;
     default:
       // WTF? should not happen, this is an error
@@ -13173,7 +13173,7 @@ Parser<ManagedTokenSource>::parse_binary_equal_expr (
 
   return std::unique_ptr<AST::ComparisonExpr> (
     new AST::ComparisonExpr (std::move (left), std::move (right),
-			     AST::ComparisonExpr::EQUAL, locus));
+			     ComparisonOperator::EQUAL, locus));
 }
 
 // Parses a binary not equal to expression (with Pratt parsing).
@@ -13195,7 +13195,7 @@ Parser<ManagedTokenSource>::parse_binary_not_equal_expr (
 
   return std::unique_ptr<AST::ComparisonExpr> (
     new AST::ComparisonExpr (std::move (left), std::move (right),
-			     AST::ComparisonExpr::NOT_EQUAL, locus));
+			     ComparisonOperator::NOT_EQUAL, locus));
 }
 
 // Parses a binary greater than expression (with Pratt parsing).
@@ -13218,7 +13218,7 @@ Parser<ManagedTokenSource>::parse_binary_greater_than_expr (
 
   return std::unique_ptr<AST::ComparisonExpr> (
     new AST::ComparisonExpr (std::move (left), std::move (right),
-			     AST::ComparisonExpr::GREATER_THAN, locus));
+			     ComparisonOperator::GREATER_THAN, locus));
 }
 
 // Parses a binary less than expression (with Pratt parsing).
@@ -13241,7 +13241,7 @@ Parser<ManagedTokenSource>::parse_binary_less_than_expr (
 
   return std::unique_ptr<AST::ComparisonExpr> (
     new AST::ComparisonExpr (std::move (left), std::move (right),
-			     AST::ComparisonExpr::LESS_THAN, locus));
+			     ComparisonOperator::LESS_THAN, locus));
 }
 
 // Parses a binary greater than or equal to expression (with Pratt parsing).
@@ -13264,7 +13264,7 @@ Parser<ManagedTokenSource>::parse_binary_greater_equal_expr (
 
   return std::unique_ptr<AST::ComparisonExpr> (
     new AST::ComparisonExpr (std::move (left), std::move (right),
-			     AST::ComparisonExpr::GREATER_OR_EQUAL, locus));
+			     ComparisonOperator::GREATER_OR_EQUAL, locus));
 }
 
 // Parses a binary less than or equal to expression (with Pratt parsing).
@@ -13287,7 +13287,7 @@ Parser<ManagedTokenSource>::parse_binary_less_equal_expr (
 
   return std::unique_ptr<AST::ComparisonExpr> (
     new AST::ComparisonExpr (std::move (left), std::move (right),
-			     AST::ComparisonExpr::LESS_OR_EQUAL, locus));
+			     ComparisonOperator::LESS_OR_EQUAL, locus));
 }
 
 // Parses a binary lazy boolean or expression (with Pratt parsing).
@@ -13309,7 +13309,7 @@ Parser<ManagedTokenSource>::parse_lazy_or_expr (
 
   return std::unique_ptr<AST::LazyBooleanExpr> (
     new AST::LazyBooleanExpr (std::move (left), std::move (right),
-			      AST::LazyBooleanExpr::LOGICAL_OR, locus));
+			      LazyBooleanOperator::LOGICAL_OR, locus));
 }
 
 // Parses a binary lazy boolean and expression (with Pratt parsing).
@@ -13332,7 +13332,7 @@ Parser<ManagedTokenSource>::parse_lazy_and_expr (
 
   return std::unique_ptr<AST::LazyBooleanExpr> (
     new AST::LazyBooleanExpr (std::move (left), std::move (right),
-			      AST::LazyBooleanExpr::LOGICAL_AND, locus));
+			      LazyBooleanOperator::LOGICAL_AND, locus));
 }
 
 // Parses a pseudo-binary infix type cast expression (with Pratt parsing).
@@ -13386,25 +13386,25 @@ get_lbp_for_compound_assignment_expr (
 {
   switch (expr_type)
     {
-    case AST::CompoundAssignmentExpr::ADD:
+    case CompoundAssignmentOperator::ADD:
       return LBP_PLUS;
-    case AST::CompoundAssignmentExpr::SUBTRACT:
+    case CompoundAssignmentOperator::SUBTRACT:
       return LBP_MINUS;
-    case AST::CompoundAssignmentExpr::MULTIPLY:
+    case CompoundAssignmentOperator::MULTIPLY:
       return LBP_MUL;
-    case AST::CompoundAssignmentExpr::DIVIDE:
+    case CompoundAssignmentOperator::DIVIDE:
       return LBP_DIV;
-    case AST::CompoundAssignmentExpr::MODULUS:
+    case CompoundAssignmentOperator::MODULUS:
       return LBP_MOD;
-    case AST::CompoundAssignmentExpr::BITWISE_AND:
+    case CompoundAssignmentOperator::BITWISE_AND:
       return LBP_AMP;
-    case AST::CompoundAssignmentExpr::BITWISE_OR:
+    case CompoundAssignmentOperator::BITWISE_OR:
       return LBP_PIPE;
-    case AST::CompoundAssignmentExpr::BITWISE_XOR:
+    case CompoundAssignmentOperator::BITWISE_XOR:
       return LBP_CARET;
-    case AST::CompoundAssignmentExpr::LEFT_SHIFT:
+    case CompoundAssignmentOperator::LEFT_SHIFT:
       return LBP_L_SHIFT;
-    case AST::CompoundAssignmentExpr::RIGHT_SHIFT:
+    case CompoundAssignmentOperator::RIGHT_SHIFT:
       return LBP_R_SHIFT;
     default:
       // WTF? should not happen, this is an error
@@ -13460,7 +13460,7 @@ Parser<ManagedTokenSource>::parse_plus_assig_expr (
 
   return std::unique_ptr<AST::CompoundAssignmentExpr> (
     new AST::CompoundAssignmentExpr (std::move (left), std::move (right),
-				     AST::CompoundAssignmentExpr::ADD, locus));
+				     CompoundAssignmentOperator::ADD, locus));
 }
 
 // Parses a binary minus-assignment expression (with Pratt parsing).
@@ -13484,7 +13484,7 @@ Parser<ManagedTokenSource>::parse_minus_assig_expr (
 
   return std::unique_ptr<AST::CompoundAssignmentExpr> (
     new AST::CompoundAssignmentExpr (std::move (left), std::move (right),
-				     AST::CompoundAssignmentExpr::SUBTRACT,
+				     CompoundAssignmentOperator::SUBTRACT,
 				     locus));
 }
 
@@ -13509,7 +13509,7 @@ Parser<ManagedTokenSource>::parse_mult_assig_expr (
 
   return std::unique_ptr<AST::CompoundAssignmentExpr> (
     new AST::CompoundAssignmentExpr (std::move (left), std::move (right),
-				     AST::CompoundAssignmentExpr::MULTIPLY,
+				     CompoundAssignmentOperator::MULTIPLY,
 				     locus));
 }
 
@@ -13534,7 +13534,7 @@ Parser<ManagedTokenSource>::parse_div_assig_expr (
 
   return std::unique_ptr<AST::CompoundAssignmentExpr> (
     new AST::CompoundAssignmentExpr (std::move (left), std::move (right),
-				     AST::CompoundAssignmentExpr::DIVIDE,
+				     CompoundAssignmentOperator::DIVIDE,
 				     locus));
 }
 
@@ -13559,7 +13559,7 @@ Parser<ManagedTokenSource>::parse_mod_assig_expr (
 
   return std::unique_ptr<AST::CompoundAssignmentExpr> (
     new AST::CompoundAssignmentExpr (std::move (left), std::move (right),
-				     AST::CompoundAssignmentExpr::MODULUS,
+				     CompoundAssignmentOperator::MODULUS,
 				     locus));
 }
 
@@ -13584,7 +13584,7 @@ Parser<ManagedTokenSource>::parse_and_assig_expr (
 
   return std::unique_ptr<AST::CompoundAssignmentExpr> (
     new AST::CompoundAssignmentExpr (std::move (left), std::move (right),
-				     AST::CompoundAssignmentExpr::BITWISE_AND,
+				     CompoundAssignmentOperator::BITWISE_AND,
 				     locus));
 }
 
@@ -13609,7 +13609,7 @@ Parser<ManagedTokenSource>::parse_or_assig_expr (
 
   return std::unique_ptr<AST::CompoundAssignmentExpr> (
     new AST::CompoundAssignmentExpr (std::move (left), std::move (right),
-				     AST::CompoundAssignmentExpr::BITWISE_OR,
+				     CompoundAssignmentOperator::BITWISE_OR,
 				     locus));
 }
 
@@ -13634,7 +13634,7 @@ Parser<ManagedTokenSource>::parse_xor_assig_expr (
 
   return std::unique_ptr<AST::CompoundAssignmentExpr> (
     new AST::CompoundAssignmentExpr (std::move (left), std::move (right),
-				     AST::CompoundAssignmentExpr::BITWISE_XOR,
+				     CompoundAssignmentOperator::BITWISE_XOR,
 				     locus));
 }
 
@@ -13659,7 +13659,7 @@ Parser<ManagedTokenSource>::parse_left_shift_assig_expr (
 
   return std::unique_ptr<AST::CompoundAssignmentExpr> (
     new AST::CompoundAssignmentExpr (std::move (left), std::move (right),
-				     AST::CompoundAssignmentExpr::LEFT_SHIFT,
+				     CompoundAssignmentOperator::LEFT_SHIFT,
 				     locus));
 }
 
@@ -13684,7 +13684,7 @@ Parser<ManagedTokenSource>::parse_right_shift_assig_expr (
 
   return std::unique_ptr<AST::CompoundAssignmentExpr> (
     new AST::CompoundAssignmentExpr (std::move (left), std::move (right),
-				     AST::CompoundAssignmentExpr::RIGHT_SHIFT,
+				     CompoundAssignmentOperator::RIGHT_SHIFT,
 				     locus));
 }
 

--- a/gcc/rust/rust-backend.h
+++ b/gcc/rust/rust-backend.h
@@ -379,8 +379,8 @@ public:
   // Return an expression for the operation LEFT OP RIGHT.
   // Supported values of OP are enumerated in ComparisonOperator.
   virtual Bexpression *comparison_expression (ComparisonOperator op,
-					       Bexpression *left,
-					       Bexpression *right, Location)
+					      Bexpression *left,
+					      Bexpression *right, Location)
     = 0;
 
   // Return an expression for the operation LEFT OP RIGHT.

--- a/gcc/rust/rust-backend.h
+++ b/gcc/rust/rust-backend.h
@@ -377,8 +377,8 @@ public:
     = 0;
 
   // Return an expression for the operation LEFT OP RIGHT.
-  // Supported values of OP are enumerated in ComparisionOperator.
-  virtual Bexpression *comparision_expression (ComparisionOperator op,
+  // Supported values of OP are enumerated in ComparisonOperator.
+  virtual Bexpression *comparison_expression (ComparisonOperator op,
 					       Bexpression *left,
 					       Bexpression *right, Location)
     = 0;

--- a/gcc/rust/rust-backend.h
+++ b/gcc/rust/rust-backend.h
@@ -362,19 +362,32 @@ public:
 			  Bexpression *else_expr, Location)
     = 0;
 
-  // Return an expression for the unary operation OP EXPR.
-  // Supported values of OP are (from operators.h):
-  //    MINUS, NOT, XOR.
-  virtual Bexpression *unary_expression (Operator op, Bexpression *expr,
-					 Location)
+  // Return an expression for the negation operation OP EXPR.
+  // Supported values of OP are enumerated in NegationOperator.
+  virtual Bexpression *negation_expression (NegationOperator op,
+					    Bexpression *expr, Location)
     = 0;
 
-  // Return an expression for the binary operation LEFT OP RIGHT.
-  // Supported values of OP are (from operators.h):
-  //    EQEQ, NOTEQ, LT, LE, GT, GE, PLUS, MINUS, OR, XOR, MULT, DIV, MOD,
-  //    LSHIFT, RSHIFT, AND, NOT.
-  virtual Bexpression *binary_expression (Operator op, Bexpression *left,
-					  Bexpression *right, Location)
+  // Return an expression for the operation LEFT OP RIGHT.
+  // Supported values of OP are enumerated in ArithmeticOrLogicalOperator.
+  virtual Bexpression *
+  arithmetic_or_logical_expression (ArithmeticOrLogicalOperator op,
+				    Bexpression *left, Bexpression *right,
+				    Location)
+    = 0;
+
+  // Return an expression for the operation LEFT OP RIGHT.
+  // Supported values of OP are enumerated in ComparisionOperator.
+  virtual Bexpression *comparision_expression (ComparisionOperator op,
+					       Bexpression *left,
+					       Bexpression *right, Location)
+    = 0;
+
+  // Return an expression for the operation LEFT OP RIGHT.
+  // Supported values of OP are enumerated in LazyBooleanOperator.
+  virtual Bexpression *lazy_boolean_expression (LazyBooleanOperator op,
+						Bexpression *left,
+						Bexpression *right, Location)
     = 0;
 
   // Return an expression that constructs BTYPE with VALS.  BTYPE must be the

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -300,9 +300,8 @@ public:
 						 Bexpression *left,
 						 Bexpression *right, Location);
 
-  Bexpression *comparison_expression (ComparisonOperator op,
-				       Bexpression *left, Bexpression *right,
-				       Location);
+  Bexpression *comparison_expression (ComparisonOperator op, Bexpression *left,
+				      Bexpression *right, Location);
 
   Bexpression *lazy_boolean_expression (LazyBooleanOperator op,
 					Bexpression *left, Bexpression *right,
@@ -1829,7 +1828,7 @@ Gcc_backend::arithmetic_or_logical_expression (ArithmeticOrLogicalOperator op,
 // Return an expression for the comparison operation LEFT OP RIGHT.
 Bexpression *
 Gcc_backend::comparison_expression (ComparisonOperator op, Bexpression *left,
-				     Bexpression *right, Location location)
+				    Bexpression *right, Location location)
 {
   /* Check if either expression is an error, in which case we return an error
      expression. */

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -293,10 +293,20 @@ public:
   Bexpression *conditional_expression (Bfunction *, Btype *, Bexpression *,
 				       Bexpression *, Bexpression *, Location);
 
-  Bexpression *unary_expression (Operator, Bexpression *, Location);
+  Bexpression *negation_expression (NegationOperator op, Bexpression *expr,
+				    Location);
 
-  Bexpression *binary_expression (Operator, Bexpression *, Bexpression *,
-				  Location);
+  Bexpression *arithmetic_or_logical_expression (ArithmeticOrLogicalOperator op,
+						 Bexpression *left,
+						 Bexpression *right, Location);
+
+  Bexpression *comparision_expression (ComparisionOperator op,
+				       Bexpression *left, Bexpression *right,
+				       Location);
+
+  Bexpression *lazy_boolean_expression (LazyBooleanOperator op,
+					Bexpression *left, Bexpression *right,
+					Location);
 
   Bexpression *constructor_expression (Btype *,
 				       const std::vector<Bexpression *> &,
@@ -1641,162 +1651,224 @@ Gcc_backend::conditional_expression (Bfunction *, Btype *btype,
   return this->make_expression (ret);
 }
 
-// Return an expression for the unary operation OP EXPR.
-
-Bexpression *
-Gcc_backend::unary_expression (Operator op, Bexpression *expr,
-			       Location location)
+/* Helper function that converts rust operators to equivalent GCC tree_code.
+   Note that CompoundAssignmentOperator don't get their corresponding tree_code,
+   because they get compiled away when we lower AST to HIR. */
+static enum tree_code
+operator_to_tree_code (NegationOperator op)
 {
-  tree expr_tree = expr->get_tree ();
+  switch (op)
+    {
+    case NegationOperator::NEGATE:
+      return NEGATE_EXPR;
+    case NegationOperator::NOT:
+      return TRUTH_NOT_EXPR;
+    default:
+      gcc_unreachable ();
+    }
+}
+
+/* Note that GCC tree code distinguishes floating point division and integer
+   division. These two types of division are represented as the same rust
+   operator, and can only be distinguished via context(i.e. the TREE_TYPE of the
+   operands). */
+static enum tree_code
+operator_to_tree_code (ArithmeticOrLogicalOperator op, bool floating_point)
+{
+  switch (op)
+    {
+    case ArithmeticOrLogicalOperator::ADD:
+      return PLUS_EXPR;
+    case ArithmeticOrLogicalOperator::SUBTRACT:
+      return MINUS_EXPR;
+    case ArithmeticOrLogicalOperator::MULTIPLY:
+      return MULT_EXPR;
+    case ArithmeticOrLogicalOperator::DIVIDE:
+      if (floating_point)
+	return RDIV_EXPR;
+      else
+	return TRUNC_DIV_EXPR;
+    case ArithmeticOrLogicalOperator::MODULUS:
+      return TRUNC_MOD_EXPR;
+    case ArithmeticOrLogicalOperator::BITWISE_AND:
+      return BIT_AND_EXPR;
+    case ArithmeticOrLogicalOperator::BITWISE_OR:
+      return BIT_IOR_EXPR;
+    case ArithmeticOrLogicalOperator::BITWISE_XOR:
+      return BIT_XOR_EXPR;
+    case ArithmeticOrLogicalOperator::LEFT_SHIFT:
+      return LSHIFT_EXPR;
+    case ArithmeticOrLogicalOperator::RIGHT_SHIFT:
+      return RSHIFT_EXPR;
+    default:
+      gcc_unreachable ();
+    }
+}
+
+static enum tree_code
+operator_to_tree_code (ComparisionOperator op)
+{
+  switch (op)
+    {
+    case ComparisionOperator::EQUAL:
+      return EQ_EXPR;
+    case ComparisionOperator::NOT_EQUAL:
+      return NE_EXPR;
+    case ComparisionOperator::GREATER_THAN:
+      return GT_EXPR;
+    case ComparisionOperator::LESS_THAN:
+      return LT_EXPR;
+    case ComparisionOperator::GREATER_OR_EQUAL:
+      return GE_EXPR;
+    case ComparisionOperator::LESS_OR_EQUAL:
+      return LE_EXPR;
+    default:
+      gcc_unreachable ();
+    }
+}
+
+static enum tree_code
+operator_to_tree_code (LazyBooleanOperator op)
+{
+  switch (op)
+    {
+    case LazyBooleanOperator::LOGICAL_OR:
+      return TRUTH_ORIF_EXPR;
+    case LazyBooleanOperator::LOGICAL_AND:
+      return TRUTH_ANDIF_EXPR;
+    default:
+      gcc_unreachable ();
+    }
+}
+
+/* Helper function for deciding if a tree is a floating point node. */
+bool
+is_floating_point (tree t)
+{
+  auto tree_type = TREE_CODE (TREE_TYPE (t));
+  return tree_type == REAL_TYPE || tree_type == COMPLEX_TYPE;
+}
+
+// Return an expression for the negation operation OP EXPR.
+Bexpression *
+Gcc_backend::negation_expression (NegationOperator op, Bexpression *expr,
+				  Location location)
+{
+  /* Check if the expression is an error, in which case we return an error
+     expression. */
+  auto expr_tree = expr->get_tree ();
   if (expr_tree == error_mark_node || TREE_TYPE (expr_tree) == error_mark_node)
     return this->error_expression ();
 
-  tree type_tree = TREE_TYPE (expr_tree);
-  enum tree_code code;
-  switch (op)
+  /* For negation operators, the resulting type should be the same as its
+     operand. */
+  auto tree_type = TREE_TYPE (expr_tree);
+  auto tree_code = operator_to_tree_code (op);
+
+  /* For floating point operations we may need to extend the precision of type.
+     For example, a 64-bit machine may not support operations on float32. */
+  bool floating_point = is_floating_point (expr_tree);
+  if (floating_point)
     {
-      case OPERATOR_MINUS: {
-	tree computed_type = excess_precision_type (type_tree);
-	if (computed_type != NULL_TREE)
-	  {
-	    expr_tree = convert (computed_type, expr_tree);
-	    type_tree = computed_type;
-	  }
-	code = NEGATE_EXPR;
-	break;
-      }
-    case OPERATOR_NOT:
-      code = TRUTH_NOT_EXPR;
-      break;
-    case OPERATOR_XOR:
-      code = BIT_NOT_EXPR;
-      break;
-    default:
-      gcc_unreachable ();
-      break;
+      auto extended_type = excess_precision_type (tree_type);
+      if (extended_type != NULL_TREE)
+	{
+	  expr_tree = convert (extended_type, expr_tree);
+	  tree_type = extended_type;
+	}
     }
 
-  tree ret
-    = fold_build1_loc (location.gcc_location (), code, type_tree, expr_tree);
-  return this->make_expression (ret);
+  /* Construct a new tree and build an expression from it. */
+  auto new_tree = fold_build1_loc (location.gcc_location (), tree_code,
+				   tree_type, expr_tree);
+  return this->make_expression (new_tree);
 }
 
-// Convert a rustfrontend operator to an equivalent tree_code.
-
-static enum tree_code
-operator_to_tree_code (Operator op, tree type)
-{
-  enum tree_code code;
-  switch (op)
-    {
-    case OPERATOR_EQEQ:
-      code = EQ_EXPR;
-      break;
-    case OPERATOR_NOTEQ:
-      code = NE_EXPR;
-      break;
-    case OPERATOR_LT:
-      code = LT_EXPR;
-      break;
-    case OPERATOR_LE:
-      code = LE_EXPR;
-      break;
-    case OPERATOR_GT:
-      code = GT_EXPR;
-      break;
-    case OPERATOR_GE:
-      code = GE_EXPR;
-      break;
-    case OPERATOR_OROR:
-      code = TRUTH_ORIF_EXPR;
-      break;
-    case OPERATOR_ANDAND:
-      code = TRUTH_ANDIF_EXPR;
-      break;
-    case OPERATOR_PLUS:
-      code = PLUS_EXPR;
-      break;
-    case OPERATOR_MINUS:
-      code = MINUS_EXPR;
-      break;
-    case OPERATOR_OR:
-      code = BIT_IOR_EXPR;
-      break;
-    case OPERATOR_XOR:
-      code = BIT_XOR_EXPR;
-      break;
-    case OPERATOR_MULT:
-      code = MULT_EXPR;
-      break;
-    case OPERATOR_DIV:
-      if (TREE_CODE (type) == REAL_TYPE || TREE_CODE (type) == COMPLEX_TYPE)
-	code = RDIV_EXPR;
-      else
-	code = TRUNC_DIV_EXPR;
-      break;
-    case OPERATOR_MOD:
-      code = TRUNC_MOD_EXPR;
-      break;
-    case OPERATOR_LSHIFT:
-      code = LSHIFT_EXPR;
-      break;
-    case OPERATOR_RSHIFT:
-      code = RSHIFT_EXPR;
-      break;
-    case OPERATOR_AND:
-      code = BIT_AND_EXPR;
-      break;
-    case OPERATOR_BITCLEAR:
-      code = BIT_AND_EXPR;
-      break;
-    default:
-      gcc_unreachable ();
-    }
-
-  return code;
-}
-
-// Return an expression for the binary operation LEFT OP RIGHT.
-
+// Return an expression for the arithmetic or logical operation LEFT OP RIGHT.
 Bexpression *
-Gcc_backend::binary_expression (Operator op, Bexpression *left,
-				Bexpression *right, Location location)
+Gcc_backend::arithmetic_or_logical_expression (ArithmeticOrLogicalOperator op,
+					       Bexpression *left,
+					       Bexpression *right,
+					       Location location)
 {
-  tree left_tree = left->get_tree ();
-  tree right_tree = right->get_tree ();
+  /* Check if either expression is an error, in which case we return an error
+     expression. */
+  auto left_tree = left->get_tree ();
+  auto right_tree = right->get_tree ();
   if (left_tree == error_mark_node || right_tree == error_mark_node)
     return this->error_expression ();
-  enum tree_code code = operator_to_tree_code (op, TREE_TYPE (left_tree));
 
-  bool use_left_type = op != OPERATOR_OROR && op != OPERATOR_ANDAND;
-  tree type_tree
-    = use_left_type ? TREE_TYPE (left_tree) : TREE_TYPE (right_tree);
-  tree computed_type = excess_precision_type (type_tree);
-  if (computed_type != NULL_TREE)
+  /* We need to determine if we're doing floating point arithmetics of integer
+     arithmetics. */
+  bool floating_point = is_floating_point (left_tree);
+
+  /* For arithmetic or logical operators, the resulting type should be the same
+     as the lhs operand. */
+  auto tree_type = TREE_TYPE (left_tree);
+  auto tree_code = operator_to_tree_code (op, floating_point);
+
+  /* For floating point operations we may need to extend the precision of type.
+     For example, a 64-bit machine may not support operations on float32. */
+  if (floating_point)
     {
-      left_tree = convert (computed_type, left_tree);
-      right_tree = convert (computed_type, right_tree);
-      type_tree = computed_type;
+      auto extended_type = excess_precision_type (tree_type);
+      if (extended_type != NULL_TREE)
+	{
+	  left_tree = convert (extended_type, left_tree);
+	  right_tree = convert (extended_type, right_tree);
+	  tree_type = extended_type;
+	}
     }
 
-  // For comparison operators, the resulting type should be boolean.
-  switch (op)
-    {
-    case OPERATOR_EQEQ:
-    case OPERATOR_NOTEQ:
-    case OPERATOR_LT:
-    case OPERATOR_LE:
-    case OPERATOR_GT:
-    case OPERATOR_GE:
-      type_tree = boolean_type_node;
-      break;
-    default:
-      break;
-    }
+  /* Construct a new tree and build an expression from it. */
+  auto new_tree = fold_build2_loc (location.gcc_location (), tree_code,
+				   tree_type, left_tree, right_tree);
+  return this->make_expression (new_tree);
+}
 
-  tree ret = fold_build2_loc (location.gcc_location (), code, type_tree,
-			      left_tree, right_tree);
-  return this->make_expression (ret);
+// Return an expression for the comparision operation LEFT OP RIGHT.
+Bexpression *
+Gcc_backend::comparision_expression (ComparisionOperator op, Bexpression *left,
+				     Bexpression *right, Location location)
+{
+  /* Check if either expression is an error, in which case we return an error
+     expression. */
+  auto left_tree = left->get_tree ();
+  auto right_tree = right->get_tree ();
+  if (left_tree == error_mark_node || right_tree == error_mark_node)
+    return this->error_expression ();
+
+  /* For comparision operators, the resulting type should be boolean. */
+  auto tree_type = boolean_type_node;
+  auto tree_code = operator_to_tree_code (op);
+
+  /* Construct a new tree and build an expression from it. */
+  auto new_tree = fold_build2_loc (location.gcc_location (), tree_code,
+				   tree_type, left_tree, right_tree);
+  return this->make_expression (new_tree);
+}
+
+// Return an expression for the lazy boolean operation LEFT OP RIGHT.
+Bexpression *
+Gcc_backend::lazy_boolean_expression (LazyBooleanOperator op, Bexpression *left,
+				      Bexpression *right, Location location)
+{
+  /* Check if either expression is an error, in which case we return an error
+     expression. */
+  auto left_tree = left->get_tree ();
+  auto right_tree = right->get_tree ();
+  if (left_tree == error_mark_node || right_tree == error_mark_node)
+    return this->error_expression ();
+
+  /* For lazy boolean operators, the resulting type should be the same as the
+     rhs operand. */
+  auto tree_type = TREE_TYPE (right_tree);
+  auto tree_code = operator_to_tree_code (op);
+
+  /* Construct a new tree and build an expression from it. */
+  auto new_tree = fold_build2_loc (location.gcc_location (), tree_code,
+				   tree_type, left_tree, right_tree);
+  return this->make_expression (new_tree);
 }
 
 // Return an expression that constructs BTYPE with VALS.

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -300,7 +300,7 @@ public:
 						 Bexpression *left,
 						 Bexpression *right, Location);
 
-  Bexpression *comparision_expression (ComparisionOperator op,
+  Bexpression *comparison_expression (ComparisonOperator op,
 				       Bexpression *left, Bexpression *right,
 				       Location);
 
@@ -1706,21 +1706,21 @@ operator_to_tree_code (ArithmeticOrLogicalOperator op, bool floating_point)
 }
 
 static enum tree_code
-operator_to_tree_code (ComparisionOperator op)
+operator_to_tree_code (ComparisonOperator op)
 {
   switch (op)
     {
-    case ComparisionOperator::EQUAL:
+    case ComparisonOperator::EQUAL:
       return EQ_EXPR;
-    case ComparisionOperator::NOT_EQUAL:
+    case ComparisonOperator::NOT_EQUAL:
       return NE_EXPR;
-    case ComparisionOperator::GREATER_THAN:
+    case ComparisonOperator::GREATER_THAN:
       return GT_EXPR;
-    case ComparisionOperator::LESS_THAN:
+    case ComparisonOperator::LESS_THAN:
       return LT_EXPR;
-    case ComparisionOperator::GREATER_OR_EQUAL:
+    case ComparisonOperator::GREATER_OR_EQUAL:
       return GE_EXPR;
-    case ComparisionOperator::LESS_OR_EQUAL:
+    case ComparisonOperator::LESS_OR_EQUAL:
       return LE_EXPR;
     default:
       gcc_unreachable ();
@@ -1826,9 +1826,9 @@ Gcc_backend::arithmetic_or_logical_expression (ArithmeticOrLogicalOperator op,
   return this->make_expression (new_tree);
 }
 
-// Return an expression for the comparision operation LEFT OP RIGHT.
+// Return an expression for the comparison operation LEFT OP RIGHT.
 Bexpression *
-Gcc_backend::comparision_expression (ComparisionOperator op, Bexpression *left,
+Gcc_backend::comparison_expression (ComparisonOperator op, Bexpression *left,
 				     Bexpression *right, Location location)
 {
   /* Check if either expression is an error, in which case we return an error
@@ -1838,7 +1838,7 @@ Gcc_backend::comparision_expression (ComparisionOperator op, Bexpression *left,
   if (left_tree == error_mark_node || right_tree == error_mark_node)
     return this->error_expression ();
 
-  /* For comparision operators, the resulting type should be boolean. */
+  /* For comparison operators, the resulting type should be boolean. */
   auto tree_type = boolean_type_node;
   auto tree_code = operator_to_tree_code (op);
 

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -515,9 +515,9 @@ public:
     auto negated_expr_ty = TypeCheckExpr::Resolve (expr.get_expr (), false);
 
     // https://doc.rust-lang.org/reference/expressions/operator-expr.html#negation-operators
-    switch (expr.get_negation_type ())
+    switch (expr.get_expr_type ())
       {
-	case HIR::NegationExpr::NegationType::NEGATE: {
+	case NegationOperator::NEGATE: {
 	  bool valid
 	    = (negated_expr_ty->get_kind () == TyTy::TypeKind::INT)
 	      || (negated_expr_ty->get_kind () == TyTy::TypeKind::UINT)
@@ -537,7 +537,7 @@ public:
 	}
 	break;
 
-	case HIR::NegationExpr::NegationType::NOT: {
+	case NegationOperator::NOT: {
 	  bool valid
 	    = (negated_expr_ty->get_kind () == TyTy::TypeKind::BOOL)
 	      || (negated_expr_ty->get_kind () == TyTy::TypeKind::INT)
@@ -881,11 +881,11 @@ private:
     // this will change later when traits are added
     switch (expr_type)
       {
-      case HIR::ArithmeticOrLogicalExpr::ADD:
-      case HIR::ArithmeticOrLogicalExpr::SUBTRACT:
-      case HIR::ArithmeticOrLogicalExpr::MULTIPLY:
-      case HIR::ArithmeticOrLogicalExpr::DIVIDE:
-      case HIR::ArithmeticOrLogicalExpr::MODULUS:
+      case ArithmeticOrLogicalOperator::ADD:
+      case ArithmeticOrLogicalOperator::SUBTRACT:
+      case ArithmeticOrLogicalOperator::MULTIPLY:
+      case ArithmeticOrLogicalOperator::DIVIDE:
+      case ArithmeticOrLogicalOperator::MODULUS:
 	return (type->get_kind () == TyTy::TypeKind::INT)
 	       || (type->get_kind () == TyTy::TypeKind::UINT)
 	       || (type->get_kind () == TyTy::TypeKind::FLOAT)
@@ -897,9 +897,9 @@ private:
 		       == TyTy::InferType::FLOAT));
 
 	// integers or bools
-      case HIR::ArithmeticOrLogicalExpr::BITWISE_AND:
-      case HIR::ArithmeticOrLogicalExpr::BITWISE_OR:
-      case HIR::ArithmeticOrLogicalExpr::BITWISE_XOR:
+      case ArithmeticOrLogicalOperator::BITWISE_AND:
+      case ArithmeticOrLogicalOperator::BITWISE_OR:
+      case ArithmeticOrLogicalOperator::BITWISE_XOR:
 	return (type->get_kind () == TyTy::TypeKind::INT)
 	       || (type->get_kind () == TyTy::TypeKind::UINT)
 	       || (type->get_kind () == TyTy::TypeKind::BOOL)
@@ -908,8 +908,8 @@ private:
 		       == TyTy::InferType::INTEGRAL));
 
 	// integers only
-      case HIR::ArithmeticOrLogicalExpr::LEFT_SHIFT:
-      case HIR::ArithmeticOrLogicalExpr::RIGHT_SHIFT:
+      case ArithmeticOrLogicalOperator::LEFT_SHIFT:
+      case ArithmeticOrLogicalOperator::RIGHT_SHIFT:
 	return (type->get_kind () == TyTy::TypeKind::INT)
 	       || (type->get_kind () == TyTy::TypeKind::UINT)
 	       || (type->get_kind () == TyTy::TypeKind::INFER


### PR DESCRIPTION
This pull request extracts and combines the operator enums in the AST and HIR namespace. The new enums are in `operator.h` and the old `enum Operator` is removed.

Fixes issue #228.