### PR TITLE
Make failing tests actually fail

### DIFF
--- a/gcc/testsuite/rust.test/rust-test.exp
+++ b/gcc/testsuite/rust.test/rust-test.exp
@@ -314,7 +314,8 @@ proc dmd2dg { base test } {
 	}
 
 	fail_compilation {
-	    puts $fdout "// { dg-do run { xfail *-*-* } }"
+	    puts $fdout "// { dg-do compile }"
+	    puts $fdout "// { dg-final { output-exists-not } }"
 	}
     }
 


### PR DESCRIPTION
As mentioned in issue #212, some tests in fail_compliation are passing when they shouldn't. The reason is that `{ dg-do run { xfail *-*-* } }` will be successful if the compilation failed _or_ if the resulting executable returns a non-zero value.

This PR fixes this by replacing it with `{ dg-do compile }`, which detects if the compiler crashed or not, followed by `{ dg-final { output-exists-not } }`, which ensures the compilation actually failed.

Now the failing tests are `fail_compilation/implicit_returns_err1.rs` and `fail_compilation/tuple_struct1.rs`.