### PR TITLE
Proof of Concept: using s-expression for AST dump

### DIFF
--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -925,7 +925,7 @@ protected:
 
 // Base array initialisation internal element representation thing (abstract)
 // aka ArrayElements
-class ArrayElems
+class ArrayElems : public SexpSerializable
 {
 public:
   virtual ~ArrayElems () {}
@@ -937,6 +937,8 @@ public:
   }
 
   virtual std::string as_string () const = 0;
+
+  virtual std::string to_sexp () const = 0;
 
   virtual void accept_vis (ASTVisitor &vis) = 0;
 
@@ -986,6 +988,11 @@ public:
   ArrayElemsValues &operator= (ArrayElemsValues &&other) = default;
 
   std::string as_string () const override;
+
+  std::string to_sexp () const override
+  {
+    return sexp ("ArrayElemsValues", values);
+  }
 
   void accept_vis (ASTVisitor &vis) override;
 
@@ -1051,6 +1058,12 @@ public:
 
   std::string as_string () const override;
 
+  std::string to_sexp () const override
+  {
+    return sexp ("ArrayElemsCopied", sexp ("value", elem_to_copy),
+		 sexp ("count", num_copies));
+  }
+
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: is this better? Or is a "vis_block" better?
@@ -1087,6 +1100,11 @@ class ArrayExpr : public ExprWithoutBlock
 
 public:
   std::string as_string () const override;
+
+  std::string to_sexp () const override
+  {
+    return sexp ("ArrayExpr", internal_elements);
+  }
 
   const std::vector<Attribute> &get_inner_attrs () const { return inner_attrs; }
   std::vector<Attribute> &get_inner_attrs () { return inner_attrs; }
@@ -2837,6 +2855,12 @@ class BlockExpr : public ExprWithBlock
 
 public:
   std::string as_string () const override;
+
+  std::string to_sexp () const override
+  {
+    return sexp ("Block", sexp ("statements", statements),
+		 sexp ("final_expr", expr));
+  }
 
   // Returns whether the block contains statements.
   bool has_statements () const { return !statements.empty (); }

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -510,7 +510,7 @@ public:
 };
 
 // A function parameter
-struct FunctionParam
+struct FunctionParam : public SexpSerializable
 {
 private:
   std::vector<Attribute> outer_attrs;
@@ -571,6 +571,8 @@ public:
   }
 
   std::string as_string () const;
+
+  std::string to_sexp () const override { return "[Param placeholder]"; }
 
   Location get_locus () const { return locus; }
 
@@ -1448,6 +1450,15 @@ class Function : public VisItem, public InherentImplItem, public TraitImplItem
 
 public:
   std::string as_string () const override;
+
+  std::string to_sexp () const override
+  {
+    auto return_type
+      = has_return_type () ? Rust::to_sexp (this->return_type) : "void";
+    return sexp ("Function", function_name, sexp ("returns", return_type),
+		 sexp ("params", function_params),
+		 sexp ("body", function_body));
+  }
 
   // Returns whether function has generic parameters.
   bool has_generics () const { return !generic_params.empty (); }
@@ -3802,8 +3813,8 @@ class ExternalItem
 public:
   virtual ~ExternalItem () {}
 
-  /* TODO: spec syntax rules state that "MacroInvocationSemi" can be used as 
-   * ExternalItem, but text body isn't so clear. Adding MacroInvocationSemi 
+  /* TODO: spec syntax rules state that "MacroInvocationSemi" can be used as
+   * ExternalItem, but text body isn't so clear. Adding MacroInvocationSemi
    * support would require a lot of refactoring. */
 
   // Returns whether item has outer attributes.

--- a/gcc/rust/util/rust-sexp.h
+++ b/gcc/rust/util/rust-sexp.h
@@ -1,0 +1,63 @@
+/* Serialize your objects into S-expression.
+   Implement SexpSerializable on your object, then call sexp() as needed. */
+
+#include <string>
+
+class SexpSerializable
+{
+public:
+  /* Serialize this object to S-expression. */
+  virtual std::string to_sexp () const = 0;
+};
+
+template <class... Ts>
+static std::string
+sexp_inner ()
+{
+  return "";
+}
+
+// Accept a string
+template <class... Ts>
+static std::string
+sexp_inner (const std::string &str, Ts... rest)
+{
+  return " " + str + sexp_inner (rest...);
+}
+
+// Accept a SexpSerializable
+template <class... Ts>
+static std::string
+sexp_inner (const SexpSerializable &obj, Ts... rest)
+{
+  return " " + obj.to_sexp ();
+}
+
+// Accept a container. Calls to_sexp() on all its objects and concatenates the
+// results.
+template <class U, class... Ts, class = decltype (std::declval<U> ().cbegin ())>
+static std::string
+sexp_inner (const U &container, Ts... rest)
+{
+  std::string str;
+  for (const auto &item : container)
+    {
+      str += " ";
+      str += item.to_sexp ();
+    }
+  return str;
+}
+
+/* Creates a compound S-expression.
+   Accepts an arbitary number of parameters.
+   Parameters can be string, SexpSerializeable, or containers of
+   SexpSerializable. */
+template <class... Ts>
+std::string
+sexp (Ts... rest)
+{
+  std::string str = sexp_inner (rest...);
+  // Remove the first character, which is an extra whitespace
+  str.erase (str.begin ());
+  return "(" + str + ")";
+}

--- a/gcc/rust/util/rust-sexp.h
+++ b/gcc/rust/util/rust-sexp.h
@@ -28,6 +28,15 @@ to_sexp (const char *str)
   return std::string (str);
 }
 
+template <typename T,
+	  typename std::enable_if<std::is_arithmetic<T>::value, void *>::type
+	  = nullptr>
+std::string
+to_sexp (const T &number)
+{
+  return std::to_string (number);
+}
+
 inline std::string
 to_sexp (const SexpSerializable &obj)
 {
@@ -61,15 +70,6 @@ to_sexp (const T &ptr)
     {
       return to_sexp (*ptr);
     }
-}
-
-template <typename T,
-	  typename std::enable_if<std::is_arithmetic<T>::value, void *>::type
-	  = nullptr>
-std::string
-to_sexp (const T &number)
-{
-  return std::to_string (number);
 }
 
 template <typename T, typename Rust::helper_t<decltype (

--- a/gcc/rust/util/rust-sexp.h
+++ b/gcc/rust/util/rust-sexp.h
@@ -91,7 +91,10 @@ to_sexp (const T &container)
       str += " ";
       str += to_sexp (item);
     }
-  str.erase (str.begin ());
+  if (str.size () > 0)
+    {
+      str.erase (str.begin ());
+    }
   return str;
 }
 

--- a/gcc/rust/util/rust-sexp.h
+++ b/gcc/rust/util/rust-sexp.h
@@ -34,6 +34,12 @@ to_sexp (const SexpSerializable &obj)
   return obj.to_sexp ();
 }
 
+inline std::string
+to_sexp (std::nullptr_t ptr)
+{
+  return "[nullptr]";
+}
+
 template <typename T> struct helper
 {
   using type = void *;
@@ -57,9 +63,9 @@ to_sexp (const T &ptr)
 {
   return to_sexp (*ptr);
 }
+
 template <typename T, typename Rust::helper_t<
 			decltype (std::declval<T> ().cbegin ())> = nullptr>
-
 std::string
 to_sexp (const T &container)
 {

--- a/gcc/rust/util/rust-sexp.h
+++ b/gcc/rust/util/rust-sexp.h
@@ -1,7 +1,13 @@
 /* Serialize your objects into S-expression.
    Implement SexpSerializable on your object, then call sexp() as needed. */
 
+#ifndef RUST_SEXP_H
+#define RUST_SEXP_H
+
 #include <string>
+#include <type_traits>
+
+namespace Rust {
 
 class SexpSerializable
 {
@@ -10,54 +16,95 @@ public:
   virtual std::string to_sexp () const = 0;
 };
 
-template <class... Ts>
-static std::string
-sexp_inner ()
+inline std::string
+to_sexp (const std::string &str)
 {
-  return "";
+  return str;
 }
 
-// Accept a string
-template <class... Ts>
-static std::string
-sexp_inner (const std::string &str, Ts... rest)
+inline std::string
+to_sexp (const char *str)
 {
-  return " " + str + sexp_inner (rest...);
+  return std::string (str);
 }
 
-// Accept a SexpSerializable
-template <class... Ts>
-static std::string
-sexp_inner (const SexpSerializable &obj, Ts... rest)
+inline std::string
+to_sexp (const SexpSerializable &obj)
 {
-  return " " + obj.to_sexp ();
+  return obj.to_sexp ();
 }
 
-// Accept a container. Calls to_sexp() on all its objects and concatenates the
-// results.
-template <class U, class... Ts, class = decltype (std::declval<U> ().cbegin ())>
-static std::string
-sexp_inner (const U &container, Ts... rest)
+template <typename T> struct helper
+{
+  using type = void *;
+};
+
+template <typename T> using helper_t = typename helper<T>::type;
+
+template <typename T,
+	  typename std::enable_if<std::is_pointer<T>::value, void *>::type
+	  = nullptr>
+std::string
+to_sexp (const T &ptr)
+{
+  return to_sexp (*ptr);
+}
+
+template <typename T, typename Rust::helper_t<decltype (
+			std::declval<T> ().T::operator* ())> = nullptr>
+std::string
+to_sexp (const T &ptr)
+{
+  return to_sexp (*ptr);
+}
+template <typename T, typename Rust::helper_t<
+			decltype (std::declval<T> ().cbegin ())> = nullptr>
+
+std::string
+to_sexp (const T &container)
 {
   std::string str;
   for (const auto &item : container)
     {
       str += " ";
-      str += item.to_sexp ();
+      str += to_sexp (item);
     }
+  str.erase (str.begin ());
   return str;
+}
+
+template <typename... Ts>
+std::string
+sexp_inner ()
+{
+  return "";
+}
+
+template <typename... Ts, typename U>
+std::string
+sexp_inner (const U &stuff, const Ts &...rest)
+{
+  return " " + to_sexp (stuff) + sexp_inner (rest...);
 }
 
 /* Creates a compound S-expression.
    Accepts an arbitary number of parameters.
-   Parameters can be string, SexpSerializeable, or containers of
-   SexpSerializable. */
-template <class... Ts>
+   The following objects are serializable:
+     - std::string
+     - any class that implements SexpSerializable
+     - containers of serializable objects(e.g. std::vector)
+     - pointers to serializable objects(e.g. std::unique_ptr)
+ */
+template <typename... Ts>
 std::string
-sexp (Ts... rest)
+sexp (const Ts &...rest)
 {
   std::string str = sexp_inner (rest...);
   // Remove the first character, which is an extra whitespace
   str.erase (str.begin ());
   return "(" + str + ")";
 }
+
+} // namespace Rust
+
+#endif

--- a/gcc/rust/util/rust-sexp.h
+++ b/gcc/rust/util/rust-sexp.h
@@ -53,7 +53,14 @@ template <typename T,
 std::string
 to_sexp (const T &ptr)
 {
-  return to_sexp (*ptr);
+  if (ptr == nullptr)
+    {
+      return "[nullptr]";
+    }
+  else
+    {
+      return to_sexp (*ptr);
+    }
 }
 
 template <typename T,
@@ -70,7 +77,7 @@ template <typename T, typename Rust::helper_t<decltype (
 std::string
 to_sexp (const T &ptr)
 {
-  return to_sexp (*ptr);
+  return to_sexp (ptr.get ());
 }
 
 template <typename T, typename Rust::helper_t<

--- a/gcc/rust/util/rust-sexp.h
+++ b/gcc/rust/util/rust-sexp.h
@@ -56,6 +56,15 @@ to_sexp (const T &ptr)
   return to_sexp (*ptr);
 }
 
+template <typename T,
+	  typename std::enable_if<std::is_arithmetic<T>::value, void *>::type
+	  = nullptr>
+std::string
+to_sexp (const T &number)
+{
+  return std::to_string (number);
+}
+
 template <typename T, typename Rust::helper_t<decltype (
 			std::declval<T> ().T::operator* ())> = nullptr>
 std::string
@@ -97,6 +106,7 @@ sexp_inner (const U &stuff, const Ts &...rest)
    Accepts an arbitary number of parameters.
    The following objects are serializable:
      - std::string
+     - numbers
      - any class that implements SexpSerializable
      - containers of serializable objects(e.g. std::vector)
      - pointers to serializable objects(e.g. std::unique_ptr)


### PR DESCRIPTION
This is a proof-of-concept implementation for dumping AST into s-expression. I chose s-expression for demonstration because it's simple enough to write a serialization procedure for it by hand. If we end up using JSON we might need to pull in additional dependency.

Two new functions are added:
* `to_sexp()` converts an object to a s-expression string. It's a overloaded template function, similar to `std::to_string()`.
* `sexp()` creates a new compound s-expression containing some sub-expressions(which is to say, wrap them with a pair of parenthesis). `sexp()` accepts an arbitrary number of parameters(via some template magic).

The follow types of objects are serializable:
* numbers
* `std::string`
* any class that implements `SexpSerializable`, which is an interface containing a single `to_sexp` method
* containers of serializable objects, e.g. `std::vector<SexpSerializable*>`
* pointers to serializable objects, e.g. `std::unique_ptr<std::string>`

Calling `to_sexp()` or `sexp()` on containers or pointers will recursively call these functions for the underlying objects. As a result, implement the `SexpSerializable` interface is often a matter of listing what values you want to dump; the rest is handled automatically.

A new header file, `util/rust-expr.h`, contains implementation of these functions. It's a big pile of meta-programming magic(I had way too much fun doing these meta-programming.)

---

As an example, here's how you would implement `SexpSerializable` for the `AST::Crate` object:

```c++
struct Crate : public SexpSerializable {
    std::vector<std::unique_ptr<Item>> items;
    NodeId node_id;

    std::string to_sexp() const override {
        return sexp("Crate", sexp("node_id", node_id),
                             sexp("items", items));
    }

    // ...other methods
}
```

Assuming the underlying types also implements `SexpSerializable`, calling `to_sexp()` on a crate will generate this:

```lisp
(Crate 
    (node_id 123)
    (items 
        (Function main 
            (returns void) 
            (params ) 
            (body 
                (Block 
                    (statements [Stmt placeholder] [Stmt placeholder]) 
                    (final_expr [nullptr]))))))
```

---

Limitations:
* I only implemented `SexpSerializable` for a few classes for demonstration purpose. It will need a lot of polish.
* Currently `to_sexp()` only generates a compact, minimal s-expression. The previous output is formatted by one of my editor plugins.

I'm happy to hear any thoughts and suggestions. This is just a phototype so I'm OK rewriting it from scratch if necessary.