### PR TITLE
added to_string() for TypeKind

### DIFF
--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -101,8 +101,10 @@ public:
 
   virtual bool has_subsititions_defined () const { return false; }
 
-  virtual std::string to_string () const {
-    switch(kind){
+  virtual std::string to_string () const 
+  {
+    switch(kind)
+      {
       case TypeKind::INFER:
         return "Infer";
         break;
@@ -118,7 +120,7 @@ public:
       case TypeKind::PARAM:
         return "PARAM";
         break;
-      case: TypeKind::ARRAY:
+      case TypeKind::ARRAY:
         return "ARRAY";
         break;
       case TypeKind::FNDEF:
@@ -160,7 +162,7 @@ public:
       default:
         return "None";
         break;
-    }
+      }
   } 
 
 protected:

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -904,62 +904,62 @@ public:
     switch (kind)
       {
       case TypeKind::INFER:
-       return "Infer";
-       break;
+	return "Infer";
+	break;
       case TypeKind::ADT:
-       return "ADT";
-       break;
+	return "ADT";
+	break;
       case TypeKind::STR:
-       return "STR";
-       break;
+	return "STR";
+	break;
       case TypeKind::REF:
-       return "REF";
-       break;
+	return "REF";
+	break;
       case TypeKind::PARAM:
-       return "PARAM";
-       break;
+	return "PARAM";
+	break;
       case TypeKind::ARRAY:
-       return "ARRAY";
-       break;
+	return "ARRAY";
+	break;
       case TypeKind::FNDEF:
-       return "FnDef";
-       break;
+	return "FnDef";
+	break;
       case TypeKind::FNPTR:
-       return "FnPtr";
-       break;
+	return "FnPtr";
+	break;
       case TypeKind::TUPLE:
-       return "Tuple";
-       break;
+	return "Tuple";
+	break;
       case TypeKind::BOOL:
-       return "Boolean";
-       break;
+	return "Boolean";
+	break;
       case TypeKind::CHAR:
-       return "Character";
-       break;
+	return "Character";
+	break;
       case TypeKind::INT:
-       return "Integer";
-       break;
+	return "Integer";
+	break;
       case TypeKind::UINT:
-       return "Unsigned Integer";
-       break;
+	return "Unsigned Integer";
+	break;
       case TypeKind::FLOAT:
-       return "Float";
-       break;
+	return "Float";
+	break;
       case TypeKind::UNIT:
-       return "Unit";
-       break;
+	return "Unit";
+	break;
       case TypeKind::USIZE:
-       return "Usize";
-       break;
+	return "Usize";
+	break;
       case TypeKind::ISIZE:
-       return "Isize";
-       break;
+	return "Isize";
+	break;
       case TypeKind::ERROR:
-       return "ERROR";
-       break;
+	return "ERROR";
+	break;
       default:
-       return "None";
-       break;
+	return "None";
+	break;
       }
   }
 };

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -904,62 +904,62 @@ public:
     switch (kind)
       {
       case TypeKind::INFER:
-        return "Infer";
-        break;
+       return "Infer";
+       break;
       case TypeKind::ADT:
-        return "ADT";
-        break;
+       return "ADT";
+       break;
       case TypeKind::STR:
-        return "STR";
-        break;
+       return "STR";
+       break;
       case TypeKind::REF:
-        return "REF";
-        break;
+       return "REF";
+       break;
       case TypeKind::PARAM:
-        return "PARAM";
-        break;
+       return "PARAM";
+       break;
       case TypeKind::ARRAY:
-        return "ARRAY";
-        break;
+       return "ARRAY";
+       break;
       case TypeKind::FNDEF:
-        return "FnDef";
-        break;
+       return "FnDef";
+       break;
       case TypeKind::FNPTR:
-        return "FnPtr";
-        break;
+       return "FnPtr";
+       break;
       case TypeKind::TUPLE:
-        return "Tuple";
-        break;
+       return "Tuple";
+       break;
       case TypeKind::BOOL:
-        return "Boolean";
-        break;
+       return "Boolean";
+       break;
       case TypeKind::CHAR:
-        return "Character";
-        break;
+       return "Character";
+       break;
       case TypeKind::INT:
-        return "Integer";
-        break;
+       return "Integer";
+       break;
       case TypeKind::UINT:
-        return "Unsigned Integer";
-        break;
+       return "Unsigned Integer";
+       break;
       case TypeKind::FLOAT:
-        return "Float";
-        break;
+       return "Float";
+       break;
       case TypeKind::UNIT:
-        return "Unit";
-        break;
+       return "Unit";
+       break;
       case TypeKind::USIZE:
-        return "Usize";
-        break;
+       return "Usize";
+       break;
       case TypeKind::ISIZE:
-        return "Isize";
-        break;
+       return "Isize";
+       break;
       case TypeKind::ERROR:
-        return "ERROR";
-        break;
+       return "ERROR";
+       break;
       default:
-        return "None";
-        break;
+       return "None";
+       break;
       }
   }
 };

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -899,10 +899,9 @@ public:
 class TypeKindFormat
 {
 public:
-
   static std::string to_string (TypeKind kind)
   {
-    switch(kind)
+    switch (kind)
       {
       case TypeKind::INFER:
         return "Infer";
@@ -962,11 +961,8 @@ public:
         return "None";
         break;
       }
-  } 
-
+  }
 };
-
-
 
 } // namespace TyTy
 } // namespace Rust

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -900,7 +900,7 @@ class TypeKindFormat
 {
 public:
 
-  static std::string to_string (TypeKind kind) const 
+  static std::string to_string (TypeKind kind)
   {
     switch(kind)
       {

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -101,70 +101,6 @@ public:
 
   virtual bool has_subsititions_defined () const { return false; }
 
-  virtual std::string to_string () const 
-  {
-    switch(kind)
-      {
-      case TypeKind::INFER:
-        return "Infer";
-        break;
-      case TypeKind::ADT:
-        return "ADT";
-        break;
-      case TypeKind::STR:
-        return "STR";
-        break;
-      case TypeKind::REF:
-        return "REF";
-        break;
-      case TypeKind::PARAM:
-        return "PARAM";
-        break;
-      case TypeKind::ARRAY:
-        return "ARRAY";
-        break;
-      case TypeKind::FNDEF:
-        return "FnDef";
-        break;
-      case TypeKind::FNPTR:
-        return "FnPtr";
-        break;
-      case TypeKind::TUPLE:
-        return "Tuple";
-        break;
-      case TypeKind::BOOL:
-        return "Boolean";
-        break;
-      case TypeKind::CHAR:
-        return "Character";
-        break;
-      case TypeKind::INT:
-        return "Integer";
-        break;
-      case TypeKind::UINT:
-        return "Unsigned Integer";
-        break;
-      case TypeKind::FLOAT:
-        return "Float";
-        break;
-      case TypeKind::UNIT:
-        return "Unit";
-        break;
-      case TypeKind::USIZE:
-        return "Usize";
-        break;
-      case TypeKind::ISIZE:
-        return "Isize";
-        break;
-      case TypeKind::ERROR:
-        return "ERROR";
-        break;
-      default:
-        return "None";
-        break;
-      }
-  } 
-
 protected:
   BaseType (HirId ref, HirId ty_ref, TypeKind kind,
 	    std::set<HirId> refs = std::set<HirId> ())
@@ -959,6 +895,78 @@ public:
 
   BaseType *clone () final override;
 };
+
+class TypeKindFormat
+{
+public:
+
+  static std::string to_string (TypeKind kind) const 
+  {
+    switch(kind)
+      {
+      case TypeKind::INFER:
+        return "Infer";
+        break;
+      case TypeKind::ADT:
+        return "ADT";
+        break;
+      case TypeKind::STR:
+        return "STR";
+        break;
+      case TypeKind::REF:
+        return "REF";
+        break;
+      case TypeKind::PARAM:
+        return "PARAM";
+        break;
+      case TypeKind::ARRAY:
+        return "ARRAY";
+        break;
+      case TypeKind::FNDEF:
+        return "FnDef";
+        break;
+      case TypeKind::FNPTR:
+        return "FnPtr";
+        break;
+      case TypeKind::TUPLE:
+        return "Tuple";
+        break;
+      case TypeKind::BOOL:
+        return "Boolean";
+        break;
+      case TypeKind::CHAR:
+        return "Character";
+        break;
+      case TypeKind::INT:
+        return "Integer";
+        break;
+      case TypeKind::UINT:
+        return "Unsigned Integer";
+        break;
+      case TypeKind::FLOAT:
+        return "Float";
+        break;
+      case TypeKind::UNIT:
+        return "Unit";
+        break;
+      case TypeKind::USIZE:
+        return "Usize";
+        break;
+      case TypeKind::ISIZE:
+        return "Isize";
+        break;
+      case TypeKind::ERROR:
+        return "ERROR";
+        break;
+      default:
+        return "None";
+        break;
+      }
+  } 
+
+};
+
+
 
 } // namespace TyTy
 } // namespace Rust

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -101,6 +101,68 @@ public:
 
   virtual bool has_subsititions_defined () const { return false; }
 
+  virtual std::string to_string () const {
+    switch(kind){
+      case TypeKind::INFER:
+        return "Infer";
+        break;
+      case TypeKind::ADT:
+        return "ADT";
+        break;
+      case TypeKind::STR:
+        return "STR";
+        break;
+      case TypeKind::REF:
+        return "REF";
+        break;
+      case TypeKind::PARAM:
+        return "PARAM";
+        break;
+      case: TypeKind::ARRAY:
+        return "ARRAY";
+        break;
+      case TypeKind::FNDEF:
+        return "FnDef";
+        break;
+      case TypeKind::FNPTR:
+        return "FnPtr";
+        break;
+      case TypeKind::TUPLE:
+        return "Tuple";
+        break;
+      case TypeKind::BOOL:
+        return "Boolean";
+        break;
+      case TypeKind::CHAR:
+        return "Character";
+        break;
+      case TypeKind::INT:
+        return "Integer";
+        break;
+      case TypeKind::UINT:
+        return "Unsigned Integer";
+        break;
+      case TypeKind::FLOAT:
+        return "Float";
+        break;
+      case TypeKind::UNIT:
+        return "Unit";
+        break;
+      case TypeKind::USIZE:
+        return "Usize";
+        break;
+      case TypeKind::ISIZE:
+        return "Isize";
+        break;
+      case TypeKind::ERROR:
+        return "ERROR";
+        break;
+      default:
+        return "None";
+        break;
+    }
+  } 
+
 protected:
   BaseType (HirId ref, HirId ty_ref, TypeKind kind,
 	    std::set<HirId> refs = std::set<HirId> ())


### PR DESCRIPTION
resolves #280 , this PR adds to_string() to TyTy::TypeKind. The method is implemented using switch case to map enum to string.