### PR TITLE
Remove TyTy::UnitType

### DIFF
--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -351,11 +351,6 @@ public:
       ctx->get_mappings ()->lookup_location (type.get_ref ()));
   }
 
-  void visit (TyTy::UnitType &) override
-  {
-    translated = ctx->get_backend ()->void_type ();
-  }
-
   void visit (TyTy::ADTType &type) override
   {
     if (ctx->lookup_compiled_types (type.get_ty_ref (), &translated, &type))
@@ -389,6 +384,12 @@ public:
 
   void visit (TyTy::TupleType &type) override
   {
+    if (type.num_fields () == 0)
+      {
+	translated = ctx->get_backend ()->void_type ();
+	return;
+      }
+
     bool ok = ctx->lookup_compiled_types (type.get_ty_ref (), &translated);
     if (ok)
       return;

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -368,7 +368,7 @@ public:
       }
 
     Bvariable *tmp = NULL;
-    bool needs_temp = if_type->get_kind () != TyTy::TypeKind::UNIT;
+    bool needs_temp = !if_type->is_unit ();
     if (needs_temp)
       {
 	fncontext fnctx = ctx->peek_fn ();
@@ -405,7 +405,7 @@ public:
       }
 
     Bvariable *tmp = NULL;
-    bool needs_temp = if_type->get_kind () != TyTy::TypeKind::UNIT;
+    bool needs_temp = !if_type->is_unit ();
     if (needs_temp)
       {
 	fncontext fnctx = ctx->peek_fn ();
@@ -441,7 +441,7 @@ public:
       }
 
     Bvariable *tmp = NULL;
-    bool needs_temp = block_tyty->get_kind () != TyTy::TypeKind::UNIT;
+    bool needs_temp = !block_tyty->is_unit ();
     if (needs_temp)
       {
 	fncontext fnctx = ctx->peek_fn ();
@@ -541,7 +541,7 @@ public:
 
     fncontext fnctx = ctx->peek_fn ();
     Bvariable *tmp = NULL;
-    bool needs_temp = block_tyty->get_kind () != TyTy::TypeKind::UNIT;
+    bool needs_temp = !block_tyty->is_unit ();
     if (needs_temp)
       {
 	Bblock *enclosing_scope = ctx->peek_enclosing_scope ();

--- a/gcc/rust/backend/rust-compile-stmt.h
+++ b/gcc/rust/backend/rust-compile-stmt.h
@@ -81,7 +81,7 @@ public:
       return;
 
     auto fnctx = ctx->peek_fn ();
-    if (ty->get_kind () == TyTy::TypeKind::UNIT)
+    if (ty->is_unit ())
       {
 	Bstatement *expr_stmt
 	  = ctx->get_backend ()->expression_statement (fnctx.fndecl, init);

--- a/gcc/rust/backend/rust-compile-tyty.h
+++ b/gcc/rust/backend/rust-compile-tyty.h
@@ -50,7 +50,13 @@ public:
 
   void visit (TyTy::ADTType &) override { gcc_unreachable (); }
 
-  void visit (TyTy::TupleType &) override { gcc_unreachable (); }
+  void visit (TyTy::TupleType &type) override
+  {
+    if (type.num_fields () == 0)
+      translated = backend->void_type ();
+    else
+      gcc_unreachable ();
+  }
 
   void visit (TyTy::ArrayType &) override { gcc_unreachable (); }
 
@@ -59,8 +65,6 @@ public:
   void visit (TyTy::ParamType &) override { gcc_unreachable (); }
 
   void visit (TyTy::FnPtr &type) override { gcc_unreachable (); }
-
-  void visit (TyTy::UnitType &) override { translated = backend->void_type (); }
 
   void visit (TyTy::FnType &type) override
   {

--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -178,7 +178,9 @@ Resolver::generate_builtins ()
   MKBUILTIN_TYPE ("str", builtins, str);
 
   // unit type ()
-  TyTy::UnitType *unit_tyty = new TyTy::UnitType (mappings->get_next_hir_id ());
+
+  TyTy::TupleType *unit_tyty
+    = new TyTy::TupleType (mappings->get_next_hir_id ());
   std::vector<std::unique_ptr<AST::Type> > elems;
   AST::TupleType *unit_type
     = new AST::TupleType (std::move (elems), Linemap::predeclared_location ());

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -143,7 +143,7 @@ public:
   {
     if (!expr.has_return_expr ())
       {
-	infered = new TyTy::UnitType (expr.get_mappings ().get_hirid ());
+	infered = new TyTy::TupleType (expr.get_mappings ().get_hirid ());
 	return;
       }
 
@@ -253,7 +253,7 @@ public:
 
   void visit (HIR::AssignmentExpr &expr) override
   {
-    infered = new TyTy::UnitType (expr.get_mappings ().get_hirid ());
+    infered = new TyTy::TupleType (expr.get_mappings ().get_hirid ());
 
     auto lhs = TypeCheckExpr::Resolve (expr.get_lhs (), false);
     auto rhs = TypeCheckExpr::Resolve (expr.get_rhs (), false);
@@ -587,7 +587,7 @@ public:
     TypeCheckExpr::Resolve (expr.get_if_condition (), false);
     TypeCheckExpr::Resolve (expr.get_if_block (), inside_loop);
 
-    infered = new TyTy::UnitType (expr.get_mappings ().get_hirid ());
+    infered = new TyTy::TupleType (expr.get_mappings ().get_hirid ());
   }
 
   void visit (HIR::IfExprConseqElse &expr) override
@@ -810,7 +810,7 @@ public:
     context->push_new_loop_context (expr.get_mappings ().get_hirid ());
     TyTy::BaseType *block_expr
       = TypeCheckExpr::Resolve (expr.get_loop_block ().get (), true);
-    if (block_expr->get_kind () != TyTy::TypeKind::UNIT)
+    if (!block_expr->is_unit ())
       {
 	rust_error_at (expr.get_loop_block ()->get_locus_slow (),
 		       "expected () got %s", block_expr->as_string ().c_str ());
@@ -827,7 +827,7 @@ public:
 
     infered = loop_context_type_infered
 		? loop_context_type
-		: new TyTy::UnitType (expr.get_mappings ().get_hirid ());
+		: new TyTy::TupleType (expr.get_mappings ().get_hirid ());
   }
 
   void visit (HIR::WhileLoopExpr &expr) override
@@ -838,7 +838,7 @@ public:
     TyTy::BaseType *block_expr
       = TypeCheckExpr::Resolve (expr.get_loop_block ().get (), true);
 
-    if (block_expr->get_kind () != TyTy::TypeKind::UNIT)
+    if (!block_expr->is_unit ())
       {
 	rust_error_at (expr.get_loop_block ()->get_locus_slow (),
 		       "expected () got %s", block_expr->as_string ().c_str ());
@@ -846,7 +846,7 @@ public:
       }
 
     context->pop_loop_context ();
-    infered = new TyTy::UnitType (expr.get_mappings ().get_hirid ());
+    infered = new TyTy::TupleType (expr.get_mappings ().get_hirid ());
   }
 
   void visit (HIR::BreakExpr &expr) override
@@ -874,7 +874,7 @@ public:
 	context->swap_head_loop_context (unified_ty);
       }
 
-    infered = new TyTy::UnitType (expr.get_mappings ().get_hirid ());
+    infered = new TyTy::TupleType (expr.get_mappings ().get_hirid ());
   }
 
   void visit (HIR::ContinueExpr &expr) override
@@ -886,7 +886,7 @@ public:
 	return;
       }
 
-    infered = new TyTy::UnitType (expr.get_mappings ().get_hirid ());
+    infered = new TyTy::TupleType (expr.get_mappings ().get_hirid ());
   }
 
   void visit (HIR::BorrowExpr &expr) override

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -66,7 +66,7 @@ public:
 
     TyTy::BaseType *ret_type = nullptr;
     if (!function.has_function_return_type ())
-      ret_type = new TyTy::UnitType (function.get_mappings ().get_hirid ());
+      ret_type = new TyTy::TupleType (function.get_mappings ().get_hirid ());
     else
       {
 	auto resolved
@@ -119,7 +119,7 @@ public:
 
     TyTy::BaseType *ret_type = nullptr;
     if (!method.has_function_return_type ())
-      ret_type = new TyTy::UnitType (method.get_mappings ().get_hirid ());
+      ret_type = new TyTy::TupleType (method.get_mappings ().get_hirid ());
     else
       {
 	auto resolved

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.h
@@ -51,7 +51,7 @@ public:
 
   void visit (HIR::LetStmt &stmt) override
   {
-    infered = new TyTy::UnitType (stmt.get_mappings ().get_hirid ());
+    infered = new TyTy::TupleType (stmt.get_mappings ().get_hirid ());
 
     TyTy::BaseType *init_expr_ty = nullptr;
     if (stmt.has_init_expr ())

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
@@ -152,7 +152,7 @@ public:
 
     TyTy::BaseType *ret_type = nullptr;
     if (!function.has_function_return_type ())
-      ret_type = new TyTy::UnitType (function.get_mappings ().get_hirid ());
+      ret_type = new TyTy::TupleType (function.get_mappings ().get_hirid ());
     else
       {
 	auto resolved

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -112,7 +112,7 @@ public:
     TyTy::BaseType *return_type
       = fntype.has_return_type ()
 	  ? TypeCheckType::Resolve (fntype.get_return_type ().get ())
-	  : new TyTy::UnitType (fntype.get_mappings ().get_hirid ());
+	  : new TyTy::TupleType (fntype.get_mappings ().get_hirid ());
 
     std::vector<TyTy::TyVar> params;
     for (auto &param : fntype.get_function_params ())

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -83,7 +83,7 @@ void
 TypeCheckExpr::visit (HIR::BlockExpr &expr)
 {
   TyTy::BaseType *block_tyty
-    = new TyTy::UnitType (expr.get_mappings ().get_hirid ());
+    = new TyTy::TupleType (expr.get_mappings ().get_hirid ());
 
   expr.iterate_stmts ([&] (HIR::Stmt *s) mutable -> bool {
     bool is_final_stmt = expr.is_final_stmt (s);
@@ -102,7 +102,7 @@ TypeCheckExpr::visit (HIR::BlockExpr &expr)
 	delete block_tyty;
 	block_tyty = resolved;
       }
-    else if (resolved->get_kind () != TyTy::TypeKind::UNIT)
+    else if (!resolved->is_unit ())
       {
 	rust_error_at (s->get_locus_slow (), "expected () got %s",
 		       resolved->as_string ().c_str ());

--- a/gcc/rust/typecheck/rust-substitution-mapper.h
+++ b/gcc/rust/typecheck/rust-substitution-mapper.h
@@ -79,7 +79,6 @@ public:
       resolved = concrete;
   }
 
-  void visit (TyTy::UnitType &) override { gcc_unreachable (); }
   void visit (TyTy::InferType &) override { gcc_unreachable (); }
   void visit (TyTy::TupleType &) override { gcc_unreachable (); }
   void visit (TyTy::FnPtr &) override { gcc_unreachable (); }
@@ -138,7 +137,6 @@ public:
       resolved = concrete;
   }
 
-  void visit (TyTy::UnitType &) override { gcc_unreachable (); }
   void visit (TyTy::InferType &) override { gcc_unreachable (); }
   void visit (TyTy::TupleType &) override { gcc_unreachable (); }
   void visit (TyTy::FnPtr &) override { gcc_unreachable (); }

--- a/gcc/rust/typecheck/rust-tyty-call.h
+++ b/gcc/rust/typecheck/rust-tyty-call.h
@@ -39,7 +39,6 @@ public:
     return checker.resolved;
   }
 
-  void visit (UnitType &type) override { gcc_unreachable (); }
   void visit (InferType &type) override { gcc_unreachable (); }
   void visit (TupleType &type) override { gcc_unreachable (); }
   void visit (ArrayType &type) override { gcc_unreachable (); }
@@ -85,7 +84,6 @@ public:
     return checker.resolved;
   }
 
-  void visit (UnitType &type) override { gcc_unreachable (); }
   void visit (InferType &type) override { gcc_unreachable (); }
   void visit (TupleType &type) override { gcc_unreachable (); }
   void visit (ArrayType &type) override { gcc_unreachable (); }

--- a/gcc/rust/typecheck/rust-tyty-rules.h
+++ b/gcc/rust/typecheck/rust-tyty-rules.h
@@ -106,14 +106,6 @@ public:
     return resolved;
   }
 
-  virtual void visit (UnitType &type) override
-  {
-    Location ref_locus = mappings->lookup_location (type.get_ref ());
-    rust_error_at (ref_locus, "expected [%s] got [%s]",
-		   get_base ()->as_string ().c_str (),
-		   type.as_string ().c_str ());
-  }
-
   virtual void visit (TupleType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
@@ -277,19 +269,6 @@ class InferRules : public BaseRules
 
 public:
   InferRules (InferType *base) : BaseRules (base), base (base) {}
-
-  void visit (UnitType &type) override
-  {
-    bool is_valid
-      = (base->get_infer_kind () == TyTy::InferType::InferTypeKind::GENERAL);
-    if (is_valid)
-      {
-	resolved = type.clone ();
-	return;
-      }
-
-    BaseRules::visit (type);
-  }
 
   void visit (BoolType &type) override
   {
@@ -503,24 +482,6 @@ private:
   BaseType *get_base () override { return base; }
 
   InferType *base;
-};
-
-class UnitRules : public BaseRules
-{
-  using Rust::TyTy::BaseRules::visit;
-
-public:
-  UnitRules (UnitType *base) : BaseRules (base), base (base) {}
-
-  void visit (UnitType &type) override
-  {
-    resolved = new UnitType (type.get_ref (), type.get_ty_ref ());
-  }
-
-private:
-  BaseType *get_base () override { return base; }
-
-  UnitType *base;
 };
 
 class FnRules : public BaseRules

--- a/gcc/rust/typecheck/rust-tyty-visitor.h
+++ b/gcc/rust/typecheck/rust-tyty-visitor.h
@@ -27,7 +27,6 @@ namespace TyTy {
 class TyVisitor
 {
 public:
-  virtual void visit (UnitType &type) = 0;
   virtual void visit (InferType &type) = 0;
   virtual void visit (ADTType &type) = 0;
   virtual void visit (TupleType &type) = 0;

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -64,31 +64,6 @@ TyVar::get_implict_infer_var ()
 }
 
 void
-UnitType::accept_vis (TyVisitor &vis)
-{
-  vis.visit (*this);
-}
-
-std::string
-UnitType::as_string () const
-{
-  return "()";
-}
-
-BaseType *
-UnitType::unify (BaseType *other)
-{
-  UnitRules r (this);
-  return r.unify (other);
-}
-
-BaseType *
-UnitType::clone ()
-{
-  return new UnitType (get_ref (), get_ty_ref (), get_combined_refs ());
-}
-
-void
 InferType::accept_vis (TyVisitor &vis)
 {
   vis.visit (*this);

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -43,7 +43,6 @@ enum TypeKind
   INT,
   UINT,
   FLOAT,
-  UNIT,
   USIZE,
   ISIZE,
   // there are more to add...
@@ -90,7 +89,7 @@ public:
     return get_kind () == other.get_kind ();
   }
 
-  virtual bool is_unit () const { return kind == TypeKind::UNIT; }
+  virtual bool is_unit () const { return false; }
 
   TypeKind get_kind () const { return kind; }
 
@@ -183,8 +182,6 @@ public:
 
   void accept_vis (TyVisitor &vis) override;
 
-  bool is_unit () const override { return false; }
-
   std::string as_string () const override;
 
   BaseType *unify (BaseType *other) override;
@@ -210,30 +207,6 @@ public:
 
   ErrorType (HirId ref, HirId ty_ref, std::set<HirId> refs = std::set<HirId> ())
     : BaseType (ref, ty_ref, TypeKind::ERROR, refs)
-  {}
-
-  void accept_vis (TyVisitor &vis) override;
-
-  bool is_unit () const override { return true; }
-
-  std::string as_string () const override;
-
-  BaseType *unify (BaseType *other) override;
-
-  BaseType *clone () final override;
-
-  std::string get_name () const override final { return as_string (); }
-};
-
-class UnitType : public BaseType
-{
-public:
-  UnitType (HirId ref, std::set<HirId> refs = std::set<HirId> ())
-    : BaseType (ref, ref, TypeKind::UNIT, refs)
-  {}
-
-  UnitType (HirId ref, HirId ty_ref, std::set<HirId> refs = std::set<HirId> ())
-    : BaseType (ref, ty_ref, TypeKind::UNIT, refs)
   {}
 
   void accept_vis (TyVisitor &vis) override;
@@ -321,19 +294,20 @@ private:
 class TupleType : public BaseType
 {
 public:
-  TupleType (HirId ref, std::vector<TyVar> fields,
+  TupleType (HirId ref, std::vector<TyVar> fields = std::vector<TyVar> (),
 	     std::set<HirId> refs = std::set<HirId> ())
     : BaseType (ref, ref, TypeKind::TUPLE, refs), fields (fields)
   {}
 
-  TupleType (HirId ref, HirId ty_ref, std::vector<TyVar> fields,
+  TupleType (HirId ref, HirId ty_ref,
+	     std::vector<TyVar> fields = std::vector<TyVar> (),
 	     std::set<HirId> refs = std::set<HirId> ())
     : BaseType (ref, ty_ref, TypeKind::TUPLE, refs), fields (fields)
   {}
 
   void accept_vis (TyVisitor &vis) override;
 
-  bool is_unit () const override { return false; }
+  bool is_unit () const override { return this->fields.empty (); }
 
   std::string as_string () const override;
 
@@ -601,8 +575,6 @@ public:
   bool get_is_tuple () { return is_tuple; }
 
   void accept_vis (TyVisitor &vis) override;
-
-  bool is_unit () const override { return false; }
 
   std::string as_string () const override;
 
@@ -1132,9 +1104,6 @@ public:
 
       case TypeKind::FLOAT:
 	return "Float";
-
-      case TypeKind::UNIT:
-	return "Unit";
 
       case TypeKind::USIZE:
 	return "Usize";


### PR DESCRIPTION
This is WIP for #252 and awaits copyright assignment.

Removed TyTy::UnitType and TyTy::TypeKind::UNIT.
Replaced by TyTy::TupleType with an empty list of fields.
Added default empty vector for fields in ctor for TyTy::TypeType.