### PR TITLE
Fix last remaining Woverloaded-virtual

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -242,7 +242,7 @@ CFLAGS-rust/rust-parse.o += $(RUST_INCLUDES)
 CFLAGS-rust/rust-session-manager.o += $(RUST_INCLUDES)
 
 # TODO: possibly find a way to ensure C++11 compilation level here?
-RUST_CXXFLAGS = -std=c++11 -Wno-unused-parameter
+RUST_CXXFLAGS = -std=c++11 -Wno-unused-parameter -Werror=overloaded-virtual
 
 # build all rust/lex files in rust folder, add cross-folder includes
 rust/%.o: rust/lex/%.cc

--- a/gcc/rust/typecheck/rust-tyty-rules.h
+++ b/gcc/rust/typecheck/rust-tyty-rules.h
@@ -497,6 +497,8 @@ private:
 
 class UnitRules : public BaseRules
 {
+  using Rust::TyTy::BaseRules::visit;
+
 public:
   UnitRules (UnitType *base) : BaseRules (base), base (base) {}
 


### PR DESCRIPTION
Add using clause for UnitRules.

Add -Werror=overloaded-virtual to avoid regressing on this warning.