### PR TITLE
Fix Backend:: mark 2 methods pure

### DIFF
--- a/gcc/rust/rust-backend.h
+++ b/gcc/rust/rust-backend.h
@@ -468,10 +468,10 @@ public:
     = 0;
 
   // infinite loop expressions
-  virtual Bexpression *loop_expression (Bblock *body, Location);
+  virtual Bexpression *loop_expression (Bblock *body, Location) = 0;
 
   // exit expressions
-  virtual Bexpression *exit_expression (Bexpression *condition, Location);
+  virtual Bexpression *exit_expression (Bexpression *condition, Location) = 0;
 
   // Create a switch statement where the case values are constants.
   // CASES and STATEMENTS must have the same number of entries.  If


### PR DESCRIPTION
virtual `loop_expression` and `exit_expression` were not marked pure and do not have
a default impl, causing error during linking when optimisation are disabled.

This fixes this error:
```
/usr/bin/ld: rust/rust-gcc.o: in function `Backend::~Backend()':
...gccrs/build/gcc/../../gcc/rust/rust-backend.h:67: undefined reference to `vtable for Backend'
/usr/bin/ld: rust/rust-gcc.o: in function `Backend::Backend()':
...gccrs/build/gcc/../../gcc/rust/rust-backend.h:64: undefined reference to `vtable for Backend'
collect2: error: ld returned 1 exit status
make: *** [../../gcc/rust/Make-lang.in:92: rust1] Error 1
```