### PR TITLE
Typo fix in substition

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -780,7 +780,7 @@ public:
       }
 
     HIR::PathExprSegment seg = expr.get_final_segment ();
-    if (!infered->supports_substitions () && seg.has_generic_args ())
+    if (!infered->supports_substitutions () && seg.has_generic_args ())
       {
 	rust_error_at (expr.get_locus (),
 		       "path does not support substitutions");
@@ -798,8 +798,8 @@ public:
 
 	TyTy::ADTType *adt = static_cast<TyTy::ADTType *> (infered);
 	infered = seg.has_generic_args ()
-		    ? adt->handle_substitions (seg.get_generic_args ())
-		    : adt->infer_substitions ();
+		    ? adt->handle_substitutions (seg.get_generic_args ())
+		    : adt->infer_substitutions ();
       }
   }
 

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
@@ -42,7 +42,7 @@ public:
 
   void visit (HIR::TupleStruct &struct_decl) override
   {
-    std::vector<TyTy::SubstitionMapping> substitions;
+    std::vector<TyTy::SubstitutionMapping> substitutions;
     if (struct_decl.has_generics ())
       {
 	for (auto &generic_param : struct_decl.get_generic_params ())
@@ -51,8 +51,8 @@ public:
 	      = TypeResolveGenericParam::Resolve (generic_param.get ());
 	    context->insert_type (generic_param->get_mappings (), param_type);
 
-	    substitions.push_back (
-	      TyTy::SubstitionMapping (generic_param, param_type));
+	    substitutions.push_back (
+	      TyTy::SubstitutionMapping (generic_param, param_type));
 	  }
       }
 
@@ -75,14 +75,14 @@ public:
       = new TyTy::ADTType (struct_decl.get_mappings ().get_hirid (),
 			   mappings->get_next_hir_id (),
 			   struct_decl.get_identifier (), true,
-			   std::move (fields), std::move (substitions));
+			   std::move (fields), std::move (substitutions));
 
     context->insert_type (struct_decl.get_mappings (), type);
   }
 
   void visit (HIR::StructStruct &struct_decl) override
   {
-    std::vector<TyTy::SubstitionMapping> substitions;
+    std::vector<TyTy::SubstitutionMapping> substitutions;
     if (struct_decl.has_generics ())
       {
 	for (auto &generic_param : struct_decl.get_generic_params ())
@@ -91,8 +91,8 @@ public:
 	      = TypeResolveGenericParam::Resolve (generic_param.get ());
 	    context->insert_type (generic_param->get_mappings (), param_type);
 
-	    substitions.push_back (
-	      TyTy::SubstitionMapping (generic_param, param_type));
+	    substitutions.push_back (
+	      TyTy::SubstitutionMapping (generic_param, param_type));
 	  }
       }
 
@@ -112,7 +112,7 @@ public:
       = new TyTy::ADTType (struct_decl.get_mappings ().get_hirid (),
 			   mappings->get_next_hir_id (),
 			   struct_decl.get_identifier (), false,
-			   std::move (fields), std::move (substitions));
+			   std::move (fields), std::move (substitutions));
 
     context->insert_type (struct_decl.get_mappings (), type);
   }
@@ -136,7 +136,7 @@ public:
 
   void visit (HIR::Function &function) override
   {
-    std::vector<TyTy::SubstitionMapping> substitions;
+    std::vector<TyTy::SubstitutionMapping> substitutions;
     if (function.has_generics ())
       {
 	for (auto &generic_param : function.get_generic_params ())
@@ -145,8 +145,8 @@ public:
 	      = TypeResolveGenericParam::Resolve (generic_param.get ());
 	    context->insert_type (generic_param->get_mappings (), param_type);
 
-	    substitions.push_back (
-	      TyTy::SubstitionMapping (generic_param, param_type));
+	    substitutions.push_back (
+	      TyTy::SubstitutionMapping (generic_param, param_type));
 	  }
       }
 

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -195,7 +195,7 @@ public:
 
 		    TyTy::ADTType *adt
 		      = static_cast<TyTy::ADTType *> (translated);
-		    translated = adt->handle_substitions (args);
+		    translated = adt->handle_substitutions (args);
 		  }
 		else
 		  {
@@ -208,7 +208,7 @@ public:
 		    return;
 		  }
 	      }
-	    else if (translated->supports_substitions ())
+	    else if (translated->supports_substitutions ())
 	      {
 		// so far we only support ADT so lets just handle it here
 		// for now
@@ -222,7 +222,7 @@ public:
 		  }
 
 		TyTy::ADTType *adt = static_cast<TyTy::ADTType *> (translated);
-		translated = adt->infer_substitions ();
+		translated = adt->infer_substitutions ();
 	      }
 
 	    return;

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -325,13 +325,13 @@ TypeCheckStructExpr::visit (HIR::PathInExpression &expr)
     }
 
   struct_path_resolved = static_cast<TyTy::ADTType *> (lookup);
-  if (struct_path_resolved->has_substitions ())
+  if (struct_path_resolved->has_substitutions ())
     {
       HIR::PathExprSegment seg = expr.get_final_segment ();
-      struct_path_resolved
-	= seg.has_generic_args ()
-	    ? struct_path_resolved->handle_substitions (seg.get_generic_args ())
-	    : struct_path_resolved->infer_substitions ();
+      struct_path_resolved = seg.has_generic_args ()
+			       ? struct_path_resolved->handle_substitutions (
+				 seg.get_generic_args ())
+			       : struct_path_resolved->infer_substitutions ();
     }
 }
 

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -228,7 +228,7 @@ ADTType::clone ()
 }
 
 ADTType *
-ADTType::infer_substitions ()
+ADTType::infer_substitutions ()
 {
   auto context = Resolver::TypeCheckContext::get ();
   ADTType *adt = static_cast<ADTType *> (clone ());
@@ -254,9 +254,9 @@ ADTType::infer_substitions ()
 }
 
 ADTType *
-ADTType::handle_substitions (HIR::GenericArgs &generic_args)
+ADTType::handle_substitutions (HIR::GenericArgs &generic_args)
 {
-  if (generic_args.get_type_args ().size () != get_num_substitions ())
+  if (generic_args.get_type_args ().size () != get_num_substitutions ())
     {
       rust_error_at (generic_args.get_locus (),
 		     "invalid number of generic arguments to generic ADT type");
@@ -288,13 +288,13 @@ ADTType::handle_substitions (HIR::GenericArgs &generic_args)
 void
 ADTType::fill_in_at (size_t index, BaseType *type)
 {
-  SubstitionMapping sub = get_substition_mapping_at (index);
-  SubstitionRef<ADTType>::fill_in_at (index, type);
+  SubstitutionMapping sub = get_substitution_mapping_at (index);
+  SubstitutionRef<ADTType>::fill_in_at (index, type);
   fill_in_params_for (sub, type);
 }
 
 void
-ADTType::fill_in_params_for (SubstitionMapping sub, BaseType *type)
+ADTType::fill_in_params_for (SubstitutionMapping sub, BaseType *type)
 {
   iterate_fields ([&] (StructFieldType *field) mutable -> bool {
     bool is_param_ty = field->get_field_type ()->get_kind () == TypeKind::PARAM;

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -97,7 +97,7 @@ public:
 
   void append_reference (HirId id) { combined.insert (id); }
 
-  virtual bool supports_substitions () const { return false; }
+  virtual bool supports_substitutions () const { return false; }
 
   virtual bool has_subsititions_defined () const { return false; }
 
@@ -322,11 +322,11 @@ private:
   HIR::GenericParam &param;
 };
 
-class SubstitionMapping
+class SubstitutionMapping
 {
 public:
-  SubstitionMapping (std::unique_ptr<HIR::GenericParam> &generic,
-		     ParamType *param)
+  SubstitutionMapping (std::unique_ptr<HIR::GenericParam> &generic,
+		       ParamType *param)
     : generic (generic), param (param)
   {}
 
@@ -334,10 +334,10 @@ public:
 
   void fill_param_ty (BaseType *type) { param->set_ty_ref (type->get_ref ()); }
 
-  SubstitionMapping clone ()
+  SubstitutionMapping clone ()
   {
-    return SubstitionMapping (generic,
-			      static_cast<ParamType *> (param->clone ()));
+    return SubstitutionMapping (generic,
+				static_cast<ParamType *> (param->clone ()));
   }
 
   const ParamType *get_param_ty () const { return param; }
@@ -347,80 +347,80 @@ private:
   ParamType *param;
 };
 
-template <class T> class SubstitionRef
+template <class T> class SubstitutionRef
 {
 public:
-  SubstitionRef (std::vector<SubstitionMapping> substitions)
-    : substitions (substitions)
+  SubstitutionRef (std::vector<SubstitutionMapping> substitutions)
+    : substitutions (substitutions)
   {}
 
-  bool has_substitions () const { return substitions.size () > 0; }
+  bool has_substitutions () const { return substitutions.size () > 0; }
 
   std::string subst_as_string () const
   {
     std::string buffer;
-    for (size_t i = 0; i < substitions.size (); i++)
+    for (size_t i = 0; i < substitutions.size (); i++)
       {
-	const SubstitionMapping &sub = substitions.at (i);
+	const SubstitutionMapping &sub = substitutions.at (i);
 	buffer += sub.as_string ();
 
-	if ((i + 1) < substitions.size ())
+	if ((i + 1) < substitutions.size ())
 	  buffer += ", ";
       }
 
     return buffer.empty () ? "" : "<" + buffer + ">";
   }
 
-  size_t get_num_substitions () const { return substitions.size (); }
+  size_t get_num_substitutions () const { return substitutions.size (); }
 
-  std::vector<SubstitionMapping> &get_substs () { return substitions; }
+  std::vector<SubstitutionMapping> &get_substs () { return substitutions; }
 
-  std::vector<SubstitionMapping> clone_substs ()
+  std::vector<SubstitutionMapping> clone_substs ()
   {
-    std::vector<SubstitionMapping> clone;
-    for (auto &sub : substitions)
+    std::vector<SubstitutionMapping> clone;
+    for (auto &sub : substitutions)
       clone.push_back (sub.clone ());
 
     return clone;
   }
 
-  virtual T *infer_substitions () = 0;
+  virtual T *infer_substitutions () = 0;
 
-  virtual T *handle_substitions (HIR::GenericArgs &generic_args) = 0;
+  virtual T *handle_substitutions (HIR::GenericArgs &generic_args) = 0;
 
 protected:
   virtual void fill_in_at (size_t index, BaseType *type)
   {
-    substitions.at (index).fill_param_ty (type);
+    substitutions.at (index).fill_param_ty (type);
   }
 
-  SubstitionMapping get_substition_mapping_at (size_t index)
+  SubstitutionMapping get_substitution_mapping_at (size_t index)
   {
-    return substitions.at (index);
+    return substitutions.at (index);
   }
 
 private:
-  std::vector<SubstitionMapping> substitions;
+  std::vector<SubstitutionMapping> substitutions;
 };
 
-class ADTType : public BaseType, public SubstitionRef<ADTType>
+class ADTType : public BaseType, public SubstitutionRef<ADTType>
 {
 public:
   ADTType (HirId ref, std::string identifier, bool is_tuple,
 	   std::vector<StructFieldType *> fields,
-	   std::vector<SubstitionMapping> subst_refs,
+	   std::vector<SubstitutionMapping> subst_refs,
 	   std::set<HirId> refs = std::set<HirId> ())
     : BaseType (ref, ref, TypeKind::ADT, refs),
-      SubstitionRef (std::move (subst_refs)), identifier (identifier),
+      SubstitutionRef (std::move (subst_refs)), identifier (identifier),
       fields (fields), is_tuple (is_tuple)
   {}
 
   ADTType (HirId ref, HirId ty_ref, std::string identifier, bool is_tuple,
 	   std::vector<StructFieldType *> fields,
-	   std::vector<SubstitionMapping> subst_refs,
+	   std::vector<SubstitutionMapping> subst_refs,
 	   std::set<HirId> refs = std::set<HirId> ())
     : BaseType (ref, ty_ref, TypeKind::ADT, refs),
-      SubstitionRef (std::move (subst_refs)), identifier (identifier),
+      SubstitutionRef (std::move (subst_refs)), identifier (identifier),
       fields (fields), is_tuple (is_tuple)
   {}
 
@@ -482,20 +482,20 @@ public:
       }
   }
 
-  bool supports_substitions () const override final { return true; }
+  bool supports_substitutions () const override final { return true; }
 
   bool has_subsititions_defined () const override final
   {
-    return has_substitions ();
+    return has_substitutions ();
   }
 
-  ADTType *infer_substitions () override final;
+  ADTType *infer_substitutions () override final;
 
-  ADTType *handle_substitions (HIR::GenericArgs &generic_args) override final;
+  ADTType *handle_substitutions (HIR::GenericArgs &generic_args) override final;
 
   void fill_in_at (size_t index, BaseType *type) override final;
 
-  void fill_in_params_for (SubstitionMapping sub, BaseType *type);
+  void fill_in_params_for (SubstitutionMapping sub, BaseType *type);
 
 private:
   std::string identifier;


### PR DESCRIPTION
Replace all occurences of [Ss]ubstition[s] by [Ss]ubstition[s].

Looks like a common typo, there are some more occurrence in other parts of GCC :)