### PR TITLE
Fix type unification for return types

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-item.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.h
@@ -77,15 +77,12 @@ public:
     auto expected_ret_tyty = resolve_fn_type->get_return_type ();
     context->push_return_type (expected_ret_tyty);
 
-    auto result
+    auto block_expr_ty
       = TypeCheckExpr::Resolve (function.get_definition ().get (), false);
-    auto ret_resolved = expected_ret_tyty->unify (result);
-    if (ret_resolved == nullptr)
-      return;
-
-    context->peek_return_type ()->append_reference (ret_resolved->get_ref ());
 
     context->pop_return_type ();
+
+    expected_ret_tyty->unify (block_expr_ty);
   }
 
 private:

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -101,6 +101,24 @@ public:
 
   virtual bool has_subsititions_defined () const { return false; }
 
+  std::string mappings_str () const
+  {
+    std::string buffer = "Ref: " + std::to_string (get_ref ())
+			 + " TyRef: " + std::to_string (get_ty_ref ());
+    buffer += "[";
+    for (auto &ref : combined)
+      buffer += std::to_string (ref) + ",";
+    buffer += "]";
+    return "(" + buffer + ")";
+  }
+
+  std::string debug_str () const
+  {
+    return as_string () + ":" + mappings_str ();
+  }
+
+  void debug () const { printf ("%s\n", debug_str ().c_str ()); }
+
 protected:
   BaseType (HirId ref, HirId ty_ref, TypeKind kind,
 	    std::set<HirId> refs = std::set<HirId> ())

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -57,7 +57,12 @@ public:
 
   HirId get_ref () const { return ref; }
 
-  void set_ref (HirId id) { ref = id; }
+  void set_ref (HirId id)
+  {
+    if (id != ref)
+      append_reference (ref);
+    ref = id;
+  }
 
   HirId get_ty_ref () const { return ty_ref; }
 

--- a/gcc/testsuite/rust.test/compilable/block_expr4.rs
+++ b/gcc/testsuite/rust.test/compilable/block_expr4.rs
@@ -1,0 +1,7 @@
+fn foo() -> isize {
+    0
+}
+
+fn main() {
+    let a = foo();
+}


### PR DESCRIPTION
Fix type unification for Inference Variables and return types
    
    When we resolve the type of an expression such as a LiteralExpr with HIR id
    10, but is the final expression in a BlockExpr of HirId 11. The same type
    is infered for the entire BlockExpr as well as the final Expr but we
    override the reference id on the TyTy::Type. This means if there is a
    change in reference id the old ID must be added to the combined reference
    chain for type inference to take place.
    
    Fixes #293