### PR TITLE
Fix error while unexpected EOF when scanning for end of comment

### DIFF
--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -427,6 +427,14 @@ Lexer::build_token ()
 		  current_column++; // for error-handling
 		  current_char = peek_input ();
 
+		  if (current_char == EOF)
+		    {
+		      rust_error_at (
+			loc, "unexpected EOF while looking for end of comment",
+			current_char);
+		      break;
+		    }
+
 		  // if /* found
 		  if (current_char == '/' && peek_input (1) == '*')
 		    {

--- a/gcc/testsuite/rust.test/fail_compilation/unterminated_c_comment.rs
+++ b/gcc/testsuite/rust.test/fail_compilation/unterminated_c_comment.rs
@@ -1,0 +1,1 @@
+/* This  comment needs closure :) !


### PR DESCRIPTION
Emit an error when EOF is reached before end of C-style comment.

fix #300