### PR TITLE
Generics on Impl Blocks WIP

### DIFF
--- a/gcc/rust/ast/rust-path.h
+++ b/gcc/rust/ast/rust-path.h
@@ -198,6 +198,8 @@ public:
   std::vector<GenericArgsBinding> &get_binding_args () { return binding_args; }
 
   std::vector<Lifetime> &get_lifetime_args () { return lifetime_args; };
+
+  Location get_locus () { return locus; }
 };
 
 /* A segment of a path in expression, including an identifier aspect and maybe
@@ -206,13 +208,9 @@ class PathExprSegment
 { // or should this extend PathIdentSegment?
 private:
   PathIdentSegment segment_name;
-
-  // bool has_generic_args;
   GenericArgs generic_args;
-
   Location locus;
-
-  // TODO: does this require visitor? pretty sure not polymorphic
+  NodeId node_id;
 
 public:
   // Returns true if there are any generic arguments
@@ -222,7 +220,8 @@ public:
   PathExprSegment (PathIdentSegment segment_name, Location locus = Location (),
 		   GenericArgs generic_args = GenericArgs::create_empty ())
     : segment_name (std::move (segment_name)),
-      generic_args (std::move (generic_args)), locus (locus)
+      generic_args (std::move (generic_args)), locus (locus),
+      node_id (Analysis::Mappings::get ()->get_next_node_id ())
   {}
 
   /* Constructor for segment with generic arguments (from segment name and all
@@ -238,7 +237,7 @@ public:
       generic_args (GenericArgs (std::move (lifetime_args),
 				 std::move (type_args),
 				 std::move (binding_args))),
-      locus (locus)
+      locus (locus), node_id (Analysis::Mappings::get ()->get_next_node_id ())
   {}
 
   // Returns whether path expression segment is in an error state.
@@ -262,6 +261,8 @@ public:
   }
 
   PathIdentSegment &get_ident_segment () { return segment_name; }
+
+  NodeId get_node_id () const { return node_id; }
 };
 
 // AST node representing a pattern that involves a "path" - abstract base class

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -297,8 +297,7 @@ public:
 
   void visit (TyTy::ParamType &param) override
   {
-    TyTy::TyVar var (param.get_ty_ref ());
-    var.get_tyty ()->accept_vis (*this);
+    param.resolve ()->accept_vis (*this);
   }
 
   void visit (TyTy::FnType &type) override

--- a/gcc/rust/backend/rust-compile-implitem.h
+++ b/gcc/rust/backend/rust-compile-implitem.h
@@ -272,6 +272,21 @@ public:
       }
 
     TyTy::FnType *fntype = static_cast<TyTy::FnType *> (fntype_tyty);
+    if (fntype->has_subsititions_defined ())
+      {
+	// we cant do anything for this only when it is used
+	if (concrete == nullptr)
+	  return;
+	else
+	  {
+	    rust_assert (concrete->get_kind () == TyTy::TypeKind::FNDEF);
+	    fntype = static_cast<TyTy::FnType *> (concrete);
+
+	    // override the Hir Lookups for the substituions in this context
+	    fntype->override_context ();
+	  }
+      }
+
     // convert to the actual function type
     ::Btype *compiled_fn_type = TyTyResolveCompile::compile (ctx, fntype);
 

--- a/gcc/rust/backend/rust-compile-implitem.h
+++ b/gcc/rust/backend/rust-compile-implitem.h
@@ -35,9 +35,10 @@ class CompileInherentImplItem : public HIRCompileBase
 
 public:
   static void Compile (TyTy::BaseType *self, HIR::InherentImplItem *item,
-		       Context *ctx, bool compile_fns)
+		       Context *ctx, bool compile_fns,
+		       TyTy::BaseType *concrete = nullptr)
   {
-    CompileInherentImplItem compiler (self, ctx, compile_fns);
+    CompileInherentImplItem compiler (self, ctx, compile_fns, concrete);
     item->accept_vis (compiler);
   }
 
@@ -92,6 +93,21 @@ public:
       }
 
     TyTy::FnType *fntype = static_cast<TyTy::FnType *> (fntype_tyty);
+    if (fntype->has_subsititions_defined ())
+      {
+	// we cant do anything for this only when it is used
+	if (concrete == nullptr)
+	  return;
+	else
+	  {
+	    rust_assert (concrete->get_kind () == TyTy::TypeKind::FNDEF);
+	    fntype = static_cast<TyTy::FnType *> (concrete);
+
+	    // override the Hir Lookups for the substituions in this context
+	    fntype->override_context ();
+	  }
+      }
+
     // convert to the actual function type
     ::Btype *compiled_fn_type = TyTyResolveCompile::compile (ctx, fntype);
 
@@ -111,7 +127,6 @@ public:
     ctx->insert_function_decl (fntype->get_ty_ref (), fndecl);
 
     // setup the params
-
     TyTy::BaseType *tyret = fntype->get_return_type ();
     std::vector<Bvariable *> param_vars;
 
@@ -431,12 +446,15 @@ public:
   }
 
 private:
-  CompileInherentImplItem (TyTy::BaseType *self, Context *ctx, bool compile_fns)
-    : HIRCompileBase (ctx), self (self), compile_fns (compile_fns)
+  CompileInherentImplItem (TyTy::BaseType *self, Context *ctx, bool compile_fns,
+			   TyTy::BaseType *concrete)
+    : HIRCompileBase (ctx), self (self), compile_fns (compile_fns),
+      concrete (concrete)
   {}
 
   TyTy::BaseType *self;
   bool compile_fns;
+  TyTy::BaseType *concrete;
 };
 
 } // namespace Compile

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -130,7 +130,7 @@ CompileExpr::visit (HIR::MethodCallExpr &expr)
       // resolve it now
       HIR::InherentImplItem *resolved_item
 	= ctx->get_mappings ()->lookup_hir_implitem (
-	  expr.get_mappings ().get_crate_num (), ref);
+	  expr.get_mappings ().get_crate_num (), ref, nullptr);
       if (resolved_item == nullptr)
 	{
 	  rust_error_at (expr.get_locus (), "failed to lookup forward decl");

--- a/gcc/rust/hir/rust-ast-lower-base.h
+++ b/gcc/rust/hir/rust-ast-lower-base.h
@@ -284,6 +284,13 @@ protected:
 
     return HIR::LoopLabel (mapping, std::move (life), loop_label.get_locus ());
   }
+
+  std::vector<std::unique_ptr<HIR::GenericParam> > lower_generic_params (
+    std::vector<std::unique_ptr<AST::GenericParam> > &params);
+
+  HIR::PathExprSegment lower_path_expr_seg (AST::PathExprSegment &s);
+
+  HIR::GenericArgs lower_generic_args (AST::GenericArgs &args);
 };
 
 } // namespace HIR

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -241,9 +241,9 @@ public:
     });
 
     auto crate_num = mappings->get_current_crate ();
-    Analysis::NodeMapping mapping (
-      crate_num, UNKNOWN_NODEID /* this can map back to the AST*/,
-      mappings->get_next_hir_id (crate_num), UNKNOWN_LOCAL_DEFID);
+    Analysis::NodeMapping mapping (crate_num, expr.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   UNKNOWN_LOCAL_DEFID);
 
     translated
       = new HIR::MethodCallExpr (mapping, std::unique_ptr<HIR::Expr> (receiver),

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -40,8 +40,6 @@ public:
     return folder.ok;
   }
 
-  virtual ~ArrayCapacityConstant () {}
-
   void visit (AST::LiteralExpr &expr) override
   {
     switch (expr.get_lit_type ())
@@ -226,9 +224,8 @@ public:
   {
     std::vector<HIR::Attribute> outer_attribs;
 
-    HIR::PathExprSegment method_path (
-      expr.get_method_name ().get_ident_segment ().as_string (),
-      expr.get_method_name ().get_locus ());
+    HIR::PathExprSegment method_path
+      = lower_path_expr_seg (expr.get_method_name ());
 
     HIR::Expr *receiver
       = ASTLoweringExpr::translate (expr.get_receiver_expr ().get ());

--- a/gcc/rust/hir/rust-ast-lower-implitem.h
+++ b/gcc/rust/hir/rust-ast-lower-implitem.h
@@ -34,9 +34,10 @@ class ASTLowerImplItem : public ASTLoweringBase
   using Rust::HIR::ASTLoweringBase::visit;
 
 public:
-  static HIR::InherentImplItem *translate (AST::InherentImplItem *item)
+  static HIR::InherentImplItem *translate (AST::InherentImplItem *item,
+					   HirId parent_impl_id)
   {
-    ASTLowerImplItem resolver;
+    ASTLowerImplItem resolver (parent_impl_id);
     item->accept_vis (resolver);
     rust_assert (resolver.translated != nullptr);
     return resolver.translated;
@@ -76,7 +77,8 @@ public:
 					outer_attrs, constant.get_locus ());
 
     mappings->insert_hir_implitem (mapping.get_crate_num (),
-				   mapping.get_hirid (), translated);
+				   mapping.get_hirid (), parent_impl_id,
+				   translated);
     mappings->insert_location (crate_num, mapping.get_hirid (),
 			       constant.get_locus ());
   }
@@ -144,7 +146,7 @@ public:
 			   std::move (vis), std::move (outer_attrs), locus);
 
     mappings->insert_hir_implitem (mapping.get_crate_num (),
-				   mapping.get_hirid (), fn);
+				   mapping.get_hirid (), parent_impl_id, fn);
     mappings->insert_location (crate_num, mapping.get_hirid (),
 			       function.get_locus ());
 
@@ -221,7 +223,7 @@ public:
 			 std::move (outer_attrs), locus);
 
     mappings->insert_hir_implitem (mapping.get_crate_num (),
-				   mapping.get_hirid (), mth);
+				   mapping.get_hirid (), parent_impl_id, mth);
     mappings->insert_location (crate_num, mapping.get_hirid (),
 			       method.get_locus ());
 
@@ -246,13 +248,15 @@ public:
   }
 
 private:
-  ASTLowerImplItem () : translated (nullptr) {}
+  ASTLowerImplItem (HirId parent_impl_id)
+    : translated (nullptr), parent_impl_id (parent_impl_id)
+  {}
 
   HIR::InherentImplItem *translated;
+  HirId parent_impl_id;
 };
 
 } // namespace HIR
-
 } // namespace Rust
 
 #endif // RUST_AST_LOWER_IMPLITEM_H

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -351,19 +351,6 @@ public:
   }
 
 private:
-  std::vector<std::unique_ptr<HIR::GenericParam> > lower_generic_params (
-    std::vector<std::unique_ptr<AST::GenericParam> > &params)
-  {
-    std::vector<std::unique_ptr<HIR::GenericParam> > lowered;
-    for (auto &ast_param : params)
-      {
-	auto hir_param = ASTLowerGenericParam::translate (ast_param.get ());
-	lowered.push_back (std::unique_ptr<HIR::GenericParam> (hir_param));
-      }
-
-    return lowered;
-  }
-
   ASTLoweringItem () : translated (nullptr) {}
 
   HIR::Item *translated;

--- a/gcc/rust/hir/tree/rust-hir-full-test.cc
+++ b/gcc/rust/hir/tree/rust-hir-full-test.cc
@@ -2692,8 +2692,7 @@ PathPattern::convert_to_simple_path (bool with_opening_scope_resolution) const
   for (const auto &segment : segments)
     {
       // return empty path if doesn't meet simple path segment requirements
-      if (segment.is_error () || segment.has_generic_args ()
-	  || segment.as_string () == "Self")
+      if (segment.has_generic_args () || segment.as_string () == "Self")
 	{
 	  return SimplePath::create_empty ();
 	}

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -2915,6 +2915,11 @@ public:
 
   std::unique_ptr<Type> &get_type () { return trait_type; };
 
+  std::vector<std::unique_ptr<GenericParam> > &get_generic_params ()
+  {
+    return generic_params;
+  }
+
 protected:
   // Mega-constructor
   Impl (Analysis::NodeMapping mappings,

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -152,6 +152,17 @@ public:
 
   void visit (AST::InherentImpl &impl_block) override
   {
+    NodeId scope_node_id = impl_block.get_node_id ();
+    resolver->get_type_scope ().push (scope_node_id);
+
+    if (impl_block.has_generics ())
+      {
+	for (auto &generic : impl_block.get_generic_params ())
+	  {
+	    ResolveGenericParam::go (generic.get (), impl_block.get_node_id ());
+	  }
+      }
+
     NodeId resolved_node = ResolveType::go (impl_block.get_type ().get (),
 					    impl_block.get_node_id ());
     if (resolved_node == UNKNOWN_NODEID)
@@ -164,6 +175,7 @@ public:
       impl_item->accept_vis (*this);
 
     resolver->get_type_scope ().peek ()->clear_name ("Self", resolved_node);
+    resolver->get_type_scope ().pop ();
   }
 
   void visit (AST::Method &method) override

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -212,15 +212,12 @@ public:
     auto expected_ret_tyty = resolve_fn_type->get_return_type ();
     context->push_return_type (expected_ret_tyty);
 
-    auto result
+    auto block_expr_ty
       = TypeCheckExpr::Resolve (function.get_definition ().get (), false);
-    auto ret_resolved = expected_ret_tyty->unify (result);
-    if (ret_resolved == nullptr)
-      return;
-
-    context->peek_return_type ()->append_reference (ret_resolved->get_ref ());
 
     context->pop_return_type ();
+
+    expected_ret_tyty->unify (block_expr_ty);
   }
 
   void visit (HIR::Method &method) override
@@ -245,15 +242,15 @@ public:
     auto expected_ret_tyty = resolve_fn_type->get_return_type ();
     context->push_return_type (expected_ret_tyty);
 
-    auto result
-      = TypeCheckExpr::Resolve (method.get_function_body ().get (), false);
-    auto ret_resolved = expected_ret_tyty->unify (result);
-    if (ret_resolved == nullptr)
-      return;
+    printf ("XXXX method body boyo: 1!!\n");
 
-    context->peek_return_type ()->append_reference (ret_resolved->get_ref ());
+    auto block_expr_ty
+      = TypeCheckExpr::Resolve (method.get_definition ().get (), false);
 
     context->pop_return_type ();
+
+    expected_ret_tyty->unify (block_expr_ty);
+    printf ("XXXX method body boyo: 2!!\n");
   }
 
 private:

--- a/gcc/rust/typecheck/rust-substitution-mapper.h
+++ b/gcc/rust/typecheck/rust-substitution-mapper.h
@@ -162,6 +162,62 @@ private:
   TyTy::SubstitutionArgumentMappings &mappings;
 };
 
+class SubstMapperFromExisting : public TyTy::TyVisitor
+{
+public:
+  static TyTy::BaseType *Resolve (TyTy::BaseType *concrete,
+				  TyTy::BaseType *receiver)
+  {
+    rust_assert (concrete->get_kind () == receiver->get_kind ());
+
+    SubstMapperFromExisting mapper (concrete, receiver);
+    concrete->accept_vis (mapper);
+    return mapper.resolved;
+  }
+
+  void visit (TyTy::FnType &type) override
+  {
+    rust_assert (type.was_substituted ());
+
+    TyTy::FnType *to_sub = static_cast<TyTy::FnType *> (receiver);
+    resolved = to_sub->handle_substitions (type.get_substitution_arguments ());
+  }
+
+  void visit (TyTy::ADTType &type) override
+  {
+    rust_assert (type.was_substituted ());
+
+    TyTy::ADTType *to_sub = static_cast<TyTy::ADTType *> (receiver);
+    resolved = to_sub->handle_substitions (type.get_substitution_arguments ());
+  }
+
+  void visit (TyTy::InferType &) override { gcc_unreachable (); }
+  void visit (TyTy::TupleType &) override { gcc_unreachable (); }
+  void visit (TyTy::FnPtr &) override { gcc_unreachable (); }
+  void visit (TyTy::ArrayType &) override { gcc_unreachable (); }
+  void visit (TyTy::BoolType &) override { gcc_unreachable (); }
+  void visit (TyTy::IntType &) override { gcc_unreachable (); }
+  void visit (TyTy::UintType &) override { gcc_unreachable (); }
+  void visit (TyTy::FloatType &) override { gcc_unreachable (); }
+  void visit (TyTy::USizeType &) override { gcc_unreachable (); }
+  void visit (TyTy::ISizeType &) override { gcc_unreachable (); }
+  void visit (TyTy::ErrorType &) override { gcc_unreachable (); }
+  void visit (TyTy::CharType &) override { gcc_unreachable (); }
+  void visit (TyTy::ReferenceType &) override { gcc_unreachable (); }
+  void visit (TyTy::ParamType &) override { gcc_unreachable (); }
+  void visit (TyTy::StrType &) override { gcc_unreachable (); }
+
+private:
+  SubstMapperFromExisting (TyTy::BaseType *concrete, TyTy::BaseType *receiver)
+    : concrete (concrete), receiver (receiver), resolved (nullptr)
+  {}
+
+  TyTy::BaseType *concrete;
+  TyTy::BaseType *receiver;
+
+  TyTy::BaseType *resolved;
+};
+
 } // namespace Resolver
 } // namespace Rust
 

--- a/gcc/rust/typecheck/rust-tyty-call.h
+++ b/gcc/rust/typecheck/rust-tyty-call.h
@@ -76,6 +76,7 @@ private:
 class TypeCheckMethodCallExpr : private TyVisitor
 {
 public:
+  // Resolve the Method parameters and return back the return type
   static BaseType *go (BaseType *ref, HIR::MethodCallExpr &call,
 		       Resolver::TypeCheckContext *context)
   {

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -354,7 +354,8 @@ ADTType::clone ()
     cloned_fields.push_back ((StructFieldType *) f->clone ());
 
   return new ADTType (get_ref (), get_ty_ref (), identifier, get_is_tuple (),
-		      cloned_fields, clone_substs (), get_combined_refs ());
+		      cloned_fields, clone_substs (), used_arguments,
+		      get_combined_refs ());
 }
 
 ADTType *
@@ -367,6 +368,8 @@ ADTType::handle_substitions (SubstitutionArgumentMappings subst_mappings)
 		     "invalid number of generic arguments to generic ADT type");
       return nullptr;
     }
+
+  used_arguments = subst_mappings;
 
   ADTType *adt = static_cast<ADTType *> (clone ());
   adt->set_ty_ref (mappings->get_next_hir_id ());
@@ -567,6 +570,8 @@ FnType::handle_substitions (SubstitutionArgumentMappings subst_mappings)
 		     "invalid number of generic arguments to generic ADT type");
       return nullptr;
     }
+
+  used_arguments = subst_mappings;
 
   FnType *fn = static_cast<FnType *> (clone ());
   fn->set_ty_ref (mappings->get_next_hir_id ());

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -260,16 +260,18 @@ Mappings::lookup_hir_item (CrateNum crateNum, HirId id)
 
 void
 Mappings::insert_hir_implitem (CrateNum crateNum, HirId id,
+			       HirId parent_impl_id,
 			       HIR::InherentImplItem *item)
 {
-  rust_assert (lookup_hir_implitem (crateNum, id) == nullptr);
-
-  hirImplItemMappings[crateNum][id] = item;
+  rust_assert (lookup_hir_implitem (crateNum, id, nullptr) == nullptr);
+  hirImplItemMappings[crateNum][id]
+    = std::pair<HirId, HIR::InherentImplItem *> (parent_impl_id, item);
   nodeIdToHirMappings[crateNum][item->get_impl_mappings ().get_nodeid ()] = id;
 }
 
 HIR::InherentImplItem *
-Mappings::lookup_hir_implitem (CrateNum crateNum, HirId id)
+Mappings::lookup_hir_implitem (CrateNum crateNum, HirId id,
+			       HirId *parent_impl_id)
 {
   auto it = hirImplItemMappings.find (crateNum);
   if (it == hirImplItemMappings.end ())
@@ -279,7 +281,11 @@ Mappings::lookup_hir_implitem (CrateNum crateNum, HirId id)
   if (iy == it->second.end ())
     return nullptr;
 
-  return iy->second;
+  std::pair<HirId, HIR::InherentImplItem *> &ref = iy->second;
+  if (parent_impl_id != nullptr)
+    *parent_impl_id = ref.first;
+
+  return ref.second;
 }
 
 void

--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -109,9 +109,10 @@ public:
   void insert_hir_item (CrateNum crateNum, HirId id, HIR::Item *item);
   HIR::Item *lookup_hir_item (CrateNum crateNum, HirId id);
 
-  void insert_hir_implitem (CrateNum crateNum, HirId id,
+  void insert_hir_implitem (CrateNum crateNum, HirId id, HirId parent_impl_id,
 			    HIR::InherentImplItem *item);
-  HIR::InherentImplItem *lookup_hir_implitem (CrateNum crateNum, HirId id);
+  HIR::InherentImplItem *lookup_hir_implitem (CrateNum crateNum, HirId id,
+					      HirId *parent_impl_id);
 
   void insert_hir_expr (CrateNum crateNum, HirId id, HIR::Expr *expr);
   HIR::Expr *lookup_hir_expr (CrateNum crateNum, HirId id);
@@ -165,7 +166,7 @@ public:
       {
 	for (auto iy = it->second.begin (); iy != it->second.end (); iy++)
 	  {
-	    if (!cb (iy->first, iy->second))
+	    if (!cb (iy->first, iy->second.second))
 	      return;
 	  }
       }
@@ -193,7 +194,8 @@ private:
   std::map<CrateNum, std::map<HirId, HIR::FunctionParam *> > hirParamMappings;
   std::map<CrateNum, std::map<HirId, HIR::StructExprField *> >
     hirStructFieldMappings;
-  std::map<CrateNum, std::map<HirId, HIR::InherentImplItem *> >
+  std::map<CrateNum,
+	   std::map<HirId, std::pair<HirId, HIR::InherentImplItem *> > >
     hirImplItemMappings;
   std::map<CrateNum, std::map<HirId, HIR::SelfParam *> > hirSelfParamMappings;
 

--- a/gcc/testsuite/rust.test/compile/generics8.rs
+++ b/gcc/testsuite/rust.test/compile/generics8.rs
@@ -1,0 +1,15 @@
+struct GenericStruct<T>(T, usize);
+
+impl<T> GenericStruct<T> {
+    fn new(a: T, b: usize) -> Self {
+        GenericStruct(a, b)
+    }
+}
+
+fn main() {
+    let a: GenericStruct<i32> = GenericStruct::<i32>::new(123, 456);
+
+    let b: GenericStruct<u32> = GenericStruct::<_>::new(123, 456);
+
+    let c: GenericStruct<f32> = GenericStruct::new(123f32, 456);
+}

--- a/gcc/testsuite/rust.test/compile/generics9.rs
+++ b/gcc/testsuite/rust.test/compile/generics9.rs
@@ -1,0 +1,22 @@
+struct GenericStruct<T>(T, usize);
+
+impl<T> GenericStruct<T> {
+    fn new(a: T, b: usize) -> Self {
+        GenericStruct(a, b)
+    }
+
+    fn get(self) -> T {
+        self.0
+    }
+}
+
+fn main() {
+    let a: GenericStruct<i32> = GenericStruct::<i32>::new(123, 456);
+    let aa: i32 = a.get();
+
+    let b: GenericStruct<u32> = GenericStruct::<_>::new(123, 456);
+    let bb: u32 = b.get();
+
+    let c: GenericStruct<f32> = GenericStruct::new(123f32, 456);
+    let cc: f32 = c.get();
+}

--- a/gcc/testsuite/rust.test/compile/methods3.rs
+++ b/gcc/testsuite/rust.test/compile/methods3.rs
@@ -1,0 +1,41 @@
+struct Point {
+    x: f64,
+    y: f64,
+}
+
+impl Point {
+    fn origin() -> Point {
+        Point { x: 0.0, y: 0.0 }
+    }
+
+    fn new(x: f64, y: f64) -> Point {
+        Point { x: x, y: y }
+    }
+}
+
+struct Rectangle {
+    p1: Point,
+    p2: Point,
+}
+
+impl Rectangle {
+    fn from(p1: Point, p2: Point) -> Self {
+        Self { p1, p2 }
+    }
+
+    fn sum_x(self) -> f64 {
+        let p1 = self.p1;
+        let p2 = self.p2;
+        p1.x + p2.x
+    }
+}
+
+fn main() {
+    let p1 = Point::origin();
+    let p2 = Point::new(3.0, 4.0);
+    let rect = Rectangle::from(p1, p2);
+
+    let sum = rect.sum_x();
+    // multiple MethodCallExpr were causing issue #310
+    let sum = rect.sum_x();
+}


### PR DESCRIPTION
ommit 6c0fb08c3b84f4de8236ed80f3485381b42f9d4b (HEAD -> phil/generics3, origin/phil/generics3)
Author: Philip Herron <philip.herron@embecosm.com>
Date:   Fri Mar 26 15:23:57 2021 +0000

    Add Generic Impl block support
    
    This extends the support from #237 to extend this to MethodCallExpr, this
    now follows a similar path to normal CallExprs and ensures the used
    arguments in substitution are preserved during unification of types. Part
    of method resolution is fixed here by taking advantage if is_equal instead
    of unify calls which could result in bad errors which are just part of the
    probe process to lookup possible candidates for method resolution.
    
    Fixes #306

commit 97d4ad5114f7f25875a66b290ec6b4f82af25e58
Author: Philip Herron <philip.herron@embecosm.com>
Date:   Sat Mar 27 16:28:45 2021 +0000

    Init NodeId for NodeMappings on HIR::MethodCallExpr
    
    We resolve methods during type resolution since it depends on the receiver
    type being used. To ensure the function is marked as used we must then
    mark the method name as resolved, this is also used in the backend
    GENERIC compilation to lookup the function definition to be compiled.
    When this was unset multiple method calls would fail.
    
    Fixes #310

commit f3aa002ff094b9f93107164c9824683f063927e7
Author: Philip Herron <philip.herron@embecosm.com>
Date:   Thu Mar 25 16:24:59 2021 +0000

    Add generics for impl blocks
    
    Generics paramters to impl blocks allows each impl-item to inherit these
    and get handled in a similar way as to normal functions.
    
    Fixes #237
