### PR TITLE
Add ICE failing tests

### DIFF
--- a/gcc/testsuite/rust.test/compile/match_self.rs
+++ b/gcc/testsuite/rust.test/compile/match_self.rs
@@ -1,0 +1,12 @@
+pub struct Struct;
+
+impl Struct {
+    pub fn method(&mut self) {
+        match self {
+            _ => {},
+        }
+    }
+}
+
+fn main() {
+}

--- a/gcc/testsuite/rust.test/compile/methods4.rs
+++ b/gcc/testsuite/rust.test/compile/methods4.rs
@@ -1,0 +1,12 @@
+struct Struct;
+
+impl Struct {
+    fn method(&mut self) -> i32 {
+        2718
+    }
+}
+
+fn main() {
+    let a: Struct;
+    let value = a.method();
+}

--- a/gcc/testsuite/rust.test/xfail_compile/match_self.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/match_self.rs
@@ -2,7 +2,7 @@ pub struct Struct;
 
 impl Struct {
     pub fn method(&mut self) {
-        match self {
+        match self { // dg-ice
             _ => {},
         }
     }


### PR DESCRIPTION
As per @philberty 's advice, I've tried finding a few failing test cases for the compiler. In both of those cases, the behaviour is unexpected: `match_self.rs` produces a segfault, while `cfg_feature.rs` ends up in an infinite loop. Would you like me to also open up issues so that they can be documented?

I'd also love to start hacking at the compiler to try and figure them out 

Here is the log for both files:

<details><summary>match_self.rs</summary>
<p>

```sh
>  gccrs ../gccrs/gcc/testsuite/rust.test/compilable/match_self.rs 
Preparing to parse files.
Attempting to parse file: ../gccrs/gcc/testsuite/rust.test/compilable/match_self.rs
beginning null denotation self/self-alias/dollar/crate/super handling
current peek token when starting path pratt parse: '{'
current token (just about to return path to null denotation): '{'
just finished parsing path (going to disambiguate) - peeked token is '{'
about to start parsing match arm patterns
successfully parsed initial match arm pattern
successfully parsed match arm patterns
successfully parsed match arm
successfully parsed inherent impl
SUCCESSFULLY PARSED CRATE
ran register_plugins (with no body)
SUCCESSFULLY REGISTERED PLUGINS
started injection
finished injection
SUCCESSFULLY FINISHED INJECTION
started expansion
finished expansion
SUCCESSFULLY FINISHED EXPANSION
rust1: internal compiler error: Segmentation fault
0xe9170f crash_signal
	../../gccrs/gcc/toplev.c:330
0x98e2ea Rust::Resolver::TypeCheckExpr::Resolve(Rust::HIR::Expr*, bool)
	../../gccrs/gcc/rust/typecheck/rust-hir-type-check-expr.h:41
0x98e773 Rust::Resolver::TypeCheckStmt::visit(Rust::HIR::ExprStmtWithBlock&)
	../../gccrs/gcc/rust/typecheck/rust-hir-type-check-stmt.h:44
0x989e81 Rust::Resolver::TypeCheckStmt::Resolve(Rust::HIR::Stmt*, bool)
	../../gccrs/gcc/rust/typecheck/rust-hir-type-check-stmt.h:38
0x989e81 operator()
	../../gccrs/gcc/rust/typecheck/rust-hir-type-check.cc:93
0x989e81 __invoke_impl<bool, Rust::Resolver::TypeCheckExpr::visit(Rust::HIR::BlockExpr&)::<lambda(Rust::HIR::Stmt*)>&, Rust::HIR::Stmt*>
	/usr/include/c++/10.2.0/bits/invoke.h:60
0x989e81 __invoke_r<bool, Rust::Resolver::TypeCheckExpr::visit(Rust::HIR::BlockExpr&)::<lambda(Rust::HIR::Stmt*)>&, Rust::HIR::Stmt*>
	/usr/include/c++/10.2.0/bits/invoke.h:141
0x989e81 _M_invoke
	/usr/include/c++/10.2.0/bits/std_function.h:291
0x98a4f6 std::function<bool (Rust::HIR::Stmt*)>::operator()(Rust::HIR::Stmt*) const
	/usr/include/c++/10.2.0/bits/std_function.h:622
0x98a4f6 Rust::HIR::BlockExpr::iterate_stmts(std::function<bool (Rust::HIR::Stmt*)>)
	../../gccrs/gcc/rust/hir/tree/rust-hir-expr.h:2576
0x98a4f6 Rust::Resolver::TypeCheckExpr::visit(Rust::HIR::BlockExpr&)
	../../gccrs/gcc/rust/typecheck/rust-hir-type-check.cc:88
0x98e311 Rust::Resolver::TypeCheckExpr::Resolve(Rust::HIR::Expr*, bool)
	../../gccrs/gcc/rust/typecheck/rust-hir-type-check-expr.h:41
0x98f489 Rust::Resolver::TypeCheckImplItem::visit(Rust::HIR::Method&)
	../../gccrs/gcc/rust/typecheck/rust-hir-type-check-implitem.h:246
0x98c82d Rust::Resolver::TypeCheckImplItem::Resolve(Rust::HIR::InherentImplItem*, Rust::TyTy::BaseType*)
	../../gccrs/gcc/rust/typecheck/rust-hir-type-check-implitem.h:187
0x98c82d Rust::Resolver::TypeCheckItem::visit(Rust::HIR::InherentImpl&)
	../../gccrs/gcc/rust/typecheck/rust-hir-type-check-item.h:55
0x98a29b Rust::Resolver::TypeCheckItem::Resolve(Rust::HIR::Item*)
	../../gccrs/gcc/rust/typecheck/rust-hir-type-check-item.h:40
0x98a29b Rust::Resolver::TypeResolution::Resolve(Rust::HIR::Crate&)
	../../gccrs/gcc/rust/typecheck/rust-hir-type-check.cc:42
0x8b9661 Rust::Session::parse_file(char const*)
	../../gccrs/gcc/rust/rust-session-manager.cc:544
0x8b9a7e Rust::Session::parse_files(int, char const**)
	../../gccrs/gcc/rust/rust-session-manager.cc:434
Please submit a full bug report,
with preprocessed source if appropriate.
Please include the complete backtrace with any bug report.
See <https://gcc.gnu.org/bugs/> for instructions.
```

</p>
</details>

<details><summary>cfg_feature.rs</summary>
<p>

```sh
checked key-value pair for cfg: 'feature', 'somefeature' - is not in target data
asked to check cfg of attrinputmetaitemcontainer - delegating to first item. container: '(feature = "somefeature", attribute = "someattr")'
checked key-value pair for cfg: 'feature', 'somefeature' - is not in target data
asked to check cfg of attrinputmetaitemcontainer - delegating to first item. container: '(feature = "somefeature", attribute = "someattr")'
checked key-value pair for cfg: 'feature', 'somefeature' - is not in target data
asked to check cfg of attrinputmetaitemcontainer - delegating to first item. container: '(feature = "somefeature", attribute = "someattr")'
checked key-value pair for cfg: 'feature', 'somefeature' - is not in target data
asked to check cfg of attrinputmetaitemcontainer - delegating to first item. container: '(feature = "somefeature", attribute = "someattr")'
checked key-value pair for cfg: 'feature', 'somefeature' - is not in target data
asked to check cfg of attrinputmetaitemcontainer - delegating to first item. container: '(feature = "somefeature", attribute = "someattr")'
checked key-value pair for cfg: 'feature', 'somefeature' - is not in target data
asked to check cfg of attrinputmetaitemcontainer - delegating to first item. container: '(feature = "somefeature", attribute = "someattr")'
checked key-value pair for cfg: 'feature', 'somefeature' - is not in target data
asked to check cfg of attrinputmetaitemcontainer - delegating to first item. container: '(feature = "somefeature", attribute = "someattr")'
checked key-value pair for cfg: 'feature', 'somefeature' - is not in target data
asked to check cfg of attrinputmetaitemcontainer - delegating to first item. container: '(feature = "somefeature", attribute = "someattr")'
checked key-value pair for cfg: 'feature', 'somefeature' - is not in target data
asked to check cfg of attrinputmetaitemcontainer - delegating to first item. container: '(feature = "somefeature", attribute = "someattr")'
checked key-value pair for cfg: 'feature', 'somefeature' - is not in target data
asked to check cfg of attrinputmetaitemcontainer - delegating to first item. container: '(feature = "somefeature", attribute = "someattr")'
checked key-value pair for cfg: 'feature', 'somefeature' - is not in target data
asked to check cfg of attrinputmetaitemcontainer - delegating to first item. container: '(feature = "somefeature", attribute = "someattr")'
checked key-value pair for cfg: 'feature', 'somefeature' - is not in target data
asked to check cfg of attrinputmetaitemcontainer - delegating to first item. container: '(feature = "somefeature", attribute = "someattr")'
...
```

</p>
</details>