### PR TITLE
Fix test after several PR were merged

### DIFF
--- a/gcc/testsuite/rust.test/xfail_compile/continue1.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/continue1.rs
@@ -1,4 +1,3 @@
-// { dg-excess-errors "Noisy error and debug" }
 fn main() {
     let mut a = 1;
     let mut b = 1;

--- a/gcc/testsuite/rust.test/xfail_compile/fail_compilation/unterminated_c_comment.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/fail_compilation/unterminated_c_comment.rs
@@ -1,1 +1,0 @@
-/* This  comment needs closure :) !

--- a/gcc/testsuite/rust.test/xfail_compile/unterminated_c_comment.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/unterminated_c_comment.rs
@@ -1,0 +1,2 @@
+// { dg-error "unexpected EOF while looking for end of comment" "" { target { *-*-* } } .+1 }
+/* This  comment needs closure :) !


### PR DESCRIPTION
the PR #302 and #301 were conflicting because they are both modifying the tests.
Move the conflicting test and add correct dg-error directive.