### PR TITLE
Proof of concept 2: First-class s-expression, inline visitors, and polymorphic values

### DIFF
--- a/gcc/rust/util/rust-inline-visitor.h
+++ b/gcc/rust/util/rust-inline-visitor.h
@@ -1,0 +1,63 @@
+/* An implementation of the inline visitor.
+   https://members.accu.org/index.php/articles/2021 */
+
+#include <utility>
+
+#ifndef RUST_INLINE_VISITOR
+#define RUST_INLINE_VISITOR
+
+namespace Rust {
+
+/* VisitorWrapper is a wrapper over a (possibly incomplete) Visitor.
+   Add another visit() method by calling on(). These lambdas are stored
+   in _args as a linked list, and passed to the actual visitor when
+   end_visitor() is called. */
+template <typename BaseVisitor, typename Args> struct VisitorWrapper
+{
+  Args _args;
+
+  VisitorWrapper (Args &&args) : _args (args) {}
+
+  // The actual visitor as an inner type.
+  // Each visitor inherits from the last one, and implements one more visit().
+  template <typename T, typename F> struct Visitor : BaseVisitor
+  {
+    F _f;
+    Visitor (std::pair<F, Args> args)
+      : BaseVisitor (args.second), _f (args.first)
+    {}
+
+    using BaseVisitor::visit;
+    virtual void visit (T &t) final override { _f (t); }
+  };
+
+  template <typename T, typename F>
+  VisitorWrapper<Visitor<T, F>, std::pair<F, Args>> on (F &&f)
+  {
+    return VisitorWrapper<Visitor<T, F>, std::pair<F, Args>> (
+      std::make_pair (f, _args));
+  }
+
+  BaseVisitor end_visitor () { return BaseVisitor (_args); }
+};
+
+/* An empty visitor. A wrapper around the target Visitor we're matching against.
+   Consumes the final nullptr of the linked list. */
+template <typename TargetVisitor> struct EmptyVisitor : TargetVisitor
+{
+  EmptyVisitor (std::nullptr_t ptr) {}
+
+  using TargetVisitor::visit;
+};
+
+// The entry point
+template <typename TargetVisitor>
+VisitorWrapper<EmptyVisitor<TargetVisitor>, std::nullptr_t>
+begin_visitor ()
+{
+  return VisitorWrapper<EmptyVisitor<TargetVisitor>, std::nullptr_t> (nullptr);
+}
+
+} // namespace Rust
+
+#endif

--- a/gcc/rust/util/rust-make-unique.h
+++ b/gcc/rust/util/rust-make-unique.h
@@ -1,0 +1,16 @@
+#ifndef RUST_MAKE_UNIQUE_H
+#define RUST_MAKE_UNIQUE_H
+
+#include <memory>
+
+namespace Rust {
+
+template <typename T, typename... Ts>
+std::unique_ptr<T> make_unique(Ts &&... params) {
+  return std::unique_ptr<T>(new T(std::forward<Ts>(params)...));
+}
+
+} // namespace Rust
+
+#endif // RUST_MAKE_UNIQUE_H
+

--- a/gcc/rust/util/rust-poly.h
+++ b/gcc/rust/util/rust-poly.h
@@ -1,0 +1,112 @@
+/* An implementation of polymophic_value for C++11.
+   https://github.com/jbcoe/polymorphic_value */
+
+#include <memory>
+#include <type_traits>
+
+#include "rust-make-unique.h"
+
+#ifndef RUST_POLY
+#define RUST_POLY
+
+namespace Rust {
+
+template <bool U>
+using enable_if_t = typename std::enable_if<U, std::nullptr_t>::type;
+
+/* Cloner acts as a type-erasure device.
+   The concrete type, U, is erased.
+   However, clone() still creates an instance of U. */
+template <typename T> class Cloner {
+public:
+  virtual ~Cloner() = default;
+  virtual std::unique_ptr<Cloner<T>> clone() = 0;
+  virtual T *get() = 0;
+};
+
+template <typename T> class ConcreteCloner : public Cloner<T> {
+private:
+  static_assert(std::is_copy_constructible<T>::value,
+                "T is not copy constructible");
+
+  std::unique_ptr<T> _t;
+
+public:
+  ConcreteCloner(std::unique_ptr<T> &&t) : _t(std::move(t)) {}
+
+  virtual std::unique_ptr<Cloner<T>> clone() override {
+    auto t2 = Rust::make_unique<T>(*_t);
+    return Rust::make_unique<ConcreteCloner<T>>(std::move(t2));
+  }
+
+  virtual T *get() override { return _t.get(); }
+};
+
+template <typename T, typename U,
+          typename Rust::enable_if_t<std::is_base_of<T, U>::value> = nullptr>
+class DelegateCloner : public Cloner<T> {
+private:
+  std::unique_ptr<Cloner<U>> _worker;
+
+public:
+  DelegateCloner(std::unique_ptr<Cloner<U>> worker)
+      : _worker(std::move(worker)) {}
+
+  virtual std::unique_ptr<Cloner<T>> clone() override {
+    return Rust::make_unique<DelegateCloner<T, U>>(_worker->clone());
+  }
+
+  virtual T *get() override { return _worker->get(); }
+};
+
+/* Value wrapper that supports polymophic dispatch.
+   It happens to be implemented on top of std::unique_ptr, but
+   conceptually it's a value, not a pointer. In particular,
+   nullptr is not allowed. As a wrapper, poly is immutable--its
+   binding cannot be changed once created.
+ */
+template <typename T> class poly {
+public:
+  std::unique_ptr<Cloner<T>> _cloner;
+
+  // Construct from raw pointer
+  // Will take ownership of the value.
+  poly(std::unique_ptr<T> &&t) {
+    if (t == nullptr) {
+      throw std::runtime_error("Attempting to create a poly from nullptr");
+    }
+    _cloner = Rust::make_unique<ConcreteCloner<T>>(std::move(t));
+  }
+
+  // Copy constructor
+  poly(const poly &rhs) { _cloner = rhs._cloner->clone(); }
+
+  // Move constructor
+  poly(poly &&rhs) noexcept : _cloner(std::move(rhs._cloner)) {}
+
+  // Covariant "copy" constructor
+  template <typename U,
+            typename Rust::enable_if_t<std::is_base_of<T, U>::value> = nullptr>
+  poly(const poly<U> &rhs)
+      : _cloner(Rust::make_unique<DelegateCloner<T, U>>(rhs._cloner->clone())) {
+  }
+
+  // Covariant "move" constructor
+  template <typename U,
+            typename Rust::enable_if_t<std::is_base_of<T, U>::value> = nullptr>
+  poly(poly<U> &&rhs) noexcept
+      : _cloner(
+            Rust::make_unique<DelegateCloner<T, U>>(std::move(rhs._cloner))) {}
+
+  T *operator->() const { return _cloner->get(); }
+
+  T *get() const { return _cloner->get(); }
+};
+
+template <typename T, typename... Args> poly<T> make_poly(Args &&... args) {
+  return poly<T>(std::move(Rust::make_unique<T>(std::forward<Args>(args)...)));
+}
+
+}; // namespace Rust
+
+#endif

--- a/gcc/rust/util/rust-poly.h
+++ b/gcc/rust/util/rust-poly.h
@@ -71,11 +71,10 @@ public:
 
   // Construct from raw pointer
   // Will take ownership of the value.
-  poly(std::unique_ptr<T> &&t) {
-    if (t == nullptr) {
-      throw std::runtime_error("Attempting to create a poly from nullptr");
-    }
-    _cloner = Rust::make_unique<ConcreteCloner<T>>(std::move(t));
+  poly (std::unique_ptr<T> &&t)
+  {
+    rust_assert (t != nullptr);
+    _cloner = Rust::make_unique<ConcreteCloner<T>> (std::move (t));
   }
 
   // Copy constructor

--- a/gcc/rust/util/rust-sexp.h
+++ b/gcc/rust/util/rust-sexp.h
@@ -1,0 +1,219 @@
+#include <algorithm>
+#include <initializer_list>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include "rust-inline-visitor.h"
+#include "rust-make-unique.h"
+#include "rust-poly.h"
+
+#ifndef RUST_SEXP
+#define RUST_SEXP
+
+namespace Rust {
+
+template <typename T> struct helper
+{
+  using type = std::nullptr_t;
+};
+template <typename T> using helper_t = typename helper<T>::type;
+
+template <typename T>
+static std::string
+join (const std::string &sep, const T &items)
+{
+  std::string result;
+  for (auto it = items.cbegin (); it != items.cend (); ++it)
+    {
+      if (it != items.cbegin ())
+	{
+	  result += " ";
+	}
+      result += *it;
+    }
+  return result;
+}
+
+class sexp;
+
+struct SString;
+struct SInt;
+struct SFloat;
+struct SList;
+
+class SValueVisitor
+{
+public:
+  virtual ~SValueVisitor () = default;
+  virtual void visit (SString &s) = 0;
+  virtual void visit (SInt &s) = 0;
+  virtual void visit (SFloat &s) = 0;
+  virtual void visit (SList &s) = 0;
+};
+
+struct SValue
+{
+  virtual ~SValue () = default;
+  virtual void accept_vis (SValueVisitor &vis) = 0;
+};
+
+struct SString : SValue
+{
+  std::string value;
+
+  SString (const std::string &str) : value (str) {}
+
+  virtual void accept_vis (SValueVisitor &vis) override { vis.visit (*this); }
+};
+
+struct SInt : SValue
+{
+  int64_t value;
+
+  SInt (int64_t value) : value (value) {}
+
+  virtual void accept_vis (SValueVisitor &vis) override { vis.visit (*this); }
+};
+
+struct SFloat : SValue
+{
+  double value;
+
+  SFloat (double value) : value (value) {}
+
+  virtual void accept_vis (SValueVisitor &vis) override { vis.visit (*this); }
+};
+
+struct SList : SValue
+{
+  std::vector<sexp> value;
+
+  template <typename It>
+  SList (It begin, It end) : value (std::vector<sexp> (begin, end))
+  {}
+
+  virtual void accept_vis (SValueVisitor &vis) override { vis.visit (*this); }
+};
+
+class sexp
+{
+private:
+  poly<SValue> _value;
+
+  template <typename T> void check_nullptr (T &ptr)
+  {
+    if (ptr == nullptr)
+      {
+	throw std::runtime_error (
+	  "Attempting to create a S-expression with nullptr");
+      }
+  }
+
+  // C++ doesn't allow late binding to member variables,
+  // but poly<SValue> doesn't have an "empty" value by design.
+  // Therefore we have to use helper functions to initialize _value within
+  // initializer list.
+  template <typename T> poly<SValue> svalue_from_ptr (T &&ptr)
+  {
+    check_nullptr (ptr);
+    auto s = sexp (*ptr);
+    return std::move (s._value);
+  }
+
+  template <typename T> poly<SValue> svalue_from_container (const T &container)
+  {
+    std::vector<sexp> items;
+    for (auto &t : container)
+      {
+	items.emplace_back (t);
+      }
+    return Rust::make_poly<SList> (items.begin (), items.end ());
+  }
+
+  template <typename T> poly<SValue> svalue_from_custom (const T &t)
+  {
+    auto s = to_sexp (t);
+    return std::move (s._value);
+  }
+
+public:
+  // Construct from std::string
+  sexp (const std::string &str) : _value (Rust::make_poly<SString> (str)) {}
+
+  // Construct from char*
+  sexp (const char *str) : _value (Rust::make_poly<SString> (str)) {}
+
+  // Construct from integers
+  template <typename T,
+	    typename std::enable_if<std::is_integral<T>::value, void *>::type
+	    = nullptr>
+  sexp (T val) : _value (Rust::make_poly<SInt> (val))
+  {}
+
+  // Construct from floating point values
+  template <typename T, typename std::enable_if<
+			  std::is_floating_point<T>::value, void *>::type
+			= nullptr>
+  sexp (T val) : _value (Rust::make_poly<SFloat> (val))
+  {}
+
+  // Construct from raw pointers to objects
+  template <typename T,
+	    typename std::enable_if<std::is_pointer<T>::value, void *>::type
+	    = nullptr>
+  sexp (T ptr) : _value (svalue_from_ptr (ptr))
+  {}
+
+  // Construct from smart pointers to objects
+  template <typename T, Rust::helper_t<decltype (
+			  std::declval<T> ().T::operator* ())> = nullptr>
+  sexp (T &&ptr) : _value (svalue_from_ptr (std::move (ptr)))
+  {}
+
+  // Construct from a container of objects
+  template <typename T,
+	    Rust::helper_t<decltype (std::declval<T> ().cbegin ())> = nullptr>
+  sexp (const T &container) : _value (svalue_from_container (container))
+  {}
+
+  // Construct from a std::initializer_list of sexp
+  sexp (std::initializer_list<sexp> items)
+    : _value (Rust::make_poly<SList> (items.begin (), items.end ()))
+  {}
+
+  // Construct from custom conversion function
+  template <typename T,
+	    Rust::helper_t<decltype (to_sexp (std::declval<T> ()))> = nullptr>
+  sexp (const T &t) : _value (svalue_from_custom (t))
+  {}
+
+  // Serialize to string
+  std::string to_string () const
+  {
+    std::string ret;
+    auto vis
+      = begin_visitor<SValueVisitor> ()
+	  .on<SString> ([&ret] (SString &s) { ret = s.value; })
+	  .on<SInt> ([&ret] (SInt &s) { ret = std::to_string (s.value); })
+	  .on<SFloat> ([&ret] (SFloat &s) { ret = std::to_string (s.value); })
+	  .on<SList> ([&ret] (SList &s) {
+	    std::vector<std::string> inner;
+	    std::transform (s.value.begin (), s.value.end (),
+			    std::back_inserter (inner),
+			    [] (const sexp &s) { return s.to_string (); });
+	    ret += "(";
+	    ret += join (" ", inner);
+	    ret += ")";
+	  })
+	  .end_visitor ();
+    _value->accept_vis (vis);
+
+    return ret;
+  }
+};
+
+} // namespace Rust
+
+#endif

--- a/gcc/rust/util/rust-sexp.h
+++ b/gcc/rust/util/rust-sexp.h
@@ -104,11 +104,7 @@ private:
 
   template <typename T> void check_nullptr (T &ptr)
   {
-    if (ptr == nullptr)
-      {
-	throw std::runtime_error (
-	  "Attempting to create a S-expression with nullptr");
-      }
+    rust_assert (ptr != nullptr);
   }
 
   // C++ doesn't allow late binding to member variables,


### PR DESCRIPTION
Here I present three pieces of "experimental technology" that may be useful for the project. I took the idea from various sources and implemented them from scratch. Maybe some of these can make it into the codebase? I'd love to hear your thoughts and suggestions.

# First-class s-expression

Taking inspiration from [nlohmann's excellent JSON library](https://github.com/nlohmann/json), this new design stores an s-expression using an intermediate data structure. This enables the use of braces to construct compound expressions. Further more, custom conversion can be implemented via functions instead of methods, so no more polluting the class interface:)

Example:

```c++
// use sexp() as a conversion function
auto e1 = sexp("hello");

// serialize by calling to_string()
auto s1 = e1.to_string(); // "hello"

// use brace initializer lists to create compound expressions
// supported datatypes are strings, integers, and floats
auto e2 = sexp{e1, 123, {"inner", "expression"}};
auto s2 = e2.to_string(); // "(hello 123 (inner expression))

// define conversion function for custom types
struct MyArray {
    std::vector<std::string> items;
};

sexp to_sexp(const MyArray& arr) {
    return sexp{"MyArray", {"item_count", items.size}, {"items", items}};
}
```

This design also plays nicely with visitor patterns. A custom conversion function only needs to be defined for the base type, either implemented as you normally would with visitor patterns, or with inline visitors(see below).

# Inline visitors

A lot of my complaints about visitors are due to their verbosity--for every operation on an ADT, you have to write an "Resolver" class. [Inline visitors](https://members.accu.org/index.php/articles/2021) make operations on ADTs much more lightweight.

Example:

```c++
// The usual setup. Skip to main() for the interesting part.
class BaseVisitor {
  public:
    virtual void visit(DerivedA& a) = 0;
    virtual void visit(DerivedB& b) = 0;
}

class Base {
  public:
    virtual ~Base() = default;

    virtual accept_vis(BaseVisitor& vis) = 0;
};

class DerivedA : public Base {
  public:
    int some_operation() { return 42; }

    virtual void accept_vis(BaseVisitor& vis) override { vis.visit(*this); }
}

class DerivedB : public Base {
  public:
    int some_other_operation() { return 13; }

    virtual void accept_vis(BaseVisitor& vis) override { vis.visit(*this); }
}

int main() {
    Base *obj = new DerivedA();

    // define an inline visitor
    // can use captured variables to return results
    int ret;
    auto vis = begin_visitor<BaseVisitor>()
                 .on<DerivedA>([&ret](DerivedA& a) {
                     ret = a.some_operation();
                 })
                 .on<DerivedB>([&ret](DerivedB& b) {
                     ret = b.some_other_operation();
                 })
                 .end_visitor();

    // apply the visitor as usual
    obj->accept_vis(vis);
}
```

# Polymorphic values

As a compiler project we're mostly concerned with tree-like ADTs, such as AST and HIR. To implement the visitor pattern, we store sub-trees using pointers, instead of composing values directly. On the other hand, we would like these data to be copy-able. Unfortunately, that means implementing copy constructors and `clone()` methods for every single data class. It is a mess.

Wouldn't it be nice if pointers could copy their underlying value automatically? That's what [polymorphic values](https://github.com/jbcoe/polymorphic_value) accomplish. It's a wrapper around `std::unique_ptr` that implements deep copying for you.

Example:

```c++
class Base {
  public:
    virtual ~Base() = default;
    virtual std::string get_content() = 0;
};

class Derived : public Base {
  private:
    std::string _content;
  public:
    Derived(const std::string& content) : _content(content) {}

    virtual std::string get_content() override { return _content; }
};

int main() {
    // create a polymorphic value
    poly<Base> obj = make_poly<DerivedA>("Hello");
    obj->get_content(); // "Hello"

    // copy a polymorphic value
    auto obj2 = obj; // calls Derived's copy constructor
    obj2->get_content(); // "Hello"

    // you can put poly inside structs or containers, and it just works
    auto arr = std::vector<poly<Base>>{obj, obj2}; // call copy constructor twice
}
```

---

With these experiments done, I'll get back to the usual bug fixing and house keeping. I'll also be preparing for my GSoC proposal--probably on the topic of HIR dump.