### PR TITLE
Initial TypeAlias support

### DIFF
--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -1720,6 +1720,8 @@ public:
     return existing_type;
   }
 
+  Identifier get_new_type_name () const { return new_type_name; }
+
 protected:
   /* Use covariance to implement clone function as returning this object
    * rather than base */

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -53,6 +53,39 @@ public:
     return resolver.translated;
   }
 
+  void visit (AST::TypeAlias &alias) override
+  {
+    std::vector<std::unique_ptr<HIR::WhereClauseItem> > where_clause_items;
+    HIR::WhereClause where_clause (std::move (where_clause_items));
+    HIR::Visibility vis = HIR::Visibility::create_public ();
+    std::vector<HIR::Attribute> outer_attrs;
+
+    std::vector<std::unique_ptr<HIR::GenericParam> > generic_params;
+    if (alias.has_generics ())
+      generic_params = lower_generic_params (alias.get_generic_params ());
+
+    HIR::Type *existing_type
+      = ASTLoweringType::translate (alias.get_type_aliased ().get ());
+
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, alias.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   mappings->get_next_localdef_id (crate_num));
+
+    translated = new HIR::TypeAlias (mapping, alias.get_new_type_name (),
+				     std::move (generic_params),
+				     std::move (where_clause),
+				     std::unique_ptr<HIR::Type> (existing_type),
+				     std::move (vis), std::move (outer_attrs),
+				     alias.get_locus ());
+
+    mappings->insert_defid_mapping (mapping.get_defid (), translated);
+    mappings->insert_hir_item (mapping.get_crate_num (), mapping.get_hirid (),
+			       translated);
+    mappings->insert_location (crate_num, mapping.get_hirid (),
+			       alias.get_locus ());
+  }
+
   void visit (AST::TupleStruct &struct_decl) override
   {
     std::vector<std::unique_ptr<HIR::GenericParam> > generic_params;

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -1504,6 +1504,31 @@ public:
 
   void accept_vis (HIRVisitor &vis) override;
 
+  std::vector<std::unique_ptr<GenericParam> > &get_generic_params ()
+  {
+    return generic_params;
+  }
+  const std::vector<std::unique_ptr<GenericParam> > &get_generic_params () const
+  {
+    return generic_params;
+  }
+
+  // TODO: is this better? Or is a "vis_block" better?
+  WhereClause &get_where_clause ()
+  {
+    rust_assert (has_where_clause ());
+    return where_clause;
+  }
+
+  // TODO: is this better? Or is a "vis_block" better?
+  std::unique_ptr<Type> &get_type_aliased ()
+  {
+    rust_assert (existing_type != nullptr);
+    return existing_type;
+  }
+
+  Identifier get_new_type_name () const { return new_type_name; }
+
 protected:
   /* Use covariance to implement clone function as returning this object
    * rather than base */

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -39,6 +39,22 @@ public:
     item->accept_vis (resolver);
   };
 
+  void visit (AST::TypeAlias &alias) override
+  {
+    NodeId scope_node_id = alias.get_node_id ();
+    resolver->get_type_scope ().push (scope_node_id);
+
+    if (alias.has_generics ())
+      {
+	for (auto &generic : alias.get_generic_params ())
+	  ResolveGenericParam::go (generic.get (), alias.get_node_id ());
+      }
+
+    ResolveType::go (alias.get_type_aliased ().get (), alias.get_node_id ());
+
+    resolver->get_type_scope ().pop ();
+  }
+
   void visit (AST::TupleStruct &struct_decl) override
   {
     NodeId scope_node_id = struct_decl.get_node_id ();

--- a/gcc/rust/resolve/rust-ast-resolve-toplevel.h
+++ b/gcc/rust/resolve/rust-ast-resolve-toplevel.h
@@ -38,6 +38,16 @@ public:
     item->accept_vis (resolver);
   };
 
+  void visit (AST::TypeAlias &alias) override
+  {
+    resolver->get_type_scope ().insert (
+      alias.get_new_type_name (), alias.get_node_id (), alias.get_locus (),
+      false, [&] (std::string, NodeId, Location locus) -> void {
+	rust_error_at (alias.get_locus (), "redefined multiple times");
+	rust_error_at (locus, "was defined here");
+      });
+  }
+
   void visit (AST::TupleStruct &struct_decl) override
   {
     resolver->get_type_scope ().insert (

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -115,10 +115,6 @@ public:
       }
 
     infered = field_tyty->get_field_type ();
-    printf ("ZXZX resolved: %s to: \n", expr.as_string ().c_str ());
-    adt->debug ();
-    infered->debug ();
-    printf ("ZXZX done\n");
   }
 
   void visit (HIR::TupleExpr &expr) override

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -242,15 +242,12 @@ public:
     auto expected_ret_tyty = resolve_fn_type->get_return_type ();
     context->push_return_type (expected_ret_tyty);
 
-    printf ("XXXX method body boyo: 1!!\n");
-
     auto block_expr_ty
       = TypeCheckExpr::Resolve (method.get_definition ().get (), false);
 
     context->pop_return_type ();
 
     expected_ret_tyty->unify (block_expr_ty);
-    printf ("XXXX method body boyo: 2!!\n");
   }
 
 private:

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
@@ -40,6 +40,14 @@ public:
     item->accept_vis (resolver);
   }
 
+  void visit (HIR::TypeAlias &alias) override
+  {
+    TyTy::BaseType *actual_type
+      = TypeCheckType::Resolve (alias.get_type_aliased ().get ());
+
+    context->insert_type (alias.get_mappings (), actual_type);
+  }
+
   void visit (HIR::TupleStruct &struct_decl) override
   {
     std::vector<TyTy::SubstitutionParamMapping> substitutions;

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -369,10 +369,9 @@ ADTType::handle_substitions (SubstitutionArgumentMappings subst_mappings)
       return nullptr;
     }
 
-  used_arguments = subst_mappings;
-
   ADTType *adt = static_cast<ADTType *> (clone ());
   adt->set_ty_ref (mappings->get_next_hir_id ());
+  adt->used_arguments = subst_mappings;
 
   for (auto &sub : adt->get_substs ())
     {
@@ -571,10 +570,9 @@ FnType::handle_substitions (SubstitutionArgumentMappings subst_mappings)
       return nullptr;
     }
 
-  used_arguments = subst_mappings;
-
   FnType *fn = static_cast<FnType *> (clone ());
   fn->set_ty_ref (mappings->get_next_hir_id ());
+  fn->used_arguments = subst_mappings;
 
   for (auto &sub : fn->get_substs ())
     {

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -527,7 +527,9 @@ public:
       }
   }
 
-  bool was_substituted () const { return !used_arguments.is_error (); }
+  bool needs_substitution () const { return used_arguments.is_error (); }
+
+  bool was_substituted () const { return !needs_substitution (); }
 
   SubstitutionArgumentMappings get_substitution_arguments ()
   {

--- a/gcc/testsuite/rust.test/compile/generics11.rs
+++ b/gcc/testsuite/rust.test/compile/generics11.rs
@@ -1,0 +1,8 @@
+struct Foo<T>(T, u32);
+
+type TypeAlias = Foo<i32>;
+
+fn main() {
+    let a: Foo<i32>;
+    a = TypeAlias { 0: 123, 1: 456 };
+}

--- a/gcc/testsuite/rust.test/compile/type-alias1.rs
+++ b/gcc/testsuite/rust.test/compile/type-alias1.rs
@@ -1,0 +1,6 @@
+type TypeAlias = (i32, u32);
+
+fn main() {
+    let a: TypeAlias;
+    a = (123, 456);
+}

--- a/gcc/testsuite/rust.test/compile/type-alias2.rs
+++ b/gcc/testsuite/rust.test/compile/type-alias2.rs
@@ -1,0 +1,6 @@
+type x = u32;
+
+fn main() {
+    let x: x = 1;
+    let y: x = 2;
+}

--- a/gcc/testsuite/rust.test/xfail_compile/type-alias1.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/type-alias1.rs
@@ -1,0 +1,6 @@
+type TypeAlias = (i32, u32);
+
+fn main() {
+    let a: TypeAlias;
+    a = (123, 456f32); // { dg-error "expected .u32. got .f32." }
+}


### PR DESCRIPTION
commit 42e13fb08b14f638ca1becd3ca9386972648f372 (HEAD -> phil/generics4, origin/phil/generics4)
Author: Philip Herron <philip.herron@embecosm.com>
Date:   Tue Mar 30 17:53:09 2021 +0100

    Add support for TypeAlias
    
    This allows for a typedef style alias of any type in rust code, as the
    types are abstracted behind the TyTy interface this falls out quite nicely.
    
    In order to support TypeAliases we needed to be able to supported already
    substituted types in #311.
    
    More testing is needed here the GenericParameters on TypeAlias are not
    being used in the type resolution pass here.
    
    Fixes #312
    Addresses #311

commit 52e63128c5491c5432960b62e664d7ac479d140a
Author: Philip Herron <philip.herron@embecosm.com>
Date:   Tue Mar 30 18:23:53 2021 +0100

    Fix bad tracking on used substitutions on generic types.
    
    When implementing generics we need to keep track of used arguments to
    recursively substitute ParamTypes when nessecary. This also applies for
    cases such as: Foo<i32> where we can check wether we need to actually
    perform a substitution.
