### PR TITLE
Fixed bug TyTy::SubstitutionRef::needs_substitution

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -243,7 +243,7 @@ public:
 	if (receiver_tyty->get_kind () == TyTy::TypeKind::ADT)
 	  {
 	    TyTy::ADTType *adt = static_cast<TyTy::ADTType *> (receiver_tyty);
-	    if (adt->has_substitutions ())
+	    if (adt->has_substitutions () && fn->needs_substitution ())
 	      {
 		rust_assert (adt->was_substituted ());
 		lookup

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -362,7 +362,6 @@ ADTType *
 ADTType::handle_substitions (SubstitutionArgumentMappings subst_mappings)
 {
   if (subst_mappings.size () != get_num_substitutions ())
-
     {
       rust_error_at (subst_mappings.get_locus (),
 		     "invalid number of generic arguments to generic ADT type");
@@ -565,8 +564,9 @@ FnType::handle_substitions (SubstitutionArgumentMappings subst_mappings)
 {
   if (subst_mappings.size () != get_num_substitutions ())
     {
-      rust_error_at (subst_mappings.get_locus (),
-		     "invalid number of generic arguments to generic ADT type");
+      rust_error_at (
+	subst_mappings.get_locus (),
+	"invalid number of generic arguments to generic Function type");
       return nullptr;
     }
 

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -527,7 +527,10 @@ public:
       }
   }
 
-  bool needs_substitution () const { return used_arguments.is_error (); }
+  bool needs_substitution () const
+  {
+    return has_substitutions () && used_arguments.is_error ();
+  }
 
   bool was_substituted () const { return !needs_substitution (); }
 

--- a/gcc/testsuite/rust.test/compile/generics12.rs
+++ b/gcc/testsuite/rust.test/compile/generics12.rs
@@ -1,0 +1,16 @@
+struct GenericStruct<T>(T, usize);
+
+impl GenericStruct<i32> {
+    fn new(a: i32, b: usize) -> Self {
+        GenericStruct(a, b)
+    }
+
+    fn get(self) -> i32 {
+        self.0
+    }
+}
+
+fn main() {
+    let a: GenericStruct<i32> = GenericStruct::<i32>::new(123, 456);
+    let aa: i32 = a.get();
+}


### PR DESCRIPTION
When we have Types capable of type substitution it only needs substituted
if it was not already substituted and it actually has substitutions defined

Fixes #311