### PR TITLE
Add dg-error to generics4.rs xfail test

### DIFF
--- a/gcc/testsuite/rust.test/xfail_compile/generics4.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/generics4.rs
@@ -3,7 +3,7 @@ struct GenericStruct<T>(T, usize);
 
 fn main() {
     let a2;
-    a2 = GenericStruct::<i8, i32>(1, 456);
+    a2 = GenericStruct::<i8, i32>(1, 456); // { dg-error "Invalid number of generic arguments to generic type" }
 
     let b2: i32 = a2.0;
     let c2: usize = a2.1;


### PR DESCRIPTION
Having at least one dg-error and not only dg-excess-error should avoid silent
regression.