### PR TITLE
Placate GCC 4.8

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -726,7 +726,7 @@ Parser<ManagedTokenSource>::parse_attr_input ()
     case LEFT_SQUARE:
       case LEFT_CURLY: {
 	// must be a delimited token tree, so parse that
-	std::unique_ptr<AST::DelimTokenTree> input_tree (
+	std::unique_ptr<AST::AttrInput> input_tree (
 	  new AST::DelimTokenTree (parse_delim_token_tree ()));
 
 	// TODO: potential checks on DelimTokenTree before returning
@@ -782,7 +782,7 @@ Parser<ManagedTokenSource>::parse_attr_input ()
 	AST::LiteralExpr lit_expr (t->get_str (), lit_type, t->get_type_hint (),
 				   {}, t->get_locus ());
 
-	std::unique_ptr<AST::AttrInputLiteral> attr_input_lit (
+	std::unique_ptr<AST::AttrInput> attr_input_lit (
 	  new AST::AttrInputLiteral (std::move (lit_expr)));
 
 	// do checks or whatever? none required, really
@@ -4863,7 +4863,7 @@ Parser<ManagedTokenSource>::parse_trait_item ()
       }
       default: {
 	// TODO: try and parse macro invocation semi - if fails, maybe error.
-	std::unique_ptr<AST::MacroInvocationSemi> macro_invoc
+	std::unique_ptr<AST::TraitItem> macro_invoc
 	  = parse_macro_invocation_semi (outer_attrs);
 
 	if (macro_invoc == nullptr)


### PR DESCRIPTION
(Sorry, but at this point) I didn't (have time to) try to understand the C++ class hierarchy etc. -- but these changes do placate GCC 4.8, and don't cause any testsuite regressions.  But somebody please review, who knows this code!

---

    In file included from [...]/gcc/rust/parse/rust-parse.h:645:0,
                     from [...]/gcc/rust/rust-session-manager.cc:34:
    [...]/gcc/rust/parse/rust-parse-impl.h: In instantiation of 'std::unique_ptr<Rust::AST::AttrInput> Rust::Parser<ManagedTokenSource>::parse_attr_input() [with ManagedTokenSource = Rust::Lexer]':
    [...]/gcc/rust/parse/rust-parse-impl.h:522:66:   required from 'Rust::AST::Attribute Rust::Parser<ManagedTokenSource>::parse_attribute_body() [with ManagedTokenSource = Rust::Lexer]'
    [...]/gcc/rust/parse/rust-parse-impl.h:493:59:   required from 'Rust::AST::Attribute Rust::Parser<ManagedTokenSource>::parse_inner_attribute() [with ManagedTokenSource = Rust::Lexer]'
    [...]/gcc/rust/parse/rust-parse-impl.h:444:58:   required from 'std::vector<Rust::AST::Attribute> Rust::Parser<ManagedTokenSource>::parse_inner_attributes() [with ManagedTokenSource = Rust::Lexer]'
    [...]/gcc/rust/parse/rust-parse-impl.h:402:69:   required from 'Rust::AST::Crate Rust::Parser<ManagedTokenSource>::parse_crate() [with ManagedTokenSource = Rust::Lexer]'
    [...]/gcc/rust/rust-session-manager.cc:458:43:   required from here
    [...]/gcc/rust/parse/rust-parse-impl.h:734:9: error: could not convert 'input_tree' from 'std::unique_ptr<Rust::AST::DelimTokenTree>' to 'std::unique_ptr<Rust::AST::AttrInput>'
      return input_tree;
             ^
    [...]/gcc/rust/parse/rust-parse-impl.h:792:9: error: could not convert 'attr_input_lit' from 'std::unique_ptr<Rust::AST::AttrInputLiteral>' to 'std::unique_ptr<Rust::AST::AttrInput>'
      return attr_input_lit;
             ^

    In file included from [...]/gcc/rust/parse/rust-parse.h:645:0,
                     from [...]/gcc/rust/rust-session-manager.cc:34:
    [...]/gcc/rust/parse/rust-parse-impl.h: In instantiation of 'std::unique_ptr<Rust::AST::TraitItem> Rust::Parser<ManagedTokenSource>::parse_trait_item() [with ManagedTokenSource = Rust::Lexer]':
    [...]/gcc/rust/parse/rust-parse-impl.h:4693:70:   required from 'std::unique_ptr<Rust::AST::Trait> Rust::Parser<ManagedTokenSource>::parse_trait(Rust::AST::Visibility, std::vector<Rust::AST::Attribute>) [with ManagedTokenSource = Rust::Lexer]'
    [...]/gcc/rust/parse/rust-parse-impl.h:1268:67:   required from 'std::unique_ptr<Rust::AST::VisItem> Rust::Parser<ManagedTokenSource>::parse_vis_item(std::vector<Rust::AST::Attribute>) [with ManagedTokenSource = Rust::Lexer]'
    [...]/gcc/rust/parse/rust-parse-impl.h:1048:53:   required from 'std::unique_ptr<Rust::AST::Item> Rust::Parser<ManagedTokenSource>::parse_item(bool) [with ManagedTokenSource = Rust::Lexer]'
    [...]/gcc/rust/parse/rust-parse-impl.h:410:58:   required from 'Rust::AST::Crate Rust::Parser<ManagedTokenSource>::parse_crate() [with ManagedTokenSource = Rust::Lexer]'
    [...]/gcc/rust/rust-session-manager.cc:458:43:   required from here
    [...]/gcc/rust/parse/rust-parse-impl.h:4876:13: error: could not convert 'macro_invoc' from 'std::unique_ptr<Rust::AST::MacroInvocationSemi>' to 'std::unique_ptr<Rust::AST::TraitItem>'
          return macro_invoc;
                 ^