### PR TITLE
Address '[...]/gcc/rust/rust-session-manager.cc:124:15: error: unused variable ‘target’ [-Werror=unused-variable]' diagnostic [#336]

### DIFF
--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -121,7 +121,6 @@ void
 Session::enable_features ()
 {
   bool has_target_crt_static = false;
-  const char *target = "PLACEHOLDER";
 
   fprintf (
     stderr,


### PR DESCRIPTION
#336