### PR TITLE
Address '[...]/gcc/rust/expand/rust-macro-expand.cc:3228:1: error: control reaches end of non-void function [-Werror=return-type]' diagnostic [#336]

### DIFF
--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -3183,6 +3183,7 @@ MacroExpander::expand_cfg_macro (AST::MacroInvocData &invoc)
     return AST::Literal ("false", AST::Literal::BOOL, CORETYPE_BOOL);
 }
 
+#if 0
 AST::ASTFragment
 MacroExpander::expand_decl_macro (AST::MacroInvocData &invoc,
 				  AST::MacroRulesDefinition &rules_def)
@@ -3226,6 +3227,7 @@ MacroExpander::expand_decl_macro (AST::MacroInvocData &invoc,
    * all the time, while still allowing the heterogenous storage of token trees.
    */
 }
+#endif
 
 void
 MacroExpander::expand_invoc (std::unique_ptr<AST::MacroInvocation> &invoc)


### PR DESCRIPTION
#336

The only caller is currently `#if 0`ed, too.