### PR TITLE
Address '[...]/gcc/rust/rust-diagnostics.cc:198:38: error: function ‘void rust_debug(Location, const char*, ...)’ might be a candidate for ‘gnu_printf’ format attribute [-Werror=suggest-attribute=format]' diagnostic [#336]

### DIFF
--- a/gcc/rust/rust-diagnostics.cc
+++ b/gcc/rust/rust-diagnostics.cc
@@ -190,6 +190,10 @@ rust_inform (const Location location, const char *fmt, ...)
 
 void
 rust_debug (const Location location, const char *fmt, ...)
+  ATTRIBUTE_PRINTF_2;
+
+void
+rust_debug (const Location location, const char *fmt, ...)
 {
   va_list ap;
 


### PR DESCRIPTION
#336