### PR TITLE
Address '[...]/gcc/rust/lex/rust-lex.cc:433:30: error: too many arguments for format [-Werror=format-extra-args]' diagnostic [#336]

### DIFF
--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -430,8 +430,7 @@ Lexer::build_token ()
 		  if (current_char == EOF)
 		    {
 		      rust_error_at (
-			loc, "unexpected EOF while looking for end of comment",
-			current_char);
+			loc, "unexpected EOF while looking for end of comment");
 		      break;
 		    }
 


### PR DESCRIPTION
#336