### PR TITLE
Address '[...]/gcc/rust/lex/rust-lex.cc:1322:21: error: comparison is always false due to limited range of data type [-Werror=type-limits]' diagnostic [#336]

### DIFF
--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -1319,7 +1319,7 @@ Lexer::parse_byte_char (Location loc)
       byte_char = std::get<0> (escape_length_pair);
       length += std::get<1> (escape_length_pair);
 
-      if (byte_char > 127)
+      if (byte_char /* > 127 */ < 0)
 	{
 	  rust_error_at (get_current_location (),
 			 "byte char %<%c%> out of range", byte_char);


### PR DESCRIPTION
#336

Should this maybe be `unsigned char`, or something else changed?

We don't seem to have any testcases?
