### PR TITLE
Address '[...]/gcc/rust/lex/rust-lex.cc:1397:27: error: comparison is always false due to limited range of data type [-Werror=type-limits]' diagnostic [#336]

### DIFF
--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -1394,7 +1394,7 @@ Lexer::parse_byte_string (Location loc)
 	  else
 	    length += std::get<1> (escape_length_pair);
 
-	  if (output_char > 127)
+	  if (output_char /* > 127 */ < 0)
 	    {
 	      rust_error_at (get_current_location (),
 			     "char %<%c%> in byte string out of range",


### PR DESCRIPTION
#336

Should this maybe be `unsigned char`, or something else changed?

We don't seem to have any testcases?