### PR TITLE
Address 'error: ‘op’ may be used uninitialized in this function [-Werror=maybe-uninitialized]' diagnostic [#336]

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -501,6 +501,8 @@ public:
       case CompoundAssignmentOperator::RIGHT_SHIFT:
 	op = ArithmeticOrLogicalOperator::RIGHT_SHIFT;
 	break;
+      default:
+	gcc_unreachable ();
       }
 
     HIR::Expr *asignee_expr


### PR DESCRIPTION
#336

    In file included from [...]/gcc/rust/hir/tree/rust-hir-full.h:24,
                     from [...]/gcc/rust/hir/rust-ast-lower.h:25,
                     from [...]/gcc/rust/hir/rust-ast-lower.cc:19:
    [...]/gcc/rust/hir/tree/rust-hir-expr.h: In member function ‘virtual void Rust::HIR::ASTLoweringExpr::visit(Rust::AST::CompoundAssignmentExpr&)’:
    [...]/gcc/rust/hir/tree/rust-hir-expr.h:426:7: error: ‘op’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
      426 |       expr_type (expr_kind), right_expr (std::move (right_value))
          |       ^~~~~~~~~~~~~~~~~~~~~
    In file included from [...]/gcc/rust/hir/rust-ast-lower-type.h:24,
                     from [...]/gcc/rust/hir/rust-ast-lower-item.h:25,
                     from [...]/gcc/rust/hir/rust-ast-lower.cc:20:
    [...]/gcc/rust/hir/rust-ast-lower-expr.h:471:33: note: ‘op’ was declared here
      471 |     ArithmeticOrLogicalOperator op;
          |                                 ^~