### PR TITLE
Address 'error: ‘kind’ may be used uninitialized in this function [-Werror=maybe-uninitialized]' diagnostic [#336]

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-type.h
+++ b/gcc/rust/hir/rust-ast-lower-type.h
@@ -67,6 +67,8 @@ public:
 	  case AST::MaybeNamedParam::ParamKind::WILDCARD:
 	    kind = HIR::MaybeNamedParam::ParamKind::WILDCARD;
 	    break;
+	  default:
+	    gcc_unreachable ();
 	  }
 
 	HIR::Type *param_type


### PR DESCRIPTION
#336

    In file included from [...]/gcc/rust/hir/tree/rust-hir-full.h:29,
                     from [...]/gcc/rust/hir/rust-ast-lower.h:25,
                     from [...]/gcc/rust/hir/rust-ast-lower.cc:19:
    [...]/gcc/rust/hir/tree/rust-hir-type.h: In member function ‘virtual void Rust::HIR::ASTLoweringType::visit(Rust::AST::BareFunctionType&)’:
    [...]/gcc/rust/hir/tree/rust-hir-type.h:785:3: error: ‘kind’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
      785 |   MaybeNamedParam (MaybeNamedParam &&other) = default;
          |   ^~~~~~~~~~~~~~~
    In file included from [...]/gcc/rust/hir/rust-ast-lower-item.h:25,
                     from [...]/gcc/rust/hir/rust-ast-lower.cc:20:
    [...]/gcc/rust/hir/rust-ast-lower-type.h:58:41: note: ‘kind’ was declared here
       58 |         HIR::MaybeNamedParam::ParamKind kind;
          |                                         ^~~~