### PR TITLE
Address 'gcc/rust/typecheck/rust-tyty.h' '-Werror=unused-parameter' diagnostics [#336]

### DIFF
--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -971,11 +971,17 @@ class USizeType : public BaseType
 public:
   USizeType (HirId ref, std::set<HirId> refs = std::set<HirId> ())
     : BaseType (ref, ref, TypeKind::USIZE)
-  {}
+  {
+    //TODO unused; should 'refs' be passed as the last argument to the 'BaseType' constructor call?  Potential change in behavior (if 'refs' is provided by caller)?
+    (void) refs;
+  }
 
   USizeType (HirId ref, HirId ty_ref, std::set<HirId> refs = std::set<HirId> ())
     : BaseType (ref, ty_ref, TypeKind::USIZE)
-  {}
+  {
+    //TODO unused; should 'refs' be passed as the last argument to the 'BaseType' constructor call?  Potential change in behavior (if 'refs' is provided by caller)?
+    (void) refs;
+  }
 
   void accept_vis (TyVisitor &vis) override;
 
@@ -993,11 +999,17 @@ class ISizeType : public BaseType
 public:
   ISizeType (HirId ref, std::set<HirId> refs = std::set<HirId> ())
     : BaseType (ref, ref, TypeKind::ISIZE)
-  {}
+  {
+    //TODO unused; should 'refs' be passed as the last argument to the 'BaseType' constructor call?  Potential change in behavior (if 'refs' is provided by caller)?
+    (void) refs;
+  }
 
   ISizeType (HirId ref, HirId ty_ref, std::set<HirId> refs = std::set<HirId> ())
     : BaseType (ref, ty_ref, TypeKind::ISIZE)
-  {}
+  {
+    //TODO unused; should 'refs' be passed as the last argument to the 'BaseType' constructor call?  Potential change in behavior (if 'refs' is provided by caller)?
+    (void) refs;
+  }
 
   void accept_vis (TyVisitor &vis) override;
 
@@ -1015,12 +1027,17 @@ class CharType : public BaseType
 public:
   CharType (HirId ref, std::set<HirId> refs = std::set<HirId> ())
     : BaseType (ref, ref, TypeKind::CHAR)
-  {}
+  {
+    //TODO unused; should 'refs' be passed as the last argument to the 'BaseType' constructor call?  Potential change in behavior (if 'refs' is provided by caller)?
+    (void) refs;
+  }
 
   CharType (HirId ref, HirId ty_ref, std::set<HirId> refs = std::set<HirId> ())
     : BaseType (ref, ty_ref, TypeKind::CHAR)
-
-  {}
+  {
+    //TODO unused; should 'refs' be passed as the last argument to the 'BaseType' constructor call?  Potential change in behavior (if 'refs' is provided by caller)?
+    (void) refs;
+  }
 
   void accept_vis (TyVisitor &vis) override;
 
@@ -1039,12 +1056,18 @@ public:
   ReferenceType (HirId ref, TyVar base,
 		 std::set<HirId> refs = std::set<HirId> ())
     : BaseType (ref, ref, TypeKind::REF), base (base)
-  {}
+  {
+    //TODO unused; should 'refs' be passed as the last argument to the 'BaseType' constructor call?  Potential change in behavior (if 'refs' is provided by caller)?
+    (void) refs;
+  }
 
   ReferenceType (HirId ref, HirId ty_ref, TyVar base,
 		 std::set<HirId> refs = std::set<HirId> ())
     : BaseType (ref, ty_ref, TypeKind::REF), base (base)
-  {}
+  {
+    //TODO unused; should 'refs' be passed as the last argument to the 'BaseType' constructor call?  Potential change in behavior (if 'refs' is provided by caller)?
+    (void) refs;
+  }
 
   BaseType *get_base () const;
 
@@ -1069,11 +1092,17 @@ class StrType : public BaseType
 public:
   StrType (HirId ref, std::set<HirId> refs = std::set<HirId> ())
     : BaseType (ref, ref, TypeKind::STR)
-  {}
+  {
+    //TODO unused; should 'refs' be passed as the last argument to the 'BaseType' constructor call?  Potential change in behavior (if 'refs' is provided by caller)?
+    (void) refs;
+  }
 
   StrType (HirId ref, HirId ty_ref, std::set<HirId> refs = std::set<HirId> ())
     : BaseType (ref, ty_ref, TypeKind::STR)
-  {}
+  {
+    //TODO unused; should 'refs' be passed as the last argument to the 'BaseType' constructor call?  Potential change in behavior (if 'refs' is provided by caller)?
+    (void) refs;
+  }
 
   std::string get_name () const override final { return as_string (); }
 


### PR DESCRIPTION
#336

    In file included from [...]/gcc/rust/typecheck/rust-hir-type-check.h:24,
                     from [...]/gcc/rust/resolve/rust-name-resolver.h:24,
                     from [...]/gcc/rust/resolve/rust-ast-resolve.h:22,
                     from [...]/gcc/rust/rust-session-manager.cc:36:
    [...]/gcc/rust/typecheck/rust-tyty.h: In constructor ‘Rust::TyTy::USizeType::USizeType(Rust::HirId, std::set<unsigned int>)’:
    [...]/gcc/rust/typecheck/rust-tyty.h:972:41: error: unused parameter ‘refs’ [-Werror=unused-parameter]
      972 |   USizeType (HirId ref, std::set<HirId> refs = std::set<HirId> ())
          |                         ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
    [...]/gcc/rust/typecheck/rust-tyty.h: In constructor ‘Rust::TyTy::USizeType::USizeType(Rust::HirId, Rust::HirId, std::set<unsigned int>)’:
    [...]/gcc/rust/typecheck/rust-tyty.h:976:55: error: unused parameter ‘refs’ [-Werror=unused-parameter]
      976 |   USizeType (HirId ref, HirId ty_ref, std::set<HirId> refs = std::set<HirId> ())
          |                                       ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
    [...]/gcc/rust/typecheck/rust-tyty.h: In constructor ‘Rust::TyTy::ISizeType::ISizeType(Rust::HirId, std::set<unsigned int>)’:
    [...]/gcc/rust/typecheck/rust-tyty.h:994:41: error: unused parameter ‘refs’ [-Werror=unused-parameter]
      994 |   ISizeType (HirId ref, std::set<HirId> refs = std::set<HirId> ())
          |                         ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
    [...]/gcc/rust/typecheck/rust-tyty.h: In constructor ‘Rust::TyTy::ISizeType::ISizeType(Rust::HirId, Rust::HirId, std::set<unsigned int>)’:
    [...]/gcc/rust/typecheck/rust-tyty.h:998:55: error: unused parameter ‘refs’ [-Werror=unused-parameter]
      998 |   ISizeType (HirId ref, HirId ty_ref, std::set<HirId> refs = std::set<HirId> ())
          |                                       ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
    [...]/gcc/rust/typecheck/rust-tyty.h: In constructor ‘Rust::TyTy::CharType::CharType(Rust::HirId, std::set<unsigned int>)’:
    [...]/gcc/rust/typecheck/rust-tyty.h:1016:40: error: unused parameter ‘refs’ [-Werror=unused-parameter]
     1016 |   CharType (HirId ref, std::set<HirId> refs = std::set<HirId> ())
          |                        ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
    [...]/gcc/rust/typecheck/rust-tyty.h: In constructor ‘Rust::TyTy::CharType::CharType(Rust::HirId, Rust::HirId, std::set<unsigned int>)’:
    [...]/gcc/rust/typecheck/rust-tyty.h:1020:54: error: unused parameter ‘refs’ [-Werror=unused-parameter]
     1020 |   CharType (HirId ref, HirId ty_ref, std::set<HirId> refs = std::set<HirId> ())
          |                                      ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
    [...]/gcc/rust/typecheck/rust-tyty.h: In constructor ‘Rust::TyTy::ReferenceType::ReferenceType(Rust::HirId, Rust::TyTy::TyVar, std::set<unsigned int>)’:
    [...]/gcc/rust/typecheck/rust-tyty.h:1040:34: error: unused parameter ‘refs’ [-Werror=unused-parameter]
     1040 |                  std::set<HirId> refs = std::set<HirId> ())
          |                  ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
    [...]/gcc/rust/typecheck/rust-tyty.h: In constructor ‘Rust::TyTy::ReferenceType::ReferenceType(Rust::HirId, Rust::HirId, Rust::TyTy::TyVar, std::set<unsigned int>)’:
    [...]/gcc/rust/typecheck/rust-tyty.h:1045:34: error: unused parameter ‘refs’ [-Werror=unused-parameter]
     1045 |                  std::set<HirId> refs = std::set<HirId> ())
          |                  ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
    [...]/gcc/rust/typecheck/rust-tyty.h: In constructor ‘Rust::TyTy::StrType::StrType(Rust::HirId, std::set<unsigned int>)’:
    [...]/gcc/rust/typecheck/rust-tyty.h:1070:39: error: unused parameter ‘refs’ [-Werror=unused-parameter]
     1070 |   StrType (HirId ref, std::set<HirId> refs = std::set<HirId> ())
          |                       ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
    [...]/gcc/rust/typecheck/rust-tyty.h: In constructor ‘Rust::TyTy::StrType::StrType(Rust::HirId, Rust::HirId, std::set<unsigned int>)’:
    [...]/gcc/rust/typecheck/rust-tyty.h:1074:53: error: unused parameter ‘refs’ [-Werror=unused-parameter]
     1074 |   StrType (HirId ref, HirId ty_ref, std::set<HirId> refs = std::set<HirId> ())
          |                                     ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
