### PR TITLE
Address miscellaneous '-Werror=unused-parameter' diagnostics [#336]

### DIFF
--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -3217,7 +3217,7 @@ public:
   Location get_locus_slow () const final override { return get_locus (); }
 
   // should never be called - error if called
-  void set_outer_attrs (std::vector<Attribute> new_attrs) override
+  void set_outer_attrs (std::vector<Attribute> /* new_attrs */) override
   {
     rust_assert (false);
   }
@@ -4377,7 +4377,7 @@ public:
 
   IfLetExpr (std::vector<std::unique_ptr<Pattern> > match_arm_patterns,
 	     std::unique_ptr<Expr> value, std::unique_ptr<BlockExpr> if_block,
-	     std::vector<Attribute> outer_attrs, Location locus)
+	     std::vector<Attribute> /* outer_attrs */, Location locus)
     : match_arm_patterns (std::move (match_arm_patterns)),
       value (std::move (value)), if_block (std::move (if_block)), locus (locus)
   {}

--- a/gcc/rust/backend/rust-compile-tyty.h
+++ b/gcc/rust/backend/rust-compile-tyty.h
@@ -64,7 +64,7 @@ public:
 
   void visit (TyTy::ParamType &) override { gcc_unreachable (); }
 
-  void visit (TyTy::FnPtr &type) override { gcc_unreachable (); }
+  void visit (TyTy::FnPtr &) override { gcc_unreachable (); }
 
   void visit (TyTy::FnType &type) override
   {

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -995,7 +995,7 @@ Gcc_backend::function_type (const Btyped_identifier &receiver,
 Btype *
 Gcc_backend::function_ptr_type (Btype *result_type,
 				const std::vector<Btype *> &parameters,
-				Location locus)
+				Location /* locus */)
 {
   tree args = NULL_TREE;
   tree *pp = &args;

--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -150,7 +150,7 @@ grs_langhook_option_lang_mask (void)
 
 /* Initialize the options structure. */
 static void
-grs_langhook_init_options_struct (struct gcc_options *opts)
+grs_langhook_init_options_struct (struct gcc_options * /* opts */)
 {
   // nothing yet - used by frontends to change specific options for the language
   session.init_options ();


### PR DESCRIPTION
#336

    In file included from [...]/gcc/rust/ast/rust-ast-full.h:23,
                     from [...]/gcc/rust/parse/rust-parse.h:21,
                     from [...]/gcc/rust/rust-session-manager.cc:34:
    [...]/gcc/rust/ast/rust-expr.h: In member function ‘virtual void Rust::AST::RangeExpr::set_outer_attrs(std::vector<Rust::AST::Attribute>)’:
    [...]/gcc/rust/ast/rust-expr.h:3220:48: error: unused parameter ‘new_attrs’ [-Werror=unused-parameter]
     3220 |   void set_outer_attrs (std::vector<Attribute> new_attrs) override
          |                         ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
    [...]/gcc/rust/ast/rust-expr.h: In constructor ‘Rust::AST::IfLetExpr::IfLetExpr(std::vector<std::unique_ptr<Rust::AST::Pattern> >, std::unique_ptr<Rust::AST::Expr>, std::unique_ptr<Rust::AST::BlockExpr>, std::vector<Rust::AST::Attribute>, Location)’:
    [...]/gcc/rust/ast/rust-expr.h:4380:37: error: unused parameter ‘outer_attrs’ [-Werror=unused-parameter]
     4380 |              std::vector<Attribute> outer_attrs, Location locus)
          |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~

    In file included from [...]/gcc/rust/backend/rust-compile-context.h:27,
                     from [...]/gcc/rust/backend/rust-compile.h:24,
                     from [...]/gcc/rust/rust-session-manager.cc:41:
    [...]/gcc/rust/backend/rust-compile-tyty.h: In member function ‘virtual void Rust::Compile::TyTyCompile::visit(Rust::TyTy::FnPtr&)’:
    [...]/gcc/rust/backend/rust-compile-tyty.h:67:28: error: unused parameter ‘type’ [-Werror=unused-parameter]
       67 |   void visit (TyTy::FnPtr &type) override { gcc_unreachable (); }
          |               ~~~~~~~~~~~~~^~~~

    [...]/gcc/rust/rust-gcc.cc: In member function ‘virtual Btype* Gcc_backend::function_ptr_type(Btype*, const std::vector<Btype*>&, Location)’:
    [...]/gcc/rust/rust-gcc.cc:998:42: error: unused parameter ‘locus’ [-Werror=unused-parameter]
      998 |                                 Location locus)
          |                                 ~~~~~~~~~^~~~~

    [...]/gcc/rust/rust-lang.cc: In function ‘void grs_langhook_init_options_struct(gcc_options*)’:
    [...]/gcc/rust/rust-lang.cc:153:55: error: unused parameter ‘opts’ [-Werror=unused-parameter]
      153 | grs_langhook_init_options_struct (struct gcc_options *opts)
          |                                   ~~~~~~~~~~~~~~~~~~~~^~~~