### PR TITLE
Address '[...]/gcc/rust/rust-target.h:23: error: "DEFHOOK" redefined' diagnostic [#336]

### DIFF
--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -28,7 +28,17 @@
 #include "tm.h"
 #include "tm_p.h"
 
-#include "rust-target.h"
+//#include "rust-target.h"
+/*TODO This isn't (currently?) necessary, but if '#include'd after '#include "target.h"', causes:
+    In file included from [...]/gcc/rust/rust-session-manager.cc:31:
+    [...]/gcc/rust/rust-target.h:23: error: "DEFHOOK" redefined [-Werror]
+       23 | #define DEFHOOK(NAME, DOC, TYPE, PARAMS, INIT) TYPE (*NAME) PARAMS;
+          | 
+    In file included from [...]/gcc/rust/rust-session-manager.cc:27:
+    [...]/gcc/target.h:272: note: this is the location of the previous definition
+      272 | #define DEFHOOK(NAME, DOC, TYPE, PARAMS, INIT) TYPE (* NAME) PARAMS;
+          | 
+*/
 
 #include "rust-lex.h"
 #include "rust-parse.h"


### PR DESCRIPTION
#336

I haven't quickly been able to understand the target hooks handling here -- seems to be WIP?

My proposed changed doesn't change any behavior.