### PR TITLE
Address 'error: ‘*<unknown>.Rust::HIR::ArrayType::<anonymous>.Rust::HIR::TypeNoBounds::<anonymous>.Rust::HIR::Type::mappings’ is used uninitialized [-Werror=uninitialized]' diagnostic [#336]

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-type.h
+++ b/gcc/rust/hir/tree/rust-hir-type.h
@@ -604,9 +604,12 @@ public:
 
   // Copy constructor requires deep copies of both unique pointers
   ArrayType (ArrayType const &other)
-    : TypeNoBounds (mappings), elem_type (other.elem_type->clone_type ()),
+    : TypeNoBounds (other.mappings), elem_type (other.elem_type->clone_type ()),
       size (other.size->clone_expr ()), locus (other.locus)
-  {}
+  {
+    // Untested.
+    gcc_unreachable ();
+  }
 
   // Overload assignment operator to deep copy pointers
   ArrayType &operator= (ArrayType const &other)


### PR DESCRIPTION
#336

... by doing the same as in the "assignment operator to deep copy pointers" a
few lines later.  I have not verified what's (supposed to be) going on here;
that code seems unused, and thus untested, and thus I marked it up as such.

    In file included from [...]/gcc/rust/hir/tree/rust-hir-full.h:29,
                     from [...]/gcc/rust/backend/rust-compile.h:23,
                     from [...]/gcc/rust/backend/rust-compile.cc:19:
    [...]/gcc/rust/hir/tree/rust-hir-type.h: In copy constructor ‘Rust::HIR::ArrayType::ArrayType(const Rust::HIR::ArrayType&)’:
    [...]/gcc/rust/hir/tree/rust-hir-type.h:607:21: error: ‘*<unknown>.Rust::HIR::ArrayType::<anonymous>.Rust::HIR::TypeNoBounds::<anonymous>.Rust::HIR::Type::mappings’ is used uninitialized [-Werror=uninitialized]
      607 |     : TypeNoBounds (mappings), elem_type (other.elem_type->clone_type ()),
          |                     ^~~~~~~~