### PR TITLE
Address 'error: ‘*<unknown>.Rust::HIR::QualifiedPathInType::<anonymous>.Rust::HIR::TypeNoBounds::<anonymous>.Rust::HIR::Type::mappings’ is used uninitialized [-Werror=uninitialized]' diagnostic [#336]

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-path.h
+++ b/gcc/rust/hir/tree/rust-hir-path.h
@@ -817,11 +817,15 @@ public:
 
   // Copy constructor with vector clone
   QualifiedPathInType (QualifiedPathInType const &other)
-    : TypeNoBounds (mappings), path_type (other.path_type), locus (other.locus)
+    : TypeNoBounds (other.mappings), path_type (other.path_type),
+      locus (other.locus)
   {
     segments.reserve (other.segments.size ());
     for (const auto &e : other.segments)
       segments.push_back (e->clone_type_path_segment ());
+
+    // Untested.
+    gcc_unreachable ();
   }
 
   // Overloaded assignment operator with vector clone


### PR DESCRIPTION
#336

... by doing the same as in the "assignment operator with vector clone" a few
lines later.  I have not verified what's (supposed to be) going on here; that
code seems unused, and thus untested, and thus I marked it up as such.

    In file included from [...]/gcc/rust/hir/tree/rust-hir-expr.h:23,
                     from [...]/gcc/rust/hir/tree/rust-hir-full.h:24,
                     from [...]/gcc/rust/backend/rust-compile.h:23,
                     from [...]/gcc/rust/backend/rust-compile.cc:19:
    [...]/gcc/rust/hir/tree/rust-hir-path.h: In copy constructor ‘Rust::HIR::QualifiedPathInType::QualifiedPathInType(const Rust::HIR::QualifiedPathInType&)’:
    [...]/gcc/rust/hir/tree/rust-hir-path.h:820:21: error: ‘*<unknown>.Rust::HIR::QualifiedPathInType::<anonymous>.Rust::HIR::TypeNoBounds::<anonymous>.Rust::HIR::Type::mappings’ is used uninitialized [-Werror=uninitialized]
      820 |     : TypeNoBounds (mappings), path_type (other.path_type), locus (other.locus)
          |                     ^~~~~~~~