### PR TITLE
Canonical Paths for Name Resolution and handle TurboFish properly

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -526,7 +526,7 @@ public:
 
   void visit (HIR::PathInExpression &expr) override
   {
-    translated = ResolvePathRef::Compile (&expr, ctx);
+    translated = ResolvePathRef::Compile (expr, ctx);
   }
 
   void visit (HIR::LoopExpr &expr) override

--- a/gcc/rust/backend/rust-compile-resolve-path.h
+++ b/gcc/rust/backend/rust-compile-resolve-path.h
@@ -30,10 +30,10 @@ class ResolvePathRef : public HIRCompileBase
   using Rust::Compile::HIRCompileBase::visit;
 
 public:
-  static Bexpression *Compile (HIR::Expr *expr, Context *ctx)
+  static Bexpression *Compile (HIR::PathInExpression &expr, Context *ctx)
   {
     ResolvePathRef resolver (ctx);
-    expr->accept_vis (resolver);
+    expr.accept_vis (resolver);
     return resolver.resolved;
   }
 

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -360,12 +360,14 @@ public:
 				   mappings->get_next_localdef_id (crate_num));
 
     std::vector<std::unique_ptr<HIR::InherentImplItem> > impl_items;
+    std::vector<HirId> impl_item_ids;
     for (auto &impl_item : impl_block.get_impl_items ())
       {
 	HIR::InherentImplItem *lowered
 	  = ASTLowerImplItem::translate (impl_item.get (),
 					 mapping.get_hirid ());
 	impl_items.push_back (std::unique_ptr<HIR::InherentImplItem> (lowered));
+	impl_item_ids.push_back (lowered->get_impl_mappings ().get_hirid ());
       }
 
     translated
@@ -381,6 +383,13 @@ public:
 			       translated);
     mappings->insert_location (crate_num, mapping.get_hirid (),
 			       impl_block.get_locus ());
+
+    for (auto &impl_item_id : impl_item_ids)
+      {
+	mappings->insert_impl_item_mapping (impl_item_id,
+					    static_cast<HIR::InherentImpl *> (
+					      translated));
+      }
   }
 
 private:

--- a/gcc/rust/hir/tree/rust-hir-path.h
+++ b/gcc/rust/hir/tree/rust-hir-path.h
@@ -255,6 +255,12 @@ public:
       }
   }
 
+  size_t get_num_segments () const { return segments.size (); }
+
+  std::vector<PathExprSegment> &get_segments () { return segments; }
+
+  PathExprSegment &get_root_seg () { return segments.at (0); }
+
   PathExprSegment get_final_segment () const { return segments.back (); }
 };
 

--- a/gcc/rust/resolve/rust-ast-resolve-expr.h
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.h
@@ -109,15 +109,16 @@ public:
 
   void visit (AST::IdentifierExpr &expr) override
   {
-    if (resolver->get_name_scope ().lookup (expr.as_string (), &resolved_node))
+    if (resolver->get_name_scope ().lookup (CanonicalPath (expr.as_string ()),
+					    &resolved_node))
       {
 	resolver->insert_resolved_name (expr.get_node_id (), resolved_node);
 	resolver->insert_new_definition (expr.get_node_id (),
 					 Definition{expr.get_node_id (),
 						    parent});
       }
-    else if (resolver->get_type_scope ().lookup (expr.as_string (),
-						 &resolved_node))
+    else if (resolver->get_type_scope ().lookup (
+	       CanonicalPath (expr.as_string ()), &resolved_node))
       {
 	resolver->insert_resolved_type (expr.get_node_id (), resolved_node);
 	resolver->insert_new_definition (expr.get_node_id (),
@@ -255,8 +256,9 @@ public:
 	auto label_name = label.get_lifetime ().get_lifetime_name ();
 	auto label_lifetime_node_id = label.get_lifetime ().get_node_id ();
 	resolver->get_label_scope ().insert (
-	  label_name, label_lifetime_node_id, label.get_locus (), false,
-	  [&] (std::string, NodeId, Location locus) -> void {
+	  CanonicalPath (label_name), label_lifetime_node_id,
+	  label.get_locus (), false,
+	  [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	    rust_error_at (label.get_locus (),
 			   "label redefined multiple times");
 	    rust_error_at (locus, "was defined here");
@@ -281,8 +283,8 @@ public:
 	  }
 
 	NodeId resolved_node = UNKNOWN_NODEID;
-	if (!resolver->get_label_scope ().lookup (label.get_lifetime_name (),
-						  &resolved_node))
+	if (!resolver->get_label_scope ().lookup (
+	      CanonicalPath (label.get_lifetime_name ()), &resolved_node))
 	  {
 	    rust_error_at (expr.get_label ().get_locus (),
 			   "failed to resolve label");
@@ -311,8 +313,9 @@ public:
 	auto label_name = label.get_lifetime ().get_lifetime_name ();
 	auto label_lifetime_node_id = label.get_lifetime ().get_node_id ();
 	resolver->get_label_scope ().insert (
-	  label_name, label_lifetime_node_id, label.get_locus (), false,
-	  [&] (std::string, NodeId, Location locus) -> void {
+	  CanonicalPath (label_name), label_lifetime_node_id,
+	  label.get_locus (), false,
+	  [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	    rust_error_at (label.get_locus (),
 			   "label redefined multiple times");
 	    rust_error_at (locus, "was defined here");
@@ -338,8 +341,8 @@ public:
 	  }
 
 	NodeId resolved_node = UNKNOWN_NODEID;
-	if (!resolver->get_label_scope ().lookup (label.get_lifetime_name (),
-						  &resolved_node))
+	if (!resolver->get_label_scope ().lookup (
+	      CanonicalPath (label.get_lifetime_name ()), &resolved_node))
 	  {
 	    rust_error_at (expr.get_label ().get_locus (),
 			   "failed to resolve label");

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -179,18 +179,21 @@ public:
 	  }
       }
 
+    bool canonicalize_type_with_generics = false;
     NodeId resolved_node = ResolveType::go (impl_block.get_type ().get (),
-					    impl_block.get_node_id ());
+					    impl_block.get_node_id (),
+					    canonicalize_type_with_generics);
     if (resolved_node == UNKNOWN_NODEID)
       return;
 
+    auto Self = CanonicalPath::get_big_self ();
     resolver->get_type_scope ().insert (
-      "Self", resolved_node, impl_block.get_type ()->get_locus_slow ());
+      Self, resolved_node, impl_block.get_type ()->get_locus_slow ());
 
     for (auto &impl_item : impl_block.get_impl_items ())
       impl_item->accept_vis (*this);
 
-    resolver->get_type_scope ().peek ()->clear_name ("Self", resolved_node);
+    resolver->get_type_scope ().peek ()->clear_name (Self, resolved_node);
     resolver->get_type_scope ().pop ();
   }
 

--- a/gcc/rust/resolve/rust-ast-resolve-pattern.h
+++ b/gcc/rust/resolve/rust-ast-resolve-pattern.h
@@ -33,7 +33,6 @@ public:
   static void go (AST::Pattern *pattern, NodeId parent)
   {
     ResolvePattern resolver (parent);
-
     pattern->accept_vis (resolver);
     if (resolver.resolved_node == UNKNOWN_NODEID)
       {
@@ -42,12 +41,10 @@ public:
       }
   };
 
-  ~ResolvePattern () {}
-
   void visit (AST::IdentifierPattern &pattern) override
   {
-    if (resolver->get_name_scope ().lookup (pattern.get_ident (),
-					    &resolved_node))
+    if (resolver->get_name_scope ().lookup (
+	  CanonicalPath (pattern.get_ident ()), &resolved_node))
       {
 	resolver->insert_resolved_name (pattern.get_node_id (), resolved_node);
 	resolver->insert_new_definition (pattern.get_node_id (),
@@ -68,23 +65,14 @@ public:
   static void go (AST::Pattern *pattern, NodeId parent)
   {
     PatternDeclaration resolver (parent);
-
     pattern->accept_vis (resolver);
-    if (resolver.resolved_node != UNKNOWN_NODEID)
-      {
-	// print both locations?!
-	rust_error_at (resolver.locus, "duplicate pattern %s",
-		       pattern->as_string ().c_str ());
-      }
   };
-
-  ~PatternDeclaration () {}
 
   void visit (AST::IdentifierPattern &pattern) override
   {
     // if we have a duplicate id this then allows for shadowing correctly
     // as new refs to this decl will match back here so it is ok to overwrite
-    resolver->get_name_scope ().insert (pattern.get_ident (),
+    resolver->get_name_scope ().insert (CanonicalPath (pattern.get_ident ()),
 					pattern.get_node_id (),
 					pattern.get_locus ());
     resolver->insert_new_definition (pattern.get_node_id (),

--- a/gcc/rust/resolve/rust-ast-verify-assignee.h
+++ b/gcc/rust/resolve/rust-ast-verify-assignee.h
@@ -57,7 +57,8 @@ public:
 
   void visit (AST::IdentifierExpr &expr) override
   {
-    if (!resolver->get_name_scope ().lookup (expr.as_string (), &resolved_node))
+    if (!resolver->get_name_scope ().lookup (CanonicalPath (expr.as_string ()),
+					     &resolved_node))
       return;
 
     ok = true;

--- a/gcc/rust/typecheck/rust-hir-inherent-impl-overlap.h
+++ b/gcc/rust/typecheck/rust-hir-inherent-impl-overlap.h
@@ -1,0 +1,220 @@
+// Copyright (C) 2020 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_HIR_INHERENT_IMPL_ITEM_OVERLAP_H
+#define RUST_HIR_INHERENT_IMPL_ITEM_OVERLAP_H
+
+#include "rust-hir-type-check-base.h"
+#include "rust-hir-full.h"
+
+namespace Rust {
+namespace Resolver {
+
+class InherentImplItemToName : public TypeCheckBase
+{
+  using Rust::Resolver::TypeCheckBase::visit;
+
+public:
+  static bool resolve (HIR::InherentImplItem *item, std::string &name_result)
+  {
+    InherentImplItemToName resolver (name_result);
+    item->accept_vis (resolver);
+    return resolver.ok;
+  }
+
+  void visit (HIR::Method &method) override
+  {
+    ok = true;
+    result.assign (method.get_method_name ());
+  }
+
+  void visit (HIR::Function &function) override
+  {
+    ok = true;
+    result.assign (function.get_function_name ());
+  }
+
+  void visit (HIR::ConstantItem &constant) override
+  {
+    ok = true;
+    result.assign (constant.get_identifier ());
+  }
+
+private:
+  InherentImplItemToName (std::string &result)
+    : TypeCheckBase (), ok (false), result (result)
+  {}
+
+  bool ok;
+  std::string &result;
+};
+
+class GetLocusFromImplItem : public TypeCheckBase
+{
+  using Rust::Resolver::TypeCheckBase::visit;
+
+public:
+  static bool Resolve (HIR::InherentImplItem *query, Location &locus)
+  {
+    GetLocusFromImplItem resolver (locus);
+    query->accept_vis (resolver);
+    return resolver.ok;
+  }
+
+  void visit (HIR::ConstantItem &constant) override
+  {
+    ok = true;
+    locus = constant.get_locus ();
+  }
+
+  void visit (HIR::Function &function) override
+  {
+    ok = true;
+    locus = function.get_locus ();
+  }
+
+  void visit (HIR::Method &method) override
+  {
+    ok = true;
+    locus = method.get_locus ();
+  }
+
+private:
+  GetLocusFromImplItem (Location &locus)
+    : TypeCheckBase (), ok (false), locus (locus)
+  {}
+
+  bool ok;
+  Location &locus;
+};
+
+class OverlappingImplItemPass : public TypeCheckBase
+{
+  using Rust::Resolver::TypeCheckBase::visit;
+
+public:
+  static void go ()
+  {
+    OverlappingImplItemPass pass;
+
+    // generate mappings
+    pass.mappings->iterate_impl_items ([&] (HirId id,
+					    HIR::InherentImplItem *impl_item,
+					    HIR::InherentImpl *impl) -> bool {
+      pass.process_impl_item (id, impl_item, impl);
+      return true;
+    });
+
+    pass.scan ();
+  }
+
+  void process_impl_item (HirId id, HIR::InherentImplItem *impl_item,
+			  HIR::InherentImpl *impl)
+  {
+    // lets make a mapping of impl-item Self type to (impl-item,name):
+    // {
+    //   impl-type -> [ (item, name), ... ]
+    // }
+
+    HirId impl_type_id = impl->get_type ()->get_mappings ().get_hirid ();
+    TyTy::BaseType *impl_type = nullptr;
+    bool ok = context->lookup_type (impl_type_id, &impl_type);
+    rust_assert (ok);
+
+    std::string impl_item_name;
+    ok = InherentImplItemToName::resolve (impl_item, impl_item_name);
+    rust_assert (ok);
+
+    std::pair<HIR::InherentImplItem *, std::string> elem (impl_item,
+							  impl_item_name);
+    impl_mappings[impl_type].insert (std::move (elem));
+  }
+
+  void scan ()
+  {
+    // we can now brute force the map looking for can_eq on each of the
+    // impl_items_types to look for possible colliding impl blocks;
+    for (auto it = impl_mappings.begin (); it != impl_mappings.end (); it++)
+      {
+	TyTy::BaseType *query = it->first;
+
+	for (auto iy = impl_mappings.begin (); iy != impl_mappings.end (); iy++)
+	  {
+	    TyTy::BaseType *candidate = iy->first;
+	    if (query == candidate)
+	      continue;
+
+	    if (query->can_eq (candidate))
+	      possible_collision (it->second, iy->second);
+	  }
+      }
+  }
+
+  void possible_collision (
+    std::set<std::pair<HIR::InherentImplItem *, std::string> > query,
+    std::set<std::pair<HIR::InherentImplItem *, std::string> > candidate)
+  {
+    for (auto &q : query)
+      {
+	HIR::InherentImplItem *query_impl_item = q.first;
+	std::string query_impl_item_name = q.second;
+
+	for (auto &c : candidate)
+	  {
+	    HIR::InherentImplItem *candidate_impl_item = c.first;
+	    std::string candidate_impl_item_name = c.second;
+
+	    if (query_impl_item_name.compare (candidate_impl_item_name) == 0)
+	      collision_detected (query_impl_item, candidate_impl_item,
+				  candidate_impl_item_name);
+	  }
+      }
+  }
+
+  void collision_detected (HIR::InherentImplItem *query,
+			   HIR::InherentImplItem *dup, const std::string &name)
+  {
+    Location qlocus;
+    bool ok = GetLocusFromImplItem::Resolve (query, qlocus);
+    rust_assert (ok);
+
+    Location dlocus;
+    ok = GetLocusFromImplItem::Resolve (dup, dlocus);
+    rust_assert (ok);
+
+    // this needs GCC Rich locations see
+    // https://github.com/Rust-GCC/gccrs/issues/97
+    rust_error_at (qlocus, "duplicate definitions with name %s", name.c_str ());
+    rust_error_at (dlocus, "duplicate def associated with");
+  }
+
+private:
+  OverlappingImplItemPass () : TypeCheckBase () {}
+
+  std::map<TyTy::BaseType *,
+	   std::set<std::pair<HIR::InherentImplItem *, std::string> > >
+    impl_mappings;
+
+  std::map<TyTy::BaseType *, std::set<TyTy::BaseType *> >
+    possible_colliding_impls;
+};
+
+} // namespace Resolver
+} // namespace Rust
+
+#endif // RUST_HIR_INHERENT_IMPL_ITEM_OVERLAP_H

--- a/gcc/rust/typecheck/rust-hir-method-resolve.h
+++ b/gcc/rust/typecheck/rust-hir-method-resolve.h
@@ -40,7 +40,8 @@ public:
     // lookup impl items for this crate and find all methods that can resolve to
     // this receiver
     probe.mappings->iterate_impl_items (
-      [&] (HirId id, HIR::InherentImplItem *item) mutable -> bool {
+      [&] (HirId id, HIR::InherentImplItem *item,
+	   HIR::InherentImpl *impl) mutable -> bool {
 	item->accept_vis (probe);
 	return true;
       });

--- a/gcc/rust/typecheck/rust-hir-path-probe.h
+++ b/gcc/rust/typecheck/rust-hir-path-probe.h
@@ -1,0 +1,162 @@
+// Copyright (C) 2020 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_HIR_PATH_PROBE_H
+#define RUST_HIR_PATH_PROBE_H
+
+#include "rust-hir-type-check-base.h"
+#include "rust-hir-full.h"
+#include "rust-tyty.h"
+#include "rust-substitution-mapper.h"
+
+namespace Rust {
+namespace Resolver {
+
+struct PathProbeCandidate
+{
+  HIR::InherentImplItem *impl_item;
+  TyTy::BaseType *ty;
+};
+
+class PathProbeType : public TypeCheckBase
+{
+  using Rust::Resolver::TypeCheckBase::visit;
+
+public:
+  static std::vector<PathProbeCandidate>
+  Probe (TyTy::BaseType *receiver, const HIR::PathIdentSegment &segment_name)
+  {
+    PathProbeType probe (receiver, segment_name);
+    probe.mappings->iterate_impl_items (
+      [&] (HirId id, HIR::InherentImplItem *item,
+	   HIR::InherentImpl *impl) mutable -> bool {
+	probe.process_candidate (id, item, impl);
+	return true;
+      });
+    return probe.candidates;
+  }
+
+  void process_candidate (HirId id, HIR::InherentImplItem *item,
+			  HIR::InherentImpl *impl)
+  {
+    HirId impl_ty_id = impl->get_type ()->get_mappings ().get_hirid ();
+    TyTy::BaseType *impl_block_ty = nullptr;
+    bool ok = context->lookup_type (impl_ty_id, &impl_block_ty);
+    rust_assert (ok);
+
+    if (!receiver->can_eq (impl_block_ty))
+      return;
+
+    // lets visit the impl_item
+    item->accept_vis (*this);
+  }
+
+  void visit (HIR::ConstantItem &constant) override
+  {
+    Identifier name = constant.get_identifier ();
+    if (search.as_string ().compare (name) == 0)
+      {
+	HirId tyid = constant.get_mappings ().get_hirid ();
+	TyTy::BaseType *ty = nullptr;
+	bool ok = context->lookup_type (tyid, &ty);
+	rust_assert (ok);
+
+	PathProbeCandidate candidate{&constant, ty};
+	candidates.push_back (std::move (candidate));
+      }
+  }
+
+  void visit (HIR::Function &function) override
+  {
+    Identifier name = function.get_function_name ();
+    if (search.as_string ().compare (name) == 0)
+      {
+	HirId tyid = function.get_mappings ().get_hirid ();
+	TyTy::BaseType *ty = nullptr;
+	bool ok = context->lookup_type (tyid, &ty);
+	rust_assert (ok);
+
+	PathProbeCandidate candidate{&function, ty};
+	candidates.push_back (std::move (candidate));
+      }
+  }
+
+  void visit (HIR::Method &method) override
+  {
+    Identifier name = method.get_method_name ();
+    if (search.as_string ().compare (name) == 0)
+      {
+	HirId tyid = method.get_mappings ().get_hirid ();
+	TyTy::BaseType *ty = nullptr;
+	bool ok = context->lookup_type (tyid, &ty);
+	rust_assert (ok);
+
+	PathProbeCandidate candidate{&method, ty};
+	candidates.push_back (std::move (candidate));
+      }
+  }
+
+private:
+  PathProbeType (TyTy::BaseType *receiver, const HIR::PathIdentSegment &query)
+    : TypeCheckBase (), receiver (receiver), search (query)
+  {}
+
+  TyTy::BaseType *receiver;
+  const HIR::PathIdentSegment &search;
+  std::vector<PathProbeCandidate> candidates;
+};
+
+class ReportMultipleCandidateError : private TypeCheckBase
+{
+  using Rust::Resolver::TypeCheckBase::visit;
+
+public:
+  static void Report (std::vector<PathProbeCandidate> &candidates,
+		      const HIR::PathIdentSegment &query, Location query_locus)
+  {
+    rust_error_at (query_locus, "multiple applicable items in scope for: %s",
+		   query.as_string ().c_str ());
+
+    ReportMultipleCandidateError visitor;
+    for (auto &c : candidates)
+      c.impl_item->accept_vis (visitor);
+  }
+
+  void visit (HIR::ConstantItem &constant) override
+  {
+    rust_error_at (constant.get_locus (), "possible candidate");
+  }
+
+  void visit (HIR::Function &function) override
+  {
+    rust_error_at (function.get_locus (), "possible candidate");
+  }
+
+  void visit (HIR::Method &method) override
+  {
+    rust_error_at (method.get_locus (), "possible candidate");
+  }
+
+private:
+  ReportMultipleCandidateError () : TypeCheckBase () {}
+};
+
+} // namespace Resolver
+} // namespace Rust
+
+#endif // RUST_HIR_PATH_PROBE_H

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.h
@@ -58,7 +58,7 @@ public:
       {
 	init_expr_ty
 	  = TypeCheckExpr::Resolve (stmt.get_init_expr (), inside_loop);
-	if (init_expr_ty == nullptr)
+	if (init_expr_ty->get_kind () == TyTy::TypeKind::ERROR)
 	  return;
 
 	init_expr_ty = init_expr_ty->clone ();

--- a/gcc/rust/typecheck/rust-hir-type-check-struct-field.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-struct-field.h
@@ -41,8 +41,6 @@ public:
 
   void visit (HIR::StructExprStructFields &struct_expr) override;
 
-  void visit (HIR::PathInExpression &path) override;
-
   void visit (HIR::StructExprFieldIdentifierValue &field) override;
 
   void visit (HIR::StructExprFieldIndexValue &field) override;

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -22,6 +22,7 @@
 #include "rust-hir-type-check-item.h"
 #include "rust-hir-type-check-expr.h"
 #include "rust-hir-type-check-struct-field.h"
+#include "rust-hir-inherent-impl-overlap.h"
 
 extern bool
 saw_errors (void);
@@ -35,6 +36,10 @@ TypeResolution::Resolve (HIR::Crate &crate)
   for (auto it = crate.items.begin (); it != crate.items.end (); it++)
     TypeCheckTopLevel::Resolve (it->get ());
 
+  if (saw_errors ())
+    return;
+
+  OverlappingImplItemPass::go ();
   if (saw_errors ())
     return;
 

--- a/gcc/rust/typecheck/rust-substitution-mapper.h
+++ b/gcc/rust/typecheck/rust-substitution-mapper.h
@@ -37,6 +37,11 @@ public:
     return mapper.resolved;
   }
 
+  static TyTy::BaseType *InferSubst (TyTy::BaseType *base, Location locus)
+  {
+    return SubstMapper::Resolve (base, locus, nullptr);
+  }
+
   bool have_generic_args () const { return generics != nullptr; }
 
   void visit (TyTy::FnType &type) override

--- a/gcc/rust/typecheck/rust-tyty-cmp.h
+++ b/gcc/rust/typecheck/rust-tyty-cmp.h
@@ -1,0 +1,812 @@
+// Copyright (C) 2020 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_TYTY_CMP_H
+#define RUST_TYTY_CMP_H
+
+#include "rust-diagnostics.h"
+#include "rust-tyty.h"
+#include "rust-tyty-visitor.h"
+#include "rust-hir-map.h"
+#include "rust-hir-type-check.h"
+
+namespace Rust {
+namespace TyTy {
+
+class BaseCmp : public TyVisitor
+{
+public:
+  virtual bool can_eq (BaseType *other)
+  {
+    if (other->get_kind () == TypeKind::PARAM)
+      {
+	ParamType *p = static_cast<ParamType *> (other);
+	if (p->can_resolve ())
+	  {
+	    other = p->resolve ();
+	  }
+      }
+
+    other->accept_vis (*this);
+    return ok;
+  }
+
+  virtual void visit (TupleType &) override { ok = false; }
+
+  virtual void visit (ADTType &) override { ok = false; }
+
+  virtual void visit (InferType &) override { ok = false; }
+
+  virtual void visit (FnType &) override { ok = false; }
+
+  virtual void visit (FnPtr &) override { ok = false; }
+
+  virtual void visit (ArrayType &) override { ok = false; }
+
+  virtual void visit (BoolType &) override { ok = false; }
+
+  virtual void visit (IntType &) override { ok = false; }
+
+  virtual void visit (UintType &) override { ok = false; }
+
+  virtual void visit (USizeType &) override { ok = false; }
+
+  virtual void visit (ISizeType &) override { ok = false; }
+
+  virtual void visit (FloatType &) override { ok = false; }
+
+  virtual void visit (ErrorType &) override { ok = false; }
+
+  virtual void visit (CharType &) override { ok = false; }
+
+  virtual void visit (ReferenceType &) override { ok = false; }
+
+  virtual void visit (ParamType &) override
+  {
+    // it is ok for types to can eq to a ParamType
+    ok = true;
+  }
+
+  virtual void visit (StrType &) override { ok = false; }
+
+protected:
+  BaseCmp (BaseType *base)
+    : mappings (Analysis::Mappings::get ()),
+      context (Resolver::TypeCheckContext::get ()), ok (false)
+  {}
+
+  Analysis::Mappings *mappings;
+  Resolver::TypeCheckContext *context;
+
+  bool ok;
+
+private:
+  /* Returns a pointer to the ty that created this rule. */
+  virtual BaseType *get_base () = 0;
+};
+
+class InferCmp : public BaseCmp
+{
+  using Rust::TyTy::BaseCmp::visit;
+
+public:
+  InferCmp (InferType *base) : BaseCmp (base), base (base) {}
+
+  void visit (BoolType &type) override
+  {
+    bool is_valid
+      = (base->get_infer_kind () == TyTy::InferType::InferTypeKind::GENERAL);
+    if (is_valid)
+      {
+	ok = true;
+	return;
+      }
+
+    BaseCmp::visit (type);
+  }
+
+  void visit (IntType &type) override
+  {
+    bool is_valid
+      = (base->get_infer_kind () == TyTy::InferType::InferTypeKind::GENERAL)
+	|| (base->get_infer_kind ()
+	    == TyTy::InferType::InferTypeKind::INTEGRAL);
+    if (is_valid)
+      {
+	ok = true;
+	return;
+      }
+
+    BaseCmp::visit (type);
+  }
+
+  void visit (UintType &type) override
+  {
+    bool is_valid
+      = (base->get_infer_kind () == TyTy::InferType::InferTypeKind::GENERAL)
+	|| (base->get_infer_kind ()
+	    == TyTy::InferType::InferTypeKind::INTEGRAL);
+    if (is_valid)
+      {
+	ok = true;
+	return;
+      }
+
+    BaseCmp::visit (type);
+  }
+
+  void visit (USizeType &type) override
+  {
+    bool is_valid
+      = (base->get_infer_kind () == TyTy::InferType::InferTypeKind::GENERAL)
+	|| (base->get_infer_kind ()
+	    == TyTy::InferType::InferTypeKind::INTEGRAL);
+    if (is_valid)
+      {
+	ok = true;
+	return;
+      }
+
+    BaseCmp::visit (type);
+  }
+
+  void visit (ISizeType &type) override
+  {
+    bool is_valid
+      = (base->get_infer_kind () == TyTy::InferType::InferTypeKind::GENERAL)
+	|| (base->get_infer_kind ()
+	    == TyTy::InferType::InferTypeKind::INTEGRAL);
+    if (is_valid)
+      {
+	ok = true;
+	return;
+      }
+
+    BaseCmp::visit (type);
+  }
+
+  void visit (FloatType &type) override
+  {
+    bool is_valid
+      = (base->get_infer_kind () == TyTy::InferType::InferTypeKind::GENERAL)
+	|| (base->get_infer_kind () == TyTy::InferType::InferTypeKind::FLOAT);
+    if (is_valid)
+      {
+	ok = true;
+	return;
+      }
+
+    BaseCmp::visit (type);
+  }
+
+  void visit (ArrayType &type) override
+  {
+    bool is_valid
+      = (base->get_infer_kind () == TyTy::InferType::InferTypeKind::GENERAL);
+    if (is_valid)
+      {
+	ok = true;
+	return;
+      }
+
+    BaseCmp::visit (type);
+  }
+
+  void visit (ADTType &type) override
+  {
+    bool is_valid
+      = (base->get_infer_kind () == TyTy::InferType::InferTypeKind::GENERAL);
+    if (is_valid)
+      {
+	ok = true;
+	return;
+      }
+
+    BaseCmp::visit (type);
+  }
+
+  void visit (TupleType &type) override
+  {
+    bool is_valid
+      = (base->get_infer_kind () == TyTy::InferType::InferTypeKind::GENERAL);
+    if (is_valid)
+      {
+	ok = true;
+	return;
+      }
+
+    BaseCmp::visit (type);
+  }
+
+  void visit (InferType &type) override
+  {
+    switch (base->get_infer_kind ())
+      {
+      case InferType::InferTypeKind::GENERAL:
+	ok = true;
+	return;
+
+	case InferType::InferTypeKind::INTEGRAL: {
+	  if (type.get_infer_kind () == InferType::InferTypeKind::INTEGRAL)
+	    {
+	      ok = true;
+	      return;
+	    }
+	  else if (type.get_infer_kind () == InferType::InferTypeKind::GENERAL)
+	    {
+	      ok = true;
+	      return;
+	    }
+	}
+	break;
+
+	case InferType::InferTypeKind::FLOAT: {
+	  if (type.get_infer_kind () == InferType::InferTypeKind::FLOAT)
+	    {
+	      ok = true;
+	      return;
+	    }
+	  else if (type.get_infer_kind () == InferType::InferTypeKind::GENERAL)
+	    {
+	      ok = true;
+	      return;
+	    }
+	}
+	break;
+      }
+
+    BaseCmp::visit (type);
+  }
+
+  void visit (CharType &type) override
+  {
+    {
+      bool is_valid
+	= (base->get_infer_kind () == TyTy::InferType::InferTypeKind::GENERAL);
+      if (is_valid)
+	{
+	  ok = true;
+	  return;
+	}
+
+      BaseCmp::visit (type);
+    }
+  }
+
+  void visit (ReferenceType &type) override
+
+  {
+    bool is_valid
+      = (base->get_infer_kind () == TyTy::InferType::InferTypeKind::GENERAL);
+    if (is_valid)
+      {
+	ok = true;
+	return;
+      }
+
+    BaseCmp::visit (type);
+  }
+
+  void visit (ParamType &type) override
+  {
+    bool is_valid
+      = (base->get_infer_kind () == TyTy::InferType::InferTypeKind::GENERAL);
+    if (is_valid)
+      {
+	ok = true;
+	return;
+      }
+
+    BaseCmp::visit (type);
+  }
+
+private:
+  BaseType *get_base () override { return base; }
+
+  InferType *base;
+};
+
+class FnCmp : public BaseCmp
+{
+  using Rust::TyTy::BaseCmp::visit;
+
+public:
+  FnCmp (FnType *base) : BaseCmp (base), base (base) {}
+
+  void visit (InferType &type) override
+  {
+    ok = type.get_infer_kind () == InferType::InferTypeKind::GENERAL;
+  }
+
+  void visit (FnType &type) override
+  {
+    if (base->num_params () != type.num_params ())
+      {
+	BaseCmp::visit (type);
+	return;
+      }
+
+    for (size_t i = 0; i < base->num_params (); i++)
+      {
+	auto a = base->param_at (i).second;
+	auto b = type.param_at (i).second;
+
+	auto unified_param = a->unify (b);
+	if (unified_param == nullptr)
+	  {
+	    BaseCmp::visit (type);
+	    return;
+	  }
+      }
+
+    auto unified_return
+      = base->get_return_type ()->unify (type.get_return_type ());
+    if (unified_return == nullptr)
+      {
+	BaseCmp::visit (type);
+	return;
+      }
+
+    ok = true;
+  }
+
+private:
+  BaseType *get_base () override { return base; }
+
+  FnType *base;
+};
+
+class FnptrCmp : public BaseCmp
+{
+  using Rust::TyTy::BaseCmp::visit;
+
+public:
+  FnptrCmp (FnPtr *base) : BaseCmp (base), base (base) {}
+
+  void visit (InferType &type) override
+  {
+    if (type.get_infer_kind () != InferType::InferTypeKind::GENERAL)
+      {
+	BaseCmp::visit (type);
+	return;
+      }
+
+    ok = true;
+  }
+
+  void visit (FnPtr &type) override
+  {
+    auto this_ret_type = base->get_return_type ();
+    auto other_ret_type = type.get_return_type ();
+    auto unified_result = this_ret_type->unify (other_ret_type);
+    if (unified_result == nullptr
+	|| unified_result->get_kind () == TypeKind::ERROR)
+      {
+	BaseCmp::visit (type);
+	return;
+      }
+
+    if (base->num_params () != type.num_params ())
+      {
+	BaseCmp::visit (type);
+	return;
+      }
+
+    for (size_t i = 0; i < base->num_params (); i++)
+      {
+	auto this_param = base->param_at (i);
+	auto other_param = type.param_at (i);
+	auto unified_param = this_param->unify (other_param);
+	if (unified_param == nullptr
+	    || unified_param->get_kind () == TypeKind::ERROR)
+	  {
+	    BaseCmp::visit (type);
+	    return;
+	  }
+      }
+
+    ok = true;
+  }
+
+  void visit (FnType &type) override
+  {
+    auto this_ret_type = base->get_return_type ();
+    auto other_ret_type = type.get_return_type ();
+    auto unified_result = this_ret_type->unify (other_ret_type);
+    if (unified_result == nullptr
+	|| unified_result->get_kind () == TypeKind::ERROR)
+      {
+	BaseCmp::visit (type);
+	return;
+      }
+
+    if (base->num_params () != type.num_params ())
+      {
+	BaseCmp::visit (type);
+	return;
+      }
+
+    for (size_t i = 0; i < base->num_params (); i++)
+      {
+	auto this_param = base->param_at (i);
+	auto other_param = type.param_at (i).second;
+	auto unified_param = this_param->unify (other_param);
+	if (unified_param == nullptr
+	    || unified_param->get_kind () == TypeKind::ERROR)
+	  {
+	    BaseCmp::visit (type);
+	    return;
+	  }
+      }
+
+    ok = true;
+  }
+
+private:
+  BaseType *get_base () override { return base; }
+
+  FnPtr *base;
+};
+
+class ArrayCmp : public BaseCmp
+{
+  using Rust::TyTy::BaseCmp::visit;
+
+public:
+  ArrayCmp (ArrayType *base) : BaseCmp (base), base (base) {}
+
+  void visit (ArrayType &type) override
+  {
+    // check base type
+    auto base_resolved
+      = base->get_element_type ()->unify (type.get_element_type ());
+    if (base_resolved == nullptr)
+      {
+	BaseCmp::visit (type);
+	return;
+      }
+
+    // need to check the base types and capacity
+    if (type.get_capacity () != base->get_capacity ())
+      {
+	Location locus = mappings->lookup_location (type.get_ref ());
+	rust_error_at (locus, "mismatch in array capacity");
+	BaseCmp::visit (type);
+	return;
+      }
+
+    ok = true;
+  }
+
+private:
+  BaseType *get_base () override { return base; }
+
+  ArrayType *base;
+};
+
+class BoolCmp : public BaseCmp
+{
+  using Rust::TyTy::BaseCmp::visit;
+
+public:
+  BoolCmp (BoolType *base) : BaseCmp (base), base (base) {}
+
+  void visit (BoolType &type) override { ok = true; }
+
+  void visit (InferType &type) override
+  {
+    ok = type.get_infer_kind () == InferType::InferTypeKind::GENERAL;
+  }
+
+private:
+  BaseType *get_base () override { return base; }
+
+  BoolType *base;
+};
+
+class IntCmp : public BaseCmp
+{
+  using Rust::TyTy::BaseCmp::visit;
+
+public:
+  IntCmp (IntType *base) : BaseCmp (base), base (base) {}
+
+  void visit (InferType &type) override
+  {
+    ok = type.get_infer_kind () != InferType::InferTypeKind::FLOAT;
+  }
+
+  void visit (IntType &type) override
+  {
+    ok = type.get_int_kind () == base->get_int_kind ();
+  }
+
+private:
+  BaseType *get_base () override { return base; }
+
+  IntType *base;
+};
+
+class UintCmp : public BaseCmp
+{
+  using Rust::TyTy::BaseCmp::visit;
+
+public:
+  UintCmp (UintType *base) : BaseCmp (base), base (base) {}
+
+  void visit (InferType &type) override
+  {
+    ok = type.get_infer_kind () != InferType::InferTypeKind::FLOAT;
+  }
+
+  void visit (UintType &type) override
+  {
+    ok = type.get_uint_kind () == base->get_uint_kind ();
+  }
+
+private:
+  BaseType *get_base () override { return base; }
+
+  UintType *base;
+};
+
+class FloatCmp : public BaseCmp
+{
+  using Rust::TyTy::BaseCmp::visit;
+
+public:
+  FloatCmp (FloatType *base) : BaseCmp (base), base (base) {}
+
+  void visit (InferType &type) override
+  {
+    ok = type.get_infer_kind () != InferType::InferTypeKind::INTEGRAL;
+  }
+
+  void visit (FloatType &type) override
+  {
+    ok = type.get_float_kind () == base->get_float_kind ();
+  }
+
+private:
+  BaseType *get_base () override { return base; }
+
+  FloatType *base;
+};
+
+class ADTCmp : public BaseCmp
+{
+  using Rust::TyTy::BaseCmp::visit;
+
+public:
+  ADTCmp (ADTType *base) : BaseCmp (base), base (base) {}
+
+  void visit (ADTType &type) override
+  {
+    if (base->get_identifier ().compare (type.get_identifier ()) != 0)
+      {
+	BaseCmp::visit (type);
+	return;
+      }
+
+    if (base->num_fields () != type.num_fields ())
+      {
+	BaseCmp::visit (type);
+	return;
+      }
+
+    for (size_t i = 0; i < type.num_fields (); ++i)
+      {
+	TyTy::StructFieldType *base_field = base->get_field (i);
+	TyTy::StructFieldType *other_field = type.get_field (i);
+
+	TyTy::BaseType *this_field_ty = base_field->get_field_type ();
+	TyTy::BaseType *other_field_ty = other_field->get_field_type ();
+
+	if (!this_field_ty->can_eq (other_field_ty))
+	  {
+	    BaseCmp::visit (type);
+	    return;
+	  }
+      }
+
+    ok = true;
+  }
+
+private:
+  BaseType *get_base () override { return base; }
+
+  ADTType *base;
+};
+
+class TupleCmp : public BaseCmp
+{
+  using Rust::TyTy::BaseCmp::visit;
+
+public:
+  TupleCmp (TupleType *base) : BaseCmp (base), base (base) {}
+
+  void visit (TupleType &type) override
+  {
+    if (base->num_fields () != type.num_fields ())
+      {
+	BaseCmp::visit (type);
+	return;
+      }
+
+    for (size_t i = 0; i < base->num_fields (); i++)
+      {
+	BaseType *bo = base->get_field (i);
+	BaseType *fo = type.get_field (i);
+
+	if (!bo->can_eq (fo))
+	  {
+	    BaseCmp::visit (type);
+	    return;
+	  }
+      }
+
+    ok = true;
+  }
+
+private:
+  BaseType *get_base () override { return base; }
+
+  TupleType *base;
+};
+
+class USizeCmp : public BaseCmp
+{
+  using Rust::TyTy::BaseCmp::visit;
+
+public:
+  USizeCmp (USizeType *base) : BaseCmp (base), base (base) {}
+
+  void visit (InferType &type) override
+  {
+    ok = type.get_infer_kind () != InferType::InferTypeKind::FLOAT;
+  }
+
+  void visit (USizeType &type) override { ok = true; }
+
+private:
+  BaseType *get_base () override { return base; }
+
+  USizeType *base;
+};
+
+class ISizeCmp : public BaseCmp
+{
+  using Rust::TyTy::BaseCmp::visit;
+
+public:
+  ISizeCmp (ISizeType *base) : BaseCmp (base), base (base) {}
+
+  void visit (InferType &type) override
+  {
+    ok = type.get_infer_kind () != InferType::InferTypeKind::FLOAT;
+  }
+
+  void visit (ISizeType &type) override { ok = true; }
+
+private:
+  BaseType *get_base () override { return base; }
+
+  ISizeType *base;
+};
+
+class CharCmp : public BaseCmp
+{
+  using Rust::TyTy::BaseCmp::visit;
+
+public:
+  CharCmp (CharType *base) : BaseCmp (base), base (base) {}
+
+  void visit (InferType &type) override
+  {
+    ok = type.get_infer_kind () == InferType::InferTypeKind::GENERAL;
+  }
+
+  void visit (CharType &type) override { ok = true; }
+
+private:
+  BaseType *get_base () override { return base; }
+
+  CharType *base;
+};
+
+class ReferenceCmp : public BaseCmp
+{
+  using Rust::TyTy::BaseCmp::visit;
+
+public:
+  ReferenceCmp (ReferenceType *base) : BaseCmp (base), base (base) {}
+
+  void visit (ReferenceType &type) override
+  {
+    auto base_type = base->get_base ();
+    auto other_base_type = type.get_base ();
+
+    ok = base_type->can_eq (other_base_type);
+  }
+
+private:
+  BaseType *get_base () override { return base; }
+
+  ReferenceType *base;
+};
+
+class ParamCmp : public BaseCmp
+{
+  using Rust::TyTy::BaseCmp::visit;
+
+public:
+  ParamCmp (ParamType *base) : BaseCmp (base), base (base) {}
+
+  // param types are a placeholder we shouldn't have cases where we unify
+  // against it. eg: struct foo<T> { a: T }; When we invoke it we can do either:
+  //
+  // foo<i32>{ a: 123 }.
+  // Then this enforces the i32 type to be referenced on the
+  // field via an hirid.
+  //
+  // rust also allows for a = foo{a:123}; Where we can use an Inference Variable
+  // to handle the typing of the struct
+  bool can_eq (BaseType *other) override final
+  {
+    if (base->get_ref () == base->get_ty_ref ())
+      return BaseCmp::can_eq (other);
+
+    auto context = Resolver::TypeCheckContext::get ();
+    BaseType *lookup = nullptr;
+    bool ok = context->lookup_type (base->get_ty_ref (), &lookup);
+    rust_assert (ok);
+
+    return lookup->can_eq (other);
+  }
+
+  void visit (ParamType &type) override
+  {
+    ok = base->get_symbol ().compare (type.get_symbol ()) == 0;
+  }
+
+private:
+  BaseType *get_base () override { return base; }
+
+  ParamType *base;
+};
+
+class StrCmp : public BaseCmp
+{
+  // FIXME we will need a enum for the StrType like ByteBuf etc..
+  using Rust::TyTy::BaseCmp::visit;
+
+public:
+  StrCmp (StrType *base) : BaseCmp (base), base (base) {}
+
+  void visit (StrType &type) override { ok = true; }
+
+private:
+  BaseType *get_base () override { return base; }
+
+  StrType *base;
+};
+
+} // namespace TyTy
+} // namespace Rust
+
+#endif // RUST_TYTY_CMP_H

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -22,6 +22,7 @@
 #include "rust-hir-type-check-expr.h"
 #include "rust-hir-type-check-type.h"
 #include "rust-tyty-rules.h"
+#include "rust-tyty-cmp.h"
 #include "rust-hir-map.h"
 #include "rust-substitution-mapper.h"
 
@@ -91,6 +92,13 @@ InferType::unify (BaseType *other)
   return r.unify (other);
 }
 
+bool
+InferType::can_eq (BaseType *other)
+{
+  InferCmp r (this);
+  return r.can_eq (other);
+}
+
 BaseType *
 InferType::clone ()
 {
@@ -107,11 +115,13 @@ InferType::default_type (BaseType **type) const
     {
     case GENERAL:
       return false;
+
       case INTEGRAL: {
 	ok = context->lookup_builtin ("i32", type);
 	rust_assert (ok);
 	return ok;
       }
+
       case FLOAT: {
 	ok = context->lookup_builtin ("f64", type);
 	rust_assert (ok);
@@ -137,6 +147,12 @@ BaseType *
 ErrorType::unify (BaseType *other)
 {
   return this;
+}
+
+bool
+ErrorType::can_eq (BaseType *other)
+{
+  return get_kind () == other->get_kind ();
 }
 
 BaseType *
@@ -304,6 +320,13 @@ ADTType::unify (BaseType *other)
 }
 
 bool
+ADTType::can_eq (BaseType *other)
+{
+  ADTCmp r (this);
+  return r.can_eq (other);
+}
+
+bool
 ADTType::is_equal (const BaseType &other) const
 {
   if (get_kind () != other.get_kind ())
@@ -418,8 +441,7 @@ ADTType::handle_substitions (SubstitutionArgumentMappings subst_mappings)
 	BaseType *concrete
 	  = Resolver::SubstMapperInternal::Resolve (fty, subst_mappings);
 
-	if (concrete == nullptr
-	    || concrete->get_kind () == TyTy::TypeKind::ERROR)
+	if (concrete->get_kind () == TyTy::TypeKind::ERROR)
 	  {
 	    rust_error_at (subst_mappings.get_locus (),
 			   "Failed to resolve field substitution type: %s",
@@ -467,6 +489,13 @@ TupleType::unify (BaseType *other)
 {
   TupleRules r (this);
   return r.unify (other);
+}
+
+bool
+TupleType::can_eq (BaseType *other)
+{
+  TupleCmp r (this);
+  return r.can_eq (other);
 }
 
 bool
@@ -521,6 +550,13 @@ FnType::unify (BaseType *other)
 {
   FnRules r (this);
   return r.unify (other);
+}
+
+bool
+FnType::can_eq (BaseType *other)
+{
+  FnCmp r (this);
+  return r.can_eq (other);
 }
 
 bool
@@ -713,6 +749,13 @@ FnPtr::unify (BaseType *other)
 }
 
 bool
+FnPtr::can_eq (BaseType *other)
+{
+  FnptrCmp r (this);
+  return r.can_eq (other);
+}
+
+bool
 FnPtr::is_equal (const BaseType &other) const
 {
   if (get_kind () != other.get_kind ())
@@ -767,6 +810,13 @@ ArrayType::unify (BaseType *other)
 }
 
 bool
+ArrayType::can_eq (BaseType *other)
+{
+  ArrayCmp r (this);
+  return r.can_eq (other);
+}
+
+bool
 ArrayType::is_equal (const BaseType &other) const
 {
   if (get_kind () != other.get_kind ())
@@ -814,6 +864,13 @@ BoolType::unify (BaseType *other)
   return r.unify (other);
 }
 
+bool
+BoolType::can_eq (BaseType *other)
+{
+  BoolCmp r (this);
+  return r.can_eq (other);
+}
+
 BaseType *
 BoolType::clone ()
 {
@@ -851,6 +908,13 @@ IntType::unify (BaseType *other)
 {
   IntRules r (this);
   return r.unify (other);
+}
+
+bool
+IntType::can_eq (BaseType *other)
+{
+  IntCmp r (this);
+  return r.can_eq (other);
 }
 
 BaseType *
@@ -903,6 +967,13 @@ UintType::unify (BaseType *other)
   return r.unify (other);
 }
 
+bool
+UintType::can_eq (BaseType *other)
+{
+  UintCmp r (this);
+  return r.can_eq (other);
+}
+
 BaseType *
 UintType::clone ()
 {
@@ -947,6 +1018,13 @@ FloatType::unify (BaseType *other)
   return r.unify (other);
 }
 
+bool
+FloatType::can_eq (BaseType *other)
+{
+  FloatCmp r (this);
+  return r.can_eq (other);
+}
+
 BaseType *
 FloatType::clone ()
 {
@@ -983,6 +1061,13 @@ USizeType::unify (BaseType *other)
   return r.unify (other);
 }
 
+bool
+USizeType::can_eq (BaseType *other)
+{
+  USizeCmp r (this);
+  return r.can_eq (other);
+}
+
 BaseType *
 USizeType::clone ()
 {
@@ -1006,6 +1091,13 @@ ISizeType::unify (BaseType *other)
 {
   ISizeRules r (this);
   return r.unify (other);
+}
+
+bool
+ISizeType::can_eq (BaseType *other)
+{
+  ISizeCmp r (this);
+  return r.can_eq (other);
 }
 
 BaseType *
@@ -1033,6 +1125,13 @@ CharType::unify (BaseType *other)
   return r.unify (other);
 }
 
+bool
+CharType::can_eq (BaseType *other)
+{
+  CharCmp r (this);
+  return r.can_eq (other);
+}
+
 BaseType *
 CharType::clone ()
 {
@@ -1056,6 +1155,13 @@ ReferenceType::unify (BaseType *other)
 {
   ReferenceRules r (this);
   return r.unify (other);
+}
+
+bool
+ReferenceType::can_eq (BaseType *other)
+{
+  ReferenceCmp r (this);
+  return r.can_eq (other);
 }
 
 bool
@@ -1108,6 +1214,13 @@ ParamType::unify (BaseType *other)
 {
   ParamRules r (this);
   return r.unify (other);
+}
+
+bool
+ParamType::can_eq (BaseType *other)
+{
+  ParamCmp r (this);
+  return r.can_eq (other);
 }
 
 BaseType *
@@ -1176,6 +1289,13 @@ StrType::unify (BaseType *other)
 {
   StrRules r (this);
   return r.unify (other);
+}
+
+bool
+StrType::can_eq (BaseType *other)
+{
+  StrCmp r (this);
+  return r.can_eq (other);
 }
 
 bool

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -91,6 +91,8 @@ public:
 
   virtual bool is_unit () const { return false; }
 
+  virtual bool is_concrete () const { return true; }
+
   TypeKind get_kind () const { return kind; }
 
   /* Returns a pointer to a clone of this. The caller is responsible for
@@ -193,6 +195,8 @@ public:
   std::string get_name () const override final { return as_string (); }
 
   bool default_type (BaseType **type) const;
+
+  bool is_concrete () const final override { return false; }
 
 private:
   InferTypeKind infer_kind;
@@ -320,6 +324,16 @@ public:
   BaseType *get_field (size_t index) const;
 
   BaseType *clone () final override;
+
+  bool is_concrete () const override final
+  {
+    for (size_t i = 0; i < num_fields (); i++)
+      {
+	if (!get_field (i)->is_concrete ())
+	  return false;
+      }
+    return true;
+  }
 
   void iterate_fields (std::function<bool (BaseType *)> cb) const
   {
@@ -823,6 +837,11 @@ public:
   BaseType *get_element_type () const;
 
   BaseType *clone () final override;
+
+  bool is_concrete () const final override
+  {
+    return get_element_type ()->is_concrete ();
+  }
 
 private:
   size_t capacity;

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -524,5 +524,24 @@ Mappings::resolve_nodeid_to_stmt (CrateNum crate, NodeId id, HIR::Stmt **stmt)
   return resolved_stmt != nullptr;
 }
 
+void
+Mappings::iterate_impl_items (
+  std::function<bool (HirId, HIR::InherentImplItem *, HIR::InherentImpl *)> cb)
+{
+  for (auto it = hirImplItemMappings.begin (); it != hirImplItemMappings.end ();
+       it++)
+    {
+      for (auto iy = it->second.begin (); iy != it->second.end (); iy++)
+	{
+	  auto id = iy->first;
+	  auto impl_item = iy->second.second;
+	  auto impl = lookup_associated_impl (
+	    impl_item->get_impl_mappings ().get_hirid ());
+	  if (!cb (id, impl_item, impl))
+	    return;
+	}
+    }
+}
+
 } // namespace Analysis
 } // namespace Rust

--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -158,19 +158,23 @@ public:
     return hirNodesWithinCrate[crate];
   }
 
-  void
-  iterate_impl_items (std::function<bool (HirId, HIR::InherentImplItem *)> cb)
+  void insert_impl_item_mapping (HirId impl_item_id, HIR::InherentImpl *impl)
   {
-    for (auto it = hirImplItemMappings.begin ();
-	 it != hirImplItemMappings.end (); it++)
-      {
-	for (auto iy = it->second.begin (); iy != it->second.end (); iy++)
-	  {
-	    if (!cb (iy->first, iy->second.second))
-	      return;
-	  }
-      }
+    rust_assert (hirImplItemsToImplMappings.find (impl_item_id)
+		 == hirImplItemsToImplMappings.end ());
+    hirImplItemsToImplMappings[impl_item_id] = impl;
   }
+
+  HIR::InherentImpl *lookup_associated_impl (HirId impl_item_id)
+  {
+    auto lookup = hirImplItemsToImplMappings.find (impl_item_id);
+    rust_assert (lookup != hirImplItemsToImplMappings.end ());
+    return lookup->second;
+  }
+
+  void iterate_impl_items (
+    std::function<bool (HirId, HIR::InherentImplItem *, HIR::InherentImpl *)>
+      cb);
 
 private:
   Mappings ();
@@ -198,6 +202,7 @@ private:
 	   std::map<HirId, std::pair<HirId, HIR::InherentImplItem *> > >
     hirImplItemMappings;
   std::map<CrateNum, std::map<HirId, HIR::SelfParam *> > hirSelfParamMappings;
+  std::map<HirId, HIR::InherentImpl *> hirImplItemsToImplMappings;
 
   // location info
   std::map<CrateNum, std::map<NodeId, Location> > locations;

--- a/gcc/testsuite/rust.test/compile/generics13.rs
+++ b/gcc/testsuite/rust.test/compile/generics13.rs
@@ -1,0 +1,34 @@
+struct Foo<A> {
+    a: A,
+}
+
+struct GenericStruct<T> {
+    a: T,
+    b: usize,
+}
+
+impl Foo<isize> {
+    fn test() -> i32 {
+        123
+    }
+
+    fn bar(self) -> isize {
+        self.a
+    }
+}
+
+fn main() {
+    let a: i32 = Foo::test();
+
+    let a2: GenericStruct<i8>;
+    a2 = GenericStruct::<i8> { a: 1, b: 456 };
+
+    let b2: i8 = a2.a;
+    let c2: usize = a2.b;
+
+    let a4;
+    a4 = GenericStruct { a: 1.0, b: 456 };
+
+    let b4: f32 = a4.a;
+    let c4: usize = a4.b;
+}

--- a/gcc/testsuite/rust.test/compile/generics13.rs
+++ b/gcc/testsuite/rust.test/compile/generics13.rs
@@ -13,22 +13,28 @@ impl Foo<isize> {
     }
 
     fn bar(self) -> isize {
+        // { dg-warning "unused name" "" { target *-*-* } .-1 }
         self.a
     }
 }
 
 fn main() {
     let a: i32 = Foo::test();
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
 
     let a2: GenericStruct<i8>;
     a2 = GenericStruct::<i8> { a: 1, b: 456 };
 
     let b2: i8 = a2.a;
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
     let c2: usize = a2.b;
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
 
     let a4;
     a4 = GenericStruct { a: 1.0, b: 456 };
 
     let b4: f32 = a4.a;
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
     let c4: usize = a4.b;
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
 }

--- a/gcc/testsuite/rust.test/compile/generics14.rs
+++ b/gcc/testsuite/rust.test/compile/generics14.rs
@@ -1,0 +1,17 @@
+struct Foo<A> {
+    a: A,
+}
+
+impl Foo<isize> {
+    fn test() -> i32 {
+        123
+    }
+
+    fn bar(self) -> isize {
+        self.a
+    }
+}
+
+fn main() {
+    let a: i32 = Foo::test();
+}

--- a/gcc/testsuite/rust.test/compile/generics14.rs
+++ b/gcc/testsuite/rust.test/compile/generics14.rs
@@ -8,10 +8,12 @@ impl Foo<isize> {
     }
 
     fn bar(self) -> isize {
+        // { dg-warning "unused name" "" { target *-*-* } .-1 }
         self.a
     }
 }
 
 fn main() {
     let a: i32 = Foo::test();
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
 }

--- a/gcc/testsuite/rust.test/compile/generics15.rs
+++ b/gcc/testsuite/rust.test/compile/generics15.rs
@@ -15,7 +15,9 @@ impl Foo<f32> {
 fn main() {
     let a = Foo(123, true);
     let aa = a.bar();
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
 
     let b = Foo(456f32, true);
     let bb = b.bar();
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
 }

--- a/gcc/testsuite/rust.test/compile/generics15.rs
+++ b/gcc/testsuite/rust.test/compile/generics15.rs
@@ -1,0 +1,21 @@
+struct Foo<T>(T, bool);
+
+impl Foo<i32> {
+    fn bar(self) -> i32 {
+        self.0
+    }
+}
+
+impl Foo<f32> {
+    fn bar(self) -> f32 {
+        self.0
+    }
+}
+
+fn main() {
+    let a = Foo(123, true);
+    let aa = a.bar();
+
+    let b = Foo(456f32, true);
+    let bb = b.bar();
+}

--- a/gcc/testsuite/rust.test/compile/generics16.rs
+++ b/gcc/testsuite/rust.test/compile/generics16.rs
@@ -23,7 +23,9 @@ impl Foo<f32> {
 fn main() {
     let a = Foo::<i32>::new();
     let aa: i32 = a.bar();
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
 
     let b = Foo::<f32>::new();
     let bb: f32 = b.bar();
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
 }

--- a/gcc/testsuite/rust.test/compile/generics16.rs
+++ b/gcc/testsuite/rust.test/compile/generics16.rs
@@ -1,0 +1,29 @@
+struct Foo<T>(T, bool);
+
+impl Foo<i32> {
+    fn new() -> Self {
+        Foo(123, true)
+    }
+
+    fn bar(self) -> i32 {
+        self.0
+    }
+}
+
+impl Foo<f32> {
+    fn new() -> Self {
+        Foo(123f32, true)
+    }
+
+    fn bar(self) -> f32 {
+        self.0
+    }
+}
+
+fn main() {
+    let a = Foo::<i32>::new();
+    let aa: i32 = a.bar();
+
+    let b = Foo::<f32>::new();
+    let bb: f32 = b.bar();
+}

--- a/gcc/testsuite/rust.test/xfail_compile/generics6.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/generics6.rs
@@ -1,0 +1,29 @@
+// { dg-excess-errors "Noisy error and debug" }
+struct Foo<A> {
+    a: A,
+}
+
+impl Foo<isize> {
+    fn test() -> i32 { // {dg-error "possible candidate" } 
+        123
+    }
+
+    fn bar(self) -> isize {
+        self.a
+    }
+}
+
+impl Foo<f32> {
+    fn test() -> i32 { // {dg-error "possible candidate" }
+        123
+    }
+
+    fn bar(self) -> f32 {
+        self.a
+    }
+}
+
+fn main() {
+    let a: i32 = Foo::test(); // { dg-error "multiple applicable items in scope for: test" }
+}
+

--- a/gcc/testsuite/rust.test/xfail_compile/generics7.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/generics7.rs
@@ -1,0 +1,27 @@
+// { dg-excess-errors "Noisy error and debug" }
+struct Foo<A> {
+    a: A,
+}
+
+impl Foo<isize> {
+    fn bar(self) -> isize { // { dg-error "duplicate definitions with name bar" }
+        self.a
+    }
+}
+
+impl Foo<char> {
+    fn bar(self) -> char { // { dg-error "duplicate definitions with name bar" }
+        self.a
+    }
+}
+
+impl<T> Foo<T> {
+    fn bar(self) -> T {
+        self.a
+    }
+}
+
+fn main() {
+    let a = Foo { a: 123 };
+    a.bar();
+}

--- a/gcc/testsuite/rust.test/xfail_compile/redef_error6.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/redef_error6.rs
@@ -2,11 +2,12 @@
 struct Foo<T>(T, usize);
 
 impl Foo<i32> {
-    fn test() -> i32 { // { dg-error "was defined here" }
+    fn test() -> i32 {
         123
     }
 
-    fn test(self) -> i32 { // { dg-error "redefined multiple times" }
+    fn test(self) -> i32 {
+        // { dg-error "redefined multiple times" "" { target *-*-* } .-1 }
         self.0
     }
 }

--- a/gcc/testsuite/rust.test/xfail_compile/redef_error6.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/redef_error6.rs
@@ -1,0 +1,14 @@
+// { dg-excess-errors "Noisy error and debug" }
+struct Foo<T>(T, usize);
+
+impl Foo<i32> {
+    fn test() -> i32 { // { dg-error "was defined here" }
+        123
+    }
+
+    fn test(self) -> i32 { // { dg-error "redefined multiple times" }
+        self.0
+    }
+}
+
+fn main() {}

--- a/gcc/testsuite/rust.test/xfail_compile/tuple1.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/tuple1.rs
@@ -1,3 +1,4 @@
+// { dg-excess-errors "Noisy error and debug" }
 fn main() {
     let a: (i32, bool) = (123, 123); // { dg-error "expected .bool. got .<integer>." }
     let b;

--- a/gcc/testsuite/rust.test/xfail_compile/type-alias1.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/type-alias1.rs
@@ -1,3 +1,4 @@
+// { dg-excess-errors "Noisy error and debug" }
 type TypeAlias = (i32, u32);
 
 fn main() {


### PR DESCRIPTION
Add Canonical paths to name resolution
    
In order to support name resolution and checks for duplicate definitions
of names we need canonical paths for all DefId items such as inherent impl
items and normal items. Consider:

```rust
  struct Foo<T>(T);

  impl Foo<f32> {
    fn name()...
  }

  impl Foo<i32> {
    fn name()...
  }
```

Each of the impl blocks have a name function but these are separate due to
the concrete impl of the Parameter type passed in.

The caveat here is that to call this Function name the programmer must be
explicit in which implentation they wish to call such as:

```rust
  let a = Foo::<f32>::name();
```

This lets the Path probe lookup the appropriate impl block. The problem here
is that rust also allows for the compiler to infer the impl you wish such
as:

```rust
  let a = Foo::name();
```

This should fail since there are multiple candidates possible for this
Path. Unless there might have only been one name function in which case
it would have worked.

This patch is also responsible to implement PathInExpression by iterating
each segment and applying generic arguments as we go.

Fixes #355 #335 #325 #353
