### PR TITLE
Add basic wrapper over gcc rich_location

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-implitem.h
+++ b/gcc/rust/resolve/rust-ast-resolve-implitem.h
@@ -44,8 +44,9 @@ public:
     resolver->get_name_scope ().insert (
       path, constant.get_node_id (), constant.get_locus (), false,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
-	rust_error_at (constant.get_locus (), "redefined multiple times");
-	rust_error_at (locus, "was defined here");
+	RichLocation r (constant.get_locus ());
+	r.add_range (locus);
+	rust_error_at (r, "redefined multiple times");
       });
     resolver->insert_new_definition (constant.get_node_id (),
 				     Definition{constant.get_node_id (),
@@ -59,8 +60,9 @@ public:
     resolver->get_name_scope ().insert (
       path, function.get_node_id (), function.get_locus (), false,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
-	rust_error_at (function.get_locus (), "redefined multiple times");
-	rust_error_at (locus, "was defined here");
+	RichLocation r (function.get_locus ());
+	r.add_range (locus);
+	rust_error_at (r, "redefined multiple times");
       });
     resolver->insert_new_definition (function.get_node_id (),
 				     Definition{function.get_node_id (),
@@ -74,8 +76,9 @@ public:
     resolver->get_name_scope ().insert (
       path, method.get_node_id (), method.get_locus (), false,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
-	rust_error_at (method.get_locus (), "redefined multiple times");
-	rust_error_at (locus, "was defined here");
+	RichLocation r (method.get_locus ());
+	r.add_range (locus);
+	rust_error_at (r, "redefined multiple times");
       });
     resolver->insert_new_definition (method.get_node_id (),
 				     Definition{method.get_node_id (),

--- a/gcc/rust/resolve/rust-ast-resolve-toplevel.h
+++ b/gcc/rust/resolve/rust-ast-resolve-toplevel.h
@@ -45,8 +45,9 @@ public:
       CanonicalPath (alias.get_new_type_name ()), alias.get_node_id (),
       alias.get_locus (), false,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
-	rust_error_at (alias.get_locus (), "redefined multiple times");
-	rust_error_at (locus, "was defined here");
+	RichLocation r (alias.get_locus ());
+	r.add_range (locus);
+	rust_error_at (r, "redefined multiple times");
       });
   }
 
@@ -56,8 +57,9 @@ public:
       CanonicalPath (struct_decl.get_identifier ()), struct_decl.get_node_id (),
       struct_decl.get_locus (), false,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
-	rust_error_at (struct_decl.get_locus (), "redefined multiple times");
-	rust_error_at (locus, "was defined here");
+	RichLocation r (struct_decl.get_locus ());
+	r.add_range (locus);
+	rust_error_at (r, "redefined multiple times");
       });
   }
 
@@ -67,8 +69,9 @@ public:
       CanonicalPath (struct_decl.get_identifier ()), struct_decl.get_node_id (),
       struct_decl.get_locus (), false,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
-	rust_error_at (struct_decl.get_locus (), "redefined multiple times");
-	rust_error_at (locus, "was defined here");
+	RichLocation r (struct_decl.get_locus ());
+	r.add_range (locus);
+	rust_error_at (r, "redefined multiple times");
       });
   }
 
@@ -78,8 +81,9 @@ public:
       CanonicalPath (var.get_identifier ()), var.get_node_id (),
       var.get_locus (), false,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
-	rust_error_at (var.get_locus (), "redefined multiple times");
-	rust_error_at (locus, "was defined here");
+	RichLocation r (var.get_locus ());
+	r.add_range (locus);
+	rust_error_at (r, "redefined multiple times");
       });
     resolver->insert_new_definition (var.get_node_id (),
 				     Definition{var.get_node_id (),
@@ -94,8 +98,9 @@ public:
     resolver->get_name_scope ().insert (
       path, constant.get_node_id (), constant.get_locus (), false,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
-	rust_error_at (constant.get_locus (), "redefined multiple times");
-	rust_error_at (locus, "was defined here");
+	RichLocation r (constant.get_locus ());
+	r.add_range (locus);
+	rust_error_at (r, "redefined multiple times");
       });
     resolver->insert_new_definition (constant.get_node_id (),
 				     Definition{constant.get_node_id (),
@@ -109,8 +114,9 @@ public:
     resolver->get_name_scope ().insert (
       path, function.get_node_id (), function.get_locus (), false,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
-	rust_error_at (function.get_locus (), "redefined multiple times");
-	rust_error_at (locus, "was defined here");
+	RichLocation r (function.get_locus ());
+	r.add_range (locus);
+	rust_error_at (r, "redefined multiple times");
       });
     resolver->insert_new_definition (function.get_node_id (),
 				     Definition{function.get_node_id (),

--- a/gcc/rust/rust-diagnostics.cc
+++ b/gcc/rust/rust-diagnostics.cc
@@ -186,6 +186,17 @@ rust_inform (const Location location, const char *fmt, ...)
   va_end (ap);
 }
 
+// Rich Locations
+void
+rust_error_at (const RichLocation location, const char *fmt, ...)
+{
+  va_list ap;
+
+  va_start (ap, fmt);
+  rust_be_error_at (location, expand_message (fmt, ap));
+  va_end (ap);
+}
+
 // rust_debug uses normal printf formatting, not GCC diagnostic formatting.
 
 void

--- a/gcc/rust/rust-diagnostics.h
+++ b/gcc/rust/rust-diagnostics.h
@@ -48,6 +48,7 @@
 // All other format specifiers are as defined by 'sprintf'. The final resulting
 // message is then sent to the back end via rust_be_error_at/rust_be_warning_at.
 
+// simple location
 extern void
 rust_error_at (const Location, const char *fmt, ...)
   RUST_ATTRIBUTE_GCC_DIAG (2, 3);
@@ -59,6 +60,11 @@ rust_fatal_error (const Location, const char *fmt, ...)
   RUST_ATTRIBUTE_GCC_DIAG (2, 3);
 extern void
 rust_inform (const Location, const char *fmt, ...)
+  RUST_ATTRIBUTE_GCC_DIAG (2, 3);
+
+// rich locations
+extern void
+rust_error_at (const RichLocation, const char *fmt, ...)
   RUST_ATTRIBUTE_GCC_DIAG (2, 3);
 
 // These interfaces provide a way for the front end to ask for
@@ -77,6 +83,8 @@ rust_close_quote ();
 
 extern void
 rust_be_error_at (const Location, const std::string &errmsg);
+extern void
+rust_be_error_at (const RichLocation, const std::string &errmsg);
 extern void
 rust_be_warning_at (const Location, int opt, const std::string &warningmsg);
 extern void

--- a/gcc/rust/rust-gcc-diagnostics.cc
+++ b/gcc/rust/rust-gcc-diagnostics.cc
@@ -51,6 +51,13 @@ rust_be_inform (const Location location, const std::string &infomsg)
 }
 
 void
+rust_be_error_at (const RichLocation location, const std::string &errmsg)
+{
+  rich_location gcc_loc = location.get ();
+  error_at (&gcc_loc, "%s", errmsg.c_str ());
+}
+
+void
 rust_be_get_quotechars (const char **open_qu, const char **close_qu)
 {
   *open_qu = open_quote;

--- a/gcc/rust/rust-linemap.cc
+++ b/gcc/rust/rust-linemap.cc
@@ -175,3 +175,46 @@ rust_get_linemap ()
 {
   return new Gcc_linemap;
 }
+
+RichLocation::RichLocation (Location root)
+  : gcc_rich_loc (line_table, root.gcc_location ())
+{
+  /*rich_location (line_maps *set, location_t loc,
+		 const range_label *label = NULL);*/
+}
+
+RichLocation::~RichLocation () {}
+
+void
+RichLocation::add_range (Location loc)
+{
+  gcc_rich_loc.add_range (loc.gcc_location ());
+}
+
+void
+RichLocation::add_fixit_insert_before (const std::string &new_parent)
+{
+  gcc_rich_loc.add_fixit_insert_before (new_parent.c_str ());
+}
+
+void
+RichLocation::add_fixit_insert_before (Location where,
+				       const std::string &new_parent)
+{
+  gcc_rich_loc.add_fixit_insert_before (where.gcc_location (),
+					new_parent.c_str ());
+}
+
+void
+RichLocation::add_fixit_insert_after (const std::string &new_parent)
+{
+  gcc_rich_loc.add_fixit_insert_after (new_parent.c_str ());
+}
+
+void
+RichLocation::add_fixit_insert_after (Location where,
+				      const std::string &new_parent)
+{
+  gcc_rich_loc.add_fixit_insert_after (where.gcc_location (),
+				       new_parent.c_str ());
+}

--- a/gcc/rust/rust-location.h
+++ b/gcc/rust/rust-location.h
@@ -80,4 +80,26 @@ operator- (Location lhs, location_t rhs)
   return lhs;
 }
 
+class RichLocation
+{
+public:
+  RichLocation (Location root);
+  ~RichLocation ();
+
+  void add_range (Location loc);
+
+  void add_fixit_insert_before (const std::string &new_parent);
+
+  void add_fixit_insert_before (Location where, const std::string &new_parent);
+
+  void add_fixit_insert_after (const std::string &new_parent);
+
+  void add_fixit_insert_after (Location where, const std::string &new_parent);
+
+  rich_location get () const { return gcc_rich_loc; }
+
+private:
+  rich_location gcc_rich_loc;
+};
+
 #endif // !defined(RUST_LOCATION_H)

--- a/gcc/rust/typecheck/rust-hir-inherent-impl-overlap.h
+++ b/gcc/rust/typecheck/rust-hir-inherent-impl-overlap.h
@@ -189,18 +189,17 @@ public:
   void collision_detected (HIR::InherentImplItem *query,
 			   HIR::InherentImplItem *dup, const std::string &name)
   {
-    Location qlocus;
+    Location qlocus; // query
     bool ok = GetLocusFromImplItem::Resolve (query, qlocus);
     rust_assert (ok);
 
-    Location dlocus;
+    Location dlocus; // dup
     ok = GetLocusFromImplItem::Resolve (dup, dlocus);
     rust_assert (ok);
 
-    // this needs GCC Rich locations see
-    // https://github.com/Rust-GCC/gccrs/issues/97
-    rust_error_at (qlocus, "duplicate definitions with name %s", name.c_str ());
-    rust_error_at (dlocus, "duplicate def associated with");
+    RichLocation r (qlocus);
+    r.add_range (dlocus);
+    rust_error_at (r, "duplicate definitions with name %s", name.c_str ());
   }
 
 private:
@@ -209,9 +208,6 @@ private:
   std::map<TyTy::BaseType *,
 	   std::set<std::pair<HIR::InherentImplItem *, std::string> > >
     impl_mappings;
-
-  std::map<TyTy::BaseType *, std::set<TyTy::BaseType *> >
-    possible_colliding_impls;
 };
 
 } // namespace Resolver

--- a/gcc/rust/typecheck/rust-hir-path-probe.h
+++ b/gcc/rust/typecheck/rust-hir-path-probe.h
@@ -129,31 +129,34 @@ public:
   static void Report (std::vector<PathProbeCandidate> &candidates,
 		      const HIR::PathIdentSegment &query, Location query_locus)
   {
-    rust_error_at (query_locus, "multiple applicable items in scope for: %s",
-		   query.as_string ().c_str ());
-
-    ReportMultipleCandidateError visitor;
+    RichLocation r (query_locus);
+    ReportMultipleCandidateError visitor (r);
     for (auto &c : candidates)
       c.impl_item->accept_vis (visitor);
+
+    rust_error_at (r, "multiple applicable items in scope for: %s",
+		   query.as_string ().c_str ());
   }
 
   void visit (HIR::ConstantItem &constant) override
   {
-    rust_error_at (constant.get_locus (), "possible candidate");
+    r.add_range (constant.get_locus ());
   }
 
   void visit (HIR::Function &function) override
   {
-    rust_error_at (function.get_locus (), "possible candidate");
+    r.add_range (function.get_locus ());
   }
 
   void visit (HIR::Method &method) override
   {
-    rust_error_at (method.get_locus (), "possible candidate");
+    r.add_range (method.get_locus ());
   }
 
 private:
-  ReportMultipleCandidateError () : TypeCheckBase () {}
+  ReportMultipleCandidateError (RichLocation &r) : TypeCheckBase (), r (r) {}
+
+  RichLocation &r;
 };
 
 } // namespace Resolver

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -290,11 +290,7 @@ public:
 
     auto result = lhs->unify (rhs);
     if (result->get_kind () == TyTy::TypeKind::ERROR)
-      {
-	rust_error_at (expr.get_locus (),
-		       "type resolution failure in AssignmentExpr");
-	return;
-      }
+      return;
 
     // in the case of declare first for an ADT Type:
     //

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.h
@@ -76,11 +76,7 @@ public:
       {
 	auto unified_ty = specified_ty->unify (init_expr_ty);
 	if (unified_ty->get_kind () == TyTy::TypeKind::ERROR)
-	  {
-	    rust_fatal_error (stmt.get_locus (),
-			      "failure in setting up let stmt type");
-	    return;
-	  }
+	  return;
 
 	context->insert_type (stmt.get_mappings (), unified_ty);
       }

--- a/gcc/rust/typecheck/rust-tyty-rules.h
+++ b/gcc/rust/typecheck/rust-tyty-rules.h
@@ -109,7 +109,10 @@ public:
   virtual void visit (TupleType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
-    rust_error_at (ref_locus, "expected [%s] got [%s]",
+    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
+    RichLocation r (ref_locus);
+    r.add_range (base_locus);
+    rust_error_at (r, "expected [%s] got [%s]",
 		   get_base ()->as_string ().c_str (),
 		   type.as_string ().c_str ());
   }
@@ -117,7 +120,10 @@ public:
   virtual void visit (ADTType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
-    rust_error_at (ref_locus, "expected [%s] got [%s]",
+    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
+    RichLocation r (ref_locus);
+    r.add_range (base_locus);
+    rust_error_at (r, "expected [%s] got [%s]",
 		   get_base ()->as_string ().c_str (),
 		   type.as_string ().c_str ());
   }
@@ -125,7 +131,10 @@ public:
   virtual void visit (InferType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
-    rust_error_at (ref_locus, "expected [%s] got [%s]",
+    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
+    RichLocation r (ref_locus);
+    r.add_range (base_locus);
+    rust_error_at (r, "expected [%s] got [%s]",
 		   get_base ()->as_string ().c_str (),
 		   type.as_string ().c_str ());
   }
@@ -133,7 +142,10 @@ public:
   virtual void visit (FnType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
-    rust_error_at (ref_locus, "expected [%s] got [%s]",
+    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
+    RichLocation r (ref_locus);
+    r.add_range (base_locus);
+    rust_error_at (r, "expected [%s] got [%s]",
 		   get_base ()->as_string ().c_str (),
 		   type.as_string ().c_str ());
   }
@@ -141,7 +153,10 @@ public:
   virtual void visit (FnPtr &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
-    rust_error_at (ref_locus, "expected [%s] got [%s]",
+    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
+    RichLocation r (ref_locus);
+    r.add_range (base_locus);
+    rust_error_at (r, "expected [%s] got [%s]",
 		   get_base ()->as_string ().c_str (),
 		   type.as_string ().c_str ());
   }
@@ -149,7 +164,10 @@ public:
   virtual void visit (ArrayType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
-    rust_error_at (ref_locus, "expected [%s] got [%s]",
+    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
+    RichLocation r (ref_locus);
+    r.add_range (base_locus);
+    rust_error_at (r, "expected [%s] got [%s]",
 		   get_base ()->as_string ().c_str (),
 		   type.as_string ().c_str ());
   }
@@ -157,7 +175,10 @@ public:
   virtual void visit (BoolType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
-    rust_error_at (ref_locus, "expected [%s] got [%s]",
+    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
+    RichLocation r (ref_locus);
+    r.add_range (base_locus);
+    rust_error_at (r, "expected [%s] got [%s]",
 		   get_base ()->as_string ().c_str (),
 		   type.as_string ().c_str ());
   }
@@ -165,7 +186,10 @@ public:
   virtual void visit (IntType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
-    rust_error_at (ref_locus, "expected [%s] got [%s]",
+    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
+    RichLocation r (ref_locus);
+    r.add_range (base_locus);
+    rust_error_at (r, "expected [%s] got [%s]",
 		   get_base ()->as_string ().c_str (),
 		   type.as_string ().c_str ());
   }
@@ -173,7 +197,10 @@ public:
   virtual void visit (UintType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
-    rust_error_at (ref_locus, "expected [%s] got [%s]",
+    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
+    RichLocation r (ref_locus);
+    r.add_range (base_locus);
+    rust_error_at (r, "expected [%s] got [%s]",
 		   get_base ()->as_string ().c_str (),
 		   type.as_string ().c_str ());
   }
@@ -181,7 +208,10 @@ public:
   virtual void visit (USizeType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
-    rust_error_at (ref_locus, "expected [%s] got [%s]",
+    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
+    RichLocation r (ref_locus);
+    r.add_range (base_locus);
+    rust_error_at (r, "expected [%s] got [%s]",
 		   get_base ()->as_string ().c_str (),
 		   type.as_string ().c_str ());
   }
@@ -189,7 +219,10 @@ public:
   virtual void visit (ISizeType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
-    rust_error_at (ref_locus, "expected [%s] got [%s]",
+    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
+    RichLocation r (ref_locus);
+    r.add_range (base_locus);
+    rust_error_at (r, "expected [%s] got [%s]",
 		   get_base ()->as_string ().c_str (),
 		   type.as_string ().c_str ());
   }
@@ -197,7 +230,10 @@ public:
   virtual void visit (FloatType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
-    rust_error_at (ref_locus, "expected [%s] got [%s]",
+    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
+    RichLocation r (ref_locus);
+    r.add_range (base_locus);
+    rust_error_at (r, "expected [%s] got [%s]",
 		   get_base ()->as_string ().c_str (),
 		   type.as_string ().c_str ());
   }
@@ -205,7 +241,10 @@ public:
   virtual void visit (ErrorType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
-    rust_error_at (ref_locus, "expected [%s] got [%s]",
+    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
+    RichLocation r (ref_locus);
+    r.add_range (base_locus);
+    rust_error_at (r, "expected [%s] got [%s]",
 		   get_base ()->as_string ().c_str (),
 		   type.as_string ().c_str ());
   }
@@ -213,7 +252,10 @@ public:
   virtual void visit (CharType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
-    rust_error_at (ref_locus, "expected [%s] got [%s]",
+    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
+    RichLocation r (ref_locus);
+    r.add_range (base_locus);
+    rust_error_at (r, "expected [%s] got [%s]",
 		   get_base ()->as_string ().c_str (),
 		   type.as_string ().c_str ());
   }
@@ -221,7 +263,10 @@ public:
   virtual void visit (ReferenceType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
-    rust_error_at (ref_locus, "expected [%s] got [%s]",
+    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
+    RichLocation r (ref_locus);
+    r.add_range (base_locus);
+    rust_error_at (r, "expected [%s] got [%s]",
 		   get_base ()->as_string ().c_str (),
 		   type.as_string ().c_str ());
   }
@@ -229,7 +274,10 @@ public:
   virtual void visit (ParamType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
-    rust_error_at (ref_locus, "expected [%s] got [%s]",
+    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
+    RichLocation r (ref_locus);
+    r.add_range (base_locus);
+    rust_error_at (r, "expected [%s] got [%s]",
 		   get_base ()->as_string ().c_str (),
 		   type.as_string ().c_str ());
   }
@@ -237,7 +285,10 @@ public:
   virtual void visit (StrType &type) override
   {
     Location ref_locus = mappings->lookup_location (type.get_ref ());
-    rust_error_at (ref_locus, "expected [%s] got [%s]",
+    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
+    RichLocation r (ref_locus);
+    r.add_range (base_locus);
+    rust_error_at (r, "expected [%s] got [%s]",
 		   get_base ()->as_string ().c_str (),
 		   type.as_string ().c_str ());
   }

--- a/gcc/testsuite/rust.test/xfail_compile/arrays1.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/arrays1.rs
@@ -1,5 +1,4 @@
 fn main() {
     let xs: [i32; 5] = [1, 2, 3, 4, 5];
     let a: bool = xs[0]; // { dg-error "expected .bool. got .i32." }
-    // { dg-error "failure in setting up let stmt type" "" { target { *-*-* } } .-1 }
 }

--- a/gcc/testsuite/rust.test/xfail_compile/arrays2.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/arrays2.rs
@@ -1,5 +1,4 @@
 fn main() {
     let array: [i32; 5] = [1, 2, 3]; // { dg-error "mismatch in array capacity" }
-    // { dg-error "expected ..i32:5.. got ..i32:3.." "" { target { *-*-* } } .-1 }
-    // { dg-error "failure in setting up let stmt type" "" { target { *-*-* } } .-2 }
+                                     // { dg-error "expected ..i32:5.. got ..i32:3.." "" { target { *-*-* } } .-1 }
 }

--- a/gcc/testsuite/rust.test/xfail_compile/bad_type1.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/bad_type1.rs
@@ -1,4 +1,3 @@
 fn main() {
     let logical: bool = 123; // { dg-error "expected .bool. got .<integer>." }
-    // { dg-error "failure in setting up let stmt type" "" { target { *-*-* } } .-1 }
 }

--- a/gcc/testsuite/rust.test/xfail_compile/bad_type2.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/bad_type2.rs
@@ -9,7 +9,6 @@ fn main() {
     let mut x;
     x = 1;
     x = true; // { dg-error "expected .<integer>. got .bool." }
-    // { dg-error "type resolution failure in AssignmentExpr" "" { target { *-*-* } } .-1 }
 
     let call_test = test(1);
 }

--- a/gcc/testsuite/rust.test/xfail_compile/generics1.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/generics1.rs
@@ -6,6 +6,6 @@ fn main() {
     let a2: GenericStruct<i8>;
     a2 = GenericStruct::<_>(1, 456);
 
-    let b2: i32 = a2.0; // { dg-error "failure in setting up let stmt type" }
+    let b2: i32 = a2.0;
     let c2: usize = a2.1;
 }

--- a/gcc/testsuite/rust.test/xfail_compile/generics2.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/generics2.rs
@@ -6,6 +6,6 @@ fn main() {
     let a2: GenericStruct<i8>;
     a2 = GenericStruct(1, 456);
 
-    let b2: i32 = a2.0; // { dg-error "failure in setting up let stmt type" }
+    let b2: i32 = a2.0;
     let c2: usize = a2.1;
 }

--- a/gcc/testsuite/rust.test/xfail_compile/generics3.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/generics3.rs
@@ -5,6 +5,6 @@ fn main() {
     let a2;
     a2 = GenericStruct::<i8>(1, 456);
 
-    let b2: i32 = a2.0; // { dg-error "failure in setting up let stmt type" }
+    let b2: i32 = a2.0;
     let c2: usize = a2.1;
 }

--- a/gcc/testsuite/rust.test/xfail_compile/generics7.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/generics7.rs
@@ -15,7 +15,7 @@ impl Foo<char> {
 }
 
 impl<T> Foo<T> {
-    fn bar(self) -> T {
+    fn bar(self) -> T { // { dg-error "duplicate definitions with name bar" }
         self.a
     }
 }

--- a/gcc/testsuite/rust.test/xfail_compile/generics7.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/generics7.rs
@@ -1,4 +1,3 @@
-// { dg-excess-errors "Noisy error and debug" }
 struct Foo<A> {
     a: A,
 }

--- a/gcc/testsuite/rust.test/xfail_compile/redef_error1.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/redef_error1.rs
@@ -1,4 +1,4 @@
-struct S1 { // { dg-error "was defined here" }
+struct S1 {
     x: f64,
     y: f64,
 }

--- a/gcc/testsuite/rust.test/xfail_compile/redef_error2.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/redef_error2.rs
@@ -1,4 +1,4 @@
-const TEST: i32 = 2;  // { dg-error "was defined here" }
-const TEST: f32 = 3.0;  // { dg-error "redefined multiple times" }
+const TEST: i32 = 2;
+const TEST: f32 = 3.0; // { dg-error "redefined multiple times" }
 
 fn main() {}

--- a/gcc/testsuite/rust.test/xfail_compile/redef_error3.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/redef_error3.rs
@@ -1,4 +1,4 @@
-fn test() -> bool {  // { dg-error "was defined here" }
+fn test() -> bool {
     true
 }
 

--- a/gcc/testsuite/rust.test/xfail_compile/redef_error4.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/redef_error4.rs
@@ -5,7 +5,7 @@ impl Foo {
         Foo(a, b)
     }
 
-    fn test() -> i32 { // { dg-error "was defined here" }
+    fn test() -> i32 {
         test()
     }
 

--- a/gcc/testsuite/rust.test/xfail_compile/redef_error5.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/redef_error5.rs
@@ -1,7 +1,7 @@
 struct Foo(i32, bool);
 
 impl Foo {
-    const TEST: i32 = 123; // { dg-error "was defined here"  }
+    const TEST: i32 = 123;
     const TEST: bool = false; // { dg-error "redefined multiple times"  }
 }
 

--- a/gcc/testsuite/rust.test/xfail_compile/redef_error6.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/redef_error6.rs
@@ -1,4 +1,3 @@
-// { dg-excess-errors "Noisy error and debug" }
 struct Foo<T>(T, usize);
 
 impl Foo<i32> {
@@ -6,8 +5,7 @@ impl Foo<i32> {
         123
     }
 
-    fn test(self) -> i32 {
-        // { dg-error "redefined multiple times" "" { target *-*-* } .-1 }
+    fn test(self) -> i32 { // { dg-error "redefined multiple times" }
         self.0
     }
 }

--- a/gcc/testsuite/rust.test/xfail_compile/tuple1.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/tuple1.rs
@@ -1,4 +1,3 @@
-// { dg-excess-errors "Noisy error and debug" }
 fn main() {
     let a: (i32, bool) = (123, 123); // { dg-error "expected .bool. got .<integer>." }
     let b;

--- a/gcc/testsuite/rust.test/xfail_compile/type-alias1.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/type-alias1.rs
@@ -1,4 +1,3 @@
-// { dg-excess-errors "Noisy error and debug" }
 type TypeAlias = (i32, u32);
 
 fn main() {


### PR DESCRIPTION
Adding rich location will improve our error message diagnostics, this is
an initial building block to keep a wrapper over the GCC stuff we call.

Addresses: #97 
Fixes: #327 