### PR TITLE
Fix crash when mapping of Generic argument changes.

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -186,14 +186,15 @@ public:
     if (resolved_node == UNKNOWN_NODEID)
       return;
 
-    auto Self = CanonicalPath::get_big_self ();
     resolver->get_type_scope ().insert (
-      Self, resolved_node, impl_block.get_type ()->get_locus_slow ());
+      CanonicalPath::get_big_self (), impl_block.get_type ()->get_node_id (),
+      impl_block.get_type ()->get_locus_slow ());
 
     for (auto &impl_item : impl_block.get_impl_items ())
       impl_item->accept_vis (*this);
 
-    resolver->get_type_scope ().peek ()->clear_name (Self, resolved_node);
+    resolver->get_type_scope ().peek ()->clear_name (
+      CanonicalPath::get_big_self (), impl_block.get_type ()->get_node_id ());
     resolver->get_type_scope ().pop ();
   }
 
@@ -208,7 +209,7 @@ public:
     resolver->push_new_name_rib (resolver->get_name_scope ().peek ());
     resolver->push_new_type_rib (resolver->get_type_scope ().peek ());
 
-    // self turns into self: Self as a function param
+    // self turns into (self: Self) as a function param
     AST::SelfParam &self_param = method.get_self_param ();
     AST::IdentifierPattern self_pattern (
       self_param.get_node_id (), "self", self_param.get_locus (),

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -195,14 +195,14 @@ public:
 		      "the type %s does not have any",
 		      path.as_string ().c_str (),
 		      translated->as_string ().c_str ());
-		    return;
 		  }
 	      }
 	    else if (translated->has_subsititions_defined ())
 	      {
 		translated
-		  = SubstMapper::Resolve (translated, path.get_locus ());
+		  = SubstMapper::InferSubst (translated, path.get_locus ());
 	      }
+
 	    return;
 	  }
       }

--- a/gcc/rust/typecheck/rust-substitution-mapper.h
+++ b/gcc/rust/typecheck/rust-substitution-mapper.h
@@ -223,6 +223,48 @@ private:
   TyTy::BaseType *resolved;
 };
 
+class GetUsedSubstArgs : public TyTy::TyVisitor
+{
+public:
+  static TyTy::SubstitutionArgumentMappings From (TyTy::BaseType *from)
+  {
+    GetUsedSubstArgs mapper;
+    from->accept_vis (mapper);
+    return mapper.args;
+  }
+
+  void visit (TyTy::FnType &type) override
+  {
+    args = type.get_substitution_arguments ();
+  }
+
+  void visit (TyTy::ADTType &type) override
+  {
+    args = type.get_substitution_arguments ();
+  }
+
+  void visit (TyTy::InferType &) override { gcc_unreachable (); }
+  void visit (TyTy::TupleType &) override { gcc_unreachable (); }
+  void visit (TyTy::FnPtr &) override { gcc_unreachable (); }
+  void visit (TyTy::ArrayType &) override { gcc_unreachable (); }
+  void visit (TyTy::BoolType &) override { gcc_unreachable (); }
+  void visit (TyTy::IntType &) override { gcc_unreachable (); }
+  void visit (TyTy::UintType &) override { gcc_unreachable (); }
+  void visit (TyTy::FloatType &) override { gcc_unreachable (); }
+  void visit (TyTy::USizeType &) override { gcc_unreachable (); }
+  void visit (TyTy::ISizeType &) override { gcc_unreachable (); }
+  void visit (TyTy::ErrorType &) override { gcc_unreachable (); }
+  void visit (TyTy::CharType &) override { gcc_unreachable (); }
+  void visit (TyTy::ReferenceType &) override { gcc_unreachable (); }
+  void visit (TyTy::ParamType &) override { gcc_unreachable (); }
+  void visit (TyTy::StrType &) override { gcc_unreachable (); }
+
+private:
+  GetUsedSubstArgs () : args (TyTy::SubstitutionArgumentMappings::error ()) {}
+
+  TyTy::SubstitutionArgumentMappings args;
+};
+
 } // namespace Resolver
 } // namespace Rust
 

--- a/gcc/rust/typecheck/rust-tyty-cmp.h
+++ b/gcc/rust/typecheck/rust-tyty-cmp.h
@@ -776,13 +776,22 @@ public:
     bool ok = context->lookup_type (base->get_ty_ref (), &lookup);
     rust_assert (ok);
 
+    if (lookup->get_kind () == TypeKind::PARAM)
+      {
+	InferType infer (UNKNOWN_HIRID, InferType::InferTypeKind::GENERAL);
+	return infer.can_eq (other);
+      }
+
     return lookup->can_eq (other);
   }
 
-  void visit (ParamType &type) override
-  {
-    ok = base->get_symbol ().compare (type.get_symbol ()) == 0;
-  }
+  // imagine the case where we have:
+  // struct Foo<T>(T);
+  // Then we declare a generic impl block
+  // impl <X>Foo<X> { ... }
+  // both of these types are compatible so we mostly care about the number of
+  // generic arguments
+  void visit (ParamType &type) override { ok = true; }
 
 private:
   BaseType *get_base () override { return base; }

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -251,10 +251,12 @@ SubstitutionRef::adjust_mappings_for_this (
   Analysis::Mappings *mappings_table = Analysis::Mappings::get ();
 
   std::vector<SubstitutionArg> resolved_mappings;
-  for (auto &subst : substitutions)
+  for (size_t i = 0; i < substitutions.size (); i++)
     {
+      auto &subst = substitutions.at (i);
+
       SubstitutionArg arg = SubstitutionArg::error ();
-      bool ok = mappings.get_argument_for_symbol (subst.get_param_ty (), &arg);
+      bool ok = mappings.get_argument_at (0, &arg);
       if (!ok)
 	{
 	  rust_error_at (mappings_table->lookup_location (
@@ -613,6 +615,7 @@ FnType::handle_substitions (SubstitutionArgumentMappings subst_mappings)
   for (auto &sub : fn->get_substs ())
     {
       SubstitutionArg arg = SubstitutionArg::error ();
+
       bool ok
 	= subst_mappings.get_argument_for_symbol (sub.get_param_ty (), &arg);
       rust_assert (ok);

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -495,6 +495,15 @@ public:
     return false;
   }
 
+  bool get_argument_at (size_t index, SubstitutionArg *argument)
+  {
+    if (index > mappings.size ())
+      return false;
+
+    *argument = mappings.at (index);
+    return true;
+  }
+
   // is_concrete means if the used args is non error, ie: non empty this will
   // verify if actual real types have been put in place of are they still
   // ParamTy

--- a/gcc/testsuite/rust.test/compile/generics17.rs
+++ b/gcc/testsuite/rust.test/compile/generics17.rs
@@ -1,0 +1,19 @@
+struct Foo<T>(T);
+
+impl<X> Foo<X> {
+    fn new(a: X) -> Self {
+        Self(a)
+    }
+
+    fn test(self) -> X {
+        self.0
+    }
+}
+
+fn main() {
+    let a;
+    a = Foo::new(123);
+
+    let b = a.test();
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust.test/compile/generics18.rs
+++ b/gcc/testsuite/rust.test/compile/generics18.rs
@@ -1,0 +1,20 @@
+struct Foo<T>(T);
+
+impl<X> Foo<X> {
+    fn new(a: X) -> Self {
+        // { dg-warning "unused name" "" { target *-*-* } .-1 }
+        Self(a)
+    }
+
+    fn test(self) -> X {
+        self.0
+    }
+}
+
+fn main() {
+    let a;
+    a = Foo(123);
+
+    let b = a.test();
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
When we have a struct Foo <T>(T) but the fntype in impl block is different
fn <X> Bar(a:X) -> Foo<X>(X) { } we must take advantage of the adjustment
code in the substitution mapper.

This affects MethodCallExpr and PathInExpressions where it used to resolve
the root segment and leave the arguments as inference variables when we
lack a segement with generic arguments.

This also fixes a bug in name resolution where the Self keyword resolved
to the struct/type the impl block resolves to but it needed to resolve
to the impl block type explicitly which ensures the parameter mappings
reflect what the parent impl block is.

Fixes: #376