### PR TITLE
Add Check for unconstrained type parameters

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
@@ -211,7 +211,8 @@ public:
 	  }
       }
 
-    auto self = TypeCheckType::Resolve (impl_block.get_type ().get ());
+    auto self
+      = TypeCheckType::Resolve (impl_block.get_type ().get (), &substitutions);
     if (self == nullptr || self->get_kind () == TyTy::TypeKind::ERROR)
       {
 	rust_error_at (impl_block.get_locus (), "failed to resolve impl type");

--- a/gcc/testsuite/rust.test/xfail_compile/unconstrained_type_param.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/unconstrained_type_param.rs
@@ -1,0 +1,12 @@
+struct Foo<T>(T, bool);
+
+impl<X, Y> Foo<X> {
+    // { dg-error "unconstrained type parameter" "" { target { *-*-* } } .-1 }
+    fn test() -> Y {
+        123
+    }
+}
+
+fn main() {
+    let a = Foo::test();
+}


### PR DESCRIPTION
When we have an impl<X,Y> Foo<X>, the type parameter Y is unconstrained
so that we cannot be sure how Y should be substituted later on.

Fixes #354