### PR TITLE
Fix dg-ice handling in rust testsuite

### DIFF
--- a/gcc/testsuite/lib/rust.exp
+++ b/gcc/testsuite/lib/rust.exp
@@ -181,7 +181,7 @@ proc rust_target_compile { source dest type options } {
     ## FIXME: until the compiler is made less verbose, we need to prune its output almost completely.
     # Only keep lines containing certain diagnostics so that we can check these.
     global additional_prunes
-    lappend additional_prunes "^((?!(error: |warning: )).)*$"
+    lappend additional_prunes "^((?!(error: |warning: |\[Ii\]nternal compiler error: )).)*$"
 
     return [target_compile $source $dest $type $options]
 }

--- a/gcc/testsuite/rust.test/xfail_compile/unsafe.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/unsafe.rs
@@ -1,0 +1,4 @@
+fn main() { // { dg-ice "#382" }
+    unsafe {
+    }
+}


### PR DESCRIPTION
Fix the pruning regex to also match ICE message and allow for dg-ice use.
Add the test from #382 as a sample example.
Should help #308