### PR TITLE
Don't remove unreachable statements at HIR lowering

### DIFF
--- a/gcc/rust/ast/rust-stmt.h
+++ b/gcc/rust/ast/rust-stmt.h
@@ -38,6 +38,8 @@ public:
 
   EmptyStmt (Location locus) : locus (locus) {}
 
+  Location get_locus_slow () const final override { return get_locus (); }
+
   Location get_locus () const { return locus; }
 
   void accept_vis (ASTVisitor &vis) override;
@@ -134,6 +136,8 @@ public:
   // move constructors
   LetStmt (LetStmt &&other) = default;
   LetStmt &operator= (LetStmt &&other) = default;
+
+  Location get_locus_slow () const final override { return get_locus (); }
 
   Location get_locus () const { return locus; }
 

--- a/gcc/testsuite/rust.test/compile/deadcode2.rs
+++ b/gcc/testsuite/rust.test/compile/deadcode2.rs
@@ -1,0 +1,10 @@
+fn foo() -> i32 {
+    return 1;
+
+    let a = -1; // { dg-warning "unreachable statement" }
+    a // { dg-warning "unreachable expression" }
+}
+
+fn main() {
+    foo();
+}

--- a/gcc/testsuite/rust.test/xfail_compile/deadcode_err1.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/deadcode_err1.rs
@@ -1,0 +1,11 @@
+fn foo() -> i32 {
+    return 1;
+
+    let mut a = 1; // { dg-warning "unreachable statement" }
+    a = 1.1; // { dg-warning "unreachable statement" }
+    // { dg-error "expected .<integer>. got .<float>." "" { target { *-*-* } } .-1 }
+}
+
+fn main() {
+    foo();
+}

--- a/gcc/testsuite/rust.test/xfail_compile/deadcode_err2.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/deadcode_err2.rs
@@ -1,0 +1,16 @@
+fn foo() -> i32 {
+    return 1;
+    return 1.5; // { dg-error "expected .i32. got .<float>." }
+    // { dg-warning "unreachable statement" "" { target *-*-* } .-1 } 
+}
+
+fn bar() -> i32 {
+    return 1.5; // { dg-error "expected .i32. got .<float>." }
+    return 1;
+    // { dg-warning "unreachable statement" "" { target *-*-* } .-1 } 
+}
+
+fn main() {
+    foo();
+    bar();
+}


### PR DESCRIPTION
This is a legal code segment:
```rust
fn foo() -> i32 {
    return 1;
    let a = 1;
    a
}
```
And this is illegal:
```rust
fn foo() -> i32 {
    return 1;
    let a = 1.5;
    a
}
```
So we shouldn't remove unreachable statements at HIR lowering. We can issue warnings for them, but they need to be kept so that their types can be checked.

*(Original in https://github.com/Rust-GCC/gccrs/pull/364)*