### PR TITLE
Basic support for lifetime parameter

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -1232,6 +1232,8 @@ class LifetimeParam : public GenericParam
   Location locus;
 
 public:
+  Lifetime get_lifetime () const { return lifetime; }
+
   // Returns whether the lifetime param has any lifetime bounds.
   bool has_lifetime_bounds () const { return !lifetime_bounds.empty (); }
 

--- a/gcc/rust/hir/rust-ast-lower-type.h
+++ b/gcc/rust/hir/rust-ast-lower-type.h
@@ -265,6 +265,34 @@ public:
     return resolver.translated;
   }
 
+  void visit (AST::LifetimeParam &param) override
+  {
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, param.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   mappings->get_next_localdef_id (crate_num));
+    HIR::Lifetime::LifetimeType ltt;
+
+    switch (param.get_lifetime ().get_lifetime_type ())
+      {
+      case AST::Lifetime::LifetimeType::NAMED:
+	ltt = HIR::Lifetime::LifetimeType::NAMED;
+	break;
+      case AST::Lifetime::LifetimeType::STATIC:
+	ltt = HIR::Lifetime::LifetimeType::STATIC;
+	break;
+      case AST::Lifetime::LifetimeType::WILDCARD:
+	ltt = HIR::Lifetime::LifetimeType::WILDCARD;
+	break;
+      }
+
+    HIR::Lifetime lt (mapping, ltt, param.get_lifetime ().get_lifetime_name (),
+		      param.get_lifetime ().get_locus ());
+
+    translated = new HIR::LifetimeParam (mapping, lt, param.get_locus (),
+					 std::vector<Lifetime> ());
+  }
+
   void visit (AST::TypeParam &param) override
   {
     HIR::Attribute outer_attr = HIR::Attribute::create_empty ();

--- a/gcc/rust/resolve/rust-ast-resolve-type.h
+++ b/gcc/rust/resolve/rust-ast-resolve-type.h
@@ -252,6 +252,12 @@ public:
     return resolver.resolved_node;
   };
 
+  void visit (AST::LifetimeParam &param) override
+  {
+    // For now do not do anything and accept everything.
+    ok = true;
+  }
+
   void visit (AST::TypeParam &param) override
   {
     ok = true;

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -59,12 +59,22 @@ public:
       {
 	for (auto &generic_param : function.get_generic_params ())
 	  {
-	    auto param_type
-	      = TypeResolveGenericParam::Resolve (generic_param.get ());
-	    context->insert_type (generic_param->get_mappings (), param_type);
+	    switch (generic_param.get ()->get_kind ())
+	      {
+	      case HIR::GenericParam::GenericKind::LIFETIME:
+		// Skipping Lifetime completely until better handling.
+		break;
+		case HIR::GenericParam::GenericKind::TYPE: {
+		  auto param_type
+		    = TypeResolveGenericParam::Resolve (generic_param.get ());
+		  context->insert_type (generic_param->get_mappings (),
+					param_type);
 
-	    substitutions.push_back (
-	      TyTy::SubstitutionParamMapping (generic_param, param_type));
+		  substitutions.push_back (
+		    TyTy::SubstitutionParamMapping (generic_param, param_type));
+		}
+		break;
+	      }
 	  }
       }
 

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
@@ -152,12 +152,21 @@ public:
       {
 	for (auto &generic_param : function.get_generic_params ())
 	  {
-	    auto param_type
-	      = TypeResolveGenericParam::Resolve (generic_param.get ());
-	    context->insert_type (generic_param->get_mappings (), param_type);
+	    switch (generic_param.get ()->get_kind ())
+	      {
+	      case HIR::GenericParam::GenericKind::LIFETIME:
+		// Skipping Lifetime completely until better handling.
+		break;
+		case HIR::GenericParam::GenericKind::TYPE: {
+		  auto param_type
+		    = TypeResolveGenericParam::Resolve (generic_param.get ());
+		  context->insert_type (generic_param->get_mappings (),
+					param_type);
 
-	    substitutions.push_back (
-	      TyTy::SubstitutionParamMapping (generic_param, param_type));
+		  substitutions.push_back (
+		    TyTy::SubstitutionParamMapping (generic_param, param_type));
+		}
+	      }
 	  }
       }
 

--- a/gcc/testsuite/rust.test/compile/generics19.rs
+++ b/gcc/testsuite/rust.test/compile/generics19.rs
@@ -1,0 +1,4 @@
+fn foo<'a>(t: &'a str)-> &'a str { // { dg-warning "function is never used: `foo`" }
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+    t
+}


### PR DESCRIPTION
refs #359
This change allow for basic lifetime usage. Only syntax is checked, nothing
more. Goal is to be able to compile known-to-be-valid code.