### PR TITLE
Add support for 'unsupported' test cases in testsuite

### DIFF
--- a/gcc/testsuite/rust.test/unsupported/lifetime_param.rs
+++ b/gcc/testsuite/rust.test/unsupported/lifetime_param.rs
@@ -1,0 +1,11 @@
+// { dg-excess-errors "warnings" }
+
+// { dg-error "lifetime not defined" "#359" { xfail *-*-* } .+1 }
+fn lifetime_undefined(t: &'a str) -> &'a str {
+    t
+}
+
+// { dg-error "lifetime not defined" "#359" { xfail *-*-* } .+1 }
+fn lifetime_undefined_bis<'a>(t: &'a str)-> &'b str {
+    t
+}

--- a/gcc/testsuite/rust.test/unsupported/slice1.rs
+++ b/gcc/testsuite/rust.test/unsupported/slice1.rs
@@ -1,0 +1,3 @@
+fn foo (e: &str) -> &str {
+    &"" // { dg-bogus "cannot strip expression in this position - outer attributes not allowed" "#391" { xfail *-*-* } }
+}

--- a/gcc/testsuite/rust.test/unsupported/struct_field_vis.rs
+++ b/gcc/testsuite/rust.test/unsupported/struct_field_vis.rs
@@ -1,0 +1,15 @@
+// { dg-xfail-if "pub visibility not supported #432"  *-*-* }
+
+mod foomod {
+    pub struct Foo {
+        pub f: i32,
+        pub g: u32,
+    }
+}
+
+fn test() -> foomod::Foo {
+    foomod::Foo{
+        f:1,
+        g:3,
+    }
+}

--- a/gcc/testsuite/rust.test/unsupported/unsupported.exp
+++ b/gcc/testsuite/rust.test/unsupported/unsupported.exp
@@ -1,0 +1,62 @@
+# Copyright (C) 2021 Free Software Foundation, Inc.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with GCC; see the file COPYING3.  If not see
+# <http://www.gnu.org/licenses/>.
+
+
+# These tests are used to keep track of known limitations :
+# 1- tests that are incorrecly build instead of being rejected
+# 2- tests that are build to an incorrect result
+# 3- tests that are rejected instead of being correctly build
+#
+# Not currently supported here:
+# - tests that are exhibiting incorrect behavior at runtime
+#
+# Here's how to annotate tests for each cases:
+#
+# 1- test is successfuly build instead of being rejected
+#
+# Expected behavior: a specific error rejecting the test
+# Observed behavior: error not present
+# Use dg-error and mark the test xfail and add reference to corresponding issue.
+# { dg-error "lifetime not defined" "#359" { xfail *-*-* } }
+#
+# 2- test is successfuly build but result is incorrect
+#
+# Expected behavior: test is correctly build and has specific property
+# Observed behavior: test is correctly build but is missing the specific property
+# Depends on the property. For example, if the property can be checked in the assembly file, use dg-final + xfail.
+# { dg-final { scan-assembler "given_string_missing_in_assembly_" "#1234" { xfail *-*-* } } }
+#
+# 3- test is rejected instead of being correctly build
+#
+# Expected behavior: test is successfully build
+# Observed behavior: the test is rejected with an error
+# Use dg-bogus + xfail to match the bogus error message, or use dg-xfail-if if it's harder to match a specific error.
+
+# Load support procs.
+load_lib rust-dg.exp
+
+# Initialize `dg'.
+dg-init
+
+# Main loop.
+set saved-dg-do-what-default ${dg-do-what-default}
+
+set dg-do-what-default "compile"
+dg-runtest [lsort [glob -nocomplain $srcdir/$subdir/*.rs]] "" ""
+set dg-do-what-default ${saved-dg-do-what-default}
+
+# All done.
+dg-finish


### PR DESCRIPTION
Add support for 'unsupported' test cases in testsuite

Introduce an 'unsupported/' directory in the testsuite. It should contains tests
case for which the compiler currently has an incorrect behavior:
- its accepts invalid input
- it rejects valid input

Some basic guidelines are provided in unsupported.exp.