### PR TITLE
Partial substitions of generic data types

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -811,8 +811,15 @@ public:
     else if (expr.get_num_segments () == 1)
       {
 	Location locus = expr.get_segments ().back ().get_locus ();
-	if (tyseg->needs_generic_substitutions ())
-	  tyseg = SubstMapper::InferSubst (tyseg, locus);
+
+	bool is_big_self
+	  = expr.get_segments ().front ().get_segment ().as_string ().compare (
+	      "Self")
+	    == 0;
+	if (!is_big_self && tyseg->needs_generic_substitutions ())
+	  {
+	    tyseg = SubstMapper::InferSubst (tyseg, locus);
+	  }
 
 	infered = tyseg;
 	return;

--- a/gcc/rust/typecheck/rust-substitution-mapper.h
+++ b/gcc/rust/typecheck/rust-substitution-mapper.h
@@ -133,6 +133,8 @@ public:
   {
     TyTy::SubstitutionArgumentMappings adjusted
       = type.adjust_mappings_for_this (mappings);
+    if (adjusted.is_error ())
+      return;
 
     TyTy::BaseType *concrete = type.handle_substitions (adjusted);
     if (concrete != nullptr)
@@ -143,6 +145,8 @@ public:
   {
     TyTy::SubstitutionArgumentMappings adjusted
       = type.adjust_mappings_for_this (mappings);
+    if (adjusted.is_error ())
+      return;
 
     TyTy::BaseType *concrete = type.handle_substitions (adjusted);
     if (concrete != nullptr)

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -408,6 +408,15 @@ public:
 
   void override_context ();
 
+  bool needs_substitution () const
+  {
+    auto p = get_param_ty ();
+    if (!p->can_resolve ())
+      return true;
+
+    return p->resolve ()->get_kind () == TypeKind::PARAM;
+  }
+
 private:
   std::unique_ptr<HIR::GenericParam> &generic;
   ParamType *param;
@@ -436,6 +445,8 @@ public:
   SubstitutionParamMapping *get_param_mapping () { return param; }
 
   static SubstitutionArg error () { return SubstitutionArg (nullptr, nullptr); }
+
+  bool is_error () const { return param == nullptr || argument == nullptr; }
 
   bool is_conrete () const
   {
@@ -598,6 +609,17 @@ public:
   SubstitutionArgumentMappings get_substitution_arguments ()
   {
     return used_arguments;
+  }
+
+  size_t num_required_substitutions () const
+  {
+    size_t n = 0;
+    for (auto &p : substitutions)
+      {
+	if (p.needs_substitution ())
+	  n++;
+      }
+    return n;
   }
 
   // We are trying to subst <i32, f32> into Struct Foo<X,Y> {}

--- a/gcc/testsuite/rust.test/compile/generics19.rs
+++ b/gcc/testsuite/rust.test/compile/generics19.rs
@@ -1,0 +1,12 @@
+struct Foo<X, Y>(X, Y);
+
+impl<T> Foo<u32, T> {
+    fn new(a: T) -> Self {
+        Self(123, a)
+    }
+}
+
+fn main() {
+    let a;
+    a = Foo::new(false);
+}

--- a/gcc/testsuite/rust.test/compile/generics20.rs
+++ b/gcc/testsuite/rust.test/compile/generics20.rs
@@ -1,0 +1,12 @@
+struct Foo<A, B>(A, B);
+
+impl<T> Foo<T, T> {
+    fn new(a: T, b: T) -> Self {
+        Self(a, b)
+    }
+}
+
+fn main() {
+    let a;
+    a = Foo::new(123, 456);
+}


### PR DESCRIPTION
Handle the case where we have a generic type:

```rust
struct Foo<A,B>(A,B);

impl<T> Foo<i32, T> { ... }
```

In this case the impl block only defines 1 type parameter but the generic datatype has two type parameters.

Fixes #386 