### PR TITLE
ReferenceTypes and Tuple can hold Type Parameters

### DIFF
--- a/gcc/rust/typecheck/rust-substitution-mapper.h
+++ b/gcc/rust/typecheck/rust-substitution-mapper.h
@@ -153,8 +153,21 @@ public:
       resolved = concrete;
   }
 
-  void visit (TyTy::InferType &) override { gcc_unreachable (); }
+  // these don't support generic arguments but might contain a type param
   void visit (TyTy::TupleType &) override { gcc_unreachable (); }
+
+  void visit (TyTy::ReferenceType &type) override
+  {
+    resolved = type.handle_substitions (mappings);
+  }
+
+  void visit (TyTy::ParamType &type) override
+  {
+    resolved = type.handle_substitions (mappings);
+  }
+
+  // nothing to do for these
+  void visit (TyTy::InferType &) override { gcc_unreachable (); }
   void visit (TyTy::FnPtr &) override { gcc_unreachable (); }
   void visit (TyTy::ArrayType &) override { gcc_unreachable (); }
   void visit (TyTy::BoolType &) override { gcc_unreachable (); }
@@ -165,8 +178,6 @@ public:
   void visit (TyTy::ISizeType &) override { gcc_unreachable (); }
   void visit (TyTy::ErrorType &) override { gcc_unreachable (); }
   void visit (TyTy::CharType &) override { gcc_unreachable (); }
-  void visit (TyTy::ReferenceType &) override { gcc_unreachable (); }
-  void visit (TyTy::ParamType &) override { gcc_unreachable (); }
   void visit (TyTy::StrType &) override { gcc_unreachable (); }
   void visit (TyTy::NeverType &) override { gcc_unreachable (); }
 

--- a/gcc/rust/typecheck/rust-substitution-mapper.h
+++ b/gcc/rust/typecheck/rust-substitution-mapper.h
@@ -154,7 +154,10 @@ public:
   }
 
   // these don't support generic arguments but might contain a type param
-  void visit (TyTy::TupleType &) override { gcc_unreachable (); }
+  void visit (TyTy::TupleType &type) override
+  {
+    resolved = type.handle_substitions (mappings);
+  }
 
   void visit (TyTy::ReferenceType &type) override
   {

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -540,6 +540,29 @@ TupleType::clone ()
 			get_combined_refs ());
 }
 
+TupleType *
+TupleType::handle_substitions (SubstitutionArgumentMappings mappings)
+{
+  auto mappings_table = Analysis::Mappings::get ();
+
+  TupleType *tuple = static_cast<TupleType *> (clone ());
+  tuple->set_ty_ref (mappings_table->get_next_hir_id ());
+
+  for (size_t i = 0; i < tuple->fields.size (); i++)
+    {
+      TyVar &field = fields.at (i);
+      if (field.get_tyty ()->contains_type_parameters ())
+	{
+	  BaseType *concrete
+	    = Resolver::SubstMapperInternal::Resolve (field.get_tyty (),
+						      mappings);
+	  tuple->fields[i] = TyVar (concrete->get_ty_ref ());
+	}
+    }
+
+  return tuple;
+}
+
 void
 FnType::accept_vis (TyVisitor &vis)
 {

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -452,7 +452,8 @@ ADTType::handle_substitions (SubstitutionArgumentMappings subst_mappings)
 	    field->get_field_type ()->set_ty_ref (argt->get_ref ());
 	  }
       }
-    else if (fty->has_subsititions_defined ())
+    else if (fty->has_subsititions_defined ()
+	     || fty->contains_type_parameters ())
       {
 	BaseType *concrete
 	  = Resolver::SubstMapperInternal::Resolve (fty, subst_mappings);
@@ -558,7 +559,7 @@ FnType::as_string () const
     }
 
   std::string ret_str = type->as_string ();
-  return "fn (" + params_str + ") -> " + ret_str;
+  return "fn" + subst_as_string () + " (" + params_str + ") -> " + ret_str;
 }
 
 BaseType *
@@ -667,7 +668,8 @@ FnType::handle_substitions (SubstitutionArgumentMappings subst_mappings)
 	  fty->set_ty_ref (argt->get_ref ());
 	}
     }
-  else if (fty->has_subsititions_defined ())
+  else if (fty->needs_generic_substitutions ()
+	   || fty->contains_type_parameters ())
     {
       BaseType *concrete
 	= Resolver::SubstMapperInternal::Resolve (fty, subst_mappings);
@@ -688,6 +690,7 @@ FnType::handle_substitions (SubstitutionArgumentMappings subst_mappings)
   for (auto &param : fn->get_params ())
     {
       auto fty = param.second;
+
       bool is_param_ty = fty->get_kind () == TypeKind::PARAM;
       if (is_param_ty)
 	{
@@ -718,7 +721,8 @@ FnType::handle_substitions (SubstitutionArgumentMappings subst_mappings)
 	      fty->set_ty_ref (argt->get_ref ());
 	    }
 	}
-      else if (fty->has_subsititions_defined ())
+      else if (fty->has_subsititions_defined ()
+	       || fty->contains_type_parameters ())
 	{
 	  BaseType *concrete
 	    = Resolver::SubstMapperInternal::Resolve (fty, subst_mappings);
@@ -1210,6 +1214,22 @@ ReferenceType::clone ()
 			    get_combined_refs ());
 }
 
+ReferenceType *
+ReferenceType::handle_substitions (SubstitutionArgumentMappings mappings)
+{
+  auto mappings_table = Analysis::Mappings::get ();
+
+  ReferenceType *ref = static_cast<ReferenceType *> (clone ());
+  ref->set_ty_ref (mappings_table->get_next_hir_id ());
+
+  // might be &T or &ADT so this needs to be recursive
+  auto base = ref->get_base ();
+  BaseType *concrete = Resolver::SubstMapperInternal::Resolve (base, mappings);
+  ref->base = TyVar (concrete->get_ty_ref ());
+
+  return ref;
+}
+
 void
 ParamType::accept_vis (TyVisitor &vis)
 {
@@ -1287,6 +1307,20 @@ ParamType::is_equal (const BaseType &other) const
     return BaseType::is_equal (other);
 
   return resolve ()->is_equal (other);
+}
+
+ParamType *
+ParamType::handle_substitions (SubstitutionArgumentMappings mappings)
+{
+  ParamType *p = static_cast<ParamType *> (clone ());
+
+  SubstitutionArg arg = SubstitutionArg::error ();
+  bool ok = mappings.get_argument_for_symbol (this, &arg);
+  rust_assert (ok);
+
+  p->set_ty_ref (arg.get_tyty ()->get_ref ());
+
+  return p;
 }
 
 BaseType *

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -122,6 +122,8 @@ public:
 
   virtual bool needs_generic_substitutions () const { return false; }
 
+  virtual bool contains_type_parameters () const { return false; }
+
   std::string mappings_str () const
   {
     std::string buffer = "Ref: " + std::to_string (get_ref ())
@@ -242,6 +244,7 @@ public:
   std::string get_name () const override final { return as_string (); }
 };
 
+class SubstitutionArgumentMappings;
 class ParamType : public BaseType
 {
 public:
@@ -277,6 +280,18 @@ public:
   std::string get_name () const override final { return as_string (); }
 
   bool is_equal (const BaseType &other) const override;
+
+  bool contains_type_parameters () const override final
+  {
+    if (can_resolve ())
+      {
+	auto r = resolve ();
+	return r->contains_type_parameters ();
+      }
+    return true;
+  }
+
+  ParamType *handle_substitions (SubstitutionArgumentMappings mappings);
 
 private:
   std::string symbol;
@@ -1211,6 +1226,13 @@ public:
   bool is_equal (const BaseType &other) const override;
 
   BaseType *clone () final override;
+
+  bool contains_type_parameters () const override final
+  {
+    return get_base ()->contains_type_parameters ();
+  }
+
+  ReferenceType *handle_substitions (SubstitutionArgumentMappings mappings);
 
 private:
   TyVar base;

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -379,6 +379,18 @@ public:
 
   std::string get_name () const override final { return as_string (); }
 
+  bool contains_type_parameters () const override final
+  {
+    for (auto &f : fields)
+      {
+	if (f.get_tyty ()->contains_type_parameters ())
+	  return true;
+      }
+    return false;
+  }
+
+  TupleType *handle_substitions (SubstitutionArgumentMappings mappings);
+
 private:
   std::vector<TyVar> fields;
 };

--- a/gcc/testsuite/rust.test/compile/generics21.rs
+++ b/gcc/testsuite/rust.test/compile/generics21.rs
@@ -1,0 +1,13 @@
+fn callee<T>(t: &T) -> i32 {
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+    32
+}
+
+fn caller(t: i32) -> i32 {
+    callee(&t)
+}
+
+fn main() {
+    let a;
+    a = caller(123);
+}

--- a/gcc/testsuite/rust.test/compile/generics22.rs
+++ b/gcc/testsuite/rust.test/compile/generics22.rs
@@ -1,0 +1,13 @@
+fn callee<T>(t: (T, bool)) -> i32 {
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+    32
+}
+
+fn caller(t: i32) -> i32 {
+    callee((t, false))
+}
+
+fn main() {
+    let a;
+    a = caller(123);
+}


### PR DESCRIPTION
We need to perform internal substitutions on Reference and Tuple Types in order to type check them.

These types cannot hold substitution parameters so they need to be performed with the internal substitution mapper.

Fixes #396 