### PR TITLE
Add locations to implicit inference variables

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -696,6 +696,7 @@ public:
   void visit (HIR::ArrayExpr &expr) override
   {
     HIR::ArrayElems *elements = expr.get_internal_elements ();
+    root_array_expr_locus = expr.get_locus ();
 
     elements->accept_vis (*this);
     if (infered_array_elems == nullptr)
@@ -717,7 +718,8 @@ public:
       return true;
     });
 
-    infered_array_elems = TyTy::TyVar::get_implicit_infer_var ().get_tyty ();
+    infered_array_elems
+      = TyTy::TyVar::get_implicit_infer_var (root_array_expr_locus).get_tyty ();
 
     for (auto &type : types)
       {
@@ -1152,6 +1154,7 @@ private:
      Stores the type of array elements, if `expr` is ArrayExpr. */
   TyTy::BaseType *infered_array_elems;
   Bexpression *folded_array_capacity;
+  Location root_array_expr_locus;
 
   bool inside_loop;
 }; // namespace Resolver

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -50,7 +50,6 @@ TypeResolution::Resolve (HIR::Crate &crate)
   if (saw_errors ())
     return;
 
-  auto resolver = Resolver::Resolver::get ();
   auto mappings = Analysis::Mappings::get ();
   auto context = TypeCheckContext::get ();
 
@@ -70,7 +69,13 @@ TypeResolution::Resolve (HIR::Crate &crate)
     TyTy::InferType *infer_var = (TyTy::InferType *) ty;
     TyTy::BaseType *default_type;
     bool ok = infer_var->default_type (&default_type);
-    if (ok)
+    if (!ok)
+      {
+	rust_error_at (mappings->lookup_location (id),
+		       "type annotations needed");
+	return true;
+      }
+    else
       {
 	auto result = ty->unify (default_type);
 	result->set_ref (id);
@@ -80,42 +85,6 @@ TypeResolution::Resolve (HIR::Crate &crate)
 	  result);
       }
 
-    return true;
-  });
-
-  // scan the ribs to ensure the decls are all setup correctly
-  resolver->iterate_name_ribs ([&] (Rib *r) -> bool {
-    r->iterate_decls ([&] (NodeId decl_node_id, Location locus) -> bool {
-      Definition def;
-      if (!resolver->lookup_definition (decl_node_id, &def))
-	{
-	  rust_error_at (locus, "failed to lookup decl def");
-	  return true;
-	}
-
-      HirId hir_node = UNKNOWN_HIRID;
-      if (!mappings->lookup_node_to_hir (mappings->get_current_crate (),
-					 def.parent, &hir_node))
-	{
-	  rust_error_at (locus, "failed to lookup type hir node id");
-	  return true;
-	}
-
-      // lookup the ty
-      TyTy::BaseType *ty = nullptr;
-      bool ok = context->lookup_type (hir_node, &ty);
-      if (!ok)
-	{
-	  rust_error_at (locus, "failed to lookup type for decl node_id: %u",
-			 decl_node_id);
-	  return true;
-	}
-
-      if (!ty->is_concrete ())
-	rust_error_at (locus, "unable to determine type");
-
-      return true;
-    });
     return true;
   });
 }
@@ -269,8 +238,8 @@ TypeCheckStructExpr::visit (HIR::StructExprStructFields &struct_expr)
 
   // everything is ok, now we need to ensure all field values are ordered
   // correctly. The GIMPLE backend uses a simple algorithm that assumes each
-  // assigned field in the constructor is in the same order as the field in the
-  // type
+  // assigned field in the constructor is in the same order as the field in
+  // the type
 
   std::vector<std::unique_ptr<HIR::StructExprField> > expr_fields
     = struct_expr.get_fields_as_owner ();

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -52,7 +52,7 @@ TyVar::get_tyty () const
 }
 
 TyVar
-TyVar::get_implicit_infer_var ()
+TyVar::get_implicit_infer_var (Location locus)
 {
   auto mappings = Analysis::Mappings::get ();
   auto context = Resolver::TypeCheckContext::get ();
@@ -64,6 +64,8 @@ TyVar::get_implicit_infer_var ()
 					       infer->get_ref (),
 					       UNKNOWN_LOCAL_DEFID),
 			infer);
+  mappings->insert_location (mappings->get_current_crate (), infer->get_ref (),
+			     locus);
   return TyVar (infer->get_ref ());
 }
 

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -171,7 +171,7 @@ public:
 
   BaseType *get_tyty () const;
 
-  static TyVar get_implicit_infer_var ();
+  static TyVar get_implicit_infer_var (Location locus);
 
 private:
   HirId ref;
@@ -695,7 +695,7 @@ public:
     std::vector<SubstitutionArg> args;
     for (auto &sub : get_substs ())
       {
-	TyVar infer_var = TyVar::get_implicit_infer_var ();
+	TyVar infer_var = TyVar::get_implicit_infer_var (locus);
 	args.push_back (SubstitutionArg (&sub, infer_var.get_tyty ()));
       }
 

--- a/gcc/testsuite/rust.test/xfail_compile/array_empty_list.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/array_empty_list.rs
@@ -1,4 +1,4 @@
-// { dg-error "unable to determine type" "" { target { *-*-* } } 0 }
 fn main() {
     let arr = [];
+    // { dg-error "type annotations needed" "" { target { *-*-* } } .-1 }
 }

--- a/gcc/testsuite/rust.test/xfail_compile/generics11.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/generics11.rs
@@ -1,0 +1,12 @@
+struct Foo<T>(T, bool);
+
+impl<T> Foo<T> {
+    fn test() -> i32 {
+        123
+    }
+}
+
+fn main() {
+    let a = Foo::test();
+    // { dg-error "type annotations needed" "" { target { *-*-* } } .-1 }
+}


### PR DESCRIPTION
When we have expression paths to generic functions we need to resolve all
type parameters to something otherwise we are left with orphaned inference
variables.

This adds the same checks from rustc back in, previously the
PathInExpression resolver abused inference variables as it was implemented
incorrectly since this is fixed in previous PRs we can bring this back in
to make typing more strict again.

Fixes #375