### PR TITLE
Fix crashing in assignment operation

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -11456,6 +11456,9 @@ Parser<ManagedTokenSource>::parse_stmt_or_expr_with_block (
   std::vector<AST::Attribute> outer_attrs)
 {
   auto expr = parse_expr_with_block (std::move (outer_attrs));
+  if (expr == nullptr)
+	  return ExprOrStmt::create_error();
+
   auto tok = lexer.peek_token ();
 
   // tail expr in a block expr

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -11457,7 +11457,7 @@ Parser<ManagedTokenSource>::parse_stmt_or_expr_with_block (
 {
   auto expr = parse_expr_with_block (std::move (outer_attrs));
   if (expr == nullptr)
-	  return ExprOrStmt::create_error();
+    return ExprOrStmt::create_error ();
 
   auto tok = lexer.peek_token ();
 

--- a/gcc/testsuite/rust.test/xfail_compile/issue-407.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/issue-407.rs
@@ -1,0 +1,5 @@
+// { dg-excess-errors "failed to parse" }
+fn test()  {
+    let mut a = 1;
+    a + = 1; // { dg-error "found unexpected token ‘=’ in null denotation"
+}


### PR DESCRIPTION
This should fix #407 
The output now looks like:
```
test1.rs:9:17: error: found unexpected token ‘=’ in null denotation
    9 |             a + = 1;
      |                 ^
test1.rs:9:13: error: failed to parse expression for expression without block (pratt-parsed expression is null)
    9 |             a + = 1;
      |             ^
test1.rs:9:13: error: failed to parse statement or expression without block in block expression
test1.rs:9:19: error: failed to parse if body block expression in if expression
    9 |             a + = 1;
      |                   ^
test1.rs:8:9: error: failed to parse expr with block in parsing expr statement
    8 |         if a < 40 {
      |         ^
test1.rs:8:9: error: failed to parse statement or expression without block in block expression
test1.rs:10:11: error: could not parse loop body in (infinite) loop expression
   10 |         } else {
      |           ^
test1.rs:7:5: error: failed to parse expr with block in parsing expr statement
    7 |     loop {
      |     ^
test1.rs:7:5: error: failed to parse statement or expression without block in block expression
test1.rs:14:5: error: unrecognised token ‘return’ for start of item
   14 |     return a;
      |     ^
test1.rs:14:5: error: failed to parse item in crate
```