### PR TITLE
We need to monomorphize tuples as well as ADT's

### DIFF
--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -66,7 +66,7 @@ public:
   bool lookup_compiled_types (HirId id, ::Btype **type,
 			      const TyTy::BaseType *ref = nullptr)
   {
-    if (ref != nullptr && ref->has_subsititions_defined ())
+    if (ref != nullptr)
       {
 	for (auto it = mono.begin (); it != mono.end (); it++)
 	  {
@@ -393,7 +393,8 @@ public:
 	return;
       }
 
-    bool ok = ctx->lookup_compiled_types (type.get_ty_ref (), &translated);
+    bool ok
+      = ctx->lookup_compiled_types (type.get_ty_ref (), &translated, &type);
     if (ok)
       return;
 
@@ -402,8 +403,7 @@ public:
     for (size_t i = 0; i < type.num_fields (); i++)
       {
 	TyTy::BaseType *field = type.get_field (i);
-	Btype *compiled_field_ty
-	  = TyTyCompile::compile (ctx->get_backend (), field);
+	Btype *compiled_field_ty = TyTyResolveCompile::compile (ctx, field);
 
 	Backend::Btyped_identifier f (std::to_string (i), compiled_field_ty,
 				      ctx->get_mappings ()->lookup_location (
@@ -418,7 +418,7 @@ public:
 					   type.get_ty_ref ()));
 
     ctx->push_type (named_struct);
-    ctx->insert_compiled_type (type.get_ty_ref (), named_struct);
+    ctx->insert_compiled_type (type.get_ty_ref (), named_struct, &type);
     translated = named_struct;
   }
 

--- a/gcc/testsuite/rust.test/compile/generics26.rs
+++ b/gcc/testsuite/rust.test/compile/generics26.rs
@@ -1,0 +1,21 @@
+// github issue #415
+fn test<A, B>(a: A, b: B) -> (A, B) {
+    (a, b)
+}
+
+fn main() {
+    let a = test::<i32, i32>(123, 456);
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+
+    let b = test::<f32, f32>(123f32, 456f32);
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+
+    let c = test::<_, _>(123, 456f32);
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+
+    let d = test(true, 1234);
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+
+    let e = test((123, false), 123f32);
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust.test/compile/generics27.rs
+++ b/gcc/testsuite/rust.test/compile/generics27.rs
@@ -1,0 +1,16 @@
+// github issue #415
+fn test<A>(a: &A) -> &A {
+    a
+}
+
+fn main() {
+    let a = 123;
+    let b = &a;
+    let c = test(b);
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+
+    let a = 123f32;
+    let b = &a;
+    let c = test(b);
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
When we have generic data types or types that can contain type parameters
we need to make sure to avoid duplicating record types and abusing
structural equality rules in GCC. We do this by looking for already
compiled types that the item is equal to so they refer to the canoncial
record type.

Fixes #415