### PR TITLE
Add testcase to cover case where type param cannot be infered

### DIFF
--- a/gcc/testsuite/rust.test/xfail_compile/generics12.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/generics12.rs
@@ -1,0 +1,6 @@
+fn main() {
+    bar();
+    // { dg-error "type annotations needed" "" { target *-*-* } .-1 }
+}
+
+fn bar<T>() {}


### PR DESCRIPTION
When the Type paramater is not used we cannot infer the type and we should
error this was fixed in #375.

Fixes #420