### PR TITLE
Fixed #419: only parse inner_attributes if it starts with "#!" not only "#"

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -442,7 +442,9 @@ Parser<ManagedTokenSource>::parse_inner_attributes ()
 {
   std::vector<AST::Attribute> inner_attributes;
 
-  while (lexer.peek_token ()->get_id () == HASH)
+  // only try to parse it if it starts with "#!" not only "#"
+  while (lexer.peek_token ()->get_id () == HASH
+	 && lexer.peek_token (1)->get_id () == EXCLAM)
     {
       AST::Attribute inner_attr = parse_inner_attribute ();
 

--- a/gcc/testsuite/rust.test/compile/top_attr.rs
+++ b/gcc/testsuite/rust.test/compile/top_attr.rs
@@ -1,0 +1,5 @@
+#![crate_name = "name"]
+
+
+#[allow(dead_code)]
+fn main() {}


### PR DESCRIPTION
Fixed #419

only parse inner_attributes if it starts with "#!" not only "#"
