### PR TITLE
Fix raw identifier parsing.

### DIFF
--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -743,6 +743,9 @@ Lexer::build_token ()
 	      TokenPtr raw_ident_ptr = parse_raw_identifier (loc);
 	      if (raw_ident_ptr != nullptr)
 		return raw_ident_ptr;
+	      else
+		continue; /* input got parsed, it just wasn't valid. An error
+			     was produced. */
 	    }
 	  else
 	    {
@@ -1523,11 +1526,9 @@ Lexer::parse_raw_identifier (Location loc)
 
   current_column += 2;
 
-  str += current_char;
-
   bool first_is_underscore = current_char == '_';
 
-  int length = 1;
+  int length = 0;
   current_char = peek_input ();
   // loop through entire name
   while (ISALPHA (current_char) || ISDIGIT (current_char)

--- a/gcc/testsuite/rust.test/compile/raw_identifiers.rs
+++ b/gcc/testsuite/rust.test/compile/raw_identifiers.rs
@@ -1,0 +1,3 @@
+pub fn square(num: i32) -> i32 { /* { dg-warning "used" } */
+    r#num * num
+}

--- a/gcc/testsuite/rust.test/compile/raw_identifiers_keywords.rs
+++ b/gcc/testsuite/rust.test/compile/raw_identifiers_keywords.rs
@@ -1,0 +1,3 @@
+pub fn plus(r#break: i32, r#unsafe: i32) -> i32 { /* { dg-warning "used" } */
+    r#break + r#unsafe
+}

--- a/gcc/testsuite/rust.test/xfail_compile/raw_identifiers_bad_keywords.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/raw_identifiers_bad_keywords.rs
@@ -1,0 +1,3 @@
+pub fn plus(n: i32, m: i32) -> i32 {
+    r#crate /* { dg-error "forbidden raw identifier" } */
+}

--- a/gcc/testsuite/rust.test/xfail_compile/raw_identifiers_underscore.rs
+++ b/gcc/testsuite/rust.test/xfail_compile/raw_identifiers_underscore.rs
@@ -1,0 +1,3 @@
+pub fn s(num: i32) -> i32 {
+    r#_ * num /* { dg-error "not a valid raw identifier" } */
+}


### PR DESCRIPTION
Lexer::parse_raw_identifier added the first character twice.

Adds tests for a simple raw identifier, a keyword as raw identifier and
xfail tests for a single underscore and forbidden keyword (crate) as raw
identifier.

To help error diagnostics continue after parse_raw_identifier failed in
Lexer::build_token.

Fixes: https://github.com/Rust-GCC/gccrs/issues/426