### PR TITLE
Initialize crateNumItr in rust-hir-map to zero.

### DIFF
--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -198,7 +198,7 @@ public:
 private:
   Mappings ();
 
-  CrateNum crateNumItr;
+  CrateNum crateNumItr = 0;
   CrateNum currentCrateNum;
 
   std::map<CrateNum, HirId> hirIdIter;


### PR DESCRIPTION
valgrind complains whenever a crate number is used because they are all
derived from the initial crateNumItr in the rust-hir-map Mapping which
is never initialized. This isn't technically a bug because all that is
required is for crate numbers to be unique. But it could cause
non-deterministic behaviour when crate numbers are used for sorting.
And it makes the valgrind output really noisy.

With this patch and configure --enable-valgrind-annotations running
rust1 should not give any valgrind errors.