### PR TITLE
Fix assert in rust-buffered-queue peek

### DIFF
--- a/gcc/rust/rust-buffered-queue.h
+++ b/gcc/rust/rust-buffered-queue.h
@@ -101,7 +101,7 @@ public:
 	     * reallocation upon resizing */
 
 	    // validate that buffer is large enough now
-	    rust_assert (end + num_queued_items < (int) buffer.size ());
+	    rust_assert (end + num_items_to_read <= (int) buffer.size ());
 	  }
 
 	/* iterate through buffer and invoke operator () on source on values


### PR DESCRIPTION
When end + num_items_to_read > buffer.size the buffer is extended to make sure it
can hold at least the extra num_items_to_read. The assert at the end of this block
however checks against end + num_queued_items. Fix the assert. This makes check-rust
zero fail on arm64.