### PR TITLE
Fix aarch64 config for rust

### DIFF
--- a/gcc/config/aarch64/aarch64-protos.h
+++ b/gcc/config/aarch64/aarch64-protos.h
@@ -786,6 +786,9 @@ std::string aarch64_get_extension_string_for_isa_flags (uint64_t, uint64_t);
 /* Defined in aarch64-d.c  */
 extern void aarch64_d_target_versions (void);
 
+/* In aarch64-rust.c  */
+extern void aarch64_rust_target_cpu_info (void);
+
 rtl_opt_pass *make_pass_fma_steering (gcc::context *);
 rtl_opt_pass *make_pass_track_speculation (gcc::context *);
 rtl_opt_pass *make_pass_tag_collision_avoidance (gcc::context *);

--- a/gcc/config/aarch64/aarch64-rust.c
+++ b/gcc/config/aarch64/aarch64-rust.c
@@ -55,7 +55,7 @@ void aarch64_rust_target_cpu_info(void) {
         rust_add_target_info("target_feature", "rcpc");
     if (TARGET_DOTPROD)
         rust_add_target_info("target_feature", "dotprod");
-    if (AARCH64_ISA_V8_1)
+    if (aarch64_isa_flags & AARCH64_FL_V8_2)
         rust_add_target_info("target_feature", "v8.1a");
     if (AARCH64_ISA_V8_2)
         rust_add_target_info("target_feature", "v8.2a");


### PR DESCRIPTION
Define aarch64_rust_target_cpu_info in aarch64-protos.h.
AARCH64_ISA_V8_1 isn't defined directly, check aarch64_isa_flags.