### PR TITLE
Mention the identifier that was unused in ScanUnused.

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-unused.h
+++ b/gcc/rust/resolve/rust-ast-resolve-unused.h
@@ -38,7 +38,7 @@ public:
       if (!r->have_references_for_node (decl_node_id)
 	  && ident.get ().at (0) != '_')
 	{
-	  rust_warning_at (locus, 0, "unused name");
+	  rust_warning_at (locus, 0, "unused name '%s'", ident.get ().c_str ());
 	}
       return true;
     });


### PR DESCRIPTION
The ScanUnused class would only mention some name was unused.
Add the actual identifier name that is unused to help the user.

Note that this warning might produce a similar warning as the
ScanDeadcode class produces if the indentifier is a function.
