### PR TITLE
Fix v8.1a typo in gcc/config/aarch64/aarch64-rust.c

### DIFF
--- a/gcc/config/aarch64/aarch64-rust.c
+++ b/gcc/config/aarch64/aarch64-rust.c
@@ -55,7 +55,7 @@ void aarch64_rust_target_cpu_info(void) {
         rust_add_target_info("target_feature", "rcpc");
     if (TARGET_DOTPROD)
         rust_add_target_info("target_feature", "dotprod");
-    if (aarch64_isa_flags & AARCH64_FL_V8_2)
+    if (aarch64_isa_flags & AARCH64_FL_V8_1)
         rust_add_target_info("target_feature", "v8.1a");
     if (AARCH64_ISA_V8_2)
         rust_add_target_info("target_feature", "v8.2a");


### PR DESCRIPTION
commit dcb3a7b62 "Fix aarch64 config for rust" fixed the build
on arm64, but introduced a typo in the aarch64_isa_flags check.
AARCH64_FL_V8_2 should have been AARCH64_FL_V8_1 for "v8.1a".
