### PR TITLE
include memmodel.h above tm_p.h in order to build success in SPARC64

### DIFF
--- a/gcc/config/sparc/sparc-rust.c
+++ b/gcc/config/sparc/sparc-rust.c
@@ -19,6 +19,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "system.h"
 #include "coretypes.h"
 #include "tm.h"
+#include "memmodel.h"
 #include "tm_p.h"
 #include "rust/rust-target.h"
 #include "rust/rust-target-def.h"

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -26,6 +26,7 @@
 
 #include "target.h"
 #include "tm.h"
+#include "memmodel.h"
 #include "tm_p.h"
 
 //#include "rust-target.h"


### PR DESCRIPTION
Fixes #450

Include "memmodel.h" above "tm_p.h" in order to build success in SPARC64

I had built rust1 in SPARC64 but got some fail tests. It's another independent issue I think.
```
Running target unix
Using /usr/share/dejagnu/baseboards/unix.exp as board description file for target.
Using /usr/share/dejagnu/config/unix.exp as generic interface file for target.
Using /home/thomasyoung/gccrs/gcc/testsuite/config/default.exp as tool-and-target-specific interface file.
Running /home/thomasyoung/gccrs/gcc/testsuite/rust.test/compile/compile.exp ...
FAIL: rust.test/compile/generics11.rs   -O0  (internal compiler error)
FAIL: rust.test/compile/generics11.rs   -O0  (test for excess errors)
FAIL: rust.test/compile/generics11.rs   -O1  (internal compiler error)
FAIL: rust.test/compile/generics11.rs   -O1  (test for excess errors)
FAIL: rust.test/compile/generics11.rs   -O2  (internal compiler error)
FAIL: rust.test/compile/generics11.rs   -O2  (test for excess errors)
FAIL: rust.test/compile/generics11.rs   -O3 -g  (internal compiler error)
FAIL: rust.test/compile/generics11.rs   -O3 -g  (test for excess errors)
FAIL: rust.test/compile/generics11.rs   -Os  (internal compiler error)
FAIL: rust.test/compile/generics11.rs   -Os  (test for excess errors)
FAIL: rust.test/compile/generics11.rs   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (internal compiler error)
FAIL: rust.test/compile/generics11.rs   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
FAIL: rust.test/compile/generics11.rs   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (internal compiler error)
FAIL: rust.test/compile/generics11.rs   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
FAIL: rust.test/compile/struct_init_2.rs   -O0  (internal compiler error)
FAIL: rust.test/compile/struct_init_2.rs   -O0   (test for warnings, line 4)
FAIL: rust.test/compile/struct_init_2.rs   -O0  (test for excess errors)
FAIL: rust.test/compile/struct_init_2.rs   -O1  (internal compiler error)
FAIL: rust.test/compile/struct_init_2.rs   -O1   (test for warnings, line 4)
FAIL: rust.test/compile/struct_init_2.rs   -O1  (test for excess errors)
FAIL: rust.test/compile/struct_init_2.rs   -O2  (internal compiler error)
FAIL: rust.test/compile/struct_init_2.rs   -O2   (test for warnings, line 4)
FAIL: rust.test/compile/struct_init_2.rs   -O2  (test for excess errors)
FAIL: rust.test/compile/struct_init_2.rs   -O3 -g  (internal compiler error)
FAIL: rust.test/compile/struct_init_2.rs   -O3 -g   (test for warnings, line 4)
FAIL: rust.test/compile/struct_init_2.rs   -O3 -g  (test for excess errors)
FAIL: rust.test/compile/struct_init_2.rs   -Os  (internal compiler error)
FAIL: rust.test/compile/struct_init_2.rs   -Os   (test for warnings, line 4)
FAIL: rust.test/compile/struct_init_2.rs   -Os  (test for excess errors)
FAIL: rust.test/compile/struct_init_2.rs   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (internal compiler error)
FAIL: rust.test/compile/struct_init_2.rs   -O2 -flto -fno-use-linker-plugin -flto-partition=none   (test for warnings, line 4)
FAIL: rust.test/compile/struct_init_2.rs   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
FAIL: rust.test/compile/struct_init_2.rs   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (internal compiler error)
FAIL: rust.test/compile/struct_init_2.rs   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   (test for warnings, line 4)
FAIL: rust.test/compile/struct_init_2.rs   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
FAIL: rust.test/compile/struct_init_3.rs   -O0  (internal compiler error)
FAIL: rust.test/compile/struct_init_3.rs   -O0   (test for warnings, line 9)
FAIL: rust.test/compile/struct_init_3.rs   -O0  (test for excess errors)
FAIL: rust.test/compile/struct_init_3.rs   -O1  (internal compiler error)
FAIL: rust.test/compile/struct_init_3.rs   -O1   (test for warnings, line 9)
FAIL: rust.test/compile/struct_init_3.rs   -O1  (test for excess errors)
FAIL: rust.test/compile/struct_init_3.rs   -O2  (internal compiler error)
FAIL: rust.test/compile/struct_init_3.rs   -O2   (test for warnings, line 9)
FAIL: rust.test/compile/struct_init_3.rs   -O2  (test for excess errors)
FAIL: rust.test/compile/struct_init_3.rs   -O3 -g  (internal compiler error)
FAIL: rust.test/compile/struct_init_3.rs   -O3 -g   (test for warnings, line 9)
FAIL: rust.test/compile/struct_init_3.rs   -O3 -g  (test for excess errors)
FAIL: rust.test/compile/struct_init_3.rs   -Os  (internal compiler error)
FAIL: rust.test/compile/struct_init_3.rs   -Os   (test for warnings, line 9)
FAIL: rust.test/compile/struct_init_3.rs   -Os  (test for excess errors)
FAIL: rust.test/compile/struct_init_3.rs   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (internal compiler error)
FAIL: rust.test/compile/struct_init_3.rs   -O2 -flto -fno-use-linker-plugin -flto-partition=none   (test for warnings, line 9)
FAIL: rust.test/compile/struct_init_3.rs   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
FAIL: rust.test/compile/struct_init_3.rs   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (internal compiler error)
FAIL: rust.test/compile/struct_init_3.rs   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   (test for warnings, line 9)
FAIL: rust.test/compile/struct_init_3.rs   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
FAIL: rust.test/compile/struct_init_8.rs   -O0  (internal compiler error)
FAIL: rust.test/compile/struct_init_8.rs   -O0   (test for warnings, line 5)
FAIL: rust.test/compile/struct_init_8.rs   -O0  (test for excess errors)
FAIL: rust.test/compile/struct_init_8.rs   -O1  (internal compiler error)
FAIL: rust.test/compile/struct_init_8.rs   -O1   (test for warnings, line 5)
FAIL: rust.test/compile/struct_init_8.rs   -O1  (test for excess errors)
FAIL: rust.test/compile/struct_init_8.rs   -O2  (internal compiler error)
FAIL: rust.test/compile/struct_init_8.rs   -O2   (test for warnings, line 5)
FAIL: rust.test/compile/struct_init_8.rs   -O2  (test for excess errors)
FAIL: rust.test/compile/struct_init_8.rs   -O3 -g  (internal compiler error)
FAIL: rust.test/compile/struct_init_8.rs   -O3 -g   (test for warnings, line 5)
FAIL: rust.test/compile/struct_init_8.rs   -O3 -g  (test for excess errors)
FAIL: rust.test/compile/struct_init_8.rs   -Os  (internal compiler error)
FAIL: rust.test/compile/struct_init_8.rs   -Os   (test for warnings, line 5)
FAIL: rust.test/compile/struct_init_8.rs   -Os  (test for excess errors)
FAIL: rust.test/compile/struct_init_8.rs   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (internal compiler error)
FAIL: rust.test/compile/struct_init_8.rs   -O2 -flto -fno-use-linker-plugin -flto-partition=none   (test for warnings, line 5)
FAIL: rust.test/compile/struct_init_8.rs   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
FAIL: rust.test/compile/struct_init_8.rs   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (internal compiler error)
FAIL: rust.test/compile/struct_init_8.rs   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   (test for warnings, line 5)
FAIL: rust.test/compile/struct_init_8.rs   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
Running /home/thomasyoung/gccrs/gcc/testsuite/rust.test/execute/execute.exp ...
Running /home/thomasyoung/gccrs/gcc/testsuite/rust.test/unsupported/unsupported.exp ...
Running /home/thomasyoung/gccrs/gcc/testsuite/rust.test/xfail_compile/xfail_compile.exp ...
FAIL: rust.test/xfail_compile/struct_init1.rs (internal compiler error)
FAIL: rust.test/xfail_compile/struct_init1.rs  (test for errors, line 7)
FAIL: rust.test/xfail_compile/struct_init1.rs  (test for errors, line 7)
FAIL: rust.test/xfail_compile/struct_init1.rs (test for excess errors)

		=== rust Summary ===

# of expected passes		2284
# of unexpected failures	81
# of expected failures		26
```