### PR TITLE
reusing AST::Attribute and remove HIR::Attribute

### DIFF
--- a/gcc/rust/analysis/rust-hir-liveness-base.h
+++ b/gcc/rust/analysis/rust-hir-liveness-base.h
@@ -33,8 +33,6 @@ class LivenessBase : public HIR::HIRVisitor
 public:
   virtual ~LivenessBase () {}
   virtual void visit (HIR::Token &) override {}
-  virtual void visit (HIR::DelimTokenTree &) override {}
-  virtual void visit (HIR::AttrInputMetaItemContainer &) override {}
   virtual void visit (HIR::IdentifierExpr &) override {}
   virtual void visit (HIR::Lifetime &) override {}
   virtual void visit (HIR::LifetimeParam &) override {}
@@ -47,9 +45,6 @@ public:
   virtual void visit (HIR::QualifiedPathInType &) override {}
 
   virtual void visit (HIR::LiteralExpr &) override {}
-  virtual void visit (HIR::AttrInputLiteral &) override {}
-  virtual void visit (HIR::MetaItemLitExpr &) override {}
-  virtual void visit (HIR::MetaItemPathLit &) override {}
   virtual void visit (HIR::BorrowExpr &) override {}
   virtual void visit (HIR::DereferenceExpr &) override {}
   virtual void visit (HIR::ErrorPropagationExpr &) override {}
@@ -161,12 +156,6 @@ public:
   virtual void visit (HIR::MacroMatcher &) override {}
   virtual void visit (HIR::MacroRulesDefinition &) override {}
   virtual void visit (HIR::MacroInvocation &) override {}
-  virtual void visit (HIR::MetaItemPath &) override {}
-  virtual void visit (HIR::MetaItemSeq &) override {}
-  virtual void visit (HIR::MetaWord &) override {}
-  virtual void visit (HIR::MetaNameValueStr &) override {}
-  virtual void visit (HIR::MetaListPaths &) override {}
-  virtual void visit (HIR::MetaListNameValueStr &) override {}
 
   virtual void visit (HIR::LiteralPattern &) override {}
   virtual void visit (HIR::IdentifierPattern &) override {}

--- a/gcc/rust/ast/rust-ast-full-test.cc
+++ b/gcc/rust/ast/rust-ast-full-test.cc
@@ -3998,6 +3998,14 @@ MaybeNamedParam::as_string () const
   return str;
 }
 
+MetaItemInner::~MetaItemInner () = default;
+
+std::unique_ptr<MetaNameValueStr>
+MetaItemInner::to_meta_name_value_str () const
+{
+  return nullptr;
+}
+
 std::string
 MetaItemSeq::as_string () const
 {

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -38,6 +38,7 @@ struct Session;
 namespace AST {
 // foward decl: ast visitor
 class ASTVisitor;
+using AttrVec = std::vector<Attribute>;
 
 // Delimiter types - used in macros and whatever.
 enum DelimType
@@ -583,7 +584,7 @@ public:
     return std::unique_ptr<MetaItemInner> (clone_meta_item_inner_impl ());
   }
 
-  virtual ~MetaItemInner () {}
+  virtual ~MetaItemInner ();
 
   virtual std::string as_string () const = 0;
 
@@ -591,10 +592,7 @@ public:
 
   /* HACK: used to simplify parsing - creates a copy of that type, or returns
    * null */
-  virtual std::unique_ptr<MetaNameValueStr> to_meta_name_value_str () const
-  {
-    return nullptr;
-  }
+  virtual std::unique_ptr<MetaNameValueStr> to_meta_name_value_str () const;
 
   // HACK: used to simplify parsing - same thing
   virtual SimplePath to_path_item () const

--- a/gcc/rust/backend/rust-compile-base.h
+++ b/gcc/rust/backend/rust-compile-base.h
@@ -32,13 +32,7 @@ public:
   virtual ~HIRCompileBase () {}
 
   // rust-ast.h
-  // virtual void visit(AttrInput& attr_input) {}
-  // virtual void visit(TokenTree& token_tree) {}
-  // virtual void visit(MacroMatch& macro_match) {}
   virtual void visit (HIR::Token &tok) {}
-  virtual void visit (HIR::DelimTokenTree &delim_tok_tree) {}
-  virtual void visit (HIR::AttrInputMetaItemContainer &input) {}
-  // virtual void visit(MetaItem& meta_item) {}
   // virtual void visit(Stmt& stmt) {}
   // virtual void visit(Expr& expr) {}
   virtual void visit (HIR::IdentifierExpr &ident_expr) {}
@@ -63,9 +57,6 @@ public:
 
   // rust-expr.h
   virtual void visit (HIR::LiteralExpr &expr) {}
-  virtual void visit (HIR::AttrInputLiteral &attr_input) {}
-  virtual void visit (HIR::MetaItemLitExpr &meta_item) {}
-  virtual void visit (HIR::MetaItemPathLit &meta_item) {}
   virtual void visit (HIR::BorrowExpr &expr) {}
   virtual void visit (HIR::DereferenceExpr &expr) {}
   virtual void visit (HIR::ErrorPropagationExpr &expr) {}
@@ -179,12 +170,6 @@ public:
   virtual void visit (HIR::MacroMatcher &matcher) {}
   virtual void visit (HIR::MacroRulesDefinition &rules_def) {}
   virtual void visit (HIR::MacroInvocation &macro_invoc) {}
-  virtual void visit (HIR::MetaItemPath &meta_item) {}
-  virtual void visit (HIR::MetaItemSeq &meta_item) {}
-  virtual void visit (HIR::MetaWord &meta_item) {}
-  virtual void visit (HIR::MetaNameValueStr &meta_item) {}
-  virtual void visit (HIR::MetaListPaths &meta_item) {}
-  virtual void visit (HIR::MetaListNameValueStr &meta_item) {}
 
   // rust-pattern.h
   virtual void visit (HIR::LiteralPattern &pattern) {}

--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -3273,7 +3273,7 @@ MacroExpander::expand_invoc (std::unique_ptr<AST::MacroInvocation> &invoc)
 /* Determines whether any cfg predicate is false and hence item with attributes
  * should be stripped. Note that attributes must be expanded before calling. */
 bool
-MacroExpander::fails_cfg (const std::vector<AST::Attribute> &attrs) const
+MacroExpander::fails_cfg (const AST::AttrVec &attrs) const
 {
   for (const auto &attr : attrs)
     {
@@ -3286,7 +3286,7 @@ MacroExpander::fails_cfg (const std::vector<AST::Attribute> &attrs) const
 /* Determines whether any cfg predicate is false and hence item with attributes
  * should be stripped. Will expand attributes as well. */
 bool
-MacroExpander::fails_cfg_with_expand (std::vector<AST::Attribute> &attrs) const
+MacroExpander::fails_cfg_with_expand (AST::AttrVec &attrs) const
 {
   // TODO: maybe have something that strips cfg attributes that evaluate true?
   for (auto &attr : attrs)
@@ -3329,7 +3329,7 @@ MacroExpander::fails_cfg_with_expand (std::vector<AST::Attribute> &attrs) const
 
 // Expands cfg_attr attributes.
 void
-MacroExpander::expand_cfg_attrs (std::vector<AST::Attribute> &attrs)
+MacroExpander::expand_cfg_attrs (AST::AttrVec &attrs)
 {
   for (std::size_t i = 0; i < attrs.size (); i++)
     {
@@ -3342,8 +3342,7 @@ MacroExpander::expand_cfg_attrs (std::vector<AST::Attribute> &attrs)
 	  if (attr.check_cfg_predicate (session))
 	    {
 	      // split off cfg_attr
-	      std::vector<AST::Attribute> new_attrs
-		= attr.separate_cfg_attrs ();
+	      AST::AttrVec new_attrs = attr.separate_cfg_attrs ();
 
 	      // remove attr from vector
 	      attrs.erase (attrs.begin () + i);

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -67,9 +67,9 @@ struct MacroExpander
   AST::ASTFragment expand_decl_macro (AST::MacroInvocData &invoc,
 				      AST::MacroRulesDefinition &rules_def);
 
-  void expand_cfg_attrs (std::vector<AST::Attribute> &attrs);
-  bool fails_cfg (const std::vector<AST::Attribute> &attr) const;
-  bool fails_cfg_with_expand (std::vector<AST::Attribute> &attrs) const;
+  void expand_cfg_attrs (AST::AttrVec &attrs);
+  bool fails_cfg (const AST::AttrVec &attr) const;
+  bool fails_cfg_with_expand (AST::AttrVec &attrs) const;
 
   // Expand the data of a cfg! macro.
   void parse_macro_to_meta_item (AST::MacroInvocData &invoc);

--- a/gcc/rust/hir/rust-ast-lower-block.h
+++ b/gcc/rust/hir/rust-ast-lower-block.h
@@ -142,7 +142,7 @@ public:
 
   void visit (AST::LoopExpr &expr) override
   {
-    std::vector<HIR::Attribute> outer_attribs;
+    AST::AttrVec outer_attribs;
     HIR::BlockExpr *loop_block
       = ASTLoweringBlock::translate (expr.get_loop_block ().get (),
 				     &terminated);

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -80,7 +80,7 @@ public:
 
   void visit (AST::TupleIndexExpr &expr) override
   {
-    std::vector<HIR::Attribute> outer_attribs;
+    AST::AttrVec outer_attribs;
 
     HIR::Expr *tuple_expr
       = ASTLoweringExpr::translate (expr.get_tuple_expr ().get (), &terminated);
@@ -99,8 +99,8 @@ public:
 
   void visit (AST::TupleExpr &expr) override
   {
-    std::vector<HIR::Attribute> inner_attribs;
-    std::vector<HIR::Attribute> outer_attribs;
+    AST::AttrVec inner_attribs;
+    AST::AttrVec outer_attribs;
     std::vector<std::unique_ptr<HIR::Expr> > tuple_elements;
     for (auto &e : expr.get_tuple_elems ())
       {
@@ -163,7 +163,7 @@ public:
 
   void visit (AST::CallExpr &expr) override
   {
-    std::vector<HIR::Attribute> outer_attribs;
+    AST::AttrVec outer_attribs;
     HIR::Expr *func
       = ASTLoweringExpr::translate (expr.get_function_expr ().get ());
     std::vector<std::unique_ptr<HIR::Expr> > params;
@@ -186,7 +186,7 @@ public:
 
   void visit (AST::MethodCallExpr &expr) override
   {
-    std::vector<HIR::Attribute> outer_attribs;
+    AST::AttrVec outer_attribs;
 
     HIR::PathExprSegment method_path
       = lower_path_expr_seg (expr.get_method_name ());
@@ -240,8 +240,8 @@ public:
 
   void visit (AST::ArrayExpr &expr) override
   {
-    std::vector<HIR::Attribute> outer_attribs;
-    std::vector<HIR::Attribute> inner_attribs;
+    AST::AttrVec outer_attribs;
+    AST::AttrVec inner_attribs;
 
     expr.get_array_elems ()->accept_vis (*this);
     rust_assert (translated_array_elems != nullptr);
@@ -259,7 +259,7 @@ public:
 
   void visit (AST::ArrayIndexExpr &expr) override
   {
-    std::vector<Attribute> outer_attribs;
+    AST::AttrVec outer_attribs;
     HIR::Expr *array_expr
       = ASTLoweringExpr::translate (expr.get_array_expr ().get ());
     HIR::Expr *array_index_expr
@@ -402,7 +402,7 @@ public:
 
   void visit (AST::NegationExpr &expr) override
   {
-    std::vector<HIR::Attribute> outer_attribs;
+    AST::AttrVec outer_attribs;
 
     HIR::Expr *negated_value
       = ASTLoweringExpr::translate (expr.get_negated_expr ().get ());
@@ -482,8 +482,8 @@ public:
 
   void visit (AST::StructExprStructFields &struct_expr) override
   {
-    std::vector<HIR::Attribute> inner_attribs;
-    std::vector<HIR::Attribute> outer_attribs;
+    AST::AttrVec inner_attribs;
+    AST::AttrVec outer_attribs;
 
     // bit of a hack for now
     HIR::PathInExpression *path
@@ -522,8 +522,8 @@ public:
 
   void visit (AST::GroupedExpr &expr) override
   {
-    std::vector<HIR::Attribute> inner_attribs;
-    std::vector<HIR::Attribute> outer_attribs;
+    AST::AttrVec inner_attribs;
+    AST::AttrVec outer_attribs;
 
     HIR::Expr *paren_expr
       = ASTLoweringExpr::translate (expr.get_expr_in_parens ().get ());
@@ -541,8 +541,8 @@ public:
 
   void visit (AST::FieldAccessExpr &expr) override
   {
-    std::vector<HIR::Attribute> inner_attribs;
-    std::vector<HIR::Attribute> outer_attribs;
+    AST::AttrVec inner_attribs;
+    AST::AttrVec outer_attribs;
 
     HIR::Expr *receiver
       = ASTLoweringExpr::translate (expr.get_receiver_expr ().get ());
@@ -570,7 +570,7 @@ public:
 
   void visit (AST::BreakExpr &expr) override
   {
-    std::vector<HIR::Attribute> outer_attribs;
+    AST::AttrVec outer_attribs;
     HIR::Lifetime break_label = lower_lifetime (expr.get_label ());
     HIR::Expr *break_expr
       = expr.has_break_expr ()
@@ -590,7 +590,7 @@ public:
 
   void visit (AST::ContinueExpr &expr) override
   {
-    std::vector<HIR::Attribute> outer_attribs;
+    AST::AttrVec outer_attribs;
     HIR::Lifetime break_label = lower_lifetime (expr.get_label ());
 
     auto crate_num = mappings->get_current_crate ();
@@ -605,7 +605,7 @@ public:
 
   void visit (AST::BorrowExpr &expr) override
   {
-    std::vector<HIR::Attribute> outer_attribs;
+    AST::AttrVec outer_attribs;
 
     HIR::Expr *borrow_lvalue
       = ASTLoweringExpr::translate (expr.get_borrowed_expr ().get ());
@@ -624,7 +624,7 @@ public:
 
   void visit (AST::DereferenceExpr &expr) override
   {
-    std::vector<HIR::Attribute> outer_attribs;
+    AST::AttrVec outer_attribs;
 
     HIR::Expr *dref_lvalue
       = ASTLoweringExpr::translate (expr.get_dereferenced_expr ().get ());

--- a/gcc/rust/hir/rust-ast-lower-implitem.h
+++ b/gcc/rust/hir/rust-ast-lower-implitem.h
@@ -60,7 +60,7 @@ public:
 
   void visit (AST::ConstantItem &constant) override
   {
-    std::vector<HIR::Attribute> outer_attrs;
+    AST::AttrVec outer_attrs;
     HIR::Visibility vis = HIR::Visibility::create_public ();
 
     HIR::Type *type = ASTLoweringType::translate (constant.get_type ().get ());
@@ -86,7 +86,7 @@ public:
   void visit (AST::Function &function) override
   {
     // ignore for now and leave empty
-    std::vector<HIR::Attribute> outer_attrs;
+    AST::AttrVec outer_attrs;
     std::vector<std::unique_ptr<HIR::WhereClauseItem> > where_clause_items;
     HIR::WhereClause where_clause (std::move (where_clause_items));
     HIR::FunctionQualifiers qualifiers (
@@ -169,7 +169,7 @@ public:
   void visit (AST::Method &method) override
   {
     // ignore for now and leave empty
-    std::vector<HIR::Attribute> outer_attrs;
+    AST::AttrVec outer_attrs;
     std::vector<std::unique_ptr<HIR::WhereClauseItem> > where_clause_items;
     HIR::WhereClause where_clause (std::move (where_clause_items));
     HIR::FunctionQualifiers qualifiers (

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -58,7 +58,7 @@ public:
     std::vector<std::unique_ptr<HIR::WhereClauseItem> > where_clause_items;
     HIR::WhereClause where_clause (std::move (where_clause_items));
     HIR::Visibility vis = HIR::Visibility::create_public ();
-    std::vector<HIR::Attribute> outer_attrs;
+    AST::AttrVec outer_attrs;
 
     std::vector<std::unique_ptr<HIR::GenericParam> > generic_params;
     if (alias.has_generics ())
@@ -98,11 +98,11 @@ public:
     std::vector<std::unique_ptr<HIR::WhereClauseItem> > where_clause_items;
     HIR::WhereClause where_clause (std::move (where_clause_items));
     HIR::Visibility vis = HIR::Visibility::create_public ();
-    std::vector<HIR::Attribute> outer_attrs;
+    AST::AttrVec outer_attrs;
 
     std::vector<HIR::TupleField> fields;
     struct_decl.iterate ([&] (AST::TupleField &field) mutable -> bool {
-      std::vector<HIR::Attribute> outer_attrs;
+      AST::AttrVec outer_attrs;
       HIR::Visibility vis = HIR::Visibility::create_public ();
       HIR::Type *type
 	= ASTLoweringType::translate (field.get_field_type ().get ());
@@ -154,12 +154,12 @@ public:
     std::vector<std::unique_ptr<HIR::WhereClauseItem> > where_clause_items;
     HIR::WhereClause where_clause (std::move (where_clause_items));
     HIR::Visibility vis = HIR::Visibility::create_public ();
-    std::vector<HIR::Attribute> outer_attrs;
+    AST::AttrVec outer_attrs;
 
     bool is_unit = struct_decl.is_unit_struct ();
     std::vector<HIR::StructField> fields;
     struct_decl.iterate ([&] (AST::StructField &field) mutable -> bool {
-      std::vector<HIR::Attribute> outer_attrs;
+      AST::AttrVec outer_attrs;
       HIR::Visibility vis = HIR::Visibility::create_public ();
       HIR::Type *type
 	= ASTLoweringType::translate (field.get_field_type ().get ());
@@ -201,7 +201,7 @@ public:
 
   void visit (AST::StaticItem &var) override
   {
-    std::vector<HIR::Attribute> outer_attrs;
+    AST::AttrVec outer_attrs;
     HIR::Visibility vis = HIR::Visibility::create_public ();
 
     HIR::Type *type = ASTLoweringType::translate (var.get_type ().get ());
@@ -227,7 +227,7 @@ public:
 
   void visit (AST::ConstantItem &constant) override
   {
-    std::vector<HIR::Attribute> outer_attrs;
+    AST::AttrVec outer_attrs;
     HIR::Visibility vis = HIR::Visibility::create_public ();
 
     HIR::Type *type = ASTLoweringType::translate (constant.get_type ().get ());
@@ -253,7 +253,7 @@ public:
   void visit (AST::Function &function) override
   {
     // ignore for now and leave empty
-    std::vector<HIR::Attribute> outer_attrs;
+    AST::AttrVec outer_attrs;
     std::vector<std::unique_ptr<HIR::WhereClauseItem> > where_clause_items;
     HIR::WhereClause where_clause (std::move (where_clause_items));
     HIR::FunctionQualifiers qualifiers (
@@ -337,8 +337,8 @@ public:
 
   void visit (AST::InherentImpl &impl_block) override
   {
-    std::vector<HIR::Attribute> inner_attrs;
-    std::vector<HIR::Attribute> outer_attrs;
+    AST::AttrVec inner_attrs;
+    AST::AttrVec outer_attrs;
     std::vector<std::unique_ptr<HIR::WhereClauseItem> > where_clause_items;
 
     HIR::WhereClause where_clause (std::move (where_clause_items));

--- a/gcc/rust/hir/rust-ast-lower-stmt.h
+++ b/gcc/rust/hir/rust-ast-lower-stmt.h
@@ -86,7 +86,7 @@ public:
 
   void visit (AST::LetStmt &stmt) override
   {
-    std::vector<HIR::Attribute> outer_attrs;
+    AST::AttrVec outer_attrs;
     HIR::Pattern *variables
       = ASTLoweringPattern::translate (stmt.get_pattern ().get ());
     HIR::Type *type = stmt.has_type ()

--- a/gcc/rust/hir/rust-ast-lower-type.h
+++ b/gcc/rust/hir/rust-ast-lower-type.h
@@ -295,7 +295,7 @@ public:
 
   void visit (AST::TypeParam &param) override
   {
-    HIR::Attribute outer_attr = HIR::Attribute::create_empty ();
+    AST::Attribute outer_attr = AST::Attribute::create_empty ();
     std::vector<std::unique_ptr<HIR::TypeParamBound> > type_param_bounds;
     HIR::Type *type = param.has_type ()
 			? ASTLoweringType::translate (param.get_type ().get ())

--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -40,7 +40,7 @@ HIR::Crate
 ASTLowering::go ()
 {
   std::vector<std::unique_ptr<HIR::Item> > items;
-  std::vector<HIR::Attribute> inner_attrs;
+  AST::AttrVec inner_attrs;
   bool has_utf8bom = false;
   bool has_shebang = false;
 
@@ -65,8 +65,8 @@ ASTLowering::go ()
 void
 ASTLoweringBlock::visit (AST::BlockExpr &expr)
 {
-  std::vector<HIR::Attribute> inner_attribs;
-  std::vector<HIR::Attribute> outer_attribs;
+  AST::AttrVec inner_attribs;
+  AST::AttrVec outer_attribs;
 
   std::vector<std::unique_ptr<HIR::Stmt> > block_stmts;
   bool block_did_terminate = false;
@@ -240,7 +240,7 @@ ASTLowerStructExprField::visit (AST::StructExprFieldIdentifier &field)
 void
 ASTLoweringExprWithBlock::visit (AST::WhileLoopExpr &expr)
 {
-  std::vector<HIR::Attribute> outer_attribs;
+  AST::AttrVec outer_attribs;
   HIR::BlockExpr *loop_block
     = ASTLoweringBlock::translate (expr.get_loop_block ().get (), &terminated);
 

--- a/gcc/rust/hir/tree/rust-hir-cond-compilation.h
+++ b/gcc/rust/hir/tree/rust-hir-cond-compilation.h
@@ -19,6 +19,7 @@
 #ifndef RUST_AST_CONDCOMPILATION
 #define RUST_AST_CONDCOMPILATION
 
+#include "rust-ast-full-decls.h"
 #include "rust-hir.h"
 
 namespace Rust {
@@ -206,18 +207,18 @@ public:
 // TODO: inline
 struct CfgAttrs
 {
-  std::vector<Attribute> cfg_attrs;
+  AST::AttrVec cfg_attrs;
 };
 
 // TODO: relationship to other attributes?
 class CfgAttrAttribute
 {
   std::unique_ptr<ConfigurationPredicate> config_to_include;
-  std::vector<Attribute> cfg_attrs;
+  AST::AttrVec cfg_attrs;
 
 public:
   CfgAttrAttribute (ConfigurationPredicate *config_to_include,
-		    std::vector<Attribute> cfg_attrs)
+		    AST::AttrVec cfg_attrs)
     : config_to_include (config_to_include), cfg_attrs (cfg_attrs)
   {}
 

--- a/gcc/rust/hir/tree/rust-hir-full-decls.h
+++ b/gcc/rust/hir/tree/rust-hir-full-decls.h
@@ -24,19 +24,10 @@
 namespace Rust {
 namespace HIR {
 // rust-ast.h
-class AttrInput;
 class TokenTree;
 class MacroMatch;
 class Token;
 struct Literal;
-class DelimTokenTree;
-class PathSegment;
-class SimplePathSegment;
-class SimplePath;
-struct Attribute;
-class MetaItemInner;
-class AttrInputMetaItemContainer;
-class MetaItem;
 class Stmt;
 class Item;
 class Expr;
@@ -76,8 +67,6 @@ class QualifiedPathInType;
 class ExprWithBlock;
 class LiteralExpr;
 class AttrInputLiteral;
-class MetaItemLitExpr;
-class MetaItemPathLit;
 class OperatorExpr;
 class BorrowExpr;
 class DereferenceExpr;
@@ -227,12 +216,6 @@ struct MacroTranscriber;
 struct MacroRule;
 class MacroRulesDefinition;
 class MacroInvocation;
-class MetaItemPath;
-class MetaItemSeq;
-class MetaWord;
-class MetaNameValueStr;
-class MetaListPaths;
-class MetaListNameValueStr;
 
 // rust-pattern.h
 class LiteralPattern;

--- a/gcc/rust/hir/tree/rust-hir-path.h
+++ b/gcc/rust/hir/tree/rust-hir-path.h
@@ -243,7 +243,8 @@ protected:
 
   /* Converts path segments to their equivalent SimplePath segments if possible,
    * and creates a SimplePath from them. */
-  SimplePath convert_to_simple_path (bool with_opening_scope_resolution) const;
+  AST::SimplePath
+  convert_to_simple_path (bool with_opening_scope_resolution) const;
 
 public:
   /* Returns whether the path is a single segment (excluding qualified path
@@ -285,8 +286,8 @@ public:
 		    std::vector<PathExprSegment> path_segments,
 		    Location locus = Location (),
 		    bool has_opening_scope_resolution = false,
-		    std::vector<Attribute> outer_attrs
-		    = std::vector<Attribute> ())
+		    std::vector<AST::Attribute> outer_attrs
+		    = std::vector<AST::Attribute> ())
     : PathPattern (std::move (path_segments)),
       PathExpr (std::move (mappings), std::move (outer_attrs)),
       has_opening_scope_resolution (has_opening_scope_resolution), locus (locus)
@@ -304,7 +305,7 @@ public:
 
   /* Converts PathInExpression to SimplePath if possible (i.e. no generic
    * arguments). Otherwise returns an empty SimplePath. */
-  SimplePath as_simple_path () const
+  AST::SimplePath as_simple_path () const
   {
     /* delegate to parent class as can't access segments. however,
      * QualifiedPathInExpression conversion to simple path wouldn't make sense,
@@ -655,7 +656,7 @@ public:
 
   /* Converts TypePath to SimplePath if possible (i.e. no generic or function
    * arguments). Otherwise returns an empty SimplePath. */
-  SimplePath as_simple_path () const;
+  AST::SimplePath as_simple_path () const;
 
   // Creates a trait bound with a clone of this type path as its only element.
   TraitBound *to_trait_bound (bool in_parens) const override;
@@ -750,8 +751,8 @@ public:
 			     QualifiedPathType qual_path_type,
 			     std::vector<PathExprSegment> path_segments,
 			     Location locus = Location (),
-			     std::vector<Attribute> outer_attrs
-			     = std::vector<Attribute> ())
+			     std::vector<AST::Attribute> outer_attrs
+			     = std::vector<AST::Attribute> ())
     : PathPattern (std::move (path_segments)),
       PathExpr (std::move (mappings), std::move (outer_attrs)),
       path_type (std::move (qual_path_type)), locus (locus)

--- a/gcc/rust/hir/tree/rust-hir-pattern.h
+++ b/gcc/rust/hir/tree/rust-hir-pattern.h
@@ -376,26 +376,26 @@ protected:
 struct StructPatternEtc
 {
 private:
-  std::vector<Attribute> outer_attrs;
+  AST::AttrVec outer_attrs;
 
   // should this store location data?
 
 public:
-  StructPatternEtc (std::vector<Attribute> outer_attribs)
+  StructPatternEtc (AST::AttrVec outer_attribs)
     : outer_attrs (std::move (outer_attribs))
   {}
 
   // Creates an empty StructPatternEtc
   static StructPatternEtc create_empty ()
   {
-    return StructPatternEtc (std::vector<Attribute> ());
+    return StructPatternEtc (AST::AttrVec ());
   }
 };
 
 // Base class for a single field in a struct pattern - abstract
 class StructPatternField
 {
-  std::vector<Attribute> outer_attrs;
+  AST::AttrVec outer_attrs;
   Location locus;
 
 public:
@@ -415,7 +415,7 @@ public:
   virtual void accept_vis (HIRVisitor &vis) = 0;
 
 protected:
-  StructPatternField (std::vector<Attribute> outer_attribs, Location locus)
+  StructPatternField (AST::AttrVec outer_attribs, Location locus)
     : outer_attrs (std::move (outer_attribs)), locus (locus)
   {}
 
@@ -432,8 +432,7 @@ class StructPatternFieldTuplePat : public StructPatternField
 public:
   StructPatternFieldTuplePat (TupleIndex index,
 			      std::unique_ptr<Pattern> tuple_pattern,
-			      std::vector<Attribute> outer_attribs,
-			      Location locus)
+			      AST::AttrVec outer_attribs, Location locus)
     : StructPatternField (std::move (outer_attribs), locus), index (index),
       tuple_pattern (std::move (tuple_pattern))
   {}
@@ -483,8 +482,7 @@ class StructPatternFieldIdentPat : public StructPatternField
 public:
   StructPatternFieldIdentPat (Identifier ident,
 			      std::unique_ptr<Pattern> ident_pattern,
-			      std::vector<Attribute> outer_attrs,
-			      Location locus)
+			      AST::AttrVec outer_attrs, Location locus)
     : StructPatternField (std::move (outer_attrs), locus),
       ident (std::move (ident)), ident_pattern (std::move (ident_pattern))
   {}
@@ -534,7 +532,7 @@ class StructPatternFieldIdent : public StructPatternField
 
 public:
   StructPatternFieldIdent (Identifier ident, bool is_ref, bool is_mut,
-			   std::vector<Attribute> outer_attrs, Location locus)
+			   AST::AttrVec outer_attrs, Location locus)
     : StructPatternField (std::move (outer_attrs), locus), has_ref (is_ref),
       has_mut (is_mut), ident (std::move (ident))
   {}

--- a/gcc/rust/hir/tree/rust-hir-stmt.h
+++ b/gcc/rust/hir/tree/rust-hir-stmt.h
@@ -52,7 +52,7 @@ protected:
 class LetStmt : public Stmt
 {
   // bool has_outer_attrs;
-  std::vector<Attribute> outer_attrs;
+  AST::AttrVec outer_attrs;
 
   std::unique_ptr<Pattern> variables_pattern;
 
@@ -79,7 +79,7 @@ public:
   LetStmt (Analysis::NodeMapping mappings,
 	   std::unique_ptr<Pattern> variables_pattern,
 	   std::unique_ptr<Expr> init_expr, std::unique_ptr<Type> type,
-	   std::vector<Attribute> outer_attrs, Location locus)
+	   AST::AttrVec outer_attrs, Location locus)
     : Stmt (std::move (mappings)), outer_attrs (std::move (outer_attrs)),
       variables_pattern (std::move (variables_pattern)),
       type (std::move (type)), init_expr (std::move (init_expr)), locus (locus)

--- a/gcc/rust/hir/tree/rust-hir-visitor.h
+++ b/gcc/rust/hir/tree/rust-hir-visitor.h
@@ -37,8 +37,8 @@ public:
   // virtual void visit(TokenTree& token_tree) = 0;
   // virtual void visit(MacroMatch& macro_match) = 0;
   virtual void visit (Token &tok) = 0;
-  virtual void visit (DelimTokenTree &delim_tok_tree) = 0;
-  virtual void visit (AttrInputMetaItemContainer &input) = 0;
+  // virtual void visit (DelimTokenTree &delim_tok_tree) = 0;
+  // virtual void visit (AttrInputMetaItemContainer &input) = 0;
   // virtual void visit(MetaItem& meta_item) = 0;
   // virtual void visit(Stmt& stmt) = 0;
   // virtual void visit(Expr& expr) = 0;
@@ -64,9 +64,9 @@ public:
 
   // rust-expr.h
   virtual void visit (LiteralExpr &expr) = 0;
-  virtual void visit (AttrInputLiteral &attr_input) = 0;
-  virtual void visit (MetaItemLitExpr &meta_item) = 0;
-  virtual void visit (MetaItemPathLit &meta_item) = 0;
+  // virtual void visit (AttrInputLiteral &attr_input) = 0;
+  // virtual void visit (MetaItemLitExpr &meta_item) = 0;
+  // virtual void visit (MetaItemPathLit &meta_item) = 0;
   virtual void visit (BorrowExpr &expr) = 0;
   virtual void visit (DereferenceExpr &expr) = 0;
   virtual void visit (ErrorPropagationExpr &expr) = 0;
@@ -179,12 +179,12 @@ public:
   virtual void visit (MacroMatcher &matcher) = 0;
   virtual void visit (MacroRulesDefinition &rules_def) = 0;
   virtual void visit (MacroInvocation &macro_invoc) = 0;
-  virtual void visit (MetaItemPath &meta_item) = 0;
-  virtual void visit (MetaItemSeq &meta_item) = 0;
-  virtual void visit (MetaWord &meta_item) = 0;
-  virtual void visit (MetaNameValueStr &meta_item) = 0;
-  virtual void visit (MetaListPaths &meta_item) = 0;
-  virtual void visit (MetaListNameValueStr &meta_item) = 0;
+  // virtual void visit (MetaItemPath &meta_item) = 0;
+  // virtual void visit (MetaItemSeq &meta_item) = 0;
+  // virtual void visit (MetaWord &meta_item) = 0;
+  // virtual void visit (MetaNameValueStr &meta_item) = 0;
+  // virtual void visit (MetaListPaths &meta_item) = 0;
+  // virtual void visit (MetaListNameValueStr &meta_item) = 0;
 
   // rust-pattern.h
   virtual void visit (LiteralPattern &pattern) = 0;

--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -101,9 +101,9 @@ private:
   void parse_statement_seq (bool (Parser::*done) ());
 
   // AST-related stuff - maybe move or something?
-  std::vector<AST::Attribute> parse_inner_attributes ();
+  AST::AttrVec parse_inner_attributes ();
   AST::Attribute parse_inner_attribute ();
-  std::vector<AST::Attribute> parse_outer_attributes ();
+  AST::AttrVec parse_outer_attributes ();
   AST::Attribute parse_outer_attribute ();
   AST::Attribute parse_attribute_body ();
   std::unique_ptr<AST::AttrInput> parse_attr_input ();
@@ -128,11 +128,11 @@ private:
   AST::DelimTokenTree parse_delim_token_tree ();
   std::unique_ptr<AST::TokenTree> parse_token_tree ();
   std::unique_ptr<AST::MacroRulesDefinition>
-  parse_macro_rules_def (std::vector<AST::Attribute> outer_attrs);
+  parse_macro_rules_def (AST::AttrVec outer_attrs);
   std::unique_ptr<AST::MacroInvocationSemi>
-  parse_macro_invocation_semi (std::vector<AST::Attribute> outer_attrs);
+  parse_macro_invocation_semi (AST::AttrVec outer_attrs);
   std::unique_ptr<AST::MacroInvocation>
-  parse_macro_invocation (std::vector<AST::Attribute> outer_attrs);
+  parse_macro_invocation (AST::AttrVec outer_attrs);
   AST::MacroRule parse_macro_rule ();
   AST::MacroMatcher parse_macro_matcher ();
   std::unique_ptr<AST::MacroMatch> parse_macro_match ();
@@ -142,23 +142,20 @@ private:
   // Top-level item-related
   std::vector<std::unique_ptr<AST::Item> > parse_items ();
   std::unique_ptr<AST::Item> parse_item (bool called_from_statement);
-  std::unique_ptr<AST::VisItem>
-  parse_vis_item (std::vector<AST::Attribute> outer_attrs);
-  std::unique_ptr<AST::MacroItem>
-  parse_macro_item (std::vector<AST::Attribute> outer_attrs);
+  std::unique_ptr<AST::VisItem> parse_vis_item (AST::AttrVec outer_attrs);
+  std::unique_ptr<AST::MacroItem> parse_macro_item (AST::AttrVec outer_attrs);
   AST::Visibility parse_visibility ();
 
   // VisItem subclass-related
-  std::unique_ptr<AST::Module>
-  parse_module (AST::Visibility vis, std::vector<AST::Attribute> outer_attrs);
+  std::unique_ptr<AST::Module> parse_module (AST::Visibility vis,
+					     AST::AttrVec outer_attrs);
   std::unique_ptr<AST::ExternCrate>
-  parse_extern_crate (AST::Visibility vis,
-		      std::vector<AST::Attribute> outer_attrs);
+  parse_extern_crate (AST::Visibility vis, AST::AttrVec outer_attrs);
   std::unique_ptr<AST::UseDeclaration>
-  parse_use_decl (AST::Visibility vis, std::vector<AST::Attribute> outer_attrs);
+  parse_use_decl (AST::Visibility vis, AST::AttrVec outer_attrs);
   std::unique_ptr<AST::UseTree> parse_use_tree ();
-  std::unique_ptr<AST::Function>
-  parse_function (AST::Visibility vis, std::vector<AST::Attribute> outer_attrs);
+  std::unique_ptr<AST::Function> parse_function (AST::Visibility vis,
+						 AST::AttrVec outer_attrs);
   AST::FunctionQualifiers parse_function_qualifiers ();
   std::vector<std::unique_ptr<AST::GenericParam> >
   parse_generic_params_in_angles ();
@@ -207,359 +204,328 @@ private:
   template <typename EndTokenPred>
   std::vector<AST::Lifetime> parse_lifetime_bounds (EndTokenPred is_end_token);
   AST::Lifetime parse_lifetime ();
-  std::unique_ptr<AST::TypeAlias>
-  parse_type_alias (AST::Visibility vis,
-		    std::vector<AST::Attribute> outer_attrs);
-  std::unique_ptr<AST::Struct>
-  parse_struct (AST::Visibility vis, std::vector<AST::Attribute> outer_attrs);
+  std::unique_ptr<AST::TypeAlias> parse_type_alias (AST::Visibility vis,
+						    AST::AttrVec outer_attrs);
+  std::unique_ptr<AST::Struct> parse_struct (AST::Visibility vis,
+					     AST::AttrVec outer_attrs);
   std::vector<AST::StructField> parse_struct_fields ();
   template <typename EndTokenPred>
   std::vector<AST::StructField> parse_struct_fields (EndTokenPred is_end_token);
   AST::StructField parse_struct_field ();
   std::vector<AST::TupleField> parse_tuple_fields ();
   AST::TupleField parse_tuple_field ();
-  std::unique_ptr<AST::Enum>
-  parse_enum (AST::Visibility vis, std::vector<AST::Attribute> outer_attrs);
+  std::unique_ptr<AST::Enum> parse_enum (AST::Visibility vis,
+					 AST::AttrVec outer_attrs);
   std::vector<std::unique_ptr<AST::EnumItem> > parse_enum_items ();
   template <typename EndTokenPred>
   std::vector<std::unique_ptr<AST::EnumItem> >
   parse_enum_items (EndTokenPred is_end_token);
   std::unique_ptr<AST::EnumItem> parse_enum_item ();
-  std::unique_ptr<AST::Union>
-  parse_union (AST::Visibility vis, std::vector<AST::Attribute> outer_attrs);
+  std::unique_ptr<AST::Union> parse_union (AST::Visibility vis,
+					   AST::AttrVec outer_attrs);
   std::unique_ptr<AST::ConstantItem>
-  parse_const_item (AST::Visibility vis,
-		    std::vector<AST::Attribute> outer_attrs);
-  std::unique_ptr<AST::StaticItem>
-  parse_static_item (AST::Visibility vis,
-		     std::vector<AST::Attribute> outer_attrs);
-  std::unique_ptr<AST::Trait>
-  parse_trait (AST::Visibility vis, std::vector<AST::Attribute> outer_attrs);
+  parse_const_item (AST::Visibility vis, AST::AttrVec outer_attrs);
+  std::unique_ptr<AST::StaticItem> parse_static_item (AST::Visibility vis,
+						      AST::AttrVec outer_attrs);
+  std::unique_ptr<AST::Trait> parse_trait (AST::Visibility vis,
+					   AST::AttrVec outer_attrs);
   std::unique_ptr<AST::TraitItem> parse_trait_item ();
   std::unique_ptr<AST::TraitItemType>
-  parse_trait_type (std::vector<AST::Attribute> outer_attrs);
+  parse_trait_type (AST::AttrVec outer_attrs);
   std::unique_ptr<AST::TraitItemConst>
-  parse_trait_const (std::vector<AST::Attribute> outer_attrs);
+  parse_trait_const (AST::AttrVec outer_attrs);
   AST::SelfParam parse_self_param ();
-  std::unique_ptr<AST::Impl>
-  parse_impl (AST::Visibility vis, std::vector<AST::Attribute> outer_attrs);
+  std::unique_ptr<AST::Impl> parse_impl (AST::Visibility vis,
+					 AST::AttrVec outer_attrs);
   std::unique_ptr<AST::InherentImplItem> parse_inherent_impl_item ();
   std::unique_ptr<AST::InherentImplItem>
-  parse_inherent_impl_function_or_method (
-    AST::Visibility vis, std::vector<AST::Attribute> outer_attrs);
+  parse_inherent_impl_function_or_method (AST::Visibility vis,
+					  AST::AttrVec outer_attrs);
   std::unique_ptr<AST::TraitImplItem> parse_trait_impl_item ();
   std::unique_ptr<AST::TraitImplItem>
   parse_trait_impl_function_or_method (AST::Visibility vis,
-				       std::vector<AST::Attribute> outer_attrs);
+				       AST::AttrVec outer_attrs);
   std::unique_ptr<AST::ExternBlock>
-  parse_extern_block (AST::Visibility vis,
-		      std::vector<AST::Attribute> outer_attrs);
+  parse_extern_block (AST::Visibility vis, AST::AttrVec outer_attrs);
   std::unique_ptr<AST::ExternalItem> parse_external_item ();
-  AST::NamedFunctionParam
-  parse_named_function_param (std::vector<AST::Attribute> outer_attrs
-			      = std::vector<AST::Attribute> ());
+  AST::NamedFunctionParam parse_named_function_param (AST::AttrVec outer_attrs
+						      = AST::AttrVec ());
   AST::Method parse_method ();
 
   // Expression-related (Pratt parsed)
-  std::unique_ptr<AST::Expr> parse_expr (std::vector<AST::Attribute> outer_attrs
-					 = std::vector<AST::Attribute> (),
-					 ParseRestrictions restrictions
-					 = ParseRestrictions ());
-  std::unique_ptr<AST::Expr> parse_expr (int right_binding_power,
-					 std::vector<AST::Attribute> outer_attrs
-					 = std::vector<AST::Attribute> (),
-					 ParseRestrictions restrictions
-					 = ParseRestrictions ());
   std::unique_ptr<AST::Expr>
-  null_denotation (const_TokenPtr t,
-		   std::vector<AST::Attribute> outer_attrs
-		   = std::vector<AST::Attribute> (),
+  parse_expr (AST::AttrVec outer_attrs = AST::AttrVec (),
+	      ParseRestrictions restrictions = ParseRestrictions ());
+  std::unique_ptr<AST::Expr>
+  parse_expr (int right_binding_power,
+	      AST::AttrVec outer_attrs = AST::AttrVec (),
+	      ParseRestrictions restrictions = ParseRestrictions ());
+  std::unique_ptr<AST::Expr>
+  null_denotation (const_TokenPtr t, AST::AttrVec outer_attrs = AST::AttrVec (),
 		   ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::Expr>
   left_denotation (const_TokenPtr t, std::unique_ptr<AST::Expr> left,
-		   std::vector<AST::Attribute> outer_attrs
-		   = std::vector<AST::Attribute> (),
+		   AST::AttrVec outer_attrs = AST::AttrVec (),
 		   ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::ArithmeticOrLogicalExpr>
   parse_arithmetic_or_logical_expr (
     const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-    std::vector<AST::Attribute> outer_attrs,
-    AST::ArithmeticOrLogicalExpr::ExprType expr_type,
+    AST::AttrVec outer_attrs, AST::ArithmeticOrLogicalExpr::ExprType expr_type,
     ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::ArithmeticOrLogicalExpr>
   parse_binary_plus_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-			  std::vector<AST::Attribute> outer_attrs,
+			  AST::AttrVec outer_attrs,
 			  ParseRestrictions restrictions
 			  = ParseRestrictions ());
   std::unique_ptr<AST::ArithmeticOrLogicalExpr>
   parse_binary_minus_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-			   std::vector<AST::Attribute> outer_attrs,
+			   AST::AttrVec outer_attrs,
 			   ParseRestrictions restrictions
 			   = ParseRestrictions ());
   std::unique_ptr<AST::ArithmeticOrLogicalExpr>
   parse_binary_mult_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-			  std::vector<AST::Attribute> outer_attrs,
+			  AST::AttrVec outer_attrs,
 			  ParseRestrictions restrictions
 			  = ParseRestrictions ());
   std::unique_ptr<AST::ArithmeticOrLogicalExpr>
   parse_binary_div_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-			 std::vector<AST::Attribute> outer_attrs,
+			 AST::AttrVec outer_attrs,
 			 ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::ArithmeticOrLogicalExpr>
   parse_binary_mod_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-			 std::vector<AST::Attribute> outer_attrs,
+			 AST::AttrVec outer_attrs,
 			 ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::ArithmeticOrLogicalExpr>
   parse_bitwise_and_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-			  std::vector<AST::Attribute> outer_attrs,
+			  AST::AttrVec outer_attrs,
 			  ParseRestrictions restrictions
 			  = ParseRestrictions ());
   std::unique_ptr<AST::ArithmeticOrLogicalExpr>
   parse_bitwise_or_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-			 std::vector<AST::Attribute> outer_attrs,
+			 AST::AttrVec outer_attrs,
 			 ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::ArithmeticOrLogicalExpr>
   parse_bitwise_xor_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-			  std::vector<AST::Attribute> outer_attrs,
+			  AST::AttrVec outer_attrs,
 			  ParseRestrictions restrictions
 			  = ParseRestrictions ());
   std::unique_ptr<AST::ArithmeticOrLogicalExpr>
   parse_left_shift_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-			 std::vector<AST::Attribute> outer_attrs,
+			 AST::AttrVec outer_attrs,
 			 ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::ArithmeticOrLogicalExpr>
   parse_right_shift_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-			  std::vector<AST::Attribute> outer_attrs,
+			  AST::AttrVec outer_attrs,
 			  ParseRestrictions restrictions
 			  = ParseRestrictions ());
   std::unique_ptr<AST::ComparisonExpr>
   parse_comparison_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-			 std::vector<AST::Attribute> outer_attrs,
+			 AST::AttrVec outer_attrs,
 			 AST::ComparisonExpr::ExprType expr_type,
 			 ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::ComparisonExpr>
   parse_binary_equal_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-			   std::vector<AST::Attribute> outer_attrs,
+			   AST::AttrVec outer_attrs,
 			   ParseRestrictions restrictions
 			   = ParseRestrictions ());
   std::unique_ptr<AST::ComparisonExpr> parse_binary_not_equal_expr (
     const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-    std::vector<AST::Attribute> outer_attrs,
+    AST::AttrVec outer_attrs,
     ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::ComparisonExpr> parse_binary_greater_than_expr (
     const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-    std::vector<AST::Attribute> outer_attrs,
+    AST::AttrVec outer_attrs,
     ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::ComparisonExpr> parse_binary_less_than_expr (
     const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-    std::vector<AST::Attribute> outer_attrs,
+    AST::AttrVec outer_attrs,
     ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::ComparisonExpr> parse_binary_greater_equal_expr (
     const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-    std::vector<AST::Attribute> outer_attrs,
+    AST::AttrVec outer_attrs,
     ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::ComparisonExpr> parse_binary_less_equal_expr (
     const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-    std::vector<AST::Attribute> outer_attrs,
+    AST::AttrVec outer_attrs,
     ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::LazyBooleanExpr>
   parse_lazy_or_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-		      std::vector<AST::Attribute> outer_attrs,
+		      AST::AttrVec outer_attrs,
 		      ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::LazyBooleanExpr>
   parse_lazy_and_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-		       std::vector<AST::Attribute> outer_attrs,
+		       AST::AttrVec outer_attrs,
 		       ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::TypeCastExpr>
   parse_type_cast_expr (const_TokenPtr tok,
 			std::unique_ptr<AST::Expr> expr_to_cast,
-			std::vector<AST::Attribute> outer_attrs,
+			AST::AttrVec outer_attrs,
 			ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::AssignmentExpr>
   parse_assig_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-		    std::vector<AST::Attribute> outer_attrs,
+		    AST::AttrVec outer_attrs,
 		    ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::CompoundAssignmentExpr> parse_compound_assignment_expr (
     const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-    std::vector<AST::Attribute> outer_attrs,
-    AST::CompoundAssignmentExpr::ExprType expr_type,
+    AST::AttrVec outer_attrs, AST::CompoundAssignmentExpr::ExprType expr_type,
     ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::CompoundAssignmentExpr>
   parse_plus_assig_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-			 std::vector<AST::Attribute> outer_attrs,
+			 AST::AttrVec outer_attrs,
 			 ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::CompoundAssignmentExpr>
   parse_minus_assig_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-			  std::vector<AST::Attribute> outer_attrs,
+			  AST::AttrVec outer_attrs,
 			  ParseRestrictions restrictions
 			  = ParseRestrictions ());
   std::unique_ptr<AST::CompoundAssignmentExpr>
   parse_mult_assig_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-			 std::vector<AST::Attribute> outer_attrs,
+			 AST::AttrVec outer_attrs,
 			 ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::CompoundAssignmentExpr>
   parse_div_assig_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-			std::vector<AST::Attribute> outer_attrs,
+			AST::AttrVec outer_attrs,
 			ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::CompoundAssignmentExpr>
   parse_mod_assig_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-			std::vector<AST::Attribute> outer_attrs,
+			AST::AttrVec outer_attrs,
 			ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::CompoundAssignmentExpr>
   parse_and_assig_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-			std::vector<AST::Attribute> outer_attrs,
+			AST::AttrVec outer_attrs,
 			ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::CompoundAssignmentExpr>
   parse_or_assig_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-		       std::vector<AST::Attribute> outer_attrs,
+		       AST::AttrVec outer_attrs,
 		       ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::CompoundAssignmentExpr>
   parse_xor_assig_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-			std::vector<AST::Attribute> outer_attrs,
+			AST::AttrVec outer_attrs,
 			ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::CompoundAssignmentExpr> parse_left_shift_assig_expr (
     const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-    std::vector<AST::Attribute> outer_attrs,
+    AST::AttrVec outer_attrs,
     ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::CompoundAssignmentExpr> parse_right_shift_assig_expr (
     const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-    std::vector<AST::Attribute> outer_attrs,
+    AST::AttrVec outer_attrs,
     ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::AwaitExpr>
   parse_await_expr (const_TokenPtr tok,
 		    std::unique_ptr<AST::Expr> expr_to_await,
-		    std::vector<AST::Attribute> outer_attrs);
+		    AST::AttrVec outer_attrs);
   std::unique_ptr<AST::MethodCallExpr> parse_method_call_expr (
     const_TokenPtr tok, std::unique_ptr<AST::Expr> receiver_expr,
-    std::vector<AST::Attribute> outer_attrs,
+    AST::AttrVec outer_attrs,
     ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::CallExpr> parse_function_call_expr (
     const_TokenPtr tok, std::unique_ptr<AST::Expr> function_expr,
-    std::vector<AST::Attribute> outer_attrs,
+    AST::AttrVec outer_attrs,
     ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::RangeExpr> parse_led_range_exclusive_expr (
     const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-    std::vector<AST::Attribute> outer_attrs,
+    AST::AttrVec outer_attrs,
     ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::RangeExpr>
-  parse_nud_range_exclusive_expr (const_TokenPtr tok,
-				  std::vector<AST::Attribute> outer_attrs);
+  parse_nud_range_exclusive_expr (const_TokenPtr tok, AST::AttrVec outer_attrs);
   std::unique_ptr<AST::RangeFromToInclExpr> parse_range_inclusive_expr (
     const_TokenPtr tok, std::unique_ptr<AST::Expr> left,
-    std::vector<AST::Attribute> outer_attrs,
+    AST::AttrVec outer_attrs,
     ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::RangeToInclExpr>
-  parse_range_to_inclusive_expr (const_TokenPtr tok,
-				 std::vector<AST::Attribute> outer_attrs);
+  parse_range_to_inclusive_expr (const_TokenPtr tok, AST::AttrVec outer_attrs);
   std::unique_ptr<AST::TupleIndexExpr> parse_tuple_index_expr (
     const_TokenPtr tok, std::unique_ptr<AST::Expr> tuple_expr,
-    std::vector<AST::Attribute> outer_attrs,
+    AST::AttrVec outer_attrs,
     ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::FieldAccessExpr> parse_field_access_expr (
     const_TokenPtr tok, std::unique_ptr<AST::Expr> struct_expr,
-    std::vector<AST::Attribute> outer_attrs,
+    AST::AttrVec outer_attrs,
     ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::ArrayIndexExpr>
   parse_index_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> array_expr,
-		    std::vector<AST::Attribute> outer_attrs,
+		    AST::AttrVec outer_attrs,
 		    ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::MacroInvocation>
   parse_macro_invocation_partial (AST::PathInExpression path,
-				  std::vector<AST::Attribute> outer_attrs);
+				  AST::AttrVec outer_attrs);
   std::unique_ptr<AST::StructExprStruct>
   parse_struct_expr_struct_partial (AST::PathInExpression path,
-				    std::vector<AST::Attribute> outer_attrs);
+				    AST::AttrVec outer_attrs);
   std::unique_ptr<AST::CallExpr>
   parse_struct_expr_tuple_partial (AST::PathInExpression path,
-				   std::vector<AST::Attribute> outer_attrs);
+				   AST::AttrVec outer_attrs);
   AST::PathInExpression parse_path_in_expression_pratt (const_TokenPtr tok);
   std::unique_ptr<AST::ClosureExpr>
   parse_closure_expr_pratt (const_TokenPtr tok,
-			    std::vector<AST::Attribute> outer_attrs
-			    = std::vector<AST::Attribute> ());
+			    AST::AttrVec outer_attrs = AST::AttrVec ());
   std::unique_ptr<AST::TupleIndexExpr> parse_tuple_index_expr_float (
     const_TokenPtr tok, std::unique_ptr<AST::Expr> tuple_expr,
-    std::vector<AST::Attribute> outer_attrs,
+    AST::AttrVec outer_attrs,
     ParseRestrictions restrictions = ParseRestrictions ());
 
   // Expression-related (non-Pratt parsed)
   std::unique_ptr<AST::ExprWithBlock>
-  parse_expr_with_block (std::vector<AST::Attribute> outer_attrs);
+  parse_expr_with_block (AST::AttrVec outer_attrs);
   std::unique_ptr<AST::ExprWithoutBlock>
-  parse_expr_without_block (std::vector<AST::Attribute> outer_attrs
-			    = std::vector<AST::Attribute> ());
-  std::unique_ptr<AST::BlockExpr>
-  parse_block_expr (std::vector<AST::Attribute> outer_attrs
-		    = std::vector<AST::Attribute> (),
-		    bool pratt_parse = false);
-  std::unique_ptr<AST::IfExpr>
-  parse_if_expr (std::vector<AST::Attribute> outer_attrs
-		 = std::vector<AST::Attribute> (),
-		 bool pratt_parse = false);
-  std::unique_ptr<AST::IfLetExpr>
-  parse_if_let_expr (std::vector<AST::Attribute> outer_attrs
-		     = std::vector<AST::Attribute> (),
-		     bool pratt_parse = false);
-  std::unique_ptr<AST::LoopExpr> parse_loop_expr (
-    std::vector<AST::Attribute> outer_attrs = std::vector<AST::Attribute> (),
-    AST::LoopLabel label = AST::LoopLabel::error (), bool pratt_parse = false);
-  std::unique_ptr<AST::WhileLoopExpr> parse_while_loop_expr (
-    std::vector<AST::Attribute> outer_attrs = std::vector<AST::Attribute> (),
-    AST::LoopLabel label = AST::LoopLabel::error (), bool pratt_parse = false);
+  parse_expr_without_block (AST::AttrVec outer_attrs = AST::AttrVec ());
+  std::unique_ptr<AST::BlockExpr> parse_block_expr (AST::AttrVec outer_attrs
+						    = AST::AttrVec (),
+						    bool pratt_parse = false);
+  std::unique_ptr<AST::IfExpr> parse_if_expr (AST::AttrVec outer_attrs
+					      = AST::AttrVec (),
+					      bool pratt_parse = false);
+  std::unique_ptr<AST::IfLetExpr> parse_if_let_expr (AST::AttrVec outer_attrs
+						     = AST::AttrVec (),
+						     bool pratt_parse = false);
+  std::unique_ptr<AST::LoopExpr>
+  parse_loop_expr (AST::AttrVec outer_attrs = AST::AttrVec (),
+		   AST::LoopLabel label = AST::LoopLabel::error (),
+		   bool pratt_parse = false);
+  std::unique_ptr<AST::WhileLoopExpr>
+  parse_while_loop_expr (AST::AttrVec outer_attrs = AST::AttrVec (),
+			 AST::LoopLabel label = AST::LoopLabel::error (),
+			 bool pratt_parse = false);
   std::unique_ptr<AST::WhileLetLoopExpr>
-  parse_while_let_loop_expr (std::vector<AST::Attribute> outer_attrs
-			     = std::vector<AST::Attribute> (),
+  parse_while_let_loop_expr (AST::AttrVec outer_attrs = AST::AttrVec (),
 			     AST::LoopLabel label = AST::LoopLabel::error ());
   std::unique_ptr<AST::ForLoopExpr>
-  parse_for_loop_expr (std::vector<AST::Attribute> outer_attrs
-		       = std::vector<AST::Attribute> (),
+  parse_for_loop_expr (AST::AttrVec outer_attrs = AST::AttrVec (),
 		       AST::LoopLabel label = AST::LoopLabel::error ());
-  std::unique_ptr<AST::MatchExpr>
-  parse_match_expr (std::vector<AST::Attribute> outer_attrs
-		    = std::vector<AST::Attribute> (),
-		    bool pratt_parse = false);
+  std::unique_ptr<AST::MatchExpr> parse_match_expr (AST::AttrVec outer_attrs
+						    = AST::AttrVec (),
+						    bool pratt_parse = false);
   AST::MatchArm parse_match_arm ();
   std::vector<std::unique_ptr<AST::Pattern> >
   parse_match_arm_patterns (TokenId end_token_id);
   std::unique_ptr<AST::BaseLoopExpr>
-  parse_labelled_loop_expr (std::vector<AST::Attribute> outer_attrs
-			    = std::vector<AST::Attribute> ());
+  parse_labelled_loop_expr (AST::AttrVec outer_attrs = AST::AttrVec ());
   AST::LoopLabel parse_loop_label ();
   std::unique_ptr<AST::AsyncBlockExpr>
-  parse_async_block_expr (std::vector<AST::Attribute> outer_attrs
-			  = std::vector<AST::Attribute> ());
+  parse_async_block_expr (AST::AttrVec outer_attrs = AST::AttrVec ());
   std::unique_ptr<AST::UnsafeBlockExpr>
-  parse_unsafe_block_expr (std::vector<AST::Attribute> outer_attrs
-			   = std::vector<AST::Attribute> ());
-  std::unique_ptr<AST::GroupedExpr>
-  parse_grouped_expr (std::vector<AST::Attribute> outer_attrs
-		      = std::vector<AST::Attribute> ());
-  std::unique_ptr<AST::ClosureExpr>
-  parse_closure_expr (std::vector<AST::Attribute> outer_attrs
-		      = std::vector<AST::Attribute> ());
+  parse_unsafe_block_expr (AST::AttrVec outer_attrs = AST::AttrVec ());
+  std::unique_ptr<AST::GroupedExpr> parse_grouped_expr (AST::AttrVec outer_attrs
+							= AST::AttrVec ());
+  std::unique_ptr<AST::ClosureExpr> parse_closure_expr (AST::AttrVec outer_attrs
+							= AST::AttrVec ());
   AST::ClosureParam parse_closure_param ();
-  std::unique_ptr<AST::LiteralExpr>
-  parse_literal_expr (std::vector<AST::Attribute> outer_attrs
-		      = std::vector<AST::Attribute> ());
-  std::unique_ptr<AST::ReturnExpr>
-  parse_return_expr (std::vector<AST::Attribute> outer_attrs
-		     = std::vector<AST::Attribute> (),
-		     bool pratt_parse = false);
-  std::unique_ptr<AST::BreakExpr>
-  parse_break_expr (std::vector<AST::Attribute> outer_attrs
-		    = std::vector<AST::Attribute> (),
-		    bool pratt_parse = false);
+  std::unique_ptr<AST::LiteralExpr> parse_literal_expr (AST::AttrVec outer_attrs
+							= AST::AttrVec ());
+  std::unique_ptr<AST::ReturnExpr> parse_return_expr (AST::AttrVec outer_attrs
+						      = AST::AttrVec (),
+						      bool pratt_parse = false);
+  std::unique_ptr<AST::BreakExpr> parse_break_expr (AST::AttrVec outer_attrs
+						    = AST::AttrVec (),
+						    bool pratt_parse = false);
   std::unique_ptr<AST::ContinueExpr>
-  parse_continue_expr (std::vector<AST::Attribute> outer_attrs
-		       = std::vector<AST::Attribute> (),
+  parse_continue_expr (AST::AttrVec outer_attrs = AST::AttrVec (),
 		       bool pratt_parse = false);
-  std::unique_ptr<AST::ArrayExpr>
-  parse_array_expr (std::vector<AST::Attribute> outer_attrs
-		    = std::vector<AST::Attribute> (),
-		    bool pratt_parse = false);
+  std::unique_ptr<AST::ArrayExpr> parse_array_expr (AST::AttrVec outer_attrs
+						    = AST::AttrVec (),
+						    bool pratt_parse = false);
   std::unique_ptr<AST::ExprWithoutBlock>
-  parse_grouped_or_tuple_expr (std::vector<AST::Attribute> outer_attrs
-			       = std::vector<AST::Attribute> (),
+  parse_grouped_or_tuple_expr (AST::AttrVec outer_attrs = AST::AttrVec (),
 			       bool pratt_parse = false);
   std::unique_ptr<AST::StructExprField> parse_struct_expr_field ();
   bool will_be_expr_with_block ();
@@ -575,26 +541,20 @@ private:
   std::unique_ptr<AST::Type> parse_paren_prefixed_type ();
   std::unique_ptr<AST::TypeNoBounds> parse_paren_prefixed_type_no_bounds ();
   std::unique_ptr<AST::Type> parse_for_prefixed_type ();
-  AST::MaybeNamedParam
-  parse_maybe_named_param (std::vector<AST::Attribute> outer_attrs);
+  AST::MaybeNamedParam parse_maybe_named_param (AST::AttrVec outer_attrs);
 
   // Statement-related
   std::unique_ptr<AST::Stmt> parse_stmt ();
-  std::unique_ptr<AST::LetStmt>
-  parse_let_stmt (std::vector<AST::Attribute> outer_attrs);
-  std::unique_ptr<AST::ExprStmt>
-  parse_expr_stmt (std::vector<AST::Attribute> outer_attrs);
+  std::unique_ptr<AST::LetStmt> parse_let_stmt (AST::AttrVec outer_attrs);
+  std::unique_ptr<AST::ExprStmt> parse_expr_stmt (AST::AttrVec outer_attrs);
   std::unique_ptr<AST::ExprStmtWithBlock>
-  parse_expr_stmt_with_block (std::vector<AST::Attribute> outer_attrs);
+  parse_expr_stmt_with_block (AST::AttrVec outer_attrs);
   std::unique_ptr<AST::ExprStmtWithoutBlock>
-  parse_expr_stmt_without_block (std::vector<AST::Attribute> outer_attrs);
+  parse_expr_stmt_without_block (AST::AttrVec outer_attrs);
   ExprOrStmt parse_stmt_or_expr_without_block ();
-  ExprOrStmt
-  parse_stmt_or_expr_with_block (std::vector<AST::Attribute> outer_attrs);
-  ExprOrStmt
-  parse_macro_invocation_maybe_semi (std::vector<AST::Attribute> outer_attrs);
-  ExprOrStmt
-  parse_path_based_stmt_or_expr (std::vector<AST::Attribute> outer_attrs);
+  ExprOrStmt parse_stmt_or_expr_with_block (AST::AttrVec outer_attrs);
+  ExprOrStmt parse_macro_invocation_maybe_semi (AST::AttrVec outer_attrs);
+  ExprOrStmt parse_path_based_stmt_or_expr (AST::AttrVec outer_attrs);
 
   // Pattern-related
   std::unique_ptr<AST::Pattern> parse_pattern ();
@@ -609,7 +569,7 @@ private:
   AST::StructPatternElements parse_struct_pattern_elems ();
   std::unique_ptr<AST::StructPatternField> parse_struct_pattern_field ();
   std::unique_ptr<AST::StructPatternField>
-  parse_struct_pattern_field_partial (std::vector<AST::Attribute> outer_attrs);
+  parse_struct_pattern_field_partial (AST::AttrVec outer_attrs);
 
   int left_binding_power (const_TokenPtr token);
 

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -657,7 +657,7 @@ Session::register_plugins (AST::Crate &crate ATTRIBUTE_UNUSED)
 
 // TODO: move somewhere else
 bool
-contains_name (const std::vector<AST::Attribute> &attrs, std::string name)
+contains_name (const AST::AttrVec &attrs, std::string name)
 {
   for (const auto &attr : attrs)
     {

--- a/gcc/rust/typecheck/rust-hir-const-fold-base.h
+++ b/gcc/rust/typecheck/rust-hir-const-fold-base.h
@@ -36,8 +36,6 @@ public:
   virtual ~ConstFoldBase () {}
 
   virtual void visit (HIR::Token &) override {}
-  virtual void visit (HIR::DelimTokenTree &) override {}
-  virtual void visit (HIR::AttrInputMetaItemContainer &) override {}
   virtual void visit (HIR::IdentifierExpr &) override {}
   virtual void visit (HIR::Lifetime &) override {}
   virtual void visit (HIR::LifetimeParam &) override {}
@@ -50,9 +48,6 @@ public:
   virtual void visit (HIR::QualifiedPathInType &) override {}
 
   virtual void visit (HIR::LiteralExpr &) override {}
-  virtual void visit (HIR::AttrInputLiteral &) override {}
-  virtual void visit (HIR::MetaItemLitExpr &) override {}
-  virtual void visit (HIR::MetaItemPathLit &) override {}
   virtual void visit (HIR::BorrowExpr &) override {}
   virtual void visit (HIR::DereferenceExpr &) override {}
   virtual void visit (HIR::ErrorPropagationExpr &) override {}
@@ -164,12 +159,6 @@ public:
   virtual void visit (HIR::MacroMatcher &) override {}
   virtual void visit (HIR::MacroRulesDefinition &) override {}
   virtual void visit (HIR::MacroInvocation &) override {}
-  virtual void visit (HIR::MetaItemPath &) override {}
-  virtual void visit (HIR::MetaItemSeq &) override {}
-  virtual void visit (HIR::MetaWord &) override {}
-  virtual void visit (HIR::MetaNameValueStr &) override {}
-  virtual void visit (HIR::MetaListPaths &) override {}
-  virtual void visit (HIR::MetaListNameValueStr &) override {}
 
   virtual void visit (HIR::LiteralPattern &) override {}
   virtual void visit (HIR::IdentifierPattern &) override {}

--- a/gcc/rust/typecheck/rust-hir-type-check-base.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.h
@@ -35,8 +35,6 @@ public:
   virtual ~TypeCheckBase () {}
 
   virtual void visit (HIR::Token &) override {}
-  virtual void visit (HIR::DelimTokenTree &) override {}
-  virtual void visit (HIR::AttrInputMetaItemContainer &) override {}
   virtual void visit (HIR::IdentifierExpr &) override {}
   virtual void visit (HIR::Lifetime &) override {}
   virtual void visit (HIR::LifetimeParam &) override {}
@@ -49,9 +47,6 @@ public:
   virtual void visit (HIR::QualifiedPathInType &) override {}
 
   virtual void visit (HIR::LiteralExpr &) override {}
-  virtual void visit (HIR::AttrInputLiteral &) override {}
-  virtual void visit (HIR::MetaItemLitExpr &) override {}
-  virtual void visit (HIR::MetaItemPathLit &) override {}
   virtual void visit (HIR::BorrowExpr &) override {}
   virtual void visit (HIR::DereferenceExpr &) override {}
   virtual void visit (HIR::ErrorPropagationExpr &) override {}
@@ -163,12 +158,6 @@ public:
   virtual void visit (HIR::MacroMatcher &) override {}
   virtual void visit (HIR::MacroRulesDefinition &) override {}
   virtual void visit (HIR::MacroInvocation &) override {}
-  virtual void visit (HIR::MetaItemPath &) override {}
-  virtual void visit (HIR::MetaItemSeq &) override {}
-  virtual void visit (HIR::MetaWord &) override {}
-  virtual void visit (HIR::MetaNameValueStr &) override {}
-  virtual void visit (HIR::MetaListPaths &) override {}
-  virtual void visit (HIR::MetaListNameValueStr &) override {}
 
   virtual void visit (HIR::LiteralPattern &) override {}
   virtual void visit (HIR::IdentifierPattern &) override {}

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -208,7 +208,7 @@ TypeCheckStructExpr::visit (HIR::StructExprStructFields &struct_expr)
 
 	      HIR::StructExprField *implicit_field = nullptr;
 
-	      std::vector<HIR::Attribute> outer_attribs;
+	      AST::AttrVec outer_attribs;
 	      auto crate_num = mappings->get_current_crate ();
 	      Analysis::NodeMapping mapping (
 		crate_num,


### PR DESCRIPTION
Deleting HIR::Attribute and reusing AST::Attribute. 

Some relative reusing classes below:
1. DelimTokenTree
2. AttrInputMetaItemContainer
3. AttrInputLiteral
4. MetaItemLitExpr
5. MetaItemPathLit
6. MetaItemPath
7. MetaItemSeq
8. MetaWord
9. MetaNameValueStr
10. MetaListPath
11. MetaListNameValueStr
12. Attrbute
13. AttrInput
14. MacroParser