### PR TITLE
Fix rs6000

### DIFF
--- a/gcc/config/rs6000/linux64.h
+++ b/gcc/config/rs6000/linux64.h
@@ -314,9 +314,8 @@ extern int dot_symbols;
     }							\
   while (0)
 
-#ifdef TARGET_RUST_OS_INFO
-# error "TARGET_RUST_OS_INFO already defined in linux64.h (rs6000) - c++ undefines it and redefines it."
-#endif
+/* Override less-specific rs6000/sysv4.h definition. */
+#undef TARGET_RUST_OS_INFO
 #define TARGET_RUST_OS_INFO()          \
   do {                                 \
     GNU_USER_TARGET_RUST_OS_INFO();		\

--- a/gcc/config/rs6000/rs6000-logue.c
+++ b/gcc/config/rs6000/rs6000-logue.c
@@ -5262,12 +5262,13 @@ rs6000_output_function_epilogue (FILE *file)
 	 use language_string.
 	 C is 0.  Fortran is 1.  Ada is 3.  Modula-2 is 8.  C++ is 9.
 	 Java is 13.  Objective-C is 14.  Objective-C++ isn't assigned
-	 a number, so for now use 9.  LTO, Go, D, and JIT aren't assigned
-	 numbers either, so for now use 0.  */
+	 a number, so for now use 9.  LTO, Go, D, Rust, and JIT aren't
+	 assigned numbers either, so for now use 0.  */
       if (lang_GNU_C ()
 	  || ! strcmp (language_string, "GNU GIMPLE")
 	  || ! strcmp (language_string, "GNU Go")
 	  || ! strcmp (language_string, "GNU D")
+	  || ! strcmp (language_string, "GNU Rust")
 	  || ! strcmp (language_string, "libgccjit"))
 	i = 0;
       else if (! strcmp (language_string, "GNU F77")


### PR DESCRIPTION
Applying 2 patches sent on GCC mailing-list.
These changes fix errors in the current Rust testsuite.