### PR TITLE
stdin: Allow compilation from standard input

### DIFF
--- a/gcc/rust/lex/rust-lex.h
+++ b/gcc/rust/lex/rust-lex.h
@@ -16,7 +16,14 @@ private:
   FILE *file;
 
 public:
-  RAIIFile (const char *filename) : file (fopen (filename, "r")) {}
+  RAIIFile (const char *filename)
+  {
+    if (strncmp (filename, "-", 1) == 0)
+      file = stdin;
+    else
+      file = fopen (filename, "r");
+  }
+
   RAIIFile (const RAIIFile &other) = delete;
   RAIIFile &operator= (const RAIIFile &other) = delete;
 
@@ -32,7 +39,7 @@ public:
 
   ~RAIIFile ()
   {
-    if (file != nullptr)
+    if (file != nullptr && file != stdin)
       fclose (file);
   }
 


### PR DESCRIPTION
Fixes #457 

I'm not really sure how to test it with `dejagnu` or if it is even possible.

This PR adds a check for the `-` filename in the `RAIIFile` class. In that case, the inner pointer should simply be `stdin`. We also have to be careful not to `fclose(stdin)` upon deallocation.
