### PR TITLE
raiifile: Allow dash-prefixed files to be parsed

### DIFF
--- a/gcc/rust/lex/rust-lex.h
+++ b/gcc/rust/lex/rust-lex.h
@@ -18,7 +18,7 @@ private:
 public:
   RAIIFile (const char *filename)
   {
-    if (strncmp (filename, "-", 1) == 0)
+    if (strcmp (filename, "-") == 0)
       file = stdin;
     else
       file = fopen (filename, "r");


### PR DESCRIPTION
Thanks to @tschwinge for finding the bug.

I added a test case, but not a lot of programs know how to handle this file. Unless there is some specific option, `gcc` complains about no input files, and `cat` does not understand it either. So I'm not sure the test case is actually useful.
