### PR TITLE
Update README.md with GCC mailing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,3 +192,5 @@ We can be found on all usual Rust channels such as Zulip, but we also have our o
 
  * GCC Rust Zulip: https://gcc-rust.zulipchat.com/
  * Twitter: https://twitter.com/gcc_rust
+ * GCC Mailing List: https://gcc.gnu.org/mailman/listinfo/gcc-rust
+ * irc: irc.oftc.net - gccrust


### PR DESCRIPTION
GCC Rust now has an associated mailing list and irc channel on the usual GCC locations.