### PR TITLE
Always print compiler debug info on stderr

### DIFF
--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -456,7 +456,7 @@ Session::parse_files (int num_files, const char **files)
 
   for (int i = 0; i < num_files; i++)
     {
-      printf ("Attempting to parse file: %s\n", files[i]);
+      fprintf (stderr, "Attempting to parse file: %s\n", files[i]);
       parse_file (files[i]);
     }
   /* TODO: should semantic analysis be dealed with here? or per file? for now,

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -142,8 +142,8 @@ public:
 
   void debug () const
   {
-    printf ("[%p] %s\n", static_cast<const void *> (this),
-	    debug_str ().c_str ());
+    fprintf (stderr, "[%p] %s\n", static_cast<const void *> (this),
+	     debug_str ().c_str ());
   }
 
 protected:
@@ -319,7 +319,7 @@ public:
 
   StructFieldType *clone () const;
 
-  void debug () const { printf ("%s\n", as_string ().c_str ()); }
+  void debug () const { fprintf (stderr, "%s\n", as_string ().c_str ()); }
 
 private:
   HirId ref;


### PR DESCRIPTION
I am starting my work on cargo-gccrs, and the output from the compiler messes with what cargo expects as output. Since much of the debug prints are already done on `stderr` instead of `stdout`, this PR fixes what I believe to be the few remaining cases using `stdout`.

I used the following regexes (with ripgrep) to find all remaining instances of debug prints on `stdout`: `[^f]printf` and `fprintf \(stdout`