### PR TITLE
Expose rust debug and use it

### DIFF
--- a/gcc/rust/ast/rust-ast-full-test.cc
+++ b/gcc/rust/ast/rust-ast-full-test.cc
@@ -169,7 +169,7 @@ unquote_string (std::string input)
 std::string
 Crate::as_string () const
 {
-  fprintf (stderr, "beginning crate recursive as-string\n");
+  rust_debug ("beginning crate recursive as-string");
 
   std::string str ("Crate: ");
   // add utf8bom and shebang
@@ -195,8 +195,8 @@ Crate::as_string () const
 	  // DEBUG: null pointer check
 	  if (item == nullptr)
 	    {
-	      fprintf (stderr, "something really terrible has gone wrong - "
-			       "null pointer item in crate.");
+	      rust_debug ("something really terrible has gone wrong - "
+			  "null pointer item in crate.");
 	      return "NULL_POINTER_MARK";
 	    }
 
@@ -261,8 +261,8 @@ DelimTokenTree::as_string () const
       end_delim = "}";
       break;
     default:
-      fprintf (stderr, "Invalid delimiter type, "
-		       "Should be PARENS, SQUARE, or CURLY.");
+      rust_debug ("Invalid delimiter type, "
+		  "Should be PARENS, SQUARE, or CURLY.");
       return "Invalid delimiter type";
     }
   std::string str = start_delim;
@@ -273,8 +273,7 @@ DelimTokenTree::as_string () const
 	  // DEBUG: null pointer check
 	  if (tree == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"token tree in delim token tree.");
 	      return "NULL_POINTER_MARK";
@@ -334,11 +333,10 @@ SimplePath::as_string () const
       // DEBUG: remove later. Checks for path error.
       if (segment.is_error ())
 	{
-	  fprintf (stderr,
-		   "segment in path is error - this should've been filtered "
-		   "out. first segment "
-		   "was '%s' \n",
-		   segments.at (0).as_string ().c_str ());
+	  rust_debug ("segment in path is error - this should've been filtered "
+		      "out. first segment "
+		      "was '%s'",
+		      segments.at (0).as_string ().c_str ());
 	}
     }
 
@@ -414,8 +412,8 @@ ModuleBodied::as_string () const
 	  // DEBUG: null pointer check
 	  if (item == nullptr)
 	    {
-	      fprintf (stderr, "something really terrible has gone wrong - "
-			       "null pointer item in crate.");
+	      rust_debug ("something really terrible has gone wrong - "
+			  "null pointer item in crate.");
 	      return "NULL_POINTER_MARK";
 	    }
 
@@ -451,8 +449,8 @@ StaticItem::as_string () const
   // DEBUG: null pointer check
   if (type == nullptr)
     {
-      fprintf (stderr, "something really terrible has gone wrong - null "
-		       "pointer type in static item.");
+      rust_debug ("something really terrible has gone wrong - null "
+		  "pointer type in static item.");
       return "NULL_POINTER_MARK";
     }
   str += "\n" + indent_spaces (stay) + "Type: " + type->as_string ();
@@ -460,8 +458,8 @@ StaticItem::as_string () const
   // DEBUG: null pointer check
   if (expr == nullptr)
     {
-      fprintf (stderr, "something really terrible has gone wrong - null "
-		       "pointer expr in static item.");
+      rust_debug ("something really terrible has gone wrong - null "
+		  "pointer expr in static item.");
       return "NULL_POINTER_MARK";
     }
   str += "\n" + indent_spaces (stay) + "Expression: " + expr->as_string ();
@@ -502,8 +500,7 @@ TupleStruct::as_string () const
 	  // DEBUG: null pointer check
 	  if (param == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"generic param in enum.");
 	      return "NULL_POINTER_MARK";
@@ -544,8 +541,8 @@ ConstantItem::as_string () const
   // DEBUG: null pointer check
   if (type == nullptr)
     {
-      fprintf (stderr, "something really terrible has gone wrong - null "
-		       "pointer type in const item.");
+      rust_debug ("something really terrible has gone wrong - null "
+		  "pointer type in const item.");
       return "NULL_POINTER_MARK";
     }
   str += "\n  Type: " + type->as_string ();
@@ -553,8 +550,8 @@ ConstantItem::as_string () const
   // DEBUG: null pointer check
   if (const_expr == nullptr)
     {
-      fprintf (stderr, "something really terrible has gone wrong - null "
-		       "pointer expr in const item.");
+      rust_debug ("something really terrible has gone wrong - null "
+		  "pointer expr in const item.");
       return "NULL_POINTER_MARK";
     }
   str += "\n  Expression: " + const_expr->as_string ();
@@ -582,8 +579,7 @@ InherentImpl::as_string () const
 	  // DEBUG: null pointer check
 	  if (param == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"generic param in inherent impl.");
 	      return "NULL_POINTER_MARK";
@@ -641,8 +637,7 @@ Method::as_string () const
 	  // DEBUG: null pointer check
 	  if (param == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"generic param in method.");
 	      return "NULL_POINTER_MARK";
@@ -703,8 +698,7 @@ StructStruct::as_string () const
 	  // DEBUG: null pointer check
 	  if (param == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"generic param in enum.");
 	      return "NULL_POINTER_MARK";
@@ -747,8 +741,7 @@ UseDeclaration::as_string () const
   // DEBUG: null pointer check
   if (use_tree == nullptr)
     {
-      fprintf (
-	stderr,
+      rust_debug (
 	"something really terrible has gone wrong - null pointer use tree in "
 	"use declaration.");
       return "NULL_POINTER_MARK";
@@ -808,9 +801,8 @@ UseTreeList::as_string () const
       // DEBUG: null pointer check
       if (*i == nullptr)
 	{
-	  fprintf (stderr,
-		   "something really terrible has gone wrong - null pointer "
-		   "tree in use tree list.");
+	  rust_debug ("something really terrible has gone wrong - null pointer "
+		      "tree in use tree list.");
 	  return "NULL_POINTER_MARK";
 	}
 
@@ -872,8 +864,7 @@ Enum::as_string () const
 	  // DEBUG: null pointer check
 	  if (param == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"generic param in enum.");
 	      return "NULL_POINTER_MARK";
@@ -902,8 +893,7 @@ Enum::as_string () const
 	  // DEBUG: null pointer check
 	  if (item == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"enum item in enum.");
 	      return "NULL_POINTER_MARK";
@@ -939,8 +929,7 @@ Trait::as_string () const
 	  // DEBUG: null pointer check
 	  if (param == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"generic param in trait.");
 	      return "NULL_POINTER_MARK";
@@ -962,8 +951,7 @@ Trait::as_string () const
 	  // DEBUG: null pointer check
 	  if (bound == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"type param bound in trait.");
 	      return "NULL_POINTER_MARK";
@@ -991,8 +979,7 @@ Trait::as_string () const
 	  // DEBUG: null pointer check
 	  if (item == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"trait item in trait.");
 	      return "NULL_POINTER_MARK";
@@ -1025,8 +1012,7 @@ Union::as_string () const
 	  // DEBUG: null pointer check
 	  if (param == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"generic param in union.");
 	      return "NULL_POINTER_MARK";
@@ -1070,8 +1056,7 @@ Function::as_string () const
       // DEBUG: null pointer check
       if (return_type == nullptr)
 	{
-	  fprintf (
-	    stderr,
+	  rust_debug (
 	    "something really terrible has gone wrong - null pointer return "
 	    "type in function.");
 	  return "NULL_POINTER_MARK";
@@ -1096,9 +1081,8 @@ Function::as_string () const
       // DEBUG: null pointer check
       if (i == e)
 	{
-	  fprintf (stderr,
-		   "something really terrible has gone wrong - null pointer "
-		   "generic param in function item.");
+	  rust_debug ("something really terrible has gone wrong - null pointer "
+		      "generic param in function item.");
 	  return "NULL_POINTER_MARK";
 	}
 
@@ -1137,8 +1121,7 @@ Function::as_string () const
   // DEBUG: null pointer check
   if (function_body == nullptr)
     {
-      fprintf (
-	stderr,
+      rust_debug (
 	"something really terrible has gone wrong - null pointer function "
 	"body in function.");
       return "NULL_POINTER_MARK";
@@ -1192,8 +1175,7 @@ BlockExpr::as_string () const
 	  // DEBUG: null pointer check
 	  if (stmt == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"stmt in block expr.");
 	      return "NULL_POINTER_MARK";
@@ -3581,8 +3563,7 @@ ExternalFunctionItem::as_string () const
 	  // DEBUG: null pointer check
 	  if (param == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"generic param in external function item.");
 	      return "NULL_POINTER_MARK";
@@ -3678,8 +3659,7 @@ TraitFunctionDecl::as_string () const
 	  // DEBUG: null pointer check
 	  if (param == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"generic param in trait function decl.");
 	      return "NULL_POINTER_MARK";
@@ -3749,8 +3729,7 @@ TraitMethodDecl::as_string () const
 	  // DEBUG: null pointer check
 	  if (param == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"generic param in trait function decl.");
 	      return "NULL_POINTER_MARK";
@@ -3821,8 +3800,7 @@ TraitItemType::as_string () const
 	  // DEBUG: null pointer check
 	  if (bound == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"type param bound in trait item type.");
 	      return "NULL_POINTER_MARK";
@@ -3961,9 +3939,8 @@ ArrayElemsValues::as_string () const
       // DEBUG: null pointer check
       if (expr == nullptr)
 	{
-	  fprintf (stderr,
-		   "something really terrible has gone wrong - null pointer "
-		   "expr in array elems values.");
+	  rust_debug ("something really terrible has gone wrong - null pointer "
+		      "expr in array elems values.");
 	  return "NULL_POINTER_MARK";
 	}
 
@@ -4333,8 +4310,7 @@ MacroParser::parse_meta_item_seq ()
   if (stream_pos != 0)
     {
       // warning?
-      fprintf (stderr,
-	       "WARNING: stream pos for parse_meta_item_seq is not 0!\n");
+      rust_debug ("WARNING: stream pos for parse_meta_item_seq is not 0!");
     }
 
   // int i = 0;
@@ -4540,10 +4516,10 @@ AttrInputMetaItemContainer::check_cfg_predicate (const Session &session) const
     return false;
 
   // DEBUG
-  fprintf (stderr,
-	   "asked to check cfg of attrinputmetaitemcontainer - delegating to "
-	   "first item. container: '%s'\n",
-	   as_string ().c_str ());
+  rust_debug (
+    "asked to check cfg of attrinputmetaitemcontainer - delegating to "
+    "first item. container: '%s'",
+    as_string ().c_str ());
 
   return items[0]->check_cfg_predicate (session);
 
@@ -4735,12 +4711,10 @@ bool
 MetaNameValueStr::check_cfg_predicate (const Session &session) const
 {
   // DEBUG
-  fprintf (stderr,
-	   "checked key-value pair for cfg: '%s', '%s' - is%s in target data\n",
-	   ident.c_str (), str.c_str (),
-	   session.options.target_data.has_key_value_pair (ident, str)
-	     ? ""
-	     : " not");
+  rust_debug (
+    "checked key-value pair for cfg: '%s', '%s' - is%s in target data",
+    ident.c_str (), str.c_str (),
+    session.options.target_data.has_key_value_pair (ident, str) ? "" : " not");
 
   return session.options.target_data.has_key_value_pair (ident, str);
 }
@@ -4875,10 +4849,10 @@ Attribute::check_cfg_predicate (const Session &session) const
       || (path.as_string () != "cfg" && path.as_string () != "cfg_attr"))
     {
       // DEBUG message
-      fprintf (stderr,
-	       "tried to check cfg predicate on attr that either has no input "
-	       "or invalid path. attr: '%s'\n",
-	       as_string ().c_str ());
+      rust_debug (
+	"tried to check cfg predicate on attr that either has no input "
+	"or invalid path. attr: '%s'",
+	as_string ().c_str ());
 
       return false;
     }

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -182,7 +182,7 @@ public:
 	str = lexer_token_ptr->get_str ();
 
 	// DEBUG
-	fprintf (stderr, "ast token created with str '%s'\n", str.c_str ());
+	rust_debug ("ast token created with str '%s'", str.c_str ());
       }
     else
       {
@@ -190,14 +190,14 @@ public:
 	str = lexer_token_ptr->get_token_description ();
 
 	// DEBUG
-	fprintf (stderr, "ast token created with string '%s'\n", str.c_str ());
+	rust_debug ("ast token created with string '%s'", str.c_str ());
       }
 
     // DEBUG
     if (lexer_token_ptr->should_have_str () && !lexer_token_ptr->has_str ())
       {
-	fprintf (stderr,
-		 "BAD: for token '%s', should have string but does not!\n",
+	rust_debug (
+		 "BAD: for token '%s', should have string but does not!",
 		 lexer_token_ptr->get_token_description ());
       }
   }

--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -3150,7 +3150,7 @@ MacroExpander::parse_macro_to_meta_item (AST::MacroInvocData &invoc)
 
   if (converted_input == nullptr)
     {
-      fprintf (stderr, "DEBUG: failed to parse macro to meta item\n");
+      rust_debug ("DEBUG: failed to parse macro to meta item");
       // TODO: do something now? is this an actual error?
     }
   else
@@ -3298,18 +3298,17 @@ MacroExpander::fails_cfg_with_expand (AST::AttrVec &attrs) const
 
 	  // DEBUG
 	  if (!attr.is_parsed_to_meta_item ())
-	    fprintf (stderr, "failed to parse attr to meta item, right before "
-			     "cfg predicate check\n");
+	    rust_debug ("failed to parse attr to meta item, right before "
+			"cfg predicate check");
 	  else
-	    fprintf (stderr, "attr has been successfully parsed to meta item, "
-			     "right before cfg predicate check\n");
+	    rust_debug ("attr has been successfully parsed to meta item, "
+			"right before cfg predicate check");
 
 	  if (!attr.check_cfg_predicate (session))
 	    {
 	      // DEBUG
-	      fprintf (
-		stderr,
-		"cfg predicate failed for attribute: \033[0;31m'%s'\033[0m\n",
+	      rust_debug (
+		"cfg predicate failed for attribute: \033[0;31m'%s'\033[0m",
 		attr.as_string ().c_str ());
 
 	      return true;
@@ -3317,10 +3316,9 @@ MacroExpander::fails_cfg_with_expand (AST::AttrVec &attrs) const
 	  else
 	    {
 	      // DEBUG
-	      fprintf (stderr,
-		       "cfg predicate succeeded for attribute: "
-		       "\033[0;31m'%s'\033[0m\n",
-		       attr.as_string ().c_str ());
+	      rust_debug ("cfg predicate succeeded for attribute: "
+			  "\033[0;31m'%s'\033[0m",
+			  attr.as_string ().c_str ());
 	    }
 	}
     }

--- a/gcc/rust/hir/tree/rust-hir-full-test.cc
+++ b/gcc/rust/hir/tree/rust-hir-full-test.cc
@@ -151,8 +151,8 @@ Crate::as_string () const
 	  // DEBUG: null pointer check
 	  if (item == nullptr)
 	    {
-	      fprintf (stderr, "something really terrible has gone wrong - "
-			       "null pointer item in crate.");
+	      rust_debug ("something really terrible has gone wrong - "
+			  "null pointer item in crate.");
 	      return "nullptr_POINTER_MARK";
 	    }
 
@@ -270,8 +270,8 @@ ModuleBodied::as_string () const
 	  // DEBUG: null pointer check
 	  if (item == nullptr)
 	    {
-	      fprintf (stderr, "something really terrible has gone wrong - "
-			       "null pointer item in crate.");
+	      rust_debug ("something really terrible has gone wrong - "
+			  "null pointer item in crate.");
 	      return "nullptr_POINTER_MARK";
 	    }
 
@@ -309,8 +309,8 @@ StaticItem::as_string () const
   // DEBUG: null pointer check
   if (type == nullptr)
     {
-      fprintf (stderr, "something really terrible has gone wrong - null "
-		       "pointer type in static item.");
+      rust_debug ("something really terrible has gone wrong - null "
+		  "pointer type in static item.");
       return "nullptr_POINTER_MARK";
     }
   str += "\n" + indent_spaces (stay) + "Type: " + type->as_string ();
@@ -318,8 +318,8 @@ StaticItem::as_string () const
   // DEBUG: null pointer check
   if (expr == nullptr)
     {
-      fprintf (stderr, "something really terrible has gone wrong - null "
-		       "pointer expr in static item.");
+      rust_debug ("something really terrible has gone wrong - null "
+		  "pointer expr in static item.");
       return "nullptr_POINTER_MARK";
     }
   str += "\n" + indent_spaces (stay) + "Expression: " + expr->as_string ();
@@ -362,8 +362,7 @@ TupleStruct::as_string () const
 	  // DEBUG: null pointer check
 	  if (param == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"generic param in enum.");
 	      return "nullptr_POINTER_MARK";
@@ -410,8 +409,8 @@ ConstantItem::as_string () const
   // DEBUG: null pointer check
   if (type == nullptr)
     {
-      fprintf (stderr, "something really terrible has gone wrong - null "
-		       "pointer type in const item.");
+      rust_debug ("something really terrible has gone wrong - null "
+		  "pointer type in const item.");
       return "nullptr_POINTER_MARK";
     }
   str += "\n  Type: " + type->as_string ();
@@ -419,8 +418,8 @@ ConstantItem::as_string () const
   // DEBUG: null pointer check
   if (const_expr == nullptr)
     {
-      fprintf (stderr, "something really terrible has gone wrong - null "
-		       "pointer expr in const item.");
+      rust_debug ("something really terrible has gone wrong - null "
+		  "pointer expr in const item.");
       return "nullptr_POINTER_MARK";
     }
   str += "\n  Expression: " + const_expr->as_string ();
@@ -448,8 +447,7 @@ InherentImpl::as_string () const
 	  // DEBUG: null pointer check
 	  if (param == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"generic param in inherent impl.");
 	      return "nullptr_POINTER_MARK";
@@ -526,8 +524,7 @@ Method::as_string () const
 	  // DEBUG: null pointer check
 	  if (param == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"generic param in method.");
 	      return "nullptr_POINTER_MARK";
@@ -598,8 +595,7 @@ StructStruct::as_string () const
 	  // DEBUG: null pointer check
 	  if (param == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"generic param in enum.");
 	      return "nullptr_POINTER_MARK";
@@ -648,8 +644,7 @@ UseDeclaration::as_string () const
   // DEBUG: null pointer check
   if (use_tree == nullptr)
     {
-      fprintf (
-	stderr,
+      rust_debug (
 	"something really terrible has gone wrong - null pointer use tree in "
 	"use declaration.");
       return "nullptr_POINTER_MARK";
@@ -709,9 +704,8 @@ UseTreeList::as_string () const
       // DEBUG: null pointer check
       if (*i == nullptr)
 	{
-	  fprintf (stderr,
-		   "something really terrible has gone wrong - null pointer "
-		   "tree in use tree list.");
+	  rust_debug ("something really terrible has gone wrong - null pointer "
+		      "tree in use tree list.");
 	  return "nullptr_POINTER_MARK";
 	}
 
@@ -773,8 +767,7 @@ Enum::as_string () const
 	  // DEBUG: null pointer check
 	  if (param == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"generic param in enum.");
 	      return "nullptr_POINTER_MARK";
@@ -807,8 +800,7 @@ Enum::as_string () const
 	  // DEBUG: null pointer check
 	  if (item == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"enum item in enum.");
 	      return "nullptr_POINTER_MARK";
@@ -846,8 +838,7 @@ Trait::as_string () const
 	  // DEBUG: null pointer check
 	  if (param == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"generic param in trait.");
 	      return "nullptr_POINTER_MARK";
@@ -869,8 +860,7 @@ Trait::as_string () const
 	  // DEBUG: null pointer check
 	  if (bound == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"type param bound in trait.");
 	      return "nullptr_POINTER_MARK";
@@ -902,8 +892,7 @@ Trait::as_string () const
 	  // DEBUG: null pointer check
 	  if (item == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"trait item in trait.");
 	      return "nullptr_POINTER_MARK";
@@ -936,8 +925,7 @@ Union::as_string () const
 	  // DEBUG: null pointer check
 	  if (param == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"generic param in union.");
 	      return "nullptr_POINTER_MARK";
@@ -987,8 +975,7 @@ Function::as_string () const
       // DEBUG: null pointer check
       if (return_type == nullptr)
 	{
-	  fprintf (
-	    stderr,
+	  rust_debug (
 	    "something really terrible has gone wrong - null pointer return "
 	    "type in function.");
 	  return "nullptr_POINTER_MARK";
@@ -1013,9 +1000,8 @@ Function::as_string () const
       // DEBUG: null pointer check
       if (i == e)
 	{
-	  fprintf (stderr,
-		   "something really terrible has gone wrong - null pointer "
-		   "generic param in function item.");
+	  rust_debug ("something really terrible has gone wrong - null pointer "
+		      "generic param in function item.");
 	  return "nullptr_POINTER_MARK";
 	}
 
@@ -1056,8 +1042,7 @@ Function::as_string () const
   // DEBUG: null pointer check
   if (function_body == nullptr)
     {
-      fprintf (
-	stderr,
+      rust_debug (
 	"something really terrible has gone wrong - null pointer function "
 	"body in function.");
       return "nullptr_POINTER_MARK";
@@ -1124,8 +1109,7 @@ BlockExpr::as_string () const
 	  // DEBUG: null pointer check
 	  if (stmt == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"stmt in block expr.");
 	      return "nullptr_POINTER_MARK";
@@ -3772,8 +3756,7 @@ ExternalFunctionItem::as_string () const
 	  // DEBUG: null pointer check
 	  if (param == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"generic param in external function item.");
 	      return "nullptr_POINTER_MARK";
@@ -3894,8 +3877,7 @@ TraitFunctionDecl::as_string () const
 	  // DEBUG: null pointer check
 	  if (param == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"generic param in trait function decl.");
 	      return "nullptr_POINTER_MARK";
@@ -3992,8 +3974,7 @@ TraitMethodDecl::as_string () const
 	  // DEBUG: null pointer check
 	  if (param == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"generic param in trait function decl.");
 	      return "nullptr_POINTER_MARK";
@@ -4101,8 +4082,7 @@ TraitItemType::as_string () const
 	  // DEBUG: null pointer check
 	  if (bound == nullptr)
 	    {
-	      fprintf (
-		stderr,
+	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
 		"type param bound in trait item type.");
 	      return "nullptr_POINTER_MARK";
@@ -4253,9 +4233,8 @@ ArrayElemsValues::as_string () const
       // DEBUG: null pointer check
       if (expr == nullptr)
 	{
-	  fprintf (stderr,
-		   "something really terrible has gone wrong - null pointer "
-		   "expr in array elems values.");
+	  rust_debug ("something really terrible has gone wrong - null pointer "
+		      "expr in array elems values.");
 	  return "nullptr_POINTER_MARK";
 	}
 

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -24,6 +24,7 @@
 #include "rust-token.h"
 #include "rust-location.h"
 #include "rust-hir-map.h"
+#include "rust-diagnostics.h"
 
 namespace Rust {
 typedef std::string Identifier;
@@ -127,7 +128,7 @@ public:
 	str = lexer_token_ptr->get_str ();
 
 	// DEBUG
-	fprintf (stderr, "ast token created with str '%s'\n", str.c_str ());
+	rust_debug ("ast token created with str '%s'", str.c_str ());
       }
     else
       {
@@ -135,15 +136,14 @@ public:
 	str = lexer_token_ptr->get_token_description ();
 
 	// DEBUG
-	fprintf (stderr, "ast token created with string '%s'\n", str.c_str ());
+	rust_debug ("ast token created with string '%s'", str.c_str ());
       }
 
     // DEBUG
     if (lexer_token_ptr->should_have_str () && !lexer_token_ptr->has_str ())
       {
-	fprintf (stderr,
-		 "BAD: for token '%s', should have string but does not!\n",
-		 lexer_token_ptr->get_token_description ());
+	rust_debug ("BAD: for token '%s', should have string but does not!",
+		    lexer_token_ptr->get_token_description ());
       }
   }
 

--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -55,8 +55,7 @@ operator+= (std::string &str, Codepoint char32)
     }
   else
     {
-      fprintf (stderr, "Invalid unicode codepoint found: '%u' \n",
-	       char32.value);
+      rust_debug ("Invalid unicode codepoint found: '%u' ", char32.value);
     }
   return str;
 }
@@ -185,7 +184,7 @@ Lexer::replace_current_token (TokenPtr replacement)
 {
   token_queue.replace_current_value (replacement);
 
-  fprintf (stderr, "called 'replace_current_token' - this is deprecated");
+  rust_debug ("called 'replace_current_token' - this is deprecated");
 }
 
 /* shitty anonymous namespace that can only be accessed inside the compilation
@@ -794,12 +793,12 @@ Lexer::build_token ()
 
       // DEBUG: check for specific character problems:
       if (current_char == '0')
-	fprintf (stderr, "'0' uncaught before unexpected character\n");
+	rust_debug ("'0' uncaught before unexpected character");
       else if (current_char == ']')
-	fprintf (stderr, "']' uncaught before unexpected character\n");
+	rust_debug ("']' uncaught before unexpected character");
       else if (current_char == 0x5d)
-	fprintf (stderr, "whatever 0x5d is (not '0' or ']') uncaught before "
-			 "unexpected character\n");
+	rust_debug ("whatever 0x5d is (not '0' or ']') uncaught before "
+		    "unexpected character");
 
       // didn't match anything so error
       rust_error_at (loc, "unexpected character %<%x%>", current_char);

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -261,10 +261,9 @@ Parser<ManagedTokenSource>::left_binding_power (const_TokenPtr token)
 	  return LBP_DOT;*/
 
     case SCOPE_RESOLUTION:
-      fprintf (
-	stderr,
+      rust_debug (
 	"possible error - looked up LBP of scope resolution operator. should "
-	"be handled elsewhere. \n");
+	"be handled elsewhere.");
       return LBP_PATH;
 
     /* Resolved by lookahead HACK that should work with current code. If next
@@ -609,10 +608,10 @@ Parser<ManagedTokenSource>::parse_simple_path ()
     {
       if (seg.is_error ())
 	{
-	  fprintf (stderr,
-		   "when parsing simple path, somehow empty path segment was "
-		   "not filtered out. Path begins with '%s' \n",
-		   segments.at (0).as_string ().c_str ());
+	  rust_debug (
+	    "when parsing simple path, somehow empty path segment was "
+	    "not filtered out. Path begins with '%s'",
+	    segments.at (0).as_string ().c_str ());
 	}
     }
 
@@ -917,11 +916,10 @@ Parser<ManagedTokenSource>::parse_delim_token_tree ()
       lexer.skip_token ();
 
       // DEBUG
-      fprintf (stderr,
-	       "finished parsing new delim token tree - peeked token is now "
-	       "'%s' while t is '%s'\n",
-	       lexer.peek_token ()->get_token_description (),
-	       t->get_token_description ());
+      rust_debug ("finished parsing new delim token tree - peeked token is now "
+		  "'%s' while t is '%s'",
+		  lexer.peek_token ()->get_token_description (),
+		  t->get_token_description ());
 
       return token_tree;
     }
@@ -1319,21 +1317,19 @@ Parser<ManagedTokenSource>::parse_macro_item (AST::AttrVec outer_attrs)
   else
     {
       // DEBUG: TODO: remove
-      fprintf (stderr,
-	       "DEBUG - parse_macro_item called and token is not macro_rules");
+      rust_debug (
+	"DEBUG - parse_macro_item called and token is not macro_rules");
       if (t->get_id () == IDENTIFIER)
 	{
-	  fprintf (stderr,
-		   "just add to last error: token is not macro_rules and is "
-		   "instead '%s'",
-		   t->get_str ().c_str ());
+	  rust_debug ("just add to last error: token is not macro_rules and is "
+		      "instead '%s'",
+		      t->get_str ().c_str ());
 	}
       else
 	{
-	  fprintf (stderr,
-		   "just add to last error: token is not macro_rules and is "
-		   "not an identifier either - it is '%s'",
-		   t->get_token_description ());
+	  rust_debug ("just add to last error: token is not macro_rules and is "
+		      "not an identifier either - it is '%s'",
+		      t->get_token_description ());
 	}
 
       return parse_macro_invocation_semi (std::move (outer_attrs));
@@ -1375,7 +1371,7 @@ Parser<ManagedTokenSource>::parse_macro_rules_def (AST::AttrVec outer_attrs)
   Identifier rule_name = ident_tok->get_str ();
 
   // DEBUG
-  fprintf (stderr, "in macro rules def, about to parse parens.\n");
+  rust_debug ("in macro rules def, about to parse parens.");
 
   // save delim type to ensure it is reused later
   AST::DelimType delim_type = AST::PARENS;
@@ -1421,7 +1417,7 @@ Parser<ManagedTokenSource>::parse_macro_rules_def (AST::AttrVec outer_attrs)
   macro_rules.push_back (std::move (initial_rule));
 
   // DEBUG
-  fprintf (stderr, "successfully pushed back initial macro rule\n");
+  rust_debug ("successfully pushed back initial macro rule");
 
   t = lexer.peek_token ();
   // parse macro rules
@@ -1434,9 +1430,8 @@ Parser<ManagedTokenSource>::parse_macro_rules_def (AST::AttrVec outer_attrs)
       if (token_id_matches_delims (lexer.peek_token ()->get_id (), delim_type))
 	{
 	  // DEBUG
-	  fprintf (
-	    stderr,
-	    "broke out of parsing macro rules loop due to finding delim\n");
+	  rust_debug (
+	    "broke out of parsing macro rules loop due to finding delim");
 
 	  break;
 	}
@@ -1455,7 +1450,7 @@ Parser<ManagedTokenSource>::parse_macro_rules_def (AST::AttrVec outer_attrs)
       macro_rules.push_back (std::move (rule));
 
       // DEBUG
-      fprintf (stderr, "successfully pushed back another macro rule\n");
+      rust_debug ("successfully pushed back another macro rule");
 
       t = lexer.peek_token ();
     }
@@ -1595,10 +1590,9 @@ Parser<ManagedTokenSource>::parse_macro_invocation_semi (
 	}
 
       // DEBUG:
-      fprintf (stderr,
-	       "skipped token is '%s', next token (current peek) is '%s'\n",
-	       t->get_token_description (),
-	       lexer.peek_token ()->get_token_description ());
+      rust_debug ("skipped token is '%s', next token (current peek) is '%s'",
+		  t->get_token_description (),
+		  lexer.peek_token ()->get_token_description ());
 
       return std::unique_ptr<AST::MacroInvocationSemi> (
 	new AST::MacroInvocationSemi (std::move (invoc_data),
@@ -1688,7 +1682,7 @@ Parser<ManagedTokenSource>::parse_macro_matcher ()
   AST::DelimType delim_type = AST::PARENS;
 
   // DEBUG
-  fprintf (stderr, "begun parsing macro matcher\n");
+  rust_debug ("begun parsing macro matcher");
 
   // Map tokens to DelimType
   const_TokenPtr t = lexer.peek_token ();
@@ -1736,7 +1730,7 @@ Parser<ManagedTokenSource>::parse_macro_matcher ()
       matches.push_back (std::move (match));
 
       // DEBUG
-      fprintf (stderr, "pushed back a match in macro matcher\n");
+      rust_debug ("pushed back a match in macro matcher");
 
       t = lexer.peek_token ();
     }
@@ -2638,20 +2632,19 @@ Parser<ManagedTokenSource>::parse_generic_params_in_angles ()
   lexer.skip_token ();
 
   // DEBUG:
-  fprintf (stderr, "skipped left angle in generic param\n");
+  rust_debug ("skipped left angle in generic param");
 
   std::vector<std::unique_ptr<AST::GenericParam>> generic_params
     = parse_generic_params (is_right_angle_tok);
 
   // DEBUG:
-  fprintf (stderr,
-	   "finished parsing actual generic params (i.e. inside angles)\n");
+  rust_debug ("finished parsing actual generic params (i.e. inside angles)");
 
   if (!skip_generics_right_angle ())
     {
       // DEBUG
-      fprintf (stderr, "failed to skip generics right angle - returning empty "
-		       "generic params\n");
+      rust_debug ("failed to skip generics right angle - returning empty "
+		  "generic params");
 
       return std::vector<std::unique_ptr<AST::GenericParam>> ();
     }
@@ -2671,8 +2664,7 @@ Parser<ManagedTokenSource>::parse_generic_params ()
   // thus, parse them all here
 
   // DEBUG
-  fprintf (stderr,
-	   "starting to parse generic params (inside angle brackets)\n");
+  rust_debug ("starting to parse generic params (inside angle brackets)");
 
   /* HACK: used to retain attribute data if a lifetime param is tentatively
    * parsed but it turns out to be type param */
@@ -2693,10 +2685,9 @@ Parser<ManagedTokenSource>::parse_generic_params ()
 	  parsed_outer_attr = std::move (outer_attr);
 
 	  // DEBUG
-	  fprintf (
-	    stderr,
+	  rust_debug (
 	    "broke from parsing lifetime params as next token isn't lifetime - "
-	    "saved attribute\n");
+	    "saved attribute");
 
 	  break;
 	}
@@ -2705,7 +2696,7 @@ Parser<ManagedTokenSource>::parse_generic_params ()
       AST::Lifetime lifetime = parse_lifetime ();
 
       // DEBUG
-      fprintf (stderr, "parsed lifetime in lifetime params\n");
+      rust_debug ("parsed lifetime in lifetime params");
 
       // parse optional bounds
       std::vector<AST::Lifetime> lifetime_bounds;
@@ -2737,8 +2728,8 @@ Parser<ManagedTokenSource>::parse_generic_params ()
       && !parsed_outer_attr.is_empty ())
     {
       // DEBUG
-      fprintf (stderr, "as parsed outer attr isn't empty, started parsing type "
-		       "param reimpl\n");
+      rust_debug ("as parsed outer attr isn't empty, started parsing type "
+		  "param reimpl");
 
       // reimpl as type param definitely exists
       const_TokenPtr ident_tok = expect_token (IDENTIFIER);
@@ -2796,9 +2787,8 @@ Parser<ManagedTokenSource>::parse_generic_params ()
     }
 
   // DEBUG
-  fprintf (
-    stderr,
-    "about to start parsing normally-parsed type params in generic params\n");
+  rust_debug (
+    "about to start parsing normally-parsed type params in generic params");
 
   // parse rest of type params - reimpl due to right angle tokens
   t = lexer.peek_token ();
@@ -2816,7 +2806,7 @@ Parser<ManagedTokenSource>::parse_generic_params ()
 	}
 
       // DEBUG
-      fprintf (stderr, "successfully parsed type param\n");
+      rust_debug ("successfully parsed type param");
 
       generic_params.push_back (std::move (type_param));
 
@@ -3625,8 +3615,8 @@ Parser<ManagedTokenSource>::parse_for_lifetimes ()
   if (!skip_generics_right_angle ())
     {
       // DEBUG
-      fprintf (stderr, "failed to skip generics right angle after (supposedly) "
-		       "finished parsing where clause items\n");
+      rust_debug ("failed to skip generics right angle after (supposedly) "
+		  "finished parsing where clause items");
       // ok, well this gets called.
 
       // skip after somewhere?
@@ -5068,7 +5058,7 @@ Parser<ManagedTokenSource>::parse_impl (AST::Visibility vis,
 	}
 
       // DEBUG
-      fprintf (stderr, "successfully parsed inherent impl\n");
+      rust_debug ("successfully parsed inherent impl");
 
       impl_items.shrink_to_fit ();
 
@@ -5135,10 +5125,10 @@ Parser<ManagedTokenSource>::parse_impl (AST::Visibility vis,
 	  t = lexer.peek_token ();
 
 	  // DEBUG
-	  fprintf (stderr, "successfully parsed a trait impl item\n");
+	  rust_debug ("successfully parsed a trait impl item");
 	}
       // DEBUG
-      fprintf (stderr, "successfully finished trait impl items\n");
+      rust_debug ("successfully finished trait impl items");
 
       if (!skip_token (RIGHT_CURLY))
 	{
@@ -5147,7 +5137,7 @@ Parser<ManagedTokenSource>::parse_impl (AST::Visibility vis,
 	}
 
       // DEBUG
-      fprintf (stderr, "successfully parsed trait impl\n");
+      rust_debug ("successfully parsed trait impl");
 
       impl_items.shrink_to_fit ();
 
@@ -5525,18 +5515,16 @@ Parser<ManagedTokenSource>::parse_trait_impl_function_or_method (
   Identifier ident = ident_tok->get_str ();
 
   // DEBUG:
-  fprintf (
-    stderr,
-    "about to start parsing generic params in trait impl function or method\n");
+  rust_debug (
+    "about to start parsing generic params in trait impl function or method");
 
   // parse generic params
   std::vector<std::unique_ptr<AST::GenericParam>> generic_params
     = parse_generic_params_in_angles ();
 
   // DEBUG:
-  fprintf (
-    stderr,
-    "finished parsing generic params in trait impl function or method\n");
+  rust_debug (
+    "finished parsing generic params in trait impl function or method");
 
   if (!skip_token (LEFT_PAREN))
     {
@@ -5561,14 +5549,12 @@ Parser<ManagedTokenSource>::parse_trait_impl_function_or_method (
 	}
 
       // DEBUG
-      fprintf (stderr,
-	       "successfully parsed self param in method trait impl item\n");
+      rust_debug ("successfully parsed self param in method trait impl item");
     }
 
   // DEBUG
-  fprintf (
-    stderr,
-    "started to parse function params in function or method trait impl item\n");
+  rust_debug (
+    "started to parse function params in function or method trait impl item");
 
   // parse trait function params (only if next token isn't right paren)
   std::vector<AST::FunctionParam> function_params;
@@ -5591,8 +5577,8 @@ Parser<ManagedTokenSource>::parse_trait_impl_function_or_method (
     }
 
   // DEBUG
-  fprintf (stderr, "successfully parsed function params in function or method "
-		   "trait impl item\n");
+  rust_debug ("successfully parsed function params in function or method "
+	      "trait impl item");
 
   if (!skip_token (RIGHT_PAREN))
     {
@@ -5604,17 +5590,15 @@ Parser<ManagedTokenSource>::parse_trait_impl_function_or_method (
   std::unique_ptr<AST::Type> return_type = parse_function_return_type ();
 
   // DEBUG
-  fprintf (
-    stderr,
-    "successfully parsed return type in function or method trait impl item\n");
+  rust_debug (
+    "successfully parsed return type in function or method trait impl item");
 
   // parse where clause (optional)
   AST::WhereClause where_clause = parse_where_clause ();
 
   // DEBUG
-  fprintf (
-    stderr,
-    "successfully parsed where clause in function or method trait impl item\n");
+  rust_debug (
+    "successfully parsed where clause in function or method trait impl item");
 
   // parse function definition (in block) - semicolon not allowed
   if (lexer.peek_token ()->get_id () == SEMICOLON)
@@ -8513,7 +8497,7 @@ Parser<ManagedTokenSource>::parse_match_arm ()
   AST::AttrVec outer_attrs = parse_outer_attributes ();
 
   // DEBUG
-  fprintf (stderr, "about to start parsing match arm patterns\n");
+  rust_debug ("about to start parsing match arm patterns");
 
   // break early if find right curly
   if (lexer.peek_token ()->get_id () == RIGHT_CURLY)
@@ -8536,7 +8520,7 @@ Parser<ManagedTokenSource>::parse_match_arm ()
     }
 
   // DEBUG
-  fprintf (stderr, "successfully parsed match arm patterns\n");
+  rust_debug ("successfully parsed match arm patterns");
 
   // parse match arm guard expr if it exists
   std::unique_ptr<AST::Expr> guard_expr = nullptr;
@@ -8557,7 +8541,7 @@ Parser<ManagedTokenSource>::parse_match_arm ()
     }
 
   // DEBUG
-  fprintf (stderr, "successfully parsed match arm\n");
+  rust_debug ("successfully parsed match arm");
 
   return AST::MatchArm (std::move (match_arm_patterns), std::move (guard_expr),
 			std::move (outer_attrs));
@@ -8593,7 +8577,7 @@ Parser<ManagedTokenSource>::parse_match_arm_patterns (TokenId end_token_id)
   patterns.push_back (std::move (initial_pattern));
 
   // DEBUG
-  fprintf (stderr, "successfully parsed initial match arm pattern\n");
+  rust_debug ("successfully parsed initial match arm pattern");
 
   // parse new patterns as long as next char is '|'
   const_TokenPtr t = lexer.peek_token ();
@@ -10331,7 +10315,7 @@ Parser<ManagedTokenSource>::parse_range_pattern_bound ()
 	  range_lower_locus));
     case FLOAT_LITERAL:
       lexer.skip_token ();
-      fprintf (stderr, "warning: used deprecated float range pattern bound");
+      rust_debug ("warning: used deprecated float range pattern bound");
       return std::unique_ptr<AST::RangePatternBoundLiteral> (
 	new AST::RangePatternBoundLiteral (
 	  AST::Literal (range_lower->get_str (), AST::Literal::FLOAT,
@@ -10351,8 +10335,7 @@ Parser<ManagedTokenSource>::parse_range_pattern_bound ()
 	      range_lower_locus, true));
 	case FLOAT_LITERAL:
 	  lexer.skip_token (1);
-	  fprintf (stderr,
-		   "warning: used deprecated float range pattern bound");
+	  rust_debug ("warning: used deprecated float range pattern bound");
 	  return std::unique_ptr<AST::RangePatternBoundLiteral> (
 	    new AST::RangePatternBoundLiteral (
 	      AST::Literal (range_lower->get_str (), AST::Literal::FLOAT,
@@ -10914,7 +10897,7 @@ Parser<ManagedTokenSource>::parse_identifier_pattern ()
       lexer.skip_token ();
 
       // DEBUG
-      fprintf (stderr, "parsed ref in identifier pattern\n");
+      rust_debug ("parsed ref in identifier pattern");
     }
 
   bool has_mut = false;
@@ -10934,7 +10917,7 @@ Parser<ManagedTokenSource>::parse_identifier_pattern ()
   Identifier ident = ident_tok->get_str ();
 
   // DEBUG
-  fprintf (stderr, "parsed identifier in identifier pattern\n");
+  rust_debug ("parsed identifier in identifier pattern");
 
   // parse optional pattern binding thing
   std::unique_ptr<AST::Pattern> bind_pattern = nullptr;
@@ -10955,7 +10938,7 @@ Parser<ManagedTokenSource>::parse_identifier_pattern ()
     }
 
   // DEBUG
-  fprintf (stderr, "about to return identifier pattern\n");
+  rust_debug ("about to return identifier pattern");
 
   return std::unique_ptr<AST::IdentifierPattern> (
     new AST::IdentifierPattern (std::move (ident), locus, has_ref, has_mut,
@@ -10993,7 +10976,7 @@ Parser<ManagedTokenSource>::parse_ident_leading_pattern ()
 	lexer.skip_token ();
 
 	// DEBUG
-	fprintf (stderr, "parsing tuple struct pattern\n");
+	rust_debug ("parsing tuple struct pattern");
 
 	// check if empty tuple
 	if (lexer.peek_token ()->get_id () == RIGHT_PAREN)
@@ -11016,7 +10999,7 @@ Parser<ManagedTokenSource>::parse_ident_leading_pattern ()
 	  }
 
 	// DEBUG
-	fprintf (stderr, "successfully parsed tuple struct items\n");
+	rust_debug ("successfully parsed tuple struct items");
 
 	if (!skip_token (RIGHT_PAREN))
 	  {
@@ -11024,7 +11007,7 @@ Parser<ManagedTokenSource>::parse_ident_leading_pattern ()
 	  }
 
 	// DEBUG
-	fprintf (stderr, "successfully parsed tuple struct pattern\n");
+	rust_debug ("successfully parsed tuple struct pattern");
 
 	return std::unique_ptr<AST::TupleStructPattern> (
 	  new AST::TupleStructPattern (std::move (path), std::move (items)));
@@ -11042,7 +11025,7 @@ Parser<ManagedTokenSource>::parse_ident_leading_pattern ()
 	  }
 
 	// DEBUG
-	fprintf (stderr, "successfully parsed struct pattern\n");
+	rust_debug ("successfully parsed struct pattern");
 
 	return std::unique_ptr<AST::StructPattern> (
 	  new AST::StructPattern (std::move (path), std::move (elems)));
@@ -11114,7 +11097,7 @@ Parser<ManagedTokenSource>::parse_tuple_struct_items ()
   std::vector<std::unique_ptr<AST::Pattern>> lower_patterns;
 
   // DEBUG
-  fprintf (stderr, "started parsing tuple struct items\n");
+  rust_debug ("started parsing tuple struct items");
 
   // check for '..' at front
   if (lexer.peek_token ()->get_id () == DOT_DOT)
@@ -11123,7 +11106,7 @@ Parser<ManagedTokenSource>::parse_tuple_struct_items ()
       lexer.skip_token ();
 
       // DEBUG
-      fprintf (stderr, "'..' at front in tuple struct items detected\n");
+      rust_debug ("'..' at front in tuple struct items detected");
 
       std::vector<std::unique_ptr<AST::Pattern>> upper_patterns;
 
@@ -11152,9 +11135,8 @@ Parser<ManagedTokenSource>::parse_tuple_struct_items ()
 	}
 
       // DEBUG
-      fprintf (
-	stderr,
-	"finished parsing tuple struct items ranged (upper/none only)\n");
+      rust_debug (
+	"finished parsing tuple struct items ranged (upper/none only)");
 
       return std::unique_ptr<AST::TupleStructItemsRange> (
 	new AST::TupleStructItemsRange (std::move (lower_patterns),
@@ -11166,7 +11148,7 @@ Parser<ManagedTokenSource>::parse_tuple_struct_items ()
   while (t->get_id () != RIGHT_PAREN && t->get_id () != DOT_DOT)
     {
       // DEBUG
-      fprintf (stderr, "about to parse pattern in tuple struct items\n");
+      rust_debug ("about to parse pattern in tuple struct items");
 
       // parse pattern, which is required
       std::unique_ptr<AST::Pattern> pattern = parse_pattern ();
@@ -11181,13 +11163,13 @@ Parser<ManagedTokenSource>::parse_tuple_struct_items ()
       lower_patterns.push_back (std::move (pattern));
 
       // DEBUG
-      fprintf (stderr, "successfully parsed pattern in tuple struct items\n");
+      rust_debug ("successfully parsed pattern in tuple struct items");
 
       if (lexer.peek_token ()->get_id () != COMMA)
 	{
 	  // DEBUG
-	  fprintf (stderr, "broke out of parsing patterns in tuple struct "
-			   "items as no comma \n");
+	  rust_debug ("broke out of parsing patterns in tuple struct "
+		      "items as no comma");
 
 	  break;
 	}
@@ -12321,8 +12303,7 @@ Parser<ManagedTokenSource>::parse_expr (int right_binding_power,
   if (expr == nullptr)
     {
       // DEBUG
-      fprintf (stderr,
-	       "null denotation is null; returning null for parse_expr\n");
+      rust_debug ("null denotation is null; returning null for parse_expr");
       return nullptr;
     }
 
@@ -12338,8 +12319,7 @@ Parser<ManagedTokenSource>::parse_expr (int right_binding_power,
       if (expr == nullptr)
 	{
 	  // DEBUG
-	  fprintf (stderr,
-		   "left denotation is null; returning null for parse_expr\n");
+	  rust_debug ("left denotation is null; returning null for parse_expr");
 
 	  return nullptr;
 	}
@@ -12378,15 +12358,15 @@ Parser<ManagedTokenSource>::null_denotation (const_TokenPtr tok,
     {
       case IDENTIFIER: {
 	// DEBUG
-	fprintf (stderr, "beginning null denotation identifier handling\n");
+	rust_debug ("beginning null denotation identifier handling");
 
 	/* best option: parse as path, then extract identifier, macro,
 	 * struct/enum, or just path info from it */
 	AST::PathInExpression path = parse_path_in_expression_pratt (tok);
 
 	// DEBUG:
-	fprintf (stderr, "finished null denotation identifier path parsing - "
-			 "next is branching \n");
+	rust_debug ("finished null denotation identifier path parsing - "
+		    "next is branching");
 
 	// branch on next token
 	const_TokenPtr t = lexer.peek_token ();
@@ -12411,15 +12391,15 @@ Parser<ManagedTokenSource>::null_denotation (const_TokenPtr tok,
 	       *  path '{' ident ':' [not a type]
 	       * otherwise, assume block expr and thus path */
 	      // DEBUG
-	      fprintf (stderr, "values of lookahead: '%s' '%s' '%s' '%s' \n",
-		       lexer.peek_token (1)->get_token_description (),
-		       lexer.peek_token (2)->get_token_description (),
-		       lexer.peek_token (3)->get_token_description (),
-		       lexer.peek_token (4)->get_token_description ());
+	      rust_debug ("values of lookahead: '%s' '%s' '%s' '%s' ",
+			  lexer.peek_token (1)->get_token_description (),
+			  lexer.peek_token (2)->get_token_description (),
+			  lexer.peek_token (3)->get_token_description (),
+			  lexer.peek_token (4)->get_token_description ());
 
-	      fprintf (stderr, "can be struct expr: '%s', not a block: '%s'\n",
-		       restrictions.can_be_struct_expr ? "true" : "false",
-		       not_a_block ? "true" : "false");
+	      rust_debug ("can be struct expr: '%s', not a block: '%s'",
+			  restrictions.can_be_struct_expr ? "true" : "false",
+			  not_a_block ? "true" : "false");
 
 	      // struct/enum expr struct
 	      if (!restrictions.can_be_struct_expr && !not_a_block)
@@ -12668,18 +12648,18 @@ Parser<ManagedTokenSource>::null_denotation (const_TokenPtr tok,
     case CRATE:
       case SUPER: {
 	// DEBUG
-	fprintf (stderr, "beginning null denotation "
-			 "self/self-alias/dollar/crate/super handling\n");
+	rust_debug ("beginning null denotation "
+		    "self/self-alias/dollar/crate/super handling");
 
 	/* best option: parse as path, then extract identifier, macro,
 	 * struct/enum, or just path info from it */
 	AST::PathInExpression path = parse_path_in_expression_pratt (tok);
 
 	// DEBUG
-	fprintf (stderr,
-		 "just finished parsing path (going to disambiguate) - peeked "
-		 "token is '%s'\n",
-		 lexer.peek_token ()->get_token_description ());
+	rust_debug (
+	  "just finished parsing path (going to disambiguate) - peeked "
+	  "token is '%s'",
+	  lexer.peek_token ()->get_token_description ());
 
 	// HACK: always make "self" by itself a path (regardless of next tokens)
 	if (tok->get_id () == SELF && path.is_single_segment ())
@@ -12700,8 +12680,8 @@ Parser<ManagedTokenSource>::null_denotation (const_TokenPtr tok,
 						   std::move (outer_attrs));
 	    case LEFT_CURLY: {
 	      // struct/enum expr struct
-	      fprintf (stderr, "can_be_struct_expr: %s\n",
-		       restrictions.can_be_struct_expr ? "true" : "false");
+	      rust_debug ("can_be_struct_expr: %s",
+			  restrictions.can_be_struct_expr ? "true" : "false");
 
 	      bool not_a_block
 		= lexer.peek_token (1)->get_id () == IDENTIFIER
@@ -14288,7 +14268,7 @@ Parser<ManagedTokenSource>::parse_macro_invocation_partial (
 
   AST::DelimTokenTree tok_tree = parse_delim_token_tree ();
 
-  fprintf (stderr, "successfully parsed macro invocation (via partial)\n");
+  rust_debug ("successfully parsed macro invocation (via partial)");
 
   Location macro_locus = converted_path.get_locus ();
 
@@ -14351,31 +14331,30 @@ Parser<ManagedTokenSource>::parse_struct_expr_struct_partial (
 	      }
 
 	    // DEBUG:
-	    fprintf (stderr,
-		     "struct/enum expr field validated to not be null \n");
+	    rust_debug ("struct/enum expr field validated to not be null");
 
 	    fields.push_back (std::move (field));
 
 	    // DEBUG:
-	    fprintf (stderr, "struct/enum expr field pushed back \n");
+	    rust_debug ("struct/enum expr field pushed back");
 
 	    if (lexer.peek_token ()->get_id () != COMMA)
 	      {
 		// DEBUG:
-		fprintf (stderr, "lack of comma detected in struct/enum expr "
-				 "fields - break \n");
+		rust_debug ("lack of comma detected in struct/enum expr "
+			    "fields - break");
 		break;
 	      }
 	    lexer.skip_token ();
 
 	    // DEBUG:
-	    fprintf (stderr, "struct/enum expr fields comma skipped \n");
+	    rust_debug ("struct/enum expr fields comma skipped ");
 
 	    t = lexer.peek_token ();
 	  }
 
 	// DEBUG:
-	fprintf (stderr, "struct/enum expr about to parse struct base \n");
+	rust_debug ("struct/enum expr about to parse struct base ");
 
 	// parse struct base if it exists
 	AST::StructBase struct_base = AST::StructBase::error ();
@@ -14396,13 +14375,12 @@ Parser<ManagedTokenSource>::parse_struct_expr_struct_partial (
 	      }
 
 	    // DEBUG:
-	    fprintf (stderr,
-		     "struct/enum expr - parsed and validated base expr \n");
+	    rust_debug ("struct/enum expr - parsed and validated base expr");
 
 	    struct_base = AST::StructBase (std::move (base_expr));
 
 	    // DEBUG:
-	    fprintf (stderr, "assigned struct base to new struct base \n");
+	    rust_debug ("assigned struct base to new struct base ");
 	  }
 
 	if (!skip_token (RIGHT_CURLY))
@@ -14411,9 +14389,8 @@ Parser<ManagedTokenSource>::parse_struct_expr_struct_partial (
 	  }
 
 	// DEBUG:
-	fprintf (
-	  stderr,
-	  "struct/enum expr skipped right curly - done and ready to return \n");
+	rust_debug (
+	  "struct/enum expr skipped right curly - done and ready to return");
 
 	return std::unique_ptr<AST::StructExprStructFields> (
 	  new AST::StructExprStructFields (std::move (path), std::move (fields),
@@ -14500,8 +14477,8 @@ Parser<ManagedTokenSource>::parse_path_in_expression_pratt (const_TokenPtr tok)
   // HACK-y way of making up for pratt-parsing consuming first token
 
   // DEBUG
-  fprintf (stderr, "current peek token when starting path pratt parse: '%s'\n",
-	   lexer.peek_token ()->get_token_description ());
+  rust_debug ("current peek token when starting path pratt parse: '%s'",
+	      lexer.peek_token ()->get_token_description ());
 
   // create segment vector
   std::vector<AST::PathExprSegment> segments;
@@ -14562,7 +14539,7 @@ Parser<ManagedTokenSource>::parse_path_in_expression_pratt (const_TokenPtr tok)
       // don't necessarily throw error but yeah
 
       // DEBUG
-      fprintf (stderr, "initial segment is error - returning null\n");
+      rust_debug ("initial segment is error - returning null");
 
       return AST::PathInExpression::create_error ();
     }
@@ -14593,9 +14570,8 @@ Parser<ManagedTokenSource>::parse_path_in_expression_pratt (const_TokenPtr tok)
     }
 
   // DEBUG:
-  fprintf (
-    stderr,
-    "current token (just about to return path to null denotation): '%s'\n",
+  rust_debug (
+    "current token (just about to return path to null denotation): '%s'",
     lexer.peek_token ()->get_token_description ());
 
   return AST::PathInExpression (std::move (segments), {}, tok->get_locus (),
@@ -14745,8 +14721,7 @@ Parser<ManagedTokenSource>::parse_tuple_index_expr_float (
     return nullptr;
 
   // DEBUG:
-  fprintf (stderr, "exact string form of float: '%s'\n",
-	   tok->get_str ().c_str ());
+  rust_debug ("exact string form of float: '%s'", tok->get_str ().c_str ());
 
   // get float string and remove dot and initial 0
   std::string index_str = tok->get_str ();

--- a/gcc/rust/rust-diagnostics.cc
+++ b/gcc/rust/rust-diagnostics.cc
@@ -197,11 +197,6 @@ rust_error_at (const RichLocation location, const char *fmt, ...)
   va_end (ap);
 }
 
-// rust_debug uses normal printf formatting, not GCC diagnostic formatting.
-
-void
-rust_debug (const Location location, const char *fmt, ...) ATTRIBUTE_PRINTF_2;
-
 void
 rust_debug (const Location location, const char *fmt, ...)
 {

--- a/gcc/rust/rust-diagnostics.h
+++ b/gcc/rust/rust-diagnostics.h
@@ -124,4 +124,15 @@ struct Error
 };
 } // namespace Rust
 
+// rust_debug uses normal printf formatting, not GCC diagnostic formatting.
+void
+rust_debug (const Location location, const char *fmt, ...) ATTRIBUTE_PRINTF_2;
+
+template <typename... Args>
+inline void
+rust_debug (const char *fmt, Args... args)
+{
+  rust_debug (Location (), fmt, args...);
+}
+
 #endif // !defined(RUST_DIAGNOSTICS_H)

--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -31,6 +31,7 @@
 #include "convert.h"
 #include "langhooks.h"
 #include "langhooks-def.h"
+#include "rust-diagnostics.h"
 
 #include <mpfr.h>
 // note: header files must be in this order or else forward declarations don't
@@ -165,7 +166,7 @@ grs_langhook_init_options_struct (struct gcc_options * /* opts */)
 static void
 grs_langhook_parse_file (void)
 {
-  fprintf (stderr, "Preparing to parse files. \n");
+  rust_debug ("Preparing to parse files. ");
 
   session.parse_files (num_in_fnames, in_fnames);
 }

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -142,9 +142,8 @@ Session::enable_features ()
 {
   bool has_target_crt_static = false;
 
-  fprintf (
-    stderr,
-    "ERROR: Somewhere in call chain Session::enable_features is called.\n");
+  rust_debug (
+    "ERROR: Somewhere in call chain Session::enable_features is called.");
 
   if (has_target_crt_static)
     {
@@ -456,7 +455,7 @@ Session::parse_files (int num_files, const char **files)
 
   for (int i = 0; i < num_files; i++)
     {
-      fprintf (stderr, "Attempting to parse file: %s\n", files[i]);
+      rust_debug ("Attempting to parse file: %s", files[i]);
       parse_file (files[i]);
     }
   /* TODO: should semantic analysis be dealed with here? or per file? for now,
@@ -517,11 +516,11 @@ Session::parse_file (const char *filename)
    * maybe buffered lints)
    *  TODO not done */
 
-  fprintf (stderr, "\033[0;31mSUCCESSFULLY PARSED CRATE \n\033[0m");
+  rust_debug ("\033[0;31mSUCCESSFULLY PARSED CRATE \033[0m");
 
   // register plugins pipeline stage
   register_plugins (parsed_crate);
-  fprintf (stderr, "\033[0;31mSUCCESSFULLY REGISTERED PLUGINS \n\033[0m");
+  rust_debug ("\033[0;31mSUCCESSFULLY REGISTERED PLUGINS \033[0m");
   if (options.dump_option_enabled (CompileOptions::REGISTER_PLUGINS_DUMP))
     {
       // TODO: what do I dump here?
@@ -529,7 +528,7 @@ Session::parse_file (const char *filename)
 
   // injection pipeline stage
   injection (parsed_crate);
-  fprintf (stderr, "\033[0;31mSUCCESSFULLY FINISHED INJECTION \n\033[0m");
+  rust_debug ("\033[0;31mSUCCESSFULLY FINISHED INJECTION \033[0m");
   if (options.dump_option_enabled (CompileOptions::INJECTION_DUMP))
     {
       // TODO: what do I dump here? injected crate names?
@@ -537,13 +536,13 @@ Session::parse_file (const char *filename)
 
   // expansion pipeline stage
   expansion (parsed_crate);
-  fprintf (stderr, "\033[0;31mSUCCESSFULLY FINISHED EXPANSION \n\033[0m");
+  rust_debug ("\033[0;31mSUCCESSFULLY FINISHED EXPANSION \033[0m");
   if (options.dump_option_enabled (CompileOptions::EXPANSION_DUMP))
     {
       // dump AST with expanded stuff
-      fprintf (stderr, "BEGIN POST-EXPANSION AST DUMP\n");
+      rust_debug ("BEGIN POST-EXPANSION AST DUMP");
       dump_ast_expanded (parser, parsed_crate);
-      fprintf (stderr, "END POST-EXPANSION AST DUMP\n");
+      rust_debug ("END POST-EXPANSION AST DUMP");
     }
 
   // resolution pipeline stage
@@ -652,7 +651,7 @@ Session::debug_dump_load_crates (Parser<Lexer> &parser)
 void
 Session::register_plugins (AST::Crate &crate ATTRIBUTE_UNUSED)
 {
-  fprintf (stderr, "ran register_plugins (with no body)\n");
+  rust_debug ("ran register_plugins (with no body)");
 }
 
 // TODO: move somewhere else
@@ -671,7 +670,7 @@ contains_name (const AST::AttrVec &attrs, std::string name)
 void
 Session::injection (AST::Crate &crate)
 {
-  fprintf (stderr, "started injection\n");
+  rust_debug ("started injection");
 
   // lint checks in future maybe?
 
@@ -792,13 +791,13 @@ Session::injection (AST::Crate &crate)
    * type is not specified, so maybe just do that. Valid crate types: bin lib
    * dylib staticlib cdylib rlib proc-macro */
 
-  fprintf (stderr, "finished injection\n");
+  rust_debug ("finished injection");
 }
 
 void
 Session::expansion (AST::Crate &crate)
 {
-  fprintf (stderr, "started expansion\n");
+  rust_debug ("started expansion");
 
   /* rustc has a modification to windows PATH temporarily here, which may end up
    * being required */
@@ -821,7 +820,7 @@ Session::expansion (AST::Crate &crate)
 
   // maybe create macro crate if not rustdoc
 
-  fprintf (stderr, "finished expansion\n");
+  rust_debug ("finished expansion");
 }
 
 void
@@ -997,8 +996,7 @@ TargetOptions::enable_implicit_feature_reqs (std::string feature)
     {
       insert_key_value_pair ("target_feature", feature);
 
-      fprintf (stderr, "had to implicitly enable feature '%s'!",
-	       feature.c_str ());
+      rust_debug ("had to implicitly enable feature '%s'!", feature.c_str ());
     }
 }
 

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -22,6 +22,7 @@
 #include "rust-backend.h"
 #include "rust-hir-map.h"
 #include "rust-hir-full.h"
+#include "rust-diagnostics.h"
 
 namespace Rust {
 namespace TyTy {
@@ -142,8 +143,8 @@ public:
 
   void debug () const
   {
-    fprintf (stderr, "[%p] %s\n", static_cast<const void *> (this),
-	     debug_str ().c_str ());
+    rust_debug ("[%p] %s", static_cast<const void *> (this),
+		debug_str ().c_str ());
   }
 
 protected:
@@ -319,7 +320,7 @@ public:
 
   StructFieldType *clone () const;
 
-  void debug () const { fprintf (stderr, "%s\n", as_string ().c_str ()); }
+  void debug () const { rust_debug ("%s", as_string ().c_str ()); }
 
 private:
   HirId ref;


### PR DESCRIPTION
Fixes #464 

@philberty I've checked and rust_debug does output on stderr correctly :)

This PR exposes the rust_debug prototype and replaces debug printfs (`fprintf (stderr, ...)`) with calls to rust_debug. This also removes the extra newlines that were added at the end of the fprintf format strings, since calling rust_debug already adds one. Without this, the tests fail due to blank lines in the output.

I have used a template to overload the rust_debug function and pass variadic arguments to the complete version. While the code looks cleaner than using `va_args`, it's also heavier C++. I'm open to changing it and definitely not attached to this implementation.

Most of the PR was made using sed and then clang-format