### PR TITLE
rs6000: Override TARGET_RUST_OS_INFO in linux.h

### DIFF
--- a/gcc/config/rs6000/linux.h
+++ b/gcc/config/rs6000/linux.h
@@ -59,9 +59,8 @@
     }							\
   while (0)
 
-#ifdef TARGET_RUST_OS_INFO
-# error "TARGET_RUST_OS_INFO already defined in linux.h (rs6000) - c++ undefines it and redefines it."
-#endif
+/* Override less-specific rs6000/sysv4.h definition. */
+#undef TARGET_RUST_OS_INFO
 #define TARGET_RUST_OS_INFO()          \
   do {                                 \
     GNU_USER_TARGET_RUST_OS_INFO();		\


### PR DESCRIPTION
Like 64-bit PowerPC, 32-bit PowerPC has the issue that
TARGET_RUST_OS_INFO is defined in both config/rs6000/sysv4.h
and config/rs6000/linux.h which triggers an error directive.
Thus, apply the same fix which undefines TARGET_RUST_OS_INFO
in linux.h first before redefining it, eliminating the error
directive.

gcc/ChangeLog:

2021-06-02  John Paul Adrian Glaubitz <glaubitz@physik.fu-berlin.de>

	* config/rs6000/linux.h: Undefine TARGET_RUST_OS_INFO before
	defining it.

Fixes #468