### PR TITLE
Remove diagnostics pruning from 'rust_target_compile' [#301, #466]

### DIFF
--- a/gcc/testsuite/lib/rust.exp
+++ b/gcc/testsuite/lib/rust.exp
@@ -178,10 +178,5 @@ proc rust_target_compile { source dest type options } {
     set options [concat "$ALWAYS_RUSTFLAGS" $options]
     set options [dg-additional-files-options $options $source]
 
-    ## FIXME: until the compiler is made less verbose, we need to prune its output almost completely.
-    # Only keep lines containing certain diagnostics so that we can check these.
-    global additional_prunes
-    lappend additional_prunes "^((?!(error: |warning: |\[Ii\]nternal compiler error: )).)*$"
-
     return [target_compile $source $dest $type $options]
 }

--- a/gcc/testsuite/rust/compile/debug-diagnostics.rs
+++ b/gcc/testsuite/rust/compile/debug-diagnostics.rs
@@ -1,0 +1,5 @@
+// Just scan for one of the Rust front end debug diagnostics:
+// { dg-message {note: Attempting to parse file: .+/gcc/testsuite/rust/compile/debug-diagnostics\.rs} "" { target *-*-* } 0 }
+
+fn main() {
+}

--- a/gcc/testsuite/rust/compile/generics4.rs
+++ b/gcc/testsuite/rust/compile/generics4.rs
@@ -1,10 +1,17 @@
-// { dg-excess-errors "Noisy error and debug" }
 struct GenericStruct<T>(T, usize);
 
 fn main() {
     let a2;
     a2 = GenericStruct::<i8, i32>(1, 456); // { dg-error "generic item takes at most 1 type arguments but 2 were supplied" }
+    // { dg-error {failed to type resolve expression} "" { target *-*-* } .-1 }
+    // { dg-error {Failed to resolve expression of function call} "" { target *-*-* } .-2 }
+    // { duplicate _dg-error {failed to type resolve expression} "" { target *-*-* } .-3 }
+    // { dg-error {expected \[T\?\] got \[<tyty::error>\]} "" { target *-*-* } .-4 }
 
     let b2: i32 = a2.0;
+    // { dg-error {Expected Tuple or ADT got: T\?} "" { target *-*-* } .-1 }
+    // { dg-error {failed to type resolve expression} "" { target *-*-* } .-2 }
     let c2: usize = a2.1;
+    // { dg-error {Expected Tuple or ADT got: T\?} "" { target *-*-* } .-1 }
+    // { dg-error {failed to type resolve expression} "" { target *-*-* } .-2 }
 }

--- a/gcc/testsuite/rust/compile/generics6.rs
+++ b/gcc/testsuite/rust/compile/generics6.rs
@@ -1,4 +1,3 @@
-// { dg-excess-errors "Noisy error and debug" }
 struct Foo<A> {
     a: A,
 }
@@ -25,5 +24,8 @@ impl Foo<f32> {
 
 fn main() {
     let a: i32 = Foo::test(); // { dg-error "multiple applicable items in scope for: test" }
+    // { dg-error {failed to type resolve expression} "" { target *-*-* } .-1 }
+    // { dg-error {Failed to resolve expression of function call} "" { target *-*-* } .-2 }
+    // { duplicate _dg-error {failed to type resolve expression} "" { target *-*-* } .-3 }
 }
 

--- a/gcc/testsuite/rust/compile/generics9.rs
+++ b/gcc/testsuite/rust/compile/generics9.rs
@@ -1,6 +1,6 @@
-// { dg-excess-errors "Noisy error and debug" }
 struct Foo<A, B = (A, B)>(A, B);
 // { dg-error "failed to resolve TypePath: B" "" { target *-*-* } .-1 }
+// { dg-error "unresolved type" "" { target *-*-* } .-2 }
 
 fn main() {
     let a: Foo<bool>;

--- a/gcc/testsuite/rust/compile/issue-407-2.rs
+++ b/gcc/testsuite/rust/compile/issue-407-2.rs
@@ -1,13 +1,21 @@
-// { dg-excess-errors "Noisy error and debug" }
-
 // #407
 pub fn loopy()  {
     let mut a = 1;
+    // { dg-error {failed to parse expr with block in parsing expr statement} "" { target *-*-* } .+2 }
+    // { dg-error {failed to parse statement or expression without block in block expression} "" { target *-*-* } .+1 }
     loop {
+        // { dg-error {failed to parse expr with block in parsing expr statement} "" { target *-*-* } .+2 }
+        // { dg-error {failed to parse statement or expression without block in block expression} "" { target *-*-* } .+1 }
 	if a < 40 {
 	    a + = 1; // { dg-error "found unexpected token '=' in null denotation" }
+            // { dg-error {failed to parse expression for expression without block \(pratt-parsed expression is null\)} "" { target *-*-* } .-1 }
+            // { dg-error {failed to parse statement or expression without block in block expression} "" { target *-*-* } .-2 }
+            // { dg-error {failed to parse if body block expression in if expression} "" { target *-*-* } .-3 }
+            // { dg-error {could not parse loop body in \(infinite\) loop expression} "" { target *-*-* } .+1 }
 	} else {
 	    break;
 	}
     }
 }
+// { dg-error {unrecognised token '\}' for start of item} "" { target *-*-* } .-1 }
+// { dg-error {failed to parse item in crate} "" { target *-*-* } .-2 }

--- a/gcc/testsuite/rust/compile/issue-407.rs
+++ b/gcc/testsuite/rust/compile/issue-407.rs
@@ -1,7 +1,9 @@
-// { dg-excess-errors "Noisy error and debug" }
-
 // This already worked before the #409 code changes.
 fn test()  {
     let mut a = 1;
     a + = 1; // { dg-error "found unexpected token '=' in null denotation" }
+    // { dg-error {failed to parse expression for expression without block \(pratt-parsed expression is null\)} "" { target *-*-* } .-1 }
+    // { dg-error {failed to parse statement or expression without block in block expression} "" { target *-*-* } .-2 }
+    // { dg-error {unrecognised token 'integer literal' for start of item} "" { target *-*-* } .-3 }
+    // { dg-error {failed to parse item in crate} "" { target *-*-* } .-4 }
 }

--- a/gcc/testsuite/rust/compile/method1.rs
+++ b/gcc/testsuite/rust/compile/method1.rs
@@ -1,4 +1,3 @@
-// { dg-excess-errors "Noisy error and debug" }
 struct Foo(i32);
 
 impl Foo {
@@ -6,9 +5,11 @@ impl Foo {
 }
 
 pub fn main() {
+    // { dg-error {expected \[\(\)\] got \[<tyty::error>\]} "" { target *-*-* } .-1 }
     let a;
     a = Foo(123);
 
     a.test()
     // { dg-error "associated function is not a method" "" { target *-*-* } .-1 }
+    // { dg-error {failed to type resolve expression} "" { target *-*-* } .-2 }
 }

--- a/gcc/testsuite/rust/compile/method2.rs
+++ b/gcc/testsuite/rust/compile/method2.rs
@@ -1,4 +1,3 @@
-// { dg-excess-errors "Noisy error and debug" }
 struct Foo<A, B>(A, B);
 
 impl Foo<i32, f32> {
@@ -14,4 +13,5 @@ fn main() {
     let b;
     b = a.test::<asfasfr>(false);
     // { dg-error "failed to resolve TypePath: asfasfr" "" { target *-*-* } .-1 }
+    // { dg-error "unresolved type" "" { target *-*-* } .-2 }
 }

--- a/gcc/testsuite/rust/compile/shadow1.rs
+++ b/gcc/testsuite/rust/compile/shadow1.rs
@@ -1,7 +1,8 @@
-// { dg-excess-errors "Noisy error and debug" }
 fn main() {
     let mut x = 5;
     let mut x;
     x = true;
     x = x + 2; // { dg-error "cannot apply this operator to types bool and <integer>"  }
+    // { dg-error {failed to type resolve expression} "" { target *-*-* } .-1 }
+    // { dg-error {expected \[bool\] got \[<tyty::error>\]} "" { target *-*-* } .-2 }
 }

--- a/gcc/testsuite/rust/compile/struct_init1.rs
+++ b/gcc/testsuite/rust/compile/struct_init1.rs
@@ -6,4 +6,5 @@ struct Foo {
 fn main() {
     let a = Foo { 0: 10.0, 1: 20.0 }; // { dg-error "failed to resolve type for field" }
     // { dg-error "unknown field" "" { target *-*-* } .-1 }
+    // { dg-prune-output "compilation terminated" }
 }

--- a/gcc/testsuite/rust/compile/type-bindings1.rs
+++ b/gcc/testsuite/rust/compile/type-bindings1.rs
@@ -1,8 +1,11 @@
-// { dg-excess-errors "Noisy error and debug" }
 struct Foo<A, B>(A, B);
 
 fn main() {
     let a;
     a = Foo::<A = i32, B = f32>(123f32);
     // { dg-error "associated type bindings are not allowed here" "" { target *-*-* } .-1 }
+    // { dg-error {failed to type resolve expression} "" { target *-*-* } .-2 }
+    // { dg-error {Failed to resolve expression of function call} "" { target *-*-* } .-3 }
+    // { duplicate _dg-error {failed to type resolve expression} "" { target *-*-* } .-4 }
+    // { dg-error {expected \[T\?\] got \[<tyty::error>\]} "" { target *-*-* } .-5 }
 }

--- a/gcc/testsuite/rust/compile/unary_negation.rs
+++ b/gcc/testsuite/rust/compile/unary_negation.rs
@@ -1,5 +1,3 @@
-// { dg-excess-errors "Noisy error and debug" }
-
 fn main() {
     let a: i32 = -1;
     let b: i32 = 3 - -1;
@@ -7,4 +5,5 @@ fn main() {
     let d: i32 = !3;
 
     let e: f32 = -true; // // { dg-error "cannot apply unary - to bool" }
+    // { dg-error {failed to type resolve expression} "" { target *-*-* } .-1 }
 }

--- a/gcc/testsuite/rust/compile/unary_not.rs
+++ b/gcc/testsuite/rust/compile/unary_not.rs
@@ -1,4 +1,3 @@
-// { dg-excess-errors "Noisy error and debug" }
 fn main() {
     let a: i32 = -1;
     let b: i32 = 3 - -1;
@@ -6,4 +5,5 @@ fn main() {
     let d: i32 = !3;
 
     let e: f32 = !5f32; // { dg-error "cannot apply unary ! to f32" }
+    // { dg-error {failed to type resolve expression} "" { target *-*-* } .-1 }
 }


### PR DESCRIPTION
This is no longer necessary after #466 "Expose rust debug and use it", where
commit 665df329a2ad60580ab593f6cbd646aa55927a37 "rust_debug: Replace fprintf
(stderr) with rust_debug" turned all 'fprintf' to 'stderr' into standard GCC
'inform' ('note: [...]') diagnostics -- which do get pruned by default.

Adjust the testsuite: instead of 'dg-excess-errors', spell out the additional
diagnostics now seen.
