### PR TITLE
Use '-frust-debug' to control dumping of various Rust front end internals

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $ make
 Running the compiler itself without make install we can simply invoke the compiler proper:
 
 ```bash
-$ ./gcc/rust1 test.rs -frust-dump-parse -Warray-bounds -dumpbase test.rs -mtune=generic -march=x86-64 -O0 -version -fdump-tree-gimple -o test.s -L/lib/x86_64-linux-gnu -L/lib/../lib64 -L/usr/lib/x86_64-linux-gnu -L/usr/lib/../lib64
+$ ./gcc/rust1 test.rs -frust-debug -frust-dump-parse -Warray-bounds -dumpbase test.rs -mtune=generic -march=x86-64 -O0 -version -fdump-tree-gimple -o test.s -L/lib/x86_64-linux-gnu -L/lib/../lib64 -L/usr/lib/x86_64-linux-gnu -L/usr/lib/../lib64
 ```
 
 To invoke the compiler driver (gccrs) we need to:
@@ -170,12 +170,7 @@ $ docker run --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp \
     gcc/testsuite/rust/compile/torture/type_infer1.rs -S -o type_infer1.s 
 ```
 
-To emit the debug outputs you can add the option -frust-dump-all :
-```bash
-$ docker run --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp \
-    gccrs-dev:latest gccrs -g -O2 \
-    gcc/testsuite/rust/compile/torture/type_infer1.rs -o type_infer1 -frust-dump-all
-```
+To emit Rust front end debug output, you may add options like `-frust-debug`, `-frust-dump-all`.
 
 
 ## Contributing

--- a/gcc/rust/lang.opt
+++ b/gcc/rust/lang.opt
@@ -35,6 +35,10 @@ L
 Rust Joined Separate
 ; Not documented
 
+frust-debug
+Rust Var(flag_rust_debug)
+Dump various Rust front end internals.
+
 frust-dump-
 Rust Joined RejectNegative
 -frust-dump-<type>	Dump Rust frontend internal information.

--- a/gcc/rust/rust-diagnostics.cc
+++ b/gcc/rust/rust-diagnostics.cc
@@ -200,6 +200,9 @@ rust_error_at (const RichLocation location, const char *fmt, ...)
 void
 rust_debug (const Location location, const char *fmt, ...)
 {
+  if (!rust_be_debug_p ())
+    return;
+
   va_list ap;
 
   va_start (ap, fmt);

--- a/gcc/rust/rust-diagnostics.h
+++ b/gcc/rust/rust-diagnostics.h
@@ -93,6 +93,8 @@ extern void
 rust_be_inform (const Location, const std::string &infomsg);
 extern void
 rust_be_get_quotechars (const char **open_quote, const char **close_quote);
+extern bool
+rust_be_debug_p (void);
 
 namespace Rust {
 /* A structure used to represent an error. Useful for enabling

--- a/gcc/rust/rust-gcc-diagnostics.cc
+++ b/gcc/rust/rust-gcc-diagnostics.cc
@@ -21,6 +21,8 @@
 #include "rust-system.h"
 #include "rust-diagnostics.h"
 
+#include "options.h"
+
 void
 rust_be_error_at (const Location location, const std::string &errmsg)
 {
@@ -62,4 +64,10 @@ rust_be_get_quotechars (const char **open_qu, const char **close_qu)
 {
   *open_qu = open_quote;
   *close_qu = close_quote;
+}
+
+bool
+rust_be_debug_p (void)
+{
+  return !!flag_rust_debug;
 }

--- a/gcc/testsuite/rust/compile/debug-diagnostics-default.rs
+++ b/gcc/testsuite/rust/compile/debug-diagnostics-default.rs
@@ -1,0 +1,5 @@
+// Make sure we don't see any 'note's:
+// { dg-bogus {note: } "" { target *-*-* } 0 }
+
+fn main() {
+}

--- a/gcc/testsuite/rust/compile/debug-diagnostics-off.rs
+++ b/gcc/testsuite/rust/compile/debug-diagnostics-off.rs
@@ -1,0 +1,7 @@
+// { dg-additional-options "-fno-rust-debug" }
+
+// Make sure we don't see any 'note's:
+// { dg-bogus {note: } "" { target *-*-* } 0 }
+
+fn main() {
+}

--- a/gcc/testsuite/rust/compile/debug-diagnostics-on.rs
+++ b/gcc/testsuite/rust/compile/debug-diagnostics-on.rs
@@ -1,0 +1,7 @@
+// { dg-additional-options "-frust-debug" }
+
+// Just scan for one of the Rust front end debug diagnostics:
+// { dg-message {note: Attempting to parse file: .+/gcc/testsuite/rust/compile/debug-diagnostics-on\.rs} "" { target *-*-* } 0 }
+
+fn main() {
+}

--- a/gcc/testsuite/rust/compile/debug-diagnostics.rs
+++ b/gcc/testsuite/rust/compile/debug-diagnostics.rs
@@ -1,5 +1,0 @@
-// Just scan for one of the Rust front end debug diagnostics:
-// { dg-message {note: Attempting to parse file: .+/gcc/testsuite/rust/compile/debug-diagnostics\.rs} "" { target *-*-* } 0 }
-
-fn main() {
-}


### PR DESCRIPTION
... as discussed in #479, and elsewhere.
