### PR TITLE
arm: Override TARGET_RUST_OS_INFO in bpabi.h

### DIFF
--- a/gcc/config/arm/bpabi.h
+++ b/gcc/config/arm/bpabi.h
@@ -109,9 +109,8 @@
     /*TODO: is this even an OS? What should go here?*/ \
   } while (0)
 
-#ifdef TARGET_RUST_OS_INFO
-# error "TARGET_RUST_OS_INFO already defined in bpabi.h - c++ undefines it and redefines it."
-#endif
+/* Override less-specific arm/linux-elf.h definition. */
+#undef TARGET_RUST_OS_INFO
 #define TARGET_RUST_OS_INFO() \
   BPABI_TARGET_RUST_OS_INFO()
 


### PR DESCRIPTION
Similar to PowerPC, 32-bit ARM has the issue that TARGET_RUST_OS_INFO
is defined in two separate headers, namely config/arm/bpabi.h and
config/arm/linux-elf.h. We can apply the same fix that was already
used for PowerPC.

gcc/ChangeLog:

2021-06-04  John Paul Adrian Glaubitz <glaubitz@physik.fu-berlin.de>

	* config/arm/bpabi.h: Undefine TARGET_RUST_OS_INFO before
	defining it.