### PR TITLE
Trait impls and initial start of traits work

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -1282,8 +1282,12 @@ class MacroItem : public Item
 class TraitItem
 {
 protected:
+  TraitItem () : node_id (Analysis::Mappings::get ()->get_next_node_id ()) {}
+
   // Clone function implementation as pure virtual method
   virtual TraitItem *clone_trait_item_impl () const = 0;
+
+  NodeId node_id;
 
 public:
   virtual ~TraitItem () {}
@@ -1300,6 +1304,8 @@ public:
 
   virtual void mark_for_strip () = 0;
   virtual bool is_marked_for_strip () const = 0;
+
+  NodeId get_node_id () const { return node_id; }
 };
 
 /* Abstract base class for items used within an inherent impl block (the impl

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -3422,6 +3422,8 @@ public:
 
   Identifier get_identifier () const { return name; }
 
+  bool is_unsafe () const { return has_unsafe; }
+
   // Mega-constructor
   Trait (Identifier name, bool is_unsafe,
 	 std::vector<std::unique_ptr<GenericParam> > generic_params,
@@ -3757,8 +3759,6 @@ public:
       trait_path (std::move (trait_path)), impl_items (std::move (impl_items))
   {}
 
-  // TODO: constructors with less params
-
   // Copy constructor with vector clone
   TraitImpl (TraitImpl const &other)
     : Impl (other), has_unsafe (other.has_unsafe),
@@ -3789,6 +3789,9 @@ public:
   TraitImpl &operator= (TraitImpl &&other) = default;
 
   void accept_vis (ASTVisitor &vis) override;
+
+  bool is_unsafe () const { return has_unsafe; };
+  bool is_exclam () const { return has_exclam; }
 
   // TODO: think of better way to do this
   const std::vector<std::unique_ptr<TraitImplItem> > &get_impl_items () const

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -3420,6 +3420,8 @@ public:
   // Returns whether trait has inner attributes.
   bool has_inner_attrs () const { return !inner_attrs.empty (); }
 
+  Identifier get_identifier () const { return name; }
+
   // Mega-constructor
   Trait (Identifier name, bool is_unsafe,
 	 std::vector<std::unique_ptr<GenericParam> > generic_params,

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -2765,6 +2765,8 @@ public:
   // Returns whether function has a where clause.
   bool has_where_clause () const { return !where_clause.is_empty (); }
 
+  Identifier get_identifier () const { return function_name; }
+
   // Mega-constructor
   TraitFunctionDecl (Identifier function_name, FunctionQualifiers qualifiers,
 		     std::vector<std::unique_ptr<GenericParam> > generic_params,
@@ -2871,14 +2873,17 @@ public:
 
   TraitItemFunc (TraitFunctionDecl decl, std::unique_ptr<BlockExpr> block_expr,
 		 std::vector<Attribute> outer_attrs, Location locus)
-    : outer_attrs (std::move (outer_attrs)), decl (std::move (decl)),
-      block_expr (std::move (block_expr)), locus (locus)
+    : TraitItem (), outer_attrs (std::move (outer_attrs)),
+      decl (std::move (decl)), block_expr (std::move (block_expr)),
+      locus (locus)
   {}
 
   // Copy constructor with clone
   TraitItemFunc (TraitItemFunc const &other)
     : outer_attrs (other.outer_attrs), decl (other.decl), locus (other.locus)
   {
+    node_id = other.node_id;
+
     // guard to prevent null dereference
     if (other.block_expr != nullptr)
       block_expr = other.block_expr->clone_block_expr ();
@@ -2891,6 +2896,7 @@ public:
     outer_attrs = other.outer_attrs;
     decl = other.decl;
     locus = other.locus;
+    node_id = other.node_id;
 
     // guard to prevent null dereference
     if (other.block_expr != nullptr)
@@ -2982,6 +2988,8 @@ public:
 
   // Returns whether method has a where clause.
   bool has_where_clause () const { return !where_clause.is_empty (); }
+
+  Identifier get_identifier () const { return function_name; }
 
   // Mega-constructor
   TraitMethodDecl (Identifier function_name, FunctionQualifiers qualifiers,
@@ -3095,14 +3103,17 @@ public:
 
   TraitItemMethod (TraitMethodDecl decl, std::unique_ptr<BlockExpr> block_expr,
 		   std::vector<Attribute> outer_attrs, Location locus)
-    : outer_attrs (std::move (outer_attrs)), decl (std::move (decl)),
-      block_expr (std::move (block_expr)), locus (locus)
+    : TraitItem (), outer_attrs (std::move (outer_attrs)),
+      decl (std::move (decl)), block_expr (std::move (block_expr)),
+      locus (locus)
   {}
 
   // Copy constructor with clone
   TraitItemMethod (TraitItemMethod const &other)
     : outer_attrs (other.outer_attrs), decl (other.decl), locus (other.locus)
   {
+    node_id = other.node_id;
+
     // guard to prevent null dereference
     if (other.block_expr != nullptr)
       block_expr = other.block_expr->clone_block_expr ();
@@ -3115,6 +3126,7 @@ public:
     outer_attrs = other.outer_attrs;
     decl = other.decl;
     locus = other.locus;
+    node_id = other.node_id;
 
     // guard to prevent null dereference
     if (other.block_expr != nullptr)
@@ -3187,14 +3199,17 @@ public:
   TraitItemConst (Identifier name, std::unique_ptr<Type> type,
 		  std::unique_ptr<Expr> expr,
 		  std::vector<Attribute> outer_attrs, Location locus)
-    : outer_attrs (std::move (outer_attrs)), name (std::move (name)),
-      type (std::move (type)), expr (std::move (expr)), locus (locus)
+    : TraitItem (), outer_attrs (std::move (outer_attrs)),
+      name (std::move (name)), type (std::move (type)), expr (std::move (expr)),
+      locus (locus)
   {}
 
   // Copy constructor with clones
   TraitItemConst (TraitItemConst const &other)
     : outer_attrs (other.outer_attrs), name (other.name), locus (other.locus)
   {
+    node_id = other.node_id;
+
     // guard to prevent null dereference
     if (other.expr != nullptr)
       expr = other.expr->clone_expr ();
@@ -3211,6 +3226,7 @@ public:
     outer_attrs = other.outer_attrs;
     name = other.name;
     locus = other.locus;
+    node_id = other.node_id;
 
     // guard to prevent null dereference
     if (other.expr != nullptr)
@@ -3259,6 +3275,8 @@ public:
     return type;
   }
 
+  Identifier get_identifier () const { return name; }
+
 protected:
   // Clone function implementation as (not pure) virtual method
   TraitItemConst *clone_trait_item_impl () const override
@@ -3289,7 +3307,8 @@ public:
     Identifier name,
     std::vector<std::unique_ptr<TypeParamBound> > type_param_bounds,
     std::vector<Attribute> outer_attrs, Location locus)
-    : outer_attrs (std::move (outer_attrs)), name (std::move (name)),
+    : TraitItem (), outer_attrs (std::move (outer_attrs)),
+      name (std::move (name)),
       type_param_bounds (std::move (type_param_bounds)), locus (locus)
   {}
 
@@ -3297,6 +3316,7 @@ public:
   TraitItemType (TraitItemType const &other)
     : outer_attrs (other.outer_attrs), name (other.name), locus (other.locus)
   {
+    node_id = other.node_id;
     type_param_bounds.reserve (other.type_param_bounds.size ());
     for (const auto &e : other.type_param_bounds)
       type_param_bounds.push_back (e->clone_type_param_bound ());
@@ -3309,6 +3329,7 @@ public:
     outer_attrs = other.outer_attrs;
     name = other.name;
     locus = other.locus;
+    node_id = other.node_id;
 
     type_param_bounds.reserve (other.type_param_bounds.size ());
     for (const auto &e : other.type_param_bounds)
@@ -3345,6 +3366,8 @@ public:
   {
     return type_param_bounds;
   }
+
+  Identifier get_identifier () const { return name; }
 
 protected:
   // Clone function implementation as (not pure) virtual method

--- a/gcc/rust/backend/rust-compile-implitem.h
+++ b/gcc/rust/backend/rust-compile-implitem.h
@@ -42,6 +42,14 @@ public:
     item->accept_vis (compiler);
   }
 
+  static void Compile (TyTy::BaseType *self, HIR::TraitImplItem *item,
+		       Context *ctx, bool compile_fns,
+		       TyTy::BaseType *concrete = nullptr)
+  {
+    CompileInherentImplItem compiler (self, ctx, compile_fns, concrete);
+    item->accept_vis (compiler);
+  }
+
   void visit (HIR::ConstantItem &constant) override
   {
     TyTy::BaseType *resolved_type = nullptr;

--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -290,6 +290,22 @@ public:
 					compile_fns);
   }
 
+  void visit (HIR::TraitImpl &impl_block) override
+  {
+    TyTy::BaseType *self_lookup = nullptr;
+    if (!ctx->get_tyctx ()->lookup_type (
+	  impl_block.get_type ()->get_mappings ().get_hirid (), &self_lookup))
+      {
+	rust_error_at (impl_block.get_locus (),
+		       "failed to resolve type of impl");
+	return;
+      }
+
+    for (auto &impl_item : impl_block.get_impl_items ())
+      CompileInherentImplItem::Compile (self_lookup, impl_item.get (), ctx,
+					compile_fns);
+  }
+
 private:
   CompileItem (Context *ctx, bool compile_fns, TyTy::BaseType *concrete)
     : HIRCompileBase (ctx), compile_fns (compile_fns), concrete (concrete)

--- a/gcc/rust/hir/rust-ast-lower-base.h
+++ b/gcc/rust/hir/rust-ast-lower-base.h
@@ -293,6 +293,8 @@ protected:
   HIR::GenericArgs lower_generic_args (AST::GenericArgs &args);
 
   HIR::GenericArgsBinding lower_binding (AST::GenericArgsBinding &binding);
+
+  HIR::SelfParam lower_self (AST::SelfParam &self);
 };
 
 } // namespace HIR

--- a/gcc/rust/hir/rust-ast-lower-implitem.h
+++ b/gcc/rust/hir/rust-ast-lower-implitem.h
@@ -43,19 +43,14 @@ public:
     return resolver.translated;
   }
 
-  HIR::SelfParam lower_self (AST::SelfParam &self)
+  static HIR::TraitImplItem *translate (AST::TraitImplItem *item,
+					HirId parent_impl_id)
   {
-    HIR::Type *type = self.has_type ()
-			? ASTLoweringType::translate (self.get_type ().get ())
-			: nullptr;
-
-    auto crate_num = mappings->get_current_crate ();
-    Analysis::NodeMapping mapping (crate_num, self.get_node_id (),
-				   mappings->get_next_hir_id (crate_num),
-				   mappings->get_next_localdef_id (crate_num));
-
-    return HIR::SelfParam (mapping, std::unique_ptr<HIR::Type> (type),
-			   self.get_is_mut (), self.get_locus ());
+    ASTLowerImplItem resolver (parent_impl_id);
+    item->accept_vis (resolver);
+    rust_assert (resolver.trait_impl_item != nullptr);
+    // can get a way with this for now since they have the same hierarchy
+    return resolver.trait_impl_item;
   }
 
   void visit (AST::ConstantItem &constant) override
@@ -70,11 +65,14 @@ public:
 				   mappings->get_next_hir_id (crate_num),
 				   mappings->get_next_localdef_id (crate_num));
 
-    translated = new HIR::ConstantItem (mapping, constant.get_identifier (),
-					vis, std::unique_ptr<HIR::Type> (type),
-					std::unique_ptr<HIR::Expr> (expr),
-					constant.get_outer_attrs (),
-					constant.get_locus ());
+    auto translated_constant
+      = new HIR::ConstantItem (mapping, constant.get_identifier (), vis,
+			       std::unique_ptr<HIR::Type> (type),
+			       std::unique_ptr<HIR::Expr> (expr),
+			       constant.get_outer_attrs (),
+			       constant.get_locus ());
+    translated = translated_constant;
+    trait_impl_item = translated_constant;
 
     mappings->insert_hir_implitem (mapping.get_crate_num (),
 				   mapping.get_hirid (), parent_impl_id,
@@ -163,6 +161,7 @@ public:
       }
 
     translated = fn;
+    trait_impl_item = fn;
   }
 
   void visit (AST::Method &method) override
@@ -251,15 +250,198 @@ public:
       }
 
     translated = mth;
+    trait_impl_item = mth;
   }
 
 private:
   ASTLowerImplItem (HirId parent_impl_id)
-    : translated (nullptr), parent_impl_id (parent_impl_id)
+    : translated (nullptr), trait_impl_item (nullptr),
+      parent_impl_id (parent_impl_id)
   {}
 
   HIR::InherentImplItem *translated;
+  HIR::TraitImplItem *trait_impl_item;
   HirId parent_impl_id;
+};
+
+class ASTLowerTraitItem : public ASTLoweringBase
+{
+  using Rust::HIR::ASTLoweringBase::visit;
+
+public:
+  static HIR::TraitItem *translate (AST::TraitItem *item)
+  {
+    ASTLowerTraitItem resolver;
+    item->accept_vis (resolver);
+    rust_assert (resolver.translated != nullptr);
+    return resolver.translated;
+  }
+
+  void visit (AST::TraitItemFunc &func) override
+  {
+    AST::TraitFunctionDecl &ref = func.get_trait_function_decl ();
+
+    std::vector<std::unique_ptr<HIR::WhereClauseItem> > where_clause_items;
+    HIR::WhereClause where_clause (std::move (where_clause_items));
+    HIR::FunctionQualifiers qualifiers (
+      HIR::FunctionQualifiers::AsyncConstStatus::NONE, false);
+
+    std::vector<std::unique_ptr<HIR::GenericParam> > generic_params;
+    if (ref.has_generics ())
+      {
+	generic_params = lower_generic_params (ref.get_generic_params ());
+      }
+
+    std::unique_ptr<HIR::Type> return_type
+      = ref.has_return_type () ? std::unique_ptr<HIR::Type> (
+	  ASTLoweringType::translate (ref.get_return_type ().get ()))
+			       : nullptr;
+
+    std::vector<HIR::FunctionParam> function_params;
+    for (auto &param : ref.get_function_params ())
+      {
+	auto translated_pattern = std::unique_ptr<HIR::Pattern> (
+	  ASTLoweringPattern::translate (param.get_pattern ().get ()));
+	auto translated_type = std::unique_ptr<HIR::Type> (
+	  ASTLoweringType::translate (param.get_type ().get ()));
+
+	auto crate_num = mappings->get_current_crate ();
+	Analysis::NodeMapping mapping (crate_num, param.get_node_id (),
+				       mappings->get_next_hir_id (crate_num),
+				       UNKNOWN_LOCAL_DEFID);
+
+	auto hir_param
+	  = HIR::FunctionParam (mapping, std::move (translated_pattern),
+				std::move (translated_type),
+				param.get_locus ());
+	function_params.push_back (hir_param);
+      }
+
+    HIR::TraitFunctionDecl decl (ref.get_identifier (), std::move (qualifiers),
+				 std::move (generic_params),
+				 std::move (function_params),
+				 std::move (return_type),
+				 std::move (where_clause));
+    HIR::Expr *block_expr
+      = func.has_definition ()
+	  ? ASTLoweringExpr::translate (func.get_definition ().get ())
+	  : nullptr;
+
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, func.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   UNKNOWN_LOCAL_DEFID);
+
+    translated
+      = new HIR::TraitItemFunc (mapping, std::move (decl),
+				std::unique_ptr<HIR::Expr> (block_expr),
+				func.get_outer_attrs (), func.get_locus ());
+  }
+
+  void visit (AST::TraitItemMethod &method) override
+  {
+    AST::TraitMethodDecl &ref = method.get_trait_method_decl ();
+
+    std::vector<std::unique_ptr<HIR::WhereClauseItem> > where_clause_items;
+    HIR::WhereClause where_clause (std::move (where_clause_items));
+    HIR::FunctionQualifiers qualifiers (
+      HIR::FunctionQualifiers::AsyncConstStatus::NONE, false);
+
+    std::vector<std::unique_ptr<HIR::GenericParam> > generic_params;
+    if (ref.has_generics ())
+      {
+	generic_params = lower_generic_params (ref.get_generic_params ());
+      }
+
+    std::unique_ptr<HIR::Type> return_type
+      = ref.has_return_type () ? std::unique_ptr<HIR::Type> (
+	  ASTLoweringType::translate (ref.get_return_type ().get ()))
+			       : nullptr;
+
+    HIR::SelfParam self_param = lower_self (ref.get_self_param ());
+
+    std::vector<HIR::FunctionParam> function_params;
+    for (auto &param : ref.get_function_params ())
+      {
+	auto translated_pattern = std::unique_ptr<HIR::Pattern> (
+	  ASTLoweringPattern::translate (param.get_pattern ().get ()));
+	auto translated_type = std::unique_ptr<HIR::Type> (
+	  ASTLoweringType::translate (param.get_type ().get ()));
+
+	auto crate_num = mappings->get_current_crate ();
+	Analysis::NodeMapping mapping (crate_num, param.get_node_id (),
+				       mappings->get_next_hir_id (crate_num),
+				       UNKNOWN_LOCAL_DEFID);
+
+	auto hir_param
+	  = HIR::FunctionParam (mapping, std::move (translated_pattern),
+				std::move (translated_type),
+				param.get_locus ());
+	function_params.push_back (hir_param);
+      }
+
+    HIR::TraitMethodDecl decl (ref.get_identifier (), std::move (qualifiers),
+			       std::move (generic_params),
+			       std::move (self_param),
+			       std::move (function_params),
+			       std::move (return_type),
+			       std::move (where_clause));
+    HIR::Expr *block_expr
+      = method.has_definition ()
+	  ? ASTLoweringExpr::translate (method.get_definition ().get ())
+	  : nullptr;
+
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, method.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   UNKNOWN_LOCAL_DEFID);
+
+    translated
+      = new HIR::TraitItemMethod (mapping, std::move (decl),
+				  std::unique_ptr<HIR::Expr> (block_expr),
+				  method.get_outer_attrs (),
+				  method.get_locus ());
+  }
+
+  void visit (AST::TraitItemConst &constant) override
+  {
+    HIR::Type *type = ASTLoweringType::translate (constant.get_type ().get ());
+    HIR::Expr *expr
+      = constant.has_expression ()
+	  ? ASTLoweringExpr::translate (constant.get_expr ().get ())
+	  : nullptr;
+
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, constant.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   UNKNOWN_LOCAL_DEFID);
+
+    translated = new HIR::TraitItemConst (mapping, constant.get_identifier (),
+					  std::unique_ptr<HIR::Type> (type),
+					  std::unique_ptr<HIR::Expr> (expr),
+					  constant.get_outer_attrs (),
+					  constant.get_locus ());
+  }
+
+  void visit (AST::TraitItemType &type) override
+  {
+    std::vector<std::unique_ptr<HIR::TypeParamBound> > type_param_bounds;
+
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, type.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   UNKNOWN_LOCAL_DEFID);
+
+    translated
+      = new HIR::TraitItemType (mapping, type.get_identifier (),
+				std::move (type_param_bounds),
+				type.get_outer_attrs (), type.get_locus ());
+  }
+
+private:
+  ASTLowerTraitItem () : translated (nullptr) {}
+
+  HIR::TraitItem *translated;
 };
 
 } // namespace HIR

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -406,6 +406,149 @@ public:
       }
   }
 
+  void visit (AST::Trait &trait) override
+  {
+    std::vector<std::unique_ptr<HIR::WhereClauseItem> > where_clause_items;
+
+    HIR::WhereClause where_clause (std::move (where_clause_items));
+    HIR::Visibility vis = HIR::Visibility::create_public ();
+
+    std::vector<std::unique_ptr<HIR::GenericParam> > generic_params;
+    if (trait.has_generics ())
+      {
+	generic_params = lower_generic_params (trait.get_generic_params ());
+
+	for (auto &generic_param : generic_params)
+	  {
+	    switch (generic_param->get_kind ())
+	      {
+		case HIR::GenericParam::GenericKind::TYPE: {
+		  const HIR::TypeParam &t
+		    = static_cast<const HIR::TypeParam &> (*generic_param);
+
+		  if (t.has_type ())
+		    {
+		      // see https://github.com/rust-lang/rust/issues/36887
+		      rust_error_at (
+			t.get_locus (),
+			"defaults for type parameters are not allowed here");
+		    }
+		}
+		break;
+
+	      default:
+		break;
+	      }
+	  }
+      }
+
+    std::vector<std::unique_ptr<HIR::TypeParamBound> > type_param_bounds;
+
+    std::vector<std::unique_ptr<HIR::TraitItem> > trait_items;
+    for (auto &item : trait.get_trait_items ())
+      {
+	HIR::TraitItem *lowered = ASTLowerTraitItem::translate (item.get ());
+	trait_items.push_back (std::unique_ptr<HIR::TraitItem> (lowered));
+      }
+
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, trait.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   mappings->get_next_localdef_id (crate_num));
+
+    translated = new HIR::Trait (mapping, trait.get_identifier (),
+				 trait.is_unsafe (), std::move (generic_params),
+				 std::move (type_param_bounds), where_clause,
+				 std::move (trait_items), vis,
+				 trait.get_outer_attrs (), trait.get_locus ());
+
+    mappings->insert_defid_mapping (mapping.get_defid (), translated);
+    mappings->insert_hir_item (mapping.get_crate_num (), mapping.get_hirid (),
+			       translated);
+    mappings->insert_location (crate_num, mapping.get_hirid (),
+			       trait.get_locus ());
+  }
+
+  void visit (AST::TraitImpl &impl_block) override
+  {
+    std::vector<std::unique_ptr<HIR::WhereClauseItem> > where_clause_items;
+    HIR::WhereClause where_clause (std::move (where_clause_items));
+    HIR::Visibility vis = HIR::Visibility::create_public ();
+
+    std::vector<std::unique_ptr<HIR::GenericParam> > generic_params;
+    if (impl_block.has_generics ())
+      {
+	generic_params
+	  = lower_generic_params (impl_block.get_generic_params ());
+
+	for (auto &generic_param : generic_params)
+	  {
+	    switch (generic_param->get_kind ())
+	      {
+		case HIR::GenericParam::GenericKind::TYPE: {
+		  const HIR::TypeParam &t
+		    = static_cast<const HIR::TypeParam &> (*generic_param);
+
+		  if (t.has_type ())
+		    {
+		      // see https://github.com/rust-lang/rust/issues/36887
+		      rust_error_at (
+			t.get_locus (),
+			"defaults for type parameters are not allowed here");
+		    }
+		}
+		break;
+
+	      default:
+		break;
+	      }
+	  }
+      }
+
+    HIR::Type *trait_type
+      = ASTLoweringType::translate (impl_block.get_type ().get ());
+    HIR::Type *trait = nullptr;
+
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, impl_block.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   mappings->get_next_localdef_id (crate_num));
+
+    std::vector<std::unique_ptr<HIR::TraitImplItem> > impl_items;
+    std::vector<HirId> impl_item_ids;
+    for (auto &impl_item : impl_block.get_impl_items ())
+      {
+	HIR::TraitImplItem *lowered
+	  = ASTLowerImplItem::translate (impl_item.get (),
+					 mapping.get_hirid ());
+	impl_items.push_back (std::unique_ptr<HIR::TraitImplItem> (lowered));
+	impl_item_ids.push_back (
+	  lowered->get_trait_impl_mappings ().get_hirid ());
+      }
+
+    translated
+      = new HIR::TraitImpl (mapping, std::unique_ptr<HIR::Type> (trait),
+			    impl_block.is_unsafe (), impl_block.is_exclam (),
+			    std::move (impl_items), std::move (generic_params),
+			    std::unique_ptr<HIR::Type> (trait_type),
+			    where_clause, vis, impl_block.get_inner_attrs (),
+			    impl_block.get_outer_attrs (),
+			    impl_block.get_locus ());
+
+    mappings->insert_defid_mapping (mapping.get_defid (), translated);
+    mappings->insert_hir_item (mapping.get_crate_num (), mapping.get_hirid (),
+			       translated);
+    mappings->insert_location (crate_num, mapping.get_hirid (),
+			       impl_block.get_locus ());
+
+    for (auto &impl_item_id : impl_item_ids)
+      {
+	mappings->insert_impl_item_mapping (impl_item_id,
+					    static_cast<HIR::InherentImpl *> (
+					      translated));
+      }
+  }
+
 private:
   ASTLoweringItem () : translated (nullptr) {}
 

--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -347,5 +347,21 @@ ASTLoweringBase::lower_generic_args (AST::GenericArgs &args)
 			   std::move (binding_args), args.get_locus ());
 }
 
+HIR::SelfParam
+ASTLoweringBase::lower_self (AST::SelfParam &self)
+{
+  HIR::Type *type = self.has_type ()
+		      ? ASTLoweringType::translate (self.get_type ().get ())
+		      : nullptr;
+
+  auto crate_num = mappings->get_current_crate ();
+  Analysis::NodeMapping mapping (crate_num, self.get_node_id (),
+				 mappings->get_next_hir_id (crate_num),
+				 mappings->get_next_localdef_id (crate_num));
+
+  return HIR::SelfParam (mapping, std::unique_ptr<HIR::Type> (type),
+			 self.get_is_mut (), self.get_locus ());
+}
+
 } // namespace HIR
 } // namespace Rust

--- a/gcc/rust/hir/tree/rust-hir-full-test.cc
+++ b/gcc/rust/hir/tree/rust-hir-full-test.cc
@@ -1170,7 +1170,7 @@ TraitImpl::as_string () const
       str += "false";
     }
 
-  str += "\n TypePath (to trait): " + trait_path.as_string ();
+  str += "\n TypePath (to trait): " + trait_path->as_string ();
 
   str += "\n Type (struct to impl on): " + trait_type->as_string ();
 

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -2485,15 +2485,18 @@ public:
   // Returns whether function has a definition or is just a declaration.
   bool has_definition () const { return block_expr != nullptr; }
 
-  TraitItemFunc (TraitFunctionDecl decl, std::unique_ptr<BlockExpr> block_expr,
+  TraitItemFunc (Analysis::NodeMapping mappings, TraitFunctionDecl decl,
+		 std::unique_ptr<BlockExpr> block_expr,
 		 AST::AttrVec outer_attrs, Location locus)
-    : outer_attrs (std::move (outer_attrs)), decl (std::move (decl)),
-      block_expr (std::move (block_expr)), locus (locus)
+    : TraitItem (mappings), outer_attrs (std::move (outer_attrs)),
+      decl (std::move (decl)), block_expr (std::move (block_expr)),
+      locus (locus)
   {}
 
   // Copy constructor with clone
   TraitItemFunc (TraitItemFunc const &other)
-    : outer_attrs (other.outer_attrs), decl (other.decl), locus (other.locus)
+    : TraitItem (other.mappings), outer_attrs (other.outer_attrs),
+      decl (other.decl), locus (other.locus)
   {
     if (other.block_expr != nullptr)
       block_expr = other.block_expr->clone_block_expr ();
@@ -2506,6 +2509,7 @@ public:
     outer_attrs = other.outer_attrs;
     decl = other.decl;
     locus = other.locus;
+    mappings = other.mappings;
     if (other.block_expr != nullptr)
       block_expr = other.block_expr->clone_block_expr ();
 
@@ -2636,16 +2640,19 @@ public:
   // Returns whether method has a definition or is just a declaration.
   bool has_definition () const { return block_expr != nullptr; }
 
-  TraitItemMethod (TraitMethodDecl decl, std::unique_ptr<BlockExpr> block_expr,
+  TraitItemMethod (Analysis::NodeMapping mappings, TraitMethodDecl decl,
+		   std::unique_ptr<BlockExpr> block_expr,
 		   AST::AttrVec outer_attrs, Location locus)
-    : outer_attrs (std::move (outer_attrs)), decl (std::move (decl)),
-      block_expr (std::move (block_expr)), locus (locus)
+    : TraitItem (mappings), outer_attrs (std::move (outer_attrs)),
+      decl (std::move (decl)), block_expr (std::move (block_expr)),
+      locus (locus)
   {}
 
   // Copy constructor with clone
   TraitItemMethod (TraitItemMethod const &other)
-    : outer_attrs (other.outer_attrs), decl (other.decl),
-      block_expr (other.block_expr->clone_block_expr ()), locus (other.locus)
+    : TraitItem (other.mappings), outer_attrs (other.outer_attrs),
+      decl (other.decl), block_expr (other.block_expr->clone_block_expr ()),
+      locus (other.locus)
   {}
 
   // Overloaded assignment operator to clone
@@ -2656,6 +2663,7 @@ public:
     decl = other.decl;
     block_expr = other.block_expr->clone_block_expr ();
     locus = other.locus;
+    mappings = other.mappings;
 
     return *this;
   }
@@ -2696,18 +2704,19 @@ public:
   // Whether the constant item has an associated expression.
   bool has_expression () const { return expr != nullptr; }
 
-  TraitItemConst (Identifier name, std::unique_ptr<Type> type,
-		  std::unique_ptr<Expr> expr, AST::AttrVec outer_attrs,
-		  Location locus)
-    : outer_attrs (std::move (outer_attrs)), name (std::move (name)),
-      type (std::move (type)), expr (std::move (expr)), locus (locus)
+  TraitItemConst (Analysis::NodeMapping mappings, Identifier name,
+		  std::unique_ptr<Type> type, std::unique_ptr<Expr> expr,
+		  AST::AttrVec outer_attrs, Location locus)
+    : TraitItem (mappings), outer_attrs (std::move (outer_attrs)),
+      name (std::move (name)), type (std::move (type)), expr (std::move (expr)),
+      locus (locus)
   {}
 
   // Copy constructor with clones
   TraitItemConst (TraitItemConst const &other)
-    : outer_attrs (other.outer_attrs), name (other.name),
-      type (other.type->clone_type ()), expr (other.expr->clone_expr ()),
-      locus (other.locus)
+    : TraitItem (other.mappings), outer_attrs (other.outer_attrs),
+      name (other.name), type (other.type->clone_type ()),
+      expr (other.expr->clone_expr ()), locus (other.locus)
   {}
 
   // Overloaded assignment operator to clone
@@ -2719,6 +2728,7 @@ public:
     type = other.type->clone_type ();
     expr = other.expr->clone_expr ();
     locus = other.locus;
+    mappings = other.mappings;
 
     return *this;
   }
@@ -2760,16 +2770,18 @@ public:
   bool has_type_param_bounds () const { return !type_param_bounds.empty (); }
 
   TraitItemType (
-    Identifier name,
+    Analysis::NodeMapping mappings, Identifier name,
     std::vector<std::unique_ptr<TypeParamBound> > type_param_bounds,
     AST::AttrVec outer_attrs, Location locus)
-    : outer_attrs (std::move (outer_attrs)), name (std::move (name)),
+    : TraitItem (mappings), outer_attrs (std::move (outer_attrs)),
+      name (std::move (name)),
       type_param_bounds (std::move (type_param_bounds)), locus (locus)
   {}
 
   // Copy constructor with vector clone
   TraitItemType (TraitItemType const &other)
-    : outer_attrs (other.outer_attrs), name (other.name), locus (other.locus)
+    : TraitItem (other.mappings), outer_attrs (other.outer_attrs),
+      name (other.name), locus (other.locus)
   {
     type_param_bounds.reserve (other.type_param_bounds.size ());
     for (const auto &e : other.type_param_bounds)
@@ -2783,6 +2795,7 @@ public:
     outer_attrs = other.outer_attrs;
     name = other.name;
     locus = other.locus;
+    mappings = other.mappings;
 
     type_param_bounds.reserve (other.type_param_bounds.size ());
     for (const auto &e : other.type_param_bounds)

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -770,29 +770,18 @@ protected:
 // Item used in trait declarations - abstract base class
 class TraitItem
 {
-  // bool has_outer_attrs;
-  // TODO: remove and rely on virtual functions and VisItem-derived attributes?
-  // std::vector<Attribute> outer_attrs;
-
-  // NOTE: all children should have outer attributes
-
 protected:
   // Constructor
-  /*TraitItem(std::vector<Attribute> outer_attrs = std::vector<Attribute>())
-    : outer_attrs(std::move(outer_attrs)) {}*/
+  TraitItem (Analysis::NodeMapping mappings) : mappings (mappings) {}
 
   // Clone function implementation as pure virtual method
   virtual TraitItem *clone_trait_item_impl () const = 0;
 
+  Analysis::NodeMapping mappings;
+
 public:
   virtual ~TraitItem () {}
 
-  // Returns whether TraitItem has outer attributes.
-  /*bool has_outer_attrs() const {
-      return !outer_attrs.empty();
-  }*/
-
-  // Unique pointer custom clone function
   std::unique_ptr<TraitItem> clone_trait_item () const
   {
     return std::unique_ptr<TraitItem> (clone_trait_item_impl ());
@@ -801,6 +790,8 @@ public:
   virtual std::string as_string () const = 0;
 
   virtual void accept_vis (HIRVisitor &vis) = 0;
+
+  const Analysis::NodeMapping &get_mappings () const { return mappings; }
 };
 
 /* Abstract base class for items used within an inherent impl block (the impl

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -838,6 +838,10 @@ public:
   virtual std::string as_string () const = 0;
 
   virtual void accept_vis (HIRVisitor &vis) = 0;
+
+  virtual Analysis::NodeMapping get_trait_impl_mappings () const = 0;
+
+  virtual Location get_trait_impl_locus () const = 0;
 };
 
 // A crate HIR object - holds all the data for a single compilation unit

--- a/gcc/rust/resolve/rust-ast-resolve-type.h
+++ b/gcc/rust/resolve/rust-ast-resolve-type.h
@@ -52,6 +52,43 @@ public:
   }
 };
 
+class ResolveTraitItemFunctionToCanonicalPath
+{
+public:
+  static CanonicalPath resolve (AST::TraitItemFunc &function)
+  {
+    return CanonicalPath (
+      function.get_trait_function_decl ().get_identifier ());
+  }
+};
+
+class ResolveTraitItemMethodToCanonicalPath
+{
+public:
+  static CanonicalPath resolve (AST::TraitItemMethod &method)
+  {
+    return CanonicalPath (method.get_trait_method_decl ().get_identifier ());
+  }
+};
+
+class ResolveTraitItemConstToCanonicalPath
+{
+public:
+  static CanonicalPath resolve (AST::TraitItemConst &constant)
+  {
+    return CanonicalPath (constant.get_identifier ());
+  }
+};
+
+class ResolveTraitItemTypeToCanonicalPath
+{
+public:
+  static CanonicalPath resolve (AST::TraitItemType &type)
+  {
+    return CanonicalPath (type.get_identifier ());
+  }
+};
+
 class ResolveTypeToCanonicalPath : public ResolverBase
 {
   using Rust::Resolver::ResolverBase::visit;

--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -41,6 +41,9 @@
     }                                                                          \
   while (0)
 
+extern bool
+saw_errors (void);
+
 namespace Rust {
 namespace Resolver {
 
@@ -321,6 +324,9 @@ NameResolution::go (AST::Crate &crate)
   // first gather the top-level namespace names then we drill down
   for (auto it = crate.items.begin (); it != crate.items.end (); it++)
     ResolveTopLevel::go (it->get ());
+
+  if (saw_errors ())
+    return;
 
   // next we can drill down into the items and their scopes
   for (auto it = crate.items.begin (); it != crate.items.end (); it++)

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -41,6 +41,14 @@ public:
     item->accept_vis (resolver);
   }
 
+  static void
+  Resolve (HIR::TraitImplItem *item, TyTy::BaseType *self,
+	   std::vector<TyTy::SubstitutionParamMapping> substitutions)
+  {
+    TypeCheckTopLevelImplItem resolver (self, substitutions);
+    item->accept_vis (resolver);
+  }
+
   void visit (HIR::ConstantItem &constant) override
   {
     TyTy::BaseType *type = TypeCheckType::Resolve (constant.get_type ());
@@ -214,6 +222,12 @@ class TypeCheckImplItem : public TypeCheckBase
 
 public:
   static void Resolve (HIR::InherentImplItem *item, TyTy::BaseType *self)
+  {
+    TypeCheckImplItem resolver (self);
+    item->accept_vis (resolver);
+  }
+
+  static void Resolve (HIR::TraitImplItem *item, TyTy::BaseType *self)
   {
     TypeCheckImplItem resolver (self);
     item->accept_vis (resolver);

--- a/gcc/rust/typecheck/rust-hir-type-check-item.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.h
@@ -55,6 +55,21 @@ public:
       TypeCheckImplItem::Resolve (impl_item.get (), self);
   }
 
+  void visit (HIR::TraitImpl &impl_block) override
+  {
+    TyTy::BaseType *self = nullptr;
+    if (!context->lookup_type (
+	  impl_block.get_type ()->get_mappings ().get_hirid (), &self))
+      {
+	rust_error_at (impl_block.get_locus (),
+		       "failed to resolve Self for TraitImpl");
+	return;
+      }
+
+    for (auto &impl_item : impl_block.get_impl_items ())
+      TypeCheckImplItem::Resolve (impl_item.get (), self);
+  }
+
   void visit (HIR::Function &function) override
   {
     TyTy::BaseType *lookup;

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
@@ -273,6 +273,47 @@ public:
 					  substitutions);
   }
 
+  void visit (HIR::TraitImpl &impl_block) override
+  {
+    std::vector<TyTy::SubstitutionParamMapping> substitutions;
+    if (impl_block.has_generics ())
+      {
+	for (auto &generic_param : impl_block.get_generic_params ())
+	  {
+	    switch (generic_param.get ()->get_kind ())
+	      {
+	      case HIR::GenericParam::GenericKind::LIFETIME:
+		// Skipping Lifetime completely until better handling.
+		break;
+
+		case HIR::GenericParam::GenericKind::TYPE: {
+		  auto param_type
+		    = TypeResolveGenericParam::Resolve (generic_param.get ());
+		  context->insert_type (generic_param->get_mappings (),
+					param_type);
+
+		  substitutions.push_back (TyTy::SubstitutionParamMapping (
+		    static_cast<HIR::TypeParam &> (*generic_param),
+		    param_type));
+		}
+		break;
+	      }
+	  }
+      }
+
+    // TODO
+    // resolve the trait and check all items implemented
+
+    auto self
+      = TypeCheckType::Resolve (impl_block.get_type ().get (), &substitutions);
+    if (self == nullptr || self->get_kind () == TyTy::TypeKind::ERROR)
+      return;
+
+    for (auto &impl_item : impl_block.get_impl_items ())
+      TypeCheckTopLevelImplItem::Resolve (impl_item.get (), self,
+					  substitutions);
+  }
+
 private:
   TypeCheckTopLevel () : TypeCheckBase () {}
 };

--- a/gcc/testsuite/rust/compile/torture/traits1.rs
+++ b/gcc/testsuite/rust/compile/torture/traits1.rs
@@ -1,0 +1,17 @@
+trait Foo {
+    fn bar() -> i32;
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+}
+
+struct Test(i32, f32);
+
+impl Foo for Test {
+    fn bar() -> i32 {
+        123
+    }
+}
+
+fn main() {
+    let a: i32;
+    a = Test::bar();
+}

--- a/gcc/testsuite/rust/compile/torture/traits2.rs
+++ b/gcc/testsuite/rust/compile/torture/traits2.rs
@@ -1,0 +1,17 @@
+trait Foo {
+    fn bar() -> i32;
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+}
+
+struct Test<T>(T);
+
+impl<T> Foo for Test<T> {
+    fn bar() -> i32 {
+        123
+    }
+}
+
+fn main() {
+    let a: i32;
+    a = Test::<i32>::bar();
+}


### PR DESCRIPTION
This does not start enforcing anything to do with traits. in order to
implement the traits milestone we need to be able to implement a
trait first.

This makes the Trait impls follow a normal impl block. As the starting
point.

Fixes #395 #472