### PR TITLE
Use PRIx64 to print 64bit hex values in legacy_hash

### DIFF
--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -442,7 +442,7 @@ legacy_hash (const std::string &fingerprint)
 
   char hex[16 + 1];
   memset (hex, 0, sizeof hex);
-  snprintf (hex, sizeof hex, "%08lx%08lx", lo, hi);
+  snprintf (hex, sizeof hex, "%08" PRIx64 "%08" PRIx64, lo, hi);
 
   return "h" + std::string (hex, sizeof (hex) - 1);
 }


### PR DESCRIPTION
* gcc/rust/backend/rust-compile.cc (legacy_hash): lo and hi are uint64_t use
PRIx64 to print them as hex values instead of %lx which is target specific.

