### PR TITLE
HIR cleanup

### DIFF
--- a/gcc/rust/backend/rust-compile-base.h
+++ b/gcc/rust/backend/rust-compile-base.h
@@ -147,7 +147,7 @@ public:
   virtual void visit (HIR::TraitItemConst &item) {}
   virtual void visit (HIR::TraitItemType &item) {}
   virtual void visit (HIR::Trait &trait) {}
-  virtual void visit (HIR::InherentImpl &impl) {}
+  virtual void visit (HIR::ImplBlock &impl) {}
 
   virtual void visit (HIR::ExternalStaticItem &item) {}
   virtual void visit (HIR::ExternalFunctionItem &item) {}

--- a/gcc/rust/backend/rust-compile-base.h
+++ b/gcc/rust/backend/rust-compile-base.h
@@ -148,8 +148,7 @@ public:
   virtual void visit (HIR::TraitItemType &item) {}
   virtual void visit (HIR::Trait &trait) {}
   virtual void visit (HIR::InherentImpl &impl) {}
-  virtual void visit (HIR::TraitImpl &impl) {}
-  // virtual void visit(ExternalItem& item) {}
+
   virtual void visit (HIR::ExternalStaticItem &item) {}
   virtual void visit (HIR::ExternalFunctionItem &item) {}
   virtual void visit (HIR::ExternBlock &block) {}

--- a/gcc/rust/backend/rust-compile-implitem.h
+++ b/gcc/rust/backend/rust-compile-implitem.h
@@ -42,14 +42,6 @@ public:
     item->accept_vis (compiler);
   }
 
-  static void Compile (TyTy::BaseType *self, HIR::TraitImplItem *item,
-		       Context *ctx, bool compile_fns,
-		       TyTy::BaseType *concrete = nullptr)
-  {
-    CompileInherentImplItem compiler (self, ctx, compile_fns, concrete);
-    item->accept_vis (compiler);
-  }
-
   void visit (HIR::ConstantItem &constant) override
   {
     TyTy::BaseType *resolved_type = nullptr;

--- a/gcc/rust/backend/rust-compile-implitem.h
+++ b/gcc/rust/backend/rust-compile-implitem.h
@@ -34,9 +34,8 @@ class CompileInherentImplItem : public HIRCompileBase
   using Rust::Compile::HIRCompileBase::visit;
 
 public:
-  static void Compile (TyTy::BaseType *self, HIR::InherentImplItem *item,
-		       Context *ctx, bool compile_fns,
-		       TyTy::BaseType *concrete = nullptr)
+  static void Compile (TyTy::BaseType *self, HIR::ImplItem *item, Context *ctx,
+		       bool compile_fns, TyTy::BaseType *concrete = nullptr)
   {
     CompileInherentImplItem compiler (self, ctx, compile_fns, concrete);
     item->accept_vis (compiler);

--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -290,22 +290,6 @@ public:
 					compile_fns);
   }
 
-  void visit (HIR::TraitImpl &impl_block) override
-  {
-    TyTy::BaseType *self_lookup = nullptr;
-    if (!ctx->get_tyctx ()->lookup_type (
-	  impl_block.get_type ()->get_mappings ().get_hirid (), &self_lookup))
-      {
-	rust_error_at (impl_block.get_locus (),
-		       "failed to resolve type of impl");
-	return;
-      }
-
-    for (auto &impl_item : impl_block.get_impl_items ())
-      CompileInherentImplItem::Compile (self_lookup, impl_item.get (), ctx,
-					compile_fns);
-  }
-
 private:
   CompileItem (Context *ctx, bool compile_fns, TyTy::BaseType *concrete)
     : HIRCompileBase (ctx), compile_fns (compile_fns), concrete (concrete)

--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -274,7 +274,7 @@ public:
     ctx->push_function (fndecl);
   }
 
-  void visit (HIR::InherentImpl &impl_block) override
+  void visit (HIR::ImplBlock &impl_block) override
   {
     TyTy::BaseType *self_lookup = nullptr;
     if (!ctx->get_tyctx ()->lookup_type (

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -91,7 +91,7 @@ ResolvePathRef::visit (HIR::PathInExpression &expr)
       else
 	{
 	  HirId parent_impl_id = UNKNOWN_HIRID;
-	  HIR::InherentImplItem *resolved_item
+	  HIR::ImplItem *resolved_item
 	    = ctx->get_mappings ()->lookup_hir_implitem (
 	      expr.get_mappings ().get_crate_num (), ref, &parent_impl_id);
 	  if (resolved_item != nullptr)
@@ -100,8 +100,7 @@ ResolvePathRef::visit (HIR::PathInExpression &expr)
 	      HIR::Item *impl_ref = ctx->get_mappings ()->lookup_hir_item (
 		expr.get_mappings ().get_crate_num (), parent_impl_id);
 	      rust_assert (impl_ref != nullptr);
-	      HIR::InherentImpl *impl
-		= static_cast<HIR::InherentImpl *> (impl_ref);
+	      HIR::ImplBlock *impl = static_cast<HIR::ImplBlock *> (impl_ref);
 
 	      TyTy::BaseType *self = nullptr;
 	      bool ok = ctx->get_tyctx ()->lookup_type (

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -137,9 +137,8 @@ CompileExpr::visit (HIR::MethodCallExpr &expr)
     {
       // this might fail because its a forward decl so we can attempt to
       // resolve it now
-      HIR::InherentImplItem *resolved_item
-	= ctx->get_mappings ()->lookup_hir_implitem (
-	  expr.get_mappings ().get_crate_num (), ref, nullptr);
+      HIR::ImplItem *resolved_item = ctx->get_mappings ()->lookup_hir_implitem (
+	expr.get_mappings ().get_crate_num (), ref, nullptr);
       if (resolved_item == nullptr)
 	{
 	  rust_error_at (expr.get_locus (), "failed to lookup forward decl");

--- a/gcc/rust/hir/rust-ast-lower-implitem.h
+++ b/gcc/rust/hir/rust-ast-lower-implitem.h
@@ -43,14 +43,13 @@ public:
     return resolver.translated;
   }
 
-  static HIR::TraitImplItem *translate (AST::TraitImplItem *item,
-					HirId parent_impl_id)
+  static HIR::InherentImplItem *translate (AST::TraitImplItem *item,
+					   HirId parent_impl_id)
   {
     ASTLowerImplItem resolver (parent_impl_id);
     item->accept_vis (resolver);
-    rust_assert (resolver.trait_impl_item != nullptr);
-    // can get a way with this for now since they have the same hierarchy
-    return resolver.trait_impl_item;
+    rust_assert (resolver.translated != nullptr);
+    return resolver.translated;
   }
 
   void visit (AST::ConstantItem &constant) override
@@ -72,7 +71,6 @@ public:
 			       constant.get_outer_attrs (),
 			       constant.get_locus ());
     translated = translated_constant;
-    trait_impl_item = translated_constant;
 
     mappings->insert_hir_implitem (mapping.get_crate_num (),
 				   mapping.get_hirid (), parent_impl_id,
@@ -161,7 +159,6 @@ public:
       }
 
     translated = fn;
-    trait_impl_item = fn;
   }
 
   void visit (AST::Method &method) override
@@ -250,17 +247,15 @@ public:
       }
 
     translated = mth;
-    trait_impl_item = mth;
   }
 
 private:
   ASTLowerImplItem (HirId parent_impl_id)
-    : translated (nullptr), trait_impl_item (nullptr),
-      parent_impl_id (parent_impl_id)
+    : translated (nullptr), parent_impl_id (parent_impl_id)
   {}
 
   HIR::InherentImplItem *translated;
-  HIR::TraitImplItem *trait_impl_item;
+
   HirId parent_impl_id;
 };
 

--- a/gcc/rust/hir/rust-ast-lower-implitem.h
+++ b/gcc/rust/hir/rust-ast-lower-implitem.h
@@ -34,8 +34,8 @@ class ASTLowerImplItem : public ASTLoweringBase
   using Rust::HIR::ASTLoweringBase::visit;
 
 public:
-  static HIR::InherentImplItem *translate (AST::InherentImplItem *item,
-					   HirId parent_impl_id)
+  static HIR::ImplItem *translate (AST::InherentImplItem *item,
+				   HirId parent_impl_id)
   {
     ASTLowerImplItem resolver (parent_impl_id);
     item->accept_vis (resolver);
@@ -43,8 +43,8 @@ public:
     return resolver.translated;
   }
 
-  static HIR::InherentImplItem *translate (AST::TraitImplItem *item,
-					   HirId parent_impl_id)
+  static HIR::ImplItem *translate (AST::TraitImplItem *item,
+				   HirId parent_impl_id)
   {
     ASTLowerImplItem resolver (parent_impl_id);
     item->accept_vis (resolver);
@@ -254,8 +254,7 @@ private:
     : translated (nullptr), parent_impl_id (parent_impl_id)
   {}
 
-  HIR::InherentImplItem *translated;
-
+  HIR::ImplItem *translated;
   HirId parent_impl_id;
 };
 

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -387,7 +387,7 @@ public:
     HIR::ImplBlock *hir_impl_block
       = new HIR::ImplBlock (mapping, std::move (impl_items),
 			    std::move (generic_params),
-			    std::unique_ptr<HIR::Type> (impl_type),
+			    std::unique_ptr<HIR::Type> (impl_type), nullptr,
 			    where_clause, vis, impl_block.get_inner_attrs (),
 			    impl_block.get_outer_attrs (),
 			    impl_block.get_locus ());
@@ -507,6 +507,8 @@ public:
 
     HIR::Type *impl_type
       = ASTLoweringType::translate (impl_block.get_type ().get ());
+    HIR::TypePath *trait_ref
+      = ASTLowerTypePath::translate (impl_block.get_trait_path ());
 
     auto crate_num = mappings->get_current_crate ();
     Analysis::NodeMapping mapping (crate_num, impl_block.get_node_id (),
@@ -528,6 +530,7 @@ public:
       = new HIR::ImplBlock (mapping, std::move (impl_items),
 			    std::move (generic_params),
 			    std::unique_ptr<HIR::Type> (impl_type),
+			    std::unique_ptr<HIR::TypePath> (trait_ref),
 			    where_clause, vis, impl_block.get_inner_attrs (),
 			    impl_block.get_outer_attrs (),
 			    impl_block.get_locus ());

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -373,24 +373,25 @@ public:
 				   mappings->get_next_hir_id (crate_num),
 				   mappings->get_next_localdef_id (crate_num));
 
-    std::vector<std::unique_ptr<HIR::InherentImplItem> > impl_items;
+    std::vector<std::unique_ptr<HIR::ImplItem> > impl_items;
     std::vector<HirId> impl_item_ids;
     for (auto &impl_item : impl_block.get_impl_items ())
       {
-	HIR::InherentImplItem *lowered
+	HIR::ImplItem *lowered
 	  = ASTLowerImplItem::translate (impl_item.get (),
 					 mapping.get_hirid ());
-	impl_items.push_back (std::unique_ptr<HIR::InherentImplItem> (lowered));
+	impl_items.push_back (std::unique_ptr<HIR::ImplItem> (lowered));
 	impl_item_ids.push_back (lowered->get_impl_mappings ().get_hirid ());
       }
 
-    translated
-      = new HIR::InherentImpl (mapping, std::move (impl_items),
-			       std::move (generic_params),
-			       std::unique_ptr<HIR::Type> (impl_type),
-			       where_clause, vis, impl_block.get_inner_attrs (),
-			       impl_block.get_outer_attrs (),
-			       impl_block.get_locus ());
+    HIR::ImplBlock *hir_impl_block
+      = new HIR::ImplBlock (mapping, std::move (impl_items),
+			    std::move (generic_params),
+			    std::unique_ptr<HIR::Type> (impl_type),
+			    where_clause, vis, impl_block.get_inner_attrs (),
+			    impl_block.get_outer_attrs (),
+			    impl_block.get_locus ());
+    translated = hir_impl_block;
 
     mappings->insert_defid_mapping (mapping.get_defid (), translated);
     mappings->insert_hir_item (mapping.get_crate_num (), mapping.get_hirid (),
@@ -400,9 +401,7 @@ public:
 
     for (auto &impl_item_id : impl_item_ids)
       {
-	mappings->insert_impl_item_mapping (impl_item_id,
-					    static_cast<HIR::InherentImpl *> (
-					      translated));
+	mappings->insert_impl_item_mapping (impl_item_id, hir_impl_block);
       }
   }
 
@@ -514,24 +513,25 @@ public:
 				   mappings->get_next_hir_id (crate_num),
 				   mappings->get_next_localdef_id (crate_num));
 
-    std::vector<std::unique_ptr<HIR::InherentImplItem> > impl_items;
+    std::vector<std::unique_ptr<HIR::ImplItem> > impl_items;
     std::vector<HirId> impl_item_ids;
     for (auto &impl_item : impl_block.get_impl_items ())
       {
-	HIR::InherentImplItem *lowered
+	HIR::ImplItem *lowered
 	  = ASTLowerImplItem::translate (impl_item.get (),
 					 mapping.get_hirid ());
-	impl_items.push_back (std::unique_ptr<HIR::InherentImplItem> (lowered));
+	impl_items.push_back (std::unique_ptr<HIR::ImplItem> (lowered));
 	impl_item_ids.push_back (lowered->get_impl_mappings ().get_hirid ());
       }
 
-    translated
-      = new HIR::InherentImpl (mapping, std::move (impl_items),
-			       std::move (generic_params),
-			       std::unique_ptr<HIR::Type> (impl_type),
-			       where_clause, vis, impl_block.get_inner_attrs (),
-			       impl_block.get_outer_attrs (),
-			       impl_block.get_locus ());
+    HIR::ImplBlock *hir_impl_block
+      = new HIR::ImplBlock (mapping, std::move (impl_items),
+			    std::move (generic_params),
+			    std::unique_ptr<HIR::Type> (impl_type),
+			    where_clause, vis, impl_block.get_inner_attrs (),
+			    impl_block.get_outer_attrs (),
+			    impl_block.get_locus ());
+    translated = hir_impl_block;
 
     mappings->insert_defid_mapping (mapping.get_defid (), translated);
     mappings->insert_hir_item (mapping.get_crate_num (), mapping.get_hirid (),
@@ -541,9 +541,7 @@ public:
 
     for (auto &impl_item_id : impl_item_ids)
       {
-	mappings->insert_impl_item_mapping (impl_item_id,
-					    static_cast<HIR::InherentImpl *> (
-					      translated));
+	mappings->insert_impl_item_mapping (impl_item_id, hir_impl_block);
       }
   }
 

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -365,7 +365,7 @@ public:
 	  }
       }
 
-    HIR::Type *trait_type
+    HIR::Type *impl_type
       = ASTLoweringType::translate (impl_block.get_type ().get ());
 
     auto crate_num = mappings->get_current_crate ();
@@ -387,7 +387,7 @@ public:
     translated
       = new HIR::InherentImpl (mapping, std::move (impl_items),
 			       std::move (generic_params),
-			       std::unique_ptr<HIR::Type> (trait_type),
+			       std::unique_ptr<HIR::Type> (impl_type),
 			       where_clause, vis, impl_block.get_inner_attrs (),
 			       impl_block.get_outer_attrs (),
 			       impl_block.get_locus ());
@@ -472,6 +472,7 @@ public:
   void visit (AST::TraitImpl &impl_block) override
   {
     std::vector<std::unique_ptr<HIR::WhereClauseItem> > where_clause_items;
+
     HIR::WhereClause where_clause (std::move (where_clause_items));
     HIR::Visibility vis = HIR::Visibility::create_public ();
 
@@ -505,35 +506,32 @@ public:
 	  }
       }
 
-    HIR::Type *trait_type
+    HIR::Type *impl_type
       = ASTLoweringType::translate (impl_block.get_type ().get ());
-    HIR::Type *trait = nullptr;
 
     auto crate_num = mappings->get_current_crate ();
     Analysis::NodeMapping mapping (crate_num, impl_block.get_node_id (),
 				   mappings->get_next_hir_id (crate_num),
 				   mappings->get_next_localdef_id (crate_num));
 
-    std::vector<std::unique_ptr<HIR::TraitImplItem> > impl_items;
+    std::vector<std::unique_ptr<HIR::InherentImplItem> > impl_items;
     std::vector<HirId> impl_item_ids;
     for (auto &impl_item : impl_block.get_impl_items ())
       {
-	HIR::TraitImplItem *lowered
+	HIR::InherentImplItem *lowered
 	  = ASTLowerImplItem::translate (impl_item.get (),
 					 mapping.get_hirid ());
-	impl_items.push_back (std::unique_ptr<HIR::TraitImplItem> (lowered));
-	impl_item_ids.push_back (
-	  lowered->get_trait_impl_mappings ().get_hirid ());
+	impl_items.push_back (std::unique_ptr<HIR::InherentImplItem> (lowered));
+	impl_item_ids.push_back (lowered->get_impl_mappings ().get_hirid ());
       }
 
     translated
-      = new HIR::TraitImpl (mapping, std::unique_ptr<HIR::Type> (trait),
-			    impl_block.is_unsafe (), impl_block.is_exclam (),
-			    std::move (impl_items), std::move (generic_params),
-			    std::unique_ptr<HIR::Type> (trait_type),
-			    where_clause, vis, impl_block.get_inner_attrs (),
-			    impl_block.get_outer_attrs (),
-			    impl_block.get_locus ());
+      = new HIR::InherentImpl (mapping, std::move (impl_items),
+			       std::move (generic_params),
+			       std::unique_ptr<HIR::Type> (impl_type),
+			       where_clause, vis, impl_block.get_inner_attrs (),
+			       impl_block.get_outer_attrs (),
+			       impl_block.get_locus ());
 
     mappings->insert_defid_mapping (mapping.get_defid (), translated);
     mappings->insert_hir_item (mapping.get_crate_num (), mapping.get_hirid (),

--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -363,5 +363,33 @@ ASTLoweringBase::lower_self (AST::SelfParam &self)
 			 self.get_is_mut (), self.get_locus ());
 }
 
+void
+ASTLowerTypePath::visit (AST::TypePathSegmentGeneric &segment)
+{
+  std::vector<HIR::GenericArgsBinding> binding_args; // TODO
+
+  std::string segment_name = segment.get_ident_segment ().as_string ();
+  bool has_separating_scope_resolution
+    = segment.get_separating_scope_resolution ();
+
+  std::vector<HIR::Lifetime> lifetime_args;
+  for (auto &lifetime : segment.get_generic_args ().get_lifetime_args ())
+    {
+      HIR::Lifetime l = lower_lifetime (lifetime);
+      lifetime_args.push_back (std::move (l));
+    }
+
+  std::vector<std::unique_ptr<HIR::Type> > type_args;
+  for (auto &type : segment.get_generic_args ().get_type_args ())
+    {
+      HIR::Type *t = ASTLoweringType::translate (type.get ());
+      type_args.push_back (std::unique_ptr<HIR::Type> (t));
+    }
+
+  translated_segment = new HIR::TypePathSegmentGeneric (
+    segment_name, has_separating_scope_resolution, std::move (lifetime_args),
+    std::move (type_args), std::move (binding_args), segment.get_locus ());
+}
+
 } // namespace HIR
 } // namespace Rust

--- a/gcc/rust/hir/tree/rust-hir-full-decls.h
+++ b/gcc/rust/hir/tree/rust-hir-full-decls.h
@@ -37,7 +37,7 @@ class GenericParam;
 class LifetimeParam;
 
 class TraitItem;
-class InherentImplItem;
+class ImplItem;
 struct Crate;
 class PathExpr;
 
@@ -193,8 +193,7 @@ class TraitItemMethod;
 class TraitItemConst;
 class TraitItemType;
 class Trait;
-class Impl;
-class InherentImpl;
+class ImplBlock;
 class ExternalItem;
 class ExternalStaticItem;
 struct NamedFunctionParam;

--- a/gcc/rust/hir/tree/rust-hir-full-decls.h
+++ b/gcc/rust/hir/tree/rust-hir-full-decls.h
@@ -38,7 +38,6 @@ class LifetimeParam;
 
 class TraitItem;
 class InherentImplItem;
-class TraitImplItem;
 struct Crate;
 class PathExpr;
 
@@ -196,7 +195,6 @@ class TraitItemType;
 class Trait;
 class Impl;
 class InherentImpl;
-class TraitImpl;
 class ExternalItem;
 class ExternalStaticItem;
 struct NamedFunctionParam;

--- a/gcc/rust/hir/tree/rust-hir-full-test.cc
+++ b/gcc/rust/hir/tree/rust-hir-full-test.cc
@@ -1084,88 +1084,6 @@ BlockExpr::as_string () const
 }
 
 std::string
-TraitImpl::as_string () const
-{
-  std::string str = VisItem::as_string ();
-
-  if (has_unsafe)
-    {
-      str += "unsafe ";
-    }
-
-  str += "impl ";
-
-  // generic params
-  str += "\n Generic params: ";
-  if (!has_generics ())
-    {
-      str += "none";
-    }
-  else
-    {
-      for (const auto &param : generic_params)
-	{
-	  str += "\n  " + param->as_string ();
-	}
-    }
-
-  str += "\n Has exclam: ";
-  if (has_exclam)
-    {
-      str += "true";
-    }
-  else
-    {
-      str += "false";
-    }
-
-  str += "\n TypePath (to trait): " + trait_path->as_string ();
-
-  str += "\n Type (struct to impl on): " + trait_type->as_string ();
-
-  str += "\n Where clause: ";
-  if (!has_where_clause ())
-    {
-      str += "none";
-    }
-  else
-    {
-      str += where_clause.as_string ();
-    }
-
-  // inner attributes
-  str += "\n inner attributes: ";
-  if (inner_attrs.empty ())
-    {
-      str += "none";
-    }
-  else
-    {
-      /* note that this does not print them with "inner attribute" syntax -
-       * just the body */
-      for (const auto &attr : inner_attrs)
-	{
-	  str += "\n  " + attr.as_string ();
-	}
-    }
-
-  str += "\n trait impl items: ";
-  if (!has_impl_items ())
-    {
-      str += "none";
-    }
-  else
-    {
-      for (const auto &item : impl_items)
-	{
-	  str += "\n  " + item->as_string ();
-	}
-    }
-
-  return str;
-}
-
-std::string
 TypeAlias::as_string () const
 {
   std::string str = VisItem::as_string ();
@@ -4688,12 +4606,6 @@ Trait::accept_vis (HIRVisitor &vis)
 
 void
 InherentImpl::accept_vis (HIRVisitor &vis)
-{
-  vis.visit (*this);
-}
-
-void
-TraitImpl::accept_vis (HIRVisitor &vis)
 {
   vis.visit (*this);
 }

--- a/gcc/rust/hir/tree/rust-hir-full-test.cc
+++ b/gcc/rust/hir/tree/rust-hir-full-test.cc
@@ -377,7 +377,7 @@ ConstantItem::as_string () const
 }
 
 std::string
-InherentImpl::as_string () const
+ImplBlock::as_string () const
 {
   std::string str = VisItem::as_string ();
 
@@ -398,7 +398,7 @@ InherentImpl::as_string () const
 	    {
 	      rust_debug (
 		"something really terrible has gone wrong - null pointer "
-		"generic param in inherent impl.");
+		"generic param in impl.");
 	      return "nullptr_POINTER_MARK";
 	    }
 
@@ -406,7 +406,7 @@ InherentImpl::as_string () const
 	}
     }
 
-  str += "\n Type: " + trait_type->as_string ();
+  str += "\n Type: " + impl_type->as_string ();
 
   str += "\n Where clause: ";
   if (has_where_clause ())
@@ -434,8 +434,7 @@ InherentImpl::as_string () const
 	}
     }
 
-  // inherent impl items
-  str += "\n Inherent impl items: ";
+  str += "\n impl items: ";
   if (!has_impl_items ())
     {
       str += "none";
@@ -4605,7 +4604,7 @@ Trait::accept_vis (HIRVisitor &vis)
 }
 
 void
-InherentImpl::accept_vis (HIRVisitor &vis)
+ImplBlock::accept_vis (HIRVisitor &vis)
 {
   vis.visit (*this);
 }

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -2884,33 +2884,28 @@ class ImplBlock : public VisItem
 {
   std::vector<std::unique_ptr<GenericParam> > generic_params;
   std::unique_ptr<Type> impl_type;
+  std::unique_ptr<TypePath> trait_ref;
   WhereClause where_clause;
   AST::AttrVec inner_attrs;
   Location locus;
   std::vector<std::unique_ptr<ImplItem> > impl_items;
 
 public:
-  std::string as_string () const override;
-
-  // Returns whether inherent impl block has inherent impl items.
-  bool has_impl_items () const { return !impl_items.empty (); }
-
-  // Mega-constructor
   ImplBlock (Analysis::NodeMapping mappings,
 	     std::vector<std::unique_ptr<ImplItem> > impl_items,
 	     std::vector<std::unique_ptr<GenericParam> > generic_params,
-	     std::unique_ptr<Type> impl_type, WhereClause where_clause,
+	     std::unique_ptr<Type> impl_type,
+	     std::unique_ptr<TypePath> trait_ref, WhereClause where_clause,
 	     Visibility vis, AST::AttrVec inner_attrs, AST::AttrVec outer_attrs,
 	     Location locus)
     : VisItem (std::move (mappings), std::move (vis), std::move (outer_attrs)),
       generic_params (std::move (generic_params)),
-      impl_type (std::move (impl_type)),
+      impl_type (std::move (impl_type)), trait_ref (std::move (trait_ref)),
       where_clause (std::move (where_clause)),
       inner_attrs (std::move (inner_attrs)), locus (locus),
       impl_items (std::move (impl_items))
   {}
 
-  // Copy constructor with vector clone
   ImplBlock (ImplBlock const &other)
     : VisItem (other), impl_type (other.impl_type->clone_type ()),
       where_clause (other.where_clause), inner_attrs (other.inner_attrs),
@@ -2925,7 +2920,6 @@ public:
       impl_items.push_back (e->clone_inherent_impl_item ());
   }
 
-  // Overloaded assignment operator with vector clone
   ImplBlock &operator= (ImplBlock const &other)
   {
     VisItem::operator= (other);
@@ -2947,6 +2941,11 @@ public:
 
   ImplBlock (ImplBlock &&other) = default;
   ImplBlock &operator= (ImplBlock &&other) = default;
+
+  std::string as_string () const override;
+
+  // Returns whether inherent impl block has inherent impl items.
+  bool has_impl_items () const { return !impl_items.empty (); }
 
   void accept_vis (HIRVisitor &vis) override;
 
@@ -2976,6 +2975,14 @@ public:
   std::vector<std::unique_ptr<GenericParam> > &get_generic_params ()
   {
     return generic_params;
+  }
+
+  bool has_trait_ref () const { return trait_ref != nullptr; }
+
+  std::unique_ptr<TypePath> &get_trait_ref ()
+  {
+    rust_assert (has_trait_ref ());
+    return trait_ref;
   }
 
 protected:

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -578,7 +578,7 @@ protected:
 };
 
 // A method (function belonging to a type)
-class Method : public InherentImplItem, public TraitImplItem
+class Method : public InherentImplItem
 {
   Analysis::NodeMapping mappings;
 
@@ -700,11 +700,6 @@ public:
     return get_mappings ();
   };
 
-  Analysis::NodeMapping get_trait_impl_mappings () const override
-  {
-    return get_mappings ();
-  };
-
   // Returns whether function has return type - if not, it is void.
   bool has_function_return_type () const { return return_type != nullptr; }
 
@@ -753,8 +748,6 @@ public:
 
   Location get_impl_locus () const final { return get_locus (); }
 
-  Location get_trait_impl_locus () const final { return get_locus (); }
-
   std::unique_ptr<BlockExpr> &get_function_body () { return function_body; }
   const std::unique_ptr<BlockExpr> &get_function_body () const
   {
@@ -765,13 +758,6 @@ protected:
   /* Use covariance to implement clone function as returning this object
    * rather than base */
   Method *clone_inherent_impl_item_impl () const override
-  {
-    return new Method (*this);
-  }
-
-  /* Use covariance to implement clone function as returning this object
-   * rather than base */
-  Method *clone_trait_impl_item_impl () const override
   {
     return new Method (*this);
   }
@@ -1274,7 +1260,7 @@ protected:
 class LetStmt;
 
 // Rust function declaration HIR node
-class Function : public VisItem, public InherentImplItem, public TraitImplItem
+class Function : public VisItem, public InherentImplItem
 {
   FunctionQualifiers qualifiers;
   Identifier function_name;
@@ -1377,16 +1363,9 @@ public:
 
   Location get_impl_locus () const final { return get_locus (); }
 
-  Location get_trait_impl_locus () const final { return get_locus (); }
-
   void accept_vis (HIRVisitor &vis) override;
 
   Analysis::NodeMapping get_impl_mappings () const override
-  {
-    return get_mappings ();
-  };
-
-  Analysis::NodeMapping get_trait_impl_mappings () const override
   {
     return get_mappings ();
   };
@@ -1444,23 +1423,10 @@ protected:
   {
     return new Function (*this);
   }
-
-  /* Use covariance to implement clone function as returning this object
-   * rather than base */
-  Function *clone_trait_impl_item_impl () const override
-  {
-    return new Function (*this);
-  }
-
-  /* Use covariance to implement clone function as returning this object
-   * rather than base */
-  /*virtual Function* clone_statement_impl() const override {
-      return new Function(*this);
-  }*/
 };
 
 // Rust type alias (i.e. typedef) HIR node
-class TypeAlias : public VisItem, public TraitImplItem
+class TypeAlias : public VisItem, public InherentImplItem
 {
   Identifier new_type_name;
 
@@ -1512,11 +1478,8 @@ public:
   {
     VisItem::operator= (other);
     new_type_name = other.new_type_name;
-    // generic_params = other.generic_params;
     where_clause = other.where_clause;
     existing_type = other.existing_type->clone_type ();
-    // visibility = other.visibility->clone_visibility();
-    // outer_attrs = other.outer_attrs;
     locus = other.locus;
 
     generic_params.reserve (other.generic_params.size ());
@@ -1532,7 +1495,7 @@ public:
 
   Location get_locus () const { return locus; }
 
-  Location get_trait_impl_locus () const final { return get_locus (); }
+  Location get_impl_locus () const final { return get_locus (); }
 
   void accept_vis (HIRVisitor &vis) override;
 
@@ -1545,14 +1508,12 @@ public:
     return generic_params;
   }
 
-  // TODO: is this better? Or is a "vis_block" better?
   WhereClause &get_where_clause ()
   {
     rust_assert (has_where_clause ());
     return where_clause;
   }
 
-  // TODO: is this better? Or is a "vis_block" better?
   std::unique_ptr<Type> &get_type_aliased ()
   {
     rust_assert (existing_type != nullptr);
@@ -1561,7 +1522,7 @@ public:
 
   Identifier get_new_type_name () const { return new_type_name; }
 
-  Analysis::NodeMapping get_trait_impl_mappings () const override
+  Analysis::NodeMapping get_impl_mappings () const override
   {
     return get_mappings ();
   };
@@ -1573,16 +1534,10 @@ protected:
 
   /* Use covariance to implement clone function as returning this object
    * rather than base */
-  TypeAlias *clone_trait_impl_item_impl () const override
+  TypeAlias *clone_inherent_impl_item_impl () const override
   {
     return new TypeAlias (*this);
   }
-
-  /* Use covariance to implement clone function as returning this object
-   * rather than base */
-  /*virtual TypeAlias* clone_statement_impl() const override {
-      return new TypeAlias(*this);
-  }*/
 };
 
 // Rust base struct declaration HIR node - abstract base class
@@ -2226,28 +2181,13 @@ protected:
   /* Use covariance to implement clone function as returning this object
    * rather than base */
   Union *clone_item_impl () const override { return new Union (*this); }
-
-  /* Use covariance to implement clone function as returning this object
-   * rather than base */
-  /*virtual Union* clone_statement_impl() const override {
-      return new Union(*this);
-  }*/
 };
 
-/* "Constant item" HIR node - used for constant, compile-time expressions
- * within module scope (like constexpr) */
-class ConstantItem : public VisItem,
-		     public InherentImplItem,
-		     public TraitImplItem
+class ConstantItem : public VisItem, public InherentImplItem
 {
-  // either has an identifier or "_" - maybe handle in identifier?
-  // bool identifier_is_underscore;
-  // if no identifier declared, identifier will be "_"
   Identifier identifier;
-
   std::unique_ptr<Type> type;
   std::unique_ptr<Expr> const_expr;
-
   Location locus;
 
 public:
@@ -2284,15 +2224,13 @@ public:
   ConstantItem (ConstantItem &&other) = default;
   ConstantItem &operator= (ConstantItem &&other) = default;
 
-  /* Returns whether constant item is an "unnamed" (wildcard underscore used
-   * as identifier) constant. */
+  // Returns whether constant item is an "unnamed" (wildcard underscore used
+  // as identifier) constant.
   bool is_unnamed () const { return identifier == std::string ("_"); }
 
   Location get_locus () const { return locus; }
 
   Location get_impl_locus () const final { return get_locus (); }
-
-  Location get_trait_impl_locus () const final { return get_locus (); }
 
   void accept_vis (HIRVisitor &vis) override;
 
@@ -2303,11 +2241,6 @@ public:
   std::string get_identifier () { return identifier; }
 
   Analysis::NodeMapping get_impl_mappings () const override
-  {
-    return get_mappings ();
-  };
-
-  Analysis::NodeMapping get_trait_impl_mappings () const override
   {
     return get_mappings ();
   };
@@ -2326,19 +2259,6 @@ protected:
   {
     return new ConstantItem (*this);
   }
-
-  /* Use covariance to implement clone function as returning this object
-   * rather than base */
-  ConstantItem *clone_trait_impl_item_impl () const override
-  {
-    return new ConstantItem (*this);
-  }
-
-  /* Use covariance to implement clone function as returning this object
-   * rather than base */
-  /*virtual ConstantItem* clone_statement_impl() const override {
-      return new ConstantItem(*this);
-  }*/
 };
 
 /* Static item HIR node - items within module scope with fixed storage
@@ -3120,104 +3040,13 @@ protected:
   {
     return new InherentImpl (*this);
   }
-
-  /* Use covariance to implement clone function as returning this object
-   * rather than base */
-  /*virtual InherentImpl* clone_statement_impl() const override {
-      return new InherentImpl(*this);
-  }*/
-};
-
-// The "impl footrait for foo" impl block declaration HIR node
-class TraitImpl : public Impl
-{
-  bool has_unsafe;
-  bool has_exclam;
-  std::unique_ptr<Type> trait_path;
-
-  // bool has_impl_items;
-  std::vector<std::unique_ptr<TraitImplItem> > impl_items;
-
-public:
-  std::string as_string () const override;
-
-  // Returns whether trait impl has impl items.
-  bool has_impl_items () const { return !impl_items.empty (); }
-
-  // Mega-constructor
-  TraitImpl (Analysis::NodeMapping mappings, std::unique_ptr<Type> trait_path,
-	     bool is_unsafe, bool has_exclam,
-	     std::vector<std::unique_ptr<TraitImplItem> > impl_items,
-	     std::vector<std::unique_ptr<GenericParam> > generic_params,
-	     std::unique_ptr<Type> trait_type, WhereClause where_clause,
-	     Visibility vis, AST::AttrVec inner_attrs, AST::AttrVec outer_attrs,
-	     Location locus)
-    : Impl (std::move (mappings), std::move (generic_params),
-	    std::move (trait_type), std::move (where_clause), std::move (vis),
-	    std::move (inner_attrs), std::move (outer_attrs), locus),
-      has_unsafe (is_unsafe), has_exclam (has_exclam),
-      trait_path (std::move (trait_path)), impl_items (std::move (impl_items))
-  {}
-
-  // TODO: constructors with less params
-
-  // Copy constructor with vector clone
-  TraitImpl (TraitImpl const &other)
-    : Impl (other), has_unsafe (other.has_unsafe),
-      has_exclam (other.has_exclam),
-      trait_path (other.trait_path->clone_type ())
-  {
-    impl_items.reserve (other.impl_items.size ());
-    for (const auto &e : other.impl_items)
-      impl_items.push_back (e->clone_trait_impl_item ());
-  }
-
-  // Overloaded assignment operator with vector clone
-  TraitImpl &operator= (TraitImpl const &other)
-  {
-    Impl::operator= (other);
-    trait_path = other.trait_path->clone_type ();
-    has_unsafe = other.has_unsafe;
-    has_exclam = other.has_exclam;
-
-    impl_items.reserve (other.impl_items.size ());
-    for (const auto &e : other.impl_items)
-      impl_items.push_back (e->clone_trait_impl_item ());
-
-    return *this;
-  }
-
-  // move constructors
-  TraitImpl (TraitImpl &&other) = default;
-  TraitImpl &operator= (TraitImpl &&other) = default;
-
-  void accept_vis (HIRVisitor &vis) override;
-  std::vector<std::unique_ptr<TraitImplItem> > &get_impl_items ()
-  {
-    return impl_items;
-  };
-
-protected:
-  /* Use covariance to implement clone function as returning this object
-   * rather than base */
-  TraitImpl *clone_item_impl () const override { return new TraitImpl (*this); }
-
-  /* Use covariance to implement clone function as returning this object
-   * rather than base */
-  /*virtual TraitImpl* clone_statement_impl() const override {
-      return new TraitImpl(*this);
-  }*/
 };
 
 // Abstract base class for an item used inside an extern block
 class ExternalItem
 {
-  // bool has_outer_attrs;
   AST::AttrVec outer_attrs;
-
-  // bool has_visibility;
   Visibility visibility;
-
   Identifier item_name;
   Location locus;
 

--- a/gcc/rust/hir/tree/rust-hir-visitor.h
+++ b/gcc/rust/hir/tree/rust-hir-visitor.h
@@ -127,7 +127,7 @@ public:
   virtual void visit (TraitItemConst &item) = 0;
   virtual void visit (TraitItemType &item) = 0;
   virtual void visit (Trait &trait) = 0;
-  virtual void visit (InherentImpl &impl) = 0;
+  virtual void visit (ImplBlock &impl) = 0;
   virtual void visit (ExternalStaticItem &item) = 0;
   virtual void visit (ExternalFunctionItem &item) = 0;
   virtual void visit (ExternBlock &block) = 0;

--- a/gcc/rust/hir/tree/rust-hir-visitor.h
+++ b/gcc/rust/hir/tree/rust-hir-visitor.h
@@ -128,7 +128,6 @@ public:
   virtual void visit (TraitItemType &item) = 0;
   virtual void visit (Trait &trait) = 0;
   virtual void visit (InherentImpl &impl) = 0;
-  virtual void visit (TraitImpl &impl) = 0;
   virtual void visit (ExternalStaticItem &item) = 0;
   virtual void visit (ExternalFunctionItem &item) = 0;
   virtual void visit (ExternBlock &block) = 0;

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -645,19 +645,19 @@ public:
   const Analysis::NodeMapping &get_mappings () const { return mappings; }
 };
 
-class InherentImplItem
+class ImplItem
 {
 protected:
   // Clone function implementation as pure virtual method
-  virtual InherentImplItem *clone_inherent_impl_item_impl () const = 0;
+  virtual ImplItem *clone_inherent_impl_item_impl () const = 0;
 
 public:
-  virtual ~InherentImplItem () {}
+  virtual ~ImplItem () {}
 
   // Unique pointer custom clone function
-  std::unique_ptr<InherentImplItem> clone_inherent_impl_item () const
+  std::unique_ptr<ImplItem> clone_inherent_impl_item () const
   {
-    return std::unique_ptr<InherentImplItem> (clone_inherent_impl_item_impl ());
+    return std::unique_ptr<ImplItem> (clone_inherent_impl_item_impl ());
   }
 
   virtual std::string as_string () const = 0;

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -645,8 +645,6 @@ public:
   const Analysis::NodeMapping &get_mappings () const { return mappings; }
 };
 
-/* Abstract base class for items used within an inherent impl block (the impl
- * name {} one) */
 class InherentImplItem
 {
 protected:
@@ -669,30 +667,6 @@ public:
   virtual Analysis::NodeMapping get_impl_mappings () const = 0;
 
   virtual Location get_impl_locus () const = 0;
-};
-
-// Abstract base class for items used in a trait impl
-class TraitImplItem
-{
-protected:
-  virtual TraitImplItem *clone_trait_impl_item_impl () const = 0;
-
-public:
-  virtual ~TraitImplItem (){};
-
-  // Unique pointer custom clone function
-  std::unique_ptr<TraitImplItem> clone_trait_impl_item () const
-  {
-    return std::unique_ptr<TraitImplItem> (clone_trait_impl_item_impl ());
-  }
-
-  virtual std::string as_string () const = 0;
-
-  virtual void accept_vis (HIRVisitor &vis) = 0;
-
-  virtual Analysis::NodeMapping get_trait_impl_mappings () const = 0;
-
-  virtual Location get_trait_impl_locus () const = 0;
 };
 
 // A crate HIR object - holds all the data for a single compilation unit

--- a/gcc/rust/lint/rust-lint-marklive-base.h
+++ b/gcc/rust/lint/rust-lint-marklive-base.h
@@ -144,7 +144,6 @@ public:
   virtual void visit (HIR::TraitItemType &) override {}
   virtual void visit (HIR::Trait &) override {}
   virtual void visit (HIR::InherentImpl &) override {}
-  virtual void visit (HIR::TraitImpl &) override {}
 
   virtual void visit (HIR::ExternalStaticItem &) override {}
   virtual void visit (HIR::ExternalFunctionItem &) override {}

--- a/gcc/rust/lint/rust-lint-marklive-base.h
+++ b/gcc/rust/lint/rust-lint-marklive-base.h
@@ -143,7 +143,7 @@ public:
   virtual void visit (HIR::TraitItemConst &) override {}
   virtual void visit (HIR::TraitItemType &) override {}
   virtual void visit (HIR::Trait &) override {}
-  virtual void visit (HIR::InherentImpl &) override {}
+  virtual void visit (HIR::ImplBlock &) override {}
 
   virtual void visit (HIR::ExternalStaticItem &) override {}
   virtual void visit (HIR::ExternalFunctionItem &) override {}

--- a/gcc/rust/lint/rust-lint-marklive.cc
+++ b/gcc/rust/lint/rust-lint-marklive.cc
@@ -80,7 +80,7 @@ MarkLive::go (HIR::Crate &crate)
       else
 	{ // the item maybe inside a trait impl
 	  HirId parent_impl_id = UNKNOWN_HIRID;
-	  HIR::InherentImplItem *implItem
+	  HIR::ImplItem *implItem
 	    = mappings->lookup_hir_implitem (crateNum, hirId, &parent_impl_id);
 	  if (implItem != nullptr)
 	    implItem->accept_vis (*this);

--- a/gcc/rust/lint/rust-lint-marklive.h
+++ b/gcc/rust/lint/rust-lint-marklive.h
@@ -80,24 +80,29 @@ public:
     expr.get_lhs ()->accept_vis (*this);
     expr.get_rhs ()->accept_vis (*this);
   }
+
   void visit (HIR::AssignmentExpr &expr) override
   {
     expr.visit_lhs (*this);
     expr.visit_rhs (*this);
   }
+
   void visit (HIR::Method &method) override
   {
     method.get_definition ().get ()->accept_vis (*this);
   }
+
   void visit (HIR::TraitItemFunc &item) override
   {
     item.get_block_expr ()->accept_vis (*this);
   }
+
   void visit (HIR::TraitItemMethod &item) override
   {
     item.get_block_expr ()->accept_vis (*this);
   }
-  void visit (HIR::InherentImpl &impl) override
+
+  void visit (HIR::ImplBlock &impl) override
   {
     for (auto &&item : impl.get_impl_items ())
       {

--- a/gcc/rust/lint/rust-lint-marklive.h
+++ b/gcc/rust/lint/rust-lint-marklive.h
@@ -104,13 +104,7 @@ public:
 	item.get ()->accept_vis (*this);
       }
   }
-  void visit (HIR::TraitImpl &impl) override
-  {
-    for (auto &&item : impl.get_impl_items ())
-      {
-	item.get ()->accept_vis (*this);
-      }
-  }
+
   void visit (HIR::LetStmt &stmt) override
   {
     if (stmt.has_init_expr ())

--- a/gcc/rust/typecheck/rust-hir-const-fold-base.h
+++ b/gcc/rust/typecheck/rust-hir-const-fold-base.h
@@ -146,7 +146,7 @@ public:
   virtual void visit (HIR::TraitItemConst &) override {}
   virtual void visit (HIR::TraitItemType &) override {}
   virtual void visit (HIR::Trait &) override {}
-  virtual void visit (HIR::InherentImpl &) override {}
+  virtual void visit (HIR::ImplBlock &) override {}
 
   virtual void visit (HIR::ExternalStaticItem &) override {}
   virtual void visit (HIR::ExternalFunctionItem &) override {}

--- a/gcc/rust/typecheck/rust-hir-const-fold-base.h
+++ b/gcc/rust/typecheck/rust-hir-const-fold-base.h
@@ -147,7 +147,6 @@ public:
   virtual void visit (HIR::TraitItemType &) override {}
   virtual void visit (HIR::Trait &) override {}
   virtual void visit (HIR::InherentImpl &) override {}
-  virtual void visit (HIR::TraitImpl &) override {}
 
   virtual void visit (HIR::ExternalStaticItem &) override {}
   virtual void visit (HIR::ExternalFunctionItem &) override {}

--- a/gcc/rust/typecheck/rust-hir-path-probe.h
+++ b/gcc/rust/typecheck/rust-hir-path-probe.h
@@ -29,7 +29,7 @@ namespace Resolver {
 
 struct PathProbeCandidate
 {
-  HIR::InherentImplItem *impl_item;
+  HIR::ImplItem *impl_item;
   TyTy::BaseType *ty;
 };
 
@@ -43,16 +43,15 @@ public:
   {
     PathProbeType probe (receiver, segment_name);
     probe.mappings->iterate_impl_items (
-      [&] (HirId id, HIR::InherentImplItem *item,
-	   HIR::InherentImpl *impl) mutable -> bool {
+      [&] (HirId id, HIR::ImplItem *item,
+	   HIR::ImplBlock *impl) mutable -> bool {
 	probe.process_candidate (id, item, impl);
 	return true;
       });
     return probe.candidates;
   }
 
-  void process_candidate (HirId id, HIR::InherentImplItem *item,
-			  HIR::InherentImpl *impl)
+  void process_candidate (HirId id, HIR::ImplItem *item, HIR::ImplBlock *impl)
   {
     HirId impl_ty_id = impl->get_type ()->get_mappings ().get_hirid ();
     TyTy::BaseType *impl_block_ty = nullptr;

--- a/gcc/rust/typecheck/rust-hir-type-check-base.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.h
@@ -146,7 +146,6 @@ public:
   virtual void visit (HIR::TraitItemType &) override {}
   virtual void visit (HIR::Trait &) override {}
   virtual void visit (HIR::InherentImpl &) override {}
-  virtual void visit (HIR::TraitImpl &) override {}
 
   virtual void visit (HIR::ExternalStaticItem &) override {}
   virtual void visit (HIR::ExternalFunctionItem &) override {}

--- a/gcc/rust/typecheck/rust-hir-type-check-base.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.h
@@ -145,7 +145,7 @@ public:
   virtual void visit (HIR::TraitItemConst &) override {}
   virtual void visit (HIR::TraitItemType &) override {}
   virtual void visit (HIR::Trait &) override {}
-  virtual void visit (HIR::InherentImpl &) override {}
+  virtual void visit (HIR::ImplBlock &) override {}
 
   virtual void visit (HIR::ExternalStaticItem &) override {}
   virtual void visit (HIR::ExternalFunctionItem &) override {}

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -229,7 +229,7 @@ public:
       }
 
     auto resolved_candidate = candidates.at (0);
-    HIR::InherentImplItem *resolved_method = resolved_candidate.impl_item;
+    HIR::ImplItem *resolved_method = resolved_candidate.impl_item;
     TyTy::BaseType *lookup_tyty = resolved_candidate.ty;
 
     if (lookup_tyty->get_kind () != TyTy::TypeKind::FNDEF)

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -41,14 +41,6 @@ public:
     item->accept_vis (resolver);
   }
 
-  static void
-  Resolve (HIR::TraitImplItem *item, TyTy::BaseType *self,
-	   std::vector<TyTy::SubstitutionParamMapping> substitutions)
-  {
-    TypeCheckTopLevelImplItem resolver (self, substitutions);
-    item->accept_vis (resolver);
-  }
-
   void visit (HIR::ConstantItem &constant) override
   {
     TyTy::BaseType *type = TypeCheckType::Resolve (constant.get_type ());
@@ -222,12 +214,6 @@ class TypeCheckImplItem : public TypeCheckBase
 
 public:
   static void Resolve (HIR::InherentImplItem *item, TyTy::BaseType *self)
-  {
-    TypeCheckImplItem resolver (self);
-    item->accept_vis (resolver);
-  }
-
-  static void Resolve (HIR::TraitImplItem *item, TyTy::BaseType *self)
   {
     TypeCheckImplItem resolver (self);
     item->accept_vis (resolver);

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -34,7 +34,7 @@ class TypeCheckTopLevelImplItem : public TypeCheckBase
 
 public:
   static void
-  Resolve (HIR::InherentImplItem *item, TyTy::BaseType *self,
+  Resolve (HIR::ImplItem *item, TyTy::BaseType *self,
 	   std::vector<TyTy::SubstitutionParamMapping> substitutions)
   {
     TypeCheckTopLevelImplItem resolver (self, substitutions);
@@ -213,7 +213,7 @@ class TypeCheckImplItem : public TypeCheckBase
   using Rust::Resolver::TypeCheckBase::visit;
 
 public:
-  static void Resolve (HIR::InherentImplItem *item, TyTy::BaseType *self)
+  static void Resolve (HIR::ImplItem *item, TyTy::BaseType *self)
   {
     TypeCheckImplItem resolver (self);
     item->accept_vis (resolver);

--- a/gcc/rust/typecheck/rust-hir-type-check-item.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.h
@@ -55,21 +55,6 @@ public:
       TypeCheckImplItem::Resolve (impl_item.get (), self);
   }
 
-  void visit (HIR::TraitImpl &impl_block) override
-  {
-    TyTy::BaseType *self = nullptr;
-    if (!context->lookup_type (
-	  impl_block.get_type ()->get_mappings ().get_hirid (), &self))
-      {
-	rust_error_at (impl_block.get_locus (),
-		       "failed to resolve Self for TraitImpl");
-	return;
-      }
-
-    for (auto &impl_item : impl_block.get_impl_items ())
-      TypeCheckImplItem::Resolve (impl_item.get (), self);
-  }
-
   void visit (HIR::Function &function) override
   {
     TyTy::BaseType *lookup;

--- a/gcc/rust/typecheck/rust-hir-type-check-item.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.h
@@ -40,14 +40,14 @@ public:
     item->accept_vis (resolver);
   }
 
-  void visit (HIR::InherentImpl &impl_block) override
+  void visit (HIR::ImplBlock &impl_block) override
   {
     TyTy::BaseType *self = nullptr;
     if (!context->lookup_type (
 	  impl_block.get_type ()->get_mappings ().get_hirid (), &self))
       {
 	rust_error_at (impl_block.get_locus (),
-		       "failed to resolve Self for InherentImpl");
+		       "failed to resolve Self for ImplBlock");
 	return;
       }
 

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
@@ -235,7 +235,7 @@ public:
     context->insert_type (function.get_mappings (), fnType);
   }
 
-  void visit (HIR::InherentImpl &impl_block) override
+  void visit (HIR::ImplBlock &impl_block) override
   {
     std::vector<TyTy::SubstitutionParamMapping> substitutions;
     if (impl_block.has_generics ())

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
@@ -273,47 +273,6 @@ public:
 					  substitutions);
   }
 
-  void visit (HIR::TraitImpl &impl_block) override
-  {
-    std::vector<TyTy::SubstitutionParamMapping> substitutions;
-    if (impl_block.has_generics ())
-      {
-	for (auto &generic_param : impl_block.get_generic_params ())
-	  {
-	    switch (generic_param.get ()->get_kind ())
-	      {
-	      case HIR::GenericParam::GenericKind::LIFETIME:
-		// Skipping Lifetime completely until better handling.
-		break;
-
-		case HIR::GenericParam::GenericKind::TYPE: {
-		  auto param_type
-		    = TypeResolveGenericParam::Resolve (generic_param.get ());
-		  context->insert_type (generic_param->get_mappings (),
-					param_type);
-
-		  substitutions.push_back (TyTy::SubstitutionParamMapping (
-		    static_cast<HIR::TypeParam &> (*generic_param),
-		    param_type));
-		}
-		break;
-	      }
-	  }
-      }
-
-    // TODO
-    // resolve the trait and check all items implemented
-
-    auto self
-      = TypeCheckType::Resolve (impl_block.get_type ().get (), &substitutions);
-    if (self == nullptr || self->get_kind () == TyTy::TypeKind::ERROR)
-      return;
-
-    for (auto &impl_item : impl_block.get_impl_items ())
-      TypeCheckTopLevelImplItem::Resolve (impl_item.get (), self,
-					  substitutions);
-  }
-
 private:
   TypeCheckTopLevel () : TypeCheckBase () {}
 };

--- a/gcc/rust/typecheck/rust-tycheck-dump.h
+++ b/gcc/rust/typecheck/rust-tycheck-dump.h
@@ -48,7 +48,7 @@ public:
 	    + "\n";
   }
 
-  void visit (HIR::InherentImpl &impl_block) override
+  void visit (HIR::ImplBlock &impl_block) override
   {
     dump += indent () + "impl "
 	    + type_string (impl_block.get_type ()->get_mappings ()) + " {\n";

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -261,16 +261,15 @@ Mappings::lookup_hir_item (CrateNum crateNum, HirId id)
 
 void
 Mappings::insert_hir_implitem (CrateNum crateNum, HirId id,
-			       HirId parent_impl_id,
-			       HIR::InherentImplItem *item)
+			       HirId parent_impl_id, HIR::ImplItem *item)
 {
   rust_assert (lookup_hir_implitem (crateNum, id, nullptr) == nullptr);
   hirImplItemMappings[crateNum][id]
-    = std::pair<HirId, HIR::InherentImplItem *> (parent_impl_id, item);
+    = std::pair<HirId, HIR::ImplItem *> (parent_impl_id, item);
   nodeIdToHirMappings[crateNum][item->get_impl_mappings ().get_nodeid ()] = id;
 }
 
-HIR::InherentImplItem *
+HIR::ImplItem *
 Mappings::lookup_hir_implitem (CrateNum crateNum, HirId id,
 			       HirId *parent_impl_id)
 {
@@ -282,7 +281,7 @@ Mappings::lookup_hir_implitem (CrateNum crateNum, HirId id,
   if (iy == it->second.end ())
     return nullptr;
 
-  std::pair<HirId, HIR::InherentImplItem *> &ref = iy->second;
+  std::pair<HirId, HIR::ImplItem *> &ref = iy->second;
   if (parent_impl_id != nullptr)
     *parent_impl_id = ref.first;
 
@@ -527,7 +526,7 @@ Mappings::resolve_nodeid_to_stmt (CrateNum crate, NodeId id, HIR::Stmt **stmt)
 
 void
 Mappings::iterate_impl_items (
-  std::function<bool (HirId, HIR::InherentImplItem *, HIR::InherentImpl *)> cb)
+  std::function<bool (HirId, HIR::ImplItem *, HIR::ImplBlock *)> cb)
 {
   for (auto it = hirImplItemMappings.begin (); it != hirImplItemMappings.end ();
        it++)

--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -129,9 +129,9 @@ public:
   HIR::Item *lookup_hir_item (CrateNum crateNum, HirId id);
 
   void insert_hir_implitem (CrateNum crateNum, HirId id, HirId parent_impl_id,
-			    HIR::InherentImplItem *item);
-  HIR::InherentImplItem *lookup_hir_implitem (CrateNum crateNum, HirId id,
-					      HirId *parent_impl_id);
+			    HIR::ImplItem *item);
+  HIR::ImplItem *lookup_hir_implitem (CrateNum crateNum, HirId id,
+				      HirId *parent_impl_id);
 
   void insert_hir_expr (CrateNum crateNum, HirId id, HIR::Expr *expr);
   HIR::Expr *lookup_hir_expr (CrateNum crateNum, HirId id);
@@ -177,14 +177,14 @@ public:
     return hirNodesWithinCrate[crate];
   }
 
-  void insert_impl_item_mapping (HirId impl_item_id, HIR::InherentImpl *impl)
+  void insert_impl_item_mapping (HirId impl_item_id, HIR::ImplBlock *impl)
   {
     rust_assert (hirImplItemsToImplMappings.find (impl_item_id)
 		 == hirImplItemsToImplMappings.end ());
     hirImplItemsToImplMappings[impl_item_id] = impl;
   }
 
-  HIR::InherentImpl *lookup_associated_impl (HirId impl_item_id)
+  HIR::ImplBlock *lookup_associated_impl (HirId impl_item_id)
   {
     auto lookup = hirImplItemsToImplMappings.find (impl_item_id);
     rust_assert (lookup != hirImplItemsToImplMappings.end ());
@@ -192,8 +192,7 @@ public:
   }
 
   void iterate_impl_items (
-    std::function<bool (HirId, HIR::InherentImplItem *, HIR::InherentImpl *)>
-      cb);
+    std::function<bool (HirId, HIR::ImplItem *, HIR::ImplBlock *)> cb);
 
 private:
   Mappings ();
@@ -217,11 +216,10 @@ private:
   std::map<CrateNum, std::map<HirId, HIR::FunctionParam *> > hirParamMappings;
   std::map<CrateNum, std::map<HirId, HIR::StructExprField *> >
     hirStructFieldMappings;
-  std::map<CrateNum,
-	   std::map<HirId, std::pair<HirId, HIR::InherentImplItem *> > >
+  std::map<CrateNum, std::map<HirId, std::pair<HirId, HIR::ImplItem *> > >
     hirImplItemMappings;
   std::map<CrateNum, std::map<HirId, HIR::SelfParam *> > hirSelfParamMappings;
-  std::map<HirId, HIR::InherentImpl *> hirImplItemsToImplMappings;
+  std::map<HirId, HIR::ImplBlock *> hirImplItemsToImplMappings;
 
   // location info
   std::map<CrateNum, std::map<NodeId, Location> > locations;


### PR DESCRIPTION
The HIR implementation has been bootstrapped from the AST, this has lead to a lot of missed desugaring. This PR removes TraitImpls and refactors the InerhentImpls to be an ImplBlock. The class hierarchy has been simplified in tandem here such that all impl items are of the same base class.

More cleanup is required but this is an isolated change that can go in now.