### PR TITLE
Avoid abort macro override the abort of std

### DIFF
--- a/gcc/rust/lex/rust-token.h
+++ b/gcc/rust/lex/rust-token.h
@@ -19,17 +19,17 @@
 #ifndef RUST_TOKEN_H
 #define RUST_TOKEN_H
 
-#include "config.h"
-#include "system.h"
-#include "coretypes.h"
-#include "input.h"
-// order: config, system, coretypes, input
-
 #include <string>
 #include <memory>
 
 #include "rust-linemap.h"
 #include "rust-codepoint.h"
+
+// order: config, system, coretypes, input
+#include "config.h"
+#include "system.h"
+#include "coretypes.h"
+#include "input.h"
 
 namespace Rust {
 // "Primitive core types" in Rust - the different int and float types, as well

--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -16,6 +16,7 @@
 // along with GCC; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
+#include "rust-diagnostics.h"
 #include "config.h"
 #include "system.h"
 #include "coretypes.h"
@@ -31,7 +32,6 @@
 #include "convert.h"
 #include "langhooks.h"
 #include "langhooks-def.h"
-#include "rust-diagnostics.h"
 
 #include <mpfr.h>
 // note: header files must be in this order or else forward declarations don't

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -17,12 +17,12 @@
 // <http://www.gnu.org/licenses/>.
 // #include "rust-session-manager.h"
 
+#include <fstream>
+#include <sstream>
 #include "rust-session-manager.h"
 #include "rust-diagnostics.h"
 #include "diagnostic.h"
 #include "input.h"
-#include <fstream>
-#include <sstream>
 
 #include "target.h"
 #include "tm.h"

--- a/gcc/rust/rust-session-manager.h
+++ b/gcc/rust/rust-session-manager.h
@@ -20,14 +20,13 @@
 #ifndef RUST_SESSION_MANAGER_H
 #define RUST_SESSION_MANAGER_H
 
+#include "rust-linemap.h"
+#include "rust-backend.h"
+
 #include "config.h"
 #include "system.h"
 #include "coretypes.h"
 #include "options.h"
-#include "rust-system.h"
-
-#include "rust-linemap.h"
-#include "rust-backend.h"
 
 namespace Rust {
 // parser forward decl


### PR DESCRIPTION
Fixing the build issue in macos by avoiding abort macro override the abort call of std.

