### PR TITLE
Remove HIR::TraitItemMethod, this can be represented by TraitItemFunction

### DIFF
--- a/gcc/rust/backend/rust-compile-base.h
+++ b/gcc/rust/backend/rust-compile-base.h
@@ -143,7 +143,6 @@ public:
   virtual void visit (HIR::ConstantItem &const_item) {}
   virtual void visit (HIR::StaticItem &static_item) {}
   virtual void visit (HIR::TraitItemFunc &item) {}
-  virtual void visit (HIR::TraitItemMethod &item) {}
   virtual void visit (HIR::TraitItemConst &item) {}
   virtual void visit (HIR::TraitItemType &item) {}
   virtual void visit (HIR::Trait &trait) {}

--- a/gcc/rust/backend/rust-compile-fnparam.h
+++ b/gcc/rust/backend/rust-compile-fnparam.h
@@ -70,7 +70,10 @@ public:
 			     HIR::SelfParam &self, Btype *decl_type,
 			     Location locus)
   {
-    if (!self.get_is_mut ())
+    bool is_immutable
+      = self.get_self_kind () == HIR::SelfParam::ImplicitSelfKind::IMM
+	|| self.get_self_kind () == HIR::SelfParam::ImplicitSelfKind::IMM_REF;
+    if (is_immutable)
       decl_type = ctx->get_backend ()->immutable_type (decl_type);
 
     return ctx->get_backend ()->parameter_variable (fndecl, "self", decl_type,

--- a/gcc/rust/hir/rust-ast-lower-implitem.h
+++ b/gcc/rust/hir/rust-ast-lower-implitem.h
@@ -313,6 +313,7 @@ public:
 
     HIR::TraitFunctionDecl decl (ref.get_identifier (), std::move (qualifiers),
 				 std::move (generic_params),
+				 HIR::SelfParam::error (),
 				 std::move (function_params),
 				 std::move (return_type),
 				 std::move (where_clause));
@@ -374,12 +375,12 @@ public:
 	function_params.push_back (hir_param);
       }
 
-    HIR::TraitMethodDecl decl (ref.get_identifier (), std::move (qualifiers),
-			       std::move (generic_params),
-			       std::move (self_param),
-			       std::move (function_params),
-			       std::move (return_type),
-			       std::move (where_clause));
+    HIR::TraitFunctionDecl decl (ref.get_identifier (), std::move (qualifiers),
+				 std::move (generic_params),
+				 std::move (self_param),
+				 std::move (function_params),
+				 std::move (return_type),
+				 std::move (where_clause));
     HIR::Expr *block_expr
       = method.has_definition ()
 	  ? ASTLoweringExpr::translate (method.get_definition ().get ())
@@ -391,10 +392,9 @@ public:
 				   UNKNOWN_LOCAL_DEFID);
 
     translated
-      = new HIR::TraitItemMethod (mapping, std::move (decl),
-				  std::unique_ptr<HIR::Expr> (block_expr),
-				  method.get_outer_attrs (),
-				  method.get_locus ());
+      = new HIR::TraitItemFunc (mapping, std::move (decl),
+				std::unique_ptr<HIR::Expr> (block_expr),
+				method.get_outer_attrs (), method.get_locus ());
   }
 
   void visit (AST::TraitItemConst &constant) override

--- a/gcc/rust/hir/tree/rust-hir-full-decls.h
+++ b/gcc/rust/hir/tree/rust-hir-full-decls.h
@@ -188,8 +188,6 @@ class ConstantItem;
 class StaticItem;
 struct TraitFunctionDecl;
 class TraitItemFunc;
-struct TraitMethodDecl;
-class TraitItemMethod;
 class TraitItemConst;
 class TraitItemType;
 class Trait;

--- a/gcc/rust/hir/tree/rust-hir-full-test.cc
+++ b/gcc/rust/hir/tree/rust-hir-full-test.cc
@@ -3599,105 +3599,11 @@ TraitFunctionDecl::as_string () const
     }
 
   str += "\n Function params: ";
-  if (has_params ())
+  if (is_method ())
     {
-      for (const auto &param : function_params)
-	{
-	  str += "\n  " + param.as_string ();
-	}
-    }
-  else
-    {
-      str += "none";
+      str += self.as_string ();
     }
 
-  str += "\n Return type: ";
-  if (has_return_type ())
-    {
-      str += return_type->as_string ();
-    }
-  else
-    {
-      str += "none (void)";
-    }
-
-  str += "\n Where clause: ";
-  if (has_where_clause ())
-    {
-      str += where_clause.as_string ();
-    }
-  else
-    {
-      str += "none";
-    }
-
-  return str;
-}
-
-std::string
-TraitItemMethod::as_string () const
-{
-  std::string str = "outer attributes: ";
-  if (outer_attrs.empty ())
-    {
-      str += "none";
-    }
-  else
-    {
-      /* note that this does not print them with "outer attribute" syntax -
-       * just the body */
-      for (const auto &attr : outer_attrs)
-	{
-	  str += "\n  " + attr.as_string ();
-	}
-    }
-
-  str += "\n" + decl.as_string ();
-
-  str += "\n Definition (block expr): ";
-  if (has_definition ())
-    {
-      str += block_expr->as_string ();
-    }
-  else
-    {
-      str += "none";
-    }
-
-  return str;
-}
-
-std::string
-TraitMethodDecl::as_string () const
-{
-  std::string str = qualifiers.as_string () + "fn " + function_name;
-
-  // generic params
-  str += "\n Generic params: ";
-  if (generic_params.empty ())
-    {
-      str += "none";
-    }
-  else
-    {
-      for (const auto &param : generic_params)
-	{
-	  // DEBUG: null pointer check
-	  if (param == nullptr)
-	    {
-	      rust_debug (
-		"something really terrible has gone wrong - null pointer "
-		"generic param in trait function decl.");
-	      return "nullptr_POINTER_MARK";
-	    }
-
-	  str += "\n  " + param->as_string ();
-	}
-    }
-
-  str += "\n Self param: " + self_param.as_string ();
-
-  str += "\n Function params: ";
   if (has_params ())
     {
       for (const auto &param : function_params)
@@ -3820,7 +3726,7 @@ SelfParam::as_string () const
 	  // type (i.e. not ref, no lifetime)
 	  std::string str;
 
-	  if (is_mut)
+	  if (is_mut ())
 	    {
 	      str += "mut ";
 	    }
@@ -3836,7 +3742,7 @@ SelfParam::as_string () const
 	  // ref and lifetime
 	  std::string str = "&" + lifetime.as_string () + " ";
 
-	  if (is_mut)
+	  if (is_mut ())
 	    {
 	      str += "mut ";
 	    }
@@ -3845,12 +3751,12 @@ SelfParam::as_string () const
 
 	  return str;
 	}
-      else if (has_ref)
+      else if (is_ref ())
 	{
 	  // ref with no lifetime
 	  std::string str = "&";
 
-	  if (is_mut)
+	  if (is_mut ())
 	    {
 	      str += " mut ";
 	    }
@@ -3864,7 +3770,7 @@ SelfParam::as_string () const
 	  // no ref, no type
 	  std::string str;
 
-	  if (is_mut)
+	  if (is_mut ())
 	    {
 	      str += "mut ";
 	    }
@@ -4575,12 +4481,6 @@ StaticItem::accept_vis (HIRVisitor &vis)
 
 void
 TraitItemFunc::accept_vis (HIRVisitor &vis)
-{
-  vis.visit (*this);
-}
-
-void
-TraitItemMethod::accept_vis (HIRVisitor &vis)
 {
   vis.visit (*this);
 }

--- a/gcc/rust/hir/tree/rust-hir-visitor.h
+++ b/gcc/rust/hir/tree/rust-hir-visitor.h
@@ -123,7 +123,6 @@ public:
   virtual void visit (ConstantItem &const_item) = 0;
   virtual void visit (StaticItem &static_item) = 0;
   virtual void visit (TraitItemFunc &item) = 0;
-  virtual void visit (TraitItemMethod &item) = 0;
   virtual void visit (TraitItemConst &item) = 0;
   virtual void visit (TraitItemType &item) = 0;
   virtual void visit (Trait &trait) = 0;

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -460,6 +460,12 @@ public:
     return lifetime_type == NAMED && lifetime_name.empty ();
   }
 
+  static Lifetime error ()
+  {
+    return Lifetime (Analysis::NodeMapping::get_error (), LifetimeType::NAMED,
+		     "", Location ());
+  }
+
   std::string as_string () const override;
 
   void accept_vis (HIRVisitor &vis) override;

--- a/gcc/rust/lint/rust-lint-marklive-base.h
+++ b/gcc/rust/lint/rust-lint-marklive-base.h
@@ -139,7 +139,6 @@ public:
   virtual void visit (HIR::ConstantItem &) override {}
   virtual void visit (HIR::StaticItem &) override {}
   virtual void visit (HIR::TraitItemFunc &) override {}
-  virtual void visit (HIR::TraitItemMethod &) override {}
   virtual void visit (HIR::TraitItemConst &) override {}
   virtual void visit (HIR::TraitItemType &) override {}
   virtual void visit (HIR::Trait &) override {}

--- a/gcc/rust/lint/rust-lint-marklive.h
+++ b/gcc/rust/lint/rust-lint-marklive.h
@@ -97,11 +97,6 @@ public:
     item.get_block_expr ()->accept_vis (*this);
   }
 
-  void visit (HIR::TraitItemMethod &item) override
-  {
-    item.get_block_expr ()->accept_vis (*this);
-  }
-
   void visit (HIR::ImplBlock &impl) override
   {
     for (auto &&item : impl.get_impl_items ())

--- a/gcc/rust/typecheck/rust-hir-const-fold-base.h
+++ b/gcc/rust/typecheck/rust-hir-const-fold-base.h
@@ -142,7 +142,6 @@ public:
   virtual void visit (HIR::ConstantItem &) override {}
   virtual void visit (HIR::StaticItem &) override {}
   virtual void visit (HIR::TraitItemFunc &) override {}
-  virtual void visit (HIR::TraitItemMethod &) override {}
   virtual void visit (HIR::TraitItemConst &) override {}
   virtual void visit (HIR::TraitItemType &) override {}
   virtual void visit (HIR::Trait &) override {}

--- a/gcc/rust/typecheck/rust-hir-type-check-base.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.h
@@ -141,7 +141,6 @@ public:
   virtual void visit (HIR::ConstantItem &) override {}
   virtual void visit (HIR::StaticItem &) override {}
   virtual void visit (HIR::TraitItemFunc &) override {}
-  virtual void visit (HIR::TraitItemMethod &) override {}
   virtual void visit (HIR::TraitItemConst &) override {}
   virtual void visit (HIR::TraitItemType &) override {}
   virtual void visit (HIR::Trait &) override {}

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -167,12 +167,13 @@ public:
     // hold all the params to the fndef
     std::vector<std::pair<HIR::Pattern *, TyTy::BaseType *> > params;
 
-    // add the self param at the front
+    // add the synthetic self param at the front, this is a placeholder for
+    // compilation to know parameter names. The types are ignored but we reuse
+    // the HIR identifier pattern which requires it
     HIR::SelfParam &self_param = method.get_self_param ();
     HIR::IdentifierPattern *self_pattern
       = new HIR::IdentifierPattern ("self", self_param.get_locus (),
-				    self_param.get_has_ref (),
-				    self_param.get_is_mut (),
+				    self_param.is_ref (), self_param.is_mut (),
 				    std::unique_ptr<HIR::Pattern> (nullptr));
     context->insert_type (self_param.get_mappings (), self->clone ());
     params.push_back (


### PR DESCRIPTION
Canonicalizing the paths of the compiler to treat functions and methods 
the same way will ensure we avoid duplication.