### PR TITLE
Cleanup warnings

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-pattern.h
+++ b/gcc/rust/hir/tree/rust-hir-pattern.h
@@ -77,7 +77,7 @@ public:
 
   Location locus;
 
-  std::string as_string () const;
+  std::string as_string () const override;
 
   // Returns whether the IdentifierPattern has a pattern to bind.
   bool has_pattern_to_bind () const { return to_bind != nullptr; }

--- a/gcc/rust/rust-diagnostics.cc
+++ b/gcc/rust/rust-diagnostics.cc
@@ -198,7 +198,7 @@ rust_error_at (const RichLocation location, const char *fmt, ...)
 }
 
 void
-rust_debug (const Location location, const char *fmt, ...)
+rust_debug_loc (const Location location, const char *fmt, ...)
 {
   if (!rust_be_debug_p ())
     return;

--- a/gcc/rust/rust-diagnostics.h
+++ b/gcc/rust/rust-diagnostics.h
@@ -127,14 +127,10 @@ struct Error
 } // namespace Rust
 
 // rust_debug uses normal printf formatting, not GCC diagnostic formatting.
-void
-rust_debug (const Location location, const char *fmt, ...) ATTRIBUTE_PRINTF_2;
+#define rust_debug(...) rust_debug_loc (Location (), __VA_ARGS__)
 
-template <typename... Args>
-inline void
-rust_debug (const char *fmt, Args... args)
-{
-  rust_debug (Location (), fmt, args...);
-}
+void
+rust_debug_loc (const Location location, const char *fmt,
+		...) ATTRIBUTE_PRINTF_2;
 
 #endif // !defined(RUST_DIAGNOSTICS_H)


### PR DESCRIPTION
This adds the missing override specifier to as_string on identifier
patterns and ensures rust_debug gains printf specifier checks.