### PR TITLE
Use DW_LANG_Rust in DWARF

### DIFF
--- a/gcc/dwarf2out.c
+++ b/gcc/dwarf2out.c
@@ -24634,6 +24634,13 @@ gen_compile_unit_die (const char *filename)
     }
   else if (strcmp (language_string, "GNU F77") == 0)
     language = DW_LANG_Fortran77;
+  else if (strcmp (language_string, "GNU Rust") == 0)
+    {
+      if (dwarf_version >= 5 || !dwarf_strict)
+	language = DW_LANG_Rust;
+      else
+	language = DW_LANG_Rust_old;
+    }
   else if (dwarf_version >= 3 || !dwarf_strict)
     {
       if (strcmp (language_string, "GNU Ada") == 0)

--- a/gcc/testsuite/rust/debug/debug.exp
+++ b/gcc/testsuite/rust/debug/debug.exp
@@ -1,0 +1,33 @@
+# Copyright (C) 2021 Free Software Foundation, Inc.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with GCC; see the file COPYING3.  If not see
+# <http://www.gnu.org/licenses/>.
+
+# Debugging tests.
+
+# Load support procs.
+load_lib rust-dg.exp
+
+# Initialize `dg'.
+dg-init
+
+# Main loop.
+set saved-dg-do-what-default ${dg-do-what-default}
+
+set dg-do-what-default "compile"
+dg-runtest [lsort [glob -nocomplain $srcdir/$subdir/*.rs]] "" ""
+set dg-do-what-default ${saved-dg-do-what-default}
+
+# All done.
+dg-finish

--- a/gcc/testsuite/rust/debug/lang.rs
+++ b/gcc/testsuite/rust/debug/lang.rs
@@ -1,0 +1,6 @@
+fn main () {
+// { dg-do compile }
+// { dg-options "-gdwarf-5 -dA" }
+// DW_LANG_Rust is 0x1c
+// { dg-final { scan-assembler "0x1c\[^\n\r]* DW_AT_language" } } */
+}

--- a/gcc/testsuite/rust/debug/oldlang.rs
+++ b/gcc/testsuite/rust/debug/oldlang.rs
@@ -1,0 +1,6 @@
+fn main () {
+// { dg-do compile }
+// { dg-options "-gstrict-dwarf -gdwarf-3 -dA" }
+// DW_LANG_Rust_old is 0x9000
+// { dg-final { scan-assembler "0x9000\[^\n\r]* DW_AT_language" } } */
+}


### PR DESCRIPTION
This changes the GCC DWARF emitterto use DW_LANG_Rust or
DW_LANG_Rust_old as appropriate.
