### PR TITLE
DWARF for Rust primitive types

### DIFF
--- a/gcc/dwarf2out.c
+++ b/gcc/dwarf2out.c
@@ -5498,6 +5498,16 @@ is_fortran (const_tree decl)
   return is_fortran ();
 }
 
+/* Return TRUE if the language is Rust.  */
+
+static inline bool
+is_rust ()
+{
+  unsigned int lang = get_AT_unsigned (comp_unit_die (), DW_AT_language);
+
+  return lang == DW_LANG_Rust || lang == DW_LANG_Rust_old;
+}
+
 /* Return TRUE if the language is Ada.  */
 
 static inline bool
@@ -12952,7 +12962,11 @@ base_type_die (tree type, bool reverse)
 	}
       if (TYPE_STRING_FLAG (type))
 	{
-	  if (TYPE_UNSIGNED (type))
+	  if ((dwarf_version >= 4 || !dwarf_strict)
+	      && is_rust ()
+	      && int_size_in_bytes (type) == 4)
+	    encoding = DW_ATE_UTF;
+	  else if (TYPE_UNSIGNED (type))
 	    encoding = DW_ATE_unsigned_char;
 	  else
 	    encoding = DW_ATE_signed_char;

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -1,5 +1,5 @@
 // rust-gcc.cc -- Rust frontend to gcc IR.
-// Copyright (C) 2011-2020 Free Software Foundation, Inc.
+// Copyright (C) 2011-2021 Free Software Foundation, Inc.
 // Contributed by Ian Lance Taylor, Google.
 // forked from gccgo
 
@@ -867,8 +867,6 @@ Gcc_backend::integer_type (bool is_unsigned, int bits)
     {
       if (bits == INT_TYPE_SIZE)
 	type = unsigned_type_node;
-      else if (bits == CHAR_TYPE_SIZE)
-	type = unsigned_char_type_node;
       else if (bits == SHORT_TYPE_SIZE)
 	type = short_unsigned_type_node;
       else if (bits == LONG_TYPE_SIZE)
@@ -882,8 +880,6 @@ Gcc_backend::integer_type (bool is_unsigned, int bits)
     {
       if (bits == INT_TYPE_SIZE)
 	type = integer_type_node;
-      else if (bits == CHAR_TYPE_SIZE)
-	type = signed_char_type_node;
       else if (bits == SHORT_TYPE_SIZE)
 	type = short_integer_type_node;
       else if (bits == LONG_TYPE_SIZE)

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -217,10 +217,8 @@ public:
 
   Btype *wchar_type ()
   {
-    // i think this is meant to be 32 bit from
-    // https://www.unicode.org/versions/Unicode13.0.0/ch03.pdf#G7404
-    int precision = 32;
-    tree wchar = make_unsigned_type (precision);
+    tree wchar = make_unsigned_type (32);
+    TYPE_STRING_FLAG (wchar) = 1;
     return this->make_type (wchar);
   }
 

--- a/gcc/testsuite/rust/debug/chartype.rs
+++ b/gcc/testsuite/rust/debug/chartype.rs
@@ -1,0 +1,10 @@
+// 'char' should use DW_ATE_UTF
+fn main () {
+    let c = 'x';
+// { dg-do compile }
+// Use -w to avoid warnings about the unused variables
+// DW_ATE_UTF entered in DWARF 4.
+// { dg-options "-w -gdwarf-4 -dA" }
+// DW_ATE_UTF = 0x10
+// { dg-final { scan-assembler "0x10\[^\n\r]* DW_AT_encoding" } } */
+}

--- a/gcc/testsuite/rust/debug/i8u8.rs
+++ b/gcc/testsuite/rust/debug/i8u8.rs
@@ -1,0 +1,12 @@
+// i8 and u8 types should not have the DWARF 'char' encoding.
+fn main () {
+    let x : i8 = 5;
+    let y : u8 = 7;
+// { dg-do compile }
+// Use -w to avoid warnings about the unused variables
+// { dg-options "-w -g -dA" }
+// DW_ATE_signed_char = 6
+// { dg-final { scan-assembler-not "0x6\[^\n\r]* DW_AT_language" } } */
+// DW_ATE_unsigned_char = 8
+// { dg-final { scan-assembler-not "0x8\[^\n\r]* DW_AT_language" } } */
+}


### PR DESCRIPTION
I found a couple of small bugs in the DWARF that is emitted for primitive types.
These two patches fix these.