### PR TITLE
Fix: do not use object after it has been moved

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-type.h
+++ b/gcc/rust/hir/rust-ast-lower-type.h
@@ -72,15 +72,15 @@ public:
     });
 
     auto crate_num = mappings->get_current_crate ();
-    Analysis::NodeMapping mapping (crate_num, path.get_node_id (),
-				   mappings->get_next_hir_id (crate_num),
+    auto hirid = mappings->get_next_hir_id (crate_num);
+    Analysis::NodeMapping mapping (crate_num, path.get_node_id (), hirid,
 				   mappings->get_next_localdef_id (crate_num));
+
     translated
       = new HIR::TypePath (std::move (mapping), std::move (translated_segments),
 			   path.get_locus (),
 			   path.has_opening_scope_resolution_op ());
-    mappings->insert_hir_type (mapping.get_crate_num (), mapping.get_hirid (),
-			       translated);
+    mappings->insert_hir_type (crate_num, hirid, translated);
   }
 
 private:


### PR DESCRIPTION
After std::move(mapping), mapping is unspecified

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[ ] GCC code require copyright assignment: https://gcc.gnu.org/contribute.html
- \[ ] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[ ] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---
-->
