### PR TITLE
Add more info in HIR dump for struct

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-full-test.cc
+++ b/gcc/rust/hir/tree/rust-hir-full-test.cc
@@ -577,11 +577,12 @@ StructStruct::as_string () const
     {
       for (const auto &field : fields)
 	{
-	  str += "\n  " + field.as_string ();
+	  str += "\n  - " + field.as_string ();
 	}
+      str += "\n";
     }
 
-  return str;
+  return str + "::" + get_mappings ().as_string () + "\n";
 }
 
 std::string


### PR DESCRIPTION
Make struct fields more visible in dumps and add the mapping in the dump string.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[ ] GCC code require copyright assignment: https://gcc.gnu.org/contribute.html
- \[ ] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[ ] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---
-->
