### PR TITLE
Make 3 error messages slightly more informational

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -183,8 +183,10 @@ public:
 	  if (!ctx->get_tyctx ()->lookup_type (
 		expr.get_mappings ().get_hirid (), &tyty))
 	    {
-	      rust_fatal_error (expr.get_locus (),
-				"did not resolve type for this literal expr");
+	      rust_fatal_error (
+		expr.get_locus (),
+		"did not resolve type for this literal expr (HirId %d)",
+		expr.get_mappings ().get_hirid ());
 	      return;
 	    }
 

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -118,18 +118,20 @@ public:
   {
     // lookup the Node this resolves to
     NodeId ref;
-    if (!resolver->lookup_resolved_type (path.get_mappings ().get_nodeid (),
-					 &ref))
+    auto nid = path.get_mappings ().get_nodeid ();
+    if (!resolver->lookup_resolved_type (nid, &ref))
       {
 	rust_fatal_error (path.get_locus (),
-			  "Failed to resolve node id to HIR");
+			  "failed to resolve node '%d' to HIR", nid);
 	return;
       }
 
     HirId hir_lookup;
     if (!context->lookup_type_by_node_id (ref, &hir_lookup))
       {
-	rust_error_at (path.get_locus (), "failed to lookup HIR node");
+	rust_error_at (path.get_locus (),
+		       "failed to lookup HIR %d for node '%s'", ref,
+		       path.as_string ().c_str ());
 	return;
       }
 


### PR DESCRIPTION
Add more context to some internal error messages (ie. not intended for user)

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[ ] GCC code require copyright assignment: https://gcc.gnu.org/contribute.html
- \[ ] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[ ] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---
-->
