### PR TITLE
Fix various Wformat-diag diagnostics

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -203,7 +203,7 @@ public:
 	      != 0)
 	    {
 	      rust_fatal_error (expr.get_locus (),
-				"bad float number in literal");
+				"bad floating-point number in literal");
 	      return;
 	    }
 

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -117,7 +117,7 @@ ResolvePathRef::visit (HIR::PathInExpression &expr)
 	  else
 	    {
 	      rust_error_at (expr.get_locus (),
-			     "failed to lookup definition decl");
+			     "failed to lookup definition declaration");
 	      return;
 	    }
 	}
@@ -125,7 +125,7 @@ ResolvePathRef::visit (HIR::PathInExpression &expr)
       if (!ctx->lookup_function_decl (lookup->get_ty_ref (), &fn))
 	{
 	  rust_fatal_error (expr.get_locus (),
-			    "forward decl was not compiled 1");
+			    "forward declaration was not compiled");
 	  return;
 	}
     }

--- a/gcc/rust/backend/rust-compile-stmt.h
+++ b/gcc/rust/backend/rust-compile-stmt.h
@@ -64,7 +64,8 @@ public:
     if (!ctx->get_tyctx ()->lookup_type (stmt.get_mappings ().get_hirid (),
 					 &ty))
       {
-	rust_fatal_error (stmt.get_locus (), "failed to lookup var decl type");
+	rust_fatal_error (stmt.get_locus (),
+			  "failed to lookup variable declaration type");
 	return;
       }
 
@@ -72,7 +73,7 @@ public:
     if (!ctx->lookup_var_decl (stmt.get_mappings ().get_hirid (), &var))
       {
 	rust_fatal_error (stmt.get_locus (),
-			  "failed to lookup compiled variable decl");
+			  "failed to lookup compiled variable declaration");
 	return;
       }
 

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -141,7 +141,8 @@ CompileExpr::visit (HIR::MethodCallExpr &expr)
 	expr.get_mappings ().get_crate_num (), ref, nullptr);
       if (resolved_item == nullptr)
 	{
-	  rust_error_at (expr.get_locus (), "failed to lookup forward decl");
+	  rust_error_at (expr.get_locus (),
+			 "failed to lookup forward declaration");
 	  return;
 	}
 
@@ -162,7 +163,8 @@ CompileExpr::visit (HIR::MethodCallExpr &expr)
 
       if (!ctx->lookup_function_decl (fntype->get_ty_ref (), &fn))
 	{
-	  rust_error_at (expr.get_locus (), "forward decl was not compiled");
+	  rust_error_at (expr.get_locus (),
+			 "forward declaration was not compiled");
 	  return;
 	}
     }

--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -1323,7 +1323,7 @@ Lexer::parse_byte_char (Location loc)
       if (byte_char > 127)
 	{
 	  rust_error_at (get_current_location (),
-			 "byte char %<%c%> out of range", byte_char);
+			 "%<byte char%> %<%c%> out of range", byte_char);
 	  byte_char = 0;
 	}
 
@@ -1331,7 +1331,7 @@ Lexer::parse_byte_char (Location loc)
 
       if (current_char != '\'')
 	{
-	  rust_error_at (get_current_location (), "unclosed byte char");
+	  rust_error_at (get_current_location (), "unclosed %<byte char%>");
 	}
 
       skip_input ();
@@ -1349,7 +1349,7 @@ Lexer::parse_byte_char (Location loc)
 
       if (current_char != '\'')
 	{
-	  rust_error_at (get_current_location (), "unclosed byte char");
+	  rust_error_at (get_current_location (), "unclosed %<byte char%>");
 	}
 
       skip_input ();
@@ -1359,7 +1359,7 @@ Lexer::parse_byte_char (Location loc)
   else
     {
       rust_error_at (get_current_location (),
-		     "no character inside %<%> for byte char");
+		     "no character inside %<%> for %<byte char%>");
     }
 
   current_column += length;
@@ -1398,7 +1398,7 @@ Lexer::parse_byte_string (Location loc)
 	  if (output_char > 127)
 	    {
 	      rust_error_at (get_current_location (),
-			     "char %<%c%> in byte string out of range",
+			     "character %<%c%> in byte string out of range",
 			     output_char);
 	      output_char = 0;
 	    }
@@ -1880,7 +1880,7 @@ Lexer::parse_decimal_int_or_float (Location loc)
 	  && type_hint != CORETYPE_UNKNOWN)
 	{
 	  rust_error_at (get_current_location (),
-			 "invalid type suffix %qs for float literal",
+			 "invalid type suffix %qs for floating-point literal",
 			 get_type_hint_string (type_hint));
 	  // ignore invalid type suffix as everything else seems fine
 	  type_hint = CORETYPE_UNKNOWN;
@@ -1929,7 +1929,7 @@ Lexer::parse_decimal_int_or_float (Location loc)
 	  && type_hint != CORETYPE_UNKNOWN)
 	{
 	  rust_error_at (get_current_location (),
-			 "invalid type suffix %qs for float literal",
+			 "invalid type suffix %qs for floating-point literal",
 			 get_type_hint_string (type_hint));
 	  // ignore invalid type suffix as everything else seems fine
 	  type_hint = CORETYPE_UNKNOWN;
@@ -1975,7 +1975,7 @@ Lexer::parse_char_or_lifetime (Location loc)
 
       if (peek_codepoint_input ().value != '\'')
 	{
-	  rust_error_at (get_current_location (), "unended char literal");
+	  rust_error_at (get_current_location (), "unended character literal");
 	}
       else
 	{
@@ -2032,7 +2032,7 @@ Lexer::parse_char_or_lifetime (Location loc)
 	{
 	  rust_error_at (
 	    get_current_location (),
-	    "expected %' after character constant in char literal");
+	    "expected %' after character constant in character literal");
 	  return nullptr;
 	}
     }

--- a/gcc/rust/lex/rust-token.cc
+++ b/gcc/rust/lex/rust-token.cc
@@ -123,8 +123,8 @@ Token::get_str () const
   if (str == NULL)
     {
       rust_error_at (get_locus (),
-		     "attempted to get string for '%s', which has no string. "
-		     "returning empty string instead.",
+		     "attempted to get string for %<%s%>, which has no string. "
+		     "returning empty string instead",
 		     get_token_description ());
       return empty;
     }

--- a/gcc/rust/lint/rust-lint-scan-deadcode.h
+++ b/gcc/rust/lint/rust-lint-scan-deadcode.h
@@ -49,7 +49,7 @@ public:
     if (live_symbols.find (hirId) == live_symbols.end ())
       {
 	rust_warning_at (function.get_locus (), 0,
-			 "function is never used: `%s`",
+			 "function is never used: %<%s%>",
 			 function.get_function_name ().c_str ());
 	return;
       }

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -472,9 +472,9 @@ Parser<ManagedTokenSource>::parse_inner_attribute ()
 {
   if (lexer.peek_token ()->get_id () != HASH)
     {
-      Error error (
-	lexer.peek_token ()->get_locus (),
-	"BUG: token %<#%> is missing, but parse_inner_attribute was invoked.");
+      Error error (lexer.peek_token ()->get_locus (),
+		   "BUG: token %<#%> is missing, but %<parse_inner_attribute%> "
+		   "was invoked");
       add_error (std::move (error));
 
       return AST::Attribute::create_empty ();
@@ -12000,7 +12000,7 @@ Parser<ManagedTokenSource>::parse_struct_expr_field ()
       add_error (
 	Error (t->get_locus (),
 	       "unrecognised token %qs as first token of struct expr field - "
-	       "expected identifier or int literal",
+	       "expected identifier or integer literal",
 	       t->get_token_description ()));
 
       return nullptr;
@@ -14402,7 +14402,7 @@ Parser<ManagedTokenSource>::parse_struct_expr_struct_partial (
       add_error (
 	Error (t->get_locus (),
 	       "unrecognised token %qs in struct (or enum) expression - "
-	       "expected %<}%>, identifier, int literal, or %<..%>",
+	       "expected %<}%>, identifier, integer literal, or %<..%>",
 	       t->get_token_description ()));
 
       return nullptr;

--- a/gcc/rust/resolve/rust-ast-resolve-type.h
+++ b/gcc/rust/resolve/rust-ast-resolve-type.h
@@ -150,7 +150,7 @@ public:
 	if (!ok)
 	  {
 	    rust_error_at (seg.get_locus (),
-			   "failed to resolve all generic args");
+			   "failed to resolve all generic arguments");
 	    return CanonicalPath::create_empty ();
 	  }
 

--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -512,7 +512,7 @@ ResolvePath::resolve_path (AST::PathInExpression *expr)
       if (!ok)
 	{
 	  rust_error_at (root_segment.get_locus (),
-			 "failed to resolve generic args");
+			 "failed to resolve generic arguments");
 	  return;
 	}
     }

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -654,7 +654,8 @@ public:
 		      == TyTy::InferType::INTEGRAL));
 	  if (!valid)
 	    {
-	      rust_error_at (expr.get_locus (), "cannot apply unary ! to %s",
+	      rust_error_at (expr.get_locus (),
+			     "cannot apply unary %<!%> to %s",
 			     negated_expr_ty->as_string ().c_str ());
 	      return;
 	    }
@@ -983,7 +984,8 @@ public:
     if (!block_expr->is_unit ())
       {
 	rust_error_at (expr.get_loop_block ()->get_locus_slow (),
-		       "expected () got %s", block_expr->as_string ().c_str ());
+		       "expected %<()%> got %s",
+		       block_expr->as_string ().c_str ());
 	return;
       }
 
@@ -1011,7 +1013,8 @@ public:
     if (!block_expr->is_unit ())
       {
 	rust_error_at (expr.get_loop_block ()->get_locus_slow (),
-		       "expected () got %s", block_expr->as_string ().c_str ());
+		       "expected %<()%> got %s",
+		       block_expr->as_string ().c_str ());
 	return;
       }
 
@@ -1023,7 +1026,7 @@ public:
   {
     if (!inside_loop)
       {
-	rust_error_at (expr.get_locus (), "cannot `break` outside of a loop");
+	rust_error_at (expr.get_locus (), "cannot %<break%> outside of a loop");
 	return;
       }
 
@@ -1036,7 +1039,7 @@ public:
 	if (loop_context->get_kind () == TyTy::TypeKind::ERROR)
 	  {
 	    rust_error_at (expr.get_locus (),
-			   "can only break with a value inside `loop`");
+			   "can only break with a value inside %<loop%>");
 	    return;
 	  }
 
@@ -1052,7 +1055,7 @@ public:
     if (!inside_loop)
       {
 	rust_error_at (expr.get_locus (),
-		       "cannot `continue` outside of a loop");
+		       "cannot %<continue%> outside of a loop");
 	return;
       }
 

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -170,7 +170,7 @@ public:
     else if (!args.is_empty ())
       {
 	rust_error_at (path.get_locus (),
-		       "TypePath %s declares generic argument's but "
+		       "TypePath %s declares generic arguments but "
 		       "the type %s does not have any",
 		       path.as_string ().c_str (),
 		       translated->as_string ().c_str ());

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -1504,7 +1504,7 @@ TypeCheckCallExpr::visit (ADTType &type)
     {
       rust_error_at (
 	call.get_locus (),
-	"expected function, tuple struct or tuple variant, found struct `%s`",
+	"expected function, tuple struct or tuple variant, found struct %<%s%>",
 	type.get_name ().c_str ());
       return;
     }

--- a/gcc/testsuite/rust/compile/break1.rs
+++ b/gcc/testsuite/rust/compile/break1.rs
@@ -1,6 +1,6 @@
 fn main() {
     let a;
     a = 1;
-    break a; // { dg-error "cannot `break` outside of a loop" }
+    break a; // { dg-error "cannot 'break' outside of a loop" }
     // { dg-error "failed to type resolve expression" "" { target *-*-* } .-1 }
 }

--- a/gcc/testsuite/rust/compile/break2.rs
+++ b/gcc/testsuite/rust/compile/break2.rs
@@ -5,7 +5,7 @@ fn main() {
     let mut c;
     while b > 10 {
         if (b == 2) {
-            break b;  // { dg-error "can only break with a value inside `loop`" }
+            break b;  // { dg-error "can only break with a value inside 'loop'" }
             // { dg-error "failed to type resolve expression" "" { target *-*-* } .-1 }
         }
         c = a + b;

--- a/gcc/testsuite/rust/compile/continue1.rs
+++ b/gcc/testsuite/rust/compile/continue1.rs
@@ -3,7 +3,7 @@ fn main() {
     let mut b = 1;
 
     let _fib = {
-        continue; // { dg-error "cannot `continue` outside of a loop" }
+        continue; // { dg-error "cannot 'continue' outside of a loop" }
         // { dg-error "failed to type resolve expression" "" { target *-*-* } .-1 }
         123
     };

--- a/gcc/testsuite/rust/compile/torture/unused.rs
+++ b/gcc/testsuite/rust/compile/torture/unused.rs
@@ -1,9 +1,9 @@
-// { dg-warning "function is never used: `bar`" "" { target *-*-* } .+1 }
+// { dg-warning "function is never used: 'bar'" "" { target *-*-* } .+1 }
 fn bar() {
     foo();
 }
 
-// { dg-warning "function is never used: `foo`" "" { target *-*-* } .+1 }
+// { dg-warning "function is never used: 'foo'" "" { target *-*-* } .+1 }
 fn foo() {
     bar();
 }

--- a/gcc/testsuite/rust/compile/torture/unused1.rs
+++ b/gcc/testsuite/rust/compile/torture/unused1.rs
@@ -3,7 +3,7 @@ fn test() -> i32 {
 }
 
 fn unused() -> i32 {
-    // { dg-warning "function is never used: `unused`" "" { target *-*-* } .-1 }
+    // { dg-warning "function is never used: 'unused'" "" { target *-*-* } .-1 }
     // { dg-warning "unused name" "" { target *-*-* } .-2 }
     2
 }

--- a/gcc/testsuite/rust/compile/tuple_struct1.rs
+++ b/gcc/testsuite/rust/compile/tuple_struct1.rs
@@ -4,7 +4,7 @@ struct Foo {
 }
 
 fn main() {
-    let a = Foo(1, 2); // { dg-error "expected function, tuple struct or tuple variant, found struct `Foo`" }
+    let a = Foo(1, 2); // { dg-error "expected function, tuple struct or tuple variant, found struct 'Foo'" }
     // { dg-error "failed to lookup type to CallExpr" "" { target *-*-* } .-1 }
     // { dg-error "failed to type resolve expression" "" { target *-*-* } .-2 }
 }

--- a/gcc/testsuite/rust/compile/unary_not.rs
+++ b/gcc/testsuite/rust/compile/unary_not.rs
@@ -4,6 +4,6 @@ fn main() {
     let c: bool = !false;
     let d: i32 = !3;
 
-    let e: f32 = !5f32; // { dg-error "cannot apply unary ! to f32" }
+    let e: f32 = !5f32; // { dg-error "cannot apply unary '!' to f32" }
     // { dg-error {failed to type resolve expression} "" { target *-*-* } .-1 }
 }


### PR DESCRIPTION
Fix warnings mainly coming from ` being used instead of %< and %>.

Also fixing occurences of :

```
../../gcc/rust/lex/rust-token.cc:126:40: warning: unquoted sequence of 2 consecutive punctuation characters ‘',’ in format [-Wformat-diag]
  126 |        "attempted to get string for '%s', which has no string. "
      |                                        ^~
../../gcc/rust/lex/rust-token.cc:127:39: warning: spurious trailing punctuation sequence ‘.’ in format [-Wformat-diag]
  127 |        "returning empty string instead.",
      |                                       ^
../../gcc/rust/lex/rust-token.cc:126:37: warning: unterminated quote character ‘'’ in format [-Wformat-diag]
  126 |        "attempted to get string for '%s', which has no string. "
      |                                     ^
```
and various occurences of :
```
../../gcc/rust/lex/rust-lex.cc:1326:11: warning: unquoted keyword ‘char’ in format [-Wformat-diag]
 1326 |     "byte char %<%c%> out of range", byte_char);
      |           ^~~~
```
Also using full word for arguments, integer, character, declaration, variable,
floting-point instead of args, int, char, decl, var, float when applicable.