### PR TITLE
Fix up test suite buglets

### DIFF
--- a/gcc/testsuite/rust/debug/chartype.rs
+++ b/gcc/testsuite/rust/debug/chartype.rs
@@ -6,5 +6,5 @@ fn main () {
 // DW_ATE_UTF entered in DWARF 4.
 // { dg-options "-w -gdwarf-4 -dA" }
 // DW_ATE_UTF = 0x10
-// { dg-final { scan-assembler "0x10\[^\n\r]* DW_AT_encoding" } } */
+// { dg-final { scan-assembler "0x10\[ \t]\[^\n\r]* DW_AT_encoding" } } */
 }

--- a/gcc/testsuite/rust/debug/i8u8.rs
+++ b/gcc/testsuite/rust/debug/i8u8.rs
@@ -6,7 +6,7 @@ fn main () {
 // Use -w to avoid warnings about the unused variables
 // { dg-options "-w -g -dA" }
 // DW_ATE_signed_char = 6
-// { dg-final { scan-assembler-not "0x6\[^\n\r]* DW_AT_language" } } */
+// { dg-final { scan-assembler-not "0x6\[ \t]\[^\n\r]* DW_AT_encoding" } } */
 // DW_ATE_unsigned_char = 8
-// { dg-final { scan-assembler-not "0x8\[^\n\r]* DW_AT_language" } } */
+// { dg-final { scan-assembler-not "0x8\[ \t]\[^\n\r]* DW_AT_encoding" } } */
 }

--- a/gcc/testsuite/rust/debug/lang.rs
+++ b/gcc/testsuite/rust/debug/lang.rs
@@ -2,5 +2,5 @@ fn main () {
 // { dg-do compile }
 // { dg-options "-gdwarf-5 -dA" }
 // DW_LANG_Rust is 0x1c
-// { dg-final { scan-assembler "0x1c\[^\n\r]* DW_AT_language" } } */
+// { dg-final { scan-assembler "0x1c\[ \t]\[^\n\r]* DW_AT_language" } } */
 }

--- a/gcc/testsuite/rust/debug/oldlang.rs
+++ b/gcc/testsuite/rust/debug/oldlang.rs
@@ -2,5 +2,5 @@ fn main () {
 // { dg-do compile }
 // { dg-options "-gstrict-dwarf -gdwarf-3 -dA" }
 // DW_LANG_Rust_old is 0x9000
-// { dg-final { scan-assembler "0x9000\[^\n\r]* DW_AT_language" } } */
+// { dg-final { scan-assembler "0x9000\[ \t]\[^\n\r]* DW_AT_language" } } */
 }


### PR DESCRIPTION
Mark Wielaard pointed out that the i8u8.rs test that I recently
introduced has a bug: it checks the DW_AT_language attribute, not
DW_AT_encoding.

Sorry about this.

This patch fixes this problem.  I've verified that this notices the
failure after temporarily backing out the corresponding GCC change.

This patch also fixes another problem that he found, namely that it's
possible for these tests to find the wrong answer, because the hex
value that is checked for might be a prefix of some longer value.
This patch also adds a whitespace check to avoid this potential
problem.
