### PR TITLE
Add support for struct definitions to be within a block

### DIFF
--- a/gcc/rust/backend/rust-compile-stmt.h
+++ b/gcc/rust/backend/rust-compile-stmt.h
@@ -35,27 +35,21 @@ public:
   {
     CompileStmt compiler (ctx);
     stmt->accept_vis (compiler);
-    rust_assert (compiler.ok);
     return compiler.translated;
   }
 
   void visit (HIR::ExprStmtWithBlock &stmt) override
   {
-    ok = true;
     translated = CompileExpr::Compile (stmt.get_expr (), ctx);
   }
 
   void visit (HIR::ExprStmtWithoutBlock &stmt) override
   {
-    ok = true;
     translated = CompileExpr::Compile (stmt.get_expr (), ctx);
   }
 
   void visit (HIR::LetStmt &stmt) override
   {
-    // marks that the statement has been looked at
-    ok = true;
-
     // nothing to do
     if (!stmt.has_init_expr ())
       return;
@@ -96,11 +90,8 @@ public:
   }
 
 private:
-  CompileStmt (Context *ctx)
-    : HIRCompileBase (ctx), ok (false), translated (nullptr)
-  {}
+  CompileStmt (Context *ctx) : HIRCompileBase (ctx), translated (nullptr) {}
 
-  bool ok;
   Bexpression *translated;
 };
 

--- a/gcc/rust/resolve/rust-ast-resolve-stmt.h
+++ b/gcc/rust/resolve/rust-ast-resolve-stmt.h
@@ -39,8 +39,6 @@ public:
     stmt->accept_vis (resolver);
   };
 
-  ~ResolveStmt () {}
-
   void visit (AST::ExprStmtWithBlock &stmt) override
   {
     ResolveExpr::go (stmt.get_expr ().get (), stmt.get_node_id ());
@@ -65,6 +63,70 @@ public:
     PatternDeclaration::go (stmt.get_pattern ().get (), stmt.get_node_id ());
     if (stmt.has_type ())
       ResolveType::go (stmt.get_type ().get (), stmt.get_node_id ());
+  }
+
+  void visit (AST::TupleStruct &struct_decl) override
+  {
+    auto path = CanonicalPath (struct_decl.get_identifier ());
+    resolver->get_type_scope ().insert (
+      path, struct_decl.get_node_id (), struct_decl.get_locus (), false,
+      [&] (const CanonicalPath &, NodeId, Location locus) -> void {
+	RichLocation r (struct_decl.get_locus ());
+	r.add_range (locus);
+	rust_error_at (r, "redefined multiple times");
+      });
+
+    NodeId scope_node_id = struct_decl.get_node_id ();
+    resolver->get_type_scope ().push (scope_node_id);
+
+    if (struct_decl.has_generics ())
+      {
+	for (auto &generic : struct_decl.get_generic_params ())
+	  {
+	    ResolveGenericParam::go (generic.get (),
+				     struct_decl.get_node_id ());
+	  }
+      }
+
+    struct_decl.iterate ([&] (AST::TupleField &field) mutable -> bool {
+      ResolveType::go (field.get_field_type ().get (),
+		       struct_decl.get_node_id ());
+      return true;
+    });
+
+    resolver->get_type_scope ().pop ();
+  }
+
+  void visit (AST::StructStruct &struct_decl) override
+  {
+    auto path = CanonicalPath (struct_decl.get_identifier ());
+    resolver->get_type_scope ().insert (
+      path, struct_decl.get_node_id (), struct_decl.get_locus (), false,
+      [&] (const CanonicalPath &, NodeId, Location locus) -> void {
+	RichLocation r (struct_decl.get_locus ());
+	r.add_range (locus);
+	rust_error_at (r, "redefined multiple times");
+      });
+
+    NodeId scope_node_id = struct_decl.get_node_id ();
+    resolver->get_type_scope ().push (scope_node_id);
+
+    if (struct_decl.has_generics ())
+      {
+	for (auto &generic : struct_decl.get_generic_params ())
+	  {
+	    ResolveGenericParam::go (generic.get (),
+				     struct_decl.get_node_id ());
+	  }
+      }
+
+    struct_decl.iterate ([&] (AST::StructField &field) mutable -> bool {
+      ResolveType::go (field.get_field_type ().get (),
+		       struct_decl.get_node_id ());
+      return true;
+    });
+
+    resolver->get_type_scope ().pop ();
   }
 
 private:

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.h
@@ -49,6 +49,12 @@ public:
     infered = TypeCheckExpr::Resolve (stmt.get_expr (), inside_loop);
   }
 
+  void visit (HIR::EmptyStmt &stmt) override
+  {
+    infered
+      = TyTy::TupleType::get_unit_type (stmt.get_mappings ().get_hirid ());
+  }
+
   void visit (HIR::LetStmt &stmt) override
   {
     infered = new TyTy::TupleType (stmt.get_mappings ().get_hirid ());
@@ -105,6 +111,109 @@ public:
     TyTy::BaseType *lookup = nullptr;
     bool ok = context->lookup_type (stmt.get_mappings ().get_hirid (), &lookup);
     rust_assert (ok);
+  }
+
+  void visit (HIR::TupleStruct &struct_decl) override
+  {
+    std::vector<TyTy::SubstitutionParamMapping> substitutions;
+    if (struct_decl.has_generics ())
+      {
+	for (auto &generic_param : struct_decl.get_generic_params ())
+	  {
+	    switch (generic_param.get ()->get_kind ())
+	      {
+	      case HIR::GenericParam::GenericKind::LIFETIME:
+		// Skipping Lifetime completely until better handling.
+		break;
+
+		case HIR::GenericParam::GenericKind::TYPE: {
+		  auto param_type
+		    = TypeResolveGenericParam::Resolve (generic_param.get ());
+		  context->insert_type (generic_param->get_mappings (),
+					param_type);
+
+		  substitutions.push_back (TyTy::SubstitutionParamMapping (
+		    static_cast<HIR::TypeParam &> (*generic_param),
+		    param_type));
+		}
+		break;
+	      }
+	  }
+      }
+
+    std::vector<TyTy::StructFieldType *> fields;
+
+    size_t idx = 0;
+    struct_decl.iterate ([&] (HIR::TupleField &field) mutable -> bool {
+      TyTy::BaseType *field_type
+	= TypeCheckType::Resolve (field.get_field_type ().get ());
+      TyTy::StructFieldType *ty_field
+	= new TyTy::StructFieldType (field.get_mappings ().get_hirid (),
+				     std::to_string (idx), field_type);
+      fields.push_back (ty_field);
+      context->insert_type (field.get_mappings (), ty_field->get_field_type ());
+      idx++;
+      return true;
+    });
+
+    TyTy::BaseType *type
+      = new TyTy::ADTType (struct_decl.get_mappings ().get_hirid (),
+			   mappings->get_next_hir_id (),
+			   struct_decl.get_identifier (), true,
+			   std::move (fields), std::move (substitutions));
+
+    context->insert_type (struct_decl.get_mappings (), type);
+    infered = type;
+  }
+
+  void visit (HIR::StructStruct &struct_decl) override
+  {
+    std::vector<TyTy::SubstitutionParamMapping> substitutions;
+    if (struct_decl.has_generics ())
+      {
+	for (auto &generic_param : struct_decl.get_generic_params ())
+	  {
+	    switch (generic_param.get ()->get_kind ())
+	      {
+	      case HIR::GenericParam::GenericKind::LIFETIME:
+		// Skipping Lifetime completely until better handling.
+		break;
+
+		case HIR::GenericParam::GenericKind::TYPE: {
+		  auto param_type
+		    = TypeResolveGenericParam::Resolve (generic_param.get ());
+		  context->insert_type (generic_param->get_mappings (),
+					param_type);
+
+		  substitutions.push_back (TyTy::SubstitutionParamMapping (
+		    static_cast<HIR::TypeParam &> (*generic_param),
+		    param_type));
+		}
+		break;
+	      }
+	  }
+      }
+
+    std::vector<TyTy::StructFieldType *> fields;
+    struct_decl.iterate ([&] (HIR::StructField &field) mutable -> bool {
+      TyTy::BaseType *field_type
+	= TypeCheckType::Resolve (field.get_field_type ().get ());
+      TyTy::StructFieldType *ty_field
+	= new TyTy::StructFieldType (field.get_mappings ().get_hirid (),
+				     field.get_field_name (), field_type);
+      fields.push_back (ty_field);
+      context->insert_type (field.get_mappings (), ty_field->get_field_type ());
+      return true;
+    });
+
+    TyTy::BaseType *type
+      = new TyTy::ADTType (struct_decl.get_mappings ().get_hirid (),
+			   mappings->get_next_hir_id (),
+			   struct_decl.get_identifier (), false,
+			   std::move (fields), std::move (substitutions));
+
+    context->insert_type (struct_decl.get_mappings (), type);
+    infered = type;
   }
 
 private:

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -342,6 +342,8 @@ public:
     : BaseType (ref, ty_ref, TypeKind::TUPLE, refs), fields (fields)
   {}
 
+  static TupleType *get_unit_type (HirId ref) { return new TupleType (ref); }
+
   void accept_vis (TyVisitor &vis) override;
 
   bool is_unit () const override { return this->fields.empty (); }

--- a/gcc/testsuite/rust/compile/torture/struct_init_10.rs
+++ b/gcc/testsuite/rust/compile/torture/struct_init_10.rs
@@ -1,0 +1,9 @@
+fn main() {
+    struct foo {
+        a: i32,
+        b: f32,
+    };
+
+    let a;
+    a = foo { a: 123, b: 456f32 };
+}

--- a/gcc/testsuite/rust/compile/torture/struct_init_11.rs
+++ b/gcc/testsuite/rust/compile/torture/struct_init_11.rs
@@ -1,0 +1,34 @@
+pub fn main() {
+    struct O(i32);
+    struct T(i32, i32);
+    struct M(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32);
+
+    // tuples
+    let z = ();
+    let o = (0,);
+    let f = o.0;
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+
+    let t = (0, 1);
+    let s = t.1;
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+
+    let m = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    let l = m.10;
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+
+    // tuple structs
+    let so = O(0);
+    let sf = so.0;
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+
+    let st = T(0, 1);
+    let fs = st.1;
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+
+    let sm = M(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    let sl = sm.10;
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+
+    z
+}

--- a/gcc/testsuite/rust/compile/torture/struct_init_9.rs
+++ b/gcc/testsuite/rust/compile/torture/struct_init_9.rs
@@ -1,0 +1,6 @@
+fn main() {
+    struct foo(i32, f32);
+
+    let a;
+    a = foo(123, 456f32);
+}


### PR DESCRIPTION
We still have bugs handling unit-structs but this allows for Tuple Structs
and normal named field structs to be declared within a block and referenced
lexically. This allows rust statements to follow the correct grammar.

Fixes #519
