### PR TITLE
Handle empty/unit tuple structs in the parser.

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -3980,7 +3980,12 @@ Parser<ManagedTokenSource>::parse_struct (AST::Visibility vis,
       lexer.skip_token ();
 
       // parse tuple fields
-      std::vector<AST::TupleField> tuple_fields = parse_tuple_fields ();
+      std::vector<AST::TupleField> tuple_fields;
+      // Might be empty tuple for unit tuple struct.
+      if (lexer.peek_token ()->get_id () == RIGHT_PAREN)
+	tuple_fields = std::vector<AST::TupleField> ();
+      else
+	tuple_fields = parse_tuple_fields ();
 
       // tuple parameters must have closing parenthesis
       if (!skip_token (RIGHT_PAREN))

--- a/gcc/testsuite/rust/compile/torture/tuple_struct_unit.rs
+++ b/gcc/testsuite/rust/compile/torture/tuple_struct_unit.rs
@@ -1,0 +1,11 @@
+struct E();
+struct T(E,E,());
+
+fn main()
+{
+  let z0 = E();
+  let z1 = E();
+  let t = T(z0,z1,());
+  let z = t.2;
+  z
+}


### PR DESCRIPTION
A tuple struct can be empty, in which case it is a unit tuple struct.
Handle this in Parser<ManagedTokenSource>::parse_struct by creating
a empty tuple_field vector instead of calling parse_tuple_fields.

Add a testcase to show empty tuple structs are now accepted.

Addresses: #385
