### PR TITLE
Handle empty/unit tuple enum variants in the parser.

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -4415,7 +4415,12 @@ Parser<ManagedTokenSource>::parse_enum_item ()
 	// tuple enum item
 	lexer.skip_token ();
 
-	std::vector<AST::TupleField> tuple_fields = parse_tuple_fields ();
+	std::vector<AST::TupleField> tuple_fields;
+	// Might be empty tuple for unit tuple enum variant.
+	if (lexer.peek_token ()->get_id () == RIGHT_PAREN)
+	  tuple_fields = std::vector<AST::TupleField> ();
+	else
+	  tuple_fields = parse_tuple_fields ();
 
 	if (!skip_token (RIGHT_PAREN))
 	  {

--- a/gcc/testsuite/rust/compile/torture/tuple_enum_variants.rs
+++ b/gcc/testsuite/rust/compile/torture/tuple_enum_variants.rs
@@ -1,0 +1,19 @@
+enum E { T0(), T1(i32), T2(i32,u32) }
+
+/* The following doesn't parse yet...
+fn f(e0: E, e1: E, e2: E) -> (E,E,E,())
+{
+  let e = e0;
+  let f = e1;
+  let g = e2;
+  (e,f,g,())
+}
+
+fn main()
+{
+  let e0 = E::T0();
+  let e1 = E::T1(0);
+  let e2 = E::T2(0,1);
+  f(e0, e1, e2).3
+}
+*/


### PR DESCRIPTION
A tuple enum variant can be empty, in which case it is a unit enum variant.
Handle this in Parser<ManagedTokenSource>::parse_enum_item by creating
a empty tuple_field vector instead of calling parse_tuple_fields.

Add a testcase to show empty tuple enum variant types are now accepted.
But note some part of the test is commented out because using the enum
type isn't actually possible right now.

Addresses #79 