### PR TITLE
Change unit-type from void_type_node to a zero sized unsigned integer

### DIFF
--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -423,7 +423,7 @@ public:
   {
     if (type.num_fields () == 0)
       {
-	translated = ctx->get_backend ()->void_type ();
+	translated = ctx->get_backend ()->unit_type ();
 	return;
       }
 
@@ -544,7 +544,7 @@ public:
 
   void visit (TyTy::NeverType &) override
   {
-    translated = ctx->get_backend ()->void_type ();
+    translated = ctx->get_backend ()->unit_type ();
   }
 
 private:

--- a/gcc/rust/backend/rust-compile-tyty.h
+++ b/gcc/rust/backend/rust-compile-tyty.h
@@ -42,8 +42,6 @@ public:
     return compiler.translated;
   }
 
-  ~TyTyCompile () {}
-
   void visit (TyTy::ErrorType &) override { gcc_unreachable (); }
 
   void visit (TyTy::InferType &) override { gcc_unreachable (); }
@@ -53,7 +51,7 @@ public:
   void visit (TyTy::TupleType &type) override
   {
     if (type.num_fields () == 0)
-      translated = backend->void_type ();
+      translated = backend->unit_type ();
     else
       gcc_unreachable ();
   }
@@ -224,7 +222,7 @@ public:
 
   void visit (TyTy::NeverType &) override
   {
-    translated = backend->void_type ();
+    translated = backend->unit_type ();
   }
 
 private:

--- a/gcc/rust/rust-backend.h
+++ b/gcc/rust/rust-backend.h
@@ -109,6 +109,9 @@ public:
   // unsafe.Pointer is represented as *void.
   virtual Btype *void_type () = 0;
 
+  // get unit-type
+  virtual Btype *unit_type () = 0;
+
   // Get the unnamed boolean type.
   virtual Btype *bool_type () = 0;
 

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -171,6 +171,19 @@ public:
 
   Btype *void_type () { return this->make_type (void_type_node); }
 
+  Btype *unit_type ()
+  {
+    static Btype *unit_type;
+    if (unit_type == nullptr)
+      {
+	auto unit_type_node = integer_type (true, 0);
+	unit_type = named_type ("()", unit_type_node,
+				::Linemap::predeclared_location ());
+      }
+
+    return unit_type;
+  }
+
   Btype *bool_type () { return this->make_type (boolean_type_node); }
 
   Btype *char_type () { return this->make_type (char_type_node); }
@@ -297,7 +310,10 @@ public:
     return this->make_expression (null_pointer_node);
   }
 
-  Bexpression *unit_expression () { return this->make_expression (void_node); }
+  Bexpression *unit_expression ()
+  {
+    return this->make_expression (integer_zero_node);
+  }
 
   Bexpression *var_expression (Bvariable *var, Location);
 

--- a/gcc/rust/typecheck/rust-hir-const-fold.h
+++ b/gcc/rust/typecheck/rust-hir-const-fold.h
@@ -54,7 +54,7 @@ public:
   void visit (TyTy::TupleType &type) override
   {
     if (type.num_fields () == 0)
-      translated = backend->void_type ();
+      translated = backend->unit_type ();
     else
       gcc_unreachable ();
   }

--- a/gcc/testsuite/rust/compile/torture/unit_type2.rs
+++ b/gcc/testsuite/rust/compile/torture/unit_type2.rs
@@ -1,0 +1,8 @@
+fn test(a: ()) -> () {
+    a
+}
+
+fn main() {
+    let a;
+    a = test(());
+}


### PR DESCRIPTION
Functions with return type of unit are still using void_type_node as there is an ICE in GCC:

```
test.rs: In function ‘main’:                                                                                                                                                                                                                           
test.rs:16:1: internal compiler error: in min_value, at wide-int.cc:346                                                                                                                                                                                
   16 | fn main() {                                                                                                                                                                                                                                    
      | ^                                                                                                                                                                                                                                              
0x1d551d5 wi::min_value(unsigned int, signop)                                                                                                                                                                                                          
        ../../gccrs/gcc/wide-int.cc:346                                                                                                                                                                                                                
0x1146ca5 irange::set_varying(tree_node*)                                                                                  
        ../../gccrs/gcc/value-range.h:476                                                                                                                                                                                                              
0x1ce5970 value_range_equiv::set_varying(tree_node*)                                                                                                                                                                                                   
        ../../gccrs/gcc/value-range-equiv.cc:71                                                                            
0x1d3da07 vr_values::set_def_to_varying(tree_node const*)                                                                  
        ../../gccrs/gcc/vr-values.c:230                                                                                    
0x1d3da70 vr_values::set_defs_to_varying(gimple*)                                                                          
        ../../gccrs/gcc/vr-values.c:241                                                                                                                                                                                                                
0x1c78b2f vrp_prop::visit_stmt(gimple*, edge_def**, tree_node**)                                                                                                                                                                                       
        ../../gccrs/gcc/tree-vrp.c:4001                                                                                                                                                                                                                
0x1ad8519 ssa_propagation_engine::simulate_stmt(gimple*)                                                                                                                                                                                               
        ../../gccrs/gcc/tree-ssa-propagate.c:230                                                                                                                                                                                                       
0x1ad8a0e ssa_propagation_engine::simulate_block(basic_block_def*)                                                                                                                                                                                     
        ../../gccrs/gcc/tree-ssa-propagate.c:337                                                                                                                                                                                                       
0x1ad9f2e ssa_propagation_engine::ssa_propagate()                                                                                                                                                                                                      
        ../../gccrs/gcc/tree-ssa-propagate.c:800                                                                                                                                                                                                       
0x1c7a0b0 execute_vrp                                                                                                                                                                                                                                  
        ../../gccrs/gcc/tree-vrp.c:4512                                                                                                                                                                                                                
0x1c7a3e4 execute                                                                                                                                                                                                                                      
        ../../gccrs/gcc/tree-vrp.c:4620                                                                                                                                                                                                                
Please submit a full bug report,
```

Addresses #155