### PR TITLE
Support BorrowExpr, DereferenceExpr, NegationExpr in marking live symbols and corresponding test cases.

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -354,7 +354,7 @@ public:
   void visit (HIR::NegationExpr &expr) override
   {
     auto op = expr.get_expr_type ();
-    auto negated_expr = CompileExpr::Compile (expr.get_expr (), ctx);
+    auto negated_expr = CompileExpr::Compile (expr.get_expr ().get (), ctx);
     auto location = expr.get_locus ();
 
     translated

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -300,8 +300,6 @@ public:
 
   void accept_vis (HIRVisitor &vis) override;
 
-  Expr *get_expr () { return main_or_left_expr.get (); }
-
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */

--- a/gcc/rust/lint/rust-lint-marklive.h
+++ b/gcc/rust/lint/rust-lint-marklive.h
@@ -49,6 +49,11 @@ public:
     expr.get_expr ().get ()->accept_vis (*this);
   }
 
+  void visit (HIR::NegationExpr &expr) override
+  {
+    expr.get_expr ().get ()->accept_vis (*this);
+  }
+
   void visit (HIR::BlockExpr &expr) override
   {
     expr.iterate_stmts ([&] (HIR::Stmt *s) mutable -> bool {

--- a/gcc/rust/lint/rust-lint-marklive.h
+++ b/gcc/rust/lint/rust-lint-marklive.h
@@ -44,6 +44,11 @@ public:
     expr.get_expr ().get ()->accept_vis (*this);
   }
 
+  void visit (HIR::DereferenceExpr &expr) override
+  {
+    expr.get_expr ().get ()->accept_vis (*this);
+  }
+
   void visit (HIR::BlockExpr &expr) override
   {
     expr.iterate_stmts ([&] (HIR::Stmt *s) mutable -> bool {

--- a/gcc/rust/lint/rust-lint-marklive.h
+++ b/gcc/rust/lint/rust-lint-marklive.h
@@ -39,6 +39,11 @@ public:
   void visit (HIR::PathInExpression &expr) override;
   void visit (HIR::IdentifierExpr &expr) override;
 
+  void visit (HIR::BorrowExpr &expr) override
+  {
+    expr.get_expr ().get ()->accept_vis (*this);
+  }
+
   void visit (HIR::BlockExpr &expr) override
   {
     expr.iterate_stmts ([&] (HIR::Stmt *s) mutable -> bool {
@@ -50,6 +55,7 @@ public:
 	expr.get_final_expr ().get ()->accept_vis (*this);
       }
   }
+
   void visit (HIR::Function &function) override
   {
     function.get_definition ().get ()->accept_vis (*this);

--- a/gcc/rust/typecheck/rust-hir-const-fold.h
+++ b/gcc/rust/typecheck/rust-hir-const-fold.h
@@ -341,7 +341,7 @@ public:
 
   void visit (HIR::NegationExpr &expr) override
   {
-    auto negated_expr = ConstFoldExpr::fold (expr.get_expr ());
+    auto negated_expr = ConstFoldExpr::fold (expr.get_expr ().get ());
     if (negated_expr == nullptr)
       return;
 

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -619,7 +619,8 @@ public:
 
   void visit (HIR::NegationExpr &expr) override
   {
-    auto negated_expr_ty = TypeCheckExpr::Resolve (expr.get_expr (), false);
+    auto negated_expr_ty
+      = TypeCheckExpr::Resolve (expr.get_expr ().get (), false);
 
     // https://doc.rust-lang.org/reference/expressions/operator-expr.html#negation-operators
     switch (expr.get_expr_type ())

--- a/gcc/testsuite/rust/compile/torture/borrow_function.rs
+++ b/gcc/testsuite/rust/compile/torture/borrow_function.rs
@@ -1,0 +1,5 @@
+fn foo() {}
+
+fn main() {
+    let _a = &foo;
+}

--- a/gcc/testsuite/rust/compile/torture/deref_function.rs
+++ b/gcc/testsuite/rust/compile/torture/deref_function.rs
@@ -1,0 +1,10 @@
+fn foo() {}
+
+
+fn main() {
+    let _c = *{
+	let _a = foo;
+	let b = &1;
+	b
+    };
+}

--- a/gcc/testsuite/rust/compile/torture/negation_function.rs
+++ b/gcc/testsuite/rust/compile/torture/negation_function.rs
@@ -1,0 +1,7 @@
+fn ret1() -> i32 {
+    return 1;
+}
+
+fn main() {
+    let _a = -ret1();
+}


### PR DESCRIPTION
Support BorrowExpr, DereferenceExpr, NegationExpr in marking live symbols and corresponding test cases.