### PR TITLE
Add unit-type support for Identifier expressions

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -527,6 +527,20 @@ public:
       }
   }
 
+  void visit (HIR::StructExprStruct &struct_expr) override
+  {
+    TyTy::BaseType *tyty = nullptr;
+    if (!ctx->get_tyctx ()->lookup_type (
+	  struct_expr.get_mappings ().get_hirid (), &tyty))
+      {
+	rust_error_at (struct_expr.get_locus (), "unknown type");
+	return;
+      }
+
+    rust_assert (tyty->is_unit ());
+    translated = ctx->get_backend ()->unit_expression ();
+  }
+
   void visit (HIR::StructExprStructFields &struct_expr) override
   {
     TyTy::BaseType *tyty = nullptr;

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -467,6 +467,24 @@ public:
 				 expr.get_locus ());
   }
 
+  void visit (AST::StructExprStruct &struct_expr) override
+  {
+    HIR::PathInExpression *path
+      = ASTLowerPathInExpression::translate (&struct_expr.get_struct_name ());
+    HIR::PathInExpression copied_path (*path);
+    delete path;
+
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, struct_expr.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   UNKNOWN_LOCAL_DEFID);
+
+    translated = new HIR::StructExprStruct (mapping, copied_path,
+					    struct_expr.get_inner_attrs (),
+					    struct_expr.get_outer_attrs (),
+					    struct_expr.get_locus ());
+  }
+
   void visit (AST::StructExprStructFields &struct_expr) override
   {
     // bit of a hack for now

--- a/gcc/rust/lint/rust-lint-marklive.cc
+++ b/gcc/rust/lint/rust-lint-marklive.cc
@@ -138,6 +138,13 @@ MarkLive::visit (HIR::IdentifierExpr &expr)
 	}
       ref_node_id = def.parent;
     }
+  else if (!resolver->lookup_resolved_type (ast_node_id, &ref_node_id))
+    {
+      rust_error_at (expr.get_locus (),
+		     "Failed to lookup type reference for node: %s",
+		     expr.as_string ().c_str ());
+      return;
+    }
 
   if (ref_node_id == UNKNOWN_NODEID)
     {

--- a/gcc/rust/resolve/rust-ast-resolve-expr.h
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.h
@@ -219,6 +219,14 @@ public:
     ResolveExpr::go (elems.get_elem_to_copy ().get (), elems.get_node_id ());
   }
 
+  // this this an empty struct constructor like 'S {}'
+  void visit (AST::StructExprStruct &struct_expr) override
+  {
+    ResolveExpr::go (&struct_expr.get_struct_name (),
+		     struct_expr.get_node_id ());
+  }
+
+  // this this a struct constructor with fields
   void visit (AST::StructExprStructFields &struct_expr) override
   {
     ResolveExpr::go (&struct_expr.get_struct_name (),

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -827,6 +827,21 @@ public:
       = TypeCheckExpr::Resolve (elems.get_elem_to_copy (), false);
   }
 
+  // empty struct
+  void visit (HIR::StructExprStruct &struct_expr) override
+  {
+    TyTy::BaseType *struct_path_ty
+      = TypeCheckExpr::Resolve (&struct_expr.get_struct_name (), false);
+    if (struct_path_ty->get_kind () != TyTy::TypeKind::ADT)
+      {
+	rust_error_at (struct_expr.get_struct_name ().get_locus (),
+		       "expected an ADT type for constructor");
+	return;
+      }
+
+    infered = struct_path_ty;
+  }
+
   void visit (HIR::StructExprStructFields &struct_expr) override
   {
     infered = TypeCheckStructExpr::Resolve (&struct_expr);

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -843,6 +843,8 @@ public:
 
   bool get_is_tuple () { return is_tuple; }
 
+  bool is_unit () const override { return this->fields.empty (); }
+
   void accept_vis (TyVisitor &vis) override;
 
   std::string as_string () const override;

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -52,6 +52,71 @@ enum TypeKind
   ERROR
 };
 
+class TypeKindFormat
+{
+public:
+  static std::string to_string (TypeKind kind)
+  {
+    switch (kind)
+      {
+      case TypeKind::INFER:
+	return "Infer";
+
+      case TypeKind::ADT:
+	return "ADT";
+
+      case TypeKind::STR:
+	return "STR";
+
+      case TypeKind::REF:
+	return "REF";
+
+      case TypeKind::PARAM:
+	return "PARAM";
+
+      case TypeKind::ARRAY:
+	return "ARRAY";
+
+      case TypeKind::FNDEF:
+	return "FnDef";
+
+      case TypeKind::FNPTR:
+	return "FnPtr";
+
+      case TypeKind::TUPLE:
+	return "Tuple";
+
+      case TypeKind::BOOL:
+	return "Bool";
+
+      case TypeKind::CHAR:
+	return "Char";
+
+      case TypeKind::INT:
+	return "Int";
+
+      case TypeKind::UINT:
+	return "Uint";
+
+      case TypeKind::FLOAT:
+	return "Float";
+
+      case TypeKind::USIZE:
+	return "Usize";
+
+      case TypeKind::ISIZE:
+	return "Isize";
+
+      case TypeKind::NEVER:
+	return "Never";
+
+      case TypeKind::ERROR:
+	return "ERROR";
+      }
+    gcc_unreachable ();
+  }
+};
+
 class TyVisitor;
 class BaseType
 {
@@ -138,7 +203,8 @@ public:
 
   std::string debug_str () const
   {
-    return as_string () + ":" + mappings_str ();
+    return TypeKindFormat::to_string (get_kind ()) + ":" + as_string () + ":"
+	   + mappings_str ();
   }
 
   void debug () const
@@ -1405,71 +1471,6 @@ public:
   std::string get_name () const override final { return as_string (); }
 
   bool is_unit () const override { return true; }
-};
-
-class TypeKindFormat
-{
-public:
-  static std::string to_string (TypeKind kind)
-  {
-    switch (kind)
-      {
-      case TypeKind::INFER:
-	return "Infer";
-
-      case TypeKind::ADT:
-	return "ADT";
-
-      case TypeKind::STR:
-	return "STR";
-
-      case TypeKind::REF:
-	return "REF";
-
-      case TypeKind::PARAM:
-	return "PARAM";
-
-      case TypeKind::ARRAY:
-	return "ARRAY";
-
-      case TypeKind::FNDEF:
-	return "FnDef";
-
-      case TypeKind::FNPTR:
-	return "FnPtr";
-
-      case TypeKind::TUPLE:
-	return "Tuple";
-
-      case TypeKind::BOOL:
-	return "Bool";
-
-      case TypeKind::CHAR:
-	return "Char";
-
-      case TypeKind::INT:
-	return "Int";
-
-      case TypeKind::UINT:
-	return "Uint";
-
-      case TypeKind::FLOAT:
-	return "Float";
-
-      case TypeKind::USIZE:
-	return "Usize";
-
-      case TypeKind::ISIZE:
-	return "Isize";
-
-      case TypeKind::NEVER:
-	return "Never";
-
-      case TypeKind::ERROR:
-	return "ERROR";
-      }
-    gcc_unreachable ();
-  }
 };
 
 } // namespace TyTy

--- a/gcc/testsuite/rust/compile/torture/unit_type3.rs
+++ b/gcc/testsuite/rust/compile/torture/unit_type3.rs
@@ -1,0 +1,6 @@
+struct S;
+
+fn main() {
+    let s = S;
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/compile/torture/unit_type4.rs
+++ b/gcc/testsuite/rust/compile/torture/unit_type4.rs
@@ -1,0 +1,5 @@
+struct S;
+
+fn main() {
+    let _s = S {};
+}


### PR DESCRIPTION
Unit type can be reference via an identifier expression. Other type references via an identifier expression are not supported yet.