### PR TITLE
Marking live symbol in break, return, while, whilelet, for expr

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -3452,6 +3452,8 @@ public:
 
   void accept_vis (HIRVisitor &vis) override;
 
+  std::unique_ptr<Expr> &get_iterator_expr () { return iterator_expr; }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -3387,6 +3387,8 @@ public:
 
   void accept_vis (HIRVisitor &vis) override;
 
+  std::unique_ptr<Expr> &get_cond () { return condition; }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */

--- a/gcc/rust/lint/rust-lint-marklive.h
+++ b/gcc/rust/lint/rust-lint-marklive.h
@@ -103,6 +103,17 @@ public:
       }
   }
 
+  void visit (HIR::LoopExpr &expr) override
+  {
+    expr.get_loop_block ()->accept_vis (*this);
+  }
+
+  void visit (HIR::BreakExpr &expr) override
+  {
+    if (expr.has_break_expr ())
+      expr.get_expr ()->accept_vis (*this);
+  }
+
   void visit (HIR::Function &function) override
   {
     function.get_definition ().get ()->accept_vis (*this);

--- a/gcc/rust/lint/rust-lint-marklive.h
+++ b/gcc/rust/lint/rust-lint-marklive.h
@@ -114,6 +114,12 @@ public:
       expr.get_expr ()->accept_vis (*this);
   }
 
+  void visit (HIR::WhileLoopExpr &expr) override
+  {
+    expr.get_loop_block ()->accept_vis (*this);
+    expr.get_predicate_expr ()->accept_vis (*this);
+  }
+
   void visit (HIR::Function &function) override
   {
     function.get_definition ().get ()->accept_vis (*this);

--- a/gcc/rust/lint/rust-lint-marklive.h
+++ b/gcc/rust/lint/rust-lint-marklive.h
@@ -137,6 +137,12 @@ public:
     expr.get_cond ()->accept_vis (*this);
   }
 
+  void visit (HIR::ForLoopExpr &expr) override
+  {
+    expr.get_loop_block ()->accept_vis (*this);
+    expr.get_iterator_expr ()->accept_vis (*this);
+  }
+
   void visit (HIR::ExprStmtWithoutBlock &stmt) override
   {
     stmt.get_expr ()->accept_vis (*this);

--- a/gcc/rust/lint/rust-lint-marklive.h
+++ b/gcc/rust/lint/rust-lint-marklive.h
@@ -131,6 +131,12 @@ public:
       expr.get_expr ()->accept_vis (*this);
   }
 
+  void visit (HIR::WhileLetLoopExpr &expr) override
+  {
+    expr.get_loop_block ()->accept_vis (*this);
+    expr.get_cond ()->accept_vis (*this);
+  }
+
   void visit (HIR::ExprStmtWithoutBlock &stmt) override
   {
     stmt.get_expr ()->accept_vis (*this);

--- a/gcc/rust/lint/rust-lint-marklive.h
+++ b/gcc/rust/lint/rust-lint-marklive.h
@@ -119,6 +119,12 @@ public:
     function.get_definition ().get ()->accept_vis (*this);
   }
 
+  void visit (HIR::ReturnExpr &expr) override
+  {
+    if (expr.has_return_expr ())
+      expr.get_expr ()->accept_vis (*this);
+  }
+
   void visit (HIR::ExprStmtWithoutBlock &stmt) override
   {
     stmt.get_expr ()->accept_vis (*this);

--- a/gcc/testsuite/rust/compile/torture/break_function.rs
+++ b/gcc/testsuite/rust/compile/torture/break_function.rs
@@ -1,0 +1,10 @@
+fn foo() -> i32 {
+    1
+}
+    
+fn main() {
+    let _a = loop {
+        break foo();
+    };
+}
+    

--- a/gcc/testsuite/rust/compile/torture/return_function.rs
+++ b/gcc/testsuite/rust/compile/torture/return_function.rs
@@ -1,0 +1,5 @@
+fn foo() {}
+
+fn main() {
+    return foo();
+}

--- a/gcc/testsuite/rust/compile/torture/while_function.rs
+++ b/gcc/testsuite/rust/compile/torture/while_function.rs
@@ -1,0 +1,10 @@
+fn foo() {}
+fn bar() -> i32 { return 10; }
+
+fn main() {
+	let mut i = 1;
+	while i < bar() {
+		foo();
+		i += 1;
+	}
+}


### PR DESCRIPTION
Marking live symbol in break, return, while, whilelet, for expr without test case for last two due to unimplemented.