### PR TITLE
Fix inner attribute parsing

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -495,7 +495,6 @@ Parser<ManagedTokenSource>::parse_inner_attribute ()
     return AST::Attribute::create_empty ();
 
   AST::Attribute actual_attribute = parse_attribute_body ();
-  lexer.skip_token ();
 
   if (!skip_token (RIGHT_SQUARE))
     return AST::Attribute::create_empty ();
@@ -785,6 +784,7 @@ Parser<ManagedTokenSource>::parse_attr_input ()
 	// create actual LiteralExpr
 	AST::LiteralExpr lit_expr (t->get_str (), lit_type, t->get_type_hint (),
 				   {}, t->get_locus ());
+	lexer.skip_token ();
 
 	std::unique_ptr<AST::AttrInput> attr_input_lit (
 	  new AST::AttrInputLiteral (std::move (lit_expr)));

--- a/gcc/testsuite/rust/compile/torture/inner_attributes.rs
+++ b/gcc/testsuite/rust/compile/torture/inner_attributes.rs
@@ -1,0 +1,3 @@
+#![allow(dead_code)]
+#![allow(unused_variables)]
+pub fn main () { }


### PR DESCRIPTION
parse_inner_attribute tried to skip the right square token twice. This caused odd error
messages in case there were multiple inner attributes. This bug masked another bug in
parse_attr_input where when the (optional) attr input was an assignment to a literal
the parser failed to skip the literal.

The existing top_attr.rs testcase relied on the two bugs cancelling each other out.
Add a new testcase inner_attributes.rs for the first bug.

Resolves: https://github.com/Rust-GCC/gccrs/issues/510
