### PR TITLE
Suppress warning in rust-ast-lower-type.h ASTLowerGenericParam.visit.

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-type.h
+++ b/gcc/rust/hir/rust-ast-lower-type.h
@@ -281,6 +281,8 @@ public:
       case AST::Lifetime::LifetimeType::WILDCARD:
 	ltt = HIR::Lifetime::LifetimeType::WILDCARD;
 	break;
+      default:
+	gcc_unreachable ();
       }
 
     HIR::Lifetime lt (mapping, ltt, param.get_lifetime ().get_lifetime_name (),


### PR DESCRIPTION
Translating the AST LifetimeType to the HIR LifetimeType causes a warning:
warning: ‘ltt’ may be used uninitialized

Add a default clause to the switch statement calling gcc_unreachable.
This will suppress the warning and make sure that if the AST lifetime type
is invalid or a new unknown type we immediately know when lowering the AST.
