### PR TITLE
Revert change to ScanUnused to not scan Types

### DIFF
--- a/gcc/testsuite/rust/compile/torture/cfg_attr.rs
+++ b/gcc/testsuite/rust/compile/torture/cfg_attr.rs
@@ -3,6 +3,6 @@ use std::env; // Add one line so gccrs doesn't believe we're parsing a shebang
 #[cfg_attr(feature = "somefeature", attribute = "someattr")]
 struct Feature;
 // { dg-warning "struct is never constructed" "" { target *-*-* } .-1 }
+// { dg-warning "unused name" "" { target *-*-* } .-2 }
 
-fn main() {
-}
+fn main() {}

--- a/gcc/testsuite/rust/compile/torture/unused1.rs
+++ b/gcc/testsuite/rust/compile/torture/unused1.rs
@@ -4,6 +4,7 @@ fn test() -> i32 {
 
 fn unused() -> i32 {
     // { dg-warning "function is never used: 'unused'" "" { target *-*-* } .-1 }
+    // { dg-warning "unused name" "" { target *-*-* } .-2 }
     2
 }
 

--- a/gcc/testsuite/rust/compile/torture/unused_struct.rs
+++ b/gcc/testsuite/rust/compile/torture/unused_struct.rs
@@ -1,8 +1,8 @@
 struct Foo {
-// { dg-warning "struct is never constructed" "" { target *-*-* } .-1 }
+    // { dg-warning "struct is never constructed" "" { target *-*-* } .-1 }
+    // { dg-warning "unused name" "" { target *-*-* } .-2 }
     one: i32,
-    two: i32
+    two: i32,
 }
 
-fn main() {
-}
+fn main() {}


### PR DESCRIPTION
The scan dead-code pass will take over this role, but let's keep both
running for a while and then we can update ScanUnused to only scan for
unused labels and variables. Dead Code pass is important as it is not possible
to rely on name resolution to know what symbols are used or not used.
Further resolution occurs during type resolution and the dead code pass runs after type resolution.
