### PR TITLE
shebang handling

### DIFF
--- a/gcc/rust/ast/rust-ast-full-test.cc
+++ b/gcc/rust/ast/rust-ast-full-test.cc
@@ -172,12 +172,9 @@ Crate::as_string () const
   rust_debug ("beginning crate recursive as-string");
 
   std::string str ("Crate: ");
-  // add utf8bom and shebang
+  // add utf8bom
   if (has_utf8bom)
     str += "\n has utf8bom";
-
-  if (has_shebang)
-    str += "\n has shebang";
 
   // inner attributes
   str += append_attributes (inner_attrs, INNER);

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -1551,7 +1551,6 @@ protected:
 struct Crate
 {
   bool has_utf8bom;
-  bool has_shebang;
 
   std::vector<Attribute> inner_attrs;
   // dodgy spacing required here
@@ -1564,17 +1563,16 @@ struct Crate
 public:
   // Constructor
   Crate (std::vector<std::unique_ptr<Item> > items,
-	 std::vector<Attribute> inner_attrs, bool has_utf8bom = false,
-	 bool has_shebang = false)
-    : has_utf8bom (has_utf8bom), has_shebang (has_shebang),
-      inner_attrs (std::move (inner_attrs)), items (std::move (items)),
+	 std::vector<Attribute> inner_attrs, bool has_utf8bom = false)
+    : has_utf8bom (has_utf8bom), inner_attrs (std::move (inner_attrs)),
+      items (std::move (items)),
       node_id (Analysis::Mappings::get ()->get_next_node_id ())
   {}
 
   // Copy constructor with vector clone
   Crate (Crate const &other)
-    : has_utf8bom (other.has_utf8bom), has_shebang (other.has_shebang),
-      inner_attrs (other.inner_attrs), node_id (other.node_id)
+    : has_utf8bom (other.has_utf8bom), inner_attrs (other.inner_attrs),
+      node_id (other.node_id)
   {
     items.reserve (other.items.size ());
     for (const auto &e : other.items)
@@ -1587,7 +1585,6 @@ public:
   Crate &operator= (Crate const &other)
   {
     inner_attrs = other.inner_attrs;
-    has_shebang = other.has_shebang;
     has_utf8bom = other.has_utf8bom;
     node_id = other.node_id;
 

--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -41,7 +41,6 @@ ASTLowering::go ()
 {
   std::vector<std::unique_ptr<HIR::Item> > items;
   bool has_utf8bom = false;
-  bool has_shebang = false;
 
   for (auto it = astCrate.items.begin (); it != astCrate.items.end (); it++)
     {
@@ -57,7 +56,7 @@ ASTLowering::go ()
 				 UNKNOWN_LOCAL_DEFID);
 
   return HIR::Crate (std::move (items), astCrate.get_inner_attrs (), mapping,
-		     has_utf8bom, has_shebang);
+		     has_utf8bom);
 }
 
 // rust-ast-lower-block.h

--- a/gcc/rust/hir/tree/rust-hir-full-test.cc
+++ b/gcc/rust/hir/tree/rust-hir-full-test.cc
@@ -73,14 +73,10 @@ std::string
 Crate::as_string () const
 {
   std::string str ("HIR::Crate: ");
-  // add utf8bom and shebang
+  // add utf8bom
   if (has_utf8bom)
     {
       str += "\n has utf8bom";
-    }
-  if (has_shebang)
-    {
-      str += "\n has shebang";
     }
 
   // inner attributes

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -679,7 +679,6 @@ public:
 struct Crate
 {
   bool has_utf8bom;
-  bool has_shebang;
 
   AST::AttrVec inner_attrs;
   // dodgy spacing required here
@@ -692,17 +691,15 @@ struct Crate
 public:
   // Constructor
   Crate (std::vector<std::unique_ptr<Item> > items, AST::AttrVec inner_attrs,
-	 Analysis::NodeMapping mappings, bool has_utf8bom = false,
-	 bool has_shebang = false)
-    : has_utf8bom (has_utf8bom), has_shebang (has_shebang),
-      inner_attrs (std::move (inner_attrs)), items (std::move (items)),
-      mappings (mappings)
+	 Analysis::NodeMapping mappings, bool has_utf8bom = false)
+    : has_utf8bom (has_utf8bom), inner_attrs (std::move (inner_attrs)),
+      items (std::move (items)), mappings (mappings)
   {}
 
   // Copy constructor with vector clone
   Crate (Crate const &other)
-    : has_utf8bom (other.has_utf8bom), has_shebang (other.has_shebang),
-      inner_attrs (other.inner_attrs), mappings (other.mappings)
+    : has_utf8bom (other.has_utf8bom), inner_attrs (other.inner_attrs),
+      mappings (other.mappings)
   {
     items.reserve (other.items.size ());
     for (const auto &e : other.items)
@@ -715,7 +712,6 @@ public:
   Crate &operator= (Crate const &other)
   {
     inner_attrs = other.inner_attrs;
-    has_shebang = other.has_shebang;
     has_utf8bom = other.has_utf8bom;
     mappings = other.mappings;
 

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -393,12 +393,11 @@ template <typename ManagedTokenSource>
 AST::Crate
 Parser<ManagedTokenSource>::parse_crate ()
 {
-  /* TODO: determine if has utf8bom and shebang. Currently, they are eliminated
-   * by the lexing phase. Neither are useful for the compiler anyway, so maybe a
+  /* TODO: determine if has utf8bom. Currently, is eliminated
+   * by the lexing phase. Not useful for the compiler anyway, so maybe a
    * better idea would be to eliminate
-   * the has_utf8bom and has_shebang variables from the crate data structure. */
+   * the has_utf8bom variable from the crate data structure. */
   bool has_utf8bom = false;
-  bool has_shebang = false;
 
   // parse inner attributes
   AST::AttrVec inner_attrs = parse_inner_attributes ();
@@ -430,8 +429,7 @@ Parser<ManagedTokenSource>::parse_crate ()
   for (const auto &error : error_table)
     error.emit_error ();
 
-  return AST::Crate (std::move (items), std::move (inner_attrs), has_utf8bom,
-		     has_shebang);
+  return AST::Crate (std::move (items), std::move (inner_attrs), has_utf8bom);
 }
 
 // Parse a contiguous block of inner attributes.
@@ -484,7 +482,7 @@ Parser<ManagedTokenSource>::parse_inner_attribute ()
   if (lexer.peek_token ()->get_id () != EXCLAM)
     {
       Error error (lexer.peek_token ()->get_locus (),
-		   "expected %<!%> or %<[%> for inner attribute or shebang");
+		   "expected %<!%> or %<[%> for inner attribute");
       add_error (std::move (error));
 
       return AST::Attribute::create_empty ();

--- a/gcc/testsuite/rust/compile/torture/not_shebang.rs
+++ b/gcc/testsuite/rust/compile/torture/not_shebang.rs
@@ -1,0 +1,3 @@
+#!
+[allow(unused)]
+fn main () { }

--- a/gcc/testsuite/rust/compile/torture/not_shebang_block_comment.rs
+++ b/gcc/testsuite/rust/compile/torture/not_shebang_block_comment.rs
@@ -1,0 +1,1 @@
+#!/*/this/is/a/comment*/[allow(unused)] fn main () { }

--- a/gcc/testsuite/rust/compile/torture/not_shebang_comment.rs
+++ b/gcc/testsuite/rust/compile/torture/not_shebang_comment.rs
@@ -1,0 +1,3 @@
+#!//this/is/a/comment
+[allow(unused)]   
+fn main () { }

--- a/gcc/testsuite/rust/compile/torture/not_shebang_multiline_comment.rs
+++ b/gcc/testsuite/rust/compile/torture/not_shebang_multiline_comment.rs
@@ -1,0 +1,7 @@
+#!//this/is/a/comment
+
+/* Also a /* nested */
+   multiline // comment
+   with some more whitespace after, but then finally a [, so not a real #! line.  */
+
+[allow(unused)] fn main () { }

--- a/gcc/testsuite/rust/compile/torture/not_shebang_spaces.rs
+++ b/gcc/testsuite/rust/compile/torture/not_shebang_spaces.rs
@@ -1,0 +1,6 @@
+#!   
+
+    [allow(unused)]   
+
+        fn main () { }
+    

--- a/gcc/testsuite/rust/compile/torture/shebang.rs
+++ b/gcc/testsuite/rust/compile/torture/shebang.rs
@@ -1,0 +1,3 @@
+#!/usr/bin/env cat 
+
+fn main () { }

--- a/gcc/testsuite/rust/compile/torture/shebang_plus_attr.rs
+++ b/gcc/testsuite/rust/compile/torture/shebang_plus_attr.rs
@@ -1,0 +1,3 @@
+#!/usr/bin/env cat 
+#![allow(unused)]
+fn main () { }

--- a/gcc/testsuite/rust/compile/torture/shebang_plus_attr2.rs
+++ b/gcc/testsuite/rust/compile/torture/shebang_plus_attr2.rs
@@ -1,0 +1,3 @@
+#!//usr/bin/env cat 
+#![allow(unused)]
+fn main () { }


### PR DESCRIPTION
 Mark Wielaard:
> Shebang handling, the first line starting with #! was not done fully
> correct and it isn't necessary to keep track of the shebang line in
> the AST or HIR Crate classes.
> 
> Because an inner attribute also starts with #! the first line isn't
> regarded as a shebang line if the #! is followed by (optional)
> whitespace and comments and a [. In that case the #! is seen as the
> start of an inner attribute.
> 
> I added various testcases that hopefully show the funny things you can
> get when the first line starts with #!.