### PR TITLE
use rust_assert in dead code pass instead of rust_error_at

### DIFF
--- a/gcc/rust/lint/rust-lint-marklive.cc
+++ b/gcc/rust/lint/rust-lint-marklive.cc
@@ -128,8 +128,8 @@ MarkLive::visit_path_segment (HIR::PathExprSegment seg)
   if (resolver->lookup_resolved_name (ast_node_id, &ref_node_id))
     {
       Resolver::Definition def;
-      bool ret = resolver->lookup_definition (ref_node_id, &def);
-      rust_assert (ret);
+      bool ok = resolver->lookup_definition (ref_node_id, &def);
+      rust_assert (ok);
       ref_node_id = def.parent;
     }
   else if (!resolver->lookup_resolved_type (ast_node_id, &ref_node_id))
@@ -158,8 +158,8 @@ MarkLive::visit (HIR::FieldAccessExpr &expr)
       rust_error_at (expr.get_receiver_expr ()->get_locus_slow (),
 		     "unresolved type for receiver");
     }
-  bool ret = receiver->get_kind () == TyTy::TypeKind::ADT;
-  rust_assert (ret);
+  bool ok = receiver->get_kind () == TyTy::TypeKind::ADT;
+  rust_assert (ok);
   TyTy::ADTType *adt = static_cast<TyTy::ADTType *> (receiver);
 
   // get the field index
@@ -233,14 +233,14 @@ MarkLive::find_ref_node_id (NodeId ast_node_id, NodeId &ref_node_id,
       // these ref_node_ids will resolve to a pattern declaration but we are
       // interested in the definition that this refers to get the parent id
       Resolver::Definition def;
-      bool ret = resolver->lookup_definition (ref_node_id, &def);
-      rust_assert (ret);
+      bool ok = resolver->lookup_definition (ref_node_id, &def);
+      rust_assert (ok);
       ref_node_id = def.parent;
     }
   else
     {
-      bool ret = resolver->lookup_resolved_type (ast_node_id, &ref_node_id);
-      rust_assert (ret);
+      bool ok = resolver->lookup_resolved_type (ast_node_id, &ref_node_id);
+      rust_assert (ok);
     }
 }
 

--- a/gcc/rust/lint/rust-lint-marklive.cc
+++ b/gcc/rust/lint/rust-lint-marklive.cc
@@ -114,9 +114,10 @@ MarkLive::visit (HIR::MethodCallExpr &expr)
 
   // node back to HIR
   HirId ref;
-  rust_assert (
-    mappings->lookup_node_to_hir (expr.get_mappings ().get_crate_num (),
-				  ref_node_id, &ref));
+  bool ret
+    = mappings->lookup_node_to_hir (expr.get_mappings ().get_crate_num (),
+				    ref_node_id, &ref);
+  rust_assert (ret);
   mark_hir_id (ref);
 }
 
@@ -129,7 +130,8 @@ MarkLive::visit_path_segment (HIR::PathExprSegment seg)
   if (resolver->lookup_resolved_name (ast_node_id, &ref_node_id))
     {
       Resolver::Definition def;
-      rust_assert (resolver->lookup_definition (ref_node_id, &def));
+      bool ret = resolver->lookup_definition (ref_node_id, &def);
+      rust_assert (ret);
       ref_node_id = def.parent;
     }
   else if (!resolver->lookup_resolved_type (ast_node_id, &ref_node_id))
@@ -137,9 +139,9 @@ MarkLive::visit_path_segment (HIR::PathExprSegment seg)
       return;
     }
   HirId ref;
-  rust_assert (
-    mappings->lookup_node_to_hir (seg.get_mappings ().get_crate_num (),
-				  ref_node_id, &ref));
+  bool ret = mappings->lookup_node_to_hir (seg.get_mappings ().get_crate_num (),
+					   ref_node_id, &ref);
+  rust_assert (ret);
   mark_hir_id (ref);
 }
 
@@ -157,7 +159,8 @@ MarkLive::visit (HIR::FieldAccessExpr &expr)
       rust_error_at (expr.get_receiver_expr ()->get_locus_slow (),
 		     "unresolved type for receiver");
     }
-  rust_assert (receiver->get_kind () == TyTy::TypeKind::ADT);
+  bool ret = receiver->get_kind () == TyTy::TypeKind::ADT;
+  rust_assert (ret);
   TyTy::ADTType *adt = static_cast<TyTy::ADTType *> (receiver);
 
   // get the field index
@@ -192,9 +195,10 @@ MarkLive::visit (HIR::IdentifierExpr &expr)
 
   // node back to HIR
   HirId ref;
-  rust_assert (
-    mappings->lookup_node_to_hir (expr.get_mappings ().get_crate_num (),
-				  ref_node_id, &ref));
+  bool ret
+    = mappings->lookup_node_to_hir (expr.get_mappings ().get_crate_num (),
+				    ref_node_id, &ref);
+  rust_assert (ret);
   mark_hir_id (ref);
 }
 
@@ -205,9 +209,10 @@ MarkLive::visit (HIR::TypeAlias &alias)
   resolver->lookup_resolved_type (
     alias.get_type_aliased ()->get_mappings ().get_nodeid (), &ast_node_id);
   HirId hir_id;
-  rust_assert (
-    mappings->lookup_node_to_hir (alias.get_mappings ().get_crate_num (),
-				  ast_node_id, &hir_id));
+  bool ret
+    = mappings->lookup_node_to_hir (alias.get_mappings ().get_crate_num (),
+				    ast_node_id, &hir_id);
+  rust_assert (ret);
   mark_hir_id (hir_id);
 }
 
@@ -230,12 +235,14 @@ MarkLive::find_ref_node_id (NodeId ast_node_id, NodeId &ref_node_id,
       // these ref_node_ids will resolve to a pattern declaration but we are
       // interested in the definition that this refers to get the parent id
       Resolver::Definition def;
-      rust_assert (resolver->lookup_definition (ref_node_id, &def));
+      bool ret = resolver->lookup_definition (ref_node_id, &def);
+      rust_assert (ret);
       ref_node_id = def.parent;
     }
   else
     {
-      rust_assert (resolver->lookup_resolved_type (ast_node_id, &ref_node_id));
+      bool ret = resolver->lookup_resolved_type (ast_node_id, &ref_node_id);
+      rust_assert (ret);
     }
 }
 

--- a/gcc/rust/lint/rust-lint-marklive.cc
+++ b/gcc/rust/lint/rust-lint-marklive.cc
@@ -92,8 +92,7 @@ void
 MarkLive::visit (HIR::PathInExpression &expr)
 {
   expr.iterate_path_segments ([&] (HIR::PathExprSegment &seg) -> bool {
-    visit_path_segment (seg);
-    return true;
+    return visit_path_segment (seg);
   });
 }
 
@@ -114,14 +113,13 @@ MarkLive::visit (HIR::MethodCallExpr &expr)
 
   // node back to HIR
   HirId ref;
-  bool ret
-    = mappings->lookup_node_to_hir (expr.get_mappings ().get_crate_num (),
-				    ref_node_id, &ref);
-  rust_assert (ret);
+  bool ok = mappings->lookup_node_to_hir (expr.get_mappings ().get_crate_num (),
+					  ref_node_id, &ref);
+  rust_assert (ok);
   mark_hir_id (ref);
 }
 
-void
+bool
 MarkLive::visit_path_segment (HIR::PathExprSegment seg)
 {
   NodeId ast_node_id = seg.get_mappings ().get_nodeid ();
@@ -136,13 +134,14 @@ MarkLive::visit_path_segment (HIR::PathExprSegment seg)
     }
   else if (!resolver->lookup_resolved_type (ast_node_id, &ref_node_id))
     {
-      return;
+      return false;
     }
   HirId ref;
-  bool ret = mappings->lookup_node_to_hir (seg.get_mappings ().get_crate_num (),
-					   ref_node_id, &ref);
-  rust_assert (ret);
+  bool ok = mappings->lookup_node_to_hir (seg.get_mappings ().get_crate_num (),
+					  ref_node_id, &ref);
+  rust_assert (ok);
   mark_hir_id (ref);
+  return true;
 }
 
 void
@@ -195,10 +194,9 @@ MarkLive::visit (HIR::IdentifierExpr &expr)
 
   // node back to HIR
   HirId ref;
-  bool ret
-    = mappings->lookup_node_to_hir (expr.get_mappings ().get_crate_num (),
-				    ref_node_id, &ref);
-  rust_assert (ret);
+  bool ok = mappings->lookup_node_to_hir (expr.get_mappings ().get_crate_num (),
+					  ref_node_id, &ref);
+  rust_assert (ok);
   mark_hir_id (ref);
 }
 
@@ -209,10 +207,10 @@ MarkLive::visit (HIR::TypeAlias &alias)
   resolver->lookup_resolved_type (
     alias.get_type_aliased ()->get_mappings ().get_nodeid (), &ast_node_id);
   HirId hir_id;
-  bool ret
+  bool ok
     = mappings->lookup_node_to_hir (alias.get_mappings ().get_crate_num (),
 				    ast_node_id, &hir_id);
-  rust_assert (ret);
+  rust_assert (ok);
   mark_hir_id (hir_id);
 }
 

--- a/gcc/rust/lint/rust-lint-marklive.h
+++ b/gcc/rust/lint/rust-lint-marklive.h
@@ -266,7 +266,7 @@ private:
       tyctx (Resolver::TypeCheckContext::get ()){};
 
   void mark_hir_id (HirId);
-  void visit_path_segment (HIR::PathExprSegment);
+  bool visit_path_segment (HIR::PathExprSegment);
   void find_ref_node_id (NodeId ast_node_id, NodeId &ref_node_id,
 			 Location locus, const std::string &node_name);
 };

--- a/gcc/rust/lint/rust-lint-marklive.h
+++ b/gcc/rust/lint/rust-lint-marklive.h
@@ -266,10 +266,9 @@ private:
       tyctx (Resolver::TypeCheckContext::get ()){};
 
   void mark_hir_id (HirId);
-  bool visit_path_segment (HIR::PathExprSegment);
+  void visit_path_segment (HIR::PathExprSegment);
   void find_ref_node_id (NodeId ast_node_id, NodeId &ref_node_id,
 			 Location locus, const std::string &node_name);
-  void node_id_to_hir_id (CrateNum, NodeId, HirId &, Location);
 };
 
 } // namespace Analysis


### PR DESCRIPTION
use rust_assert in dead code pass instead of rust_error_at

Fixed #550 