### PR TITLE
Remove HIR MacroItem and other hir macro forward declarations

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -3094,9 +3094,6 @@ protected:
   }
 };
 
-// Forward decl - defined in rust-macro.h
-class MacroInvocation;
-
 // An unsafe block HIR node
 class UnsafeBlockExpr : public ExprWithBlock
 {

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -3020,9 +3020,6 @@ protected:
   }*/
 };
 
-// Replaced with forward decls - defined in "rust-macro.h"
-class MacroItem;
-class MacroRulesDefinition;
 } // namespace HIR
 } // namespace Rust
 

--- a/gcc/rust/hir/tree/rust-hir-pattern.h
+++ b/gcc/rust/hir/tree/rust-hir-pattern.h
@@ -1152,8 +1152,6 @@ class PathPattern;
 class PathInExpression;
 class QualifiedPathInExpression;
 
-// Replaced with forward decl - defined in rust-macro.h
-class MacroInvocation;
 } // namespace HIR
 } // namespace Rust
 

--- a/gcc/rust/hir/tree/rust-hir-type.h
+++ b/gcc/rust/hir/tree/rust-hir-type.h
@@ -907,9 +907,6 @@ protected:
   }
 };
 
-// Forward decl - defined in rust-macro.h
-class MacroInvocation;
-
 /* TODO: possible types
  * struct type?
  * "enum" (tagged union) type?

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -613,17 +613,6 @@ protected:
   }
 };
 
-// A macro item HIR node - potentially abstract base class
-class MacroItem : public Item
-{
-  /*public:
-  std::string as_string() const;*/
-protected:
-  MacroItem (Analysis::NodeMapping mappings, AST::AttrVec outer_attribs)
-    : Item (std::move (mappings), std::move (outer_attribs))
-  {}
-};
-
 // Item used in trait declarations - abstract base class
 class TraitItem
 {


### PR DESCRIPTION
Remove trailing macro items from HIR

Fixes #69
