### PR TITLE
Further error checking for trait impl blocks

### DIFF
--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -3265,10 +3265,12 @@ public:
   std::vector<Attribute> &get_outer_attrs () { return outer_attrs; }
   const std::vector<Attribute> &get_outer_attrs () const { return outer_attrs; }
 
+  bool has_expr () const { return expr != nullptr; }
+
   // TODO: is this better? Or is a "vis_block" better?
   std::unique_ptr<Expr> &get_expr ()
   {
-    rust_assert (expr != nullptr);
+    rust_assert (has_expr ());
     return expr;
   }
 

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -168,7 +168,9 @@ public:
   void visit (AST::TraitItemConst &constant) override
   {
     ResolveType::go (constant.get_type ().get (), constant.get_node_id ());
-    ResolveExpr::go (constant.get_expr ().get (), constant.get_node_id ());
+
+    if (constant.has_expr ())
+      ResolveExpr::go (constant.get_expr ().get (), constant.get_node_id ());
 
     // the mutability checker needs to verify for immutable decls the number
     // of assignments are <1. This marks an implicit assignment

--- a/gcc/rust/typecheck/rust-hir-trait-ref.h
+++ b/gcc/rust/typecheck/rust-hir-trait-ref.h
@@ -236,6 +236,13 @@ public:
     return TraitItemReference::error_node ();
   }
 
+  size_t size () const { return item_refs.size (); }
+
+  const std::vector<TraitItemReference> &get_trait_items () const
+  {
+    return item_refs;
+  }
+
 private:
   const HIR::Trait *hir_trait_ref;
   std::vector<TraitItemReference> item_refs;

--- a/gcc/rust/typecheck/rust-hir-trait-ref.h
+++ b/gcc/rust/typecheck/rust-hir-trait-ref.h
@@ -27,6 +27,7 @@ namespace Resolver {
 
 // Data Objects for the associated trait items in a structure we can work with
 // https://doc.rust-lang.org/edition-guide/rust-2018/trait-system/associated-constants.html
+class TypeCheckContext;
 class TraitItemReference
 {
 public:
@@ -39,17 +40,11 @@ public:
   };
 
   TraitItemReference (std::string identifier, bool optional, TraitItemType type,
-		      const HIR::TraitItem *hir_trait_item, TyTy::BaseType *ty,
-		      Location locus)
-    : identifier (identifier), optional_flag (optional), type (type),
-      hir_trait_item (hir_trait_item), ty (ty), locus (locus)
-  {}
+		      HIR::TraitItem *hir_trait_item, TyTy::BaseType *self,
+		      std::vector<TyTy::SubstitutionParamMapping> substitutions,
+		      Location locus);
 
-  TraitItemReference (TraitItemReference const &other)
-    : identifier (other.identifier), optional_flag (other.optional_flag),
-      type (other.type), hir_trait_item (other.hir_trait_item), ty (other.ty),
-      locus (other.locus)
-  {}
+  TraitItemReference (TraitItemReference const &other);
 
   TraitItemReference &operator= (TraitItemReference const &other)
   {
@@ -57,8 +52,13 @@ public:
     optional_flag = other.optional_flag;
     type = other.type;
     hir_trait_item = other.hir_trait_item;
-    ty = other.ty;
+    self = other.self;
     locus = other.locus;
+    context = other.context;
+
+    inherited_substitutions.reserve (other.inherited_substitutions.size ());
+    for (size_t i = 0; i < other.inherited_substitutions.size (); i++)
+      inherited_substitutions.push_back (other.inherited_substitutions.at (i));
 
     return *this;
   }
@@ -68,7 +68,8 @@ public:
 
   static TraitItemReference error ()
   {
-    return TraitItemReference ("", false, ERROR, nullptr, nullptr, Location ());
+    return TraitItemReference ("", false, ERROR, nullptr, nullptr, {},
+			       Location ());
   }
 
   static TraitItemReference &error_node ()
@@ -82,7 +83,7 @@ public:
   std::string as_string () const
   {
     return "(" + trait_item_type_as_string (type) + " " + identifier + " "
-	   + ty->as_string () + ")";
+	   + ")";
   }
 
   static std::string trait_item_type_as_string (TraitItemType ty)
@@ -109,17 +110,65 @@ public:
 
   const HIR::TraitItem *get_hir_trait_item () const { return hir_trait_item; }
 
-  TyTy::BaseType *get_tyty () const { return ty; }
-
   Location get_locus () const { return locus; }
 
+  const Analysis::NodeMapping &get_mappings () const
+  {
+    return hir_trait_item->get_mappings ();
+  }
+
+  TyTy::BaseType *get_tyty () const
+  {
+    rust_assert (hir_trait_item != nullptr);
+
+    switch (type)
+      {
+      case CONST:
+	return get_type_from_constant (
+	  static_cast</*const*/ HIR::TraitItemConst &> (*hir_trait_item));
+	break;
+
+      case TYPE:
+	return get_type_from_typealias (
+	  static_cast</*const*/ HIR::TraitItemType &> (*hir_trait_item));
+
+      case FN:
+	return get_type_from_fn (
+	  static_cast</*const*/ HIR::TraitItemFunc &> (*hir_trait_item));
+	break;
+
+      default:
+	return get_error ();
+      }
+
+    gcc_unreachable ();
+    return get_error ();
+  }
+
 private:
+  TyTy::ErrorType *get_error () const
+  {
+    return new TyTy::ErrorType (get_mappings ().get_hirid ());
+  }
+
+  TyTy::BaseType *get_type_from_typealias (/*const*/
+					   HIR::TraitItemType &type) const;
+
+  TyTy::BaseType *
+  get_type_from_constant (/*const*/ HIR::TraitItemConst &constant) const;
+
+  TyTy::BaseType *get_type_from_fn (/*const*/ HIR::TraitItemFunc &fn) const;
+
   std::string identifier;
   bool optional_flag;
   TraitItemType type;
-  const HIR::TraitItem *hir_trait_item;
-  TyTy::BaseType *ty;
+  HIR::TraitItem *hir_trait_item;
+  std::vector<TyTy::SubstitutionParamMapping> inherited_substitutions;
   Location locus;
+
+  TyTy::BaseType
+    *self; // this is the implict Self TypeParam required for methods
+  Resolver::TypeCheckContext *context;
 };
 
 class TraitReference

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -289,6 +289,7 @@ public:
 	return;
       }
 
+    context->insert_type (trait_item_ref.get_mappings (), lookup->clone ());
     resolved_trait_item = trait_item_ref;
   }
 

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -214,117 +214,109 @@ public:
 
   void visit (HIR::ConstantItem &constant) override
   {
-    TypeCheckImplItem::visit (constant);
-
-    // we get the error checking from the base method here
-    TyTy::BaseType *lookup;
-    if (!context->lookup_type (constant.get_mappings ().get_hirid (), &lookup))
-      return;
-
-    const TraitItemReference &trait_item_ref
-      = trait_reference.lookup_trait_item (
-	constant.get_identifier (), TraitItemReference::TraitItemType::CONST);
+    resolved_trait_item = trait_reference.lookup_trait_item (
+      constant.get_identifier (), TraitItemReference::TraitItemType::CONST);
 
     // unknown trait item
-    if (trait_item_ref.is_error ())
+    if (resolved_trait_item.is_error ())
       {
 	RichLocation r (constant.get_locus ());
 	r.add_range (trait_reference.get_locus ());
 	rust_error_at (r, "constant %<%s%> is not a member of trait %<%s%>",
 		       constant.get_identifier ().c_str (),
 		       trait_reference.get_name ().c_str ());
-	return;
       }
 
+    // normal resolution of the item
+    TypeCheckImplItem::visit (constant);
+    TyTy::BaseType *lookup;
+    if (!context->lookup_type (constant.get_mappings ().get_hirid (), &lookup))
+      return;
+    if (resolved_trait_item.is_error ())
+      return;
+
     // check the types are compatible
-    if (!trait_item_ref.get_tyty ()->can_eq (lookup, true))
+    if (!resolved_trait_item.get_tyty ()->can_eq (lookup, true))
       {
 	RichLocation r (constant.get_locus ());
-	r.add_range (trait_item_ref.get_locus ());
+	r.add_range (resolved_trait_item.get_locus ());
 
 	rust_error_at (
 	  r, "constant %<%s%> has an incompatible type for trait %<%s%>",
 	  constant.get_identifier ().c_str (),
 	  trait_reference.get_name ().c_str ());
-	return;
       }
-
-    resolved_trait_item = trait_item_ref;
   }
 
   void visit (HIR::TypeAlias &type) override
   {
-    TypeCheckImplItem::visit (type);
-
-    // we get the error checking from the base method here
-    TyTy::BaseType *lookup;
-    if (!context->lookup_type (type.get_mappings ().get_hirid (), &lookup))
-      return;
-
-    const TraitItemReference &trait_item_ref
-      = trait_reference.lookup_trait_item (
-	type.get_new_type_name (), TraitItemReference::TraitItemType::TYPE);
+    resolved_trait_item = trait_reference.lookup_trait_item (
+      type.get_new_type_name (), TraitItemReference::TraitItemType::TYPE);
 
     // unknown trait item
-    if (trait_item_ref.is_error ())
+    if (resolved_trait_item.is_error ())
       {
 	RichLocation r (type.get_locus ());
 	r.add_range (trait_reference.get_locus ());
 	rust_error_at (r, "type alias %<%s%> is not a member of trait %<%s%>",
 		       type.get_new_type_name ().c_str (),
 		       trait_reference.get_name ().c_str ());
-	return;
       }
 
+    // normal resolution of the item
+    TypeCheckImplItem::visit (type);
+    TyTy::BaseType *lookup;
+    if (!context->lookup_type (type.get_mappings ().get_hirid (), &lookup))
+      return;
+    if (resolved_trait_item.is_error ())
+      return;
+
     // check the types are compatible
-    if (!trait_item_ref.get_tyty ()->can_eq (lookup, true))
+    if (!resolved_trait_item.get_tyty ()->can_eq (lookup, true))
       {
 	RichLocation r (type.get_locus ());
-	r.add_range (trait_item_ref.get_locus ());
+	r.add_range (resolved_trait_item.get_locus ());
 
 	rust_error_at (
 	  r, "type alias %<%s%> has an incompatible type for trait %<%s%>",
 	  type.get_new_type_name ().c_str (),
 	  trait_reference.get_name ().c_str ());
-	return;
       }
 
-    context->insert_type (trait_item_ref.get_mappings (), lookup->clone ());
-    resolved_trait_item = trait_item_ref;
+    context->insert_type (resolved_trait_item.get_mappings (),
+			  lookup->clone ());
   }
 
   void visit (HIR::Function &function) override
   {
-    TypeCheckImplItem::visit (function);
-
-    // we get the error checking from the base method here
-    TyTy::BaseType *lookup;
-    if (!context->lookup_type (function.get_mappings ().get_hirid (), &lookup))
-      return;
-
-    if (lookup->get_kind () != TyTy::TypeKind::FNDEF)
-      return;
-
-    TyTy::FnType *fntype = static_cast<TyTy::FnType *> (lookup);
-    const TraitItemReference &trait_item_ref
-      = trait_reference.lookup_trait_item (
-	fntype->get_identifier (), TraitItemReference::TraitItemType::FN);
+    resolved_trait_item = trait_reference.lookup_trait_item (
+      function.get_function_name (), TraitItemReference::TraitItemType::FN);
 
     // unknown trait item
-    if (trait_item_ref.is_error ())
+    if (resolved_trait_item.is_error ())
       {
 	RichLocation r (function.get_locus ());
 	r.add_range (trait_reference.get_locus ());
 	rust_error_at (r, "method %<%s%> is not a member of trait %<%s%>",
-		       fntype->get_identifier ().c_str (),
+		       function.get_function_name ().c_str (),
 		       trait_reference.get_name ().c_str ());
-	return;
       }
 
-    rust_assert (trait_item_ref.get_tyty ()->get_kind ()
+    // we get the error checking from the base method here
+    TypeCheckImplItem::visit (function);
+    TyTy::BaseType *lookup;
+    if (!context->lookup_type (function.get_mappings ().get_hirid (), &lookup))
+      return;
+    if (resolved_trait_item.is_error ())
+      return;
+
+    rust_assert (lookup->get_kind () == TyTy::TypeKind::FNDEF);
+    rust_assert (resolved_trait_item.get_tyty ()->get_kind ()
 		 == TyTy::TypeKind::FNDEF);
+
+    TyTy::FnType *fntype = static_cast<TyTy::FnType *> (lookup);
     TyTy::FnType *trait_item_fntype
-      = static_cast<TyTy::FnType *> (trait_item_ref.get_tyty ());
+      = static_cast<TyTy::FnType *> (resolved_trait_item.get_tyty ());
 
     // sets substitute self into the trait_item_ref->tyty
     TyTy::SubstitutionParamMapping *self_mapping = nullptr;
@@ -351,16 +343,13 @@ public:
     if (!trait_item_fntype->can_eq (fntype, true))
       {
 	RichLocation r (function.get_locus ());
-	r.add_range (trait_item_ref.get_locus ());
+	r.add_range (resolved_trait_item.get_locus ());
 
 	rust_error_at (
 	  r, "method %<%s%> has an incompatible type for trait %<%s%>",
 	  fntype->get_identifier ().c_str (),
 	  trait_reference.get_name ().c_str ());
-	return;
       }
-
-    resolved_trait_item = trait_item_ref;
   }
 
 private:

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -409,10 +409,14 @@ TraitItemReference::get_type_from_constant (
   /*const*/ HIR::TraitItemConst &constant) const
 {
   TyTy::BaseType *type = TypeCheckType::Resolve (constant.get_type ().get ());
-  TyTy::BaseType *expr
-    = TypeCheckExpr::Resolve (constant.get_expr ().get (), false);
+  if (constant.has_expr ())
+    {
+      TyTy::BaseType *expr
+	= TypeCheckExpr::Resolve (constant.get_expr ().get (), false);
 
-  return type->unify (expr);
+      return type->unify (expr);
+    }
+  return type;
 }
 
 TyTy::BaseType *

--- a/gcc/testsuite/rust/compile/torture/traits6.rs
+++ b/gcc/testsuite/rust/compile/torture/traits6.rs
@@ -1,0 +1,23 @@
+trait Foo {
+    type A;
+    // { dg-warning "unused name .Foo::A." "" { target *-*-* } .-1 }
+
+    fn baz(a: Self::A) -> Self::A;
+    // { dg-warning "unused name .a." "" { target *-*-* } .-1 }
+    // { dg-warning "unused name .Foo::baz." "" { target *-*-* } .-2 }
+}
+
+struct Bar<T>(T);
+
+impl<T> Foo for Bar<T> {
+    type A = T;
+
+    fn baz(a: Self::A) -> T {
+        a
+    }
+}
+
+fn main() {
+    let a;
+    a = Bar::<i32>::baz(123);
+}

--- a/gcc/testsuite/rust/compile/torture/traits7.rs
+++ b/gcc/testsuite/rust/compile/torture/traits7.rs
@@ -1,0 +1,22 @@
+trait Foo {
+    const A: i32;
+    // { dg-warning "unused name .Foo::A." "" { target *-*-* } .-1 }
+
+    fn test(self);
+    // { dg-warning "unused name .self." "" { target *-*-* } .-1 }
+    // { dg-warning "unused name .Foo::test." "" { target *-*-* } .-2 }
+}
+
+struct Bar;
+impl Foo for Bar {
+    const A: i32 = 123;
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+
+    fn test(self) {}
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+}
+
+fn main() {
+    let a = Bar;
+    a.test();
+}

--- a/gcc/testsuite/rust/compile/traits3.rs
+++ b/gcc/testsuite/rust/compile/traits3.rs
@@ -1,0 +1,22 @@
+trait Foo {
+    type A;
+
+    fn baz(a: Self::A) -> Self::A;
+}
+
+struct Bar<T>(T);
+
+impl<T> Foo for Bar<T> {
+    type A = i32;
+
+    fn baz(a: f32) -> f32 {
+        // { dg-error "expected .i32. got .f32." "" { target *-*-* } .-1 }
+        // { dg-error "method .baz. has an incompatible type for trait .Foo." "" { target *-*-* } .-2 }
+        a
+    }
+}
+
+fn main() {
+    let a;
+    a = Bar::<i32>::baz(123f32);
+}

--- a/gcc/testsuite/rust/compile/traits4.rs
+++ b/gcc/testsuite/rust/compile/traits4.rs
@@ -1,0 +1,16 @@
+trait Foo {
+    const A: i32;
+
+    fn test(self);
+}
+
+struct Bar;
+impl Foo for Bar {
+    // { dg-error "missing A in implementation of trait .Foo." "" { target *-*-* } .-1 }
+    fn test(self) {}
+}
+
+fn main() {
+    let a = Bar;
+    a.test();
+}

--- a/gcc/testsuite/rust/compile/traits5.rs
+++ b/gcc/testsuite/rust/compile/traits5.rs
@@ -1,0 +1,9 @@
+trait Foo {
+    const A: i32;
+
+    fn test(self);
+}
+
+struct Bar;
+impl Foo for Bar {}
+// { dg-error "missing A, test in implementation of trait .Foo." "" { target *-*-* } .-1 }


### PR DESCRIPTION
This PR introduces enhanced type checking for trait constants
and associated types. It also brings in the check to ensure all
mandatory trait items are implemented. Note optional trait items
cannot be referenced or used yet and will be done in a separate PR.