### PR TITLE
Add missing DefId mappings

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-implitem.h
+++ b/gcc/rust/hir/rust-ast-lower-implitem.h
@@ -70,13 +70,14 @@ public:
 				   mappings->get_next_hir_id (crate_num),
 				   mappings->get_next_localdef_id (crate_num));
 
-    translated = new HIR::TypeAlias (mapping, alias.get_new_type_name (),
-				     std::move (generic_params),
-				     std::move (where_clause),
-				     std::unique_ptr<HIR::Type> (existing_type),
-				     std::move (vis), alias.get_outer_attrs (),
-				     alias.get_locus ());
+    auto type_alias = new HIR::TypeAlias (
+      mapping, alias.get_new_type_name (), std::move (generic_params),
+      std::move (where_clause), std::unique_ptr<HIR::Type> (existing_type),
+      std::move (vis), alias.get_outer_attrs (), alias.get_locus ());
 
+    translated = type_alias;
+
+    mappings->insert_defid_mapping (mapping.get_defid (), type_alias);
     mappings->insert_hir_implitem (mapping.get_crate_num (),
 				   mapping.get_hirid (), parent_impl_id,
 				   translated);
@@ -104,6 +105,7 @@ public:
 			       constant.get_locus ());
     translated = translated_constant;
 
+    mappings->insert_defid_mapping (mapping.get_defid (), translated_constant);
     mappings->insert_hir_implitem (mapping.get_crate_num (),
 				   mapping.get_hirid (), parent_impl_id,
 				   translated);
@@ -177,6 +179,7 @@ public:
 			   std::move (vis), function.get_outer_attrs (),
 			   HIR::SelfParam::error (), locus);
 
+    mappings->insert_defid_mapping (mapping.get_defid (), fn);
     mappings->insert_hir_implitem (mapping.get_crate_num (),
 				   mapping.get_hirid (), parent_impl_id, fn);
     mappings->insert_location (crate_num, mapping.get_hirid (),
@@ -257,6 +260,7 @@ public:
 			   std::move (vis), method.get_outer_attrs (),
 			   std::move (self_param), locus);
 
+    mappings->insert_defid_mapping (mapping.get_defid (), mth);
     mappings->insert_hir_implitem (mapping.get_crate_num (),
 				   mapping.get_hirid (), parent_impl_id, mth);
     mappings->insert_location (crate_num, mapping.get_hirid (),

--- a/gcc/rust/hir/rust-ast-lower-implitem.h
+++ b/gcc/rust/hir/rust-ast-lower-implitem.h
@@ -362,7 +362,7 @@ public:
     auto crate_num = mappings->get_current_crate ();
     Analysis::NodeMapping mapping (crate_num, func.get_node_id (),
 				   mappings->get_next_hir_id (crate_num),
-				   UNKNOWN_LOCAL_DEFID);
+				   mappings->get_next_localdef_id (crate_num));
 
     translated
       = new HIR::TraitItemFunc (mapping, std::move (decl),
@@ -426,7 +426,7 @@ public:
     auto crate_num = mappings->get_current_crate ();
     Analysis::NodeMapping mapping (crate_num, method.get_node_id (),
 				   mappings->get_next_hir_id (crate_num),
-				   UNKNOWN_LOCAL_DEFID);
+				   mappings->get_next_localdef_id (crate_num));
 
     translated
       = new HIR::TraitItemFunc (mapping, std::move (decl),
@@ -445,7 +445,7 @@ public:
     auto crate_num = mappings->get_current_crate ();
     Analysis::NodeMapping mapping (crate_num, constant.get_node_id (),
 				   mappings->get_next_hir_id (crate_num),
-				   UNKNOWN_LOCAL_DEFID);
+				   mappings->get_next_localdef_id (crate_num));
 
     translated = new HIR::TraitItemConst (mapping, constant.get_identifier (),
 					  std::unique_ptr<HIR::Type> (type),
@@ -461,7 +461,7 @@ public:
     auto crate_num = mappings->get_current_crate ();
     Analysis::NodeMapping mapping (crate_num, type.get_node_id (),
 				   mappings->get_next_hir_id (crate_num),
-				   UNKNOWN_LOCAL_DEFID);
+				   mappings->get_next_localdef_id (crate_num));
 
     translated
       = new HIR::TraitItemType (mapping, type.get_identifier (),

--- a/gcc/rust/hir/rust-ast-lower-stmt.h
+++ b/gcc/rust/hir/rust-ast-lower-stmt.h
@@ -283,7 +283,7 @@ public:
     auto crate_num = mappings->get_current_crate ();
     Analysis::NodeMapping mapping (crate_num, function.get_node_id (),
 				   mappings->get_next_hir_id (crate_num),
-				   UNKNOWN_LOCAL_DEFID);
+				   mappings->get_next_localdef_id (crate_num));
 
     mappings->insert_location (crate_num,
 			       function_body->get_mappings ().get_hirid (),

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -135,6 +135,7 @@ public:
       }
 
     auto fnType = new TyTy::FnType (function.get_mappings ().get_hirid (),
+				    function.get_mappings ().get_defid (),
 				    function.get_function_name (),
 				    function.is_method (), std::move (params),
 				    ret_type, std::move (substitutions));

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.h
@@ -276,6 +276,7 @@ public:
       }
 
     auto fnType = new TyTy::FnType (function.get_mappings ().get_hirid (),
+				    function.get_mappings ().get_defid (),
 				    function.get_function_name (), false,
 				    std::move (params), ret_type,
 				    std::move (substitutions));

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
@@ -229,6 +229,7 @@ public:
       }
 
     auto fnType = new TyTy::FnType (function.get_mappings ().get_hirid (),
+				    function.get_mappings ().get_defid (),
 				    function.get_function_name (), false,
 				    std::move (params), ret_type,
 				    std::move (substitutions));

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -498,6 +498,7 @@ TraitItemReference::get_type_from_fn (/*const*/ HIR::TraitItemFunc &fn) const
     }
 
   return new TyTy::FnType (fn.get_mappings ().get_hirid (),
+			   fn.get_mappings ().get_defid (),
 			   function.get_function_name (), function.is_method (),
 			   std::move (params), ret_type, substitutions);
 }

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -715,7 +715,7 @@ FnType::clone ()
     cloned_params.push_back (
       std::pair<HIR::Pattern *, BaseType *> (p.first, p.second->clone ()));
 
-  return new FnType (get_ref (), get_ty_ref (), get_identifier (),
+  return new FnType (get_ref (), get_ty_ref (), get_id (), get_identifier (),
 		     is_method_flag, std::move (cloned_params),
 		     get_return_type ()->clone (), clone_substs (),
 		     get_combined_refs ());

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -929,7 +929,7 @@ private:
 class FnType : public BaseType, public SubstitutionRef
 {
 public:
-  FnType (HirId ref, std::string identifier, bool is_method,
+  FnType (HirId ref, DefId id, std::string identifier, bool is_method,
 	  std::vector<std::pair<HIR::Pattern *, BaseType *> > params,
 	  BaseType *type, std::vector<SubstitutionParamMapping> subst_refs,
 	  std::set<HirId> refs = std::set<HirId> ())
@@ -937,10 +937,14 @@ public:
       SubstitutionRef (std::move (subst_refs),
 		       SubstitutionArgumentMappings::error ()),
       params (std::move (params)), type (type), is_method_flag (is_method),
-      identifier (identifier)
-  {}
+      identifier (identifier), id (id)
+  {
+    LocalDefId local_def_id = id & DEF_ID_LOCAL_DEF_MASK;
+    rust_assert (local_def_id != UNKNOWN_LOCAL_DEFID);
+  }
 
-  FnType (HirId ref, HirId ty_ref, std::string identifier, bool is_method,
+  FnType (HirId ref, HirId ty_ref, DefId id, std::string identifier,
+	  bool is_method,
 	  std::vector<std::pair<HIR::Pattern *, BaseType *> > params,
 	  BaseType *type, std::vector<SubstitutionParamMapping> subst_refs,
 	  std::set<HirId> refs = std::set<HirId> ())
@@ -948,8 +952,11 @@ public:
       SubstitutionRef (std::move (subst_refs),
 		       SubstitutionArgumentMappings::error ()),
       params (params), type (type), is_method_flag (is_method),
-      identifier (identifier)
-  {}
+      identifier (identifier), id (id)
+  {
+    LocalDefId local_def_id = id & DEF_ID_LOCAL_DEF_MASK;
+    rust_assert (local_def_id != UNKNOWN_LOCAL_DEFID);
+  }
 
   void accept_vis (TyVisitor &vis) override;
 
@@ -973,6 +980,8 @@ public:
 
     return is_method_flag;
   }
+
+  DefId get_id () const { return id; }
 
   // get the Self type for the method
   BaseType *get_self_type () const
@@ -1026,6 +1035,7 @@ private:
   BaseType *type;
   bool is_method_flag;
   std::string identifier;
+  DefId id;
 };
 
 class FnPtr : public BaseType


### PR DESCRIPTION
DefIds need to be managed for fntypes which will help in the compilation
of optional traitt functions