### PR TITLE
Add missing test case to close out unit-structs

### DIFF
--- a/gcc/testsuite/rust/compile/torture/unit_type5.rs
+++ b/gcc/testsuite/rust/compile/torture/unit_type5.rs
@@ -1,0 +1,8 @@
+struct Foo;
+
+fn main() {
+    let a = Foo {};
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+    let b = Foo;
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
This test case will catch regressions in changes to initializing unit structs.

Fixes #155