### PR TITLE
Cleanup and add const modifiers to equlity interface

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -396,6 +396,8 @@ public:
     mappings->insert_defid_mapping (mapping.get_defid (), translated);
     mappings->insert_hir_item (mapping.get_crate_num (), mapping.get_hirid (),
 			       translated);
+    mappings->insert_hir_impl_block (mapping.get_crate_num (),
+				     mapping.get_hirid (), hir_impl_block);
     mappings->insert_location (crate_num, mapping.get_hirid (),
 			       impl_block.get_locus ());
 
@@ -540,6 +542,8 @@ public:
     mappings->insert_defid_mapping (mapping.get_defid (), translated);
     mappings->insert_hir_item (mapping.get_crate_num (), mapping.get_hirid (),
 			       translated);
+    mappings->insert_hir_impl_block (mapping.get_crate_num (),
+				     mapping.get_hirid (), hir_impl_block);
     mappings->insert_location (crate_num, mapping.get_hirid (),
 			       impl_block.get_locus ());
 

--- a/gcc/rust/typecheck/rust-tyty-visitor.h
+++ b/gcc/rust/typecheck/rust-tyty-visitor.h
@@ -48,6 +48,30 @@ public:
   virtual void visit (PlaceholderType &type) = 0;
 };
 
+class TyConstVisitor
+{
+public:
+  virtual void visit (const InferType &type) = 0;
+  virtual void visit (const ADTType &type) = 0;
+  virtual void visit (const TupleType &type) = 0;
+  virtual void visit (const FnType &type) = 0;
+  virtual void visit (const FnPtr &type) = 0;
+  virtual void visit (const ArrayType &type) = 0;
+  virtual void visit (const BoolType &type) = 0;
+  virtual void visit (const IntType &type) = 0;
+  virtual void visit (const UintType &type) = 0;
+  virtual void visit (const FloatType &type) = 0;
+  virtual void visit (const USizeType &type) = 0;
+  virtual void visit (const ISizeType &type) = 0;
+  virtual void visit (const ErrorType &type) = 0;
+  virtual void visit (const CharType &type) = 0;
+  virtual void visit (const ReferenceType &type) = 0;
+  virtual void visit (const ParamType &type) = 0;
+  virtual void visit (const StrType &type) = 0;
+  virtual void visit (const NeverType &type) = 0;
+  virtual void visit (const PlaceholderType &type) = 0;
+};
+
 } // namespace TyTy
 } // namespace Rust
 

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -75,6 +75,12 @@ InferType::accept_vis (TyVisitor &vis)
   vis.visit (*this);
 }
 
+void
+InferType::accept_vis (TyConstVisitor &vis) const
+{
+  vis.visit (*this);
+}
+
 std::string
 InferType::as_string () const
 {
@@ -98,7 +104,7 @@ InferType::unify (BaseType *other)
 }
 
 bool
-InferType::can_eq (BaseType *other, bool emit_errors)
+InferType::can_eq (const BaseType *other, bool emit_errors) const
 {
   InferCmp r (this, emit_errors);
   return r.can_eq (other);
@@ -142,6 +148,12 @@ ErrorType::accept_vis (TyVisitor &vis)
   vis.visit (*this);
 }
 
+void
+ErrorType::accept_vis (TyConstVisitor &vis) const
+{
+  vis.visit (*this);
+}
+
 std::string
 ErrorType::as_string () const
 {
@@ -155,7 +167,7 @@ ErrorType::unify (BaseType *other)
 }
 
 bool
-ErrorType::can_eq (BaseType *other, bool emit_errors)
+ErrorType::can_eq (const BaseType *other, bool emit_errors) const
 {
   return get_kind () == other->get_kind ();
 }
@@ -379,6 +391,12 @@ ADTType::accept_vis (TyVisitor &vis)
   vis.visit (*this);
 }
 
+void
+ADTType::accept_vis (TyConstVisitor &vis) const
+{
+  vis.visit (*this);
+}
+
 std::string
 ADTType::as_string () const
 {
@@ -421,7 +439,7 @@ ADTType::unify (BaseType *other)
 }
 
 bool
-ADTType::can_eq (BaseType *other, bool emit_errors)
+ADTType::can_eq (const BaseType *other, bool emit_errors) const
 {
   ADTCmp r (this, emit_errors);
   return r.can_eq (other);
@@ -556,6 +574,12 @@ TupleType::accept_vis (TyVisitor &vis)
   vis.visit (*this);
 }
 
+void
+TupleType::accept_vis (TyConstVisitor &vis) const
+{
+  vis.visit (*this);
+}
+
 std::string
 TupleType::as_string () const
 {
@@ -582,7 +606,7 @@ TupleType::unify (BaseType *other)
 }
 
 bool
-TupleType::can_eq (BaseType *other, bool emit_errors)
+TupleType::can_eq (const BaseType *other, bool emit_errors) const
 {
   TupleCmp r (this, emit_errors);
   return r.can_eq (other);
@@ -642,6 +666,12 @@ FnType::accept_vis (TyVisitor &vis)
   vis.visit (*this);
 }
 
+void
+FnType::accept_vis (TyConstVisitor &vis) const
+{
+  vis.visit (*this);
+}
+
 std::string
 FnType::as_string () const
 {
@@ -666,7 +696,7 @@ FnType::unify (BaseType *other)
 }
 
 bool
-FnType::can_eq (BaseType *other, bool emit_errors)
+FnType::can_eq (const BaseType *other, bool emit_errors) const
 {
   FnCmp r (this, emit_errors);
   return r.can_eq (other);
@@ -842,6 +872,12 @@ FnPtr::accept_vis (TyVisitor &vis)
   vis.visit (*this);
 }
 
+void
+FnPtr::accept_vis (TyConstVisitor &vis) const
+{
+  vis.visit (*this);
+}
+
 std::string
 FnPtr::as_string () const
 {
@@ -861,7 +897,7 @@ FnPtr::unify (BaseType *other)
 }
 
 bool
-FnPtr::can_eq (BaseType *other, bool emit_errors)
+FnPtr::can_eq (const BaseType *other, bool emit_errors) const
 {
   FnptrCmp r (this, emit_errors);
   return r.can_eq (other);
@@ -907,6 +943,12 @@ ArrayType::accept_vis (TyVisitor &vis)
   vis.visit (*this);
 }
 
+void
+ArrayType::accept_vis (TyConstVisitor &vis) const
+{
+  vis.visit (*this);
+}
+
 std::string
 ArrayType::as_string () const
 {
@@ -928,7 +970,7 @@ ArrayType::unify (BaseType *other)
 }
 
 bool
-ArrayType::can_eq (BaseType *other, bool emit_errors)
+ArrayType::can_eq (const BaseType *other, bool emit_errors) const
 {
   ArrayCmp r (this, emit_errors);
   return r.can_eq (other);
@@ -969,6 +1011,12 @@ BoolType::accept_vis (TyVisitor &vis)
   vis.visit (*this);
 }
 
+void
+BoolType::accept_vis (TyConstVisitor &vis) const
+{
+  vis.visit (*this);
+}
+
 std::string
 BoolType::as_string () const
 {
@@ -983,7 +1031,7 @@ BoolType::unify (BaseType *other)
 }
 
 bool
-BoolType::can_eq (BaseType *other, bool emit_errors)
+BoolType::can_eq (const BaseType *other, bool emit_errors) const
 {
   BoolCmp r (this, emit_errors);
   return r.can_eq (other);
@@ -997,6 +1045,12 @@ BoolType::clone ()
 
 void
 IntType::accept_vis (TyVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+void
+IntType::accept_vis (TyConstVisitor &vis) const
 {
   vis.visit (*this);
 }
@@ -1029,7 +1083,7 @@ IntType::unify (BaseType *other)
 }
 
 bool
-IntType::can_eq (BaseType *other, bool emit_errors)
+IntType::can_eq (const BaseType *other, bool emit_errors) const
 {
   IntCmp r (this, emit_errors);
   return r.can_eq (other);
@@ -1054,6 +1108,12 @@ IntType::is_equal (const BaseType &other) const
 
 void
 UintType::accept_vis (TyVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+void
+UintType::accept_vis (TyConstVisitor &vis) const
 {
   vis.visit (*this);
 }
@@ -1086,7 +1146,7 @@ UintType::unify (BaseType *other)
 }
 
 bool
-UintType::can_eq (BaseType *other, bool emit_errors)
+UintType::can_eq (const BaseType *other, bool emit_errors) const
 {
   UintCmp r (this, emit_errors);
   return r.can_eq (other);
@@ -1115,6 +1175,12 @@ FloatType::accept_vis (TyVisitor &vis)
   vis.visit (*this);
 }
 
+void
+FloatType::accept_vis (TyConstVisitor &vis) const
+{
+  vis.visit (*this);
+}
+
 std::string
 FloatType::as_string () const
 {
@@ -1137,7 +1203,7 @@ FloatType::unify (BaseType *other)
 }
 
 bool
-FloatType::can_eq (BaseType *other, bool emit_errors)
+FloatType::can_eq (const BaseType *other, bool emit_errors) const
 {
   FloatCmp r (this, emit_errors);
   return r.can_eq (other);
@@ -1166,6 +1232,12 @@ USizeType::accept_vis (TyVisitor &vis)
   vis.visit (*this);
 }
 
+void
+USizeType::accept_vis (TyConstVisitor &vis) const
+{
+  vis.visit (*this);
+}
+
 std::string
 USizeType::as_string () const
 {
@@ -1180,7 +1252,7 @@ USizeType::unify (BaseType *other)
 }
 
 bool
-USizeType::can_eq (BaseType *other, bool emit_errors)
+USizeType::can_eq (const BaseType *other, bool emit_errors) const
 {
   USizeCmp r (this, emit_errors);
   return r.can_eq (other);
@@ -1194,6 +1266,12 @@ USizeType::clone ()
 
 void
 ISizeType::accept_vis (TyVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+void
+ISizeType::accept_vis (TyConstVisitor &vis) const
 {
   vis.visit (*this);
 }
@@ -1212,7 +1290,7 @@ ISizeType::unify (BaseType *other)
 }
 
 bool
-ISizeType::can_eq (BaseType *other, bool emit_errors)
+ISizeType::can_eq (const BaseType *other, bool emit_errors) const
 {
   ISizeCmp r (this, emit_errors);
   return r.can_eq (other);
@@ -1226,6 +1304,12 @@ ISizeType::clone ()
 
 void
 CharType::accept_vis (TyVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+void
+CharType::accept_vis (TyConstVisitor &vis) const
 {
   vis.visit (*this);
 }
@@ -1244,7 +1328,7 @@ CharType::unify (BaseType *other)
 }
 
 bool
-CharType::can_eq (BaseType *other, bool emit_errors)
+CharType::can_eq (const BaseType *other, bool emit_errors) const
 {
   CharCmp r (this, emit_errors);
   return r.can_eq (other);
@@ -1258,6 +1342,12 @@ CharType::clone ()
 
 void
 ReferenceType::accept_vis (TyVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+void
+ReferenceType::accept_vis (TyConstVisitor &vis) const
 {
   vis.visit (*this);
 }
@@ -1276,7 +1366,7 @@ ReferenceType::unify (BaseType *other)
 }
 
 bool
-ReferenceType::can_eq (BaseType *other, bool emit_errors)
+ReferenceType::can_eq (const BaseType *other, bool emit_errors) const
 {
   ReferenceCmp r (this, emit_errors);
   return r.can_eq (other);
@@ -1327,6 +1417,12 @@ ParamType::accept_vis (TyVisitor &vis)
   vis.visit (*this);
 }
 
+void
+ParamType::accept_vis (TyConstVisitor &vis) const
+{
+  vis.visit (*this);
+}
+
 std::string
 ParamType::as_string () const
 {
@@ -1351,7 +1447,7 @@ ParamType::unify (BaseType *other)
 }
 
 bool
-ParamType::can_eq (BaseType *other, bool emit_errors)
+ParamType::can_eq (const BaseType *other, bool emit_errors) const
 {
   ParamCmp r (this, emit_errors);
   return r.can_eq (other);
@@ -1437,6 +1533,12 @@ StrType::accept_vis (TyVisitor &vis)
   vis.visit (*this);
 }
 
+void
+StrType::accept_vis (TyConstVisitor &vis) const
+{
+  vis.visit (*this);
+}
+
 std::string
 StrType::as_string () const
 {
@@ -1451,7 +1553,7 @@ StrType::unify (BaseType *other)
 }
 
 bool
-StrType::can_eq (BaseType *other, bool emit_errors)
+StrType::can_eq (const BaseType *other, bool emit_errors) const
 {
   StrCmp r (this, emit_errors);
   return r.can_eq (other);
@@ -1465,6 +1567,12 @@ StrType::is_equal (const BaseType &other) const
 
 void
 NeverType::accept_vis (TyVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+void
+NeverType::accept_vis (TyConstVisitor &vis) const
 {
   vis.visit (*this);
 }
@@ -1483,7 +1591,7 @@ NeverType::unify (BaseType *other)
 }
 
 bool
-NeverType::can_eq (BaseType *other, bool emit_errors)
+NeverType::can_eq (const BaseType *other, bool emit_errors) const
 {
   NeverCmp r (this, emit_errors);
   return r.can_eq (other);
@@ -1497,6 +1605,12 @@ NeverType::clone ()
 
 void
 PlaceholderType::accept_vis (TyVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+void
+PlaceholderType::accept_vis (TyConstVisitor &vis) const
 {
   vis.visit (*this);
 }
@@ -1515,7 +1629,7 @@ PlaceholderType::unify (BaseType *other)
 }
 
 bool
-PlaceholderType::can_eq (BaseType *other, bool emit_errors)
+PlaceholderType::can_eq (const BaseType *other, bool emit_errors) const
 {
   PlaceholderCmp r (this, emit_errors);
   return r.can_eq (other);

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -122,6 +122,7 @@ public:
 };
 
 class TyVisitor;
+class TyConstVisitor;
 class BaseType
 {
 public:
@@ -140,8 +141,9 @@ public:
 
   void set_ty_ref (HirId id) { ty_ref = id; }
 
-  /* Visitor pattern for double dispatch. BaseRules implements TyVisitor. */
   virtual void accept_vis (TyVisitor &vis) = 0;
+
+  virtual void accept_vis (TyConstVisitor &vis) const = 0;
 
   virtual std::string as_string () const = 0;
 
@@ -155,7 +157,7 @@ public:
 
   // similar to unify but does not actually perform type unification but
   // determines whether they are compatible
-  virtual bool can_eq (BaseType *other, bool emit_errors) = 0;
+  virtual bool can_eq (const BaseType *other, bool emit_errors) const = 0;
 
   // Check value equality between two ty. Type inference rules are ignored. Two
   //   ty are considered equal if they're of the same kind, and
@@ -269,12 +271,13 @@ public:
   {}
 
   void accept_vis (TyVisitor &vis) override;
+  void accept_vis (TyConstVisitor &vis) const override;
 
   std::string as_string () const override;
 
   BaseType *unify (BaseType *other) override;
 
-  bool can_eq (BaseType *other, bool emit_errors) override;
+  bool can_eq (const BaseType *other, bool emit_errors) const override final;
 
   BaseType *clone () final override;
 
@@ -302,13 +305,14 @@ public:
   {}
 
   void accept_vis (TyVisitor &vis) override;
+  void accept_vis (TyConstVisitor &vis) const override;
 
   bool is_unit () const override { return true; }
 
   std::string as_string () const override;
 
   BaseType *unify (BaseType *other) override;
-  bool can_eq (BaseType *other, bool emit_errors) override;
+  bool can_eq (const BaseType *other, bool emit_errors) const override final;
 
   BaseType *clone () final override;
 
@@ -332,11 +336,12 @@ public:
   {}
 
   void accept_vis (TyVisitor &vis) override;
+  void accept_vis (TyConstVisitor &vis) const override;
 
   std::string as_string () const override;
 
   BaseType *unify (BaseType *other) override;
-  bool can_eq (BaseType *other, bool emit_errors) override;
+  bool can_eq (const BaseType *other, bool emit_errors) const override final;
 
   BaseType *clone () final override;
 
@@ -415,13 +420,14 @@ public:
   static TupleType *get_unit_type (HirId ref) { return new TupleType (ref); }
 
   void accept_vis (TyVisitor &vis) override;
+  void accept_vis (TyConstVisitor &vis) const override;
 
   bool is_unit () const override { return this->fields.empty (); }
 
   std::string as_string () const override;
 
   BaseType *unify (BaseType *other) override;
-  bool can_eq (BaseType *other, bool emit_errors) override;
+  bool can_eq (const BaseType *other, bool emit_errors) const override final;
 
   bool is_equal (const BaseType &other) const override;
 
@@ -849,11 +855,12 @@ public:
   bool is_unit () const override { return this->fields.empty (); }
 
   void accept_vis (TyVisitor &vis) override;
+  void accept_vis (TyConstVisitor &vis) const override;
 
   std::string as_string () const override;
 
   BaseType *unify (BaseType *other) override;
-  bool can_eq (BaseType *other, bool emit_errors) override;
+  bool can_eq (const BaseType *other, bool emit_errors) const override final;
 
   bool is_equal (const BaseType &other) const override;
 
@@ -873,6 +880,11 @@ public:
   const StructFieldType *get_field (size_t index) const;
 
   StructFieldType *get_field (size_t index) { return fields.at (index); }
+
+  const StructFieldType *get_imm_field (size_t index) const
+  {
+    return fields.at (index);
+  }
 
   StructFieldType *get_field (const std::string &lookup,
 			      size_t *index = nullptr) const
@@ -959,6 +971,7 @@ public:
   }
 
   void accept_vis (TyVisitor &vis) override;
+  void accept_vis (TyConstVisitor &vis) const override;
 
   std::string as_string () const override;
 
@@ -967,7 +980,7 @@ public:
   std::string get_identifier () const { return identifier; }
 
   BaseType *unify (BaseType *other) override;
-  bool can_eq (BaseType *other, bool emit_errors) override;
+  bool can_eq (const BaseType *other, bool emit_errors) const override final;
 
   bool is_equal (const BaseType &other) const override;
 
@@ -1062,11 +1075,12 @@ public:
   BaseType *param_at (size_t idx) const { return params.at (idx).get_tyty (); }
 
   void accept_vis (TyVisitor &vis) override;
+  void accept_vis (TyConstVisitor &vis) const override;
 
   std::string as_string () const override;
 
   BaseType *unify (BaseType *other) override;
-  bool can_eq (BaseType *other, bool emit_errors) override;
+  bool can_eq (const BaseType *other, bool emit_errors) const override final;
 
   bool is_equal (const BaseType &other) const override;
 
@@ -1102,13 +1116,14 @@ public:
   {}
 
   void accept_vis (TyVisitor &vis) override;
+  void accept_vis (TyConstVisitor &vis) const override;
 
   std::string as_string () const override;
 
   std::string get_name () const override final { return as_string (); }
 
   BaseType *unify (BaseType *other) override;
-  bool can_eq (BaseType *other, bool emit_errors) override;
+  bool can_eq (const BaseType *other, bool emit_errors) const override final;
 
   bool is_equal (const BaseType &other) const override;
 
@@ -1141,13 +1156,14 @@ public:
   {}
 
   void accept_vis (TyVisitor &vis) override;
+  void accept_vis (TyConstVisitor &vis) const override;
 
   std::string as_string () const override;
 
   std::string get_name () const override final { return as_string (); }
 
   BaseType *unify (BaseType *other) override;
-  bool can_eq (BaseType *other, bool emit_errors) override;
+  bool can_eq (const BaseType *other, bool emit_errors) const override final;
 
   BaseType *clone () final override;
 };
@@ -1174,13 +1190,14 @@ public:
   {}
 
   void accept_vis (TyVisitor &vis) override;
+  void accept_vis (TyConstVisitor &vis) const override;
 
   std::string as_string () const override;
 
   std::string get_name () const override final { return as_string (); }
 
   BaseType *unify (BaseType *other) override;
-  bool can_eq (BaseType *other, bool emit_errors) override;
+  bool can_eq (const BaseType *other, bool emit_errors) const override final;
 
   IntKind get_int_kind () const { return int_kind; }
 
@@ -1214,13 +1231,14 @@ public:
   {}
 
   void accept_vis (TyVisitor &vis) override;
+  void accept_vis (TyConstVisitor &vis) const override;
 
   std::string as_string () const override;
 
   std::string get_name () const override final { return as_string (); }
 
   BaseType *unify (BaseType *other) override;
-  bool can_eq (BaseType *other, bool emit_errors) override;
+  bool can_eq (const BaseType *other, bool emit_errors) const override final;
 
   UintKind get_uint_kind () const { return uint_kind; }
 
@@ -1252,13 +1270,14 @@ public:
   {}
 
   void accept_vis (TyVisitor &vis) override;
+  void accept_vis (TyConstVisitor &vis) const override;
 
   std::string as_string () const override;
 
   std::string get_name () const override final { return as_string (); }
 
   BaseType *unify (BaseType *other) override;
-  bool can_eq (BaseType *other, bool emit_errors) override;
+  bool can_eq (const BaseType *other, bool emit_errors) const override final;
 
   FloatKind get_float_kind () const { return float_kind; }
 
@@ -1292,13 +1311,14 @@ public:
   }
 
   void accept_vis (TyVisitor &vis) override;
+  void accept_vis (TyConstVisitor &vis) const override;
 
   std::string as_string () const override;
 
   std::string get_name () const override final { return as_string (); }
 
   BaseType *unify (BaseType *other) override;
-  bool can_eq (BaseType *other, bool emit_errors) override;
+  bool can_eq (const BaseType *other, bool emit_errors) const override final;
 
   BaseType *clone () final override;
 };
@@ -1325,13 +1345,14 @@ public:
   }
 
   void accept_vis (TyVisitor &vis) override;
+  void accept_vis (TyConstVisitor &vis) const override;
 
   std::string as_string () const override;
 
   std::string get_name () const override final { return as_string (); }
 
   BaseType *unify (BaseType *other) override;
-  bool can_eq (BaseType *other, bool emit_errors) override;
+  bool can_eq (const BaseType *other, bool emit_errors) const override final;
 
   BaseType *clone () final override;
 };
@@ -1358,13 +1379,14 @@ public:
   }
 
   void accept_vis (TyVisitor &vis) override;
+  void accept_vis (TyConstVisitor &vis) const override;
 
   std::string as_string () const override;
 
   std::string get_name () const override final { return as_string (); }
 
   BaseType *unify (BaseType *other) override;
-  bool can_eq (BaseType *other, bool emit_errors) override;
+  bool can_eq (const BaseType *other, bool emit_errors) const override final;
 
   BaseType *clone () final override;
 };
@@ -1395,13 +1417,14 @@ public:
   BaseType *get_base () const;
 
   void accept_vis (TyVisitor &vis) override;
+  void accept_vis (TyConstVisitor &vis) const override;
 
   std::string as_string () const override;
 
   std::string get_name () const override final { return as_string (); }
 
   BaseType *unify (BaseType *other) override;
-  bool can_eq (BaseType *other, bool emit_errors) override;
+  bool can_eq (const BaseType *other, bool emit_errors) const override final;
 
   bool is_equal (const BaseType &other) const override;
 
@@ -1442,11 +1465,12 @@ public:
   std::string get_name () const override final { return as_string (); }
 
   void accept_vis (TyVisitor &vis) override;
+  void accept_vis (TyConstVisitor &vis) const override;
 
   std::string as_string () const override;
 
   BaseType *unify (BaseType *other) override;
-  bool can_eq (BaseType *other, bool emit_errors) override;
+  bool can_eq (const BaseType *other, bool emit_errors) const override final;
 
   bool is_equal (const BaseType &other) const override;
 
@@ -1475,11 +1499,12 @@ public:
   {}
 
   void accept_vis (TyVisitor &vis) override;
+  void accept_vis (TyConstVisitor &vis) const override;
 
   std::string as_string () const override;
 
   BaseType *unify (BaseType *other) override;
-  bool can_eq (BaseType *other, bool emit_errors) override;
+  bool can_eq (const BaseType *other, bool emit_errors) const override final;
 
   BaseType *clone () final override;
 
@@ -1503,11 +1528,12 @@ public:
   {}
 
   void accept_vis (TyVisitor &vis) override;
+  void accept_vis (TyConstVisitor &vis) const override;
 
   std::string as_string () const override;
 
   BaseType *unify (BaseType *other) override;
-  bool can_eq (BaseType *other, bool emit_errors) override;
+  bool can_eq (const BaseType *other, bool emit_errors) const override final;
 
   BaseType *clone () final override;
 

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -260,6 +260,30 @@ Mappings::lookup_hir_item (CrateNum crateNum, HirId id)
 }
 
 void
+Mappings::insert_hir_impl_block (CrateNum crateNum, HirId id,
+				 HIR::ImplBlock *item)
+{
+  rust_assert (lookup_hir_impl_block (crateNum, id) == nullptr);
+
+  hirImplBlockMappings[crateNum][id] = item;
+  nodeIdToHirMappings[crateNum][item->get_mappings ().get_nodeid ()] = id;
+}
+
+HIR::ImplBlock *
+Mappings::lookup_hir_impl_block (CrateNum crateNum, HirId id)
+{
+  auto it = hirImplBlockMappings.find (crateNum);
+  if (it == hirImplBlockMappings.end ())
+    return nullptr;
+
+  auto iy = it->second.find (id);
+  if (iy == it->second.end ())
+    return nullptr;
+
+  return iy->second;
+}
+
+void
 Mappings::insert_hir_implitem (CrateNum crateNum, HirId id,
 			       HirId parent_impl_id, HIR::ImplItem *item)
 {

--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -128,6 +128,10 @@ public:
   void insert_hir_item (CrateNum crateNum, HirId id, HIR::Item *item);
   HIR::Item *lookup_hir_item (CrateNum crateNum, HirId id);
 
+  void insert_hir_impl_block (CrateNum crateNum, HirId id,
+			      HIR::ImplBlock *item);
+  HIR::ImplBlock *lookup_hir_impl_block (CrateNum crateNum, HirId id);
+
   void insert_hir_implitem (CrateNum crateNum, HirId id, HirId parent_impl_id,
 			    HIR::ImplItem *item);
   HIR::ImplItem *lookup_hir_implitem (CrateNum crateNum, HirId id,
@@ -227,6 +231,7 @@ private:
     hirImplItemMappings;
   std::map<CrateNum, std::map<HirId, HIR::SelfParam *> > hirSelfParamMappings;
   std::map<HirId, HIR::ImplBlock *> hirImplItemsToImplMappings;
+  std::map<CrateNum, std::map<HirId, HIR::ImplBlock *> > hirImplBlockMappings;
 
   // location info
   std::map<CrateNum, std::map<NodeId, Location> > locations;


### PR DESCRIPTION
As part of an effort to cleanup some of the interfaces within the TyTy module
this PR adds a const visitor for accessing each type and updates the can_eq
interface to also be const as it should not require mutability.

These changes fell out of a branch for optional trait items support.