### PR TITLE
HIR and GENERIC lowering for unsafe blocks

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -527,6 +527,11 @@ public:
       }
   }
 
+  void visit (HIR::UnsafeBlockExpr &expr) override
+  {
+    expr.get_block_expr ()->accept_vis (*this);
+  }
+
   void visit (HIR::StructExprStruct &struct_expr) override
   {
     TyTy::BaseType *tyty = nullptr;

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -135,6 +135,11 @@ public:
     translated = ASTLoweringBlock::translate (&expr, &terminated);
   }
 
+  void visit (AST::UnsafeBlockExpr &expr) override
+  {
+    translated = ASTLoweringBlock::translate (&expr, &terminated);
+  }
+
   void visit (AST::PathInExpression &expr) override
   {
     translated = ASTLowerPathInExpression::translate (&expr);

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -3138,6 +3138,8 @@ public:
 
   void accept_vis (HIRVisitor &vis) override;
 
+  std::unique_ptr<BlockExpr> &get_block_expr () { return expr; }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */

--- a/gcc/rust/resolve/rust-ast-resolve-expr.h
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.h
@@ -196,6 +196,11 @@ public:
 
   void visit (AST::BlockExpr &expr) override;
 
+  void visit (AST::UnsafeBlockExpr &expr) override
+  {
+    expr.get_block_expr ()->accept_vis (*this);
+  }
+
   void visit (AST::ArrayElemsValues &elems) override
   {
     elems.iterate ([&] (AST::Expr *elem) mutable -> bool {

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -711,6 +711,12 @@ public:
 
   void visit (HIR::BlockExpr &expr) override;
 
+  void visit (HIR::UnsafeBlockExpr &expr) override
+  {
+    infered
+      = TypeCheckExpr::Resolve (expr.get_block_expr ().get (), inside_loop);
+  }
+
   void visit (HIR::ArrayIndexExpr &expr) override
   {
     TyTy::BaseType *size_ty;

--- a/gcc/testsuite/rust/compile/torture/unsafe1.rs
+++ b/gcc/testsuite/rust/compile/torture/unsafe1.rs
@@ -1,0 +1,12 @@
+fn test() -> i32 {
+    unsafe {
+        let a;
+        a = 123;
+        a
+    }
+}
+
+fn main() {
+    let a;
+    a = test();
+}

--- a/gcc/testsuite/rust/compile/torture/unsafe2.rs
+++ b/gcc/testsuite/rust/compile/torture/unsafe2.rs
@@ -1,0 +1,4 @@
+fn main() {
+    unsafe {}
+    ()
+}

--- a/gcc/testsuite/rust/compile/unsafe.rs
+++ b/gcc/testsuite/rust/compile/unsafe.rs
@@ -1,5 +1,0 @@
-fn main() { // { dg-ice "#382" }
-    unsafe {
-    }
-    ()
-}


### PR DESCRIPTION
This wires up the code nessecary to compile an unsafe block
it does not implement any rules or checks yet.

Fixes #382 