### PR TITLE
Add iterate impl_blocks helper

### DIFF
--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -567,5 +567,21 @@ Mappings::iterate_impl_items (
     }
 }
 
+void
+Mappings::iterate_impl_blocks (std::function<bool (HirId, HIR::ImplBlock *)> cb)
+{
+  for (auto it = hirImplBlockMappings.begin ();
+       it != hirImplBlockMappings.end (); it++)
+    {
+      for (auto iy = it->second.begin (); iy != it->second.end (); iy++)
+	{
+	  HirId id = iy->first;
+	  HIR::ImplBlock *impl_block = iy->second;
+	  if (!cb (id, impl_block))
+	    return;
+	}
+    }
+}
+
 } // namespace Analysis
 } // namespace Rust

--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -198,6 +198,8 @@ public:
   void iterate_impl_items (
     std::function<bool (HirId, HIR::ImplItem *, HIR::ImplBlock *)> cb);
 
+  void iterate_impl_blocks (std::function<bool (HirId, HIR::ImplBlock *)> cb);
+
   bool is_impl_item (HirId id)
   {
     HirId parent_impl_block_id = UNKNOWN_HIRID;


### PR DESCRIPTION
This helper will allow use to use mappings to iterate
all impl blocks within the specified crate.