### PR TITLE
Add testcase to cover parse errors in unsafe expressions

### DIFF
--- a/gcc/testsuite/rust/compile/torture/unsafe3.rs
+++ b/gcc/testsuite/rust/compile/torture/unsafe3.rs
@@ -1,0 +1,9 @@
+pub fn test() -> i32 {
+    let a = unsafe { 123 };
+    a
+}
+
+pub fn main() {
+    let a = test();
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
Fixes #584
