### PR TITLE
Support dereference of pointers

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -1103,15 +1103,29 @@ public:
   {
     TyTy::BaseType *resolved_base
       = TypeCheckExpr::Resolve (expr.get_expr ().get (), false);
-    if (resolved_base->get_kind () != TyTy::TypeKind::REF)
+
+    bool is_valid_type
+      = resolved_base->get_kind () == TyTy::TypeKind::REF
+	|| resolved_base->get_kind () == TyTy::TypeKind::POINTER;
+    if (!is_valid_type)
       {
 	rust_error_at (expr.get_locus (), "expected reference type got %s",
 		       resolved_base->as_string ().c_str ());
 	return;
       }
 
-    TyTy::ReferenceType *ref_base = (TyTy::ReferenceType *) resolved_base;
-    infered = ref_base->get_base ()->clone ();
+    if (resolved_base->get_kind () == TyTy::TypeKind::REF)
+      {
+	TyTy::ReferenceType *ref_base
+	  = static_cast<TyTy::ReferenceType *> (resolved_base);
+	infered = ref_base->get_base ()->clone ();
+      }
+    else
+      {
+	TyTy::PointerType *ref_base
+	  = static_cast<TyTy::PointerType *> (resolved_base);
+	infered = ref_base->get_base ()->clone ();
+      }
   }
 
 private:

--- a/gcc/testsuite/rust/compile/torture/pointer1.rs
+++ b/gcc/testsuite/rust/compile/torture/pointer1.rs
@@ -1,0 +1,9 @@
+pub fn main() {
+    let mut num = 2;
+    let r1: *const i32 = &num;
+    let r2 = unsafe { *r1 } + unsafe { *r1 };
+    let r3 = num;
+    num = 4;
+    let r4 = num + unsafe { *r1 } * r3;
+    let _eightteen = r2 + r3 + r4;
+}


### PR DESCRIPTION
Dereference expressions can also be pointer types not just references.

Fixes #588