### PR TITLE
Support byte and byte string literals

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -278,7 +278,14 @@ public:
 	}
 	return;
 
-	case HIR::Literal::STRING: {
+	case HIR::Literal::BYTE: {
+	  char c = literal_value->as_string ().c_str ()[0];
+	  translated = ctx->get_backend ()->char_constant_expression (c);
+	}
+	return;
+
+      case HIR::Literal::STRING:
+	case HIR::Literal::BYTE_STRING: {
 	  auto base = ctx->get_backend ()->string_constant_expression (
 	    literal_value->as_string ());
 	  translated

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -12545,9 +12545,17 @@ Parser<ManagedTokenSource>::null_denotation (const_TokenPtr tok,
       return std::unique_ptr<AST::LiteralExpr> (
 	new AST::LiteralExpr (tok->get_str (), AST::Literal::STRING,
 			      tok->get_type_hint (), {}, tok->get_locus ()));
+    case BYTE_STRING_LITERAL:
+      return std::unique_ptr<AST::LiteralExpr> (
+	new AST::LiteralExpr (tok->get_str (), AST::Literal::BYTE_STRING,
+			      tok->get_type_hint (), {}, tok->get_locus ()));
     case CHAR_LITERAL:
       return std::unique_ptr<AST::LiteralExpr> (
 	new AST::LiteralExpr (tok->get_str (), AST::Literal::CHAR,
+			      tok->get_type_hint (), {}, tok->get_locus ()));
+    case BYTE_CHAR_LITERAL:
+      return std::unique_ptr<AST::LiteralExpr> (
+	new AST::LiteralExpr (tok->get_str (), AST::Literal::BYTE,
 			      tok->get_type_hint (), {}, tok->get_locus ()));
     case TRUE_LITERAL:
       return std::unique_ptr<AST::LiteralExpr> (

--- a/gcc/rust/rust-backend.h
+++ b/gcc/rust/rust-backend.h
@@ -332,6 +332,9 @@ public:
   virtual Bexpression *string_constant_expression (const std::string &val) = 0;
 
   // Get a char literal
+  virtual Bexpression *char_constant_expression (char c) = 0;
+
+  // Get a char literal
   virtual Bexpression *wchar_constant_expression (wchar_t c) = 0;
 
   // Return an expression for the boolean value VAL.

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -333,6 +333,8 @@ public:
 
   Bexpression *wchar_constant_expression (wchar_t c);
 
+  Bexpression *char_constant_expression (char c);
+
   Bexpression *boolean_constant_expression (bool val);
 
   Bexpression *real_part_expression (Bexpression *bcomplex, Location);
@@ -1554,6 +1556,13 @@ Bexpression *
 Gcc_backend::wchar_constant_expression (wchar_t c)
 {
   tree ret = build_int_cst (this->wchar_type ()->get_tree (), c);
+  return this->make_expression (ret);
+}
+
+Bexpression *
+Gcc_backend::char_constant_expression (char c)
+{
+  tree ret = build_int_cst (this->char_type ()->get_tree (), c);
   return this->make_expression (ret);
 }
 

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -542,7 +542,26 @@ public:
 	}
 	break;
 
+	case HIR::Literal::LitType::BYTE: {
+	  auto ok = context->lookup_builtin ("u8", &infered);
+	  rust_assert (ok);
+	}
+	break;
+
 	case HIR::Literal::LitType::STRING: {
+	  TyTy::BaseType *base = nullptr;
+	  auto ok = context->lookup_builtin ("str", &base);
+	  rust_assert (ok);
+
+	  infered
+	    = new TyTy::ReferenceType (expr.get_mappings ().get_hirid (),
+				       TyTy::TyVar (base->get_ref ()), false);
+	}
+	break;
+
+	case HIR::Literal::LitType::BYTE_STRING: {
+	  /* We just treat this as a string, but it really is an arraytype of
+	     u8. It isn't in UTF-8, but really just a byte array.  */
 	  TyTy::BaseType *base = nullptr;
 	  auto ok = context->lookup_builtin ("str", &base);
 	  rust_assert (ok);

--- a/gcc/testsuite/rust/compile/torture/byte_char_str.rs
+++ b/gcc/testsuite/rust/compile/torture/byte_char_str.rs
@@ -1,0 +1,8 @@
+pub fn main ()
+{
+  let _c = 'x';
+  let _bc = b'x';
+
+  let _s = "abc";
+  let _bs = b"abc";
+}


### PR DESCRIPTION
A byte literal is an u8 created as a ascii char or hex escape
e.g. b'X'.  A byte string literal is a string created from ascii or
hex chars. bytes are represented as u8 and byte strings as str (with
just ascii < 256 chars), but it should really be &'static [u8; n].