### PR TITLE
union support for hir type checking and gcc backend

### DIFF
--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -2489,6 +2489,15 @@ public:
   std::vector<StructField> &get_variants () { return variants; }
   const std::vector<StructField> &get_variants () const { return variants; }
 
+  void iterate (std::function<bool (StructField &)> cb)
+  {
+    for (auto &variant : variants)
+      {
+	if (!cb (variant))
+	  return;
+      }
+  }
+
   std::vector<std::unique_ptr<GenericParam> > &get_generic_params ()
   {
     return generic_params;
@@ -2504,6 +2513,8 @@ public:
     rust_assert (has_where_clause ());
     return where_clause;
   }
+
+  Identifier get_identifier () const { return union_name; }
 
 protected:
   /* Use covariance to implement clone function as returning this object

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -417,9 +417,13 @@ public:
 	fields.push_back (std::move (f));
       }
 
-    Btype *struct_type_record = ctx->get_backend ()->struct_type (fields);
+    Btype *type_record;
+    if (type.is_union ())
+      type_record = ctx->get_backend ()->union_type (fields);
+    else
+      type_record = ctx->get_backend ()->struct_type (fields);
     Btype *named_struct
-      = ctx->get_backend ()->named_type (type.get_name (), struct_type_record,
+      = ctx->get_backend ()->named_type (type.get_name (), type_record,
 					 ctx->get_mappings ()->lookup_location (
 					   type.get_ty_ref ()));
 

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -80,7 +80,7 @@ public:
       }
 
     translated
-      = ctx->get_backend ()->constructor_expression (tuple_type, vals,
+      = ctx->get_backend ()->constructor_expression (tuple_type, vals, -1,
 						     expr.get_locus ());
   }
 
@@ -595,6 +595,7 @@ public:
 
     translated
       = ctx->get_backend ()->constructor_expression (type, vals,
+						     struct_expr.union_index,
 						     struct_expr.get_locus ());
   }
 

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -79,7 +79,7 @@ CompileExpr::visit (HIR::CallExpr &expr)
       });
 
       translated
-	= ctx->get_backend ()->constructor_expression (type, vals,
+	= ctx->get_backend ()->constructor_expression (type, vals, -1,
 						       expr.get_locus ());
     }
   else

--- a/gcc/rust/hir/rust-ast-lower-stmt.h
+++ b/gcc/rust/hir/rust-ast-lower-stmt.h
@@ -215,6 +215,59 @@ public:
 			       struct_decl.get_locus ());
   }
 
+  void visit (AST::Union &union_decl) override
+  {
+    std::vector<std::unique_ptr<HIR::GenericParam> > generic_params;
+    if (union_decl.has_generics ())
+      {
+	generic_params
+	  = lower_generic_params (union_decl.get_generic_params ());
+      }
+
+    std::vector<std::unique_ptr<HIR::WhereClauseItem> > where_clause_items;
+    HIR::WhereClause where_clause (std::move (where_clause_items));
+    HIR::Visibility vis = HIR::Visibility::create_public ();
+
+    std::vector<HIR::StructField> variants;
+    union_decl.iterate ([&] (AST::StructField &variant) mutable -> bool {
+      HIR::Visibility vis = HIR::Visibility::create_public ();
+      HIR::Type *type
+	= ASTLoweringType::translate (variant.get_field_type ().get ());
+
+      auto crate_num = mappings->get_current_crate ();
+      Analysis::NodeMapping mapping (crate_num, variant.get_node_id (),
+				     mappings->get_next_hir_id (crate_num),
+				     mappings->get_next_localdef_id (
+				       crate_num));
+
+      // FIXME
+      // AST::StructField is missing Location info
+      Location variant_locus;
+      HIR::StructField translated_variant (mapping, variant.get_field_name (),
+					   std::unique_ptr<HIR::Type> (type),
+					   vis, variant_locus,
+					   variant.get_outer_attrs ());
+      variants.push_back (std::move (translated_variant));
+      return true;
+    });
+
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, union_decl.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   mappings->get_next_localdef_id (crate_num));
+
+    translated
+      = new HIR::Union (mapping, union_decl.get_identifier (), vis,
+			std::move (generic_params), std::move (where_clause),
+			std::move (variants), union_decl.get_outer_attrs (),
+			union_decl.get_locus ());
+
+    mappings->insert_hir_stmt (mapping.get_crate_num (), mapping.get_hirid (),
+			       translated);
+    mappings->insert_location (crate_num, mapping.get_hirid (),
+			       union_decl.get_locus ());
+  }
+
   void visit (AST::EmptyStmt &empty) override
   {
     auto crate_num = mappings->get_current_crate ();

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -1449,6 +1449,10 @@ public:
   // FIXME make unique_ptr
   StructBase *struct_base;
 
+  // For unions there is just one field, the index
+  // is set when type checking
+  int union_index = -1;
+
   std::string as_string () const override;
 
   bool has_struct_base () const { return struct_base != nullptr; }
@@ -1467,7 +1471,8 @@ public:
 
   // copy constructor with vector clone
   StructExprStructFields (StructExprStructFields const &other)
-    : StructExprStruct (other), struct_base (other.struct_base)
+    : StructExprStruct (other), struct_base (other.struct_base),
+      union_index (other.union_index)
   {
     fields.reserve (other.fields.size ());
     for (const auto &e : other.fields)
@@ -1479,6 +1484,7 @@ public:
   {
     StructExprStruct::operator= (other);
     struct_base = other.struct_base;
+    union_index = other.union_index;
 
     fields.reserve (other.fields.size ());
     for (const auto &e : other.fields)

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -1989,9 +1989,25 @@ public:
   Union (Union &&other) = default;
   Union &operator= (Union &&other) = default;
 
+  std::vector<std::unique_ptr<GenericParam> > &get_generic_params ()
+  {
+    return generic_params;
+  }
+
+  Identifier get_identifier () const { return union_name; }
+
   Location get_locus () const { return locus; }
 
   void accept_vis (HIRVisitor &vis) override;
+
+  void iterate (std::function<bool (StructField &)> cb)
+  {
+    for (auto &variant : variants)
+      {
+	if (!cb (variant))
+	  return;
+      }
+  }
 
 protected:
   /* Use covariance to implement clone function as returning this object

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -260,6 +260,28 @@ public:
     resolver->get_type_scope ().pop ();
   }
 
+  void visit (AST::Union &union_decl) override
+  {
+    NodeId scope_node_id = union_decl.get_node_id ();
+    resolver->get_type_scope ().push (scope_node_id);
+
+    if (union_decl.has_generics ())
+      {
+	for (auto &generic : union_decl.get_generic_params ())
+	  {
+	    ResolveGenericParam::go (generic.get (), union_decl.get_node_id ());
+	  }
+      }
+
+    union_decl.iterate ([&] (AST::StructField &field) mutable -> bool {
+      ResolveType::go (field.get_field_type ().get (),
+		       union_decl.get_node_id ());
+      return true;
+    });
+
+    resolver->get_type_scope ().pop ();
+  }
+
   void visit (AST::StaticItem &var) override
   {
     ResolveType::go (var.get_type ().get (), var.get_node_id ());

--- a/gcc/rust/resolve/rust-ast-resolve-stmt.h
+++ b/gcc/rust/resolve/rust-ast-resolve-stmt.h
@@ -131,6 +131,38 @@ public:
     resolver->get_type_scope ().pop ();
   }
 
+  void visit (AST::Union &union_decl) override
+  {
+    auto path = CanonicalPath::new_seg (union_decl.get_node_id (),
+					union_decl.get_identifier ());
+    resolver->get_type_scope ().insert (
+      path, union_decl.get_node_id (), union_decl.get_locus (), false,
+      [&] (const CanonicalPath &, NodeId, Location locus) -> void {
+	RichLocation r (union_decl.get_locus ());
+	r.add_range (locus);
+	rust_error_at (r, "redefined multiple times");
+      });
+
+    NodeId scope_node_id = union_decl.get_node_id ();
+    resolver->get_type_scope ().push (scope_node_id);
+
+    if (union_decl.has_generics ())
+      {
+	for (auto &generic : union_decl.get_generic_params ())
+	  {
+	    ResolveGenericParam::go (generic.get (), union_decl.get_node_id ());
+	  }
+      }
+
+    union_decl.iterate ([&] (AST::StructField &field) mutable -> bool {
+      ResolveType::go (field.get_field_type ().get (),
+		       union_decl.get_node_id ());
+      return true;
+    });
+
+    resolver->get_type_scope ().pop ();
+  }
+
   void visit (AST::Function &function) override
   {
     auto path = ResolveFunctionItemToCanonicalPath::resolve (function);

--- a/gcc/rust/resolve/rust-ast-resolve-toplevel.h
+++ b/gcc/rust/resolve/rust-ast-resolve-toplevel.h
@@ -81,6 +81,20 @@ public:
       });
   }
 
+  void visit (AST::Union &union_decl) override
+  {
+    auto path
+      = prefix.append (CanonicalPath::new_seg (union_decl.get_node_id (),
+					       union_decl.get_identifier ()));
+    resolver->get_type_scope ().insert (
+      path, union_decl.get_node_id (), union_decl.get_locus (), false,
+      [&] (const CanonicalPath &, NodeId, Location locus) -> void {
+	RichLocation r (union_decl.get_locus ());
+	r.add_range (locus);
+	rust_error_at (r, "redefined multiple times");
+      });
+  }
+
   void visit (AST::StaticItem &var) override
   {
     auto path = prefix.append (

--- a/gcc/rust/rust-backend.h
+++ b/gcc/rust/rust-backend.h
@@ -178,6 +178,9 @@ public:
   // Get a struct type.
   virtual Btype *struct_type (const std::vector<Btyped_identifier> &fields) = 0;
 
+  // Get a union type.
+  virtual Btype *union_type (const std::vector<Btyped_identifier> &fields) = 0;
+
   // Get an array type.
   virtual Btype *array_type (Btype *element_type, Bexpression *length) = 0;
 
@@ -424,7 +427,7 @@ public:
   // corresponding fields in BTYPE.
   virtual Bexpression *
   constructor_expression (Btype *btype, const std::vector<Bexpression *> &vals,
-			  Location)
+			  int, Location)
     = 0;
 
   // Return an expression that constructs an array of BTYPE with INDEXES and

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
@@ -94,7 +94,8 @@ public:
     TyTy::BaseType *type
       = new TyTy::ADTType (struct_decl.get_mappings ().get_hirid (),
 			   mappings->get_next_hir_id (),
-			   struct_decl.get_identifier (), true,
+			   struct_decl.get_identifier (),
+			   TyTy::ADTType::ADTKind::TUPLE_STRUCT,
 			   std::move (fields), std::move (substitutions));
 
     context->insert_type (struct_decl.get_mappings (), type);
@@ -143,10 +144,62 @@ public:
     TyTy::BaseType *type
       = new TyTy::ADTType (struct_decl.get_mappings ().get_hirid (),
 			   mappings->get_next_hir_id (),
-			   struct_decl.get_identifier (), false,
+			   struct_decl.get_identifier (),
+			   TyTy::ADTType::ADTKind::STRUCT_STRUCT,
 			   std::move (fields), std::move (substitutions));
 
     context->insert_type (struct_decl.get_mappings (), type);
+  }
+
+  void visit (HIR::Union &union_decl) override
+  {
+    std::vector<TyTy::SubstitutionParamMapping> substitutions;
+    if (union_decl.has_generics ())
+      {
+	for (auto &generic_param : union_decl.get_generic_params ())
+	  {
+	    switch (generic_param.get ()->get_kind ())
+	      {
+	      case HIR::GenericParam::GenericKind::LIFETIME:
+		// Skipping Lifetime completely until better handling.
+		break;
+
+		case HIR::GenericParam::GenericKind::TYPE: {
+		  auto param_type
+		    = TypeResolveGenericParam::Resolve (generic_param.get ());
+		  context->insert_type (generic_param->get_mappings (),
+					param_type);
+
+		  substitutions.push_back (TyTy::SubstitutionParamMapping (
+		    static_cast<HIR::TypeParam &> (*generic_param),
+		    param_type));
+		}
+		break;
+	      }
+	  }
+      }
+
+    std::vector<TyTy::StructFieldType *> variants;
+    union_decl.iterate ([&] (HIR::StructField &variant) mutable -> bool {
+      TyTy::BaseType *variant_type
+	= TypeCheckType::Resolve (variant.get_field_type ().get ());
+      TyTy::StructFieldType *ty_variant
+	= new TyTy::StructFieldType (variant.get_mappings ().get_hirid (),
+				     variant.get_field_name (), variant_type);
+      variants.push_back (ty_variant);
+      context->insert_type (variant.get_mappings (),
+			    ty_variant->get_field_type ());
+      return true;
+    });
+
+    TyTy::BaseType *type
+      = new TyTy::ADTType (union_decl.get_mappings ().get_hirid (),
+			   mappings->get_next_hir_id (),
+			   union_decl.get_identifier (),
+			   TyTy::ADTType::ADTKind::UNION, std::move (variants),
+			   std::move (substitutions));
+
+    context->insert_type (union_decl.get_mappings (), type);
   }
 
   void visit (HIR::StaticItem &var) override

--- a/gcc/rust/typecheck/rust-tycheck-dump.h
+++ b/gcc/rust/typecheck/rust-tycheck-dump.h
@@ -48,6 +48,12 @@ public:
 	    + "\n";
   }
 
+  void visit (HIR::Union &union_decl) override
+  {
+    dump
+      += indent () + "union " + type_string (union_decl.get_mappings ()) + "\n";
+  }
+
   void visit (HIR::ImplBlock &impl_block) override
   {
     dump += indent () + "impl "

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -537,7 +537,7 @@ ADTType::clone ()
   for (auto &f : fields)
     cloned_fields.push_back ((StructFieldType *) f->clone ());
 
-  return new ADTType (get_ref (), get_ty_ref (), identifier, get_is_tuple (),
+  return new ADTType (get_ref (), get_ty_ref (), identifier, get_adt_kind (),
 		      cloned_fields, clone_substs (), used_arguments,
 		      get_combined_refs ());
 }
@@ -1999,7 +1999,7 @@ PlaceholderType::clone ()
 void
 TypeCheckCallExpr::visit (ADTType &type)
 {
-  if (!type.get_is_tuple ())
+  if (!type.is_tuple_struct ())
     {
       rust_error_at (
 	call.get_locus (),

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -855,7 +855,15 @@ protected:
 class ADTType : public BaseType, public SubstitutionRef
 {
 public:
-  ADTType (HirId ref, std::string identifier, bool is_tuple,
+  enum ADTKind
+  {
+    STRUCT_STRUCT,
+    TUPLE_STRUCT,
+    UNION,
+    // ENUM ?
+  };
+
+  ADTType (HirId ref, std::string identifier, ADTKind adt_kind,
 	   std::vector<StructFieldType *> fields,
 	   std::vector<SubstitutionParamMapping> subst_refs,
 	   SubstitutionArgumentMappings generic_arguments
@@ -863,10 +871,10 @@ public:
 	   std::set<HirId> refs = std::set<HirId> ())
     : BaseType (ref, ref, TypeKind::ADT, refs),
       SubstitutionRef (std::move (subst_refs), std::move (generic_arguments)),
-      identifier (identifier), fields (fields), is_tuple (is_tuple)
+      identifier (identifier), fields (fields), adt_kind (adt_kind)
   {}
 
-  ADTType (HirId ref, HirId ty_ref, std::string identifier, bool is_tuple,
+  ADTType (HirId ref, HirId ty_ref, std::string identifier, ADTKind adt_kind,
 	   std::vector<StructFieldType *> fields,
 	   std::vector<SubstitutionParamMapping> subst_refs,
 	   SubstitutionArgumentMappings generic_arguments
@@ -874,10 +882,12 @@ public:
 	   std::set<HirId> refs = std::set<HirId> ())
     : BaseType (ref, ty_ref, TypeKind::ADT, refs),
       SubstitutionRef (std::move (subst_refs), std::move (generic_arguments)),
-      identifier (identifier), fields (fields), is_tuple (is_tuple)
+      identifier (identifier), fields (fields), adt_kind (adt_kind)
   {}
 
-  bool get_is_tuple () { return is_tuple; }
+  ADTKind get_adt_kind () { return adt_kind; }
+  bool is_tuple_struct () { return adt_kind == TUPLE_STRUCT; }
+  bool is_union () { return adt_kind == UNION; }
 
   bool is_unit () const override { return this->fields.empty (); }
 
@@ -964,7 +974,7 @@ public:
 private:
   std::string identifier;
   std::vector<StructFieldType *> fields;
-  bool is_tuple;
+  ADTType::ADTKind adt_kind;
 };
 
 class FnType : public BaseType, public SubstitutionRef

--- a/gcc/testsuite/rust/compile/torture/union.rs
+++ b/gcc/testsuite/rust/compile/torture/union.rs
@@ -1,0 +1,35 @@
+// { dg-do compile }
+// { dg-options "-w" }
+
+union U
+{
+  f1: u8
+}
+
+union V
+{
+  f1: u8,
+  f2: u16,
+  f3: i32,
+}
+
+struct S
+{
+  f1: U,
+  f2: V
+}
+
+fn main ()
+{
+  let u = U { f1: 16 };
+  let v = V { f2: 365 };
+  let s = S { f1: u, f2: v };
+  let _v125 = unsafe
+    { let mut uv: u64;
+      uv = s.f1.f1 as u64;
+      uv += s.f2.f1 as u64;
+      uv += s.f2.f2 as u64;
+      uv -= s.f2.f3 as u64;
+      uv
+    };
+}

--- a/gcc/testsuite/rust/compile/torture/union_union.rs
+++ b/gcc/testsuite/rust/compile/torture/union_union.rs
@@ -1,0 +1,27 @@
+union union
+{
+  union: u32,
+  inion: i32,
+  u8ion: u8,
+  i64on: i64,
+  u64on: u64
+}
+
+pub fn main ()
+{
+  let union = union { union: 2 };
+  let inion = union { inion: -2 };
+  let mut mnion = union { inion: -16 };
+  let m1 = unsafe { mnion.union };
+  unsafe { mnion.union = union.union };
+  let m2 = unsafe { mnion.inion };
+  let u1 = unsafe { union.union };
+  let i1 = unsafe { union.inion };
+  let u2 = unsafe { inion.union };
+  let i2 = unsafe { inion.inion };
+  let _r1 = u2 - u1 - m1;
+  let _r2 = i1 + i2 + m2;
+  let _u8 = unsafe { union.u8ion };
+  let _i64 = unsafe { union.i64on };
+  let _u64 = unsafe { union.u64on };
+}


### PR DESCRIPTION
From Mark Wielaard : https://gcc.gnu.org/pipermail/gcc-rust/2021-August/000107.html

> 
> Treat a union as a Struct variant like a tuple struct.  Add an
> iterator and get_identifier functions to the AST Union class.  Same
> for the HIR Union class, plus a get_generics_params method. Add a new
> ADTKind enum and adt_kind field to the ADTType to select the
> underlying abstract data type (struct struct, tuple struct or union,
> with enum as possible future variant).
> 
> An union constructor can have only one field. Add an union_index field
> to StructExprStruct which is set during type checking in the
> TypeCheckStructExpr HIR StructExprStructFields visitor.
> 
> For the Gcc_backend class rename fill_in_struct to fill_in_fields and
> use it from a new union_type method. Handle union_index in
> constructor_expression (so only one field is initialized).

Fixes #157 