### PR TITLE
Add locus to TupleField and pass it and union variants to HIR class

### DIFF
--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -2002,8 +2002,9 @@ private:
 
   std::unique_ptr<Type> field_type;
 
-  // should this store location info?
   NodeId node_id;
+
+  Location locus;
 
 public:
   // Returns whether tuple field has outer attributes.
@@ -2014,17 +2015,17 @@ public:
   bool has_visibility () const { return !visibility.is_error (); }
 
   // Complete constructor
-  TupleField (std::unique_ptr<Type> field_type, Visibility vis,
+  TupleField (std::unique_ptr<Type> field_type, Visibility vis, Location locus,
 	      std::vector<Attribute> outer_attrs = std::vector<Attribute> ())
     : outer_attrs (std::move (outer_attrs)), visibility (std::move (vis)),
       field_type (std::move (field_type)),
-      node_id (Analysis::Mappings::get ()->get_next_node_id ())
+      node_id (Analysis::Mappings::get ()->get_next_node_id ()), locus (locus)
   {}
 
   // Copy constructor with clone
   TupleField (TupleField const &other)
     : outer_attrs (other.outer_attrs), visibility (other.visibility),
-      node_id (other.node_id)
+      node_id (other.node_id), locus (other.locus)
   {
     // guard to prevent null dereference (only required if error)
     if (other.field_type != nullptr)
@@ -2039,6 +2040,7 @@ public:
     visibility = other.visibility;
     outer_attrs = other.outer_attrs;
     node_id = other.node_id;
+    locus = other.locus;
 
     // guard to prevent null dereference (only required if error)
     if (other.field_type != nullptr)
@@ -2059,12 +2061,14 @@ public:
   // Creates an error state tuple field.
   static TupleField create_error ()
   {
-    return TupleField (nullptr, Visibility::create_error ());
+    return TupleField (nullptr, Visibility::create_error (), Location ());
   }
 
   std::string as_string () const;
 
-  NodeId get_node_id () const { return node_id; };
+  NodeId get_node_id () const { return node_id; }
+
+  Location get_locus () const { return locus; }
 
   // TODO: this mutable getter seems really dodgy. Think up better way.
   std::vector<Attribute> &get_outer_attrs () { return outer_attrs; }

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -111,12 +111,10 @@ public:
 				     mappings->get_next_localdef_id (
 				       crate_num));
 
-      // FIXME
-      // AST::TupleField is missing Location info
-      Location field_locus;
       HIR::TupleField translated_field (mapping,
 					std::unique_ptr<HIR::Type> (type), vis,
-					field_locus, field.get_outer_attrs ());
+					field.get_locus (),
+					field.get_outer_attrs ());
       fields.push_back (std::move (translated_field));
       return true;
     });

--- a/gcc/rust/hir/rust-ast-lower-stmt.h
+++ b/gcc/rust/hir/rust-ast-lower-stmt.h
@@ -187,12 +187,10 @@ public:
 				     mappings->get_next_localdef_id (
 				       crate_num));
 
-      // FIXME
-      // AST::StructField is missing Location info
-      Location field_locus;
       HIR::StructField translated_field (mapping, field.get_field_name (),
 					 std::unique_ptr<HIR::Type> (type), vis,
-					 field_locus, field.get_outer_attrs ());
+					 field.get_locus (),
+					 field.get_outer_attrs ());
       fields.push_back (std::move (translated_field));
       return true;
     });
@@ -240,12 +238,9 @@ public:
 				     mappings->get_next_localdef_id (
 				       crate_num));
 
-      // FIXME
-      // AST::StructField is missing Location info
-      Location variant_locus;
       HIR::StructField translated_variant (mapping, variant.get_field_name (),
 					   std::unique_ptr<HIR::Type> (type),
-					   vis, variant_locus,
+					   vis, variant.get_locus (),
 					   variant.get_outer_attrs ());
       variants.push_back (std::move (translated_variant));
       return true;

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -4295,6 +4295,8 @@ Parser<ManagedTokenSource>::parse_tuple_field ()
   // parse visibility if it exists
   AST::Visibility vis = parse_visibility ();
 
+  Location locus = lexer.peek_token ()->get_locus ();
+
   // parse type, which is required
   std::unique_ptr<AST::Type> field_type = parse_type ();
   if (field_type == nullptr)
@@ -4308,7 +4310,7 @@ Parser<ManagedTokenSource>::parse_tuple_field ()
       return AST::TupleField::create_error ();
     }
 
-  return AST::TupleField (std::move (field_type), std::move (vis),
+  return AST::TupleField (std::move (field_type), std::move (vis), locus,
 			  std::move (outer_attrs));
 }
 


### PR DESCRIPTION
From Mark Wielaard : https://gcc.gnu.org/pipermail/gcc-rust/2021-August/000108.html

> TupleField was missing a Location field and we dropped to locus when
> lowering Union fields to HIR.