### PR TITLE
Handle 'UnsafeBlockExpr' in liveness analysis

### DIFF
--- a/gcc/rust/lint/rust-lint-marklive.h
+++ b/gcc/rust/lint/rust-lint-marklive.h
@@ -107,6 +107,11 @@ public:
       }
   }
 
+  void visit (HIR::UnsafeBlockExpr &expr) override
+  {
+    expr.get_block_expr ()->accept_vis (*this);
+  }
+
   void visit (HIR::LoopExpr &expr) override
   {
     expr.get_loop_block ()->accept_vis (*this);

--- a/gcc/testsuite/rust/compile/torture/forward_decl_3-unsafe.rs
+++ b/gcc/testsuite/rust/compile/torture/forward_decl_3-unsafe.rs
@@ -1,0 +1,13 @@
+fn main() {
+    unsafe {
+        let struct_test = Foo { one: 1, two: 2 };
+        // { dg-warning "unused name" "" { target *-*-* } .-1 }
+    };
+}
+
+struct Foo {
+    one: i32,
+    // { dg-warning "field is never read" "" { target *-*-* } .-1 }
+    two: i32,
+    // { dg-warning "field is never read" "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/compile/torture/union.rs
+++ b/gcc/testsuite/rust/compile/torture/union.rs
@@ -1,6 +1,3 @@
-// { dg-do compile }
-// { dg-options "-w" }
-
 union U
 {
   f1: u8

--- a/gcc/testsuite/rust/compile/torture/unsafe4.rs
+++ b/gcc/testsuite/rust/compile/torture/unsafe4.rs
@@ -1,0 +1,12 @@
+struct SS {
+    one: i32,
+    two: i32,
+}
+struct TS(i32, i32);
+
+fn main() {
+    unsafe {
+        let ss = SS { one: 1, two: 2 };
+        let _ts = TS(ss.one, ss.two);
+    };
+}


### PR DESCRIPTION
We may then remove the '{ dg-options "-w" }' as discussed in
<http://mid.mail-archive.com/YQciMeKNpCH+ZMsJ@wildebeest.org> and #601.
