### PR TITLE
Always check the result of expect_token while parsing

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -1898,6 +1898,9 @@ Parser<ManagedTokenSource>::parse_macro_match_fragment ()
 
   // get MacroFragSpec for macro
   const_TokenPtr t = expect_token (IDENTIFIER);
+  if (t == nullptr)
+    return nullptr;
+
   AST::MacroFragSpec frag = AST::get_frag_spec_from_str (t->get_str ());
   if (frag == AST::INVALID)
     {
@@ -4325,6 +4328,9 @@ Parser<ManagedTokenSource>::parse_enum (AST::Visibility vis,
 
   // parse enum name
   const_TokenPtr enum_name_tok = expect_token (IDENTIFIER);
+  if (enum_name_tok == nullptr)
+    return nullptr;
+
   Identifier enum_name = enum_name_tok->get_str ();
 
   // parse generic params (of enum container, not enum variants) if they exist
@@ -4650,6 +4656,9 @@ Parser<ManagedTokenSource>::parse_static_item (AST::Visibility vis,
     }
 
   const_TokenPtr ident_tok = expect_token (IDENTIFIER);
+  if (ident_tok == nullptr)
+    return nullptr;
+
   Identifier ident = ident_tok->get_str ();
 
   if (!skip_token (COLON))
@@ -4700,6 +4709,9 @@ Parser<ManagedTokenSource>::parse_trait (AST::Visibility vis,
 
   // parse trait name
   const_TokenPtr ident_tok = expect_token (IDENTIFIER);
+  if (ident_tok == nullptr)
+    return nullptr;
+
   Identifier ident = ident_tok->get_str ();
 
   // parse generic parameters (if they exist)
@@ -4805,6 +4817,9 @@ Parser<ManagedTokenSource>::parse_trait_item ()
 
 	// parse function or method name
 	const_TokenPtr ident_tok = expect_token (IDENTIFIER);
+	if (ident_tok == nullptr)
+	  return nullptr;
+
 	Identifier ident = ident_tok->get_str ();
 
 	// parse generic params
@@ -4937,6 +4952,9 @@ Parser<ManagedTokenSource>::parse_trait_type (AST::AttrVec outer_attrs)
   skip_token (TYPE);
 
   const_TokenPtr ident_tok = expect_token (IDENTIFIER);
+  if (ident_tok == nullptr)
+    return nullptr;
+
   Identifier ident = ident_tok->get_str ();
 
   std::vector<std::unique_ptr<AST::TypeParamBound>> bounds;
@@ -4973,6 +4991,9 @@ Parser<ManagedTokenSource>::parse_trait_const (AST::AttrVec outer_attrs)
 
   // parse constant item name
   const_TokenPtr ident_tok = expect_token (IDENTIFIER);
+  if (ident_tok == nullptr)
+    return nullptr;
+
   Identifier ident = ident_tok->get_str ();
 
   if (!skip_token (COLON))
@@ -5338,6 +5359,9 @@ Parser<ManagedTokenSource>::parse_inherent_impl_function_or_method (
 
   // parse function or method name
   const_TokenPtr ident_tok = expect_token (IDENTIFIER);
+  if (ident_tok == nullptr)
+    return nullptr;
+
   Identifier ident = ident_tok->get_str ();
 
   // parse generic params
@@ -14210,6 +14234,9 @@ Parser<ManagedTokenSource>::parse_field_access_expr (
   /* get field name identifier (assume that this is a field access expr and not
    * await, for instance) */
   const_TokenPtr ident_tok = expect_token (IDENTIFIER);
+  if (ident_tok == nullptr)
+    return nullptr;
+
   Identifier ident = ident_tok->get_str ();
 
   Location locus = struct_expr->get_locus_slow ();

--- a/gcc/testsuite/rust/compile/torture/identifier-missing-impl-1.rs
+++ b/gcc/testsuite/rust/compile/torture/identifier-missing-impl-1.rs
@@ -1,0 +1,19 @@
+struct I();
+
+impl I {
+    fn () {
+        // { dg-error {expecting 'identifier' but '\(' found} "" { target *-*-* } .-1 }
+        // { dg-error {failed to parse inherent impl item in inherent impl} "" { target *-*-* } .-2 }
+        // { dg-error {failed to parse item in crate} "" { target *-*-* } .-3 }
+    }
+}
+
+impl I {
+    unsafe fn () {
+        // { dg-error {expecting 'identifier' but '\(' found} "" { xfail *-*-* } .-1 }
+    }
+}
+
+fn main() {
+    let _i = I();
+}


### PR DESCRIPTION
From Mark Wielaard : https://gcc.gnu.org/pipermail/gcc-rust/2021-August/000111.html

> When expect_token fails it produces an error and return a
> nullptr. Make sure to always check the result of expect_token so we
> don't use a nullptr token and crash.
> 
> Resolves: https://github.com/Rust-GCC/gccrs/issues/603