### PR TITLE
Remove split-stack from backend

### DIFF
--- a/gcc/rust/rust-backend.h
+++ b/gcc/rust/rust-backend.h
@@ -790,27 +790,23 @@ public:
   // recover and must be visible for correct panic recovery.
   static const unsigned int function_is_inlinable = 1 << 2;
 
-  // Set if the function may not split the stack.  This is set for the
-  // implementation of recover itself, among other things.
-  static const unsigned int function_no_split_stack = 1 << 3;
-
   // Set if the function does not return.  This is set for the
   // implementation of panic.
-  static const unsigned int function_does_not_return = 1 << 4;
+  static const unsigned int function_does_not_return = 1 << 3;
 
   // Set if the function should be put in a unique section if
   // possible.  This is used for field tracking.
-  static const unsigned int function_in_unique_section = 1 << 5;
+  static const unsigned int function_in_unique_section = 1 << 4;
 
   // Set if the function should be available for inlining in the
   // backend, but should not be emitted as a standalone function.  Any
   // call to the function that is not inlined should be treated as a
   // call to a function defined in a different compilation unit.  This
   // is like a C99 function marked inline but not extern.
-  static const unsigned int function_only_inline = 1 << 6;
+  static const unsigned int function_only_inline = 1 << 5;
 
   // const function
-  static const unsigned int function_read_only = 1 << 7;
+  static const unsigned int function_read_only = 1 << 6;
 
   // Declare or define a function of FNTYPE.
   // NAME is the Go name of the function.  ASM_NAME, if not the empty

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -3382,11 +3382,6 @@ Gcc_backend::function (Btype *fntype, const std::string &name,
     }
   if ((flags & function_is_inlinable) == 0)
     DECL_UNINLINABLE (decl) = 1;
-  if ((flags & function_no_split_stack) != 0)
-    {
-      tree attr = get_identifier ("no_split_stack");
-      DECL_ATTRIBUTES (decl) = tree_cons (attr, NULL_TREE, NULL_TREE);
-    }
   if ((flags & function_does_not_return) != 0)
     TREE_THIS_VOLATILE (decl) = 1;
   if ((flags & function_in_unique_section) != 0)

--- a/gcc/rust/rustspec.cc
+++ b/gcc/rust/rustspec.cc
@@ -104,9 +104,6 @@ lang_specific_driver (struct cl_decoded_option **in_decoded_options,
   /* The total number of arguments with the new stuff.  */
   int num_args = 1;
 
-  /* Supports split stack */
-  int supports_split_stack = 0;
-
   /* Whether the -o option was used.  */
   bool saw_opt_o = false;
 
@@ -117,11 +114,6 @@ lang_specific_driver (struct cl_decoded_option **in_decoded_options,
 
   /* Whether the -S option was used.  */
   bool saw_opt_S = false;
-
-#ifdef TARGET_CAN_SPLIT_STACK_64BIT
-  /* Whether the -m64 option is in force. */
-  bool is_m64 = TARGET_CAN_SPLIT_STACK_64BIT;
-#endif
 
   /* The first input file with an extension of .go.  */
   const char *first_go_file = NULL;
@@ -158,16 +150,6 @@ lang_specific_driver (struct cl_decoded_option **in_decoded_options,
 	    /* Unrecognized libraries (e.g. -lfoo) may require libgo.  */
 	    library = (library == 0) ? 1 : library;
 	  break;
-
-#ifdef TARGET_CAN_SPLIT_STACK_64BIT
-	case OPT_m32:
-	  is_m64 = false;
-	  break;
-
-	case OPT_m64:
-	  is_m64 = true;
-	  break;
-#endif
 
 	case OPT_pg:
 	case OPT_p:
@@ -252,23 +234,6 @@ lang_specific_driver (struct cl_decoded_option **in_decoded_options,
 
   /* Copy the 0th argument, i.e., the name of the program itself.  */
   new_decoded_options[j++] = decoded_options[i++];
-
-#ifdef TARGET_CAN_SPLIT_STACK
-  supports_split_stack = 1;
-#endif
-
-#ifdef TARGET_CAN_SPLIT_STACK_64BIT
-  if (is_m64)
-    supports_split_stack = 1;
-#endif
-
-  /* If we are linking, pass -fsplit-stack if it is supported.  */
-  if ((library >= 0) && supports_split_stack)
-    {
-      generate_option (OPT_fsplit_stack, NULL, 1, CL_DRIVER,
-		       &new_decoded_options[j]);
-      j++;
-    }
 
   /* NOTE: We start at 1 now, not 0.  */
   while (i < argc)
@@ -401,18 +366,6 @@ lang_specific_driver (struct cl_decoded_option **in_decoded_options,
   if (shared_libgcc && !static_link)
     generate_option (OPT_shared_libgcc, NULL, 1, CL_DRIVER,
 		     &new_decoded_options[j++]);
-
-  /* libgcc wraps pthread_create to support split stack, however, due to
-     relative ordering of -lpthread and -lgcc, we can't just mark
-     __real_pthread_create in libgcc as non-weak.  But we need to link in
-     pthread_create from pthread if we are statically linking, so we work-
-     around by passing -u pthread_create to the linker. */
-  if (static_link && supports_split_stack)
-    {
-      generate_option (OPT_Wl_, "-u,pthread_create", 1, CL_DRIVER,
-		       &new_decoded_options[j]);
-      j++;
-    }
 
 #if defined(TARGET_SOLARIS) && !defined(USE_GLD)
   /* We use a common symbol for go$zerovalue.  On Solaris, when not


### PR DESCRIPTION
From Mark Wielaard : https://gcc.gnu.org/pipermail/gcc-rust/2021-August/000110.html

> The backend was derived from the go backend which enables split stack
> support by default. This inserts a __morestack call at the start of
> each function. This is not needed for the rust backend. Remove the
> split stack support code from the rust backend and spec.
