### PR TITLE
Add `parse_items()` function from `parse_crate()`

### DIFF
--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -141,7 +141,6 @@ private:
   std::unique_ptr<AST::MacroMatchRepetition> parse_macro_match_repetition ();
 
   // Top-level item-related
-  std::vector<std::unique_ptr<AST::Item> > parse_items ();
   std::unique_ptr<AST::Item> parse_item (bool called_from_statement);
   std::unique_ptr<AST::VisItem> parse_vis_item (AST::AttrVec outer_attrs);
   std::unique_ptr<AST::MacroItem> parse_macro_item (AST::AttrVec outer_attrs);
@@ -580,10 +579,15 @@ private:
   bool done_end_of_file ();
 
   void add_error (Error error) { error_table.push_back (std::move (error)); }
+  std::vector<Error> &get_errors () { return error_table; }
 
 public:
   // Construct parser with specified "managed" token source.
   Parser (ManagedTokenSource tokenSource) : lexer (std::move (tokenSource)) {}
+
+  // Parse items without parsing an entire crate. This function is the main
+  // parsing loop of AST::Crate::parse_crate().
+  std::vector<std::unique_ptr<AST::Item> > parse_items ();
 
   // Main entry point for parser.
   AST::Crate parse_crate ();


### PR DESCRIPTION
In order to support multiple file parsing, we will need to be able to parse items from a file without specifically parsing an entire crate. This PR splits up the `parse_crate()` function in two and exposes the `parse_items()` function.

The function was previously hidden and didn't have the exact same behavior as the main loop of `parse_crate()`.

This will be especially useful when trying to expand 
```rust
mod <file>;
```
to
```rust
mod <file> {
    <items>
}
```
in the AST as we will need to parse the items present in the file.