### PR TITLE
More rustspec.cc cleanups

### DIFF
--- a/gcc/common.opt
+++ b/gcc/common.opt
@@ -3449,6 +3449,10 @@ static-libgo
 Driver
 ; Documented for Go, but always accepted by driver.
 
+static-librust
+Driver
+; Documented for Rust, but always accepted by driver.
+
 static-libasan
 Driver
 

--- a/gcc/rust/config-lang.in
+++ b/gcc/rust/config-lang.in
@@ -1,4 +1,4 @@
-# config-lang.in -- Top level configure fragment for gcc Go frontend.
+# config-lang.in -- Top level configure fragment for gcc Rust frontend.
 
 # Copyright (C) 2009-2019 Free Software Foundation, Inc.
 

--- a/gcc/rust/rustspec.cc
+++ b/gcc/rust/rustspec.cc
@@ -1,4 +1,4 @@
-/* rustspec.c -- Specific flags and argument handling of the gcc Go front end.
+/* rustspec.c -- Specific flags and argument handling of the gcc Rust front end.
    Copyright (C) 2009-2020 Free Software Foundation, Inc.
 
 This file is part of GCC.
@@ -28,24 +28,10 @@ along with GCC; see the file COPYING3.  If not see
 
 /* This bit is set if we saw a `-xfoo' language specification.  */
 #define LANGSPEC (1 << 1)
-/* This bit is set if they did `-lm' or `-lmath'.  */
-#define MATHLIB (1 << 2)
-/* This bit is set if they did `-lpthread'.  */
-#define THREADLIB (1 << 3)
 /* This bit is set if they did `-lc'.  */
-#define WITHLIBC (1 << 4)
+#define WITHLIBC (1 << 2)
 /* Skip this option.  */
-#define SKIPOPT (1 << 5)
-
-#ifndef MATH_LIBRARY
-#define MATH_LIBRARY "m"
-#endif
-#ifndef MATH_LIBRARY_PROFILE
-#define MATH_LIBRARY_PROFILE MATH_LIBRARY
-#endif
-
-#define THREAD_LIBRARY "pthread"
-#define THREAD_LIBRARY_PROFILE THREAD_LIBRARY
+#define SKIPOPT (1 << 3)
 
 void
 lang_specific_driver (struct cl_decoded_option **in_decoded_options,
@@ -54,37 +40,22 @@ lang_specific_driver (struct cl_decoded_option **in_decoded_options,
 {
   unsigned int i, j;
 
-  /* If true, the user gave us the `-p' or `-pg' flag.  */
-  bool saw_profile_flag = false;
-
   /* This is a tristate:
-     -1 means we should not link in libgo
-     0  means we should link in libgo if it is needed
-     1  means libgo is needed and should be linked in.
-     2  means libgo is needed and should be linked statically.  */
+     -1 means we should not link in librust
+     0  means we should link in librust if it is needed
+     1  means librust is needed and should be linked in.
+     2  means librust is needed and should be linked statically.  */
   int library = 0;
 
   /* The new argument list will be contained in this.  */
   struct cl_decoded_option *new_decoded_options;
 
-  /* "-lm" or "-lmath" if it appears on the command line.  */
-  const struct cl_decoded_option *saw_math = 0;
-
-  /* "-lpthread" if it appears on the command line.  */
-  const struct cl_decoded_option *saw_thread = 0;
-
   /* "-lc" if it appears on the command line.  */
   const struct cl_decoded_option *saw_libc = 0;
 
   /* An array used to flag each argument that needs a bit set for
-     LANGSPEC, MATHLIB, or WITHLIBC.  */
+     LANGSPEC or WITHLIBC.  */
   int *args;
-
-  /* Whether we need the thread library.  */
-  int need_thread = 0;
-
-  /* By default, we throw on the math library if we have one.  */
-  int need_math = (MATH_LIBRARY[0] != '\0');
 
   /* True if we saw -static.  */
   int static_link = 0;
@@ -115,8 +86,8 @@ lang_specific_driver (struct cl_decoded_option **in_decoded_options,
   /* Whether the -S option was used.  */
   bool saw_opt_S = false;
 
-  /* The first input file with an extension of .go.  */
-  const char *first_go_file = NULL;
+  /* The first input file with an extension of .rs.  */
+  const char *first_rust_file = NULL;
 
   argc = *in_decoded_options_count;
   decoded_options = *in_decoded_options;
@@ -137,34 +108,22 @@ lang_specific_driver (struct cl_decoded_option **in_decoded_options,
 	  break;
 
 	case OPT_l:
-	  if (strcmp (arg, MATH_LIBRARY) == 0)
-	    {
-	      args[i] |= MATHLIB;
-	      need_math = 0;
-	    }
-	  else if (strcmp (arg, THREAD_LIBRARY) == 0)
-	    args[i] |= THREADLIB;
-	  else if (strcmp (arg, "c") == 0)
+	  if (strcmp (arg, "c") == 0)
 	    args[i] |= WITHLIBC;
 	  else
-	    /* Unrecognized libraries (e.g. -lfoo) may require libgo.  */
+	    /* Unrecognized libraries (e.g. -lfoo) may require librust.  */
 	    library = (library == 0) ? 1 : library;
 	  break;
 
-	case OPT_pg:
-	case OPT_p:
-	  saw_profile_flag = true;
-	  break;
-
 	case OPT_x:
-	  if (library == 0 && strcmp (arg, "go") == 0)
+	  if (library == 0 && strcmp (arg, "rust") == 0)
 	    library = 1;
 	  break;
 
 	case OPT_Xlinker:
 	case OPT_Wl_:
 	  /* Arguments that go directly to the linker might be .o files,
-	     or something, and so might cause libgo to be needed.  */
+	     or something, and so might cause librust to be needed.  */
 	  if (library == 0)
 	    library = 1;
 	  break;
@@ -197,7 +156,7 @@ lang_specific_driver (struct cl_decoded_option **in_decoded_options,
 	  shared_libgcc = 0;
 	  break;
 
-	case OPT_static_libgo:
+	case OPT_static_librust:
 	  library = library >= 0 ? 2 : library;
 	  args[i] |= SKIPOPT;
 	  break;
@@ -206,13 +165,13 @@ lang_specific_driver (struct cl_decoded_option **in_decoded_options,
 	  if (library == 0)
 	    library = 1;
 
-	  if (first_go_file == NULL)
+	  if (first_rust_file == NULL)
 	    {
 	      int len;
 
 	      len = strlen (arg);
-	      if (len > 3 && strcmp (arg + len - 3, ".go") == 0)
-		first_go_file = arg;
+	      if (len > 3 && strcmp (arg + len - 3, ".rs") == 0)
+		first_rust_file = arg;
 	    }
 
 	  break;
@@ -226,7 +185,7 @@ lang_specific_driver (struct cl_decoded_option **in_decoded_options,
 #endif
 
   /* Make sure to have room for the trailing NULL argument.  */
-  num_args = argc + need_math + shared_libgcc + (library > 0) * 5 + 10;
+  num_args = argc + shared_libgcc + (library > 0) * 5 + 10;
   new_decoded_options = XNEWVEC (struct cl_decoded_option, num_args);
 
   i = 0;
@@ -239,20 +198,6 @@ lang_specific_driver (struct cl_decoded_option **in_decoded_options,
   while (i < argc)
     {
       new_decoded_options[j] = decoded_options[i];
-
-      /* Make sure -lgo is before the math library, since libgo itself
-	 uses those math routines.  */
-      if (!saw_math && (args[i] & MATHLIB) && library > 0)
-	{
-	  --j;
-	  saw_math = &decoded_options[i];
-	}
-
-      if (!saw_thread && (args[i] & THREADLIB) && library > 0)
-	{
-	  --j;
-	  saw_thread = &decoded_options[i];
-	}
 
       if (!saw_libc && (args[i] & WITHLIBC) && library > 0)
 	{
@@ -268,11 +213,11 @@ lang_specific_driver (struct cl_decoded_option **in_decoded_options,
     }
 
   /* If we didn't see a -o option, add one.  This is because we need
-     the driver to pass all .go files to go1.  Without a -o option the
-     driver will invoke go1 separately for each input file.  FIXME:
+     the driver to pass all .rs files to rust1.  Without a -o option the
+     driver will invoke rust1 separately for each input file.  FIXME:
      This should probably use some other interface to force the driver
      to set combine_inputs.  */
-  if (first_go_file != NULL && !saw_opt_o)
+  if (first_rust_file != NULL && !saw_opt_o)
     {
       if (saw_opt_c || saw_opt_S)
 	{
@@ -281,7 +226,7 @@ lang_specific_driver (struct cl_decoded_option **in_decoded_options,
 	  int alen;
 	  char *out;
 
-	  base = lbasename (first_go_file);
+	  base = lbasename (first_rust_file);
 	  baselen = strlen (base) - 3;
 	  alen = baselen + 3;
 	  out = XNEWVEC (char, alen);
@@ -301,7 +246,7 @@ lang_specific_driver (struct cl_decoded_option **in_decoded_options,
       j++;
     }
 
-  /* Add `-lgo' if we haven't already done so.  */
+  /* Add `-lrust' if we haven't already done so.  */
   if (library > 0)
     {
       // generate_option (OPT_l, LIBGOBEGIN, 1, CL_DRIVER,
@@ -318,7 +263,7 @@ lang_specific_driver (struct cl_decoded_option **in_decoded_options,
 	}
 #endif
 
-	// generate_option (OPT_l, saw_profile_flag ? LIBGO_PROFILE : LIBGO, 1,
+	// generate_option (OPT_l, LIBGO, 1,
 	//   	       CL_DRIVER, &new_decoded_options[j]);
 	// added_libraries++;
 	// j++;
@@ -331,34 +276,6 @@ lang_specific_driver (struct cl_decoded_option **in_decoded_options,
 	  j++;
 	}
 #endif
-
-      /* When linking libgo statically we also need to link with the
-	 pthread library.  */
-      if (library > 1 || static_link)
-	need_thread = 1;
-    }
-
-  if (saw_thread)
-    new_decoded_options[j++] = *saw_thread;
-  else if (library > 0 && need_thread)
-    {
-      generate_option (OPT_l,
-		       (saw_profile_flag ? THREAD_LIBRARY_PROFILE
-					 : THREAD_LIBRARY),
-		       1, CL_DRIVER, &new_decoded_options[j]);
-      added_libraries++;
-      j++;
-    }
-
-  if (saw_math)
-    new_decoded_options[j++] = *saw_math;
-  else if (library > 0 && need_math)
-    {
-      generate_option (OPT_l,
-		       saw_profile_flag ? MATH_LIBRARY_PROFILE : MATH_LIBRARY,
-		       1, CL_DRIVER, &new_decoded_options[j]);
-      added_libraries++;
-      j++;
     }
 
   if (saw_libc)
@@ -367,15 +284,6 @@ lang_specific_driver (struct cl_decoded_option **in_decoded_options,
     generate_option (OPT_shared_libgcc, NULL, 1, CL_DRIVER,
 		     &new_decoded_options[j++]);
 
-#if defined(TARGET_SOLARIS) && !defined(USE_GLD)
-  /* We use a common symbol for go$zerovalue.  On Solaris, when not
-     using the GNU linker, the Solaris linker needs an option to not
-     warn about this.  Everything works without this option, but you
-     get unsightly warnings at link time.  */
-  generate_option (OPT_Wl_, "-t", 1, CL_DRIVER, &new_decoded_options[j]);
-  j++;
-#endif
-
   *in_decoded_options_count = j;
   *in_decoded_options = new_decoded_options;
   *in_added_libraries = added_libraries;
@@ -383,10 +291,10 @@ lang_specific_driver (struct cl_decoded_option **in_decoded_options,
 
 /* Called before linking.  Returns 0 on success and -1 on failure.  */
 int
-lang_specific_pre_link (void) /* Not used for Go.  */
+lang_specific_pre_link (void) /* Not used for Rust.  */
 {
   return 0;
 }
 
 /* Number of extra output files that lang_specific_pre_link may generate.  */
-int lang_specific_extra_outfiles = 0; /* Not used for Go.  */
+int lang_specific_extra_outfiles = 0; /* Not used for Rust.  */


### PR DESCRIPTION
From Mark Wielaard : https://gcc.gnu.org/pipermail/gcc-rust/2021-August/000117.html

> rustspec.cc was based on the Go frontend gospec.cc. Remove special
> handling of math and pthread libraries and profiling option. Handle
> .rs files instead of .go files. Keep support for linking with (static)
> librust which is currently commented out. Add generic static-librust
> option to common.opt.