### PR TITLE
Add check for TypeBounds on argument substitutions

### DIFF
--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -108,7 +108,7 @@ ResolvePathRef::visit (HIR::PathInExpression &expr)
 		  trait_item->get_mappings ().get_hirid ());
 
 	      Resolver::TraitReference &trait_ref
-		= Resolver::TraitResolver::error_node ();
+		= Resolver::TraitReference::error_node ();
 	      bool ok = ctx->get_tyctx ()->lookup_trait_reference (
 		trait->get_mappings ().get_defid (), trait_ref);
 	      rust_assert (ok);

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -107,10 +107,10 @@ ResolvePathRef::visit (HIR::PathInExpression &expr)
 		= ctx->get_mappings ()->lookup_trait_item_mapping (
 		  trait_item->get_mappings ().get_hirid ());
 
-	      Resolver::TraitReference &trait_ref
-		= Resolver::TraitReference::error_node ();
+	      Resolver::TraitReference *trait_ref
+		= &Resolver::TraitReference::error_node ();
 	      bool ok = ctx->get_tyctx ()->lookup_trait_reference (
-		trait->get_mappings ().get_defid (), trait_ref);
+		trait->get_mappings ().get_defid (), &trait_ref);
 	      rust_assert (ok);
 
 	      TyTy::BaseType *receiver = nullptr;

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -151,7 +151,7 @@ CompileExpr::visit (HIR::MethodCallExpr &expr)
 	    trait_item->get_mappings ().get_hirid ());
 
 	  Resolver::TraitReference &trait_ref
-	    = Resolver::TraitResolver::error_node ();
+	    = Resolver::TraitReference::error_node ();
 	  bool ok = ctx->get_tyctx ()->lookup_trait_reference (
 	    trait->get_mappings ().get_defid (), trait_ref);
 	  rust_assert (ok);

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -150,10 +150,10 @@ CompileExpr::visit (HIR::MethodCallExpr &expr)
 	  HIR::Trait *trait = ctx->get_mappings ()->lookup_trait_item_mapping (
 	    trait_item->get_mappings ().get_hirid ());
 
-	  Resolver::TraitReference &trait_ref
-	    = Resolver::TraitReference::error_node ();
+	  Resolver::TraitReference *trait_ref
+	    = &Resolver::TraitReference::error_node ();
 	  bool ok = ctx->get_tyctx ()->lookup_trait_reference (
-	    trait->get_mappings ().get_defid (), trait_ref);
+	    trait->get_mappings ().get_defid (), &trait_ref);
 	  rust_assert (ok);
 
 	  TyTy::BaseType *receiver = nullptr;

--- a/gcc/rust/typecheck/rust-hir-trait-ref.h
+++ b/gcc/rust/typecheck/rust-hir-trait-ref.h
@@ -233,14 +233,18 @@ public:
     return hir_trait_ref->get_mappings ();
   }
 
-  const TraitItemReference &lookup_trait_item (const std::string &ident) const
+  bool lookup_trait_item (const std::string &ident,
+			  const TraitItemReference **ref) const
   {
     for (auto &item : item_refs)
       {
 	if (ident.compare (item.get_identifier ()) == 0)
-	  return item;
+	  {
+	    *ref = &item;
+	    return true;
+	  }
       }
-    return TraitItemReference::error_node ();
+    return false;
   }
 
   const TraitItemReference &

--- a/gcc/rust/typecheck/rust-hir-trait-ref.h
+++ b/gcc/rust/typecheck/rust-hir-trait-ref.h
@@ -199,6 +199,12 @@ public:
 
   bool is_error () const { return hir_trait_ref == nullptr; }
 
+  static TraitReference &error_node ()
+  {
+    static TraitReference trait_error_node = TraitReference::error ();
+    return trait_error_node;
+  }
+
   Location get_locus () const { return hir_trait_ref->get_locus (); }
 
   std::string get_name () const

--- a/gcc/rust/typecheck/rust-hir-trait-resolve.h
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.h
@@ -106,12 +106,6 @@ public:
     return resolver.go (path);
   }
 
-  static TraitReference &error_node ()
-  {
-    static TraitReference trait_error_node = TraitReference::error ();
-    return trait_error_node;
-  }
-
 private:
   TraitResolver () : TypeCheckBase () {}
 
@@ -122,7 +116,7 @@ private:
 					 &ref))
       {
 	rust_error_at (path.get_locus (), "Failed to resolve path to node-id");
-	return error_node ();
+	return TraitReference::error_node ();
       }
 
     HirId hir_node = UNKNOWN_HIRID;
@@ -130,7 +124,7 @@ private:
 				       &hir_node))
       {
 	rust_error_at (path.get_locus (), "Failed to resolve path to hir-id");
-	return error_node ();
+	return TraitReference::error_node ();
       }
 
     HIR::Item *resolved_item
@@ -140,7 +134,7 @@ private:
     resolved_item->accept_vis (*this);
     rust_assert (trait_reference != nullptr);
 
-    TraitReference &tref = error_node ();
+    TraitReference &tref = TraitReference::error_node ();
     if (context->lookup_trait_reference (
 	  trait_reference->get_mappings ().get_defid (), tref))
       {
@@ -189,7 +183,7 @@ private:
     context->insert_trait_reference (
       trait_reference->get_mappings ().get_defid (), std::move (tref));
 
-    tref = error_node ();
+    tref = TraitReference::error_node ();
     bool ok = context->lookup_trait_reference (
       trait_reference->get_mappings ().get_defid (), tref);
     rust_assert (ok);

--- a/gcc/rust/typecheck/rust-hir-type-bounds.h
+++ b/gcc/rust/typecheck/rust-hir-type-bounds.h
@@ -31,8 +31,7 @@ class TypeBoundsProbe : public TypeCheckBase
   using Rust::Resolver::TypeCheckBase::visit;
 
 public:
-  static std::vector<std::reference_wrapper<TraitReference>>
-  Probe (const TyTy::BaseType *receiver)
+  static std::vector<TraitReference *> Probe (const TyTy::BaseType *receiver)
   {
     TypeBoundsProbe probe (receiver);
     probe.scan ();
@@ -48,7 +47,7 @@ private:
   {}
 
   const TyTy::BaseType *receiver;
-  std::vector<std::reference_wrapper<TraitReference>> trait_references;
+  std::vector<TraitReference *> trait_references;
 };
 
 } // namespace Resolver

--- a/gcc/rust/typecheck/rust-hir-type-check-base.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.h
@@ -202,7 +202,7 @@ protected:
       context (TypeCheckContext::get ())
   {}
 
-  TraitReference &resolve_trait_path (HIR::TypePath &);
+  TraitReference *resolve_trait_path (HIR::TypePath &);
 
   Analysis::Mappings *mappings;
   Resolver *resolver;

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -244,7 +244,7 @@ public:
       = resolved_candidate.is_impl_candidate ()
 	  ? resolved_candidate.item.impl.impl_item->get_impl_mappings ()
 	      .get_nodeid ()
-	  : resolved_candidate.item.trait.item_ref.get_mappings ()
+	  : resolved_candidate.item.trait.item_ref->get_mappings ()
 	      .get_nodeid ();
 
     if (lookup_tyty->get_kind () != TyTy::TypeKind::FNDEF)
@@ -994,7 +994,7 @@ public:
 	else
 	  {
 	    resolved_node_id
-	      = candidate.item.trait.item_ref.get_mappings ().get_nodeid ();
+	      = candidate.item.trait.item_ref->get_mappings ().get_nodeid ();
 	  }
 
 	if (seg.has_generic_args ())

--- a/gcc/rust/typecheck/rust-hir-type-check-item.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.h
@@ -43,7 +43,7 @@ public:
 
   void visit (HIR::ImplBlock &impl_block) override
   {
-    TraitReference &trait_reference = TraitResolver::error_node ();
+    TraitReference &trait_reference = TraitReference::error_node ();
     if (impl_block.has_trait_ref ())
       {
 	std::unique_ptr<HIR::TypePath> &ref = impl_block.get_trait_ref ();

--- a/gcc/rust/typecheck/rust-hir-type-check-item.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.h
@@ -43,12 +43,12 @@ public:
 
   void visit (HIR::ImplBlock &impl_block) override
   {
-    TraitReference &trait_reference = TraitReference::error_node ();
+    TraitReference *trait_reference = &TraitReference::error_node ();
     if (impl_block.has_trait_ref ())
       {
 	std::unique_ptr<HIR::TypePath> &ref = impl_block.get_trait_ref ();
 	trait_reference = TraitResolver::Resolve (*ref.get ());
-	rust_assert (!trait_reference.is_error ());
+	rust_assert (!trait_reference->is_error ());
       }
 
     TyTy::BaseType *self = nullptr;
@@ -60,7 +60,7 @@ public:
 	return;
       }
 
-    bool is_trait_impl_block = !trait_reference.is_error ();
+    bool is_trait_impl_block = !trait_reference->is_error ();
 
     std::vector<std::reference_wrapper<const TraitItemReference>>
       trait_item_refs;
@@ -72,20 +72,20 @@ public:
 	  {
 	    auto &trait_item_ref
 	      = TypeCheckImplItemWithTrait::Resolve (impl_item.get (), self,
-						     trait_reference);
+						     *trait_reference);
 	    trait_item_refs.push_back (trait_item_ref);
 	  }
       }
 
     bool impl_block_missing_trait_items
       = is_trait_impl_block
-	&& trait_reference.size () != trait_item_refs.size ();
+	&& trait_reference->size () != trait_item_refs.size ();
     if (impl_block_missing_trait_items)
       {
 	// filter the missing impl_items
 	std::vector<std::reference_wrapper<const TraitItemReference>>
 	  missing_trait_items;
-	for (auto &trait_item_ref : trait_reference.get_trait_items ())
+	for (auto &trait_item_ref : trait_reference->get_trait_items ())
 	  {
 	    bool found = false;
 	    for (const TraitItemReference &implemented_trait_item :
@@ -120,7 +120,7 @@ public:
 
 	    rust_error_at (r, "missing %s in implementation of trait %<%s%>",
 			   missing_items_buf.c_str (),
-			   trait_reference.get_name ().c_str ());
+			   trait_reference->get_name ().c_str ());
 	  }
       }
   }

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -283,7 +283,7 @@ public:
 
 		  TraitReference *trait = resolve_trait_path (b->get_path ());
 		  TyTy::TypeBoundPredicate predicate (
-		    trait->get_mappings ().get_defid ());
+		    trait->get_mappings ().get_defid (), b->get_locus ());
 
 		  specified_bounds.push_back (std::move (predicate));
 		}

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -280,8 +280,11 @@ public:
 		case HIR::TypeParamBound::BoundType::TRAITBOUND: {
 		  HIR::TraitBound *b
 		    = static_cast<HIR::TraitBound *> (bound.get ());
+
+		  TraitReference *trait = resolve_trait_path (b->get_path ());
 		  TyTy::TypeBoundPredicate predicate (
-		    &resolve_trait_path (b->get_path ()));
+		    trait->get_mappings ().get_defid ());
+
 		  specified_bounds.push_back (std::move (predicate));
 		}
 		break;

--- a/gcc/rust/typecheck/rust-hir-type-check.h
+++ b/gcc/rust/typecheck/rust-hir-type-check.h
@@ -92,13 +92,13 @@ public:
     trait_context.emplace (id, std::move (ref));
   }
 
-  bool lookup_trait_reference (DefId id, TraitReference &ref)
+  bool lookup_trait_reference (DefId id, TraitReference **ref)
   {
     auto it = trait_context.find (id);
     if (it == trait_context.end ())
       return false;
 
-    ref = it->second;
+    *ref = &it->second;
     return true;
   }
 

--- a/gcc/rust/typecheck/rust-tyty-bounds.cc
+++ b/gcc/rust/typecheck/rust-tyty-bounds.cc
@@ -83,5 +83,11 @@ TypeBoundPredicate::get () const
   return ref;
 }
 
+std::string
+TypeBoundPredicate::get_name () const
+{
+  return get ()->get_name ();
+}
+
 } // namespace TyTy
 } // namespace Rust

--- a/gcc/rust/typecheck/rust-tyty-bounds.cc
+++ b/gcc/rust/typecheck/rust-tyty-bounds.cc
@@ -48,14 +48,14 @@ TypeBoundsProbe::scan ()
 
   for (auto &trait_path : possible_trait_paths)
     {
-      TraitReference &trait_ref = TraitResolver::Resolve (*trait_path);
+      TraitReference *trait_ref = TraitResolver::Resolve (*trait_path);
 
-      if (!trait_ref.is_error ())
+      if (!trait_ref->is_error ())
 	trait_references.push_back (trait_ref);
     }
 }
 
-TraitReference &
+TraitReference *
 TypeCheckBase::resolve_trait_path (HIR::TypePath &path)
 {
   return TraitResolver::Resolve (path);
@@ -68,7 +68,19 @@ namespace TyTy {
 std::string
 TypeBoundPredicate::as_string () const
 {
-  return reference->as_string ();
+  return get ()->as_string ();
+}
+
+const Resolver::TraitReference *
+TypeBoundPredicate::get () const
+{
+  auto context = Resolver::TypeCheckContext::get ();
+
+  Resolver::TraitReference *ref = nullptr;
+  bool ok = context->lookup_trait_reference (reference, &ref);
+  rust_assert (ok);
+
+  return ref;
 }
 
 } // namespace TyTy

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -49,11 +49,11 @@ BaseType::satisfies_bound (const TypeBoundPredicate &predicate) const
 	return true;
     }
 
-  std::vector<std::reference_wrapper<Resolver::TraitReference>> probed
+  std::vector<Resolver::TraitReference *> probed
     = Resolver::TypeBoundsProbe::Probe (this);
-  for (const Resolver::TraitReference &bound : probed)
+  for (const Resolver::TraitReference *bound : probed)
     {
-      bool found = bound.get_mappings ().get_defid ()
+      bool found = bound->get_mappings ().get_defid ()
 		   == query->get_mappings ().get_defid ();
       if (found)
 	return true;

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -132,26 +132,14 @@ public:
 class TypeBoundPredicate
 {
 public:
-  TypeBoundPredicate (Resolver::TraitReference *reference)
-    : reference (reference)
-  {}
-
-  TypeBoundPredicate (const TypeBoundPredicate &other)
-    : reference (other.reference)
-  {}
-
-  TypeBoundPredicate &operator= (const TypeBoundPredicate &other)
-  {
-    reference = other.reference;
-    return *this;
-  }
+  TypeBoundPredicate (DefId reference) : reference (reference) {}
 
   std::string as_string () const;
 
-  const Resolver::TraitReference *get () const { return reference; }
+  const Resolver::TraitReference *get () const;
 
 private:
-  Resolver::TraitReference *reference;
+  DefId reference;
 };
 
 class TypeBoundsMappings

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -132,14 +132,21 @@ public:
 class TypeBoundPredicate
 {
 public:
-  TypeBoundPredicate (DefId reference) : reference (reference) {}
+  TypeBoundPredicate (DefId reference, Location locus)
+    : reference (reference), locus (locus)
+  {}
 
   std::string as_string () const;
 
   const Resolver::TraitReference *get () const;
 
+  Location get_locus () const { return locus; }
+
+  std::string get_name () const;
+
 private:
   DefId reference;
+  Location locus;
 };
 
 class TypeBoundsMappings
@@ -241,34 +248,9 @@ public:
 
   bool satisfies_bound (const TypeBoundPredicate &predicate) const;
 
-  bool bounds_compatible (const BaseType &other, Location locus) const
-  {
-    std::vector<std::reference_wrapper<const TypeBoundPredicate>>
-      unsatisfied_bounds;
-    for (auto &bound : get_specified_bounds ())
-      {
-	if (!other.satisfies_bound (bound))
-	  unsatisfied_bounds.push_back (bound);
-      }
+  bool bounds_compatible (const BaseType &other, Location locus) const;
 
-    if (unsatisfied_bounds.size () > 0)
-      {
-	RichLocation r (locus);
-	rust_error_at (r, "bounds not satisfied for %s",
-		       other.as_string ().c_str ());
-	return false;
-      }
-
-    return unsatisfied_bounds.size () == 0;
-  }
-
-  void inherit_bounds (const BaseType &other)
-  {
-    for (auto &bound : other.get_specified_bounds ())
-      {
-	add_bound (bound);
-      }
-  }
+  void inherit_bounds (const BaseType &other);
 
   virtual bool is_unit () const { return false; }
 

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -23,13 +23,6 @@
 namespace Rust {
 namespace Analysis {
 
-NodeMapping::NodeMapping (CrateNum crateNum, NodeId nodeId, HirId hirId,
-			  LocalDefId localDefId)
-  : crateNum (crateNum), nodeId (nodeId), hirId (hirId), localDefId (localDefId)
-{}
-
-NodeMapping::~NodeMapping () {}
-
 NodeMapping
 NodeMapping::get_error ()
 {

--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -53,8 +53,10 @@ class NodeMapping
 {
 public:
   NodeMapping (CrateNum crateNum, NodeId nodeId, HirId hirId,
-	       LocalDefId localDefId);
-  ~NodeMapping ();
+	       LocalDefId localDefId)
+    : crateNum (crateNum), nodeId (nodeId), hirId (hirId),
+      localDefId (localDefId)
+  {}
 
   static NodeMapping get_error ();
 
@@ -67,6 +69,14 @@ public:
   static DefId get_defid (CrateNum crate_num, LocalDefId local_defid);
 
   std::string as_string () const;
+
+  bool is_equal (const NodeMapping &other) const
+  {
+    return get_crate_num () == other.get_crate_num ()
+	   && get_nodeid () == other.get_nodeid ()
+	   && get_hirid () == other.get_hirid ()
+	   && get_local_defid () == other.get_local_defid ();
+  }
 
 private:
   CrateNum crateNum;

--- a/gcc/testsuite/rust/compile/traits6.rs
+++ b/gcc/testsuite/rust/compile/traits6.rs
@@ -1,0 +1,15 @@
+trait Foo {
+    fn default() -> i32;
+}
+
+struct Bar(i32);
+
+fn type_bound_test<T: Foo>() -> i32 {
+    T::default()
+}
+
+fn main() {
+    let a;
+    a = type_bound_test::<Bar>();
+    // { dg-error "bounds not satisfied for Bar" "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/compile/traits7.rs
+++ b/gcc/testsuite/rust/compile/traits7.rs
@@ -1,0 +1,24 @@
+trait Foo {
+    fn default() -> i32;
+}
+
+trait Bar {
+    fn not_default() -> i32;
+}
+
+struct Test(i32);
+
+impl Foo for Test {
+    fn default() -> i32 {
+        1234
+    }
+}
+
+fn type_bound_test<T: Foo + Bar>() -> i32 {
+    T::default()
+}
+
+fn main() {
+    let a = type_bound_test::<Test>();
+    // { dg-error "bounds not satisfied for Test" "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
TypeParameters contain specified bounds, when we substitute them we need
to ensure that the argument satisfies those bounds otherwise... it fails
the contract.

Addreses #440
