### PR TITLE
Turn Session Manager into basic singleton

### DIFF
--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -97,14 +97,12 @@ struct GTY (()) language_function
   int dummy;
 };
 
-// Kinda HACK-ish - store parsing session as static variable
-static Rust::Session session;
-
 // has to be in same compilation unit as session, so here for now
 void
 rust_add_target_info (const char *key, const char *value)
 {
-  session.options.target_data.insert_key_value_pair (key, value);
+  Rust::Session::get_instance ().options.target_data.insert_key_value_pair (
+    key, value);
 }
 
 /* Language hooks.  */
@@ -136,7 +134,7 @@ grs_langhook_init (void)
   using_eh_for_cleanups ();
 
   // initialise compiler session
-  session.init ();
+  Rust::Session::get_instance ().init ();
 
   return true;
 }
@@ -154,7 +152,7 @@ static void
 grs_langhook_init_options_struct (struct gcc_options * /* opts */)
 {
   // nothing yet - used by frontends to change specific options for the language
-  session.init_options ();
+  Rust::Session::get_instance ().init_options ();
 }
 
 /* Main entry point for front-end, apparently. Finds input file names in global
@@ -168,7 +166,7 @@ grs_langhook_parse_file (void)
 {
   rust_debug ("Preparing to parse files. ");
 
-  session.parse_files (num_in_fnames, in_fnames);
+  Rust::Session::get_instance ().parse_files (num_in_fnames, in_fnames);
 }
 
 /* Seems to get the exact type for a specific type - e.g. for scalar float with
@@ -294,7 +292,8 @@ grs_langhook_handle_option (
   // bool ret = true;
 
   // delegate to session manager
-  return session.handle_option (code, arg, value, kind, loc, handlers);
+  return Rust::Session::get_instance ().handle_option (code, arg, value, kind,
+						       loc, handlers);
 
   // Handles options as listed in lang.opt.
   /*switch (code) {

--- a/gcc/rust/rust-session-manager.h
+++ b/gcc/rust/rust-session-manager.h
@@ -221,9 +221,25 @@ struct Session
   Linemap *linemap;
 
 public:
-  /* Initialise compiler session. Corresponds to langhook grs_langhook_init().
-   * Note that this is called after option handling. */
+  /* Get a reference to the static session instance */
+  static Session &get_instance ()
+  {
+    static Session instance;
+
+    return instance;
+  }
+
+  ~Session () = default;
+
+  /* This initializes the compiler session. Corresponds to langhook
+   * grs_langhook_init(). Note that this is called after option handling. */
   void init ();
+
+  // delete those constructors so we don't access the singleton in any
+  // other way than via `get_instance()`
+  Session (Session const &) = delete;
+  void operator= (Session const &) = delete;
+
   bool handle_option (enum opt_code code, const char *arg, HOST_WIDE_INT value,
 		      int kind, location_t loc,
 		      const struct cl_option_handlers *handlers);
@@ -231,6 +247,7 @@ public:
   void init_options ();
 
 private:
+  Session () = default;
   void parse_file (const char *filename);
   bool enable_dump (std::string arg);
 


### PR DESCRIPTION
This PR changes the behavior of the compiler's session manager: Instead of keeping a single static instance in `rust-lang.cc`, the class now exposes a static instance via a `get_instance()` method. This is important for external module parsing as a new lexer and parser need to be instantiated during macro expansion, and a lexer must rely on a linemap, of which a single instance exists and is contained in the `Session` instance.

I ran into a few issues trying to make this a bit smarter (for example, by calling `init()` on the first `get_instance()` invocation) because I ran into a race condition. I haven't looked into it, but it seems that the calls to the various language hooks are sometimes multithreaded.