### PR TITLE
Resolve module filename

### DIFF
--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -1053,6 +1053,9 @@ public:
     return *this;
   }
 
+  // Search for the filename associated with an external module
+  std::string get_filename ();
+
   void accept_vis (ASTVisitor &vis) override;
 
   /* Override that runs the function recursively on all items contained within

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -977,6 +977,8 @@ private:
   Location locus;
   ModuleKind kind;
 
+  // Name of the file including the module
+  std::string outer_filename;
   // bool has_inner_attrs;
   std::vector<Attribute> inner_attrs;
   // bool has_items;
@@ -998,10 +1000,11 @@ public:
 
   // Unloaded module constructor
   Module (Identifier module_name, Visibility visibility,
-	  std::vector<Attribute> outer_attrs, Location locus)
+	  std::vector<Attribute> outer_attrs, Location locus,
+	  std::string outer_filename)
     : VisItem (std::move (visibility), std::move (outer_attrs)),
       module_name (module_name), locus (locus), kind (ModuleKind::UNLOADED),
-      inner_attrs (std::vector<Attribute> ()),
+      outer_filename (outer_filename), inner_attrs (std::vector<Attribute> ()),
       items (std::vector<std::unique_ptr<Item>> ())
   {}
 
@@ -1013,7 +1016,8 @@ public:
 	  std::vector<Attribute> outer_attrs = std::vector<Attribute> ())
     : VisItem (std::move (visibility), std::move (outer_attrs)),
       module_name (name), locus (locus), kind (ModuleKind::LOADED),
-      inner_attrs (std::move (inner_attrs)), items (std::move (items))
+      outer_filename (std::string ()), inner_attrs (std::move (inner_attrs)),
+      items (std::move (items))
   {}
 
   // Copy constructor with vector clone

--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -2036,6 +2036,10 @@ public:
 	    return;
 	  }
       }
+    else
+      {
+	std::string mod_file = module.get_filename ();
+      }
 
     // strip items if required
     expand_pointer_allow_strip (module.get_items ());

--- a/gcc/rust/lex/rust-lex.h
+++ b/gcc/rust/lex/rust-lex.h
@@ -14,6 +14,7 @@ struct RAIIFile
 {
 private:
   FILE *file;
+  const char *filename;
 
   void close ()
   {
@@ -22,7 +23,7 @@ private:
   }
 
 public:
-  RAIIFile (const char *filename)
+  RAIIFile (const char *filename) : filename (filename)
   {
     if (strcmp (filename, "-") == 0)
       file = stdin;
@@ -47,6 +48,7 @@ public:
   ~RAIIFile () { close (); }
 
   FILE *get_raw () { return file; }
+  const char *get_filename () { return filename; }
 };
 
 class Lexer
@@ -136,6 +138,7 @@ public:
   void split_current_token (TokenId new_left, TokenId new_right);
 
   Linemap *get_line_map () { return line_map; }
+  std::string get_filename () { return std::string (input.get_filename ()); }
 
 private:
   // File for use as input.

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -2101,6 +2101,7 @@ Parser<ManagedTokenSource>::parse_module (AST::Visibility vis,
     case SEMICOLON:
       lexer.skip_token ();
 
+      // Construct an external module
       return std::unique_ptr<AST::Module> (
 	new AST::Module (std::move (name), std::move (vis),
 			 std::move (outer_attrs), locus,

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -2103,8 +2103,8 @@ Parser<ManagedTokenSource>::parse_module (AST::Visibility vis,
 
       return std::unique_ptr<AST::Module> (
 	new AST::Module (std::move (name), std::move (vis),
-			 std::move (outer_attrs),
-			 locus)); // module name?
+			 std::move (outer_attrs), locus,
+			 lexer.get_filename ()));
       case LEFT_CURLY: {
 	lexer.skip_token ();
 

--- a/gcc/rust/rust-system.h
+++ b/gcc/rust/rust-system.h
@@ -59,6 +59,14 @@
 #include "diagnostic-core.h" /* For error_at and friends.  */
 #include "intl.h"	     /* For _().  */
 
+// File separator to use based on whether or not the OS we're working with is
+// DOS-based
+#if defined(HAVE_DOS_BASED_FILE_SYSTEM)
+constexpr static const char *file_separator = "\\";
+#else
+constexpr static const char *file_separator = "/";
+#endif /* HAVE_DOS_BASED_FILE_SYSTEM */
+
 // When using gcc, rust_assert is just gcc_assert.
 #define rust_assert(EXPR) gcc_assert (EXPR)
 


### PR DESCRIPTION
This PR is a first attempt at resolving the filename corresponding to an external module correctly. Some of the cases are not handled yet and a lot of FIXMEs are still here, as I am looking for feedback on certain things:

* Am I correct in assuming that we have to go through directories the C way because we are using C++11 and the `filesystem` header is not available until C++17? Is there some gcc abstraction for this that I'm overlooking?
* How important is the existence of a separate SEPARATOR macro for Windows? From what I'm understanding, the OS also understands normal slashes `/` on top of the backward slashes it usually uses `\`. I don't know what happens when they are mixed and matched or how the file system handles it.
* For review simplicity, outer attributes could be accessed in a later PR. I believe they can already be accessed and looked at but haven't looked into it. I'm also unsure if this would be the right place to implement that outer_attr lookup