### PR TITLE
Pass pratt parsed token to expr parser functions to fix expr locus

### DIFF
--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -120,9 +120,13 @@ private:
   AST::TypePathFunction parse_type_path_function ();
   AST::PathInExpression parse_path_in_expression ();
   AST::PathExprSegment parse_path_expr_segment ();
+  // When given a pratt_parsed_token, use it as the first token parsed
+  // in the expression.
   AST::QualifiedPathInExpression
-  parse_qualified_path_in_expression (bool pratt_parse = false);
-  AST::QualifiedPathType parse_qualified_path_type (bool pratt_parse = false);
+  parse_qualified_path_in_expression (const_TokenPtr pratt_parsed_token
+				      = nullptr);
+  AST::QualifiedPathType
+  parse_qualified_path_type (const_TokenPtr pratt_parsed_token = nullptr);
   AST::QualifiedPathInType parse_qualified_path_in_type ();
 
   // Token tree or macro related
@@ -469,32 +473,34 @@ private:
   parse_expr_with_block (AST::AttrVec outer_attrs);
   std::unique_ptr<AST::ExprWithoutBlock>
   parse_expr_without_block (AST::AttrVec outer_attrs = AST::AttrVec ());
-  std::unique_ptr<AST::BlockExpr> parse_block_expr (AST::AttrVec outer_attrs
-						    = AST::AttrVec (),
-						    bool pratt_parse = false);
-  std::unique_ptr<AST::IfExpr> parse_if_expr (AST::AttrVec outer_attrs
-					      = AST::AttrVec (),
-					      bool pratt_parse = false);
-  std::unique_ptr<AST::IfLetExpr> parse_if_let_expr (AST::AttrVec outer_attrs
-						     = AST::AttrVec (),
-						     bool pratt_parse = false);
+  // When given a pratt_parsed_token, use it as the first token parsed
+  // in the expression.
+  std::unique_ptr<AST::BlockExpr>
+  parse_block_expr (AST::AttrVec outer_attrs = AST::AttrVec (),
+		    const_TokenPtr pratt_parsed_token = nullptr);
+  std::unique_ptr<AST::IfExpr>
+  parse_if_expr (AST::AttrVec outer_attrs = AST::AttrVec (),
+		 const_TokenPtr pratt_parsed_token = nullptr);
+  std::unique_ptr<AST::IfLetExpr>
+  parse_if_let_expr (AST::AttrVec outer_attrs = AST::AttrVec (),
+		     const_TokenPtr pratt_parsed_token = nullptr);
   std::unique_ptr<AST::LoopExpr>
   parse_loop_expr (AST::AttrVec outer_attrs = AST::AttrVec (),
 		   AST::LoopLabel label = AST::LoopLabel::error (),
-		   bool pratt_parse = false);
+		   const_TokenPtr pratt_parsed_token = nullptr);
   std::unique_ptr<AST::WhileLoopExpr>
   parse_while_loop_expr (AST::AttrVec outer_attrs = AST::AttrVec (),
 			 AST::LoopLabel label = AST::LoopLabel::error (),
-			 bool pratt_parse = false);
+			 const_TokenPtr pratt_parsed_token = nullptr);
   std::unique_ptr<AST::WhileLetLoopExpr>
   parse_while_let_loop_expr (AST::AttrVec outer_attrs = AST::AttrVec (),
 			     AST::LoopLabel label = AST::LoopLabel::error ());
   std::unique_ptr<AST::ForLoopExpr>
   parse_for_loop_expr (AST::AttrVec outer_attrs = AST::AttrVec (),
 		       AST::LoopLabel label = AST::LoopLabel::error ());
-  std::unique_ptr<AST::MatchExpr> parse_match_expr (AST::AttrVec outer_attrs
-						    = AST::AttrVec (),
-						    bool pratt_parse = false);
+  std::unique_ptr<AST::MatchExpr>
+  parse_match_expr (AST::AttrVec outer_attrs = AST::AttrVec (),
+		    const_TokenPtr pratt_parsed_token = nullptr);
   AST::MatchArm parse_match_arm ();
   std::vector<std::unique_ptr<AST::Pattern> >
   parse_match_arm_patterns (TokenId end_token_id);
@@ -510,24 +516,26 @@ private:
   AST::ClosureParam parse_closure_param ();
   std::unique_ptr<AST::LiteralExpr> parse_literal_expr (AST::AttrVec outer_attrs
 							= AST::AttrVec ());
-  std::unique_ptr<AST::ReturnExpr> parse_return_expr (AST::AttrVec outer_attrs
-						      = AST::AttrVec (),
-						      bool pratt_parse = false);
-  std::unique_ptr<AST::BreakExpr> parse_break_expr (AST::AttrVec outer_attrs
-						    = AST::AttrVec (),
-						    bool pratt_parse = false);
+  // When given a pratt_parsed_token, use it as the first token parsed
+  // in the expression.
+  std::unique_ptr<AST::ReturnExpr>
+  parse_return_expr (AST::AttrVec outer_attrs = AST::AttrVec (),
+		     const_TokenPtr pratt_parsed_token = nullptr);
+  std::unique_ptr<AST::BreakExpr>
+  parse_break_expr (AST::AttrVec outer_attrs = AST::AttrVec (),
+		    const_TokenPtr pratt_parsed_token = nullptr);
   std::unique_ptr<AST::ContinueExpr>
   parse_continue_expr (AST::AttrVec outer_attrs = AST::AttrVec (),
-		       bool pratt_parse = false);
+		       const_TokenPtr pratt_parsed_token = nullptr);
   std::unique_ptr<AST::UnsafeBlockExpr>
   parse_unsafe_block_expr (AST::AttrVec outer_attrs = AST::AttrVec (),
-			   bool pratt_parse = false);
-  std::unique_ptr<AST::ArrayExpr> parse_array_expr (AST::AttrVec outer_attrs
-						    = AST::AttrVec (),
-						    bool pratt_parse = false);
+			   const_TokenPtr pratt_parsed_token = nullptr);
+  std::unique_ptr<AST::ArrayExpr>
+  parse_array_expr (AST::AttrVec outer_attrs = AST::AttrVec (),
+		    const_TokenPtr pratt_parsed_token = nullptr);
   std::unique_ptr<AST::ExprWithoutBlock>
   parse_grouped_or_tuple_expr (AST::AttrVec outer_attrs = AST::AttrVec (),
-			       bool pratt_parse = false);
+			       const_TokenPtr pratt_parsed_token = nullptr);
   std::unique_ptr<AST::StructExprField> parse_struct_expr_field ();
   bool will_be_expr_with_block ();
 


### PR DESCRIPTION
Before gccrs would generate the following error message:

return.rs:3:22: error: cannot ‘break’ outside of a loop
    3 |     let x = 5 - break return (16 + 2);
      |                      ^~~~~~~~~~~~~~~~~

Now we get:

return.rs:3:17: error: cannot ‘break’ outside of a loop
    3 |     let x = 5 - break return (16 + 2);
      |                 ^