### PR TITLE
Make insert_new_definition permissive of the same mapping.

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -203,8 +203,11 @@ void
 Resolver::insert_new_definition (NodeId id, Definition def)
 {
   auto it = name_definitions.find (id);
-  rust_assert (it == name_definitions.end ());
-
+  if (it != name_definitions.end ())
+    {
+      rust_assert (it->second.is_equal (def));
+      return;
+    }
   name_definitions[id] = def;
 }
 

--- a/gcc/rust/resolve/rust-name-resolver.h
+++ b/gcc/rust/resolve/rust-name-resolver.h
@@ -356,6 +356,11 @@ struct Definition
   NodeId node;
   NodeId parent;
   // add kind ?
+
+  bool is_equal (const Definition &other)
+  {
+    return node == other.node && parent == other.parent;
+  }
 };
 
 class Resolver


### PR DESCRIPTION
This was a fix required for @dkm work on the module support.
