### PR TITLE
Rename CanonicalPath::is_error to is_empty

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-implitem.h
+++ b/gcc/rust/resolve/rust-ast-resolve-implitem.h
@@ -111,7 +111,7 @@ private:
   ResolveToplevelImplItem (const CanonicalPath &prefix)
     : ResolverBase (UNKNOWN_NODEID), prefix (prefix)
   {
-    rust_assert (!prefix.is_error ());
+    rust_assert (!prefix.is_empty ());
   }
 
   const CanonicalPath &prefix;

--- a/gcc/rust/resolve/rust-ast-resolve-type.h
+++ b/gcc/rust/resolve/rust-ast-resolve-type.h
@@ -193,7 +193,7 @@ public:
       = ResolveTypeToCanonicalPath::resolve (path,
 					     canonicalize_type_with_generics,
 					     true);
-    if (canonical_path.is_error ())
+    if (canonical_path.is_empty ())
       {
 	rust_error_at (path.get_locus (),
 		       "Failed to resolve canonical path for TypePath");
@@ -201,7 +201,7 @@ public:
       }
 
     CanonicalPath lookup = canonical_path;
-    if (!prefix.is_error ())
+    if (!prefix.is_empty ())
       lookup = prefix.append (canonical_path);
 
     auto resolver = Resolver::get ();

--- a/gcc/rust/resolve/rust-name-resolver.h
+++ b/gcc/rust/resolve/rust-name-resolver.h
@@ -80,12 +80,12 @@ public:
 
   static CanonicalPath create_empty () { return CanonicalPath ({}); }
 
-  bool is_error () const { return segs.size () == 0; }
+  bool is_empty () const { return segs.size () == 0; }
 
   CanonicalPath append (const CanonicalPath &other) const
   {
-    rust_assert (!other.is_error ());
-    if (is_error ())
+    rust_assert (!other.is_empty ());
+    if (is_empty ())
       return CanonicalPath (other.segs);
 
     std::vector<std::pair<NodeId, std::string>> copy (segs);


### PR DESCRIPTION
`is_error` connotes that an error has been found or that the object is faulty.
It is possible to `create_empty` paths and pass them around. Having to use
`is_error` to test for valid emptiness can be misleading.