### PR TITLE
Add mappings for canonical paths

### DIFF
--- a/gcc/rust/resolve/rust-name-resolver.h
+++ b/gcc/rust/resolve/rust-name-resolver.h
@@ -62,6 +62,9 @@ public:
     reverse_mappings.insert (std::pair<NodeId, CanonicalPath> (id, path));
     decls_within_rib.insert (std::pair<NodeId, Location> (id, locus));
     references[id] = {};
+
+    auto mappings = Analysis::Mappings::get ();
+    mappings->insert_canonical_path (mappings->get_current_crate (), id, path);
   }
 
   bool lookup_name (const CanonicalPath &ident, NodeId *id)

--- a/gcc/rust/util/rust-canonical-path.h
+++ b/gcc/rust/util/rust-canonical-path.h
@@ -110,16 +110,20 @@ public:
       }
   }
 
+  size_t size () const { return segs.size (); }
+
   NodeId get_id () const
   {
     rust_assert (!segs.empty ());
     return segs.back ().first;
   }
 
-  bool operator== (const CanonicalPath &b) const
+  bool is_equal (const CanonicalPath &b) const
   {
     return get ().compare (b.get ()) == 0;
   }
+
+  bool operator== (const CanonicalPath &b) const { return is_equal (b); }
 
   bool operator< (const CanonicalPath &b) const { return get () < b.get (); }
 

--- a/gcc/rust/util/rust-canonical-path.h
+++ b/gcc/rust/util/rust-canonical-path.h
@@ -1,0 +1,137 @@
+// Copyright (C) 2020 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_CANONICAL_PATH
+#define RUST_CANONICAL_PATH
+
+#include "rust-system.h"
+#include "rust-mapping-common.h"
+
+namespace Rust {
+namespace Resolver {
+
+// https://doc.rust-lang.org/reference/paths.html#canonical-paths
+//
+// struct X - path X
+// impl X { fn test - path X::test }
+//
+// struct X<T> - path X
+//
+// impl X<T>   { fn test - path X::test}
+// impl X<i32> { fn test - path X<i32>::test }
+// impl X<f32> { fn test - path X<f32>::test }
+//
+// pub trait Trait { // ::a::Trait
+//   fn f(&self); // ::a::Trait::f
+// }
+//
+// impl Trait for Struct {
+//    fn f(&self) {} // <::a::Struct as ::a::Trait>::f
+// }
+class CanonicalPath
+{
+public:
+  CanonicalPath (const CanonicalPath &other) : segs (other.segs) {}
+
+  CanonicalPath &operator= (const CanonicalPath &other)
+  {
+    segs = other.segs;
+    return *this;
+  }
+
+  static CanonicalPath new_seg (NodeId id, const std::string &path)
+  {
+    rust_assert (!path.empty ());
+    return CanonicalPath ({std::pair<NodeId, std::string> (id, path)});
+  }
+
+  std::string get () const
+  {
+    std::string buf;
+    for (size_t i = 0; i < segs.size (); i++)
+      {
+	bool have_more = (i + 1) < segs.size ();
+	const std::string &seg = segs.at (i).second;
+	buf += seg + (have_more ? "::" : "");
+      }
+    return buf;
+  }
+
+  static CanonicalPath get_big_self (NodeId id)
+  {
+    return CanonicalPath::new_seg (id, "Self");
+  }
+
+  static CanonicalPath create_empty () { return CanonicalPath ({}); }
+
+  bool is_empty () const { return segs.size () == 0; }
+
+  CanonicalPath append (const CanonicalPath &other) const
+  {
+    rust_assert (!other.is_empty ());
+    if (is_empty ())
+      return CanonicalPath (other.segs);
+
+    std::vector<std::pair<NodeId, std::string>> copy (segs);
+    for (auto &s : other.segs)
+      copy.push_back (s);
+
+    return CanonicalPath (copy);
+  }
+
+  // if we have the path A::B::C this will give a callback for each segment
+  // example:
+  //   A
+  //   A::B
+  //   A::B::C
+  void iterate (std::function<bool (const CanonicalPath &)> cb) const
+  {
+    std::vector<std::pair<NodeId, std::string>> buf;
+    for (auto &seg : segs)
+      {
+	buf.push_back (seg);
+	if (!cb (CanonicalPath (buf)))
+	  return;
+      }
+  }
+
+  NodeId get_id () const
+  {
+    rust_assert (!segs.empty ());
+    return segs.back ().first;
+  }
+
+  bool operator== (const CanonicalPath &b) const
+  {
+    return get ().compare (b.get ()) == 0;
+  }
+
+  bool operator< (const CanonicalPath &b) const { return get () < b.get (); }
+
+private:
+  explicit CanonicalPath (std::vector<std::pair<NodeId, std::string>> path)
+    : segs (path)
+  {}
+
+  std::vector<std::pair<NodeId, std::string>> segs;
+};
+
+} // namespace Resolver
+} // namespace Rust
+
+#endif // RUST_CANONICAL_PATH

--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -21,32 +21,12 @@
 
 #include "rust-system.h"
 #include "rust-location.h"
+#include "rust-mapping-common.h"
 
 #include "rust-ast-full-decls.h"
 #include "rust-hir-full-decls.h"
 
 namespace Rust {
-
-// refers to a Crate
-typedef uint32_t CrateNum;
-// refers to any node in the AST in current Crate
-typedef uint32_t NodeId;
-// refers to any node in the HIR for the current crate
-typedef uint32_t HirId;
-// refers to any top-level decl in HIR
-typedef uint32_t LocalDefId;
-// refers to <Crate><DefId>
-typedef uint64_t DefId;
-
-#define DEF_ID_CRATE_MASK 0xFFFFFFFF00000000
-#define DEF_ID_LOCAL_DEF_MASK 0x00000000FFFFFFFF
-
-#define UNKNOWN_CREATENUM ((uint32_t) (0))
-#define UNKNOWN_NODEID ((uint32_t) (0))
-#define UNKNOWN_HIRID ((uint32_t) (0))
-#define UNKNOWN_LOCAL_DEFID ((uint32_t) (0))
-#define UNKNOWN_DEFID ((uint64_t) (0))
-
 namespace Analysis {
 
 class NodeMapping

--- a/gcc/rust/util/rust-mapping-common.h
+++ b/gcc/rust/util/rust-mapping-common.h
@@ -1,0 +1,48 @@
+// Copyright (C) 2020 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_MAPPING_COMMON
+#define RUST_MAPPING_COMMON
+
+#include "rust-system.h"
+
+namespace Rust {
+
+// refers to a Crate
+typedef uint32_t CrateNum;
+// refers to any node in the AST in current Crate
+typedef uint32_t NodeId;
+// refers to any node in the HIR for the current crate
+typedef uint32_t HirId;
+// refers to any top-level decl in HIR
+typedef uint32_t LocalDefId;
+// refers to <Crate><DefId>
+typedef uint64_t DefId;
+
+#define DEF_ID_CRATE_MASK 0xFFFFFFFF00000000
+#define DEF_ID_LOCAL_DEF_MASK 0x00000000FFFFFFFF
+
+#define UNKNOWN_CREATENUM ((uint32_t) (0))
+#define UNKNOWN_NODEID ((uint32_t) (0))
+#define UNKNOWN_HIRID ((uint32_t) (0))
+#define UNKNOWN_LOCAL_DEFID ((uint32_t) (0))
+#define UNKNOWN_DEFID ((uint64_t) (0))
+
+} // namespace Rust
+
+#endif // RUST_MAPPING_COMMON


### PR DESCRIPTION
We need to be able to lookup canonical paths in order
to do proper name mangling as well as give more meaning
full names to the GENERIC IR. This is important since
the gcc IR is flat and makes it hard to distinguish which function
is which, especially when modules support will be added.