### PR TITLE
 Change name resolver's iterate_* function to allow early exit

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-unused.h
+++ b/gcc/rust/resolve/rust-ast-resolve-unused.h
@@ -27,7 +27,7 @@ namespace Resolver {
 class ScanUnused
 {
 public:
-  static void ScanRib (Rib *r)
+  static bool ScanRib (Rib *r)
   {
     r->iterate_decls ([&] (NodeId decl_node_id, Location locus) -> bool {
       CanonicalPath ident = CanonicalPath::create_empty ();
@@ -43,14 +43,15 @@ public:
 	}
       return true;
     });
+    return true;
   }
 
   static void Scan ()
   {
     auto resolver = Resolver::get ();
-    resolver->iterate_name_ribs ([&] (Rib *r) -> void { ScanRib (r); });
-    resolver->iterate_type_ribs ([&] (Rib *r) -> void { ScanRib (r); });
-    resolver->iterate_label_ribs ([&] (Rib *r) -> void { ScanRib (r); });
+    resolver->iterate_name_ribs ([&] (Rib *r) -> bool { return ScanRib (r); });
+    resolver->iterate_type_ribs ([&] (Rib *r) -> bool { return ScanRib (r); });
+    resolver->iterate_label_ribs ([&] (Rib *r) -> bool { return ScanRib (r); });
   }
 };
 

--- a/gcc/rust/resolve/rust-name-resolver.h
+++ b/gcc/rust/resolve/rust-name-resolver.h
@@ -335,27 +335,30 @@ public:
     return it->second.size ();
   }
 
-  void iterate_name_ribs (std::function<void (Rib *)> cb)
+  void iterate_name_ribs (std::function<bool (Rib *)> cb)
   {
     for (auto it = name_ribs.begin (); it != name_ribs.end (); it++)
-      cb (it->second);
+      if (!cb (it->second))
+	break;
   }
 
-  void iterate_type_ribs (std::function<void (Rib *)> cb)
+  void iterate_type_ribs (std::function<bool (Rib *)> cb)
   {
     for (auto it = type_ribs.begin (); it != type_ribs.end (); it++)
       {
 	if (it->first == global_type_node_id)
 	  continue;
 
-	cb (it->second);
+	if (!cb (it->second))
+	  break;
       }
   }
 
-  void iterate_label_ribs (std::function<void (Rib *)> cb)
+  void iterate_label_ribs (std::function<bool (Rib *)> cb)
   {
     for (auto it = label_ribs.begin (); it != label_ribs.end (); it++)
-      cb (it->second);
+      if (!cb (it->second))
+	break;
   }
 
 private:


### PR DESCRIPTION
The callback now returns a bool for continuing the iteration (true) or stopping
it (false).
Fixed the scanning for unused names without changing its behavior (always doing
full iteration).