### PR TITLE
Optional trait items

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -80,6 +80,7 @@ GRS_OBJS = \
     rust/rust-tyty.o \
     rust/rust-tyctx.o \
     rust/rust-tyty-bounds.o \
+    rust/rust-hir-trait-resolve.o \
     rust/rust-hir-const-fold.o \
     rust/rust-lint-marklive.o \
     $(END)

--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -80,6 +80,7 @@ GRS_OBJS = \
     rust/rust-tyty.o \
     rust/rust-tyctx.o \
     rust/rust-tyty-bounds.o \
+    rust/rust-hir-type-check-util.o \
     rust/rust-hir-trait-resolve.o \
     rust/rust-hir-const-fold.o \
     rust/rust-lint-marklive.o \

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -338,6 +338,8 @@ public:
 
   void visit (TyTy::PlaceholderType &) override { gcc_unreachable (); }
 
+  void visit (TyTy::ProjectionType &) override { gcc_unreachable (); }
+
   void visit (TyTy::ParamType &param) override
   {
     param.resolve ()->accept_vis (*this);

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -336,9 +336,12 @@ public:
 
   void visit (TyTy::InferType &) override { gcc_unreachable (); }
 
-  void visit (TyTy::PlaceholderType &) override { gcc_unreachable (); }
-
   void visit (TyTy::ProjectionType &) override { gcc_unreachable (); }
+
+  void visit (TyTy::PlaceholderType &type) override
+  {
+    type.resolve ()->accept_vis (*this);
+  }
 
   void visit (TyTy::ParamType &param) override
   {

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -287,7 +287,7 @@ public:
 
   // this needs to support Legacy and V0 see github #429 or #305
   std::string mangle_item (const TyTy::BaseType *ty,
-			   const std::string &name) const;
+			   const Resolver::CanonicalPath &path) const;
 
   std::string mangle_impl_item (const TyTy::BaseType *self,
 				const TyTy::BaseType *ty,

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -629,6 +629,11 @@ public:
 						      expr.get_locus ());
   }
 
+  void visit (HIR::QualifiedPathInExpression &expr) override
+  {
+    translated = ResolvePathRef::Compile (expr, ctx);
+  }
+
   void visit (HIR::PathInExpression &expr) override
   {
     translated = ResolvePathRef::Compile (expr, ctx);

--- a/gcc/rust/backend/rust-compile-implitem.h
+++ b/gcc/rust/backend/rust-compile-implitem.h
@@ -297,6 +297,219 @@ private:
   TyTy::BaseType *concrete;
 };
 
+class CompileTraitItem : public HIRCompileBase
+{
+  using Rust::Compile::HIRCompileBase::visit;
+
+public:
+  static void Compile (TyTy::BaseType *self, HIR::TraitItem *item, Context *ctx,
+		       TyTy::BaseType *concrete)
+  {
+    CompileTraitItem compiler (self, ctx, concrete);
+    item->accept_vis (compiler);
+  }
+
+  void visit (HIR::TraitItemFunc &func) override
+  {
+    rust_assert (func.has_block_defined ());
+
+    rust_assert (concrete->get_kind () == TyTy::TypeKind::FNDEF);
+    TyTy::FnType *fntype = static_cast<TyTy::FnType *> (concrete);
+
+    // items can be forward compiled which means we may not need to invoke this
+    // code. We might also have already compiled this generic function as well.
+    Bfunction *lookup = nullptr;
+    if (ctx->lookup_function_decl (fntype->get_ty_ref (), &lookup, fntype))
+      {
+	// has this been added to the list then it must be finished
+	if (ctx->function_completed (lookup))
+	  {
+	    Bfunction *dummy = nullptr;
+	    if (!ctx->lookup_function_decl (fntype->get_ty_ref (), &dummy))
+	      ctx->insert_function_decl (fntype->get_ty_ref (), lookup, fntype);
+
+	    return;
+	  }
+      }
+
+    if (fntype->has_subsititions_defined ())
+      {
+	// override the Hir Lookups for the substituions in this context
+	fntype->override_context ();
+      }
+
+    // convert to the actual function type
+    ::Btype *compiled_fn_type = TyTyResolveCompile::compile (ctx, fntype);
+
+    HIR::TraitFunctionDecl &function = func.get_decl ();
+    unsigned int flags = 0;
+
+    const Resolver::CanonicalPath *canonical_path = nullptr;
+    rust_assert (ctx->get_mappings ()->lookup_canonical_path (
+      func.get_mappings ().get_crate_num (), func.get_mappings ().get_nodeid (),
+      &canonical_path));
+
+    std::string fn_identifier = canonical_path->get ();
+    std::string asm_name
+      = ctx->mangle_impl_item (self, fntype, function.get_function_name ());
+
+    Bfunction *fndecl
+      = ctx->get_backend ()->function (compiled_fn_type, fn_identifier,
+				       asm_name, flags, func.get_locus ());
+    ctx->insert_function_decl (fntype->get_ty_ref (), fndecl, fntype);
+
+    // setup the params
+    TyTy::BaseType *tyret = fntype->get_return_type ();
+    std::vector<Bvariable *> param_vars;
+
+    if (function.is_method ())
+      {
+	// insert self
+	TyTy::BaseType *self_tyty_lookup = nullptr;
+	if (!ctx->get_tyctx ()->lookup_type (
+	      function.get_self ().get_mappings ().get_hirid (),
+	      &self_tyty_lookup))
+	  {
+	    rust_error_at (function.get_self ().get_locus (),
+			   "failed to lookup self param type");
+	    return;
+	  }
+
+	Btype *self_type = TyTyResolveCompile::compile (ctx, self_tyty_lookup);
+	if (self_type == nullptr)
+	  {
+	    rust_error_at (function.get_self ().get_locus (),
+			   "failed to compile self param type");
+	    return;
+	  }
+
+	Bvariable *compiled_self_param
+	  = CompileSelfParam::compile (ctx, fndecl, function.get_self (),
+				       self_type,
+				       function.get_self ().get_locus ());
+	if (compiled_self_param == nullptr)
+	  {
+	    rust_error_at (function.get_self ().get_locus (),
+			   "failed to compile self param variable");
+	    return;
+	  }
+
+	param_vars.push_back (compiled_self_param);
+	ctx->insert_var_decl (function.get_self ().get_mappings ().get_hirid (),
+			      compiled_self_param);
+      }
+
+    // offset from + 1 for the TyTy::FnType being used when this is a method to
+    // skip over Self on the FnType
+    size_t i = function.is_method () ? 1 : 0;
+    for (auto referenced_param : function.get_function_params ())
+      {
+	auto tyty_param = fntype->param_at (i);
+	auto param_tyty = tyty_param.second;
+
+	auto compiled_param_type
+	  = TyTyResolveCompile::compile (ctx, param_tyty);
+	if (compiled_param_type == nullptr)
+	  {
+	    rust_error_at (referenced_param.get_locus (),
+			   "failed to compile parameter type");
+	    return;
+	  }
+
+	Location param_locus
+	  = ctx->get_mappings ()->lookup_location (param_tyty->get_ref ());
+	Bvariable *compiled_param_var
+	  = CompileFnParam::compile (ctx, fndecl, &referenced_param,
+				     compiled_param_type, param_locus);
+	if (compiled_param_var == nullptr)
+	  {
+	    rust_error_at (param_locus, "Failed to compile parameter variable");
+	    return;
+	  }
+
+	param_vars.push_back (compiled_param_var);
+
+	ctx->insert_var_decl (referenced_param.get_mappings ().get_hirid (),
+			      compiled_param_var);
+	i++;
+      }
+
+    if (!ctx->get_backend ()->function_set_parameters (fndecl, param_vars))
+      {
+	rust_fatal_error (func.get_locus (),
+			  "failed to setup parameter variables");
+	return;
+      }
+
+    // lookup locals
+    auto block_expr = func.get_block_expr ().get ();
+    auto body_mappings = block_expr->get_mappings ();
+
+    Resolver::Rib *rib = nullptr;
+    if (!ctx->get_resolver ()->find_name_rib (body_mappings.get_nodeid (),
+					      &rib))
+      {
+	rust_fatal_error (func.get_locus (),
+			  "failed to setup locals per block");
+	return;
+      }
+
+    std::vector<Bvariable *> locals;
+    bool ok = compile_locals_for_block (*rib, fndecl, locals);
+    rust_assert (ok);
+
+    Bblock *enclosing_scope = NULL;
+    HIR::BlockExpr *function_body = func.get_block_expr ().get ();
+    Location start_location = function_body->get_locus ();
+    Location end_location = function_body->get_closing_locus ();
+
+    Bblock *code_block
+      = ctx->get_backend ()->block (fndecl, enclosing_scope, locals,
+				    start_location, end_location);
+    ctx->push_block (code_block);
+
+    Bvariable *return_address = nullptr;
+    if (function.has_return_type ())
+      {
+	Btype *return_type = TyTyResolveCompile::compile (ctx, tyret);
+
+	bool address_is_taken = false;
+	Bstatement *ret_var_stmt = nullptr;
+
+	return_address = ctx->get_backend ()->temporary_variable (
+	  fndecl, code_block, return_type, NULL, address_is_taken,
+	  func.get_locus (), &ret_var_stmt);
+
+	ctx->add_statement (ret_var_stmt);
+      }
+
+    ctx->push_fn (fndecl, return_address);
+
+    compile_function_body (fndecl, func.get_block_expr (),
+			   function.has_return_type ());
+
+    ctx->pop_block ();
+    auto body = ctx->get_backend ()->block_statement (code_block);
+    if (!ctx->get_backend ()->function_set_body (fndecl, body))
+      {
+	rust_error_at (func.get_locus (), "failed to set body to function");
+	return;
+      }
+
+    ctx->pop_fn ();
+    ctx->push_function (fndecl);
+  }
+
+private:
+  CompileTraitItem (TyTy::BaseType *self, Context *ctx,
+		    TyTy::BaseType *concrete)
+    : HIRCompileBase (ctx), self (self), concrete (concrete)
+  {}
+
+  TyTy::BaseType *self;
+  TyTy::BaseType *concrete;
+};
+
 } // namespace Compile
 } // namespace Rust
 

--- a/gcc/rust/backend/rust-compile-implitem.h
+++ b/gcc/rust/backend/rust-compile-implitem.h
@@ -352,8 +352,7 @@ public:
       &canonical_path));
 
     std::string fn_identifier = canonical_path->get ();
-    std::string asm_name
-      = ctx->mangle_impl_item (self, fntype, function.get_function_name ());
+    std::string asm_name = ctx->mangle_item (fntype, *canonical_path);
 
     Bfunction *fndecl
       = ctx->get_backend ()->function (compiled_fn_type, fn_identifier,

--- a/gcc/rust/backend/rust-compile-implitem.h
+++ b/gcc/rust/backend/rust-compile-implitem.h
@@ -319,15 +319,17 @@ public:
     // items can be forward compiled which means we may not need to invoke this
     // code. We might also have already compiled this generic function as well.
     Bfunction *lookup = nullptr;
-    if (ctx->lookup_function_decl (fntype->get_ty_ref (), &lookup, fntype))
+    if (ctx->lookup_function_decl (fntype->get_ty_ref (), &lookup))
       {
 	// has this been added to the list then it must be finished
 	if (ctx->function_completed (lookup))
 	  {
 	    Bfunction *dummy = nullptr;
 	    if (!ctx->lookup_function_decl (fntype->get_ty_ref (), &dummy))
-	      ctx->insert_function_decl (fntype->get_ty_ref (), lookup, fntype);
-
+	      {
+		ctx->insert_function_decl (fntype->get_ty_ref (), lookup,
+					   fntype);
+	      }
 	    return;
 	  }
       }

--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -59,7 +59,7 @@ public:
       &canonical_path));
 
     std::string name = canonical_path->get ();
-    std::string asm_name = ctx->mangle_item (resolved_type, name);
+    std::string asm_name = ctx->mangle_item (resolved_type, *canonical_path);
 
     bool is_external = false;
     bool is_hidden = false;
@@ -168,12 +168,24 @@ public:
 
     std::string ir_symbol_name
       = canonical_path->get () + fntype->subst_as_string ();
+
     std::string asm_name = function.get_function_name ();
 
     // we don't mangle the main fn since we haven't implemented the main shim
     // yet
     if (!is_main_fn)
-      asm_name = ctx->mangle_item (fntype, ir_symbol_name);
+      {
+	std::string substs_str = fntype->subst_as_string ();
+
+	Resolver::CanonicalPath mangle_me
+	  = substs_str.empty ()
+	      ? *canonical_path
+	      : canonical_path->append (
+		Resolver::CanonicalPath::new_seg (0,
+						  fntype->subst_as_string ()));
+
+	asm_name = ctx->mangle_item (fntype, mangle_me);
+      }
 
     Bfunction *fndecl
       = ctx->get_backend ()->function (compiled_fn_type, ir_symbol_name,

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -27,18 +27,33 @@ namespace Rust {
 namespace Compile {
 
 void
+ResolvePathRef::visit (HIR::QualifiedPathInExpression &expr)
+{
+  resolve (expr.get_final_segment ().get_segment (), expr.get_mappings (),
+	   expr.get_locus (), true);
+}
+
+void
 ResolvePathRef::visit (HIR::PathInExpression &expr)
+{
+  resolve (expr.get_final_segment ().get_segment (), expr.get_mappings (),
+	   expr.get_locus (), false);
+}
+
+void
+ResolvePathRef::resolve (const HIR::PathIdentSegment &final_segment,
+			 const Analysis::NodeMapping &mappings,
+			 Location expr_locus, bool is_qualified_path)
 {
   // need to look up the reference for this identifier
   NodeId ref_node_id = UNKNOWN_NODEID;
-  if (ctx->get_resolver ()->lookup_resolved_name (
-	expr.get_mappings ().get_nodeid (), &ref_node_id))
+  if (ctx->get_resolver ()->lookup_resolved_name (mappings.get_nodeid (),
+						  &ref_node_id))
     {
       Resolver::Definition def;
       if (!ctx->get_resolver ()->lookup_definition (ref_node_id, &def))
 	{
-	  rust_error_at (expr.get_locus (),
-			 "unknown reference for resolved name");
+	  rust_error_at (expr_locus, "unknown reference for resolved name");
 	  return;
 	}
       ref_node_id = def.parent;
@@ -50,10 +65,10 @@ ResolvePathRef::visit (HIR::PathInExpression &expr)
     return;
 
   HirId ref;
-  if (!ctx->get_mappings ()->lookup_node_to_hir (
-	expr.get_mappings ().get_crate_num (), ref_node_id, &ref))
+  if (!ctx->get_mappings ()->lookup_node_to_hir (mappings.get_crate_num (),
+						 ref_node_id, &ref))
     {
-      rust_error_at (expr.get_locus (), "reverse call path lookup failure");
+      rust_error_at (expr_locus, "reverse call path lookup failure");
       return;
     }
 
@@ -65,15 +80,14 @@ ResolvePathRef::visit (HIR::PathInExpression &expr)
   Bvariable *var = nullptr;
   if (ctx->lookup_var_decl (ref, &var))
     {
-      resolved = ctx->get_backend ()->var_expression (var, expr.get_locus ());
+      resolved = ctx->get_backend ()->var_expression (var, expr_locus);
       return;
     }
 
   // must be a function call but it might be a generic function which needs to
   // be compiled first
   TyTy::BaseType *lookup = nullptr;
-  bool ok = ctx->get_tyctx ()->lookup_type (expr.get_mappings ().get_hirid (),
-					    &lookup);
+  bool ok = ctx->get_tyctx ()->lookup_type (mappings.get_hirid (), &lookup);
   rust_assert (ok);
   rust_assert (lookup->get_kind () == TyTy::TypeKind::FNDEF);
   TyTy::FnType *fntype = static_cast<TyTy::FnType *> (lookup);
@@ -82,8 +96,9 @@ ResolvePathRef::visit (HIR::PathInExpression &expr)
   if (!ctx->lookup_function_decl (lookup->get_ty_ref (), &fn))
     {
       // it must resolve to some kind of HIR::Item or HIR::InheritImplItem
-      HIR::Item *resolved_item = ctx->get_mappings ()->lookup_hir_item (
-	expr.get_mappings ().get_crate_num (), ref);
+      HIR::Item *resolved_item
+	= ctx->get_mappings ()->lookup_hir_item (mappings.get_crate_num (),
+						 ref);
       if (resolved_item != nullptr)
 	{
 	  if (!lookup->has_subsititions_defined ())
@@ -96,14 +111,14 @@ ResolvePathRef::visit (HIR::PathInExpression &expr)
 	  HirId parent_impl_id = UNKNOWN_HIRID;
 	  HIR::ImplItem *resolved_item
 	    = ctx->get_mappings ()->lookup_hir_implitem (
-	      expr.get_mappings ().get_crate_num (), ref, &parent_impl_id);
+	      mappings.get_crate_num (), ref, &parent_impl_id);
 
 	  if (resolved_item == nullptr)
 	    {
 	      // it might be resolved to a trait item
 	      HIR::TraitItem *trait_item
 		= ctx->get_mappings ()->lookup_hir_trait_item (
-		  expr.get_mappings ().get_crate_num (), ref);
+		  mappings.get_crate_num (), ref);
 	      HIR::Trait *trait
 		= ctx->get_mappings ()->lookup_trait_item_mapping (
 		  trait_item->get_mappings ().get_hirid ());
@@ -115,8 +130,8 @@ ResolvePathRef::visit (HIR::PathInExpression &expr)
 	      rust_assert (ok);
 
 	      TyTy::BaseType *receiver = nullptr;
-	      ok = ctx->get_tyctx ()->lookup_receiver (
-		expr.get_mappings ().get_hirid (), &receiver);
+	      ok = ctx->get_tyctx ()->lookup_receiver (mappings.get_hirid (),
+						       &receiver);
 	      rust_assert (ok);
 
 	      if (receiver->get_kind () == TyTy::TypeKind::PARAM)
@@ -130,10 +145,13 @@ ResolvePathRef::visit (HIR::PathInExpression &expr)
 	      // item so its up to us to figure out if this path should resolve
 	      // to an trait-impl-block-item or if it can be defaulted to the
 	      // trait-impl-item's definition
-	      std::vector<Resolver::PathProbeCandidate> candidates
-		= Resolver::PathProbeType::Probe (
-		  receiver, expr.get_final_segment ().get_segment (), true,
-		  false, true);
+	      std::vector<Resolver::PathProbeCandidate> candidates;
+	      if (!is_qualified_path)
+		{
+		  candidates
+		    = Resolver::PathProbeType::Probe (receiver, final_segment,
+						      true, false, true);
+		}
 
 	      if (candidates.size () == 0)
 		{
@@ -152,6 +170,7 @@ ResolvePathRef::visit (HIR::PathInExpression &expr)
 		    = ctx->get_tyctx ()
 			->lookup_associated_impl_mapping_for_self (
 			  trait_mappings.get_hirid (), receiver);
+
 		  rust_assert (associated_impl_id != UNKNOWN_HIRID);
 
 		  Resolver::AssociatedImplTrait *associated = nullptr;
@@ -168,7 +187,7 @@ ResolvePathRef::visit (HIR::PathInExpression &expr)
 		  if (!ctx->lookup_function_decl (fntype->get_ty_ref (), &fn))
 		    {
 		      resolved = ctx->get_backend ()->error_expression ();
-		      rust_error_at (expr.get_locus (),
+		      rust_error_at (expr_locus,
 				     "forward declaration was not compiled");
 		      return;
 		    }
@@ -201,7 +220,7 @@ ResolvePathRef::visit (HIR::PathInExpression &expr)
 	    {
 	      rust_assert (parent_impl_id != UNKNOWN_HIRID);
 	      HIR::Item *impl_ref = ctx->get_mappings ()->lookup_hir_item (
-		expr.get_mappings ().get_crate_num (), parent_impl_id);
+		mappings.get_crate_num (), parent_impl_id);
 	      rust_assert (impl_ref != nullptr);
 	      HIR::ImplBlock *impl = static_cast<HIR::ImplBlock *> (impl_ref);
 
@@ -222,14 +241,12 @@ ResolvePathRef::visit (HIR::PathInExpression &expr)
       if (!ctx->lookup_function_decl (lookup->get_ty_ref (), &fn))
 	{
 	  resolved = ctx->get_backend ()->error_expression ();
-	  rust_error_at (expr.get_locus (),
-			 "forward declaration was not compiled");
+	  rust_error_at (expr_locus, "forward declaration was not compiled");
 	  return;
 	}
     }
 
-  resolved
-    = ctx->get_backend ()->function_code_expression (fn, expr.get_locus ());
+  resolved = ctx->get_backend ()->function_code_expression (fn, expr_locus);
 }
 
 } // namespace Compile

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -138,8 +138,35 @@ ResolvePathRef::visit (HIR::PathInExpression &expr)
 		{
 		  // this means we are defaulting back to the trait_item if
 		  // possible
-		  // TODO
-		  gcc_unreachable ();
+		  Resolver::TraitItemReference *trait_item_ref = nullptr;
+		  bool ok = trait_ref->lookup_hir_trait_item (*trait_item,
+							      &trait_item_ref);
+		  rust_assert (ok); // found
+		  rust_assert (
+		    trait_item_ref->is_optional ()); // has definition
+
+		  // FIXME
+		  // TyTy::BaseType *self_type = nullptr;
+		  // if (!ctx->get_tyctx ()->lookup_type (
+		  //       expr.get_receiver ()->get_mappings ().get_hirid (),
+		  //       &self_type))
+		  //   {
+		  //     rust_error_at (expr.get_locus (),
+		  //       	     "failed to resolve type for self param");
+		  //     return;
+		  //   }
+
+		  // CompileTraitItem::Compile (
+		  //   self_type, trait_item_ref->get_hir_trait_item (), ctx,
+		  //   fntype);
+		  // if (!ctx->lookup_function_decl (fntype->get_ty_ref (),
+		  // &fn))
+		  //   {
+		  //     translated = ctx->get_backend ()->error_expression ();
+		  //     rust_error_at (expr.get_locus (),
+		  //       	     "forward declaration was not compiled");
+		  //     return;
+		  //   }
 		}
 	      else
 		{

--- a/gcc/rust/backend/rust-compile-resolve-path.h
+++ b/gcc/rust/backend/rust-compile-resolve-path.h
@@ -30,6 +30,14 @@ class ResolvePathRef : public HIRCompileBase
   using Rust::Compile::HIRCompileBase::visit;
 
 public:
+  static Bexpression *Compile (HIR::QualifiedPathInExpression &expr,
+			       Context *ctx)
+  {
+    ResolvePathRef resolver (ctx);
+    expr.accept_vis (resolver);
+    return resolver.resolved;
+  }
+
   static Bexpression *Compile (HIR::PathInExpression &expr, Context *ctx)
   {
     ResolvePathRef resolver (ctx);
@@ -39,8 +47,16 @@ public:
 
   void visit (HIR::PathInExpression &expr) override;
 
+  void visit (HIR::QualifiedPathInExpression &expr) override;
+
 private:
-  ResolvePathRef (Context *ctx) : HIRCompileBase (ctx), resolved (nullptr) {}
+  ResolvePathRef (Context *ctx)
+    : HIRCompileBase (ctx), resolved (ctx->get_backend ()->error_expression ())
+  {}
+
+  void resolve (const HIR::PathIdentSegment &final_segment,
+		const Analysis::NodeMapping &mappings, Location locus,
+		bool is_qualified_path);
 
   Bexpression *resolved;
 };

--- a/gcc/rust/backend/rust-compile-tyty.h
+++ b/gcc/rust/backend/rust-compile-tyty.h
@@ -50,6 +50,8 @@ public:
 
   void visit (TyTy::PlaceholderType &) override { gcc_unreachable (); }
 
+  void visit (TyTy::ProjectionType &) override { gcc_unreachable (); }
+
   void visit (TyTy::TupleType &type) override
   {
     if (type.num_fields () == 0)

--- a/gcc/rust/hir/rust-ast-lower-base.h
+++ b/gcc/rust/hir/rust-ast-lower-base.h
@@ -284,6 +284,9 @@ protected:
   HIR::Type *lower_type_no_bounds (AST::TypeNoBounds *type);
 
   HIR::TypeParamBound *lower_bound (AST::TypeParamBound *bound);
+
+  HIR::QualifiedPathType
+  lower_qual_path_type (AST::QualifiedPathType &qual_path_type);
 };
 
 } // namespace HIR

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -48,6 +48,28 @@ private:
   HIR::PathInExpression *translated;
 };
 
+class ASTLowerQualPathInExpression : public ASTLoweringBase
+{
+  using Rust::HIR::ASTLoweringBase::visit;
+
+public:
+  static HIR::QualifiedPathInExpression *
+  translate (AST::QualifiedPathInExpression *expr)
+  {
+    ASTLowerQualPathInExpression compiler;
+    expr->accept_vis (compiler);
+    rust_assert (compiler.translated);
+    return compiler.translated;
+  }
+
+  void visit (AST::QualifiedPathInExpression &expr) override;
+
+private:
+  ASTLowerQualPathInExpression () : translated (nullptr) {}
+
+  HIR::QualifiedPathInExpression *translated;
+};
+
 class ASTLoweringExpr : public ASTLoweringBase
 {
   using Rust::HIR::ASTLoweringBase::visit;
@@ -143,6 +165,11 @@ public:
   void visit (AST::PathInExpression &expr) override
   {
     translated = ASTLowerPathInExpression::translate (&expr);
+  }
+
+  void visit (AST::QualifiedPathInExpression &expr) override
+  {
+    translated = ASTLowerQualPathInExpression::translate (&expr);
   }
 
   void visit (AST::ReturnExpr &expr) override

--- a/gcc/rust/hir/rust-ast-lower-implitem.h
+++ b/gcc/rust/hir/rust-ast-lower-implitem.h
@@ -354,10 +354,12 @@ public:
 				 std::move (function_params),
 				 std::move (return_type),
 				 std::move (where_clause));
-    HIR::Expr *block_expr
-      = func.has_definition ()
-	  ? ASTLoweringExpr::translate (func.get_definition ().get ())
-	  : nullptr;
+    bool terminated = false;
+    std::unique_ptr<HIR::BlockExpr> block_expr
+      = func.has_definition () ? std::unique_ptr<HIR::BlockExpr> (
+	  ASTLoweringBlock::translate (func.get_definition ().get (),
+				       &terminated))
+			       : nullptr;
 
     auto crate_num = mappings->get_current_crate ();
     Analysis::NodeMapping mapping (crate_num, func.get_node_id (),
@@ -366,8 +368,8 @@ public:
 
     HIR::TraitItemFunc *trait_item
       = new HIR::TraitItemFunc (mapping, std::move (decl),
-				std::unique_ptr<HIR::Expr> (block_expr),
-				func.get_outer_attrs (), func.get_locus ());
+				std::move (block_expr), func.get_outer_attrs (),
+				func.get_locus ());
     translated = trait_item;
     mappings->insert_hir_trait_item (mapping.get_crate_num (),
 				     mapping.get_hirid (), translated);
@@ -423,10 +425,12 @@ public:
 				 std::move (function_params),
 				 std::move (return_type),
 				 std::move (where_clause));
-    HIR::Expr *block_expr
-      = method.has_definition ()
-	  ? ASTLoweringExpr::translate (method.get_definition ().get ())
-	  : nullptr;
+    bool terminated = false;
+    std::unique_ptr<HIR::BlockExpr> block_expr
+      = method.has_definition () ? std::unique_ptr<HIR::BlockExpr> (
+	  ASTLoweringBlock::translate (method.get_definition ().get (),
+				       &terminated))
+				 : nullptr;
 
     auto crate_num = mappings->get_current_crate ();
     Analysis::NodeMapping mapping (crate_num, method.get_node_id (),
@@ -435,7 +439,7 @@ public:
 
     HIR::TraitItemFunc *trait_item
       = new HIR::TraitItemFunc (mapping, std::move (decl),
-				std::unique_ptr<HIR::Expr> (block_expr),
+				std::move (block_expr),
 				method.get_outer_attrs (), method.get_locus ());
     translated = trait_item;
     mappings->insert_hir_trait_item (mapping.get_crate_num (),

--- a/gcc/rust/hir/rust-ast-lower-implitem.h
+++ b/gcc/rust/hir/rust-ast-lower-implitem.h
@@ -375,6 +375,15 @@ public:
 				     mapping.get_hirid (), translated);
     mappings->insert_location (crate_num, mapping.get_hirid (),
 			       trait_item->get_locus ());
+
+    // add the mappings for the function params at the end
+    for (auto &param : trait_item->get_decl ().get_function_params ())
+      {
+	mappings->insert_hir_param (mapping.get_crate_num (),
+				    param.get_mappings ().get_hirid (), &param);
+	mappings->insert_location (crate_num, mapping.get_hirid (),
+				   param.get_locus ());
+      }
   }
 
   void visit (AST::TraitItemMethod &method) override
@@ -446,6 +455,23 @@ public:
 				     mapping.get_hirid (), translated);
     mappings->insert_location (crate_num, mapping.get_hirid (),
 			       trait_item->get_locus ());
+
+    // insert mappings for self
+    mappings->insert_hir_self_param (crate_num,
+				     self_param.get_mappings ().get_hirid (),
+				     &self_param);
+    mappings->insert_location (crate_num,
+			       self_param.get_mappings ().get_hirid (),
+			       self_param.get_locus ());
+
+    // add the mappings for the function params at the end
+    for (auto &param : trait_item->get_decl ().get_function_params ())
+      {
+	mappings->insert_hir_param (mapping.get_crate_num (),
+				    param.get_mappings ().get_hirid (), &param);
+	mappings->insert_location (crate_num, mapping.get_hirid (),
+				   param.get_locus ());
+      }
   }
 
   void visit (AST::TraitItemConst &constant) override

--- a/gcc/rust/hir/tree/rust-hir-full-test.cc
+++ b/gcc/rust/hir/tree/rust-hir-full-test.cc
@@ -1192,11 +1192,11 @@ std::string
 QualifiedPathType::as_string () const
 {
   std::string str ("<");
-  str += type_to_invoke_on->as_string ();
+  str += type->as_string ();
 
   if (has_as_clause ())
     {
-      str += " as " + trait_path.as_string ();
+      str += " as " + trait->as_string ();
     }
 
   return str + ">";

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -2270,7 +2270,7 @@ class TraitItemFunc : public TraitItem
 {
   AST::AttrVec outer_attrs;
   TraitFunctionDecl decl;
-  std::unique_ptr<Expr> block_expr;
+  std::unique_ptr<BlockExpr> block_expr;
   Location locus;
 
 public:
@@ -2278,8 +2278,8 @@ public:
   bool has_definition () const { return block_expr != nullptr; }
 
   TraitItemFunc (Analysis::NodeMapping mappings, TraitFunctionDecl decl,
-		 std::unique_ptr<Expr> block_expr, AST::AttrVec outer_attrs,
-		 Location locus)
+		 std::unique_ptr<BlockExpr> block_expr,
+		 AST::AttrVec outer_attrs, Location locus)
     : TraitItem (mappings), outer_attrs (std::move (outer_attrs)),
       decl (std::move (decl)), block_expr (std::move (block_expr)),
       locus (locus)
@@ -2291,7 +2291,7 @@ public:
       decl (other.decl), locus (other.locus)
   {
     if (other.block_expr != nullptr)
-      block_expr = other.block_expr->clone_expr ();
+      block_expr = other.block_expr->clone_block_expr ();
   }
 
   // Overloaded assignment operator to clone
@@ -2303,7 +2303,7 @@ public:
     locus = other.locus;
     mappings = other.mappings;
     if (other.block_expr != nullptr)
-      block_expr = other.block_expr->clone_expr ();
+      block_expr = other.block_expr->clone_block_expr ();
 
     return *this;
   }
@@ -2322,10 +2322,15 @@ public:
 
   bool has_block_defined () const { return block_expr != nullptr; }
 
-  std::unique_ptr<Expr> &get_block_expr ()
+  std::unique_ptr<BlockExpr> &get_block_expr ()
   {
     rust_assert (has_block_defined ());
     return block_expr;
+  }
+
+  const std::string trait_identifier () const override final
+  {
+    return decl.get_function_name ();
   }
 
 protected:
@@ -2400,6 +2405,8 @@ public:
     return expr;
   }
 
+  const std::string trait_identifier () const override final { return name; }
+
 protected:
   // Clone function implementation as (not pure) virtual method
   TraitItemConst *clone_trait_item_impl () const override
@@ -2473,6 +2480,8 @@ public:
   {
     return type_param_bounds;
   }
+
+  const std::string trait_identifier () const override final { return name; }
 
 protected:
   // Clone function implementation as (not pure) virtual method

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -646,7 +646,9 @@ public:
 
   virtual void accept_vis (HIRVisitor &vis) = 0;
 
-  const Analysis::NodeMapping &get_mappings () const { return mappings; }
+  virtual const std::string trait_identifier () const = 0;
+
+  const Analysis::NodeMapping get_mappings () const { return mappings; }
 };
 
 class ImplItem

--- a/gcc/rust/resolve/rust-ast-resolve-expr.h
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.h
@@ -39,10 +39,22 @@ public:
     resolver.resolve_path (expr);
   }
 
+  static void go (AST::QualifiedPathInExpression *expr, NodeId parent)
+  {
+    ResolvePath resolver (parent);
+    resolver.resolve_path (expr);
+  }
+
 private:
   ResolvePath (NodeId parent) : ResolverBase (parent) {}
 
   void resolve_path (AST::PathInExpression *expr);
+
+  void resolve_path (AST::QualifiedPathInExpression *expr);
+
+  void resolve_segments (CanonicalPath prefix, size_t offs,
+			 std::vector<AST::PathExprSegment> &segs,
+			 NodeId expr_node_id, Location expr_locus);
 };
 
 class ResolveExpr : public ResolverBase
@@ -71,6 +83,11 @@ public:
   }
 
   void visit (AST::PathInExpression &expr) override
+  {
+    ResolvePath::go (&expr, parent);
+  }
+
+  void visit (AST::QualifiedPathInExpression &expr) override
   {
     ResolvePath::go (&expr, parent);
   }

--- a/gcc/rust/resolve/rust-ast-resolve-toplevel.h
+++ b/gcc/rust/resolve/rust-ast-resolve-toplevel.h
@@ -206,6 +206,19 @@ public:
 				      impl_type_seg);
     CanonicalPath impl_prefix = prefix.append (projection);
 
+    resolver->get_name_scope ().insert (
+      impl_prefix, impl_block.get_node_id (), impl_block.get_locus (), false,
+      [&] (const CanonicalPath &, NodeId, Location locus) -> void {
+	RichLocation r (impl_block.get_locus ());
+	r.add_range (locus);
+	rust_error_at (r, "redefined multiple times");
+      });
+    resolver->insert_new_definition (impl_block.get_node_id (),
+				     Definition{impl_block.get_node_id (),
+						impl_block.get_node_id ()});
+    resolver->insert_resolved_name (impl_block.get_node_id (),
+				    impl_block.get_node_id ());
+
     for (auto &impl_item : impl_block.get_impl_items ())
       ResolveToplevelImplItem::go (impl_item.get (), impl_prefix);
   }

--- a/gcc/rust/typecheck/rust-hir-const-fold.h
+++ b/gcc/rust/typecheck/rust-hir-const-fold.h
@@ -55,6 +55,8 @@ public:
 
   void visit (TyTy::PlaceholderType &) override { gcc_unreachable (); }
 
+  void visit (TyTy::ProjectionType &) override { gcc_unreachable (); }
+
   void visit (TyTy::TupleType &type) override
   {
     if (type.num_fields () == 0)

--- a/gcc/rust/typecheck/rust-hir-trait-ref.h
+++ b/gcc/rust/typecheck/rust-hir-trait-ref.h
@@ -111,9 +111,11 @@ public:
 
   const HIR::TraitItem *get_hir_trait_item () const { return hir_trait_item; }
 
+  HIR::TraitItem *get_hir_trait_item () { return hir_trait_item; }
+
   Location get_locus () const { return locus; }
 
-  const Analysis::NodeMapping &get_mappings () const
+  const Analysis::NodeMapping get_mappings () const
   {
     return hir_trait_item->get_mappings ();
   }
@@ -146,6 +148,13 @@ public:
     return get_error ();
   }
 
+  // this is called when the trait is completed resolution and gives the items a
+  // chance to run their specific type resolution passes. If we call their
+  // resolution on construction it can lead to a case where the trait being
+  // resolved recursively trying to resolve the trait itself infinitely since
+  // the trait will not be stored in its own map yet
+  void on_resolved ();
+
 private:
   TyTy::ErrorType *get_error () const
   {
@@ -159,6 +168,11 @@ private:
   get_type_from_constant (/*const*/ HIR::TraitItemConst &constant) const;
 
   TyTy::BaseType *get_type_from_fn (/*const*/ HIR::TraitItemFunc &fn) const;
+
+  bool is_item_resolved () const;
+  void resolve_item (HIR::TraitItemType &type);
+  void resolve_item (HIR::TraitItemConst &constant);
+  void resolve_item (HIR::TraitItemFunc &func);
 
   std::string identifier;
   bool optional_flag;
@@ -233,6 +247,31 @@ public:
     return hir_trait_ref->get_mappings ();
   }
 
+  bool lookup_hir_trait_item (const HIR::TraitItem &item,
+			      TraitItemReference **ref)
+  {
+    return lookup_trait_item (item.trait_identifier (), ref);
+  }
+
+  bool lookup_trait_item (const std::string &ident, TraitItemReference **ref)
+  {
+    for (auto &item : item_refs)
+      {
+	if (ident.compare (item.get_identifier ()) == 0)
+	  {
+	    *ref = &item;
+	    return true;
+	  }
+      }
+    return false;
+  }
+
+  bool lookup_hir_trait_item (const HIR::TraitItem &item,
+			      const TraitItemReference **ref) const
+  {
+    return lookup_trait_item (item.trait_identifier (), ref);
+  }
+
   bool lookup_trait_item (const std::string &ident,
 			  const TraitItemReference **ref) const
   {
@@ -267,6 +306,14 @@ public:
   const std::vector<TraitItemReference> &get_trait_items () const
   {
     return item_refs;
+  }
+
+  void on_resolved ()
+  {
+    for (auto &item : item_refs)
+      {
+	item.on_resolved ();
+      }
   }
 
 private:

--- a/gcc/rust/typecheck/rust-hir-trait-ref.h
+++ b/gcc/rust/typecheck/rust-hir-trait-ref.h
@@ -359,6 +359,10 @@ public:
 
   void reset_associated_types ();
 
+  TyTy::BaseType *get_projected_type (const TraitItemReference *trait_item_ref,
+				      TyTy::BaseType *reciever, HirId ref,
+				      Location expr_locus);
+
 private:
   TraitReference *trait;
   HIR::ImplBlock *impl;

--- a/gcc/rust/typecheck/rust-hir-trait-resolve.cc
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.cc
@@ -1,0 +1,68 @@
+// Copyright (C) 2021 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-hir-trait-resolve.h"
+
+namespace Rust {
+namespace Resolver {
+
+void
+ResolveTraitItemToRef::visit (HIR::TraitItemType &type)
+{
+  TyTy::BaseType *ty
+    = new TyTy::PlaceholderType (type.get_mappings ().get_hirid ());
+  context->insert_type (type.get_mappings (), ty);
+
+  // create trait-item-ref
+  Location locus = type.get_locus ();
+  bool is_optional = false;
+  std::string identifier = type.get_name ();
+
+  resolved = TraitItemReference (identifier, is_optional,
+				 TraitItemReference::TraitItemType::TYPE, &type,
+				 self, substitutions, locus);
+}
+
+void
+ResolveTraitItemToRef::visit (HIR::TraitItemConst &cst)
+{
+  // create trait-item-ref
+  Location locus = cst.get_locus ();
+  bool is_optional = cst.has_expr ();
+  std::string identifier = cst.get_name ();
+
+  resolved = TraitItemReference (identifier, is_optional,
+				 TraitItemReference::TraitItemType::CONST, &cst,
+				 self, substitutions, locus);
+}
+
+void
+ResolveTraitItemToRef::visit (HIR::TraitItemFunc &fn)
+{
+  // create trait-item-ref
+  Location locus = fn.get_locus ();
+  bool is_optional = fn.has_block_defined ();
+  std::string identifier = fn.get_decl ().get_function_name ();
+
+  resolved = TraitItemReference (identifier, is_optional,
+				 TraitItemReference::TraitItemType::FN, &fn,
+				 self, substitutions, locus);
+}
+
+} // namespace Resolver
+} // namespace Rust

--- a/gcc/rust/typecheck/rust-hir-trait-resolve.cc
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.cc
@@ -17,6 +17,7 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-hir-trait-resolve.h"
+#include "rust-hir-type-check-expr.h"
 
 namespace Rust {
 namespace Resolver {
@@ -62,6 +63,69 @@ ResolveTraitItemToRef::visit (HIR::TraitItemFunc &fn)
   resolved = TraitItemReference (identifier, is_optional,
 				 TraitItemReference::TraitItemType::FN, &fn,
 				 self, substitutions, locus);
+}
+
+// TraitItemReference items
+
+void
+TraitItemReference::on_resolved ()
+{
+  switch (type)
+    {
+    case CONST:
+      resolve_item (static_cast<HIR::TraitItemConst &> (*hir_trait_item));
+      break;
+
+    case TYPE:
+      resolve_item (static_cast<HIR::TraitItemType &> (*hir_trait_item));
+      break;
+
+    case FN:
+      resolve_item (static_cast<HIR::TraitItemFunc &> (*hir_trait_item));
+      break;
+
+    default:
+      break;
+    }
+}
+
+void
+TraitItemReference::resolve_item (HIR::TraitItemType &type)
+{
+  // TODO
+}
+
+void
+TraitItemReference::resolve_item (HIR::TraitItemConst &constant)
+{
+  // TODO
+}
+
+void
+TraitItemReference::resolve_item (HIR::TraitItemFunc &func)
+{
+  if (!is_optional ())
+    return;
+
+  TyTy::BaseType *item_tyty = get_tyty ();
+  if (item_tyty->get_kind () == TyTy::TypeKind::ERROR)
+    return;
+
+  // check the block and return types
+  rust_assert (item_tyty->get_kind () == TyTy::TypeKind::FNDEF);
+
+  // need to get the return type from this
+  TyTy::FnType *resolved_fn_type = static_cast<TyTy::FnType *> (item_tyty);
+  auto expected_ret_tyty = resolved_fn_type->get_return_type ();
+  context->push_return_type (expected_ret_tyty);
+
+  auto block_expr_ty
+    = TypeCheckExpr::Resolve (func.get_block_expr ().get (), false);
+
+  context->pop_return_type ();
+
+  if (block_expr_ty->get_kind () != TyTy::NEVER)
+    expected_ret_tyty->unify (block_expr_ty);
 }
 
 } // namespace Resolver

--- a/gcc/rust/typecheck/rust-hir-trait-resolve.h
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.h
@@ -154,6 +154,11 @@ private:
       trait_reference->get_mappings ().get_defid (), &tref);
     rust_assert (ok);
 
+    // hook to allow the trait to resolve its optional item blocks, we cant
+    // resolve the blocks of functions etc because it can end up in a recursive
+    // loop of trying to resolve traits as required by the types
+    tref->on_resolved ();
+
     return tref;
   }
 

--- a/gcc/rust/typecheck/rust-hir-trait-resolve.h
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.h
@@ -42,45 +42,11 @@ public:
     return resolver.resolved;
   }
 
-  void visit (HIR::TraitItemType &type) override
-  {
-    TyTy::BaseType *ty
-      = new TyTy::PlaceholderType (type.get_mappings ().get_hirid ());
-    context->insert_type (type.get_mappings (), ty);
+  void visit (HIR::TraitItemType &type) override;
 
-    // create trait-item-ref
-    Location locus = type.get_locus ();
-    bool is_optional = false;
-    std::string identifier = type.get_name ();
+  void visit (HIR::TraitItemConst &cst) override;
 
-    resolved = TraitItemReference (identifier, is_optional,
-				   TraitItemReference::TraitItemType::TYPE,
-				   &type, self, substitutions, locus);
-  }
-
-  void visit (HIR::TraitItemConst &cst) override
-  {
-    // create trait-item-ref
-    Location locus = cst.get_locus ();
-    bool is_optional = cst.has_expr ();
-    std::string identifier = cst.get_name ();
-
-    resolved = TraitItemReference (identifier, is_optional,
-				   TraitItemReference::TraitItemType::CONST,
-				   &cst, self, substitutions, locus);
-  }
-
-  void visit (HIR::TraitItemFunc &fn) override
-  {
-    // create trait-item-ref
-    Location locus = fn.get_locus ();
-    bool is_optional = fn.has_block_defined ();
-    std::string identifier = fn.get_decl ().get_function_name ();
-
-    resolved = TraitItemReference (identifier, is_optional,
-				   TraitItemReference::TraitItemType::FN, &fn,
-				   self, substitutions, locus);
-  }
+  void visit (HIR::TraitItemFunc &fn) override;
 
 private:
   ResolveTraitItemToRef (

--- a/gcc/rust/typecheck/rust-hir-type-bounds.h
+++ b/gcc/rust/typecheck/rust-hir-type-bounds.h
@@ -31,7 +31,8 @@ class TypeBoundsProbe : public TypeCheckBase
   using Rust::Resolver::TypeCheckBase::visit;
 
 public:
-  static std::vector<TraitReference *> Probe (const TyTy::BaseType *receiver)
+  static std::vector<std::pair<TraitReference *, HIR::ImplBlock *>>
+  Probe (const TyTy::BaseType *receiver)
   {
     TypeBoundsProbe probe (receiver);
     probe.scan ();
@@ -41,9 +42,11 @@ public:
   static bool is_bound_satisfied_for_type (TyTy::BaseType *receiver,
 					   TraitReference *ref)
   {
-    std::vector<TraitReference *> bounds = Probe (receiver);
-    for (TraitReference *b : bounds)
+    std::vector<std::pair<TraitReference *, HIR::ImplBlock *>> bounds
+      = Probe (receiver);
+    for (auto &bound : bounds)
       {
+	TraitReference *b = bound.first;
 	if (b == ref)
 	  return true;
       }
@@ -59,7 +62,7 @@ private:
   {}
 
   const TyTy::BaseType *receiver;
-  std::vector<TraitReference *> trait_references;
+  std::vector<std::pair<TraitReference *, HIR::ImplBlock *>> trait_references;
 };
 
 } // namespace Resolver

--- a/gcc/rust/typecheck/rust-hir-type-bounds.h
+++ b/gcc/rust/typecheck/rust-hir-type-bounds.h
@@ -38,6 +38,18 @@ public:
     return probe.trait_references;
   }
 
+  static bool is_bound_satisfied_for_type (TyTy::BaseType *receiver,
+					   TraitReference *ref)
+  {
+    std::vector<TraitReference *> bounds = Probe (receiver);
+    for (TraitReference *b : bounds)
+      {
+	if (b == ref)
+	  return true;
+      }
+    return false;
+  }
+
 private:
   void scan ();
 

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -975,7 +975,6 @@ public:
       }
 
     // TODO self and generic arguments
-
     infered = trait_item_ref->get_tyty ();
     rust_debug_loc (expr.get_locus (), "resolved to:");
     infered->debug ();
@@ -1370,6 +1369,22 @@ private:
 	  {
 	    resolved_node_id
 	      = candidate.item.trait.item_ref->get_mappings ().get_nodeid ();
+
+	    // lookup the associated-impl-trait
+	    HIR::ImplBlock *impl = candidate.item.trait.impl;
+	    if (impl != nullptr)
+	      {
+		AssociatedImplTrait *lookup_associated = nullptr;
+		bool found_impl_trait = context->lookup_associated_trait_impl (
+		  impl->get_mappings ().get_hirid (), &lookup_associated);
+		rust_assert (found_impl_trait);
+
+		lookup_associated->setup_associated_types ();
+
+		// we need a new ty_ref_id for this trait item
+		tyseg = tyseg->clone ();
+		tyseg->set_ty_ref (mappings->get_next_hir_id ());
+	      }
 	  }
 
 	if (seg.has_generic_args ())

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -383,8 +383,7 @@ public:
 	  trait_reference.get_name ().c_str ());
       }
 
-    context->insert_type (resolved_trait_item.get_mappings (),
-			  lookup->clone ());
+    resolved_trait_item.associated_type_set (lookup);
   }
 
   void visit (HIR::Function &function) override

--- a/gcc/rust/typecheck/rust-hir-type-check-item.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.h
@@ -123,6 +123,19 @@ public:
 			   trait_reference->get_name ().c_str ());
 	  }
       }
+
+    if (is_trait_impl_block)
+      {
+	trait_reference->clear_associated_types ();
+
+	AssociatedImplTrait associated (trait_reference, &impl_block, self,
+					context);
+	context->insert_associated_trait_impl (
+	  impl_block.get_mappings ().get_hirid (), std::move (associated));
+	context->insert_associated_impl_mapping (
+	  trait_reference->get_mappings ().get_hirid (), self,
+	  impl_block.get_mappings ().get_hirid ());
+      }
   }
 
   void visit (HIR::Function &function) override

--- a/gcc/rust/typecheck/rust-hir-type-check-util.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-util.cc
@@ -1,0 +1,41 @@
+// Copyright (C) 2021 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-hir-type-check-util.h"
+#include "rust-hir-full.h"
+
+namespace Rust {
+namespace Resolver {
+
+void
+ImplTypeIterator::go ()
+{
+  for (auto &item : impl.get_impl_items ())
+    {
+      item->accept_vis (*this);
+    }
+}
+
+void
+ImplTypeIterator::visit (HIR::TypeAlias &alias)
+{
+  cb (alias);
+}
+
+} // namespace Resolver
+} // namespace Rust

--- a/gcc/rust/typecheck/rust-hir-type-check-util.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-util.h
@@ -1,0 +1,216 @@
+// Copyright (C) 2021 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_HIR_TYPE_CHECK_UTIL_H
+#define RUST_HIR_TYPE_CHECK_UTIL_H
+
+#include <functional>
+#include "rust-hir-visitor.h"
+
+namespace Rust {
+namespace Resolver {
+
+class SimpleHirVisitor : public HIR::HIRVisitor
+{
+public:
+  virtual ~SimpleHirVisitor () {}
+
+  virtual void visit (HIR::IdentifierExpr &) override {}
+  virtual void visit (HIR::Lifetime &) override {}
+  virtual void visit (HIR::LifetimeParam &) override {}
+  virtual void visit (HIR::PathInExpression &) override {}
+  virtual void visit (HIR::TypePathSegment &) override {}
+  virtual void visit (HIR::TypePathSegmentGeneric &) override {}
+  virtual void visit (HIR::TypePathSegmentFunction &) override {}
+  virtual void visit (HIR::TypePath &) override {}
+  virtual void visit (HIR::QualifiedPathInExpression &) override {}
+  virtual void visit (HIR::QualifiedPathInType &) override {}
+
+  virtual void visit (HIR::LiteralExpr &) override {}
+  virtual void visit (HIR::BorrowExpr &) override {}
+  virtual void visit (HIR::DereferenceExpr &) override {}
+  virtual void visit (HIR::ErrorPropagationExpr &) override {}
+  virtual void visit (HIR::NegationExpr &) override {}
+  virtual void visit (HIR::ArithmeticOrLogicalExpr &) override {}
+  virtual void visit (HIR::ComparisonExpr &) override {}
+  virtual void visit (HIR::LazyBooleanExpr &) override {}
+  virtual void visit (HIR::TypeCastExpr &) override {}
+  virtual void visit (HIR::AssignmentExpr &) override {}
+
+  virtual void visit (HIR::GroupedExpr &) override {}
+
+  virtual void visit (HIR::ArrayElemsValues &) override {}
+  virtual void visit (HIR::ArrayElemsCopied &) override {}
+  virtual void visit (HIR::ArrayExpr &) override {}
+  virtual void visit (HIR::ArrayIndexExpr &) override {}
+  virtual void visit (HIR::TupleExpr &) override {}
+  virtual void visit (HIR::TupleIndexExpr &) override {}
+  virtual void visit (HIR::StructExprStruct &) override {}
+
+  virtual void visit (HIR::StructExprFieldIdentifier &) override {}
+  virtual void visit (HIR::StructExprFieldIdentifierValue &) override {}
+
+  virtual void visit (HIR::StructExprFieldIndexValue &) override {}
+  virtual void visit (HIR::StructExprStructFields &) override {}
+  virtual void visit (HIR::StructExprStructBase &) override {}
+  virtual void visit (HIR::StructExprTuple &) override {}
+  virtual void visit (HIR::StructExprUnit &) override {}
+
+  virtual void visit (HIR::EnumExprFieldIdentifier &) override {}
+  virtual void visit (HIR::EnumExprFieldIdentifierValue &) override {}
+
+  virtual void visit (HIR::EnumExprFieldIndexValue &) override {}
+  virtual void visit (HIR::EnumExprStruct &) override {}
+  virtual void visit (HIR::EnumExprTuple &) override {}
+  virtual void visit (HIR::EnumExprFieldless &) override {}
+  virtual void visit (HIR::CallExpr &) override {}
+  virtual void visit (HIR::MethodCallExpr &) override {}
+  virtual void visit (HIR::FieldAccessExpr &) override {}
+  virtual void visit (HIR::ClosureExprInner &) override {}
+  virtual void visit (HIR::BlockExpr &) override {}
+  virtual void visit (HIR::ClosureExprInnerTyped &) override {}
+  virtual void visit (HIR::ContinueExpr &) override {}
+  virtual void visit (HIR::BreakExpr &) override {}
+  virtual void visit (HIR::RangeFromToExpr &) override {}
+  virtual void visit (HIR::RangeFromExpr &) override {}
+  virtual void visit (HIR::RangeToExpr &) override {}
+  virtual void visit (HIR::RangeFullExpr &) override {}
+  virtual void visit (HIR::RangeFromToInclExpr &) override {}
+  virtual void visit (HIR::RangeToInclExpr &) override {}
+  virtual void visit (HIR::ReturnExpr &) override {}
+  virtual void visit (HIR::UnsafeBlockExpr &) override {}
+  virtual void visit (HIR::LoopExpr &) override {}
+  virtual void visit (HIR::WhileLoopExpr &) override {}
+  virtual void visit (HIR::WhileLetLoopExpr &) override {}
+  virtual void visit (HIR::ForLoopExpr &) override {}
+  virtual void visit (HIR::IfExpr &) override {}
+  virtual void visit (HIR::IfExprConseqElse &) override {}
+  virtual void visit (HIR::IfExprConseqIf &) override {}
+  virtual void visit (HIR::IfExprConseqIfLet &) override {}
+  virtual void visit (HIR::IfLetExpr &) override {}
+  virtual void visit (HIR::IfLetExprConseqElse &) override {}
+  virtual void visit (HIR::IfLetExprConseqIf &) override {}
+  virtual void visit (HIR::IfLetExprConseqIfLet &) override {}
+
+  virtual void visit (HIR::MatchExpr &) override {}
+  virtual void visit (HIR::AwaitExpr &) override {}
+  virtual void visit (HIR::AsyncBlockExpr &) override {}
+
+  virtual void visit (HIR::TypeParam &) override {}
+
+  virtual void visit (HIR::LifetimeWhereClauseItem &) override {}
+  virtual void visit (HIR::TypeBoundWhereClauseItem &) override {}
+  virtual void visit (HIR::ModuleBodied &) override {}
+  virtual void visit (HIR::ModuleNoBody &) override {}
+  virtual void visit (HIR::ExternCrate &) override {}
+
+  virtual void visit (HIR::UseTreeGlob &) override {}
+  virtual void visit (HIR::UseTreeList &) override {}
+  virtual void visit (HIR::UseTreeRebind &) override {}
+  virtual void visit (HIR::UseDeclaration &) override {}
+  virtual void visit (HIR::Function &) override {}
+  virtual void visit (HIR::TypeAlias &) override {}
+  virtual void visit (HIR::StructStruct &) override {}
+  virtual void visit (HIR::TupleStruct &) override {}
+  virtual void visit (HIR::EnumItem &) override {}
+  virtual void visit (HIR::EnumItemTuple &) override {}
+  virtual void visit (HIR::EnumItemStruct &) override {}
+  virtual void visit (HIR::EnumItemDiscriminant &) override {}
+  virtual void visit (HIR::Enum &) override {}
+  virtual void visit (HIR::Union &) override {}
+  virtual void visit (HIR::ConstantItem &) override {}
+  virtual void visit (HIR::StaticItem &) override {}
+  virtual void visit (HIR::TraitItemFunc &) override {}
+  virtual void visit (HIR::TraitItemConst &) override {}
+  virtual void visit (HIR::TraitItemType &) override {}
+  virtual void visit (HIR::Trait &) override {}
+  virtual void visit (HIR::ImplBlock &) override {}
+
+  virtual void visit (HIR::ExternalStaticItem &) override {}
+  virtual void visit (HIR::ExternalFunctionItem &) override {}
+  virtual void visit (HIR::ExternBlock &) override {}
+
+  virtual void visit (HIR::LiteralPattern &) override {}
+  virtual void visit (HIR::IdentifierPattern &) override {}
+  virtual void visit (HIR::WildcardPattern &) override {}
+
+  virtual void visit (HIR::RangePatternBoundLiteral &) override {}
+  virtual void visit (HIR::RangePatternBoundPath &) override {}
+  virtual void visit (HIR::RangePatternBoundQualPath &) override {}
+  virtual void visit (HIR::RangePattern &) override {}
+  virtual void visit (HIR::ReferencePattern &) override {}
+
+  virtual void visit (HIR::StructPatternFieldTuplePat &) override {}
+  virtual void visit (HIR::StructPatternFieldIdentPat &) override {}
+  virtual void visit (HIR::StructPatternFieldIdent &) override {}
+  virtual void visit (HIR::StructPattern &) override {}
+
+  virtual void visit (HIR::TupleStructItemsNoRange &) override {}
+  virtual void visit (HIR::TupleStructItemsRange &) override {}
+  virtual void visit (HIR::TupleStructPattern &) override {}
+
+  virtual void visit (HIR::TuplePatternItemsMultiple &) override {}
+  virtual void visit (HIR::TuplePatternItemsRanged &) override {}
+  virtual void visit (HIR::TuplePattern &) override {}
+  virtual void visit (HIR::GroupedPattern &) override {}
+  virtual void visit (HIR::SlicePattern &) override {}
+
+  virtual void visit (HIR::EmptyStmt &) override {}
+  virtual void visit (HIR::LetStmt &) override {}
+  virtual void visit (HIR::ExprStmtWithoutBlock &) override {}
+  virtual void visit (HIR::ExprStmtWithBlock &) override {}
+
+  virtual void visit (HIR::TraitBound &) override {}
+  virtual void visit (HIR::ImplTraitType &) override {}
+  virtual void visit (HIR::TraitObjectType &) override {}
+  virtual void visit (HIR::ParenthesisedType &) override {}
+  virtual void visit (HIR::ImplTraitTypeOneBound &) override {}
+  virtual void visit (HIR::TraitObjectTypeOneBound &) override {}
+  virtual void visit (HIR::TupleType &) override {}
+  virtual void visit (HIR::NeverType &) override {}
+  virtual void visit (HIR::RawPointerType &) override {}
+  virtual void visit (HIR::ReferenceType &) override {}
+  virtual void visit (HIR::ArrayType &) override {}
+  virtual void visit (HIR::SliceType &) override {}
+  virtual void visit (HIR::InferredType &) override {}
+  virtual void visit (HIR::BareFunctionType &) override {}
+};
+
+class ImplTypeIterator : public SimpleHirVisitor
+{
+  using SimpleHirVisitor::visit;
+
+public:
+  ImplTypeIterator (HIR::ImplBlock &impl,
+		    std::function<void (HIR::TypeAlias &alias)> cb)
+    : impl (impl), cb (cb)
+  {}
+
+  void go ();
+
+  void visit (HIR::TypeAlias &alias) override;
+
+private:
+  HIR::ImplBlock &impl;
+  std::function<void (HIR::TypeAlias &alias)> cb;
+};
+
+} // namespace Resolver
+} // namespace Rust
+
+#endif // RUST_HIR_TYPE_CHECK_UTIL_H

--- a/gcc/rust/typecheck/rust-substitution-mapper.h
+++ b/gcc/rust/typecheck/rust-substitution-mapper.h
@@ -108,6 +108,7 @@ public:
   void visit (TyTy::StrType &) override { gcc_unreachable (); }
   void visit (TyTy::NeverType &) override { gcc_unreachable (); }
   void visit (TyTy::PlaceholderType &) override { gcc_unreachable (); }
+  void visit (TyTy::ProjectionType &) override { gcc_unreachable (); }
 
 private:
   SubstMapper (HirId ref, HIR::GenericArgs *generics, Location locus)
@@ -191,6 +192,7 @@ public:
   void visit (TyTy::StrType &) override { gcc_unreachable (); }
   void visit (TyTy::NeverType &) override { gcc_unreachable (); }
   void visit (TyTy::PlaceholderType &) override { gcc_unreachable (); }
+  void visit (TyTy::ProjectionType &) override { gcc_unreachable (); }
 
 private:
   SubstMapperInternal (HirId ref, TyTy::SubstitutionArgumentMappings &mappings)
@@ -248,6 +250,7 @@ public:
   void visit (TyTy::StrType &) override { gcc_unreachable (); }
   void visit (TyTy::NeverType &) override { gcc_unreachable (); }
   void visit (TyTy::PlaceholderType &) override { gcc_unreachable (); }
+  void visit (TyTy::ProjectionType &) override { gcc_unreachable (); }
 
 private:
   SubstMapperFromExisting (TyTy::BaseType *concrete, TyTy::BaseType *receiver)
@@ -298,6 +301,7 @@ public:
   void visit (TyTy::StrType &) override {}
   void visit (TyTy::NeverType &) override {}
   void visit (TyTy::PlaceholderType &) override {}
+  void visit (TyTy::ProjectionType &) override {}
 
 private:
   GetUsedSubstArgs () : args (TyTy::SubstitutionArgumentMappings::error ()) {}

--- a/gcc/rust/typecheck/rust-tyty-bounds.cc
+++ b/gcc/rust/typecheck/rust-tyty-bounds.cc
@@ -25,7 +25,8 @@ namespace Resolver {
 void
 TypeBoundsProbe::scan ()
 {
-  std::vector<HIR::TypePath *> possible_trait_paths;
+  std::vector<std::pair<HIR::TypePath *, HIR::ImplBlock *>>
+    possible_trait_paths;
   mappings->iterate_impl_blocks (
     [&] (HirId id, HIR::ImplBlock *impl) mutable -> bool {
       // we are filtering for trait-impl-blocks
@@ -42,16 +43,17 @@ TypeBoundsProbe::scan ()
       if (!receiver->can_eq (impl_type, false))
 	return true;
 
-      possible_trait_paths.push_back (impl->get_trait_ref ().get ());
+      possible_trait_paths.push_back ({impl->get_trait_ref ().get (), impl});
       return true;
     });
 
-  for (auto &trait_path : possible_trait_paths)
+  for (auto &path : possible_trait_paths)
     {
+      HIR::TypePath *trait_path = path.first;
       TraitReference *trait_ref = TraitResolver::Resolve (*trait_path);
 
       if (!trait_ref->is_error ())
-	trait_references.push_back (trait_ref);
+	trait_references.push_back ({trait_ref, path.second});
     }
 }
 

--- a/gcc/rust/typecheck/rust-tyty-call.h
+++ b/gcc/rust/typecheck/rust-tyty-call.h
@@ -56,6 +56,7 @@ public:
   void visit (StrType &) override { gcc_unreachable (); }
   void visit (NeverType &) override { gcc_unreachable (); }
   void visit (PlaceholderType &) override { gcc_unreachable (); }
+  void visit (ProjectionType &) override { gcc_unreachable (); }
 
   // tuple-structs
   void visit (ADTType &type) override;
@@ -106,6 +107,7 @@ public:
   void visit (StrType &) override { gcc_unreachable (); }
   void visit (NeverType &) override { gcc_unreachable (); }
   void visit (PlaceholderType &) override { gcc_unreachable (); }
+  void visit (ProjectionType &) override { gcc_unreachable (); }
 
   // FIXME
   void visit (FnPtr &type) override { gcc_unreachable (); }

--- a/gcc/rust/typecheck/rust-tyty-cast.h
+++ b/gcc/rust/typecheck/rust-tyty-cast.h
@@ -307,6 +307,17 @@ public:
 		   type.as_string ().c_str ());
   }
 
+  virtual void visit (ProjectionType &type) override
+  {
+    Location ref_locus = mappings->lookup_location (type.get_ref ());
+    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
+    RichLocation r (ref_locus);
+    r.add_range (base_locus);
+    rust_error_at (r, "invalid cast [%s] to [%s]",
+		   get_base ()->as_string ().c_str (),
+		   type.as_string ().c_str ());
+  }
+
 protected:
   BaseCastRules (BaseType *base)
     : mappings (Analysis::Mappings::get ()),

--- a/gcc/rust/typecheck/rust-tyty-cmp.h
+++ b/gcc/rust/typecheck/rust-tyty-cmp.h
@@ -337,6 +337,22 @@ public:
       }
   }
 
+  virtual void visit (const ProjectionType &type) override
+  {
+    ok = false;
+    if (emit_error_flag)
+      {
+	Location ref_locus = mappings->lookup_location (type.get_ref ());
+	Location base_locus
+	  = mappings->lookup_location (get_base ()->get_ref ());
+	RichLocation r (ref_locus);
+	r.add_range (base_locus);
+	rust_error_at (r, "expected [%s] got [%s]",
+		       get_base ()->as_string ().c_str (),
+		       type.as_string ().c_str ());
+      }
+  }
+
   virtual void visit (const PlaceholderType &type) override
   {
     // it is ok for types to can eq to a placeholder

--- a/gcc/rust/typecheck/rust-tyty-cmp.h
+++ b/gcc/rust/typecheck/rust-tyty-cmp.h
@@ -43,6 +43,16 @@ public:
 	    return ok;
 	  }
       }
+    else if (other->get_kind () == TypeKind::PLACEHOLDER)
+      {
+	const PlaceholderType *p = static_cast<const PlaceholderType *> (other);
+	if (p->can_resolve ())
+	  {
+	    const BaseType *resolved = p->resolve ();
+	    resolved->accept_vis (*this);
+	    return ok;
+	  }
+      }
 
     other->accept_vis (*this);
     return ok;
@@ -1165,43 +1175,55 @@ public:
     : BaseCmp (base, emit_errors), base (base)
   {}
 
-  virtual void visit (const TupleType &) override { ok = true; }
+  bool can_eq (const BaseType *other) override
+  {
+    if (!base->can_resolve ())
+      return BaseCmp::can_eq (other);
 
-  virtual void visit (const ADTType &) override { ok = true; }
+    BaseType *lookup = base->resolve ();
+    return lookup->can_eq (other, emit_error_flag);
+  }
 
-  virtual void visit (const InferType &) override { ok = true; }
+  void visit (const TupleType &) override { ok = true; }
 
-  virtual void visit (const FnType &) override { ok = true; }
+  void visit (const ADTType &) override { ok = true; }
 
-  virtual void visit (const FnPtr &) override { ok = true; }
+  void visit (const InferType &) override { ok = true; }
 
-  virtual void visit (const ArrayType &) override { ok = true; }
+  void visit (const FnType &) override { ok = true; }
 
-  virtual void visit (const BoolType &) override { ok = true; }
+  void visit (const FnPtr &) override { ok = true; }
 
-  virtual void visit (const IntType &) override { ok = true; }
+  void visit (const ArrayType &) override { ok = true; }
 
-  virtual void visit (const UintType &) override { ok = true; }
+  void visit (const BoolType &) override { ok = true; }
 
-  virtual void visit (const USizeType &) override { ok = true; }
+  void visit (const IntType &) override { ok = true; }
 
-  virtual void visit (const ISizeType &) override { ok = true; }
+  void visit (const UintType &) override { ok = true; }
 
-  virtual void visit (const FloatType &) override { ok = true; }
+  void visit (const USizeType &) override { ok = true; }
 
-  virtual void visit (const ErrorType &) override { ok = true; }
+  void visit (const ISizeType &) override { ok = true; }
 
-  virtual void visit (const CharType &) override { ok = true; }
+  void visit (const FloatType &) override { ok = true; }
 
-  virtual void visit (const ReferenceType &) override { ok = true; }
+  void visit (const ErrorType &) override { ok = true; }
 
-  virtual void visit (const ParamType &) override { ok = true; }
+  void visit (const CharType &) override { ok = true; }
 
-  virtual void visit (const StrType &) override { ok = true; }
+  void visit (const ReferenceType &) override { ok = true; }
 
-  virtual void visit (const NeverType &) override { ok = true; }
+  void visit (const ParamType &) override { ok = true; }
 
-  virtual void visit (const PlaceholderType &) override { ok = true; }
+  void visit (const StrType &) override { ok = true; }
+
+  void visit (const NeverType &) override { ok = true; }
+
+  void visit (const PlaceholderType &type) override
+  {
+    ok = base->get_symbol ().compare (type.get_symbol ()) == 0;
+  }
 
 private:
   const BaseType *get_base () const override { return base; }

--- a/gcc/rust/typecheck/rust-tyty-coercion.h
+++ b/gcc/rust/typecheck/rust-tyty-coercion.h
@@ -307,6 +307,17 @@ public:
 		   type.as_string ().c_str ());
   }
 
+  virtual void visit (ProjectionType &type) override
+  {
+    Location ref_locus = mappings->lookup_location (type.get_ref ());
+    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
+    RichLocation r (ref_locus);
+    r.add_range (base_locus);
+    rust_error_at (r, "expected [%s] got [%s]",
+		   get_base ()->as_string ().c_str (),
+		   type.as_string ().c_str ());
+  }
+
 protected:
   BaseCoercionRules (BaseType *base)
     : mappings (Analysis::Mappings::get ()),

--- a/gcc/rust/typecheck/rust-tyty-rules.h
+++ b/gcc/rust/typecheck/rust-tyty-rules.h
@@ -329,6 +329,17 @@ public:
 		   type.as_string ().c_str ());
   }
 
+  virtual void visit (ProjectionType &type) override
+  {
+    Location ref_locus = mappings->lookup_location (type.get_ref ());
+    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
+    RichLocation r (ref_locus);
+    r.add_range (base_locus);
+    rust_error_at (r, "expected [%s] got [%s]",
+		   get_base ()->as_string ().c_str (),
+		   type.as_string ().c_str ());
+  }
+
 protected:
   BaseRules (BaseType *base)
     : mappings (Analysis::Mappings::get ()),

--- a/gcc/rust/typecheck/rust-tyty-visitor.h
+++ b/gcc/rust/typecheck/rust-tyty-visitor.h
@@ -47,6 +47,7 @@ public:
   virtual void visit (StrType &type) = 0;
   virtual void visit (NeverType &type) = 0;
   virtual void visit (PlaceholderType &type) = 0;
+  virtual void visit (ProjectionType &type) = 0;
 };
 
 class TyConstVisitor
@@ -72,6 +73,7 @@ public:
   virtual void visit (const StrType &type) = 0;
   virtual void visit (const NeverType &type) = 0;
   virtual void visit (const PlaceholderType &type) = 0;
+  virtual void visit (const ProjectionType &type) = 0;
 };
 
 } // namespace TyTy

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -2015,6 +2015,8 @@ NeverType::clone () const
   return new NeverType (get_ref (), get_ty_ref (), get_combined_refs ());
 }
 
+// placeholder type
+
 void
 PlaceholderType::accept_vis (TyVisitor &vis)
 {
@@ -2065,6 +2067,61 @@ BaseType *
 PlaceholderType::clone () const
 {
   return new PlaceholderType (get_ref (), get_ty_ref (), get_combined_refs ());
+}
+
+// Projection type
+
+void
+ProjectionType::accept_vis (TyVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+void
+ProjectionType::accept_vis (TyConstVisitor &vis) const
+{
+  vis.visit (*this);
+}
+
+std::string
+ProjectionType::as_string () const
+{
+  return "<Projection>";
+}
+
+BaseType *
+ProjectionType::unify (BaseType *other)
+{
+  gcc_unreachable ();
+  return nullptr;
+}
+
+BaseType *
+ProjectionType::coerce (BaseType *other)
+{
+  gcc_unreachable ();
+  return nullptr;
+}
+
+BaseType *
+ProjectionType::cast (BaseType *other)
+{
+  gcc_unreachable ();
+  return nullptr;
+}
+
+bool
+ProjectionType::can_eq (const BaseType *other, bool emit_errors) const
+{
+  gcc_unreachable ();
+  return false;
+}
+
+BaseType *
+ProjectionType::clone () const
+{
+  return new ProjectionType (get_ref (), get_ty_ref (), base, trait, item,
+			     get_combined_refs ());
 }
 
 // rust-tyty-call.h

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -2174,7 +2174,7 @@ BaseType *
 ProjectionType::clone () const
 {
   return new ProjectionType (get_ref (), get_ty_ref (), base, trait, item,
-			     get_combined_refs ());
+			     associated, get_combined_refs ());
 }
 
 // rust-tyty-call.h

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -1683,13 +1683,15 @@ public:
 class PlaceholderType : public BaseType
 {
 public:
-  PlaceholderType (HirId ref, std::set<HirId> refs = std::set<HirId> ())
-    : BaseType (ref, ref, TypeKind::PLACEHOLDER, refs)
+  PlaceholderType (std::string symbol, HirId ref,
+		   std::set<HirId> refs = std::set<HirId> ())
+    : BaseType (ref, ref, TypeKind::PLACEHOLDER, refs), symbol (symbol)
+
   {}
 
-  PlaceholderType (HirId ref, HirId ty_ref,
+  PlaceholderType (std::string symbol, HirId ref, HirId ty_ref,
 		   std::set<HirId> refs = std::set<HirId> ())
-    : BaseType (ref, ty_ref, TypeKind::PLACEHOLDER, refs)
+    : BaseType (ref, ty_ref, TypeKind::PLACEHOLDER, refs), symbol (symbol)
   {}
 
   void accept_vis (TyVisitor &vis) override;
@@ -1707,6 +1709,21 @@ public:
   std::string get_name () const override final { return as_string (); }
 
   bool is_unit () const override { return true; }
+
+  std::string get_symbol () const { return symbol; }
+
+  void set_associated_type (HirId ref);
+
+  void clear_associated_type ();
+
+  bool can_resolve () const;
+
+  BaseType *resolve () const;
+
+  bool is_equal (const BaseType &other) const override;
+
+private:
+  std::string symbol;
 };
 
 class ProjectionType : public BaseType

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -27,7 +27,8 @@
 namespace Rust {
 namespace Resolver {
 class TraitReference;
-}
+class AssociatedImplTrait;
+} // namespace Resolver
 
 namespace TyTy {
 
@@ -1730,16 +1731,18 @@ class ProjectionType : public BaseType
 {
 public:
   ProjectionType (HirId ref, TyVar base, Resolver::TraitReference *trait,
-		  DefId item, std::set<HirId> refs = std::set<HirId> ())
+		  DefId item, Resolver::AssociatedImplTrait *associated,
+		  std::set<HirId> refs = std::set<HirId> ())
     : BaseType (ref, ref, TypeKind::PROJECTION, refs), base (base),
-      trait (trait), item (item)
+      trait (trait), item (item), associated (associated)
   {}
 
   ProjectionType (HirId ref, HirId ty_ref, TyVar base,
 		  Resolver::TraitReference *trait, DefId item,
+		  Resolver::AssociatedImplTrait *associated,
 		  std::set<HirId> refs = std::set<HirId> ())
     : BaseType (ref, ty_ref, TypeKind::PROJECTION, refs), base (base),
-      trait (trait), item (item)
+      trait (trait), item (item), associated (associated)
   {}
 
   void accept_vis (TyVisitor &vis) override;
@@ -1762,6 +1765,7 @@ private:
   TyVar base;
   Resolver::TraitReference *trait;
   DefId item;
+  Resolver::AssociatedImplTrait *associated;
 };
 
 } // namespace TyTy

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -54,6 +54,7 @@ enum TypeKind
   ISIZE,
   NEVER,
   PLACEHOLDER,
+  PROJECTION,
   // there are more to add...
   ERROR
 };
@@ -121,6 +122,9 @@ public:
 
       case TypeKind::PLACEHOLDER:
 	return "Placeholder";
+
+      case TypeKind::PROJECTION:
+	return "Projection";
 
       case TypeKind::ERROR:
 	return "ERROR";
@@ -1703,6 +1707,44 @@ public:
   std::string get_name () const override final { return as_string (); }
 
   bool is_unit () const override { return true; }
+};
+
+class ProjectionType : public BaseType
+{
+public:
+  ProjectionType (HirId ref, TyVar base, Resolver::TraitReference *trait,
+		  DefId item, std::set<HirId> refs = std::set<HirId> ())
+    : BaseType (ref, ref, TypeKind::PROJECTION, refs), base (base),
+      trait (trait), item (item)
+  {}
+
+  ProjectionType (HirId ref, HirId ty_ref, TyVar base,
+		  Resolver::TraitReference *trait, DefId item,
+		  std::set<HirId> refs = std::set<HirId> ())
+    : BaseType (ref, ty_ref, TypeKind::PROJECTION, refs), base (base),
+      trait (trait), item (item)
+  {}
+
+  void accept_vis (TyVisitor &vis) override;
+  void accept_vis (TyConstVisitor &vis) const override;
+
+  std::string as_string () const override;
+
+  BaseType *unify (BaseType *other) override;
+  bool can_eq (const BaseType *other, bool emit_errors) const override final;
+  BaseType *coerce (BaseType *other) override;
+  BaseType *cast (BaseType *other) override;
+
+  BaseType *clone () const final override;
+
+  std::string get_name () const override final { return as_string (); }
+
+  bool is_unit () const override { return false; }
+
+private:
+  TyVar base;
+  Resolver::TraitReference *trait;
+  DefId item;
 };
 
 } // namespace TyTy

--- a/gcc/rust/util/rust-canonical-path.h
+++ b/gcc/rust/util/rust-canonical-path.h
@@ -110,6 +110,17 @@ public:
       }
   }
 
+  void iterate_segs (std::function<bool (const CanonicalPath &)> cb) const
+  {
+    for (auto &seg : segs)
+      {
+	std::vector<std::pair<NodeId, std::string>> buf;
+	buf.push_back ({seg.first, seg.second});
+	if (!cb (CanonicalPath (buf)))
+	  return;
+      }
+  }
+
   size_t size () const { return segs.size (); }
 
   NodeId get_id () const

--- a/gcc/testsuite/rust/compile/torture/traits10.rs
+++ b/gcc/testsuite/rust/compile/torture/traits10.rs
@@ -1,0 +1,32 @@
+trait Foo
+where
+    Self: Sized,
+{
+    fn get(self) -> i32;
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+
+    fn test(self) -> i32 {
+        self.get()
+    }
+}
+
+struct Bar(i32);
+impl Foo for Bar {
+    fn get(self) -> i32 {
+        self.0
+    }
+}
+
+fn main() {
+    let a;
+    a = Bar(123);
+
+    let b;
+    b = Bar::get(a);
+
+    let a;
+    a = Bar(123);
+
+    let b;
+    b = a.test();
+}

--- a/gcc/testsuite/rust/compile/torture/traits11.rs
+++ b/gcc/testsuite/rust/compile/torture/traits11.rs
@@ -1,0 +1,32 @@
+trait Foo {
+    type A;
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+
+    fn test(a: Self::A) -> Self::A {
+        a
+    }
+}
+
+struct Bar(i32);
+impl Foo for Bar {
+    type A = i32;
+}
+
+struct Baz(f32);
+impl Foo for Baz {
+    type A = f32;
+}
+
+fn main() {
+    let a;
+    a = Bar(123);
+
+    let b;
+    b = Bar::test(a.0);
+
+    let c;
+    c = Baz(123f32);
+
+    let d;
+    d = Baz::test(c.0);
+}

--- a/gcc/testsuite/rust/compile/traits1.rs
+++ b/gcc/testsuite/rust/compile/traits1.rs
@@ -1,5 +1,6 @@
 trait Foo {
     fn Bar() -> i32 {}
+    // { dg-error "expected .i32. got .()." "" { target *-*-* } .-1 }
 }
 
 struct Baz;

--- a/gcc/testsuite/rust/compile/traits2.rs
+++ b/gcc/testsuite/rust/compile/traits2.rs
@@ -1,5 +1,6 @@
 trait Foo {
     fn Bar() -> i32 {}
+    // { dg-error "expected .i32. got .()." "" { target *-*-* } .-1 }
 }
 
 struct Baz;

--- a/gcc/testsuite/rust/execute/torture/trait1.rs
+++ b/gcc/testsuite/rust/execute/torture/trait1.rs
@@ -1,0 +1,52 @@
+/* { dg-output "S::f\nT1::f\nT2::f\n" } */
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+struct S;
+
+impl S {
+    fn f() {
+        unsafe {
+            let a = "S::f\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c);
+        }
+    }
+}
+
+trait T1 {
+    fn f() {
+        unsafe {
+            let a = "T1::f\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c);
+        }
+    }
+}
+impl T1 for S {}
+
+trait T2 {
+    fn f() {
+        unsafe {
+            let a = "T2::f\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c);
+        }
+    }
+}
+impl T2 for S {}
+
+fn main() -> i32 {
+    S::f();
+    <S as T1>::f();
+    <S as T2>::f();
+
+    0
+}


### PR DESCRIPTION
Optional trait items like function may contain associated types. These
are dependant on the associated impl block for this type in order to
correctly propagate the correct types for the associated trait item during
type checking and compilation.

Fixes #542 