### PR TITLE
parse if expression with unary minus or not expression

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -12547,6 +12547,8 @@ Parser<ManagedTokenSource>::null_denotation (const_TokenPtr tok,
       case MINUS: { // unary minus
 	ParseRestrictions entered_from_unary;
 	entered_from_unary.entered_from_unary = true;
+	if (!restrictions.can_be_struct_expr)
+	  entered_from_unary.can_be_struct_expr = false;
 	std::unique_ptr<AST::Expr> expr
 	  = parse_expr (LBP_UNARY_MINUS, {}, entered_from_unary);
 
@@ -12571,6 +12573,8 @@ Parser<ManagedTokenSource>::null_denotation (const_TokenPtr tok,
       case EXCLAM: { // logical or bitwise not
 	ParseRestrictions entered_from_unary;
 	entered_from_unary.entered_from_unary = true;
+	if (!restrictions.can_be_struct_expr)
+	  entered_from_unary.can_be_struct_expr = false;
 	std::unique_ptr<AST::Expr> expr
 	  = parse_expr (LBP_UNARY_EXCLAM, {}, entered_from_unary);
 

--- a/gcc/testsuite/rust/compile/torture/ifunaryexpr.rs
+++ b/gcc/testsuite/rust/compile/torture/ifunaryexpr.rs
@@ -1,0 +1,22 @@
+extern "C"
+{
+  pub fn abort ();
+}
+
+struct B { b: bool }
+
+pub fn main ()
+{
+  let n = 1;
+  if 0 > -n { } else { unsafe { abort (); } }
+
+  let b = true;
+  if !b { unsafe { abort (); } }
+  if !!b { } else { unsafe { abort (); } }
+
+  let bb = B { b: false };
+
+  if !bb.b && !b { unsafe { abort (); } }
+
+  if (B { b: true }).b { } else { unsafe { abort (); } }
+}


### PR DESCRIPTION
From Mark Wielaard : https://gcc.gnu.org/pipermail/gcc-rust/2021-August/000140.html

> An if conditional expression doesn't need brackets, but that means
> that it doesn't accept struct expressions. Those are not easy to
> distinquish from the block that follows. What isn't immediately clear
> from the grammar is that unary conditions like minus '-' or not '!'
> also shouldn't accept struct expressions (when part of an if
> conditional expression) because those also cannot be easily
> distinquished from the block that follows.
> 
> Add a testcase "ifunaryexpr.rs" that shows a couple of contructs that
> should be accepted as if conditional expressions and fix the parser to
> pass the restriction of not accepting struct expressions after a unary
> expression.