### PR TITLE
Use builtin bool instead of creating new bool types for ComparisonExpr

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -630,10 +630,8 @@ public:
     if (result == nullptr || result->get_kind () == TyTy::TypeKind::ERROR)
       return;
 
-    // we expect this to be
-    infered = new TyTy::BoolType (expr.get_mappings ().get_hirid ());
-    infered->append_reference (lhs->get_ref ());
-    infered->append_reference (rhs->get_ref ());
+    bool ok = context->lookup_builtin ("bool", &infered);
+    rust_assert (ok);
   }
 
   void visit (HIR::LazyBooleanExpr &expr) override

--- a/gcc/testsuite/rust/compile/torture/bools_eq.rs
+++ b/gcc/testsuite/rust/compile/torture/bools_eq.rs
@@ -1,0 +1,18 @@
+extern "C"
+{
+  fn abort ();
+}
+
+fn beq (a: bool, b: bool) -> bool
+{
+  let bools_eq = a == b;
+  bools_eq
+}
+
+pub fn main ()
+{
+  let a = true;
+  let b = false;
+  let r = beq (a, b);
+  if r { unsafe { abort (); } }
+}


### PR DESCRIPTION
From Mark Wielaard : https://gcc.gnu.org/pipermail/gcc-rust/2021-August/000141.html 

> The TypeCheckExpr creates a new TyTy::BoolType for a
> ComparisonExpr. This new BoolType is unknown to TyTyResolveCompile
> which causes a crash when trying to compile the inferred new
> BoolType. Resolve this by looking up the builtin bool type.
> The new "bools_eq.rs" testcase uses several bools which show
> this issue.
> 
> Also the lhs and rhs types need to be compatible, but don't
> need to be bool type themselves. So don't append the reference
> to the inferred type. The existing "ifunaryexpr.rs" testcase
> will fail without this fix.