### PR TITLE
Use default type_for_size langhook

### DIFF
--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -224,20 +224,6 @@ grs_langhook_type_for_mode (machine_mode mode, int unsignedp)
   return NULL;
 }
 
-/* This appears to be used for creating different types for different bit sizes
- * (e.g. int and long). Also, the Go frontend calls this from type_for_mode to
- * determine the type from a specific bitsize for integer types.
- * FIXME: change this when working on AST-GENERIC conversion to allow the full
- * range of Rust type sizes. */
-static tree
-grs_langhook_type_for_size (unsigned int bits ATTRIBUTE_UNUSED,
-			    int unsignedp ATTRIBUTE_UNUSED)
-{
-  gcc_unreachable ();
-  return NULL_TREE;
-  // nothing at the moment, but change later
-}
-
 // Record a builtin function. We just ignore builtin functions.
 static tree
 grs_langhook_builtin_function (tree decl ATTRIBUTE_UNUSED)
@@ -420,7 +406,6 @@ rust_localize_identifier (const char *ident)
 #undef LANG_HOOKS_POST_OPTIONS
 #undef LANG_HOOKS_PARSE_FILE
 #undef LANG_HOOKS_TYPE_FOR_MODE
-#undef LANG_HOOKS_TYPE_FOR_SIZE
 #undef LANG_HOOKS_BUILTIN_FUNCTION
 #undef LANG_HOOKS_GLOBAL_BINDINGS_P
 #undef LANG_HOOKS_PUSHDECL
@@ -442,12 +427,10 @@ rust_localize_identifier (const char *ident)
  */
 #define LANG_HOOKS_PARSE_FILE grs_langhook_parse_file
 #define LANG_HOOKS_TYPE_FOR_MODE grs_langhook_type_for_mode
-#define LANG_HOOKS_TYPE_FOR_SIZE grs_langhook_type_for_size
 #define LANG_HOOKS_BUILTIN_FUNCTION grs_langhook_builtin_function
 #define LANG_HOOKS_GLOBAL_BINDINGS_P grs_langhook_global_bindings_p
 #define LANG_HOOKS_PUSHDECL grs_langhook_pushdecl
 #define LANG_HOOKS_GETDECLS grs_langhook_getdecls
-#define LANG_HOOKS_WRITE_GLOBALS grs_langhook_write_globals
 #define LANG_HOOKS_GIMPLIFY_EXPR grs_langhook_gimplify_expr
 #define LANG_HOOKS_EH_PERSONALITY grs_langhook_eh_personality
 

--- a/gcc/testsuite/rust/compile/torture/prims_struct_eq.rs
+++ b/gcc/testsuite/rust/compile/torture/prims_struct_eq.rs
@@ -1,0 +1,91 @@
+extern "C"
+{
+  fn abort ();
+}
+
+struct Prims
+{
+  b1: bool,
+  b2: bool,
+  b3: bool,
+  b4: bool,
+  c1: char,
+  c2: char,
+  u81: u8,
+  u82: u8,
+  u83: u8,
+  u84: u8,
+  i81: i8,
+  i82: i8,
+  i83: i8,
+  i84: i8,
+  u161: u16,
+  u162: u16,
+  i161: i16,
+  i162: i16,
+  u321: u32,
+  u322: u32,
+  i321: i32,
+  i322: i32,
+  u641: u64,
+  i641: i64,
+  u1281: u128,
+  i1281: i128,
+  usize1: usize,
+  isize1: isize,
+}
+
+fn prims_eq (p1: Prims, p2: Prims) -> bool
+{
+  return p1.b1 == p2.b1
+         && p1.b2 == p2.b2
+         && p1.b3 == p2.b3
+         && p1.b4 == p2.b4
+         && p1.c1 == p2.c1
+         && p1.c2 == p2.c2
+         && p1.u81 == p2.u81
+         && p1.u82 == p2.u82
+         && p1.u83 == p2.u83
+         && p1.u84 == p2.u84
+         && p1.i81 == p2.i81
+         && p1.i82 == p2.i82
+         && p1.i83 == p2.i83
+         && p1.i84 == p2.i84
+         && p1.u161 == p2.u161
+         && p1.u162 == p2.u162
+         && p1.i161 == p2.i161
+         && p1.i162 == p2.i162
+         && p1.u321 == p2.u321
+         && p1.u322 == p2.u322
+         && p1.i321 == p2.i321
+         && p1.i322 == p2.i322
+         && p1.u641 == p2.u641
+         && p1.i641 == p2.i641
+         && p1.u1281 == p2.u1281
+         && p1.i1281 == p2.i1281
+         && p1.usize1 == p2.usize1
+         && p1.isize1 == p2.isize1;
+}
+
+pub fn main ()
+{
+  let p1 = Prims { b1: true, b2: false, b3: false, b4: true,
+                   c1: 'a', c2: 'b',
+                   u81: 1, u82: 2, u83: 3, u84: 4,
+                   i81: -1, i82: -2, i83: -3, i84: -4,
+                   u161: 1, u162: 2,
+                   i161: -1, i162: -2,
+                   u321: 1, u322: 2,
+                   i321: -1, i322: -2,
+                   u641: 1,
+                   i641: -1,
+                   u1281: 1,
+                   i1281: -1,
+                   usize1: 1,
+                   isize1: -1 };
+  let p2 = Prims { usize1: 1, .. p1 };
+  let p3 = Prims { u1281: 0, .. p2 };
+  let p4 = Prims { i1281: 0, .. p3 };
+  if !prims_eq (p1, p2) { unsafe { abort (); } }
+  if prims_eq (p3, p4) { unsafe { abort (); } }
+}


### PR DESCRIPTION
From Mark Wielaard : https://gcc.gnu.org/pipermail/gcc-rust/2021-August/000144.html

> The gcc constant folding code uses the type_for_size langhook. Use the
> default implementation instead of crashing when the langhook is
> called. Add a new testcase "prims_struct_eq.rs" that creates trees
> that triggers the constant folding.
> 
> Also remove the write_globals langhook which was removed when early
> debug was integrated into gcc.