### PR TITLE
Suppress uninitialized candidate_type warning in process_traits_for_candidates

### DIFF
--- a/gcc/rust/typecheck/rust-hir-path-probe.h
+++ b/gcc/rust/typecheck/rust-hir-path-probe.h
@@ -260,6 +260,7 @@ private:
 	    break;
 
 	  case TraitItemReference::TraitItemType::ERROR:
+	  default:
 	    gcc_unreachable ();
 	    break;
 	  }


### PR DESCRIPTION
From Mark Wielaard : https://gcc.gnu.org/pipermail/gcc-rust/2021-August/000142.html

> Without handling the default case in the switch statement gcc 10.2.1 will warn:
> 
> rust-hir-path-probe.h:75:40: warning: ‘candidate_type’ may be used uninitialized
>   in this function [-Wmaybe-uninitialized]