### PR TITLE
hir: Merge both module classes in one

### DIFF
--- a/gcc/rust/backend/rust-compile-base.h
+++ b/gcc/rust/backend/rust-compile-base.h
@@ -121,8 +121,7 @@ public:
   // virtual void visit(WhereClauseItem& item) {}
   virtual void visit (HIR::LifetimeWhereClauseItem &item) {}
   virtual void visit (HIR::TypeBoundWhereClauseItem &item) {}
-  virtual void visit (HIR::ModuleBodied &module) {}
-  virtual void visit (HIR::ModuleNoBody &module) {}
+  virtual void visit (HIR::Module &module) {}
   virtual void visit (HIR::ExternCrate &crate) {}
   // virtual void visit(UseTree& use_tree) {}
   virtual void visit (HIR::UseTreeGlob &use_tree) {}

--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -313,7 +313,7 @@ public:
       }
   }
 
-  void visit (HIR::ModuleBodied &module) override
+  void visit (HIR::Module &module) override
   {
     for (auto &item : module.get_items ())
       CompileItem::compile (item.get (), ctx, compile_fns);

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -78,10 +78,9 @@ public:
     AST::AttrVec outer_attrs;
 
     translated
-      = new HIR::ModuleBodied (mapping, module.get_name (), module.get_locus (),
-			       std::move (items), std::move (vis),
-			       std::move (inner_attrs),
-			       std::move (outer_attrs));
+      = new HIR::Module (mapping, module.get_name (), module.get_locus (),
+			 std::move (items), std::move (vis),
+			 std::move (inner_attrs), std::move (outer_attrs));
 
     mappings->insert_defid_mapping (mapping.get_defid (), translated);
     mappings->insert_hir_item (mapping.get_crate_num (), mapping.get_hirid (),

--- a/gcc/rust/hir/tree/rust-hir-full-decls.h
+++ b/gcc/rust/hir/tree/rust-hir-full-decls.h
@@ -162,8 +162,6 @@ struct FunctionParam;
 struct Visibility;
 class VisItem;
 class Module;
-class ModuleBodied;
-class ModuleNoBody;
 class ExternCrate;
 class UseTree;
 class UseTreeGlob;

--- a/gcc/rust/hir/tree/rust-hir-full-test.cc
+++ b/gcc/rust/hir/tree/rust-hir-full-test.cc
@@ -170,16 +170,8 @@ Item::as_string () const
 std::string
 Module::as_string () const
 {
-  std::string vis_item = VisItem::as_string ();
-
-  return vis_item + "mod " + module_name;
-}
-
-std::string
-ModuleBodied::as_string () const
-{
   // get module string for "[vis] mod [name]"
-  std::string str = Module::as_string ();
+  std::string str = VisItem::as_string () + "mod " + module_name;
 
   // inner attributes
   str += "\n inner attributes: ";
@@ -218,16 +210,6 @@ ModuleBodied::as_string () const
 	  str += "\n  " + item->as_string ();
 	}
     }
-
-  return str + "\n";
-}
-
-std::string
-ModuleNoBody::as_string () const
-{
-  std::string str = Module::as_string ();
-
-  str += "\n no body (reference to external file)";
 
   return str + "\n";
 }
@@ -3794,7 +3776,7 @@ MaybeNamedParam::as_string () const
 /* Override that calls the function recursively on all items contained within
  * the module. */
 void
-ModuleBodied::add_crate_name (std::vector<std::string> &names) const
+Module::add_crate_name (std::vector<std::string> &names) const
 {
   /* TODO: test whether module has been 'cfg'-ed out to determine whether to
    * exclude it from search */
@@ -4266,13 +4248,7 @@ TypeBoundWhereClauseItem::accept_vis (HIRVisitor &vis)
 }
 
 void
-ModuleBodied::accept_vis (HIRVisitor &vis)
-{
-  vis.visit (*this);
-}
-
-void
-ModuleNoBody::accept_vis (HIRVisitor &vis)
+Module::accept_vis (HIRVisitor &vis)
 {
   vis.visit (*this);
 }

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -644,26 +644,6 @@ class Module : public VisItem
 {
   Identifier module_name;
   Location locus;
-
-protected:
-  // Protected constructor
-  Module (Analysis::NodeMapping mappings, Identifier module_name,
-	  Visibility visibility, Location locus,
-	  AST::AttrVec outer_attrs = AST::AttrVec ())
-    : VisItem (std::move (mappings), std::move (visibility),
-	       std::move (outer_attrs)),
-      module_name (module_name), locus (locus)
-  {}
-
-public:
-  std::string as_string () const override;
-
-  Location get_locus () const { return locus; }
-};
-
-// Module with a body, defined in file
-class ModuleBodied : public Module
-{
   // bool has_inner_attrs;
   AST::AttrVec inner_attrs;
   // bool has_items;
@@ -679,20 +659,20 @@ public:
   bool has_inner_attrs () const { return !inner_attrs.empty (); }
 
   // Full constructor
-  ModuleBodied (Analysis::NodeMapping mappings, Identifier name, Location locus,
-		std::vector<std::unique_ptr<Item> > items
-		= std::vector<std::unique_ptr<Item> > (),
-		Visibility visibility = Visibility::create_error (),
-		AST::AttrVec inner_attrs = AST::AttrVec (),
-		AST::AttrVec outer_attrs = AST::AttrVec ())
-    : Module (std::move (mappings), std::move (name), std::move (visibility),
-	      locus, std::move (outer_attrs)),
+  Module (Analysis::NodeMapping mappings, Identifier module_name,
+	  Location locus, std::vector<std::unique_ptr<Item> > items,
+	  Visibility visibility = Visibility::create_error (),
+	  AST::AttrVec inner_attrs = AST::AttrVec (),
+	  AST::AttrVec outer_attrs = AST::AttrVec ())
+    : VisItem (std::move (mappings), std::move (visibility),
+	       std::move (outer_attrs)),
+      module_name (module_name), locus (locus),
       inner_attrs (std::move (inner_attrs)), items (std::move (items))
   {}
 
   // Copy constructor with vector clone
-  ModuleBodied (ModuleBodied const &other)
-    : Module (other), inner_attrs (other.inner_attrs)
+  Module (Module const &other)
+    : VisItem (other), inner_attrs (other.inner_attrs)
   {
     items.reserve (other.items.size ());
     for (const auto &e : other.items)
@@ -700,9 +680,9 @@ public:
   }
 
   // Overloaded assignment operator with vector clone
-  ModuleBodied &operator= (ModuleBodied const &other)
+  Module &operator= (Module const &other)
   {
-    Module::operator= (other);
+    VisItem::operator= (other);
     inner_attrs = other.inner_attrs;
 
     items.reserve (other.items.size ());
@@ -713,8 +693,8 @@ public:
   }
 
   // move constructors
-  ModuleBodied (ModuleBodied &&other) = default;
-  ModuleBodied &operator= (ModuleBodied &&other) = default;
+  Module (Module &&other) = default;
+  Module &operator= (Module &&other) = default;
 
   void accept_vis (HIRVisitor &vis) override;
 
@@ -724,48 +704,17 @@ public:
    * the module. */
   void add_crate_name (std::vector<std::string> &names) const override;
 
-protected:
-  /* Use covariance to implement clone function as returning this object
-   * rather than base */
-  ModuleBodied *clone_item_impl () const override
-  {
-    return new ModuleBodied (*this);
-  }
-
-  /* Use covariance to implement clone function as returning this object
-   * rather than base */
-  /*virtual ModuleBodied* clone_statement_impl() const override {
-      return new ModuleBodied(*this);
-  }*/
-};
-
-// Module without a body, loaded from external file
-class ModuleNoBody : public Module
-{
-public:
-  std::string as_string () const override;
-
-  // Full constructor
-  ModuleNoBody (Analysis::NodeMapping mappings, Identifier name,
-		Visibility visibility, AST::AttrVec outer_attrs, Location locus)
-    : Module (std::move (mappings), std::move (name), std::move (visibility),
-	      locus, std::move (outer_attrs))
-  {}
-
-  void accept_vis (HIRVisitor &vis) override;
+  Location get_locus () const { return locus; }
 
 protected:
   /* Use covariance to implement clone function as returning this object
    * rather than base */
-  ModuleNoBody *clone_item_impl () const override
-  {
-    return new ModuleNoBody (*this);
-  }
+  Module *clone_item_impl () const override { return new Module (*this); }
 
   /* Use covariance to implement clone function as returning this object
    * rather than base */
-  /*virtual ModuleNoBody* clone_statement_impl() const override {
-      return new ModuleNoBody(*this);
+  /*virtual Module* clone_statement_impl() const override {
+      return new Module(*this);
   }*/
 };
 

--- a/gcc/rust/hir/tree/rust-hir-visitor.h
+++ b/gcc/rust/hir/tree/rust-hir-visitor.h
@@ -102,8 +102,7 @@ public:
   virtual void visit (TypeParam &param) = 0;
   virtual void visit (LifetimeWhereClauseItem &item) = 0;
   virtual void visit (TypeBoundWhereClauseItem &item) = 0;
-  virtual void visit (ModuleBodied &module) = 0;
-  virtual void visit (ModuleNoBody &module) = 0;
+  virtual void visit (Module &module) = 0;
   virtual void visit (ExternCrate &crate) = 0;
   virtual void visit (UseTreeGlob &use_tree) = 0;
   virtual void visit (UseTreeList &use_tree) = 0;

--- a/gcc/rust/lint/rust-lint-marklive-base.h
+++ b/gcc/rust/lint/rust-lint-marklive-base.h
@@ -117,8 +117,7 @@ public:
 
   virtual void visit (HIR::LifetimeWhereClauseItem &) override {}
   virtual void visit (HIR::TypeBoundWhereClauseItem &) override {}
-  virtual void visit (HIR::ModuleBodied &) override {}
-  virtual void visit (HIR::ModuleNoBody &) override {}
+  virtual void visit (HIR::Module &) override {}
   virtual void visit (HIR::ExternCrate &) override {}
 
   virtual void visit (HIR::UseTreeGlob &) override {}

--- a/gcc/rust/typecheck/rust-hir-const-fold-base.h
+++ b/gcc/rust/typecheck/rust-hir-const-fold-base.h
@@ -120,8 +120,7 @@ public:
 
   virtual void visit (HIR::LifetimeWhereClauseItem &) override {}
   virtual void visit (HIR::TypeBoundWhereClauseItem &) override {}
-  virtual void visit (HIR::ModuleBodied &) override {}
-  virtual void visit (HIR::ModuleNoBody &) override {}
+  virtual void visit (HIR::Module &) override {}
   virtual void visit (HIR::ExternCrate &) override {}
 
   virtual void visit (HIR::UseTreeGlob &) override {}

--- a/gcc/rust/typecheck/rust-hir-type-check-base.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.h
@@ -121,8 +121,7 @@ public:
 
   virtual void visit (HIR::LifetimeWhereClauseItem &) override {}
   virtual void visit (HIR::TypeBoundWhereClauseItem &) override {}
-  virtual void visit (HIR::ModuleBodied &) override {}
-  virtual void visit (HIR::ModuleNoBody &) override {}
+  virtual void visit (HIR::Module &) override {}
   virtual void visit (HIR::ExternCrate &) override {}
 
   virtual void visit (HIR::UseTreeGlob &) override {}

--- a/gcc/rust/typecheck/rust-hir-type-check-item.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.h
@@ -169,7 +169,7 @@ public:
       expected_ret_tyty->unify (block_expr_ty);
   }
 
-  void visit (HIR::ModuleBodied &module) override
+  void visit (HIR::Module &module) override
   {
     for (auto &item : module.get_items ())
       TypeCheckItem::Resolve (item.get ());

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
@@ -101,7 +101,7 @@ public:
     context->insert_type (struct_decl.get_mappings (), type);
   }
 
-  void visit (HIR::ModuleBodied &module) override
+  void visit (HIR::Module &module) override
   {
     for (auto &item : module.get_items ())
       TypeCheckTopLevel::Resolve (item.get ());

--- a/gcc/rust/typecheck/rust-hir-type-check-util.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-util.h
@@ -115,8 +115,7 @@ public:
 
   virtual void visit (HIR::LifetimeWhereClauseItem &) override {}
   virtual void visit (HIR::TypeBoundWhereClauseItem &) override {}
-  virtual void visit (HIR::ModuleBodied &) override {}
-  virtual void visit (HIR::ModuleNoBody &) override {}
+  virtual void visit (HIR::Module &) override {}
   virtual void visit (HIR::ExternCrate &) override {}
 
   virtual void visit (HIR::UseTreeGlob &) override {}


### PR DESCRIPTION
At this point in the pipeline, all modules are either internal and
contain items, or external and have been previously expanded in the
macro-expand phase. Thus, all HIR modules will contain their final set
of items