### PR TITLE
Ignore impl trait blocks in overlap pass

### DIFF
--- a/gcc/rust/typecheck/rust-hir-inherent-impl-overlap.h
+++ b/gcc/rust/typecheck/rust-hir-inherent-impl-overlap.h
@@ -109,6 +109,10 @@ public:
     // generate mappings
     pass.mappings->iterate_impl_items (
       [&] (HirId id, HIR::ImplItem *impl_item, HIR::ImplBlock *impl) -> bool {
+	// ignoring trait-impls might need thought later on
+	if (impl->has_trait_ref ())
+	  return true;
+
 	pass.process_impl_item (id, impl_item, impl);
 	return true;
       });

--- a/gcc/testsuite/rust/compile/traits8.rs
+++ b/gcc/testsuite/rust/compile/traits8.rs
@@ -1,0 +1,37 @@
+trait A {
+    fn get(self) -> f64;
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+}
+
+trait B {
+    fn get(self) -> u8;
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+}
+
+struct Foo(u8, f64);
+
+impl A for Foo {
+    fn get(self) -> f64 {
+        self.1
+    }
+}
+
+impl B for Foo {
+    fn get(self) -> u8 {
+        self.0
+    }
+}
+
+fn main() {
+    let _a;
+    _a = Foo(123, 456f64);
+
+    let _b: f64;
+    _b = <Foo as A>::get(_a);
+
+    let _a;
+    _a = Foo(123, 456f64);
+
+    let _c: u8;
+    _c = <Foo as B>::get(_a)
+}


### PR DESCRIPTION
Ignore trait-impls in overlapping check this needs some though for generics traits.