### PR TITLE
Reject duplicate field names in structs and unions.

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -175,6 +175,25 @@ public:
 			       struct_decl.get_locus ());
   }
 
+  /* Checks whether the name of a field already exists.  Returns true
+     and produces an error if so.  */
+  static bool struct_field_name_exists (std::vector<HIR::StructField> &fields,
+					HIR::StructField &new_field)
+  {
+    for (auto &field : fields)
+      {
+	if (field.get_field_name ().compare (new_field.get_field_name ()) == 0)
+	  {
+	    RichLocation r (new_field.get_locus ());
+	    r.add_range (field.get_locus ());
+	    rust_error_at (r, "duplicate field name %qs",
+			   field.get_field_name ().c_str ());
+	    return true;
+	  }
+      }
+    return false;
+  }
+
   void visit (AST::StructStruct &struct_decl) override
   {
     std::vector<std::unique_ptr<HIR::GenericParam> > generic_params;
@@ -205,6 +224,10 @@ public:
 					 std::unique_ptr<HIR::Type> (type), vis,
 					 field.get_locus (),
 					 field.get_outer_attrs ());
+
+      if (struct_field_name_exists (fields, translated_field))
+	return false;
+
       fields.push_back (std::move (translated_field));
       return true;
     });
@@ -257,6 +280,10 @@ public:
 					   std::unique_ptr<HIR::Type> (type),
 					   vis, variant.get_locus (),
 					   variant.get_outer_attrs ());
+
+      if (struct_field_name_exists (variants, translated_variant))
+	return false;
+
       variants.push_back (std::move (translated_variant));
       return true;
     });

--- a/gcc/testsuite/rust/compile/dup_fields.rs
+++ b/gcc/testsuite/rust/compile/dup_fields.rs
@@ -1,0 +1,23 @@
+struct S { a: i32, b: i32, c: u8, a: i128 }
+// { dg-error "duplicate field" "" { target *-*-* } .-1 }
+
+union U
+  {
+    a: i32,
+    b: i32,
+    c: u8,
+    b: char // { dg-error "duplicate field" "" { target *-*-* } }
+  }
+
+fn main ()
+{
+  struct SS { alpha: i32, beta: i32, gamma: u8, gamma: i128 }
+  // { dg-error "duplicate field" "" { target *-*-* } .-1 }
+
+  union UU
+    {
+      alpha: i32, beta: i32,
+      gamma: u8, beta: char
+      // { dg-error "duplicate field" "" { target *-*-* } .-1 }
+    }
+}


### PR DESCRIPTION
From Mark Wielaard : https://gcc.gnu.org/pipermail/gcc-rust/2021-August/000150.html

> Odd things happen if structs or unions have duplicate field names.
> Emit an error when lowering an struct/union item or declaration
> statement and a duplicate field name is detected.  A new testcase
> 'dup_fields.rs' checks an error is actually produced.