### PR TITLE
Resolve module filename from path attribute

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -457,6 +457,8 @@ public:
 
   Location get_locus () const { return locus; }
 
+  AttrInput &get_attr_input () const { return *attr_input; }
+
   /* e.g.:
       #![crate_type = "lib"]
       #[test]

--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -2039,6 +2039,8 @@ public:
     else
       {
 	std::string mod_file = module.get_filename ();
+	if (!mod_file.empty ())
+	  rust_debug ("Module filename found: %s", mod_file.c_str ());
       }
 
     // strip items if required

--- a/gcc/rust/lex/rust-lex.h
+++ b/gcc/rust/lex/rust-lex.h
@@ -35,11 +35,15 @@ public:
   RAIIFile &operator= (const RAIIFile &other) = delete;
 
   // have to specify setting file to nullptr, otherwise unintended fclose occurs
-  RAIIFile (RAIIFile &&other) : file (other.file) { other.file = nullptr; }
+  RAIIFile (RAIIFile &&other) : file (other.file), filename (other.filename)
+  {
+    other.file = nullptr;
+  }
   RAIIFile &operator= (RAIIFile &&other)
   {
     close ();
     file = other.file;
+    filename = other.filename;
     other.file = nullptr;
 
     return *this;

--- a/gcc/testsuite/rust/compile/extern_mod2.rs
+++ b/gcc/testsuite/rust/compile/extern_mod2.rs
@@ -1,0 +1,14 @@
+#[path = "modules/valid_path.rs"]
+mod not_a_valid_path;
+
+#[path] // { dg-error "path attributes must contain a filename" }
+mod error; // { dg-error "no candidate found for module error" }
+
+// This is "valid", and should only error out when parsing
+// the file
+// FIXME: Add a dg-error directive on the `mod another_error` line once module expansion
+// is added
+#[path = "not_a_valid_file.rs"]
+mod another_error;
+
+fn main() {}

--- a/gcc/testsuite/rust/compile/modules/valid_path.rs
+++ b/gcc/testsuite/rust/compile/modules/valid_path.rs
@@ -1,0 +1,1 @@
+fn unused() {}


### PR DESCRIPTION
Allow for the user to specify the path of a module using the `#[path]` attributegg