### PR TITLE
Fix issue with mangled name on function items with substitutions

### DIFF
--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -199,16 +199,7 @@ public:
     // yet
     if (!is_main_fn)
       {
-	std::string substs_str = fntype->subst_as_string ();
-
-	Resolver::CanonicalPath mangle_me
-	  = substs_str.empty ()
-	      ? *canonical_path
-	      : canonical_path->append (
-		Resolver::CanonicalPath::new_seg (0,
-						  fntype->subst_as_string ()));
-
-	asm_name = ctx->mangle_item (fntype, mangle_me);
+	asm_name = ctx->mangle_item (fntype, *canonical_path);
       }
 
     Bfunction *fndecl

--- a/gcc/testsuite/rust/execute/torture/issue-647.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-647.rs
@@ -1,0 +1,33 @@
+/* { dg-output "Hello World 123\n" }*/
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+struct Foo<T>(T);
+
+struct Bar<T> {
+    a: Foo<T>,
+    b: bool,
+    // { dg-warning "field is never read" "" { target *-*-* } .-1 }
+}
+
+fn test<T>(a: Bar<T>) -> Foo<T> {
+    a.a
+}
+
+fn main() -> i32 {
+    let a: Bar<i32> = Bar::<i32> {
+        a: Foo::<i32>(123),
+        b: true,
+    };
+    let result: Foo<i32> = test(a);
+
+    unsafe {
+        let a = "Hello World %i\n";
+        let b = a as *const str;
+        let c = b as *const i8;
+
+        printf(c, result.0);
+    }
+    0
+}


### PR DESCRIPTION
Rust legacy name mangling does not contain the substitutions as part of
its mangled name for Item's. Rust avoids duplicate symbol collisions with
the legacy mangling scheme, but including a 128bit hash at the end of the
symbol, which is made up with metadata and in this case the mangled symbol
contains a hash of the type which this function is.

Fixes #647
