### PR TITLE
Qualified paths have a mandatory initial segment

### DIFF
--- a/gcc/rust/ast/rust-path.h
+++ b/gcc/rust/ast/rust-path.h
@@ -939,6 +939,7 @@ protected:
 class QualifiedPathInType : public TypeNoBounds
 {
   QualifiedPathType path_type;
+  std::unique_ptr<TypePathSegment> associated_segment;
   std::vector<std::unique_ptr<TypePathSegment> > segments;
   Location locus;
 
@@ -953,9 +954,11 @@ protected:
 public:
   QualifiedPathInType (
     QualifiedPathType qual_path_type,
+    std::unique_ptr<TypePathSegment> associated_segment,
     std::vector<std::unique_ptr<TypePathSegment> > path_segments,
-    Location locus = Location ())
+    Location locus)
     : path_type (std::move (qual_path_type)),
+      associated_segment (std::move (associated_segment)),
       segments (std::move (path_segments)), locus (locus)
   {}
 
@@ -995,8 +998,8 @@ public:
   static QualifiedPathInType create_error ()
   {
     return QualifiedPathInType (
-      QualifiedPathType::create_error (),
-      std::vector<std::unique_ptr<TypePathSegment> > ());
+      QualifiedPathType::create_error (), nullptr,
+      std::vector<std::unique_ptr<TypePathSegment> > (), Location ());
   }
 
   std::string as_string () const override;
@@ -1008,6 +1011,11 @@ public:
   {
     rust_assert (!path_type.is_error ());
     return path_type;
+  }
+
+  std::unique_ptr<TypePathSegment> &get_associated_segment ()
+  {
+    return associated_segment;
   }
 
   // TODO: this seems kinda dodgy

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -6742,10 +6742,6 @@ Parser<ManagedTokenSource>::parse_qualified_path_in_type ()
       return AST::QualifiedPathInType::create_error ();
     }
 
-  // parse path segments
-  std::vector<std::unique_ptr<AST::TypePathSegment>> segments;
-  segments.reserve (1);
-
   // parse initial required segment
   if (!expect_token (SCOPE_RESOLUTION))
     {
@@ -6765,9 +6761,9 @@ Parser<ManagedTokenSource>::parse_qualified_path_in_type ()
 
       return AST::QualifiedPathInType::create_error ();
     }
-  segments.push_back (std::move (initial_segment));
 
   // parse optional segments (as long as scope resolution operator exists)
+  std::vector<std::unique_ptr<AST::TypePathSegment>> segments;
   const_TokenPtr t = lexer.peek_token ();
   while (t->get_id () == SCOPE_RESOLUTION)
     {
@@ -6796,6 +6792,7 @@ Parser<ManagedTokenSource>::parse_qualified_path_in_type ()
   segments.shrink_to_fit ();
 
   return AST::QualifiedPathInType (std::move (qual_path_type),
+				   std::move (initial_segment),
 				   std::move (segments), locus);
 }
 


### PR DESCRIPTION
see https://doc.rust-lang.org/reference/paths.html#qualified-paths

The initial segment is mandatory this changes the AST to reflect this
it simplifies error handling down the line.