### PR TITLE
Generic Qualified Paths

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -83,6 +83,7 @@ GRS_OBJS = \
     rust/rust-hir-type-check-util.o \
     rust/rust-hir-trait-resolve.o \
     rust/rust-hir-const-fold.o \
+    rust/rust-hir-type-check-type.o \
     rust/rust-lint-marklive.o \
     rust/rust-hir-type-check-path.o \
     $(END)

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -3535,7 +3535,16 @@ public:
 
   void insert_implict_self (std::unique_ptr<AST::GenericParam> &&param)
   {
-    generic_params.push_back (std::move (param));
+    std::vector<std::unique_ptr<GenericParam>> new_list;
+    new_list.reserve (generic_params.size () + 1);
+
+    new_list.push_back (std::move (param));
+    for (auto &p : generic_params)
+      {
+	new_list.push_back (std::move (p));
+      }
+
+    generic_params = std::move (new_list);
   }
 
 protected:

--- a/gcc/rust/ast/rust-path.h
+++ b/gcc/rust/ast/rust-path.h
@@ -1029,6 +1029,15 @@ public:
   }
 
   Location get_locus () const override final { return locus; }
+
+  void iterate_segments (std::function<bool (TypePathSegment *)> cb)
+  {
+    for (auto it = segments.begin (); it != segments.end (); it++)
+      {
+	if (!cb ((*it).get ()))
+	  return;
+      }
+  }
 };
 } // namespace AST
 } // namespace Rust

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -336,7 +336,10 @@ public:
 
   void visit (TyTy::InferType &) override { gcc_unreachable (); }
 
-  void visit (TyTy::ProjectionType &) override { gcc_unreachable (); }
+  void visit (TyTy::ProjectionType &type) override
+  {
+    type.get ()->accept_vis (*this);
+  }
 
   void visit (TyTy::PlaceholderType &type) override
   {

--- a/gcc/rust/hir/rust-ast-lower-type.h
+++ b/gcc/rust/hir/rust-ast-lower-type.h
@@ -28,6 +28,7 @@ namespace HIR {
 
 class ASTLowerTypePath : public ASTLoweringBase
 {
+protected:
   using Rust::HIR::ASTLoweringBase::visit;
 
 public:
@@ -88,9 +89,30 @@ public:
     mappings->insert_hir_type (crate_num, hirid, translated);
   }
 
+protected:
+  HIR::TypePathSegment *translated_segment;
+
 private:
   HIR::TypePath *translated;
-  HIR::TypePathSegment *translated_segment;
+};
+
+class ASTLowerQualifiedPathInType : public ASTLowerTypePath
+{
+  using ASTLowerTypePath::visit;
+
+public:
+  static HIR::QualifiedPathInType *translate (AST::QualifiedPathInType &type)
+  {
+    ASTLowerQualifiedPathInType resolver;
+    type.accept_vis (resolver);
+    rust_assert (resolver.translated != nullptr);
+    return resolver.translated;
+  }
+
+  void visit (AST::QualifiedPathInType &path) override;
+
+private:
+  HIR::QualifiedPathInType *translated;
 };
 
 class ASTLoweringType : public ASTLoweringBase
@@ -185,6 +207,11 @@ public:
   void visit (AST::TypePath &path) override
   {
     translated = ASTLowerTypePath::translate (path);
+  }
+
+  void visit (AST::QualifiedPathInType &path) override
+  {
+    translated = ASTLowerQualifiedPathInType::translate (path);
   }
 
   void visit (AST::ArrayType &type) override

--- a/gcc/rust/hir/tree/rust-hir-path.h
+++ b/gcc/rust/hir/tree/rust-hir-path.h
@@ -819,6 +819,7 @@ protected:
 class QualifiedPathInType : public TypeNoBounds
 {
   QualifiedPathType path_type;
+  std::unique_ptr<TypePathSegment> associated_segment;
   std::vector<std::unique_ptr<TypePathSegment> > segments;
   Location locus;
 
@@ -840,9 +841,11 @@ protected:
 public:
   QualifiedPathInType (
     Analysis::NodeMapping mappings, QualifiedPathType qual_path_type,
+    std::unique_ptr<TypePathSegment> associated_segment,
     std::vector<std::unique_ptr<TypePathSegment> > path_segments,
     Location locus = Location ())
     : TypeNoBounds (mappings), path_type (std::move (qual_path_type)),
+      associated_segment (std::move (associated_segment)),
       segments (std::move (path_segments)), locus (locus)
   {}
 
@@ -883,6 +886,20 @@ public:
   std::string as_string () const override;
 
   void accept_vis (HIRVisitor &vis) override;
+
+  QualifiedPathType &get_path_type () { return path_type; }
+
+  std::unique_ptr<TypePathSegment> &get_associated_segment ()
+  {
+    return associated_segment;
+  }
+
+  std::vector<std::unique_ptr<TypePathSegment> > &get_segments ()
+  {
+    return segments;
+  }
+
+  Location get_locus () { return locus; }
 };
 } // namespace HIR
 } // namespace Rust

--- a/gcc/rust/hir/tree/rust-hir-path.h
+++ b/gcc/rust/hir/tree/rust-hir-path.h
@@ -767,6 +767,27 @@ public:
     rust_assert (has_as_clause ());
     return trait;
   }
+
+  bool trait_has_generic_args () const
+  {
+    rust_assert (has_as_clause ());
+    bool is_generic_seg = trait->get_final_segment ()->get_type ()
+			  == TypePathSegment::SegmentType::GENERIC;
+    if (!is_generic_seg)
+      return false;
+
+    TypePathSegmentGeneric *seg = static_cast<TypePathSegmentGeneric *> (
+      trait->get_final_segment ().get ());
+    return seg->has_generic_args ();
+  }
+
+  GenericArgs &get_trait_generic_args ()
+  {
+    rust_assert (trait_has_generic_args ());
+    TypePathSegmentGeneric *seg = static_cast<TypePathSegmentGeneric *> (
+      trait->get_final_segment ().get ());
+    return seg->get_generic_args ();
+  }
 };
 
 /* HIR node representing a qualified path-in-expression pattern (path that

--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -243,8 +243,8 @@ Resolver::lookup_resolved_name (NodeId refId, NodeId *defId)
 void
 Resolver::insert_resolved_type (NodeId refId, NodeId defId)
 {
-  auto it = resolved_types.find (refId);
-  rust_assert (it == resolved_types.end ());
+  // auto it = resolved_types.find (refId);
+  // rust_assert (it == resolved_types.end ());
 
   resolved_types[refId] = defId;
   get_type_scope ().append_reference_for_def (refId, defId);
@@ -560,17 +560,15 @@ ResolvePath::resolve_path (AST::QualifiedPathInExpression *expr)
   ResolveType::go (root_segment.get_type ().get (), root_segment.get_node_id (),
 		   canonicalize_type_with_generics);
 
-  bool canonicalize_type_args = true;
   bool type_resolve_generic_args = true;
-
   CanonicalPath impl_type_seg
     = ResolveTypeToCanonicalPath::resolve (*root_segment.get_type ().get (),
-					   canonicalize_type_args,
+					   canonicalize_type_with_generics,
 					   type_resolve_generic_args);
 
   CanonicalPath trait_type_seg
     = ResolveTypeToCanonicalPath::resolve (root_segment.get_as_type_path (),
-					   canonicalize_type_args,
+					   canonicalize_type_with_generics,
 					   type_resolve_generic_args);
   CanonicalPath root_seg_path
     = TraitImplProjection::resolve (root_segment.get_node_id (), trait_type_seg,
@@ -756,16 +754,16 @@ ResolveRelativeTypePath::resolve_qual_seg (AST::QualifiedPathType &seg,
 		     seg.as_string ().c_str ());
       return false;
     }
+  bool include_generic_args_in_path = false;
 
-  bool canonicalize_type_with_generics = true;
   NodeId type_resolved_node
-    = ResolveType::go (seg.get_type ().get (), seg.get_node_id (),
-		       canonicalize_type_with_generics);
+    = ResolveType::go (seg.get_type ().get (), seg.get_node_id ());
   if (type_resolved_node == UNKNOWN_NODEID)
     return false;
 
   CanonicalPath impl_type_seg
-    = ResolveTypeToCanonicalPath::resolve (*seg.get_type ().get ());
+    = ResolveTypeToCanonicalPath::resolve (*seg.get_type ().get (),
+					   include_generic_args_in_path);
   if (!seg.has_as_clause ())
     {
       result = result.append (impl_type_seg);
@@ -773,14 +771,13 @@ ResolveRelativeTypePath::resolve_qual_seg (AST::QualifiedPathType &seg,
     }
 
   NodeId trait_resolved_node
-    = ResolveType::go (&seg.get_as_type_path (), seg.get_node_id (),
-		       canonicalize_type_with_generics);
-
+    = ResolveType::go (&seg.get_as_type_path (), seg.get_node_id ());
   if (trait_resolved_node == UNKNOWN_NODEID)
     return false;
 
   CanonicalPath trait_type_seg
-    = ResolveTypeToCanonicalPath::resolve (seg.get_as_type_path ());
+    = ResolveTypeToCanonicalPath::resolve (seg.get_as_type_path (),
+					   include_generic_args_in_path);
   CanonicalPath projection
     = TraitImplProjection::resolve (seg.get_node_id (), trait_type_seg,
 				    impl_type_seg);

--- a/gcc/rust/typecheck/rust-hir-path-probe.h
+++ b/gcc/rust/typecheck/rust-hir-path-probe.h
@@ -276,6 +276,18 @@ protected:
 
 	TyTy::BaseType *trait_item_tyty = trait_item_ref->get_tyty ();
 
+	if (impl != nullptr)
+	  {
+	    HirId impl_block_id = impl->get_mappings ().get_hirid ();
+	    AssociatedImplTrait *lookup_associated = nullptr;
+	    bool found_impl_trait
+	      = context->lookup_associated_trait_impl (impl_block_id,
+						       &lookup_associated);
+	    // see testsuite/rust/compile/torture/traits10.rs this can be false
+	    if (found_impl_trait)
+	      lookup_associated->setup_associated_types ();
+	  }
+
 	// we can substitute the Self with the receiver here
 	if (trait_item_tyty->get_kind () == TyTy::TypeKind::FNDEF)
 	  {

--- a/gcc/rust/typecheck/rust-hir-trait-ref.h
+++ b/gcc/rust/typecheck/rust-hir-trait-ref.h
@@ -47,26 +47,7 @@ public:
 
   TraitItemReference (TraitItemReference const &other);
 
-  TraitItemReference &operator= (TraitItemReference const &other)
-  {
-    identifier = other.identifier;
-    optional_flag = other.optional_flag;
-    type = other.type;
-    hir_trait_item = other.hir_trait_item;
-    self = other.self;
-    locus = other.locus;
-    context = other.context;
-
-    inherited_substitutions.clear ();
-    inherited_substitutions.reserve (other.inherited_substitutions.size ());
-    for (size_t i = 0; i < other.inherited_substitutions.size (); i++)
-      inherited_substitutions.push_back (other.inherited_substitutions.at (i));
-
-    return *this;
-  }
-
-  TraitItemReference (TraitItemReference &&other) = default;
-  TraitItemReference &operator= (TraitItemReference &&other) = default;
+  TraitItemReference &operator= (TraitItemReference const &other);
 
   static TraitItemReference error ()
   {
@@ -368,6 +349,7 @@ public:
 
   TyTy::BaseType *get_projected_type (const TraitItemReference *trait_item_ref,
 				      TyTy::BaseType *reciever, HirId ref,
+				      HIR::GenericArgs &trait_generics,
 				      Location expr_locus);
 
 private:

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -1,0 +1,229 @@
+// Copyright (C) 2020 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-hir-type-check-type.h"
+#include "rust-hir-trait-resolve.h"
+
+namespace Rust {
+namespace Resolver {
+
+void
+TypeCheckType::visit (HIR::TypePath &path)
+{
+  // lookup the Node this resolves to
+  NodeId ref;
+  auto nid = path.get_mappings ().get_nodeid ();
+  if (!resolver->lookup_resolved_type (nid, &ref))
+    {
+      rust_fatal_error (path.get_locus (), "failed to resolve node '%d' to HIR",
+			nid);
+      return;
+    }
+
+  HirId hir_lookup;
+  if (!context->lookup_type_by_node_id (ref, &hir_lookup))
+    {
+      rust_error_at (path.get_locus (), "failed to lookup HIR %d for node '%s'",
+		     ref, path.as_string ().c_str ());
+      return;
+    }
+
+  TyTy::BaseType *lookup = nullptr;
+  if (!context->lookup_type (hir_lookup, &lookup))
+    {
+      rust_error_at (path.get_locus (), "failed to lookup HIR TyTy");
+      return;
+    }
+
+  TyTy::BaseType *path_type = lookup->clone ();
+  path_type->set_ref (path.get_mappings ().get_hirid ());
+
+  HIR::TypePathSegment *final_seg = path.get_final_segment ().get ();
+  HIR::GenericArgs args = TypeCheckResolveGenericArguments::resolve (final_seg);
+
+  bool is_big_self = final_seg->is_ident_only ()
+		     && (final_seg->as_string ().compare ("Self") == 0);
+
+  if (path_type->needs_generic_substitutions ())
+    {
+      if (is_big_self)
+	{
+	  translated = path_type;
+	  return;
+	}
+
+      translated = SubstMapper::Resolve (path_type, path.get_locus (), &args);
+      if (translated->get_kind () != TyTy::TypeKind::ERROR
+	  && mappings != nullptr)
+	{
+	  check_for_unconstrained (args.get_type_args ());
+	}
+    }
+  else if (!args.is_empty ())
+    {
+      rust_error_at (path.get_locus (),
+		     "TypePath %s declares generic arguments but "
+		     "the type %s does not have any",
+		     path.as_string ().c_str (),
+		     translated->as_string ().c_str ());
+    }
+  else
+    {
+      translated = path_type;
+    }
+}
+
+void
+TypeCheckType::visit (HIR::QualifiedPathInType &path)
+{
+  HIR::QualifiedPathType qual_path_type = path.get_path_type ();
+  TyTy::BaseType *root
+    = TypeCheckType::Resolve (qual_path_type.get_type ().get ());
+  if (root->get_kind () == TyTy::TypeKind::ERROR)
+    {
+      rust_debug_loc (path.get_locus (), "failed to resolve the root");
+      return;
+    }
+
+  if (!qual_path_type.has_as_clause ())
+    {
+      // then this is just a normal path-in-expression
+      NodeId root_resolved_node_id = UNKNOWN_NODEID;
+      bool ok = resolver->lookup_resolved_type (
+	qual_path_type.get_type ()->get_mappings ().get_nodeid (),
+	&root_resolved_node_id);
+      rust_assert (ok);
+
+      resolve_segments (root_resolved_node_id, path.get_segments (), 0,
+			translated, path.get_mappings (), path.get_locus ());
+    }
+
+  // Resolve the trait now
+  TraitReference *trait_ref
+    = TraitResolver::Resolve (*qual_path_type.get_trait ().get ());
+  if (trait_ref->is_error ())
+    return;
+
+  // does this type actually implement this type-bound?
+  if (!TypeBoundsProbe::is_bound_satisfied_for_type (root, trait_ref))
+    return;
+
+  // we need resolve to the impl block
+  NodeId impl_resolved_id = UNKNOWN_NODEID;
+  bool ok = resolver->lookup_resolved_name (
+    qual_path_type.get_mappings ().get_nodeid (), &impl_resolved_id);
+  rust_assert (ok);
+
+  HirId impl_block_id;
+  ok = mappings->lookup_node_to_hir (path.get_mappings ().get_crate_num (),
+				     impl_resolved_id, &impl_block_id);
+  rust_assert (ok);
+
+  AssociatedImplTrait *lookup_associated = nullptr;
+  bool found_impl_trait
+    = context->lookup_associated_trait_impl (impl_block_id, &lookup_associated);
+  rust_assert (found_impl_trait);
+
+  DefId resolved_item_id = UNKNOWN_DEFID;
+  std::unique_ptr<HIR::TypePathSegment> &item_seg
+    = path.get_associated_segment ();
+
+  const TraitItemReference *trait_item_ref = nullptr;
+  ok
+    = trait_ref->lookup_trait_item (item_seg->get_ident_segment ().as_string (),
+				    &trait_item_ref);
+  if (!ok)
+    {
+      rust_error_at (item_seg->get_locus (), "unknown associated item");
+      return;
+    }
+  resolved_item_id = trait_item_ref->get_mappings ().get_defid ();
+
+  // project
+  lookup_associated->setup_associated_types ();
+
+  translated = lookup_associated->get_projected_type (
+    trait_item_ref, root, item_seg->get_mappings ().get_hirid (),
+    item_seg->get_locus ());
+
+  if (translated->get_kind () == TyTy::TypeKind::PLACEHOLDER)
+    {
+      // lets grab the actual projection type
+      TyTy::PlaceholderType *p
+	= static_cast<TyTy::PlaceholderType *> (translated);
+      if (p->can_resolve ())
+	{
+	  translated = p->resolve ();
+	}
+    }
+
+  if (item_seg->get_type () == HIR::TypePathSegment::SegmentType::GENERIC)
+    {
+      HIR::TypePathSegmentGeneric &generic_seg
+	= static_cast<HIR::TypePathSegmentGeneric &> (*item_seg.get ());
+
+      // turbo-fish segment path::<ty>
+      if (generic_seg.has_generic_args ())
+	{
+	  if (!translated->can_substitute ())
+	    {
+	      rust_error_at (item_seg->get_locus (),
+			     "substitutions not supported for %s",
+			     translated->as_string ().c_str ());
+	      translated
+		= new TyTy::ErrorType (path.get_mappings ().get_hirid ());
+	      return;
+	    }
+	  translated = SubstMapper::Resolve (translated, path.get_locus (),
+					     &generic_seg.get_generic_args ());
+	}
+    }
+
+  TyTy::ProjectionType *projection
+    = new TyTy::ProjectionType (qual_path_type.get_mappings ().get_hirid (),
+				TyTy::TyVar (root->get_ref ()), trait_ref,
+				resolved_item_id, lookup_associated);
+  context->insert_type (qual_path_type.get_mappings (), projection);
+
+  // continue on as a path-in-expression
+  NodeId root_resolved_node_id = trait_item_ref->get_mappings ().get_nodeid ();
+  bool fully_resolved = path.get_segments ().empty ();
+  if (fully_resolved)
+    {
+      resolver->insert_resolved_name (path.get_mappings ().get_nodeid (),
+				      root_resolved_node_id);
+      context->insert_receiver (path.get_mappings ().get_hirid (), root);
+      return;
+    }
+
+  resolve_segments (root_resolved_node_id, path.get_segments (), 0, translated,
+		    path.get_mappings (), path.get_locus ());
+}
+
+void
+TypeCheckType::resolve_segments (
+  NodeId root_resolved_node_id,
+  std::vector<std::unique_ptr<HIR::TypePathSegment>> &segments, size_t offset,
+  TyTy::BaseType *tyseg, const Analysis::NodeMapping &expr_mappings,
+  Location expr_locus)
+{
+  gcc_unreachable ();
+}
+
+} // namespace Resolver
+} // namespace Rust

--- a/gcc/rust/typecheck/rust-hir-type-check.h
+++ b/gcc/rust/typecheck/rust-hir-type-check.h
@@ -42,6 +42,8 @@ public:
 		    TyTy::BaseType *type);
   bool lookup_type (HirId id, TyTy::BaseType **type);
 
+  void insert_implicit_type (HirId id, TyTy::BaseType *type);
+
   void insert_type_by_node_id (NodeId ref, HirId id);
   bool lookup_type_by_node_id (NodeId ref, HirId *id);
 

--- a/gcc/rust/typecheck/rust-tyctx.cc
+++ b/gcc/rust/typecheck/rust-tyctx.cc
@@ -83,6 +83,13 @@ TypeCheckContext::insert_type (const Analysis::NodeMapping &mappings,
   resolved[id] = type;
 }
 
+void
+TypeCheckContext::insert_implicit_type (HirId id, TyTy::BaseType *type)
+{
+  rust_assert (type != nullptr);
+  resolved[id] = type;
+}
+
 bool
 TypeCheckContext::lookup_type (HirId id, TyTy::BaseType **type)
 {

--- a/gcc/rust/typecheck/rust-tyty-coercion.h
+++ b/gcc/rust/typecheck/rust-tyty-coercion.h
@@ -46,6 +46,19 @@ public:
 	    other = p->resolve ();
 	  }
       }
+    else if (other->get_kind () == TypeKind::PLACEHOLDER)
+      {
+	PlaceholderType *p = static_cast<PlaceholderType *> (other);
+	if (p->can_resolve ())
+	  {
+	    other = p->resolve ();
+	  }
+      }
+    else if (other->get_kind () == TypeKind::PROJECTION)
+      {
+	ProjectionType *p = static_cast<ProjectionType *> (other);
+	other = p->get ();
+      }
 
     other->accept_vis (*this);
     if (resolved->get_kind () == TyTy::TypeKind::ERROR)

--- a/gcc/rust/typecheck/rust-tyty-rules.h
+++ b/gcc/rust/typecheck/rust-tyty-rules.h
@@ -76,6 +76,11 @@ public:
 	    other = p->resolve ();
 	  }
       }
+    else if (other->get_kind () == TypeKind::PROJECTION)
+      {
+	ProjectionType *p = static_cast<ProjectionType *> (other);
+	other = p->get ();
+      }
 
     other->accept_vis (*this);
     if (resolved->get_kind () == TyTy::TypeKind::ERROR)

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -1709,7 +1709,11 @@ public:
 
   std::string get_name () const override final { return as_string (); }
 
-  bool is_unit () const override { return true; }
+  bool is_unit () const override
+  {
+    rust_assert (can_resolve ());
+    return resolve ()->is_unit ();
+  }
 
   std::string get_symbol () const { return symbol; }
 

--- a/gcc/testsuite/rust/compile/torture/traits12.rs
+++ b/gcc/testsuite/rust/compile/torture/traits12.rs
@@ -1,0 +1,29 @@
+trait Foo {
+    type A;
+
+    fn test(a: Self::A) -> Self::A {
+        a
+    }
+}
+
+struct Bar(i32);
+// { dg-warning "struct is never constructed" "" { target *-*-* } .-1 }
+
+impl Foo for Bar {
+    type A = i32;
+}
+
+struct Baz(f32);
+// { dg-warning "struct is never constructed" "" { target *-*-* } .-1 }
+
+impl Foo for Baz {
+    type A = f32;
+}
+
+fn main() {
+    let a: <Baz as Foo>::A;
+    a = 123f32;
+
+    let b;
+    b = <Baz as Foo>::test(a);
+}

--- a/gcc/testsuite/rust/compile/torture/traits13.rs
+++ b/gcc/testsuite/rust/compile/torture/traits13.rs
@@ -1,0 +1,17 @@
+trait Trait {
+    const FOO: usize;
+    type Target;
+}
+
+struct S;
+// { dg-warning "struct is never constructed" "" { target *-*-* } .-1 }
+
+impl Trait for S {
+    const FOO: usize = 0;
+    type Target = usize;
+}
+
+fn main() {
+    let a: <S as Trait>::Target;
+    a = <S as Trait>::FOO;
+}

--- a/gcc/testsuite/rust/compile/torture/traits14.rs
+++ b/gcc/testsuite/rust/compile/torture/traits14.rs
@@ -1,0 +1,23 @@
+trait Foo<T> {
+    type A;
+
+    fn test(a: T) -> T {
+        a
+    }
+}
+
+struct Bar<T>(T);
+impl<T> Foo<T> for Bar<T> {
+    type A = T;
+}
+
+pub fn main() {
+    let a;
+    a = Bar(123);
+
+    let b: <Bar<i32> as Foo<i32>>::A;
+    b = 456;
+
+    let c: <Bar<i32> as Foo<i32>>::A;
+    c = <Bar<i32> as Foo<i32>>::test(a.0);
+}

--- a/gcc/testsuite/rust/compile/torture/traits15.rs
+++ b/gcc/testsuite/rust/compile/torture/traits15.rs
@@ -1,0 +1,23 @@
+trait Foo<T> {
+    type A;
+
+    fn test(a: T, b: Self::A) -> (T, Self::A) {
+        (a, b)
+    }
+}
+
+struct Bar<T>(T);
+impl<T> Foo<T> for Bar<T> {
+    type A = T;
+}
+
+pub fn main() {
+    let a;
+    a = Bar(123);
+
+    let b: <Bar<i32> as Foo<i32>>::A;
+    b = 456;
+
+    let c;
+    c = <Bar<i32> as Foo<i32>>::test(a.0, 123);
+}


### PR DESCRIPTION
This fixes how we handle associated types in relation to generic
traits. Generic traits are interesting because, a TypePath usually
resolves to a normal TyTy type which can be substituted using the
mapper classes, but a trait is a definition of behaviour which 
is made up of types, constants or functions. In order to handle
generic traits we must add substitution support to the associated types
which are represented by projections see this commit for detail on the changes
0798add3d3c1bf4b20ecc1b4fa1047ba4ba19759

Also see https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/sty/struct.ProjectionTy.html

Fixes #434 