### PR TITLE
Add mangling switch

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -70,6 +70,7 @@ GRS_OBJS = \
     rust/rust-ast-full-test.o \
     rust/rust-session-manager.o \
     rust/rust-compile.o \
+    rust/rust-mangle.o \
     rust/rust-compile-resolve-path.o \
     rust/rust-macro-expand.o \
     rust/rust-hir-full-test.o \

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -46,7 +46,7 @@ public:
     : backend (backend), resolver (Resolver::Resolver::get ()),
       tyctx (Resolver::TypeCheckContext::get ()),
       mappings (Analysis::Mappings::get ()),
-      const_ctx (ConstFold::Context::get ()), mangler (Mangler (Mangler::MangleVersion::LEGACY))
+      const_ctx (ConstFold::Context::get ()), mangler (Mangler ())
   {
     // insert the builtins
     auto builtins = resolver->get_builtin_types ();

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -28,6 +28,7 @@
 #include "rust-ast-full.h"
 #include "rust-hir-full.h"
 #include "rust-hir-const-fold-ctx.h"
+#include "rust-mangle.h"
 
 namespace Rust {
 namespace Compile {
@@ -45,7 +46,7 @@ public:
     : backend (backend), resolver (Resolver::Resolver::get ()),
       tyctx (Resolver::TypeCheckContext::get ()),
       mappings (Analysis::Mappings::get ()),
-      const_ctx (ConstFold::Context::get ())
+      const_ctx (ConstFold::Context::get ()), mangler (Mangler (Mangler::MangleVersion::LEGACY))
   {
     // insert the builtins
     auto builtins = resolver->get_builtin_types ();
@@ -285,13 +286,19 @@ public:
     return pop;
   }
 
-  // this needs to support Legacy and V0 see github #429 or #305
   std::string mangle_item (const TyTy::BaseType *ty,
-			   const Resolver::CanonicalPath &path) const;
+			   const Resolver::CanonicalPath &path) const
+  {
+    return mangler.mangle_item (ty, path, mappings->get_current_crate_name ());
+  }
 
   std::string mangle_impl_item (const TyTy::BaseType *self,
 				const TyTy::BaseType *ty,
-				const std::string &name) const;
+				const std::string &name) const
+  {
+    return mangler.mangle_impl_item (self, ty, name,
+				     mappings->get_current_crate_name ());
+  }
 
 private:
   ::Backend *backend;
@@ -300,6 +307,7 @@ private:
   Analysis::Mappings *mappings;
   ConstFold::Context *const_ctx;
   std::set<HirId> builtin_range;
+  Mangler mangler;
 
   // state
   std::vector<fncontext> fn_stack;

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -22,7 +22,6 @@
 #include "rust-compile-struct-field-expr.h"
 #include "rust-hir-trait-resolve.h"
 #include "rust-hir-path-probe.h"
-#include "fnv-hash.h"
 
 namespace Rust {
 namespace Compile {
@@ -538,107 +537,5 @@ HIRCompileBase::compile_locals_for_block (Resolver::Rib &rib, Bfunction *fndecl,
 
   return true;
 }
-
-// Mr Mangle time
-
-static const std::string kMangledSymbolPrefix = "_ZN";
-static const std::string kMangledSymbolDelim = "E";
-static const std::string kMangledGenericDelim = "$C$";
-static const std::string kMangledSubstBegin = "$LT$";
-static const std::string kMangledSubstEnd = "$GT$";
-
-static std::string
-mangle_name (const std::string &name)
-{
-  return std::to_string (name.size ()) + name;
-}
-
-static std::string
-mangle_canonical_path (const Resolver::CanonicalPath &path)
-{
-  std::string buffer;
-  path.iterate_segs ([&] (const Resolver::CanonicalPath &p) -> bool {
-    buffer += mangle_name (p.get ());
-    return true;
-  });
-  return buffer;
-}
-
-// rustc uses a sip128 hash for legacy mangling, but an fnv 128 was quicker to
-// implement for now
-static std::string
-legacy_hash (const std::string &fingerprint)
-{
-  Hash::FNV128 hasher;
-  hasher.write ((const unsigned char *) fingerprint.c_str (),
-		fingerprint.size ());
-
-  uint64_t hi, lo;
-  hasher.sum (&hi, &lo);
-
-  char hex[16 + 1];
-  memset (hex, 0, sizeof hex);
-  snprintf (hex, sizeof hex, "%08" PRIx64 "%08" PRIx64, lo, hi);
-
-  return "h" + std::string (hex, sizeof (hex) - 1);
-}
-
-static std::string
-mangle_self (const TyTy::BaseType *self)
-{
-  if (self->get_kind () != TyTy::TypeKind::ADT)
-    return mangle_name (self->get_name ());
-
-  const TyTy::ADTType *s = static_cast<const TyTy::ADTType *> (self);
-  std::string buf = s->get_identifier ();
-
-  if (s->has_subsititions_defined ())
-    {
-      buf += kMangledSubstBegin;
-
-      const std::vector<TyTy::SubstitutionParamMapping> &params
-	= s->get_substs ();
-      for (size_t i = 0; i < params.size (); i++)
-	{
-	  const TyTy::SubstitutionParamMapping &sub = params.at (i);
-	  buf += sub.as_string ();
-
-	  if ((i + 1) < params.size ())
-	    buf += kMangledGenericDelim;
-	}
-
-      buf += kMangledSubstEnd;
-    }
-
-  return mangle_name (buf);
-}
-
-std::string
-Context::mangle_item (const TyTy::BaseType *ty,
-		      const Resolver::CanonicalPath &path) const
-{
-  const std::string &crate_name = mappings->get_current_crate_name ();
-
-  const std::string hash = legacy_hash (ty->as_string ());
-  const std::string hash_sig = mangle_name (hash);
-
-  return kMangledSymbolPrefix + mangle_name (crate_name)
-	 + mangle_canonical_path (path) + hash_sig + kMangledSymbolDelim;
-}
-
-// FIXME this is a wee bit broken
-std::string
-Context::mangle_impl_item (const TyTy::BaseType *self, const TyTy::BaseType *ty,
-			   const std::string &name) const
-{
-  const std::string &crate_name = mappings->get_current_crate_name ();
-
-  const std::string hash = legacy_hash (ty->as_string ());
-  const std::string hash_sig = mangle_name (hash);
-
-  return kMangledSymbolPrefix + mangle_name (crate_name) + mangle_self (self)
-	 + mangle_name (name) + hash_sig + kMangledSymbolDelim;
-}
-
 } // namespace Compile
 } // namespace Rust

--- a/gcc/rust/backend/rust-mangle.cc
+++ b/gcc/rust/backend/rust-mangle.cc
@@ -1,0 +1,149 @@
+#include "rust-mangle.h"
+#include "fnv-hash.h"
+
+// FIXME: Rename those to legacy_*
+static const std::string kMangledSymbolPrefix = "_ZN";
+static const std::string kMangledSymbolDelim = "E";
+static const std::string kMangledGenericDelim = "$C$";
+static const std::string kMangledSubstBegin = "$LT$";
+static const std::string kMangledSubstEnd = "$GT$";
+
+namespace Rust {
+namespace Compile {
+
+static std::string
+legacy_mangle_name (const std::string &name)
+{
+  return std::to_string (name.size ()) + name;
+}
+
+static std::string
+legacy_mangle_canonical_path (const Resolver::CanonicalPath &path)
+{
+  std::string buffer;
+  path.iterate_segs ([&] (const Resolver::CanonicalPath &p) -> bool {
+    buffer += legacy_mangle_name (p.get ());
+    return true;
+  });
+  return buffer;
+}
+
+// rustc uses a sip128 hash for legacy mangling, but an fnv 128 was quicker to
+// implement for now
+static std::string
+legacy_hash (const std::string &fingerprint)
+{
+  Hash::FNV128 hasher;
+  hasher.write ((const unsigned char *) fingerprint.c_str (),
+		fingerprint.size ());
+
+  uint64_t hi, lo;
+  hasher.sum (&hi, &lo);
+
+  char hex[16 + 1];
+  memset (hex, 0, sizeof hex);
+  snprintf (hex, sizeof hex, "%08" PRIx64 "%08" PRIx64, lo, hi);
+
+  return "h" + std::string (hex, sizeof (hex) - 1);
+}
+
+static std::string
+legacy_mangle_self (const TyTy::BaseType *self)
+{
+  if (self->get_kind () != TyTy::TypeKind::ADT)
+    return legacy_mangle_name (self->get_name ());
+
+  const TyTy::ADTType *s = static_cast<const TyTy::ADTType *> (self);
+  std::string buf = s->get_identifier ();
+
+  if (s->has_subsititions_defined ())
+    {
+      buf += kMangledSubstBegin;
+
+      const std::vector<TyTy::SubstitutionParamMapping> &params
+	= s->get_substs ();
+      for (size_t i = 0; i < params.size (); i++)
+	{
+	  const TyTy::SubstitutionParamMapping &sub = params.at (i);
+	  buf += sub.as_string ();
+
+	  if ((i + 1) < params.size ())
+	    buf += kMangledGenericDelim;
+	}
+
+      buf += kMangledSubstEnd;
+    }
+
+  return legacy_mangle_name (buf);
+}
+
+static std::string
+legacy_mangle_item (const TyTy::BaseType *ty, const Resolver::CanonicalPath &path,
+			     const std::string &crate_name)
+{
+  const std::string hash = legacy_hash (ty->as_string ());
+  const std::string hash_sig = legacy_mangle_name (hash);
+
+  return kMangledSymbolPrefix + legacy_mangle_name (crate_name)
+	 + legacy_mangle_canonical_path (path) + hash_sig + kMangledSymbolDelim;
+}
+
+// FIXME this is a wee bit broken
+static std::string
+legacy_mangle_impl_item (const TyTy::BaseType *self,
+				  const TyTy::BaseType *ty,
+				  const std::string &name,
+				  const std::string &crate_name)
+{
+  const std::string hash = legacy_hash (ty->as_string ());
+  const std::string hash_sig = legacy_mangle_name (hash);
+
+  return kMangledSymbolPrefix + legacy_mangle_name (crate_name)
+	 + legacy_mangle_self (self) + legacy_mangle_name (name) + hash_sig
+	 + kMangledSymbolDelim;
+}
+
+// FIXME: Uncomment once v0 mangling is implemented
+// static std::string
+// Mangler::v0_mangle_item (const TyTy::BaseType *ty,
+// 			 const std::string &name)
+// {}
+//
+// static std::string
+// Mangler::v0_mangle_impl_item (const TyTy::BaseType *self,
+// 			      const TyTy::BaseType *ty,
+// 			      const std::string &name)
+// {}
+
+std::string
+Mangler::mangle_item (const TyTy::BaseType *ty, const Resolver::CanonicalPath &path,
+		      const std::string &crate_name) const
+{
+  switch (version)
+    {
+    case Mangler::MangleVersion::LEGACY:
+      return legacy_mangle_item (ty, path, crate_name);
+    case Mangler::MangleVersion::V0:
+      gcc_unreachable ();
+    default:
+      gcc_unreachable ();
+    }
+}
+
+std::string
+Mangler::mangle_impl_item (const TyTy::BaseType *self, const TyTy::BaseType *ty,
+			   const std::string &name,
+			   const std::string &crate_name) const
+{
+  switch (version)
+    {
+    case Mangler::MangleVersion::LEGACY:
+      return legacy_mangle_impl_item (self, ty, name, crate_name);
+    case Mangler::MangleVersion::V0:
+      gcc_unreachable ();
+    default:
+      gcc_unreachable ();
+    }
+}
+} // namespace Compile
+} // namespace Rust

--- a/gcc/rust/backend/rust-mangle.cc
+++ b/gcc/rust/backend/rust-mangle.cc
@@ -11,6 +11,8 @@ static const std::string kMangledSubstEnd = "$GT$";
 namespace Rust {
 namespace Compile {
 
+Mangler::MangleVersion Mangler::version = MangleVersion::LEGACY;
+
 static std::string
 legacy_mangle_name (const std::string &name)
 {
@@ -78,8 +80,9 @@ legacy_mangle_self (const TyTy::BaseType *self)
 }
 
 static std::string
-legacy_mangle_item (const TyTy::BaseType *ty, const Resolver::CanonicalPath &path,
-			     const std::string &crate_name)
+legacy_mangle_item (const TyTy::BaseType *ty,
+		    const Resolver::CanonicalPath &path,
+		    const std::string &crate_name)
 {
   const std::string hash = legacy_hash (ty->as_string ());
   const std::string hash_sig = legacy_mangle_name (hash);
@@ -90,10 +93,8 @@ legacy_mangle_item (const TyTy::BaseType *ty, const Resolver::CanonicalPath &pat
 
 // FIXME this is a wee bit broken
 static std::string
-legacy_mangle_impl_item (const TyTy::BaseType *self,
-				  const TyTy::BaseType *ty,
-				  const std::string &name,
-				  const std::string &crate_name)
+legacy_mangle_impl_item (const TyTy::BaseType *self, const TyTy::BaseType *ty,
+			 const std::string &name, const std::string &crate_name)
 {
   const std::string hash = legacy_hash (ty->as_string ());
   const std::string hash_sig = legacy_mangle_name (hash);
@@ -116,7 +117,8 @@ legacy_mangle_impl_item (const TyTy::BaseType *self,
 // {}
 
 std::string
-Mangler::mangle_item (const TyTy::BaseType *ty, const Resolver::CanonicalPath &path,
+Mangler::mangle_item (const TyTy::BaseType *ty,
+		      const Resolver::CanonicalPath &path,
 		      const std::string &crate_name) const
 {
   switch (version)
@@ -145,5 +147,6 @@ Mangler::mangle_impl_item (const TyTy::BaseType *self, const TyTy::BaseType *ty,
       gcc_unreachable ();
     }
 }
+
 } // namespace Compile
 } // namespace Rust

--- a/gcc/rust/backend/rust-mangle.h
+++ b/gcc/rust/backend/rust-mangle.h
@@ -26,23 +26,33 @@ class Mangler
 public:
   enum MangleVersion
   {
-    LEGACY,
+    LEGACY = 0,
     V0,
   };
 
-  Mangler (MangleVersion version) : version (version) {}
-
   // this needs to support Legacy and V0 see github #429 or #305
-  std::string mangle_item (const TyTy::BaseType *ty, const Resolver::CanonicalPath &path,
+  std::string mangle_item (const TyTy::BaseType *ty,
+			   const Resolver::CanonicalPath &path,
 			   const std::string &crate_name) const;
 
   std::string mangle_impl_item (const TyTy::BaseType *self,
 				const TyTy::BaseType *ty,
 				const std::string &name,
-			   const std::string &crate_name) const;
+				const std::string &crate_name) const;
 
-private:
-  enum MangleVersion version;
+  static bool choose_mangling (std::string arg)
+  {
+    if (arg == "legacy")
+      version = MangleVersion::LEGACY;
+    else if (arg == "v0")
+      version = MangleVersion::V0;
+    else
+      return false;
+
+    return true;
+  }
+
+  static enum MangleVersion version;
 };
 } // namespace Compile
 } // namespace Rust

--- a/gcc/rust/backend/rust-mangle.h
+++ b/gcc/rust/backend/rust-mangle.h
@@ -1,0 +1,49 @@
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_MANGLE_H
+#define RUST_MANGLE_H
+
+#include "rust-compile-tyty.h"
+
+namespace Rust {
+namespace Compile {
+class Mangler
+{
+public:
+  enum MangleVersion
+  {
+    LEGACY,
+    V0,
+  };
+
+  Mangler (MangleVersion version) : version (version) {}
+
+  // this needs to support Legacy and V0 see github #429 or #305
+  std::string mangle_item (const TyTy::BaseType *ty, const Resolver::CanonicalPath &path,
+			   const std::string &crate_name) const;
+
+  std::string mangle_impl_item (const TyTy::BaseType *self,
+				const TyTy::BaseType *ty,
+				const std::string &name,
+			   const std::string &crate_name) const;
+
+private:
+  enum MangleVersion version;
+};
+} // namespace Compile
+} // namespace Rust
+#endif // RUST_MANGLE_H

--- a/gcc/rust/backend/rust-mangle.h
+++ b/gcc/rust/backend/rust-mangle.h
@@ -26,8 +26,9 @@ class Mangler
 public:
   enum MangleVersion
   {
+    // Values defined in rust/lang.opt
     LEGACY = 0,
-    V0,
+    V0 = 1,
   };
 
   // this needs to support Legacy and V0 see github #429 or #305
@@ -40,18 +41,12 @@ public:
 				const std::string &name,
 				const std::string &crate_name) const;
 
-  static bool choose_mangling (std::string arg)
+  static void set_mangling (int frust_mangling_value)
   {
-    if (arg == "legacy")
-      version = MangleVersion::LEGACY;
-    else if (arg == "v0")
-      version = MangleVersion::V0;
-    else
-      return false;
-
-    return true;
+    version = static_cast<MangleVersion> (frust_mangling_value);
   }
 
+private:
   static enum MangleVersion version;
 };
 } // namespace Compile

--- a/gcc/rust/lang.opt
+++ b/gcc/rust/lang.opt
@@ -43,6 +43,10 @@ frust-dump-
 Rust Joined RejectNegative
 -frust-dump-<type>	Dump Rust frontend internal information.
 
+frust-mangling=
+Rust Joined RejectNegative
+-frust-mangling=<version> Choose which version to use for name mangling (legacy, v0)
+
 o
 Rust Joined Separate
 ; Documented in common.opt

--- a/gcc/rust/lang.opt
+++ b/gcc/rust/lang.opt
@@ -44,8 +44,17 @@ Rust Joined RejectNegative
 -frust-dump-<type>	Dump Rust frontend internal information.
 
 frust-mangling=
-Rust Joined RejectNegative
--frust-mangling=<version> Choose which version to use for name mangling (legacy, v0)
+Rust Joined RejectNegative Enum(frust_mangling) Var(flag_rust_mangling)
+-frust-mangling=[legacy|v0]     Choose which version to use for name mangling
+
+Enum
+Name(frust_mangling) Type(int) UnknownError(unknown rust mangling option %qs)
+
+EnumValue
+Enum(frust_mangling) String(legacy) Value(0)
+
+EnumValue
+Enum(frust_mangling) String(v0) Value(1)
 
 o
 Rust Joined Separate

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -370,6 +370,9 @@ Session::handle_option (
 	  ret = false;
 	}
       break;
+    case OPT_frust_mangling_:
+      if (arg != nullptr)
+	ret = Compile::Mangler::choose_mangling (std::string (arg));
     // no option handling for -o
     default:
       // return 1 to indicate option is valid

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -371,8 +371,7 @@ Session::handle_option (
 	}
       break;
     case OPT_frust_mangling_:
-      if (arg != nullptr)
-	ret = Compile::Mangler::choose_mangling (std::string (arg));
+      Compile::Mangler::set_mangling (flag_rust_mangling);
     // no option handling for -o
     default:
       // return 1 to indicate option is valid


### PR DESCRIPTION
Add option to choose mangling scheme.

Closes #429 

This PR splits the `Mangler` class in its own set of header and source and adds the base for v0 name mangling.

You are now able to specify the mangling scheme to use using `-frust-mangling=<value>`.

When inputting an invalid value, the compiler errors out using `unrecognized command-line option `-frust-mangling=<not_valid>`. Is there a better way to do this? Is there also a way to test this behaviour using dejagnu?