### PR TITLE
Add support for choosing other builtin GCC calling conventions

### DIFF
--- a/gcc/rust/backend/rust-compile-extern.h
+++ b/gcc/rust/backend/rust-compile-extern.h
@@ -119,7 +119,7 @@ public:
 	fntype->override_context ();
       }
 
-    if (fntype->get_abi () == TyTy::FnType::ABI::INTRINSIC)
+    if (fntype->get_abi () == ABI::INTRINSIC)
       {
 	Intrinsics compile (ctx);
 	Bfunction *fndecl = compile.compile (fntype);
@@ -127,19 +127,21 @@ public:
 	return;
       }
 
-    rust_assert (fntype->get_abi () == TyTy::FnType::ABI::C);
     ::Btype *compiled_fn_type = TyTyResolveCompile::compile (ctx, fntype);
+    compiled_fn_type
+      = ctx->get_backend ()->specify_abi_attribute (compiled_fn_type,
+						    fntype->get_abi ());
 
     const unsigned int flags
       = Backend::function_is_declaration | Backend::function_is_visible;
 
     std::string ir_symbol_name = function.get_item_name ();
-    // FIXME this assumes C ABI
     std::string asm_name = function.get_item_name ();
 
     Bfunction *fndecl
       = ctx->get_backend ()->function (compiled_fn_type, ir_symbol_name,
 				       asm_name, flags, function.get_locus ());
+
     ctx->insert_function_decl (fntype->get_ty_ref (), fndecl, fntype);
   }
 

--- a/gcc/rust/backend/rust-compile-intrinsic.cc
+++ b/gcc/rust/backend/rust-compile-intrinsic.cc
@@ -24,8 +24,9 @@ Intrinsics::Intrinsics (Context *ctx) : ctx (ctx) {}
 Bfunction *
 Intrinsics::compile (TyTy::FnType *fntype)
 {
-  rust_assert (fntype->get_abi () == TyTy::FnType::ABI::INTRINSIC);
+  rust_assert (fntype->get_abi () == ABI::INTRINSIC);
 
+  // https://github.com/rust-lang/rust/blob/master/library/core/src/intrinsics.rs
   // https://github.com/rust-lang/rust/blob/master/compiler/rustc_codegen_llvm/src/intrinsic.rs
   // https://github.com/Rust-GCC/gccrs/issues/658
 

--- a/gcc/rust/rust-abi.h
+++ b/gcc/rust/rust-abi.h
@@ -1,0 +1,35 @@
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_ABI_OPTIONS_H
+#define RUST_ABI_OPTIONS_H
+
+namespace Rust {
+
+enum ABI
+{
+  UNKNOWN,
+  RUST,
+  INTRINSIC,
+  C,
+  CDECL,
+  STDCALL,
+  FASTCALL,
+};
+
+} // namespace Rust
+
+#endif // RUST_ABI_OPTIONS_H

--- a/gcc/rust/typecheck/rust-hir-type-check-base.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.h
@@ -24,6 +24,7 @@
 #include "rust-name-resolver.h"
 #include "rust-hir-visitor.h"
 #include "rust-hir-map.h"
+#include "rust-backend.h"
 
 namespace Rust {
 namespace Resolver {

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -118,8 +118,7 @@ public:
     auto fnType = new TyTy::FnType (
       function.get_mappings ().get_hirid (),
       function.get_mappings ().get_defid (), function.get_item_name (), flags,
-      TyTy::FnType::get_abi_from_string (parent.get_abi (),
-					 parent.get_locus ()),
+      ::Backend::get_abi_from_string (parent.get_abi (), parent.get_locus ()),
       std::move (params), ret_type, std::move (substitutions));
     context->insert_type (function.get_mappings (), fnType);
   }
@@ -238,14 +237,11 @@ public:
 	context->insert_type (param.get_mappings (), param_tyty);
       }
 
-    auto fnType
-      = new TyTy::FnType (function.get_mappings ().get_hirid (),
-			  function.get_mappings ().get_defid (),
-			  function.get_function_name (),
-			  function.is_method () ? FNTYPE_IS_METHOD_FLAG
-						: FNTYPE_DEFAULT_FLAGS,
-			  TyTy::FnType::ABI::RUST, std::move (params), ret_type,
-			  std::move (substitutions));
+    auto fnType = new TyTy::FnType (
+      function.get_mappings ().get_hirid (),
+      function.get_mappings ().get_defid (), function.get_function_name (),
+      function.is_method () ? FNTYPE_IS_METHOD_FLAG : FNTYPE_DEFAULT_FLAGS,
+      ABI::RUST, std::move (params), ret_type, std::move (substitutions));
     context->insert_type (function.get_mappings (), fnType);
   }
 

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.h
@@ -333,7 +333,7 @@ public:
       = new TyTy::FnType (function.get_mappings ().get_hirid (),
 			  function.get_mappings ().get_defid (),
 			  function.get_function_name (), FNTYPE_DEFAULT_FLAGS,
-			  TyTy::FnType::ABI::RUST, std::move (params), ret_type,
+			  ABI::RUST, std::move (params), ret_type,
 			  std::move (substitutions));
     context->insert_type (function.get_mappings (), fnType);
 

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
@@ -291,7 +291,7 @@ public:
       = new TyTy::FnType (function.get_mappings ().get_hirid (),
 			  function.get_mappings ().get_defid (),
 			  function.get_function_name (), FNTYPE_DEFAULT_FLAGS,
-			  TyTy::FnType::ABI::RUST, std::move (params), ret_type,
+			  ABI::RUST, std::move (params), ret_type,
 			  std::move (substitutions));
     context->insert_type (function.get_mappings (), fnType);
   }

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -546,11 +546,13 @@ TraitItemReference::get_type_from_fn (/*const*/ HIR::TraitItemFunc &fn) const
       context->insert_type (param.get_mappings (), param_tyty);
     }
 
-  auto resolved = new TyTy::FnType (
-    fn.get_mappings ().get_hirid (), fn.get_mappings ().get_defid (),
-    function.get_function_name (),
-    function.is_method () ? FNTYPE_IS_METHOD_FLAG : FNTYPE_DEFAULT_FLAGS,
-    TyTy::FnType::ABI::RUST, std::move (params), ret_type, substitutions);
+  auto resolved
+    = new TyTy::FnType (fn.get_mappings ().get_hirid (),
+			fn.get_mappings ().get_defid (),
+			function.get_function_name (),
+			function.is_method () ? FNTYPE_IS_METHOD_FLAG
+					      : FNTYPE_DEFAULT_FLAGS,
+			ABI::RUST, std::move (params), ret_type, substitutions);
 
   context->insert_type (fn.get_mappings (), resolved);
   return resolved;

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -23,6 +23,7 @@
 #include "rust-hir-map.h"
 #include "rust-hir-full.h"
 #include "rust-diagnostics.h"
+#include "rust-abi.h"
 
 namespace Rust {
 namespace Resolver {
@@ -1076,44 +1077,6 @@ public:
 #define FNTYPE_IS_METHOD_FLAG 0x01
 #define FNTYPE_IS_EXTERN_FLAG 0x02
 #define FNTYPE_IS_VARADIC_FLAG 0X04
-
-  enum ABI
-  {
-    UNKNOWN,
-    RUST,
-    INTRINSIC,
-    C,
-  };
-
-  static ABI get_abi_from_string (const std::string &abi, Location locus)
-  {
-    if (abi.compare ("rust") == 0)
-      return ABI::C;
-    else if (abi.compare ("rust-intrinsic") == 0)
-      return ABI::INTRINSIC;
-    else if (abi.compare ("C") == 0)
-      return ABI::C;
-
-    rust_error_at (locus, "unknown abi specified");
-    return ABI::UNKNOWN;
-  }
-
-  static std::string get_string_from_abi (ABI abi)
-  {
-    switch (abi)
-      {
-      case ABI::RUST:
-	return "rust";
-      case ABI::INTRINSIC:
-	return "rust-intrinsic";
-      case ABI::C:
-	return "C";
-
-      case ABI::UNKNOWN:
-	return "unknown";
-      }
-    return "unknown";
-  }
 
   FnType (HirId ref, DefId id, std::string identifier, uint8_t flags, ABI abi,
 	  std::vector<std::pair<HIR::Pattern *, BaseType *>> params,


### PR DESCRIPTION
Add support for some other ABI options.

I was able to test this with linking against some C code but
these options like stdcall seem to be limited to 32 bit mode

```rust
extern "stdcall" {
    pub fn test(a: i32) -> i32;
}

extern "C" {
    fn printf(s: *const i8, ...);
}

fn main() -> i32 {
    unsafe {
        let a = 3;
        let res = test(a);

        let a = "%i\n\0";
        let b = a as *const str;
        let c = b as *const i8;

        printf(c, res);
    }
    0
}
```

```c
__attribute__ ((stdcall)) int test(int x)  {
  return x + 3;
}

```

Compiling like this:

```
$ gccrs -g -O0 -m32 -c test.rs -o test.o
$ gcc -g -O0 -m32 -c lib.c -o lib.o
$ gcc -m32 -o test test.o lib.o
```

More testing will be required over time here but this was
kind of fun to see that it worked.