### PR TITLE
Fix usage of path attributes and module filename processing

### DIFF
--- a/gcc/testsuite/rust/compile/torture/extern_mod2.rs
+++ b/gcc/testsuite/rust/compile/torture/extern_mod2.rs
@@ -3,14 +3,21 @@
 #[path = "modules/valid_path.rs"]
 mod not_a_valid_path;
 
-// #[path]
-// FIXME: This is wrong
-// mod error; 
+#[path ="modules/valid_path.rs"]
+mod path_without_extra_equal;
+
+#[path= "modules/valid_path.rs"]
+mod no_leading_equal;
+
+#[path       =     "modules/valid_path.rs"]
+mod extra_spaces;
+
+#[path] // { dg-error "path attributes must contain a filename" }
+mod error; // { dg-error "no candidate found" }
 
 // This is "valid", and should only error out when parsing
 // the file
-// FIXME: Fix path attribute expanding
-// #[path = "not_a_valid_file.rs"]
-// mod another_error;
+#[path = "not_a_valid_file.rs"]
+mod another_error; // { dg-error "No such file or directory" }
 
 fn main() {}


### PR DESCRIPTION
`#[path]` attributes were used wrongly in two ways:
- The attribute's value would still contain extra data such as an equal
sign and whitespaces, which need to be discarded in order to fetch the
proper file path.
- `#[path]`s are relative to the directory where the current source file
is located. So we actually need to compute them later on down the line,
once the including directory has been figured out.

Another issue was that in the case that no candidates were found, or too
many were founds, the function `process_file_path` would still return
"successfully" despite erroring out. This causes the function to return
early and thus not assign any string to the `module_file` member.

We also have the ability to emit an error for the module's location,
which looks better for the user, instead of using a new `Location()`
like the session manager does (because it cannot do otherwise, as it
is starting to parse a file and thus has no file location information)