### PR TITLE
Fix bug with monomorphizing of trait items

### DIFF
--- a/gcc/rust/backend/rust-compile-extern.h
+++ b/gcc/rust/backend/rust-compile-extern.h
@@ -100,14 +100,15 @@ public:
     // items can be forward compiled which means we may not need to invoke this
     // code. We might also have already compiled this generic function as well.
     Bfunction *lookup = nullptr;
-    if (ctx->lookup_function_decl (fntype->get_ty_ref (), &lookup, fntype))
+    if (ctx->lookup_function_decl (fntype->get_ty_ref (), &lookup,
+				   fntype->get_id (), fntype))
       {
 	// has this been added to the list then it must be finished
 	if (ctx->function_completed (lookup))
 	  {
 	    Bfunction *dummy = nullptr;
 	    if (!ctx->lookup_function_decl (fntype->get_ty_ref (), &dummy))
-	      ctx->insert_function_decl (fntype->get_ty_ref (), lookup, fntype);
+	      ctx->insert_function_decl (fntype, lookup);
 
 	    return;
 	  }
@@ -123,7 +124,7 @@ public:
       {
 	Intrinsics compile (ctx);
 	Bfunction *fndecl = compile.compile (fntype);
-	ctx->insert_function_decl (fntype->get_ty_ref (), fndecl, fntype);
+	ctx->insert_function_decl (fntype, fndecl);
 	return;
       }
 
@@ -141,8 +142,7 @@ public:
     Bfunction *fndecl
       = ctx->get_backend ()->function (compiled_fn_type, ir_symbol_name,
 				       asm_name, flags, function.get_locus ());
-
-    ctx->insert_function_decl (fntype->get_ty_ref (), fndecl, fntype);
+    ctx->insert_function_decl (fntype, fndecl);
   }
 
 private:

--- a/gcc/rust/backend/rust-compile-implitem.h
+++ b/gcc/rust/backend/rust-compile-implitem.h
@@ -113,7 +113,8 @@ public:
     // items can be forward compiled which means we may not need to invoke this
     // code. We might also have already compiled this generic function as well.
     Bfunction *lookup = nullptr;
-    if (ctx->lookup_function_decl (fntype->get_ty_ref (), &lookup, fntype))
+    if (ctx->lookup_function_decl (fntype->get_ty_ref (), &lookup,
+				   fntype->get_id (), fntype))
       {
 	// has this been added to the list then it must be finished
 	if (ctx->function_completed (lookup))
@@ -121,8 +122,7 @@ public:
 	    Bfunction *dummy = nullptr;
 	    if (!ctx->lookup_function_decl (fntype->get_ty_ref (), &dummy))
 	      {
-		ctx->insert_function_decl (fntype->get_ty_ref (), lookup,
-					   fntype);
+		ctx->insert_function_decl (fntype, lookup);
 	      }
 	    reference
 	      = ctx->get_backend ()->function_code_expression (lookup,
@@ -160,7 +160,7 @@ public:
     Bfunction *fndecl
       = ctx->get_backend ()->function (compiled_fn_type, ir_symbol_name,
 				       asm_name, flags, function.get_locus ());
-    ctx->insert_function_decl (fntype->get_ty_ref (), fndecl, fntype);
+    ctx->insert_function_decl (fntype, fndecl);
 
     // setup the params
     TyTy::BaseType *tyret = fntype->get_return_type ();
@@ -381,7 +381,8 @@ public:
     // items can be forward compiled which means we may not need to invoke this
     // code. We might also have already compiled this generic function as well.
     Bfunction *lookup = nullptr;
-    if (ctx->lookup_function_decl (fntype->get_ty_ref (), &lookup))
+    if (ctx->lookup_function_decl (fntype->get_ty_ref (), &lookup,
+				   fntype->get_id (), fntype))
       {
 	// has this been added to the list then it must be finished
 	if (ctx->function_completed (lookup))
@@ -389,8 +390,7 @@ public:
 	    Bfunction *dummy = nullptr;
 	    if (!ctx->lookup_function_decl (fntype->get_ty_ref (), &dummy))
 	      {
-		ctx->insert_function_decl (fntype->get_ty_ref (), lookup,
-					   fntype);
+		ctx->insert_function_decl (fntype, lookup);
 	      }
 	    reference
 	      = ctx->get_backend ()->function_code_expression (lookup,
@@ -422,7 +422,7 @@ public:
     Bfunction *fndecl
       = ctx->get_backend ()->function (compiled_fn_type, fn_identifier,
 				       asm_name, flags, func.get_locus ());
-    ctx->insert_function_decl (fntype->get_ty_ref (), fndecl, fntype);
+    ctx->insert_function_decl (fntype, fndecl);
 
     // setup the params
     TyTy::BaseType *tyret = fntype->get_return_type ();

--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -150,7 +150,8 @@ public:
     // items can be forward compiled which means we may not need to invoke this
     // code. We might also have already compiled this generic function as well.
     Bfunction *lookup = nullptr;
-    if (ctx->lookup_function_decl (fntype->get_ty_ref (), &lookup, fntype))
+    if (ctx->lookup_function_decl (fntype->get_ty_ref (), &lookup,
+				   fntype->get_id (), fntype))
       {
 	// has this been added to the list then it must be finished
 	if (ctx->function_completed (lookup))
@@ -158,8 +159,7 @@ public:
 	    Bfunction *dummy = nullptr;
 	    if (!ctx->lookup_function_decl (fntype->get_ty_ref (), &dummy))
 	      {
-		ctx->insert_function_decl (fntype->get_ty_ref (), lookup,
-					   fntype);
+		ctx->insert_function_decl (fntype, lookup);
 	      }
 
 	    reference
@@ -205,7 +205,7 @@ public:
     Bfunction *fndecl
       = ctx->get_backend ()->function (compiled_fn_type, ir_symbol_name,
 				       asm_name, flags, function.get_locus ());
-    ctx->insert_function_decl (fntype->get_ty_ref (), fndecl, fntype);
+    ctx->insert_function_decl (fntype, fndecl);
 
     // setup the params
     TyTy::BaseType *tyret = fntype->get_return_type ();


### PR DESCRIPTION
When we monomorphize functions we need to check if we have already
generated this function already. All function items have a DefId which is
unique for the crate and HIR item this means for generic implementations
of an item we end up with mappings of:

  DefId -> [ (concete-tyty-fntype, GCC::Function), ... ]

So for any function we can lookup for that DefId is there a suitable
version of this function already compiled. This was working untill we have
generic trait items which also need to be handled in the same way.

Fixes #668
