### PR TITLE
Support indirection for struct and tuple field access

### DIFF
--- a/gcc/testsuite/rust/compile/torture/autoderef1.rs
+++ b/gcc/testsuite/rust/compile/torture/autoderef1.rs
@@ -1,0 +1,15 @@
+struct Foo(i32, bool);
+struct Bar {
+    a: i32,
+    b: bool,
+}
+
+fn main() {
+    let a = &Foo(123, false);
+    let _b: i32 = a.0;
+    let _c: bool = a.1;
+
+    let a = &Bar { a: 456, b: false };
+    let _b: i32 = a.a;
+    let _c: bool = a.b;
+}


### PR DESCRIPTION
This allows for fat pointers to be used for tuple or struct field access by
supporting the GCC indirect references by binding the type to the reference.

This might get updated when we support the autoderef mechanism and if the
type supports the deref trait.

Addresses #241
