### PR TITLE
Initial autoderef support for method calls

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -310,10 +310,10 @@ struct SelfParam
 public:
   enum ImplicitSelfKind
   {
-    IMM,
-    MUT,
-    IMM_REF,
-    MUT_REF,
+    IMM,     // self
+    MUT,     // mut self
+    IMM_REF, // &self
+    MUT_REF, // &mut self
     NONE
   };
 

--- a/gcc/rust/typecheck/rust-autoderef.h
+++ b/gcc/rust/typecheck/rust-autoderef.h
@@ -1,0 +1,74 @@
+// Copyright (C) 2020 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_AUTODEREF
+#define RUST_AUTODEREF
+
+#include "rust-tyty.h"
+
+namespace Rust {
+namespace Resolver {
+
+class Adjustment
+{
+public:
+  enum AdjustmentType
+  {
+    IMM_REF,
+    MUT_REF,
+    DEREF_REF
+  };
+
+  Adjustment (AdjustmentType type, TyTy::BaseType *expected)
+    : type (type), expected (expected)
+  {}
+
+  AdjustmentType get_type () const { return type; }
+
+  TyTy::BaseType *get_expected () const { return expected; }
+
+  std::string as_string () const
+  {
+    return Adjustment::type_string (get_type ()) + "->"
+	   + get_expected ()->debug_str ();
+  }
+
+  static std::string type_string (AdjustmentType type)
+  {
+    switch (type)
+      {
+      case AdjustmentType::IMM_REF:
+	return "IMM_REF";
+      case AdjustmentType::MUT_REF:
+	return "MUT_REF";
+      case AdjustmentType::DEREF_REF:
+	return "DEREF_REF";
+      }
+    gcc_unreachable ();
+    return "";
+  }
+
+private:
+  AdjustmentType type;
+  TyTy::BaseType *expected;
+};
+
+} // namespace Resolver
+} // namespace Rust
+
+#endif // RUST_AUTODEREF

--- a/gcc/rust/typecheck/rust-hir-dot-operator.h
+++ b/gcc/rust/typecheck/rust-hir-dot-operator.h
@@ -1,0 +1,182 @@
+// Copyright (C) 2020 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_HIR_DOT_OPERATOR
+#define RUST_HIR_DOT_OPERATOR
+
+#include "rust-hir-path-probe.h"
+
+namespace Rust {
+namespace Resolver {
+
+// lookup if method exists for current type
+// if exists: done
+// if not: check again for auto-ref and auto-mut-ref
+// deref and start again with 1.*/
+
+// https://doc.rust-lang.org/nightly/nomicon/dot-operator.html
+
+class MethodResolution
+{
+public:
+  static PathProbeCandidate *
+  Select (std::vector<PathProbeCandidate> &candidates, TyTy::BaseType *receiver,
+	  std::vector<Adjustment> &adjustments)
+  {
+    TyTy::BaseType *r = receiver;
+    while (true)
+      {
+	PathProbeCandidate *c = nullptr;
+
+	// 1. try raw
+	c = Try (candidates, r);
+	if (c != nullptr)
+	  return c;
+
+	// 2. try ref
+	TyTy::ReferenceType *r1
+	  = new TyTy::ReferenceType (r->get_ref (), TyTy::TyVar (r->get_ref ()),
+				     false);
+	c = Try (candidates, r1);
+	if (c != nullptr)
+	  {
+	    adjustments.push_back (
+	      Adjustment (Adjustment::AdjustmentType::IMM_REF, r1));
+	    return c;
+	  }
+
+	// 3. try mut ref
+	TyTy::ReferenceType *r2
+	  = new TyTy::ReferenceType (r->get_ref (), TyTy::TyVar (r->get_ref ()),
+				     true);
+	c = Try (candidates, r2);
+	if (c != nullptr)
+	  {
+	    adjustments.push_back (
+	      Adjustment (Adjustment::AdjustmentType::MUT_REF, r2));
+	    return c;
+	  }
+
+	// 4. deref to to 1, if cannot deref then quit
+	bool can_deref = r->get_kind () == TyTy::TypeKind::REF;
+	if (!can_deref)
+	  return nullptr;
+
+	// FIXME this needs to use deref trait and fall back to unsized to
+	// remove array syntax
+
+	TyTy::ReferenceType *rr = static_cast<TyTy::ReferenceType *> (r);
+	r = rr->get_base ();
+	adjustments.push_back (
+	  Adjustment (Adjustment::AdjustmentType::DEREF_REF, r));
+      }
+    return nullptr;
+  }
+
+private:
+  static PathProbeCandidate *Try (std::vector<PathProbeCandidate> &candidates,
+				  const TyTy::BaseType *receiver)
+  {
+    TypeCheckContext *context = TypeCheckContext::get ();
+
+    // probe impls
+    for (auto &c : candidates)
+      {
+	bool is_func = c.type == PathProbeCandidate::CandidateType::IMPL_FUNC;
+	HIR::ImplBlock *block = c.item.impl.parent;
+	if (is_func && !block->has_trait_ref ())
+	  {
+	    HIR::Function *func
+	      = static_cast<HIR::Function *> (c.item.impl.impl_item);
+
+	    TyTy::BaseType *lookup = nullptr;
+	    bool ok = context->lookup_type (func->get_mappings ().get_hirid (),
+					    &lookup);
+	    rust_assert (ok);
+	    rust_assert (lookup->get_kind () == TyTy::TypeKind::FNDEF);
+
+	    TyTy::FnType *fn = static_cast<TyTy::FnType *> (lookup);
+	    if (fn->is_method ())
+	      {
+		TyTy::BaseType *fn_self = fn->get_self_type ();
+		if (receiver->can_eq (fn_self, false))
+		  {
+		    return &c;
+		  }
+	      }
+	  }
+      }
+
+    // probe trait impls
+    for (auto &c : candidates)
+      {
+	bool is_func = c.type == PathProbeCandidate::CandidateType::IMPL_FUNC;
+	HIR::ImplBlock *block = c.item.impl.parent;
+	if (is_func && block->has_trait_ref ())
+	  {
+	    HIR::Function *func
+	      = static_cast<HIR::Function *> (c.item.impl.impl_item);
+
+	    TyTy::BaseType *lookup = nullptr;
+	    bool ok = context->lookup_type (func->get_mappings ().get_hirid (),
+					    &lookup);
+	    rust_assert (ok);
+	    rust_assert (lookup->get_kind () == TyTy::TypeKind::FNDEF);
+
+	    TyTy::FnType *fn = static_cast<TyTy::FnType *> (lookup);
+	    if (fn->is_method ())
+	      {
+		TyTy::BaseType *fn_self = fn->get_self_type ();
+		if (receiver->can_eq (fn_self, false))
+		  {
+		    return &c;
+		  }
+	      }
+	  }
+      }
+
+    // probe trait bounds
+    for (auto &c : candidates)
+      {
+	bool is_func = c.type == PathProbeCandidate::CandidateType::TRAIT_FUNC;
+	if (is_func)
+	  {
+	    const TraitItemReference *item_ref = c.item.trait.item_ref;
+	    TyTy::BaseType *lookup = item_ref->get_tyty ();
+	    rust_assert (lookup->get_kind () == TyTy::TypeKind::FNDEF);
+
+	    TyTy::FnType *fn = static_cast<TyTy::FnType *> (lookup);
+	    if (fn->is_method ())
+	      {
+		TyTy::BaseType *fn_self = fn->get_self_type ();
+		if (receiver->can_eq (fn_self, false))
+		  {
+		    return &c;
+		  }
+	      }
+	  }
+      }
+
+    return nullptr;
+  }
+};
+
+} // namespace Resolver
+} // namespace Rust
+
+#endif // RUST_HIR_DOT_OPERATOR

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -220,10 +220,45 @@ public:
 	HIR::IdentifierPattern *self_pattern = new HIR::IdentifierPattern (
 	  "self", self_param.get_locus (), self_param.is_ref (),
 	  self_param.is_mut (), std::unique_ptr<HIR::Pattern> (nullptr));
-	context->insert_type (self_param.get_mappings (), self->clone ());
+
+	// might have a specified type
+	TyTy::BaseType *self_type = nullptr;
+	if (self_param.has_type ())
+	  {
+	    std::unique_ptr<HIR::Type> &specified_type = self_param.get_type ();
+	    self_type = TypeCheckType::Resolve (specified_type.get ());
+	  }
+	else
+	  {
+	    switch (self_param.get_self_kind ())
+	      {
+	      case HIR::SelfParam::IMM:
+	      case HIR::SelfParam::MUT:
+		self_type = self->clone ();
+		break;
+
+	      case HIR::SelfParam::IMM_REF:
+		self_type = new TyTy::ReferenceType (
+		  self_param.get_mappings ().get_hirid (),
+		  TyTy::TyVar (self->get_ref ()), false);
+		break;
+
+	      case HIR::SelfParam::MUT_REF:
+		self_type = new TyTy::ReferenceType (
+		  self_param.get_mappings ().get_hirid (),
+		  TyTy::TyVar (self->get_ref ()), true);
+		break;
+
+	      default:
+		gcc_unreachable ();
+		return;
+	      }
+	  }
+
+	context->insert_type (self_param.get_mappings (), self_type);
 	params.push_back (
 	  std::pair<HIR::Pattern *, TyTy::BaseType *> (self_pattern,
-						       self->clone ()));
+						       self_type));
       }
 
     for (auto &param : function.get_function_params ())
@@ -242,6 +277,7 @@ public:
       function.get_mappings ().get_defid (), function.get_function_name (),
       function.is_method () ? FNTYPE_IS_METHOD_FLAG : FNTYPE_DEFAULT_FLAGS,
       ABI::RUST, std::move (params), ret_type, std::move (substitutions));
+
     context->insert_type (function.get_mappings (), fnType);
   }
 

--- a/gcc/rust/typecheck/rust-hir-type-check.h
+++ b/gcc/rust/typecheck/rust-hir-type-check.h
@@ -23,6 +23,7 @@
 #include "rust-hir-map.h"
 #include "rust-tyty.h"
 #include "rust-hir-trait-ref.h"
+#include "rust-autoderef.h"
 
 namespace Rust {
 namespace Resolver {
@@ -183,6 +184,24 @@ public:
     return UNKNOWN_HIRID;
   }
 
+  void insert_autoderef_mappings (HirId id,
+				  std::vector<Adjustment> &&adjustments)
+  {
+    rust_assert (autoderef_mappings.find (id) == autoderef_mappings.end ());
+    autoderef_mappings.emplace (id, std::move (adjustments));
+  }
+
+  bool lookup_autoderef_mappings (HirId id,
+				  std::vector<Adjustment> **adjustments)
+  {
+    auto it = autoderef_mappings.find (id);
+    if (it == autoderef_mappings.end ())
+      return false;
+
+    *adjustments = &it->second;
+    return true;
+  }
+
 private:
   TypeCheckContext ();
 
@@ -200,6 +219,9 @@ private:
     associated_traits_to_impls;
 
   std::map<HirId, HirId> associated_type_mappings;
+
+  // adjustment mappings
+  std::map<HirId, std::vector<Adjustment>> autoderef_mappings;
 };
 
 class TypeResolution

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -112,6 +112,18 @@ BaseType::inherit_bounds (
     }
 }
 
+BaseType *
+BaseType::get_root ()
+{
+  BaseType *root = this;
+  while (root->get_kind () == TyTy::REF)
+    {
+      ReferenceType *r = static_cast<ReferenceType *> (root);
+      root = r->get_base ();
+    }
+  return root;
+}
+
 TyVar::TyVar (HirId ref) : ref (ref)
 {
   // ensure this reference is defined within the context

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -221,8 +221,7 @@ public:
 
   // Unify two types. Returns a pointer to the newly-created unified ty, or
   // nullptr if the two ty cannot be unified. The caller is responsible for
-  // releasing the memory of the returned ty. using ignore_errors alows for a
-  // can_eq style unification
+  // releasing the memory of the returned ty.
   virtual BaseType *unify (BaseType *other) = 0;
 
   // similar to unify but does not actually perform type unification but
@@ -311,6 +310,8 @@ public:
     rust_debug ("[%p] %s", static_cast<const void *> (this),
 		debug_str ().c_str ());
   }
+
+  BaseType *get_root ();
 
 protected:
   BaseType (HirId ref, HirId ty_ref, TypeKind kind,
@@ -1146,8 +1147,7 @@ public:
   BaseType *get_self_type () const
   {
     rust_assert (is_method ());
-    // FIXME this will need updated when we support coercion for & mut self etc
-    return get_params ().at (0).second;
+    return param_at (0).second;
   }
 
   std::vector<std::pair<HIR::Pattern *, BaseType *>> &get_params ()

--- a/gcc/testsuite/rust/compile/method1.rs
+++ b/gcc/testsuite/rust/compile/method1.rs
@@ -1,15 +1,13 @@
 struct Foo(i32);
-
 impl Foo {
     fn test() {}
 }
 
 pub fn main() {
-    // { dg-error {expected \[\(\)\] got \[<tyty::error>\]} "" { target *-*-* } .-1 }
     let a;
     a = Foo(123);
 
-    a.test()
-    // { dg-error "associated function is not a method" "" { target *-*-* } .-1 }
+    a.test();
+    // { dg-error "failed to resolve method" "" { target *-*-* } .-1 }
     // { dg-error {failed to type resolve expression} "" { target *-*-* } .-2 }
 }

--- a/gcc/testsuite/rust/execute/torture/method1.rs
+++ b/gcc/testsuite/rust/execute/torture/method1.rs
@@ -1,0 +1,27 @@
+/* { dg-output "124\n458" } */
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+struct Foo(i32);
+impl Foo {
+    fn bar(&self, i: i32) {
+        unsafe {
+            let a = "%i\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c, self.0 + i);
+        }
+    }
+}
+
+fn main() -> i32 {
+    let a = Foo(123);
+    a.bar(1);
+
+    let b = &Foo(456);
+    b.bar(2);
+
+    0
+}


### PR DESCRIPTION
The commit message contains more detail but this reference is good:
https://doc.rust-lang.org/nightly/nomicon/dot-operator.html

This is not 100% complete since we do not yet support operator overloading
so we will require an update to support the Deref operator overload for
more complex types.

Fixes: #241