### PR TITLE
Allow GCC to decide to inline functions is possible

### DIFF
--- a/gcc/rust/rust-backend.h
+++ b/gcc/rust/rust-backend.h
@@ -830,10 +830,9 @@ public:
   // the definition will be in another compilation unit.
   static const unsigned int function_is_declaration = 1 << 1;
 
-  // Set if the function can be inlined.  This is normally set, but is
-  // false for functions that may not be inlined because they call
+  // Set if the function should never be inlined because they call
   // recover and must be visible for correct panic recovery.
-  static const unsigned int function_is_inlinable = 1 << 2;
+  static const unsigned int function_is_uninlinable = 1 << 2;
 
   // Set if the function does not return.  This is set for the
   // implementation of panic.

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -3370,7 +3370,7 @@ Gcc_backend::function (Btype *fntype, const std::string &name,
       DECL_CONTEXT (resdecl) = decl;
       DECL_RESULT (decl) = resdecl;
     }
-  if ((flags & function_is_inlinable) == 0)
+  if ((flags & function_is_uninlinable) != 0)
     DECL_UNINLINABLE (decl) = 1;
   if ((flags & function_does_not_return) != 0)
     TREE_THIS_VOLATILE (decl) = 1;


### PR DESCRIPTION
By default the forked GCC wrapper from the go front-end was marking
all functions as DECL_UNINLINABLE this changes the behaviour to
allow GCC to decide what can be inlined.

Fixes #547