### PR TITLE
Add test case to close out generics bug

### DIFF
--- a/gcc/testsuite/rust/compile/torture/issue-368.rs
+++ b/gcc/testsuite/rust/compile/torture/issue-368.rs
@@ -1,0 +1,9 @@
+struct S;
+
+fn foo<S>(s: S) -> S {
+    s
+}
+
+fn main() {
+    let _s: S = foo(S);
+}


### PR DESCRIPTION
It seems this issue was fixed by 58637abaeab1. This added a test case
to close out the issue.

Fixes #368