### PR TITLE
Fix bug when calling method from generic reciever type-bound

### DIFF
--- a/gcc/testsuite/rust/execute/torture/trait4.rs
+++ b/gcc/testsuite/rust/execute/torture/trait4.rs
@@ -1,0 +1,36 @@
+/* { dg-output "123\n" }*/
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+struct Foo(i32);
+trait Bar {
+    fn baz(&self);
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+}
+
+impl Bar for Foo {
+    fn baz(&self) {
+        // { dg-warning "unused name" "" { target *-*-* } .-1 }
+        unsafe {
+            let a = "%i\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c, self.0);
+        }
+    }
+}
+
+fn type_bound<T: Bar>(t: &T) {
+    t.baz();
+}
+
+fn main() -> i32 {
+    let a;
+
+    a = &Foo(123);
+    type_bound(a);
+
+    0
+}


### PR DESCRIPTION
When we have a generic function with a specified type bound, this means the
method resolution can only resolve this to the trait item. During code
generation we must then monomorphize this and lookup the associated impl
block item for this trait (if it exists) and call this function.

Fixes #678
