### PR TITLE
Building blocks for TraitObject Types

### DIFF
--- a/gcc/rust/ast/rust-type.h
+++ b/gcc/rust/ast/rust-type.h
@@ -367,6 +367,8 @@ public:
     // TODO: check to ensure invariants are met?
     return trait_bound;
   }
+
+  bool is_dyn () const { return has_dyn; }
 };
 
 class TypePath; // definition moved to "rust-path.h"

--- a/gcc/rust/hir/rust-ast-lower-type.h
+++ b/gcc/rust/hir/rust-ast-lower-type.h
@@ -289,6 +289,8 @@ public:
 			       translated);
   }
 
+  void visit (AST::TraitObjectTypeOneBound &type) override;
+
 private:
   ASTLoweringType () : ASTLoweringBase (), translated (nullptr) {}
 

--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -515,6 +515,29 @@ ASTLowerQualifiedPathInType::visit (AST::QualifiedPathInType &path)
   mappings->insert_hir_type (crate_num, hirid, translated);
 }
 
+void
+ASTLoweringType::visit (AST::TraitObjectTypeOneBound &type)
+{
+  HIR::TypeParamBound *b
+    = ASTLoweringTypeBounds::translate (&type.get_trait_bound ());
+  rust_assert (b->get_bound_type () == HIR::TypeParamBound::TRAITBOUND);
+  HIR::TraitBound *bb = static_cast<HIR::TraitBound *> (b);
+  HIR::TraitBound bound (*bb);
+  delete bb;
+
+  auto crate_num = mappings->get_current_crate ();
+  Analysis::NodeMapping mapping (crate_num, type.get_node_id (),
+				 mappings->get_next_hir_id (crate_num),
+				 mappings->get_next_localdef_id (crate_num));
+
+  translated
+    = new HIR::TraitObjectTypeOneBound (mapping, std::move (bound),
+					type.get_locus (), type.is_dyn ());
+
+  mappings->insert_hir_type (mapping.get_crate_num (), mapping.get_hirid (),
+			     translated);
+}
+
 // rust-ast-lower-base
 
 HIR::Type *

--- a/gcc/rust/hir/tree/rust-hir-type.h
+++ b/gcc/rust/hir/tree/rust-hir-type.h
@@ -310,7 +310,6 @@ class TraitObjectTypeOneBound : public TypeNoBounds
 {
   bool has_dyn;
   TraitBound trait_bound;
-
   Location locus;
 
 protected:
@@ -318,37 +317,31 @@ protected:
    * than base */
   TraitObjectTypeOneBound *clone_type_impl () const override
   {
-    return new TraitObjectTypeOneBound (*this);
+    return new TraitObjectTypeOneBound (mappings, trait_bound, locus, has_dyn);
   }
 
   /* Use covariance to implement clone function as returning this object rather
    * than base */
   TraitObjectTypeOneBound *clone_type_no_bounds_impl () const override
   {
-    return new TraitObjectTypeOneBound (*this);
+    return new TraitObjectTypeOneBound (mappings, trait_bound, locus, has_dyn);
   }
 
 public:
   TraitObjectTypeOneBound (Analysis::NodeMapping mappings,
 			   TraitBound trait_bound, Location locus,
-			   bool is_dyn_dispatch = false)
+			   bool is_dyn_dispatch)
     : TypeNoBounds (mappings), has_dyn (is_dyn_dispatch),
       trait_bound (std::move (trait_bound)), locus (locus)
   {}
 
   std::string as_string () const override;
 
-  // Creates a trait bound (clone of this one's trait bound) - HACK
-  TraitBound *to_trait_bound (bool in_parens ATTRIBUTE_UNUSED) const override
-  {
-    /* NOTE: this assumes there is no dynamic dispatch specified- if there was,
-     * this cloning would not be required as parsing is unambiguous. */
-    return new HIR::TraitBound (trait_bound);
-  }
-
   Location get_locus () const { return locus; }
 
   void accept_vis (HIRVisitor &vis) override;
+
+  TraitBound &get_trait_bound () { return trait_bound; }
 };
 
 class TypePath; // definition moved to "rust-path.h"

--- a/gcc/rust/resolve/rust-ast-resolve-type.h
+++ b/gcc/rust/resolve/rust-ast-resolve-type.h
@@ -359,6 +359,8 @@ public:
     type.get_type_pointed_to ()->accept_vis (*this);
   }
 
+  void visit (AST::TraitObjectTypeOneBound &type) override;
+
 private:
   ResolveType (NodeId parent, bool canonicalize_type_with_generics)
     : ResolverBase (parent),

--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -720,6 +720,14 @@ ResolveType::visit (AST::ArrayType &type)
   ResolveExpr::go (type.get_size_expr ().get (), type.get_node_id ());
 }
 
+void
+ResolveType::visit (AST::TraitObjectTypeOneBound &type)
+{
+  NodeId bound_resolved_id
+    = ResolveTypeBound::go (&type.get_trait_bound (), type.get_node_id ());
+  ok = bound_resolved_id != UNKNOWN_NODEID;
+}
+
 // rust-ast-resolve-item.h
 
 void


### PR DESCRIPTION
This adds name resolution and HIR lowering for TraitObjectTypeOneBound
This is the most basic form of dynamic dispatch but all forms derive from
this piece of work.