### PR TITLE
Initial Dynamic dispatch support

### DIFF
--- a/gcc/rust/backend/rust-compile-base.h
+++ b/gcc/rust/backend/rust-compile-base.h
@@ -200,6 +200,19 @@ protected:
 
   bool compile_locals_for_block (Resolver::Rib &rib, Bfunction *fndecl,
 				 std::vector<Bvariable *> &locals);
+
+  Bexpression *coercion_site (Bexpression *compiled_ref, TyTy::BaseType *actual,
+			      TyTy::BaseType *expected, Location locus);
+
+  Bexpression *coerce_to_dyn_object (Bexpression *compiled_ref,
+				     TyTy::BaseType *actual,
+				     TyTy::BaseType *expected,
+				     TyTy::DynamicObjectType *ty,
+				     Location locus);
+
+  Bexpression *
+  compute_address_for_trait_item (const Resolver::TraitItemReference *ref,
+				  TyTy::BaseType *receiver);
 };
 
 } // namespace Compile

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -610,6 +610,8 @@ public:
     translated = ctx->get_backend ()->unit_type ();
   }
 
+  void visit (TyTy::DynamicObjectType &) override { gcc_unreachable (); }
+
 private:
   TyTyResolveCompile (Context *ctx) : ctx (ctx), translated (nullptr) {}
 

--- a/gcc/rust/backend/rust-compile-tyty.h
+++ b/gcc/rust/backend/rust-compile-tyty.h
@@ -237,6 +237,8 @@ public:
     translated = backend->unit_type ();
   }
 
+  void visit (TyTy::DynamicObjectType &) override { gcc_unreachable (); }
+
 private:
   TyTyCompile (::Backend *backend)
     : backend (backend), translated (nullptr),

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -2264,6 +2264,8 @@ public:
 
   TraitFunctionDecl &get_decl () { return decl; }
 
+  const TraitFunctionDecl &get_decl () const { return decl; }
+
   bool has_block_defined () const { return block_expr != nullptr; }
 
   std::unique_ptr<BlockExpr> &get_block_expr ()

--- a/gcc/rust/typecheck/rust-hir-const-fold.h
+++ b/gcc/rust/typecheck/rust-hir-const-fold.h
@@ -191,6 +191,8 @@ public:
 
   void visit (TyTy::NeverType &) override { gcc_unreachable (); }
 
+  void visit (TyTy::DynamicObjectType &) override { gcc_unreachable (); }
+
 private:
   ConstFoldType (::Backend *backend)
     : backend (backend), translated (backend->error_type ())

--- a/gcc/rust/typecheck/rust-hir-trait-ref.h
+++ b/gcc/rust/typecheck/rust-hir-trait-ref.h
@@ -177,6 +177,7 @@ private:
 };
 
 // this wraps up the HIR::Trait so we can do analysis on it
+
 class TraitReference
 {
 public:

--- a/gcc/rust/typecheck/rust-hir-trait-resolve.h
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.h
@@ -153,6 +153,7 @@ private:
       TyTy::TypeBoundPredicate (trait_reference->get_mappings ().get_defid (),
 				trait_reference->get_locus ()));
 
+    std::vector<const TraitReference *> super_traits;
     if (trait_reference->has_type_param_bounds ())
       {
 	for (auto &bound : trait_reference->get_type_param_bounds ())
@@ -170,6 +171,7 @@ private:
 		  trait->get_mappings ().get_defid (), bound->get_locus ());
 
 		specified_bounds.push_back (std::move (predicate));
+		super_traits.push_back (predicate.get ());
 	      }
 	  }
       }
@@ -189,7 +191,8 @@ private:
 	item_refs.push_back (std::move (trait_item_ref));
       }
 
-    TraitReference trait_object (trait_reference, item_refs);
+    TraitReference trait_object (trait_reference, item_refs,
+				 std::move (super_traits));
     context->insert_trait_reference (
       trait_reference->get_mappings ().get_defid (), std::move (trait_object));
 

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -227,10 +227,13 @@ public:
     // which is simple. There will need to be adjustments to ensure we can turn
     // the receiver into borrowed references etc
 
-    bool reciever_is_generic = root->get_kind () == TyTy::TypeKind::PARAM;
+    bool receiver_is_type_param = root->get_kind () == TyTy::TypeKind::PARAM;
+    bool receiver_is_dyn = root->get_kind () == TyTy::TypeKind::DYNAMIC;
+
+    bool receiver_is_generic = receiver_is_type_param || receiver_is_dyn;
     bool probe_bounds = true;
-    bool probe_impls = !reciever_is_generic;
-    bool ignore_mandatory_trait_items = !reciever_is_generic;
+    bool probe_impls = !receiver_is_generic;
+    bool ignore_mandatory_trait_items = !receiver_is_generic;
 
     auto candidates
       = PathProbeType::Probe (root, expr.get_method_name ().get_segment (),
@@ -345,7 +348,7 @@ public:
 	  }
       }
 
-    if (!reciever_is_generic)
+    if (!receiver_is_type_param)
       {
 	// apply any remaining generic arguments
 	if (expr.get_method_name ().has_generic_args ())

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -424,9 +424,6 @@ public:
 	  trait_reference.get_name ().c_str ());
       }
 
-    rust_debug_loc (type.get_locus (), "type-alias within impl block");
-    lookup->debug ();
-
     // its actually a projection, since we need a way to actually bind the
     // generic substitutions to the type itself
     TyTy::ProjectionType *projection = new TyTy::ProjectionType (

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -231,10 +231,13 @@ TypeCheckType::visit (HIR::TraitObjectTypeOneBound &type)
   TyTy::TypeBoundPredicate predicate (trait->get_mappings ().get_defid (),
 				      trait_bound.get_locus ());
 
-  specified_bounds.push_back (std::move (predicate));
-
-  translated = new TyTy::DynamicObjectType (type.get_mappings ().get_hirid (),
-					    std::move (specified_bounds));
+  if (predicate.is_object_safe (true, type.get_locus ()))
+    {
+      specified_bounds.push_back (std::move (predicate));
+      translated
+	= new TyTy::DynamicObjectType (type.get_mappings ().get_hirid (),
+				       std::move (specified_bounds));
+    }
 }
 
 } // namespace Resolver

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -221,5 +221,21 @@ TypeCheckType::resolve_segments (
   gcc_unreachable ();
 }
 
+void
+TypeCheckType::visit (HIR::TraitObjectTypeOneBound &type)
+{
+  std::vector<TyTy::TypeBoundPredicate> specified_bounds;
+
+  HIR::TraitBound &trait_bound = type.get_trait_bound ();
+  TraitReference *trait = resolve_trait_path (trait_bound.get_path ());
+  TyTy::TypeBoundPredicate predicate (trait->get_mappings ().get_defid (),
+				      trait_bound.get_locus ());
+
+  specified_bounds.push_back (std::move (predicate));
+
+  translated = new TyTy::DynamicObjectType (type.get_mappings ().get_hirid (),
+					    std::move (specified_bounds));
+}
+
 } // namespace Resolver
 } // namespace Rust

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -66,7 +66,8 @@ public:
     type->accept_vis (resolver);
 
     if (resolver.translated == nullptr)
-      return new TyTy::ErrorType (type->get_mappings ().get_hirid ());
+      resolver.translated
+	= new TyTy::ErrorType (type->get_mappings ().get_hirid ());
 
     resolver.context->insert_type (type->get_mappings (), resolver.translated);
     return resolver.translated;

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -146,6 +146,8 @@ public:
 				      TyTy::InferType::InferTypeKind::GENERAL);
   }
 
+  void visit (HIR::TraitObjectTypeOneBound &type) override;
+
 private:
   TypeCheckType (std::vector<TyTy::SubstitutionParamMapping> *subst_mappings)
     : TypeCheckBase (), subst_mappings (subst_mappings), translated (nullptr)

--- a/gcc/rust/typecheck/rust-substitution-mapper.h
+++ b/gcc/rust/typecheck/rust-substitution-mapper.h
@@ -137,6 +137,7 @@ public:
   void visit (TyTy::ParamType &) override { gcc_unreachable (); }
   void visit (TyTy::StrType &) override { gcc_unreachable (); }
   void visit (TyTy::NeverType &) override { gcc_unreachable (); }
+  void visit (TyTy::DynamicObjectType &) override { gcc_unreachable (); }
 
 private:
   SubstMapper (HirId ref, HIR::GenericArgs *generics, Location locus)
@@ -230,6 +231,7 @@ public:
   void visit (TyTy::CharType &) override { gcc_unreachable (); }
   void visit (TyTy::StrType &) override { gcc_unreachable (); }
   void visit (TyTy::NeverType &) override { gcc_unreachable (); }
+  void visit (TyTy::DynamicObjectType &) override { gcc_unreachable (); }
 
 private:
   SubstMapperInternal (HirId ref, TyTy::SubstitutionArgumentMappings &mappings)
@@ -288,6 +290,7 @@ public:
   void visit (TyTy::NeverType &) override { gcc_unreachable (); }
   void visit (TyTy::PlaceholderType &) override { gcc_unreachable (); }
   void visit (TyTy::ProjectionType &) override { gcc_unreachable (); }
+  void visit (TyTy::DynamicObjectType &) override { gcc_unreachable (); }
 
 private:
   SubstMapperFromExisting (TyTy::BaseType *concrete, TyTy::BaseType *receiver)
@@ -339,6 +342,7 @@ public:
   void visit (TyTy::NeverType &) override {}
   void visit (TyTy::PlaceholderType &) override {}
   void visit (TyTy::ProjectionType &) override {}
+  void visit (TyTy::DynamicObjectType &) override {}
 
 private:
   GetUsedSubstArgs () : args (TyTy::SubstitutionArgumentMappings::error ()) {}

--- a/gcc/rust/typecheck/rust-tyty-bounds.cc
+++ b/gcc/rust/typecheck/rust-tyty-bounds.cc
@@ -88,7 +88,16 @@ TypeBoundPredicate::get () const
 std::string
 TypeBoundPredicate::get_name () const
 {
-  return get ()->get_name ();
+  auto mappings = Analysis::Mappings::get ();
+  auto trait = get ();
+  auto nodeid = trait->get_mappings ().get_nodeid ();
+
+  const Resolver::CanonicalPath *p = nullptr;
+  if (mappings->lookup_canonical_path (mappings->get_current_crate (), nodeid,
+				       &p))
+    return p->get ();
+
+  return trait->get_name ();
 }
 
 bool

--- a/gcc/rust/typecheck/rust-tyty-bounds.cc
+++ b/gcc/rust/typecheck/rust-tyty-bounds.cc
@@ -91,5 +91,13 @@ TypeBoundPredicate::get_name () const
   return get ()->get_name ();
 }
 
+bool
+TypeBoundPredicate::is_object_safe (bool emit_error, Location locus) const
+{
+  const Resolver::TraitReference *trait = get ();
+  rust_assert (trait != nullptr);
+  return trait->is_object_safe (emit_error, locus);
+}
+
 } // namespace TyTy
 } // namespace Rust

--- a/gcc/rust/typecheck/rust-tyty-call.h
+++ b/gcc/rust/typecheck/rust-tyty-call.h
@@ -39,24 +39,25 @@ public:
     return checker.resolved;
   }
 
-  void visit (InferType &type) override { gcc_unreachable (); }
-  void visit (TupleType &type) override { gcc_unreachable (); }
-  void visit (ArrayType &type) override { gcc_unreachable (); }
-  void visit (BoolType &type) override { gcc_unreachable (); }
-  void visit (IntType &type) override { gcc_unreachable (); }
-  void visit (UintType &type) override { gcc_unreachable (); }
-  void visit (FloatType &type) override { gcc_unreachable (); }
-  void visit (USizeType &type) override { gcc_unreachable (); }
-  void visit (ISizeType &type) override { gcc_unreachable (); }
-  void visit (ErrorType &type) override { gcc_unreachable (); }
-  void visit (CharType &type) override { gcc_unreachable (); }
-  void visit (ReferenceType &type) override { gcc_unreachable (); }
-  void visit (PointerType &type) override { gcc_unreachable (); }
+  void visit (InferType &) override { gcc_unreachable (); }
+  void visit (TupleType &) override { gcc_unreachable (); }
+  void visit (ArrayType &) override { gcc_unreachable (); }
+  void visit (BoolType &) override { gcc_unreachable (); }
+  void visit (IntType &) override { gcc_unreachable (); }
+  void visit (UintType &) override { gcc_unreachable (); }
+  void visit (FloatType &) override { gcc_unreachable (); }
+  void visit (USizeType &) override { gcc_unreachable (); }
+  void visit (ISizeType &) override { gcc_unreachable (); }
+  void visit (ErrorType &) override { gcc_unreachable (); }
+  void visit (CharType &) override { gcc_unreachable (); }
+  void visit (ReferenceType &) override { gcc_unreachable (); }
+  void visit (PointerType &) override { gcc_unreachable (); }
   void visit (ParamType &) override { gcc_unreachable (); }
   void visit (StrType &) override { gcc_unreachable (); }
   void visit (NeverType &) override { gcc_unreachable (); }
   void visit (PlaceholderType &) override { gcc_unreachable (); }
   void visit (ProjectionType &) override { gcc_unreachable (); }
+  void visit (DynamicObjectType &) override { gcc_unreachable (); }
 
   // tuple-structs
   void visit (ADTType &type) override;
@@ -89,25 +90,26 @@ public:
     return checker.resolved;
   }
 
-  void visit (InferType &type) override { gcc_unreachable (); }
-  void visit (TupleType &type) override { gcc_unreachable (); }
-  void visit (ArrayType &type) override { gcc_unreachable (); }
-  void visit (BoolType &type) override { gcc_unreachable (); }
-  void visit (IntType &type) override { gcc_unreachable (); }
-  void visit (UintType &type) override { gcc_unreachable (); }
-  void visit (FloatType &type) override { gcc_unreachable (); }
-  void visit (USizeType &type) override { gcc_unreachable (); }
-  void visit (ISizeType &type) override { gcc_unreachable (); }
-  void visit (ErrorType &type) override { gcc_unreachable (); }
-  void visit (ADTType &type) override { gcc_unreachable (); };
-  void visit (CharType &type) override { gcc_unreachable (); }
-  void visit (ReferenceType &type) override { gcc_unreachable (); }
-  void visit (PointerType &type) override { gcc_unreachable (); }
+  void visit (InferType &) override { gcc_unreachable (); }
+  void visit (TupleType &) override { gcc_unreachable (); }
+  void visit (ArrayType &) override { gcc_unreachable (); }
+  void visit (BoolType &) override { gcc_unreachable (); }
+  void visit (IntType &) override { gcc_unreachable (); }
+  void visit (UintType &) override { gcc_unreachable (); }
+  void visit (FloatType &) override { gcc_unreachable (); }
+  void visit (USizeType &) override { gcc_unreachable (); }
+  void visit (ISizeType &) override { gcc_unreachable (); }
+  void visit (ErrorType &) override { gcc_unreachable (); }
+  void visit (ADTType &) override { gcc_unreachable (); };
+  void visit (CharType &) override { gcc_unreachable (); }
+  void visit (ReferenceType &) override { gcc_unreachable (); }
+  void visit (PointerType &) override { gcc_unreachable (); }
   void visit (ParamType &) override { gcc_unreachable (); }
   void visit (StrType &) override { gcc_unreachable (); }
   void visit (NeverType &) override { gcc_unreachable (); }
   void visit (PlaceholderType &) override { gcc_unreachable (); }
   void visit (ProjectionType &) override { gcc_unreachable (); }
+  void visit (DynamicObjectType &) override { gcc_unreachable (); }
 
   // FIXME
   void visit (FnPtr &type) override { gcc_unreachable (); }

--- a/gcc/rust/typecheck/rust-tyty-coercion.h
+++ b/gcc/rust/typecheck/rust-tyty-coercion.h
@@ -1326,6 +1326,37 @@ public:
     : BaseCoercionRules (base), base (base)
   {}
 
+  BaseType *coerce (BaseType *other) override final
+  {
+    if (!base->can_resolve ())
+      return BaseCoercionRules::coerce (other);
+
+    BaseType *lookup = base->resolve ();
+    return lookup->unify (other);
+  }
+
+  void visit (PlaceholderType &type) override
+  {
+    if (base->get_symbol ().compare (type.get_symbol ()) != 0)
+      {
+	BaseCoercionRules::visit (type);
+	return;
+      }
+
+    resolved = type.clone ();
+  }
+
+  void visit (InferType &type) override
+  {
+    if (type.get_infer_kind () != InferType::InferTypeKind::GENERAL)
+      {
+	BaseCoercionRules::visit (type);
+	return;
+      }
+
+    resolved = base->clone ();
+  }
+
 private:
   BaseType *get_base () override { return base; }
 

--- a/gcc/rust/typecheck/rust-tyty-coercion.h
+++ b/gcc/rust/typecheck/rust-tyty-coercion.h
@@ -24,6 +24,7 @@
 #include "rust-tyty-visitor.h"
 #include "rust-hir-map.h"
 #include "rust-hir-type-check.h"
+#include "rust-hir-type-bounds.h"
 
 extern ::Backend *
 rust_get_backend ();
@@ -1386,6 +1387,16 @@ public:
 	BaseCoercionRules::visit (type);
 	return;
       }
+
+    resolved = base->clone ();
+  }
+
+  void visit (ADTType &type) override
+  {
+    Location ref_locus = mappings->lookup_location (type.get_ref ());
+    bool ok = base->bounds_compatible (type, ref_locus, true);
+    if (!ok)
+      return;
 
     resolved = base->clone ();
   }

--- a/gcc/rust/typecheck/rust-tyty-coercion.h
+++ b/gcc/rust/typecheck/rust-tyty-coercion.h
@@ -1130,7 +1130,7 @@ public:
     auto base_type = base->get_base ();
     auto other_base_type = type.get_base ();
 
-    TyTy::BaseType *base_resolved = base_type->unify (other_base_type);
+    TyTy::BaseType *base_resolved = base_type->coerce (other_base_type);
     if (base_resolved == nullptr
 	|| base_resolved->get_kind () == TypeKind::ERROR)
       {

--- a/gcc/rust/typecheck/rust-tyty-visitor.h
+++ b/gcc/rust/typecheck/rust-tyty-visitor.h
@@ -48,6 +48,7 @@ public:
   virtual void visit (NeverType &type) = 0;
   virtual void visit (PlaceholderType &type) = 0;
   virtual void visit (ProjectionType &type) = 0;
+  virtual void visit (DynamicObjectType &type) = 0;
 };
 
 class TyConstVisitor
@@ -74,6 +75,7 @@ public:
   virtual void visit (const NeverType &type) = 0;
   virtual void visit (const PlaceholderType &type) = 0;
   virtual void visit (const ProjectionType &type) = 0;
+  virtual void visit (const DynamicObjectType &type) = 0;
 };
 
 } // namespace TyTy

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -2358,7 +2358,7 @@ TypeCheckCallExpr::visit (ADTType &type)
 	return false;
       }
 
-    auto res = field_tyty->unify (arg);
+    auto res = field_tyty->coerce (arg);
     if (res->get_kind () == TyTy::TypeKind::ERROR)
       {
 	return false;
@@ -2420,7 +2420,7 @@ TypeCheckCallExpr::visit (FnType &type)
     if (i < type.num_params ())
       {
 	auto fnparam = type.param_at (i);
-	resolved_argument_type = fnparam.second->unify (argument_expr_tyty);
+	resolved_argument_type = fnparam.second->coerce (argument_expr_tyty);
 	if (argument_expr_tyty->get_kind () == TyTy::TypeKind::ERROR)
 	  {
 	    rust_error_at (param->get_locus (),
@@ -2479,7 +2479,7 @@ TypeCheckCallExpr::visit (FnPtr &type)
 	return false;
       }
 
-    auto resolved_argument_type = fnparam->unify (argument_expr_tyty);
+    auto resolved_argument_type = fnparam->coerce (argument_expr_tyty);
     if (argument_expr_tyty->get_kind () == TyTy::TypeKind::ERROR)
       {
 	rust_error_at (param->get_locus (),
@@ -2530,7 +2530,7 @@ TypeCheckMethodCallExpr::visit (FnType &type)
 	return false;
       }
 
-    auto resolved_argument_type = fnparam.second->unify (argument_expr_tyty);
+    auto resolved_argument_type = fnparam.second->coerce (argument_expr_tyty);
     if (argument_expr_tyty->get_kind () == TyTy::TypeKind::ERROR)
       {
 	rust_error_at (param->get_locus (),

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -2312,6 +2312,13 @@ DynamicObjectType::clone () const
 				get_combined_refs ());
 }
 
+std::string
+DynamicObjectType::get_name () const
+{
+  std::string bounds = "[" + raw_bounds_as_string () + "]";
+  return "dyn " + bounds;
+}
+
 bool
 DynamicObjectType::is_equal (const BaseType &other) const
 {
@@ -2322,6 +2329,35 @@ DynamicObjectType::is_equal (const BaseType &other) const
     return false;
 
   return bounds_compatible (other, Location (), false);
+}
+
+const std::vector<const Resolver::TraitItemReference *>
+DynamicObjectType::get_object_items () const
+{
+  std::vector<const Resolver::TraitItemReference *> items;
+  for (auto &bound : get_specified_bounds ())
+    {
+      const Resolver::TraitReference *trait = bound.get ();
+      for (auto &item : trait->get_trait_items ())
+	{
+	  if (item.get_trait_item_type ()
+		== Resolver::TraitItemReference::TraitItemType::FN
+	      && item.is_object_safe ())
+	    items.push_back (&item);
+	}
+
+      for (auto &super_trait : trait->get_super_traits ())
+	{
+	  for (auto &item : super_trait->get_trait_items ())
+	    {
+	      if (item.get_trait_item_type ()
+		    == Resolver::TraitItemReference::TraitItemType::FN
+		  && item.is_object_safe ())
+		items.push_back (&item);
+	    }
+	}
+    }
+  return items;
 }
 
 // rust-tyty-call.h

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -2352,14 +2352,14 @@ TypeCheckCallExpr::visit (ADTType &type)
     BaseType *field_tyty = field->get_field_type ();
 
     BaseType *arg = Resolver::TypeCheckExpr::Resolve (p, false);
-    if (arg == nullptr)
+    if (arg->get_kind () == TyTy::TypeKind::ERROR)
       {
 	rust_error_at (p->get_locus (), "failed to resolve argument type");
 	return false;
       }
 
     auto res = field_tyty->unify (arg);
-    if (res == nullptr)
+    if (res->get_kind () == TyTy::TypeKind::ERROR)
       {
 	return false;
       }
@@ -2407,7 +2407,7 @@ TypeCheckCallExpr::visit (FnType &type)
   size_t i = 0;
   call.iterate_params ([&] (HIR::Expr *param) mutable -> bool {
     auto argument_expr_tyty = Resolver::TypeCheckExpr::Resolve (param, false);
-    if (argument_expr_tyty == nullptr)
+    if (argument_expr_tyty->get_kind () == TyTy::TypeKind::ERROR)
       {
 	rust_error_at (param->get_locus (),
 		       "failed to resolve type for argument expr in CallExpr");
@@ -2421,7 +2421,7 @@ TypeCheckCallExpr::visit (FnType &type)
       {
 	auto fnparam = type.param_at (i);
 	resolved_argument_type = fnparam.second->unify (argument_expr_tyty);
-	if (resolved_argument_type == nullptr)
+	if (argument_expr_tyty->get_kind () == TyTy::TypeKind::ERROR)
 	  {
 	    rust_error_at (param->get_locus (),
 			   "Type Resolution failure on parameter");
@@ -2472,7 +2472,7 @@ TypeCheckCallExpr::visit (FnPtr &type)
   call.iterate_params ([&] (HIR::Expr *param) mutable -> bool {
     auto fnparam = type.param_at (i);
     auto argument_expr_tyty = Resolver::TypeCheckExpr::Resolve (param, false);
-    if (argument_expr_tyty == nullptr)
+    if (argument_expr_tyty->get_kind () == TyTy::TypeKind::ERROR)
       {
 	rust_error_at (param->get_locus (),
 		       "failed to resolve type for argument expr in CallExpr");
@@ -2480,7 +2480,7 @@ TypeCheckCallExpr::visit (FnPtr &type)
       }
 
     auto resolved_argument_type = fnparam->unify (argument_expr_tyty);
-    if (resolved_argument_type == nullptr)
+    if (argument_expr_tyty->get_kind () == TyTy::TypeKind::ERROR)
       {
 	rust_error_at (param->get_locus (),
 		       "Type Resolution failure on parameter");
@@ -2523,7 +2523,7 @@ TypeCheckMethodCallExpr::visit (FnType &type)
   call.iterate_params ([&] (HIR::Expr *param) mutable -> bool {
     auto fnparam = type.param_at (i);
     auto argument_expr_tyty = Resolver::TypeCheckExpr::Resolve (param, false);
-    if (argument_expr_tyty == nullptr)
+    if (argument_expr_tyty->get_kind () == TyTy::TypeKind::ERROR)
       {
 	rust_error_at (param->get_locus (),
 		       "failed to resolve type for argument expr in CallExpr");
@@ -2531,7 +2531,7 @@ TypeCheckMethodCallExpr::visit (FnType &type)
       }
 
     auto resolved_argument_type = fnparam.second->unify (argument_expr_tyty);
-    if (resolved_argument_type == nullptr)
+    if (argument_expr_tyty->get_kind () == TyTy::TypeKind::ERROR)
       {
 	rust_error_at (param->get_locus (),
 		       "Type Resolution failure on parameter");

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -154,6 +154,10 @@ public:
 
   std::string get_name () const;
 
+  // check that this predicate is object-safe see:
+  // https://doc.rust-lang.org/reference/items/traits.html#object-safety
+  bool is_object_safe (bool emit_error, Location locus) const;
+
 private:
   DefId reference;
   Location locus;

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -26,8 +26,10 @@
 #include "rust-abi.h"
 
 namespace Rust {
+
 namespace Resolver {
 class TraitReference;
+class TraitItemReference;
 class AssociatedImplTrait;
 } // namespace Resolver
 
@@ -186,9 +188,12 @@ public:
   std::string raw_bounds_as_string () const
   {
     std::string buf;
-    for (auto &b : specified_bounds)
-      buf += b.as_string () + " + ";
-
+    for (size_t i = 0; i < specified_bounds.size (); i++)
+      {
+	const TypeBoundPredicate &b = specified_bounds.at (i);
+	bool has_next = (i + 1) < specified_bounds.size ();
+	buf += b.get_name () + (has_next ? " + " : "");
+      }
     return buf;
   }
 
@@ -1857,7 +1862,11 @@ public:
 
   BaseType *clone () const final override;
 
-  std::string get_name () const override final { return as_string (); }
+  std::string get_name () const override final;
+
+  // this returns a flat list of items including super trait bounds
+  const std::vector<const Resolver::TraitItemReference *>
+  get_object_items () const;
 };
 
 } // namespace TyTy

--- a/gcc/testsuite/rust/compile/traits10.rs
+++ b/gcc/testsuite/rust/compile/traits10.rs
@@ -1,0 +1,16 @@
+struct Foo(i32);
+
+trait Bar {
+    const A: i32 = 123;
+    fn B();
+    fn C(&self);
+}
+
+pub fn main() {
+    let a;
+    a = Foo(123);
+
+    let b: &dyn Bar = &a;
+    // { dg-error "trait bound is not object safe" "" { target *-*-* } .-1 }
+    // { dg-error "expected" "" { target *-*-* } .-2 }
+}

--- a/gcc/testsuite/rust/compile/traits11.rs
+++ b/gcc/testsuite/rust/compile/traits11.rs
@@ -1,0 +1,20 @@
+struct Foo(i32);
+
+trait A {
+    const A: i32 = 123;
+    fn B();
+    fn C(&self);
+}
+
+trait B: A {
+    fn test(&self);
+}
+
+pub fn main() {
+    let a;
+    a = Foo(123);
+
+    let b: &dyn B = &a;
+    // { dg-error "trait bound is not object safe" "" { target *-*-* } .-1 }
+    // { dg-error "expected" "" { target *-*-* } .-2 }
+}

--- a/gcc/testsuite/rust/compile/traits9.rs
+++ b/gcc/testsuite/rust/compile/traits9.rs
@@ -1,0 +1,13 @@
+struct Foo(i32);
+trait Bar {
+    fn baz(&self);
+}
+
+fn main() {
+    let a;
+    a = Foo(123);
+
+    let b: &dyn Bar = &a;
+    // { dg-error "bounds not satisfied for Foo .Bar. is not satisfied" "" { target *-*-* } .-1 }
+    // { dg-error "expected" "" { target *-*-* } .-2 }
+}

--- a/gcc/testsuite/rust/compile/tuple_struct3.rs
+++ b/gcc/testsuite/rust/compile/tuple_struct3.rs
@@ -1,5 +1,9 @@
 struct Foo(i32, i32, bool);
 
 fn main() {
-    let c = Foo(1, 2f32, true); // { dg-error "expected .i32. got .f32." }
+    let c = Foo(1, 2f32, true);
+    // { dg-error "expected .i32. got .f32." "" { target *-*-* } .-1 }
+    // { dg-error "unexpected number of arguments 1 expected 3" "" { target *-*-* } .-2 }
+    // { dg-error "failed to lookup type to CallExpr" "" { target *-*-* } .-3 }
+    // { dg-error "failed to type resolve expression" "" { target *-*-* } .-4 }
 }

--- a/gcc/testsuite/rust/execute/torture/trait5.rs
+++ b/gcc/testsuite/rust/execute/torture/trait5.rs
@@ -1,0 +1,41 @@
+/* { dg-output "123\n123\n" } */
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+struct Foo(i32);
+trait Bar {
+    fn baz(&self);
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+}
+
+impl Bar for Foo {
+    fn baz(&self) {
+        // { dg-warning "unused name" "" { target *-*-* } .-1 }
+        unsafe {
+            let a = "%i\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c, self.0);
+        }
+    }
+}
+
+fn static_dispatch<T: Bar>(t: &T) {
+    t.baz();
+}
+
+fn dynamic_dispatch(t: &dyn Bar) {
+    t.baz();
+}
+
+fn main() -> i32 {
+    let a = &Foo(123);
+    static_dispatch(a);
+
+    let b: &dyn Bar = a;
+    dynamic_dispatch(b);
+
+    0
+}


### PR DESCRIPTION
This rebases my branch for dynamic dispatch (dyn bound) support it supports
the HIR::TraitObjectOneBound for now but can be easily extended. The computation
of the addresses of the methods only supports impl items and does not support
optional trait methods yet but the change set was already 10 commits and this seems like
a good initial stab at support here.

Please see the git commits for more detail information on each change.

Fixes #197 