### PR TITLE
Fix byte char and byte string lexing code

### DIFF
--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -1559,13 +1559,6 @@ Lexer::parse_byte_char (Location loc)
       byte_char = std::get<0> (escape_length_pair);
       length += std::get<1> (escape_length_pair);
 
-      if (byte_char > 127)
-	{
-	  rust_error_at (get_current_location (),
-			 "%<byte char%> %<%c%> out of range", byte_char);
-	  byte_char = 0;
-	}
-
       current_char = peek_input ();
 
       if (current_char != '\'')
@@ -1633,14 +1626,6 @@ Lexer::parse_byte_string (Location loc)
 	    length = std::get<1> (escape_length_pair) - 1;
 	  else
 	    length += std::get<1> (escape_length_pair);
-
-	  if (output_char > 127)
-	    {
-	      rust_error_at (get_current_location (),
-			     "character %<%c%> in byte string out of range",
-			     output_char);
-	      output_char = 0;
-	    }
 
 	  if (output_char != 0)
 	    str += output_char;

--- a/gcc/testsuite/rust/compile/bytecharstring.rs
+++ b/gcc/testsuite/rust/compile/bytecharstring.rs
@@ -1,0 +1,8 @@
+fn main ()
+{
+  let _bc = b'\x80';
+  let _bs = b"foo\x80bar";
+
+  let _c = '\xef';        // { dg-error "out of range" }
+  let _s = "Foo\xEFBar";  // { dg-error "out of range" }
+}


### PR DESCRIPTION
There were two warnings in lexer parse_byte_char and parse_byte_string
code for arches with signed chars:

```
rust-lex.cc: In member function
             ‘Rust::TokenPtr Rust::Lexer::parse_byte_char(Location)’:
rust-lex.cc:1564:21: warning: comparison is always false due to limited
                     range of data type [-Wtype-limits]
 1564 |       if (byte_char > 127)
      |           ~~~~~~~~~~^~~~~
rust-lex.cc: In member function
             ‘Rust::TokenPtr Rust::Lexer::parse_byte_string(Location)’:
rust-lex.cc:1639:27: warning: comparison is always false due to limited
                     range of data type [-Wtype-limits]
 1639 |           if (output_char > 127)
      |               ~~~~~~~~~~~~^~~~~
```

The fix would be to cast to an unsigned char before the comparison.
But that is actually wrong, and would produce the following errors
parsing a byte char or byte string:

```
bytecharstring.rs:3:14: error: ‘byte char’ ‘�’ out of range
    3 |   let _bc = b'\x80';
      |              ^
bytecharstring.rs:4:14: error: character ‘�’ in byte string out of range
    4 |   let _bs = b"foo\x80bar";
      |              ^
```

Both byte chars and byte strings may contain up to \xFF (255)
characters. It is utf-8 chars or strings that can only

Remove the faulty check and add a new testcase bytecharstring.rs
that checks byte chars and strings do accept > 127 hex char
escapes, but utf-8 chars and strings reject such hex char escapes.

---

<http://mid.mail-archive.com/20210921225430.166550-1-mark@klomp.org>

---

Addresses: #336 
Fixes: #343, #344
