### PR TITLE
A bit of 'RichLocation' C++ tuning [#247], [#97, #374]

### DIFF
--- a/gcc/rust/rust-diagnostics.cc
+++ b/gcc/rust/rust-diagnostics.cc
@@ -188,7 +188,7 @@ rust_inform (const Location location, const char *fmt, ...)
 
 // Rich Locations
 void
-rust_error_at (const RichLocation location, const char *fmt, ...)
+rust_error_at (const RichLocation &location, const char *fmt, ...)
 {
   va_list ap;
 

--- a/gcc/rust/rust-diagnostics.h
+++ b/gcc/rust/rust-diagnostics.h
@@ -64,7 +64,7 @@ rust_inform (const Location, const char *fmt, ...)
 
 // rich locations
 extern void
-rust_error_at (const RichLocation, const char *fmt, ...)
+rust_error_at (const RichLocation &, const char *fmt, ...)
   RUST_ATTRIBUTE_GCC_DIAG (2, 3);
 
 // These interfaces provide a way for the front end to ask for
@@ -84,7 +84,7 @@ rust_close_quote ();
 extern void
 rust_be_error_at (const Location, const std::string &errmsg);
 extern void
-rust_be_error_at (const RichLocation, const std::string &errmsg);
+rust_be_error_at (const RichLocation &, const std::string &errmsg);
 extern void
 rust_be_warning_at (const Location, int opt, const std::string &warningmsg);
 extern void

--- a/gcc/rust/rust-gcc-diagnostics.cc
+++ b/gcc/rust/rust-gcc-diagnostics.cc
@@ -53,9 +53,10 @@ rust_be_inform (const Location location, const std::string &infomsg)
 }
 
 void
-rust_be_error_at (const RichLocation location, const std::string &errmsg)
+rust_be_error_at (const RichLocation &location, const std::string &errmsg)
 {
-  rich_location gcc_loc = location.get ();
+  /* TODO: 'error_at' would like a non-'const' 'rich_location *'.  */
+  rich_location &gcc_loc = const_cast<rich_location &> (location.get ());
   error_at (&gcc_loc, "%s", errmsg.c_str ());
 }
 

--- a/gcc/rust/rust-location.h
+++ b/gcc/rust/rust-location.h
@@ -96,7 +96,7 @@ public:
 
   void add_fixit_insert_after (Location where, const std::string &new_parent);
 
-  rich_location get () const { return gcc_rich_loc; }
+  const rich_location &get () const { return gcc_rich_loc; }
 
 private:
   rich_location gcc_rich_loc;


### PR DESCRIPTION
... in preparation for a merge from GCC upstream, where we otherwise run into
several different build errors.

Follow-up to commit ed651fcdec170456f7460703edbd0ca5901f0026
"Add basic wrapper over gcc rich_location".
