### PR TITLE
Implement Byte Strings

### DIFF
--- a/gcc/testsuite/rust/compile/torture/byte_str.rs
+++ b/gcc/testsuite/rust/compile/torture/byte_str.rs
@@ -1,0 +1,4 @@
+pub fn main() {
+    let a: &[u8; 4];
+    a = b"test";
+}


### PR DESCRIPTION
Byte strings are not str's they are arrays of [u8; capacity], this
preserves their type guarantees as a byte string.

This patch merges work from Mark to implement the correct typing, the
missing piece was that each implicit type needed its own implicit id, other
wise their is a loop in looking up the covariant types.

Fixes #697

Co-authored-by: Mark Wielaard <mark@klomp.org>
