### PR TITLE
Remove raw string and raw byte string references from ast and hir

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -259,10 +259,8 @@ public:
   {
     CHAR,
     STRING,
-    RAW_STRING,
     BYTE,
     BYTE_STRING,
-    RAW_BYTE_STRING,
     INT,
     FLOAT,
     BOOL

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -32,7 +32,7 @@ class MacroInvocationSemi;
 // TODO: inline?
 /*struct AbiName {
     std::string abi_name;
-    // Technically is meant to be STRING_LITERAL or RAW_STRING_LITERAL
+    // Technically is meant to be STRING_LITERAL
 
   public:
     // Returns whether abi name is empty, i.e. doesn't exist.

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -332,17 +332,11 @@ public:
       case AST::Literal::LitType::STRING:
 	type = HIR::Literal::LitType::STRING;
 	break;
-      case AST::Literal::LitType::RAW_STRING:
-	type = HIR::Literal::LitType::RAW_STRING;
-	break;
       case AST::Literal::LitType::BYTE:
 	type = HIR::Literal::LitType::BYTE;
 	break;
       case AST::Literal::LitType::BYTE_STRING:
 	type = HIR::Literal::LitType::BYTE_STRING;
-	break;
-      case AST::Literal::LitType::RAW_BYTE_STRING:
-	type = HIR::Literal::LitType::RAW_BYTE_STRING;
 	break;
       case AST::Literal::LitType::INT:
 	type = HIR::Literal::LitType::INT;

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -45,10 +45,8 @@ public:
   {
     CHAR,
     STRING,
-    RAW_STRING,
     BYTE,
     BYTE_STRING,
-    RAW_BYTE_STRING,
     INT,
     FLOAT,
     BOOL

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -7556,8 +7556,6 @@ Parser<ManagedTokenSource>::parse_literal_expr (AST::AttrVec outer_attrs)
       literal_value = t->get_str ();
       lexer.skip_token ();
       break;
-    // case RAW_STRING_LITERAL:
-    // put here if lexer changes to have these
     case BYTE_CHAR_LITERAL:
       type = AST::Literal::BYTE;
       literal_value = t->get_str ();
@@ -7568,7 +7566,6 @@ Parser<ManagedTokenSource>::parse_literal_expr (AST::AttrVec outer_attrs)
       literal_value = t->get_str ();
       lexer.skip_token ();
       break;
-    // case RAW_BYTE_STRING_LITERAL:
     case INT_LITERAL:
       type = AST::Literal::INT;
       literal_value = t->get_str ();


### PR DESCRIPTION
Raw strings and raw byte strings are simply different ways to
create string and byte string literals. Only the lexer cares
how those literals are constructed and which escapes are used
to construct them. The parser and hir simply see strings or
byte strings.
