### PR TITLE
Ensure for Coercion Sites we emit the code nessecary

### DIFF
--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -69,39 +69,120 @@ CompileExpr::visit (HIR::CallExpr &expr)
 	       || tyty->get_kind () == TyTy::TypeKind::FNPTR;
   if (!is_fn)
     {
-      Btype *type = TyTyResolveCompile::compile (ctx, tyty);
+      rust_assert (tyty->get_kind () == TyTy::TypeKind::ADT);
+      TyTy::ADTType *adt = static_cast<TyTy::ADTType *> (tyty);
+      Btype *compiled_adt_type = TyTyResolveCompile::compile (ctx, tyty);
 
       // this assumes all fields are in order from type resolution and if a
       // base struct was specified those fields are filed via accesors
       std::vector<Bexpression *> vals;
-      for (auto &argument : expr.get_arguments ())
+      for (size_t i = 0; i < expr.get_arguments ().size (); i++)
 	{
-	  Bexpression *e = CompileExpr::Compile (argument.get (), ctx);
-	  vals.push_back (e);
+	  auto &argument = expr.get_arguments ().at (i);
+	  auto rvalue = CompileExpr::Compile (argument.get (), ctx);
+
+	  // assignments are coercion sites so lets convert the rvalue if
+	  // necessary
+	  auto respective_field = adt->get_field (i);
+	  auto expected = respective_field->get_field_type ();
+
+	  TyTy::BaseType *actual = nullptr;
+	  bool ok = ctx->get_tyctx ()->lookup_type (
+	    argument->get_mappings ().get_hirid (), &actual);
+	  rust_assert (ok);
+
+	  // coerce it if required
+	  rvalue = coercion_site (rvalue, actual, expected, expr.get_locus ());
+
+	  // add it to the list
+	  vals.push_back (rvalue);
 	}
 
       translated
-	= ctx->get_backend ()->constructor_expression (type, vals, -1,
-						       expr.get_locus ());
+	= ctx->get_backend ()->constructor_expression (compiled_adt_type, vals,
+						       -1, expr.get_locus ());
     }
   else
     {
-      // must be a call to a function
-      Bexpression *fn = CompileExpr::Compile (expr.get_fnexpr (), ctx);
-      rust_assert (fn != nullptr);
+      auto get_parameter_tyty_at_index
+	= [] (const TyTy::BaseType *base, size_t index,
+	      TyTy::BaseType **result) -> bool {
+	bool is_fn = base->get_kind () == TyTy::TypeKind::FNDEF
+		     || base->get_kind () == TyTy::TypeKind::FNPTR;
+	rust_assert (is_fn);
 
-      std::vector<Bexpression *> args;
-      for (auto &argument : expr.get_arguments ())
+	if (base->get_kind () == TyTy::TypeKind::FNPTR)
+	  {
+	    const TyTy::FnPtr *fn = static_cast<const TyTy::FnPtr *> (base);
+	    *result = fn->param_at (index);
+
+	    return true;
+	  }
+
+	const TyTy::FnType *fn = static_cast<const TyTy::FnType *> (base);
+	auto param = fn->param_at (index);
+	*result = param.second;
+
+	return true;
+      };
+
+      bool is_varadic = false;
+      if (tyty->get_kind () == TyTy::TypeKind::FNDEF)
 	{
-	  Bexpression *compiled_expr
-	    = CompileExpr::Compile (argument.get (), ctx);
-	  args.push_back (compiled_expr);
+	  const TyTy::FnType *fn = static_cast<const TyTy::FnType *> (tyty);
+	  is_varadic = fn->is_varadic ();
 	}
 
+      size_t required_num_args;
+      if (tyty->get_kind () == TyTy::TypeKind::FNDEF)
+	{
+	  const TyTy::FnType *fn = static_cast<const TyTy::FnType *> (tyty);
+	  required_num_args = fn->num_params ();
+	}
+      else
+	{
+	  const TyTy::FnPtr *fn = static_cast<const TyTy::FnPtr *> (tyty);
+	  required_num_args = fn->num_params ();
+	}
+
+      std::vector<Bexpression *> args;
+      for (size_t i = 0; i < expr.get_arguments ().size (); i++)
+	{
+	  auto &argument = expr.get_arguments ().at (i);
+	  auto rvalue = CompileExpr::Compile (argument.get (), ctx);
+
+	  if (is_varadic && i >= required_num_args)
+	    {
+	      args.push_back (rvalue);
+	      continue;
+	    }
+
+	  // assignments are coercion sites so lets convert the rvalue if
+	  // necessary
+	  bool ok;
+	  TyTy::BaseType *expected = nullptr;
+	  ok = get_parameter_tyty_at_index (tyty, i, &expected);
+	  rust_assert (ok);
+
+	  TyTy::BaseType *actual = nullptr;
+	  ok = ctx->get_tyctx ()->lookup_type (
+	    argument->get_mappings ().get_hirid (), &actual);
+	  rust_assert (ok);
+
+	  // coerce it if required
+	  rvalue = coercion_site (rvalue, actual, expected, expr.get_locus ());
+
+	  // add it to the list
+	  args.push_back (rvalue);
+	}
+
+      // must be a call to a function
+      auto fn_address = CompileExpr::Compile (expr.get_fnexpr (), ctx);
       auto fncontext = ctx->peek_fn ();
       translated
-	= ctx->get_backend ()->call_expression (fncontext.fndecl, fn, args,
-						nullptr, expr.get_locus ());
+	= ctx->get_backend ()->call_expression (fncontext.fndecl, fn_address,
+						args, nullptr,
+						expr.get_locus ());
     }
 }
 

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -74,11 +74,11 @@ CompileExpr::visit (HIR::CallExpr &expr)
       // this assumes all fields are in order from type resolution and if a
       // base struct was specified those fields are filed via accesors
       std::vector<Bexpression *> vals;
-      expr.iterate_params ([&] (HIR::Expr *argument) mutable -> bool {
-	Bexpression *e = CompileExpr::Compile (argument, ctx);
-	vals.push_back (e);
-	return true;
-      });
+      for (auto &argument : expr.get_arguments ())
+	{
+	  Bexpression *e = CompileExpr::Compile (argument.get (), ctx);
+	  vals.push_back (e);
+	}
 
       translated
 	= ctx->get_backend ()->constructor_expression (type, vals, -1,
@@ -91,12 +91,12 @@ CompileExpr::visit (HIR::CallExpr &expr)
       rust_assert (fn != nullptr);
 
       std::vector<Bexpression *> args;
-      expr.iterate_params ([&] (HIR::Expr *p) mutable -> bool {
-	Bexpression *compiled_expr = CompileExpr::Compile (p, ctx);
-	rust_assert (compiled_expr != nullptr);
-	args.push_back (compiled_expr);
-	return true;
-      });
+      for (auto &argument : expr.get_arguments ())
+	{
+	  Bexpression *compiled_expr
+	    = CompileExpr::Compile (argument.get (), ctx);
+	  args.push_back (compiled_expr);
+	}
 
       auto fncontext = ctx->peek_fn ();
       translated

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -224,12 +224,12 @@ CompileExpr::visit (HIR::MethodCallExpr &expr)
 
       std::vector<Bexpression *> args;
       args.push_back (self_argument);
-      expr.iterate_params ([&] (HIR::Expr *p) mutable -> bool {
-	Bexpression *compiled_expr = CompileExpr::Compile (p, ctx);
-	rust_assert (compiled_expr != nullptr);
-	args.push_back (compiled_expr);
-	return true;
-      });
+      for (auto &argument : expr.get_arguments ())
+	{
+	  Bexpression *compiled_expr
+	    = CompileExpr::Compile (argument.get (), ctx);
+	  args.push_back (compiled_expr);
+	}
 
       Bexpression *fn_expr
 	= ctx->get_backend ()->var_expression (fn_convert_expr_tmp,
@@ -414,12 +414,11 @@ CompileExpr::visit (HIR::MethodCallExpr &expr)
   args.push_back (self);
 
   // normal args
-  expr.iterate_params ([&] (HIR::Expr *p) mutable -> bool {
-    Bexpression *compiled_expr = CompileExpr::Compile (p, ctx);
-    rust_assert (compiled_expr != nullptr);
-    args.push_back (compiled_expr);
-    return true;
-  });
+  for (auto &argument : expr.get_arguments ())
+    {
+      Bexpression *compiled_expr = CompileExpr::Compile (argument.get (), ctx);
+      args.push_back (compiled_expr);
+    }
 
   auto fncontext = ctx->peek_fn ();
   translated

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -1725,21 +1725,13 @@ public:
 
   PathExprSegment get_method_name () const { return method_name; };
 
-  std::vector<std::unique_ptr<Expr> > &get_params () { return params; }
-  const std::vector<std::unique_ptr<Expr> > &get_params () const
-  {
-    return params;
-  }
-
   size_t num_params () const { return params.size (); }
 
-  void iterate_params (std::function<bool (Expr *)> cb)
+  std::vector<std::unique_ptr<Expr> > &get_arguments () { return params; }
+
+  const std::vector<std::unique_ptr<Expr> > &get_arguments () const
   {
-    for (auto &param : params)
-      {
-	if (!cb (param.get ()))
-	  return;
-      }
+    return params;
   }
 
 protected:

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -1578,14 +1578,10 @@ protected:
   }
 };
 
-// Forward decl for Function - used in CallExpr
-class Function;
-
 // Function call expression HIR node
 class CallExpr : public ExprWithoutBlock
 {
   std::unique_ptr<Expr> function;
-  // inlined form of CallParams
   std::vector<std::unique_ptr<Expr> > params;
 
   Location locus;
@@ -1642,13 +1638,11 @@ public:
 
   size_t num_params () const { return params.size (); }
 
-  void iterate_params (std::function<bool (Expr *)> cb)
+  std::vector<std::unique_ptr<Expr> > &get_arguments () { return params; }
+
+  const std::vector<std::unique_ptr<Expr> > &get_arguments () const
   {
-    for (auto &param : params)
-      {
-	if (!cb (param.get ()))
-	  return;
-      }
+    return params;
   }
 
 protected:

--- a/gcc/rust/lint/rust-lint-marklive.cc
+++ b/gcc/rust/lint/rust-lint-marklive.cc
@@ -149,10 +149,8 @@ MarkLive::visit (HIR::MethodCallExpr &expr)
 {
   expr.get_receiver ()->accept_vis (*this);
   visit_path_segment (expr.get_method_name ());
-  expr.iterate_params ([&] (HIR::Expr *param) -> bool {
-    param->accept_vis (*this);
-    return true;
-  });
+  for (auto &argument : expr.get_arguments ())
+    argument->accept_vis (*this);
 
   // Trying to find the method definition and mark it alive.
   NodeId ast_node_id = expr.get_mappings ().get_nodeid ();

--- a/gcc/rust/lint/rust-lint-marklive.h
+++ b/gcc/rust/lint/rust-lint-marklive.h
@@ -165,10 +165,8 @@ public:
   void visit (HIR::CallExpr &expr) override
   {
     expr.get_fnexpr ()->accept_vis (*this);
-    expr.iterate_params ([&] (HIR::Expr *expr) -> bool {
-      expr->accept_vis (*this);
-      return true;
-    });
+    for (auto &argument : expr.get_arguments ())
+      argument->accept_vis (*this);
   }
 
   void visit (HIR::ArithmeticOrLogicalExpr &expr) override

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -2383,27 +2383,28 @@ TypeCheckCallExpr::visit (ADTType &type)
     }
 
   size_t i = 0;
-  call.iterate_params ([&] (HIR::Expr *p) mutable -> bool {
-    StructFieldType *field = type.get_field (i);
-    BaseType *field_tyty = field->get_field_type ();
+  for (auto &argument : call.get_arguments ())
+    {
+      StructFieldType *field = type.get_field (i);
+      BaseType *field_tyty = field->get_field_type ();
 
-    BaseType *arg = Resolver::TypeCheckExpr::Resolve (p, false);
-    if (arg->get_kind () == TyTy::TypeKind::ERROR)
-      {
-	rust_error_at (p->get_locus (), "failed to resolve argument type");
-	return false;
-      }
+      BaseType *arg = Resolver::TypeCheckExpr::Resolve (argument.get (), false);
+      if (arg->get_kind () == TyTy::TypeKind::ERROR)
+	{
+	  rust_error_at (argument->get_locus (),
+			 "failed to resolve argument type");
+	  return;
+	}
 
-    auto res = field_tyty->coerce (arg);
-    if (res->get_kind () == TyTy::TypeKind::ERROR)
-      {
-	return false;
-      }
+      auto res = field_tyty->coerce (arg);
+      if (res->get_kind () == TyTy::TypeKind::ERROR)
+	{
+	  return;
+	}
 
-    delete res;
-    i++;
-    return true;
-  });
+      delete res;
+      i++;
+    }
 
   if (i != call.num_params ())
     {
@@ -2441,35 +2442,37 @@ TypeCheckCallExpr::visit (FnType &type)
     }
 
   size_t i = 0;
-  call.iterate_params ([&] (HIR::Expr *param) mutable -> bool {
-    auto argument_expr_tyty = Resolver::TypeCheckExpr::Resolve (param, false);
-    if (argument_expr_tyty->get_kind () == TyTy::TypeKind::ERROR)
-      {
-	rust_error_at (param->get_locus (),
-		       "failed to resolve type for argument expr in CallExpr");
-	return false;
-      }
+  for (auto &argument : call.get_arguments ())
+    {
+      auto argument_expr_tyty
+	= Resolver::TypeCheckExpr::Resolve (argument.get (), false);
+      if (argument_expr_tyty->get_kind () == TyTy::TypeKind::ERROR)
+	{
+	  rust_error_at (
+	    argument->get_locus (),
+	    "failed to resolve type for argument expr in CallExpr");
+	  return;
+	}
 
-    auto resolved_argument_type = argument_expr_tyty;
+      auto resolved_argument_type = argument_expr_tyty;
 
-    // it might be a varadic function
-    if (i < type.num_params ())
-      {
-	auto fnparam = type.param_at (i);
-	resolved_argument_type = fnparam.second->coerce (argument_expr_tyty);
-	if (argument_expr_tyty->get_kind () == TyTy::TypeKind::ERROR)
-	  {
-	    rust_error_at (param->get_locus (),
-			   "Type Resolution failure on parameter");
-	    return false;
-	  }
-      }
+      // it might be a varadic function
+      if (i < type.num_params ())
+	{
+	  auto fnparam = type.param_at (i);
+	  resolved_argument_type = fnparam.second->coerce (argument_expr_tyty);
+	  if (argument_expr_tyty->get_kind () == TyTy::TypeKind::ERROR)
+	    {
+	      rust_error_at (argument->get_locus (),
+			     "Type Resolution failure on parameter");
+	      return;
+	    }
+	}
 
-    context->insert_type (param->get_mappings (), resolved_argument_type);
+      context->insert_type (argument->get_mappings (), resolved_argument_type);
 
-    i++;
-    return true;
-  });
+      i++;
+    }
 
   if (i < call.num_params ())
     {
@@ -2505,29 +2508,31 @@ TypeCheckCallExpr::visit (FnPtr &type)
     }
 
   size_t i = 0;
-  call.iterate_params ([&] (HIR::Expr *param) mutable -> bool {
-    auto fnparam = type.param_at (i);
-    auto argument_expr_tyty = Resolver::TypeCheckExpr::Resolve (param, false);
-    if (argument_expr_tyty->get_kind () == TyTy::TypeKind::ERROR)
-      {
-	rust_error_at (param->get_locus (),
-		       "failed to resolve type for argument expr in CallExpr");
-	return false;
-      }
+  for (auto &argument : call.get_arguments ())
+    {
+      auto fnparam = type.param_at (i);
+      auto argument_expr_tyty
+	= Resolver::TypeCheckExpr::Resolve (argument.get (), false);
+      if (argument_expr_tyty->get_kind () == TyTy::TypeKind::ERROR)
+	{
+	  rust_error_at (
+	    argument->get_locus (),
+	    "failed to resolve type for argument expr in CallExpr");
+	  return;
+	}
 
-    auto resolved_argument_type = fnparam->coerce (argument_expr_tyty);
-    if (argument_expr_tyty->get_kind () == TyTy::TypeKind::ERROR)
-      {
-	rust_error_at (param->get_locus (),
-		       "Type Resolution failure on parameter");
-	return false;
-      }
+      auto resolved_argument_type = fnparam->coerce (argument_expr_tyty);
+      if (argument_expr_tyty->get_kind () == TyTy::TypeKind::ERROR)
+	{
+	  rust_error_at (argument->get_locus (),
+			 "Type Resolution failure on parameter");
+	  return;
+	}
 
-    context->insert_type (param->get_mappings (), resolved_argument_type);
+      context->insert_type (argument->get_mappings (), resolved_argument_type);
 
-    i++;
-    return true;
-  });
+      i++;
+    }
 
   if (i != call.num_params ())
     {

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -2454,14 +2454,13 @@ TypeCheckCallExpr::visit (FnType &type)
 	  return;
 	}
 
-      auto resolved_argument_type = argument_expr_tyty;
-
       // it might be a varadic function
       if (i < type.num_params ())
 	{
 	  auto fnparam = type.param_at (i);
-	  resolved_argument_type = fnparam.second->coerce (argument_expr_tyty);
-	  if (argument_expr_tyty->get_kind () == TyTy::TypeKind::ERROR)
+	  auto resolved_argument_type
+	    = fnparam.second->coerce (argument_expr_tyty);
+	  if (resolved_argument_type->get_kind () == TyTy::TypeKind::ERROR)
 	    {
 	      rust_error_at (argument->get_locus (),
 			     "Type Resolution failure on parameter");
@@ -2469,7 +2468,7 @@ TypeCheckCallExpr::visit (FnType &type)
 	    }
 	}
 
-      context->insert_type (argument->get_mappings (), resolved_argument_type);
+      context->insert_type (argument->get_mappings (), argument_expr_tyty);
 
       i++;
     }
@@ -2522,14 +2521,14 @@ TypeCheckCallExpr::visit (FnPtr &type)
 	}
 
       auto resolved_argument_type = fnparam->coerce (argument_expr_tyty);
-      if (argument_expr_tyty->get_kind () == TyTy::TypeKind::ERROR)
+      if (resolved_argument_type->get_kind () == TyTy::TypeKind::ERROR)
 	{
 	  rust_error_at (argument->get_locus (),
 			 "Type Resolution failure on parameter");
 	  return;
 	}
 
-      context->insert_type (argument->get_mappings (), resolved_argument_type);
+      context->insert_type (argument->get_mappings (), argument_expr_tyty);
 
       i++;
     }
@@ -2575,14 +2574,14 @@ TypeCheckMethodCallExpr::visit (FnType &type)
 	}
 
       auto resolved_argument_type = fnparam.second->coerce (argument_expr_tyty);
-      if (argument_expr_tyty->get_kind () == TyTy::TypeKind::ERROR)
+      if (resolved_argument_type->get_kind () == TyTy::TypeKind::ERROR)
 	{
 	  rust_error_at (argument->get_locus (),
 			 "Type Resolution failure on parameter");
 	  return;
 	}
 
-      context->insert_type (argument->get_mappings (), resolved_argument_type);
+      context->insert_type (argument->get_mappings (), argument_expr_tyty);
 
       i++;
     }

--- a/gcc/testsuite/rust/compile/func3.rs
+++ b/gcc/testsuite/rust/compile/func3.rs
@@ -3,5 +3,9 @@ fn test(a: i32, b: i32) -> i32 {
 }
 
 fn main() {
-    let a = test(1, true); // { dg-error "expected .i32. got .bool." }
+    let a = test(1, true);
+    // { dg-error "expected .i32. got .bool." "" { target *-*-* } .-1 }
+    // { dg-error "Type Resolution failure on parameter" "" { target *-*-* } .-2 }
+    // { dg-error "failed to lookup type to CallExpr" "" { target *-*-* } .-3 }
+    // { dg-error "failed to type resolve expression" "" { target *-*-* } .-4 }
 }

--- a/gcc/testsuite/rust/compile/tuple_struct3.rs
+++ b/gcc/testsuite/rust/compile/tuple_struct3.rs
@@ -3,7 +3,6 @@ struct Foo(i32, i32, bool);
 fn main() {
     let c = Foo(1, 2f32, true);
     // { dg-error "expected .i32. got .f32." "" { target *-*-* } .-1 }
-    // { dg-error "unexpected number of arguments 1 expected 3" "" { target *-*-* } .-2 }
-    // { dg-error "failed to lookup type to CallExpr" "" { target *-*-* } .-3 }
-    // { dg-error "failed to type resolve expression" "" { target *-*-* } .-4 }
+    // { dg-error "failed to lookup type to CallExpr" "" { target *-*-* } .-2 }
+    // { dg-error "failed to type resolve expression" "" { target *-*-* } .-3 }
 }

--- a/gcc/testsuite/rust/execute/torture/coercion1.rs
+++ b/gcc/testsuite/rust/execute/torture/coercion1.rs
@@ -1,0 +1,43 @@
+/* { dg-output "123\n123\n" } */
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+struct Foo(i32);
+trait Bar {
+    fn baz(&self);
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+}
+
+impl Bar for Foo {
+    fn baz(&self) {
+        // { dg-warning "unused name" "" { target *-*-* } .-1 }
+        unsafe {
+            let a = "%i\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c, self.0);
+        }
+    }
+}
+
+fn static_dispatch<T: Bar>(t: &T) {
+    t.baz();
+}
+
+fn dynamic_dispatch(t: &dyn Bar) {
+    t.baz();
+}
+
+fn main() -> i32 {
+    let a;
+    a = Foo(123);
+    static_dispatch(&a);
+
+    let b: &dyn Bar;
+    b = &a;
+    dynamic_dispatch(b);
+
+    0
+}

--- a/gcc/testsuite/rust/execute/torture/coercion2.rs
+++ b/gcc/testsuite/rust/execute/torture/coercion2.rs
@@ -1,0 +1,41 @@
+/* { dg-output "123\n123\n" } */
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+struct Foo(i32);
+trait Bar {
+    fn baz(&self);
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+}
+
+impl Bar for Foo {
+    fn baz(&self) {
+        // { dg-warning "unused name" "" { target *-*-* } .-1 }
+        unsafe {
+            let a = "%i\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c, self.0);
+        }
+    }
+}
+
+fn static_dispatch<T: Bar>(t: &T) {
+    t.baz();
+}
+
+fn dynamic_dispatch(t: &dyn Bar) {
+    t.baz();
+}
+
+fn main() -> i32 {
+    let a;
+    a = &Foo(123);
+
+    static_dispatch(a);
+    dynamic_dispatch(a);
+
+    0
+}


### PR DESCRIPTION
Coercion sites in Rust can require extra code generation for
CallExpressions arguments for example. This ensures we detect
those cases and emit the extra code necessary. Please read the individual
commit messages for more detail on how this works.

Fixes #700 #708 #709  