### PR TITLE
Remove lambda iterators in various HIR classes

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -412,11 +412,11 @@ public:
 
   void visit (HIR::ArrayElemsValues &elems) override
   {
-    elems.iterate ([&] (HIR::Expr *e) mutable -> bool {
-      Bexpression *translated_expr = CompileExpr::Compile (e, ctx);
-      constructor.push_back (translated_expr);
-      return true;
-    });
+    for (auto &elem : elems.get_values ())
+      {
+	Bexpression *translated_expr = CompileExpr::Compile (elem.get (), ctx);
+	constructor.push_back (translated_expr);
+      }
   }
 
   void visit (HIR::ArrayElemsCopied &elems) override
@@ -646,11 +646,11 @@ public:
     // this assumes all fields are in order from type resolution and if a base
     // struct was specified those fields are filed via accesors
     std::vector<Bexpression *> vals;
-    struct_expr.iterate ([&] (HIR::StructExprField *field) mutable -> bool {
-      Bexpression *expr = CompileStructExprField::Compile (field, ctx);
-      vals.push_back (expr);
-      return true;
-    });
+    for (auto &field : struct_expr.get_fields ())
+      {
+	Bexpression *expr = CompileStructExprField::Compile (field.get (), ctx);
+	vals.push_back (expr);
+      }
 
     translated
       = ctx->get_backend ()->constructor_expression (type, vals,

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -796,14 +796,7 @@ public:
 
   size_t get_num_elements () const { return values.size (); }
 
-  void iterate (std::function<bool (Expr *)> cb)
-  {
-    for (auto it = values.begin (); it != values.end (); it++)
-      {
-	if (!cb ((*it).get ()))
-	  return;
-      }
-  }
+  std::vector<std::unique_ptr<Expr>>& get_values () { return values; }
 
 protected:
   ArrayElemsValues *clone_array_elems_impl () const override
@@ -1069,15 +1062,6 @@ public:
   }
 
   bool is_unit () const { return tuple_elems.size () == 0; }
-
-  void iterate (std::function<bool (Expr *)> cb)
-  {
-    for (auto &tuple_elem : tuple_elems)
-      {
-	if (!cb (tuple_elem.get ()))
-	  return;
-      }
-  }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather
@@ -1491,15 +1475,6 @@ public:
 
   void accept_vis (HIRVisitor &vis) override;
 
-  void iterate (std::function<bool (StructExprField *)> cb)
-  {
-    for (auto &field : fields)
-      {
-	if (!cb (field.get ()))
-	  return;
-      }
-  }
-
   std::vector<std::unique_ptr<StructExprField> > &get_fields ()
   {
     return fields;
@@ -1508,11 +1483,6 @@ public:
   const std::vector<std::unique_ptr<StructExprField> > &get_fields () const
   {
     return fields;
-  };
-
-  std::vector<std::unique_ptr<StructExprField> > get_fields_as_owner ()
-  {
-    return std::move (fields);
   };
 
   void set_fields_as_owner (

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -1492,14 +1492,7 @@ public:
 
   void accept_vis (HIRVisitor &vis) override;
 
-  void iterate (std::function<bool (StructField &)> cb)
-  {
-    for (auto &field : fields)
-      {
-	if (!cb (field))
-	  return;
-      }
-  }
+  std::vector<StructField>& get_fields() { return fields; }
 
 protected:
   /* Use covariance to implement clone function as returning this object
@@ -1609,15 +1602,6 @@ public:
 
   std::vector<TupleField> &get_fields () { return fields; }
   const std::vector<TupleField> &get_fields () const { return fields; }
-
-  void iterate (std::function<bool (TupleField &)> cb)
-  {
-    for (auto &field : fields)
-      {
-	if (!cb (field))
-	  return;
-      }
-  }
 
 protected:
   /* Use covariance to implement clone function as returning this object

--- a/gcc/rust/lint/rust-lint-marklive.h
+++ b/gcc/rust/lint/rust-lint-marklive.h
@@ -81,18 +81,18 @@ public:
 
   void visit (HIR::ArrayElemsValues &expr) override
   {
-    expr.iterate ([&] (HIR::Expr *expr) mutable -> bool {
-      expr->accept_vis (*this);
-      return true;
-    });
+    for (auto &elem : expr.get_values ())
+      {
+	elem->accept_vis (*this);
+      }
   }
 
   void visit (HIR::TupleExpr &expr) override
   {
-    expr.iterate ([&] (HIR::Expr *expr) mutable -> bool {
-      expr->accept_vis (*this);
-      return true;
-    });
+    for (auto &elem : expr.get_tuple_elems ())
+      {
+	elem->accept_vis (*this);
+      }
   }
 
   void visit (HIR::BlockExpr &expr) override
@@ -236,10 +236,10 @@ public:
 
   void visit (HIR::StructExprStructFields &stct) override
   {
-    stct.iterate ([&] (HIR::StructExprField *field) -> bool {
-      field->accept_vis (*this);
-      return true;
-    });
+    for (auto &field : stct.get_fields ())
+      {
+	field->accept_vis (*this);
+      }
 
     stct.get_struct_name ().accept_vis (*this);
     if (stct.has_struct_base ())

--- a/gcc/rust/lint/rust-lint-scan-deadcode.h
+++ b/gcc/rust/lint/rust-lint-scan-deadcode.h
@@ -88,16 +88,16 @@ public:
     else
       {
 	// only warn the unused fields when in unwarned struct.
-	stct.iterate ([&] (HIR::StructField &field) -> bool {
-	  HirId field_hir_id = field.get_mappings ().get_hirid ();
-	  if (should_warn (field_hir_id))
-	    {
-	      rust_warning_at (field.get_locus (), 0,
-			       "field is never read: %<%s%>",
-			       field.get_field_name ().c_str ());
-	    }
-	  return true;
-	});
+	for (auto &field : stct.get_fields ())
+	  {
+	    HirId field_hir_id = field.get_mappings ().get_hirid ();
+	    if (should_warn (field_hir_id))
+	      {
+		rust_warning_at (field.get_locus (), 0,
+				 "field is never read: %<%s%>",
+				 field.get_field_name ().c_str ());
+	      }
+	  }
       }
   }
 

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -880,10 +880,11 @@ public:
   void visit (HIR::ArrayElemsValues &elems) override
   {
     std::vector<TyTy::BaseType *> types;
-    elems.iterate ([&] (HIR::Expr *e) mutable -> bool {
-      types.push_back (TypeCheckExpr::Resolve (e, false));
-      return true;
-    });
+
+    for (auto &elem : elems.get_values ())
+      {
+	types.push_back (TypeCheckExpr::Resolve (elem.get (), false));
+      }
 
     infered_array_elems
       = TyTy::TyVar::get_implicit_infer_var (root_array_expr_locus).get_tyty ();

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.h
@@ -144,17 +144,18 @@ public:
     std::vector<TyTy::StructFieldType *> fields;
 
     size_t idx = 0;
-    struct_decl.iterate ([&] (HIR::TupleField &field) mutable -> bool {
-      TyTy::BaseType *field_type
-	= TypeCheckType::Resolve (field.get_field_type ().get ());
-      TyTy::StructFieldType *ty_field
-	= new TyTy::StructFieldType (field.get_mappings ().get_hirid (),
-				     std::to_string (idx), field_type);
-      fields.push_back (ty_field);
-      context->insert_type (field.get_mappings (), ty_field->get_field_type ());
-      idx++;
-      return true;
-    });
+    for (auto &field : struct_decl.get_fields ())
+      {
+	TyTy::BaseType *field_type
+	  = TypeCheckType::Resolve (field.get_field_type ().get ());
+	TyTy::StructFieldType *ty_field
+	  = new TyTy::StructFieldType (field.get_mappings ().get_hirid (),
+				       std::to_string (idx), field_type);
+	fields.push_back (ty_field);
+	context->insert_type (field.get_mappings (),
+			      ty_field->get_field_type ());
+	idx++;
+      }
 
     TyTy::BaseType *type
       = new TyTy::ADTType (struct_decl.get_mappings ().get_hirid (),
@@ -196,16 +197,17 @@ public:
       }
 
     std::vector<TyTy::StructFieldType *> fields;
-    struct_decl.iterate ([&] (HIR::StructField &field) mutable -> bool {
-      TyTy::BaseType *field_type
-	= TypeCheckType::Resolve (field.get_field_type ().get ());
-      TyTy::StructFieldType *ty_field
-	= new TyTy::StructFieldType (field.get_mappings ().get_hirid (),
-				     field.get_field_name (), field_type);
-      fields.push_back (ty_field);
-      context->insert_type (field.get_mappings (), ty_field->get_field_type ());
-      return true;
-    });
+    for (auto &field : struct_decl.get_fields ())
+      {
+	TyTy::BaseType *field_type
+	  = TypeCheckType::Resolve (field.get_field_type ().get ());
+	TyTy::StructFieldType *ty_field
+	  = new TyTy::StructFieldType (field.get_mappings ().get_hirid (),
+				       field.get_field_name (), field_type);
+	fields.push_back (ty_field);
+	context->insert_type (field.get_mappings (),
+			      ty_field->get_field_type ());
+      }
 
     TyTy::BaseType *type
       = new TyTy::ADTType (struct_decl.get_mappings ().get_hirid (),

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
@@ -79,17 +79,18 @@ public:
     std::vector<TyTy::StructFieldType *> fields;
 
     size_t idx = 0;
-    struct_decl.iterate ([&] (HIR::TupleField &field) mutable -> bool {
-      TyTy::BaseType *field_type
-	= TypeCheckType::Resolve (field.get_field_type ().get ());
-      TyTy::StructFieldType *ty_field
-	= new TyTy::StructFieldType (field.get_mappings ().get_hirid (),
-				     std::to_string (idx), field_type);
-      fields.push_back (ty_field);
-      context->insert_type (field.get_mappings (), ty_field->get_field_type ());
-      idx++;
-      return true;
-    });
+    for (auto &field : struct_decl.get_fields ())
+      {
+	TyTy::BaseType *field_type
+	  = TypeCheckType::Resolve (field.get_field_type ().get ());
+	TyTy::StructFieldType *ty_field
+	  = new TyTy::StructFieldType (field.get_mappings ().get_hirid (),
+				       std::to_string (idx), field_type);
+	fields.push_back (ty_field);
+	context->insert_type (field.get_mappings (),
+			      ty_field->get_field_type ());
+	idx++;
+      }
 
     TyTy::BaseType *type
       = new TyTy::ADTType (struct_decl.get_mappings ().get_hirid (),
@@ -136,16 +137,18 @@ public:
       }
 
     std::vector<TyTy::StructFieldType *> fields;
-    struct_decl.iterate ([&] (HIR::StructField &field) mutable -> bool {
-      TyTy::BaseType *field_type
-	= TypeCheckType::Resolve (field.get_field_type ().get ());
-      TyTy::StructFieldType *ty_field
-	= new TyTy::StructFieldType (field.get_mappings ().get_hirid (),
-				     field.get_field_name (), field_type);
-      fields.push_back (ty_field);
-      context->insert_type (field.get_mappings (), ty_field->get_field_type ());
-      return true;
-    });
+
+    for (auto &field : struct_decl.get_fields ())
+      {
+	TyTy::BaseType *field_type
+	  = TypeCheckType::Resolve (field.get_field_type ().get ());
+	TyTy::StructFieldType *ty_field
+	  = new TyTy::StructFieldType (field.get_mappings ().get_hirid (),
+				       field.get_field_name (), field_type);
+	fields.push_back (ty_field);
+	context->insert_type (field.get_mappings (),
+			      ty_field->get_field_type ());
+      }
 
     TyTy::BaseType *type
       = new TyTy::ADTType (struct_decl.get_mappings ().get_hirid (),

--- a/gcc/rust/typecheck/rust-tycheck-dump.h
+++ b/gcc/rust/typecheck/rust-tycheck-dump.h
@@ -162,11 +162,11 @@ public:
 
   void visit (HIR::ArrayElemsValues &elems) override
   {
-    elems.iterate ([&] (HIR::Expr *e) mutable -> bool {
-      e->accept_vis (*this);
-      dump += ",";
-      return true;
-    });
+    for (auto &elem : elems.get_values ())
+      {
+	elem->accept_vis (*this);
+	dump += ",";
+      }
   }
 
   void visit (HIR::GroupedExpr &expr) override


### PR DESCRIPTION
From David Faust : https://gcc.gnu.org/pipermail/gcc-rust/2021-October/000233.html

This patch removes the lambda iterators used in various HIR objects.
These iterators make interacting with the IR for static analysis more
difficult. Instead, get_X () helpers are added for accessing elements,
and uses of the iterators replaced with for loops.

The following objects are adjusted in this patch:
- HIR::TupleExpr
- HIR::StructExprField
- HIR::StructStruct
- HIR::TupleStruct

Fixes: #703, #704, #705, #706, #707