### PR TITLE
Remove `AST::BlockExpr` lambda and add `get_statements`

### DIFF
--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -2438,15 +2438,6 @@ public:
   void mark_for_strip () override { marked_for_strip = true; }
   bool is_marked_for_strip () const override { return marked_for_strip; }
 
-  void iterate_stmts (std::function<bool (Stmt *)> cb)
-  {
-    for (auto it = statements.begin (); it != statements.end (); it++)
-      {
-	if (!cb (it->get ()))
-	  return;
-      }
-  }
-
   size_t num_statements () const { return statements.size (); }
 
   // TODO: this mutable getter seems really dodgy. Think up better way.

--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -64,16 +64,17 @@ ASTLoweringBlock::visit (AST::BlockExpr &expr)
 {
   std::vector<std::unique_ptr<HIR::Stmt> > block_stmts;
   bool block_did_terminate = false;
-  expr.iterate_stmts ([&] (AST::Stmt *s) mutable -> bool {
-    if (block_did_terminate)
-      rust_warning_at (s->get_locus (), 0, "unreachable statement");
 
-    bool terminated = false;
-    auto translated_stmt = ASTLoweringStmt::translate (s, &terminated);
-    block_stmts.push_back (std::unique_ptr<HIR::Stmt> (translated_stmt));
-    block_did_terminate |= terminated;
-    return true;
-  });
+  for (auto &s : expr.get_statements ())
+    {
+      if (block_did_terminate)
+	rust_warning_at (s->get_locus (), 0, "unreachable statement");
+
+      bool terminated = false;
+      auto translated_stmt = ASTLoweringStmt::translate (s.get (), &terminated);
+      block_stmts.push_back (std::unique_ptr<HIR::Stmt> (translated_stmt));
+      block_did_terminate |= terminated;
+    }
 
   if (expr.has_tail_expr () && block_did_terminate)
     {

--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -348,10 +348,8 @@ ResolveExpr::visit (AST::BlockExpr &expr)
   resolver->push_new_type_rib (resolver->get_type_scope ().peek ());
   resolver->push_new_label_rib (resolver->get_type_scope ().peek ());
 
-  expr.iterate_stmts ([&] (AST::Stmt *s) mutable -> bool {
-    ResolveStmt::go (s, s->get_node_id ());
-    return true;
-  });
+  for (auto &s : expr.get_statements ())
+    ResolveStmt::go (s.get (), s->get_node_id ());
 
   if (expr.has_tail_expr ())
     ResolveExpr::go (expr.get_tail_expr ().get (), expr.get_node_id ());


### PR DESCRIPTION
This PR Fixes #724.

This patch removes lambda iterators in `AST::BlockExpr` and replace these with `get_statements`. These lambda iterators need to be removed they make working with the IR's more complex for static analysis. 