### PR TITLE
Refactor TyTy with new TypeMutability enum

### DIFF
--- a/gcc/rust/typecheck/rust-hir-dot-operator.h
+++ b/gcc/rust/typecheck/rust-hir-dot-operator.h
@@ -51,7 +51,7 @@ public:
 	// 2. try ref
 	TyTy::ReferenceType *r1
 	  = new TyTy::ReferenceType (r->get_ref (), TyTy::TyVar (r->get_ref ()),
-				     false);
+				     TyTy::TypeMutability::IMMUT);
 	c = Try (candidates, r1);
 	if (c != nullptr)
 	  {
@@ -63,7 +63,7 @@ public:
 	// 3. try mut ref
 	TyTy::ReferenceType *r2
 	  = new TyTy::ReferenceType (r->get_ref (), TyTy::TyVar (r->get_ref ()),
-				     true);
+				     TyTy::TypeMutability::MUT);
 	c = Try (candidates, r2);
 	if (c != nullptr)
 	  {

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -602,9 +602,9 @@ public:
 	  auto ok = context->lookup_builtin ("str", &base);
 	  rust_assert (ok);
 
-	  infered
-	    = new TyTy::ReferenceType (expr.get_mappings ().get_hirid (),
-				       TyTy::TyVar (base->get_ref ()), false);
+	  infered = new TyTy::ReferenceType (expr.get_mappings ().get_hirid (),
+					     TyTy::TyVar (base->get_ref ()),
+					     TyTy::TypeMutability::IMMUT);
 	}
 	break;
 
@@ -649,9 +649,9 @@ public:
 				   TyTy::TyVar (u8->get_ref ()));
 	  context->insert_type (array_mapping, array);
 
-	  infered
-	    = new TyTy::ReferenceType (expr.get_mappings ().get_hirid (),
-				       TyTy::TyVar (array->get_ref ()), false);
+	  infered = new TyTy::ReferenceType (expr.get_mappings ().get_hirid (),
+					     TyTy::TyVar (array->get_ref ()),
+					     TyTy::TypeMutability::IMMUT);
 	}
 	break;
 
@@ -1093,7 +1093,9 @@ public:
 
     infered = new TyTy::ReferenceType (expr.get_mappings ().get_hirid (),
 				       TyTy::TyVar (resolved_base->get_ref ()),
-				       expr.get_is_mut ());
+				       expr.get_is_mut ()
+					 ? TyTy::TypeMutability::MUT
+					 : TyTy::TypeMutability::IMMUT);
   }
 
   void visit (HIR::DereferenceExpr &expr) override

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -240,13 +240,13 @@ public:
 	      case HIR::SelfParam::IMM_REF:
 		self_type = new TyTy::ReferenceType (
 		  self_param.get_mappings ().get_hirid (),
-		  TyTy::TyVar (self->get_ref ()), false);
+		  TyTy::TyVar (self->get_ref ()), TyTy::TypeMutability::IMMUT);
 		break;
 
 	      case HIR::SelfParam::MUT_REF:
 		self_type = new TyTy::ReferenceType (
 		  self_param.get_mappings ().get_hirid (),
-		  TyTy::TyVar (self->get_ref ()), true);
+		  TyTy::TyVar (self->get_ref ()), TyTy::TypeMutability::MUT);
 		break;
 
 	      default:

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -129,7 +129,9 @@ public:
       = TypeCheckType::Resolve (type.get_base_type ().get ());
     translated = new TyTy::ReferenceType (type.get_mappings ().get_hirid (),
 					  TyTy::TyVar (base->get_ref ()),
-					  type.get_has_mut ());
+					  type.get_has_mut ()
+					    ? TyTy::TypeMutability::MUT
+					    : TyTy::TypeMutability::IMMUT);
   }
 
   void visit (HIR::RawPointerType &type) override
@@ -138,7 +140,9 @@ public:
       = TypeCheckType::Resolve (type.get_base_type ().get ());
     translated
       = new TyTy::PointerType (type.get_mappings ().get_hirid (),
-			       TyTy::TyVar (base->get_ref ()), type.is_mut ());
+			       TyTy::TyVar (base->get_ref ()),
+			       type.is_mut () ? TyTy::TypeMutability::MUT
+					      : TyTy::TypeMutability::IMMUT);
   }
 
   void visit (HIR::InferredType &type) override

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -548,13 +548,13 @@ TraitItemReference::get_type_from_fn (/*const*/ HIR::TraitItemFunc &fn) const
 	    case HIR::SelfParam::IMM_REF:
 	      self_type = new TyTy::ReferenceType (
 		self_param.get_mappings ().get_hirid (),
-		TyTy::TyVar (self->get_ref ()), false);
+		TyTy::TyVar (self->get_ref ()), TyTy::TypeMutability::IMMUT);
 	      break;
 
 	    case HIR::SelfParam::MUT_REF:
 	      self_type = new TyTy::ReferenceType (
 		self_param.get_mappings ().get_hirid (),
-		TyTy::TyVar (self->get_ref ()), true);
+		TyTy::TyVar (self->get_ref ()), TyTy::TypeMutability::MUT);
 	      break;
 
 	    default:

--- a/gcc/rust/typecheck/rust-tyty-coercion.h
+++ b/gcc/rust/typecheck/rust-tyty-coercion.h
@@ -1146,7 +1146,7 @@ public:
       {
 	resolved = new ReferenceType (base->get_ref (), base->get_ty_ref (),
 				      TyVar (base_resolved->get_ref ()),
-				      base->is_mutable ());
+				      base->mutability ());
 	return;
       }
 
@@ -1188,7 +1188,7 @@ public:
       {
 	resolved = new PointerType (base->get_ref (), base->get_ty_ref (),
 				    TyVar (base_resolved->get_ref ()),
-				    base->is_mutable ());
+				    base->mutability ());
 	return;
       }
 
@@ -1215,7 +1215,7 @@ public:
       {
 	resolved = new PointerType (base->get_ref (), base->get_ty_ref (),
 				    TyVar (base_resolved->get_ref ()),
-				    base->is_mutable ());
+				    base->mutability ());
 	return;
       }
 

--- a/gcc/rust/typecheck/rust-tyty-rules.h
+++ b/gcc/rust/typecheck/rust-tyty-rules.h
@@ -1160,7 +1160,7 @@ public:
 
     resolved = new ReferenceType (base->get_ref (), base->get_ty_ref (),
 				  TyVar (base_resolved->get_ref ()),
-				  base->is_mutable ());
+				  base->mutability ());
   }
 
 private:
@@ -1197,7 +1197,7 @@ public:
 
     resolved = new PointerType (base->get_ref (), base->get_ty_ref (),
 				TyVar (base_resolved->get_ref ()),
-				base->is_mutable ());
+				base->mutability ());
   }
 
 private:

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -1692,7 +1692,7 @@ ReferenceType::get_base () const
 BaseType *
 ReferenceType::clone () const
 {
-  return new ReferenceType (get_ref (), get_ty_ref (), base, is_mutable (),
+  return new ReferenceType (get_ref (), get_ty_ref (), base, mutability (),
 			    get_combined_refs ());
 }
 
@@ -1778,7 +1778,7 @@ PointerType::get_base () const
 BaseType *
 PointerType::clone () const
 {
-  return new PointerType (get_ref (), get_ty_ref (), base, is_mutable (),
+  return new PointerType (get_ref (), get_ty_ref (), base, mutability (),
 			  get_combined_refs ());
 }
 

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -35,6 +35,12 @@ class AssociatedImplTrait;
 
 namespace TyTy {
 
+enum TypeMutability
+{
+  IMMUT,
+  MUT
+};
+
 // https://rustc-dev-guide.rust-lang.org/type-inference.html#inference-variables
 // https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/enum.TyKind.html#variants
 enum TypeKind
@@ -1552,14 +1558,14 @@ public:
 class ReferenceType : public BaseType
 {
 public:
-  ReferenceType (HirId ref, TyVar base, bool is_mut,
+  ReferenceType (HirId ref, TyVar base, TypeMutability mut,
 		 std::set<HirId> refs = std::set<HirId> ())
-    : BaseType (ref, ref, TypeKind::REF, refs), base (base), is_mut (is_mut)
+    : BaseType (ref, ref, TypeKind::REF, refs), base (base), mut (mut)
   {}
 
-  ReferenceType (HirId ref, HirId ty_ref, TyVar base, bool is_mut,
+  ReferenceType (HirId ref, HirId ty_ref, TyVar base, TypeMutability mut,
 		 std::set<HirId> refs = std::set<HirId> ())
-    : BaseType (ref, ty_ref, TypeKind::REF, refs), base (base), is_mut (is_mut)
+    : BaseType (ref, ty_ref, TypeKind::REF, refs), base (base), mut (mut)
   {}
 
   BaseType *get_base () const;
@@ -1587,25 +1593,26 @@ public:
 
   ReferenceType *handle_substitions (SubstitutionArgumentMappings mappings);
 
-  bool is_mutable () const { return is_mut; }
+  TypeMutability mutability () const { return mut; }
+
+  bool is_mutable () const { return mut == TypeMutability::MUT; }
 
 private:
   TyVar base;
-  bool is_mut;
+  TypeMutability mut;
 };
 
 class PointerType : public BaseType
 {
 public:
-  PointerType (HirId ref, TyVar base, bool is_mut,
+  PointerType (HirId ref, TyVar base, TypeMutability mut,
 	       std::set<HirId> refs = std::set<HirId> ())
-    : BaseType (ref, ref, TypeKind::POINTER, refs), base (base), is_mut (is_mut)
+    : BaseType (ref, ref, TypeKind::POINTER, refs), base (base), mut (mut)
   {}
 
-  PointerType (HirId ref, HirId ty_ref, TyVar base, bool is_mut,
+  PointerType (HirId ref, HirId ty_ref, TyVar base, TypeMutability mut,
 	       std::set<HirId> refs = std::set<HirId> ())
-    : BaseType (ref, ty_ref, TypeKind::POINTER, refs), base (base),
-      is_mut (is_mut)
+    : BaseType (ref, ty_ref, TypeKind::POINTER, refs), base (base), mut (mut)
   {}
 
   BaseType *get_base () const;
@@ -1633,13 +1640,15 @@ public:
 
   PointerType *handle_substitions (SubstitutionArgumentMappings mappings);
 
-  bool is_mutable () const { return is_mut; }
+  TypeMutability mutability () const { return mut; }
 
-  bool is_const () const { return !is_mut; }
+  bool is_mutable () const { return mut == TypeMutability::MUT; }
+
+  bool is_const () const { return mut == TypeMutability::IMMUT; }
 
 private:
   TyVar base;
-  bool is_mut;
+  TypeMutability mut;
 };
 
 class StrType : public BaseType


### PR DESCRIPTION
Add `TyTy::TypeMutability` enum and start using it instead of `bool is_mut`.
This is just a start, the new enum could be used in many places. 

Fixes: #677
