### PR TITLE
Refactor HIR to use new Mutability enum

### DIFF
--- a/gcc/rust/backend/rust-compile-fnparam.h
+++ b/gcc/rust/backend/rust-compile-fnparam.h
@@ -40,7 +40,7 @@ public:
 
   void visit (HIR::IdentifierPattern &pattern) override
   {
-    if (!pattern.is_mut)
+    if (!pattern.is_mut ())
       decl_type = ctx->get_backend ()->immutable_type (decl_type);
 
     translated

--- a/gcc/rust/backend/rust-compile-var-decl.h
+++ b/gcc/rust/backend/rust-compile-var-decl.h
@@ -54,7 +54,7 @@ public:
 
   void visit (HIR::IdentifierPattern &pattern) override
   {
-    if (!pattern.is_mut)
+    if (!pattern.is_mut ())
       translated_type = ctx->get_backend ()->immutable_type (translated_type);
 
     translated

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -649,11 +649,10 @@ public:
 				   mappings->get_next_hir_id (crate_num),
 				   UNKNOWN_LOCAL_DEFID);
 
-    translated
-      = new HIR::BorrowExpr (mapping,
-			     std::unique_ptr<HIR::Expr> (borrow_lvalue),
-			     expr.get_is_mut (), expr.get_is_double_borrow (),
-			     expr.get_outer_attrs (), expr.get_locus ());
+    translated = new HIR::BorrowExpr (
+      mapping, std::unique_ptr<HIR::Expr> (borrow_lvalue),
+      expr.get_is_mut () ? Mutability::Mut : Mutability::Imm,
+      expr.get_is_double_borrow (), expr.get_outer_attrs (), expr.get_locus ());
   }
 
   void visit (AST::DereferenceExpr &expr) override

--- a/gcc/rust/hir/rust-ast-lower-extern.h
+++ b/gcc/rust/hir/rust-ast-lower-extern.h
@@ -48,12 +48,10 @@ public:
 				   mappings->get_next_hir_id (crate_num),
 				   mappings->get_next_localdef_id (crate_num));
 
-    HIR::ExternalStaticItem *static_item
-      = new HIR::ExternalStaticItem (mapping, item.get_identifier (),
-				     std::unique_ptr<HIR::Type> (static_type),
-				     item.is_mut (), std::move (vis),
-				     item.get_outer_attrs (),
-				     item.get_locus ());
+    HIR::ExternalStaticItem *static_item = new HIR::ExternalStaticItem (
+      mapping, item.get_identifier (), std::unique_ptr<HIR::Type> (static_type),
+      item.is_mut () ? Mutability::Mut : Mutability::Imm, std::move (vis),
+      item.get_outer_attrs (), item.get_locus ());
 
     translated = static_item;
 

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -339,11 +339,12 @@ public:
 				   mappings->get_next_hir_id (crate_num),
 				   mappings->get_next_localdef_id (crate_num));
 
-    translated
-      = new HIR::StaticItem (mapping, var.get_identifier (), var.is_mutable (),
-			     std::unique_ptr<HIR::Type> (type),
-			     std::unique_ptr<HIR::Expr> (expr), vis,
-			     var.get_outer_attrs (), var.get_locus ());
+    translated = new HIR::StaticItem (mapping, var.get_identifier (),
+				      var.is_mutable () ? Mutability::Mut
+							: Mutability::Imm,
+				      std::unique_ptr<HIR::Type> (type),
+				      std::unique_ptr<HIR::Expr> (expr), vis,
+				      var.get_outer_attrs (), var.get_locus ());
 
     mappings->insert_defid_mapping (mapping.get_defid (), translated);
     mappings->insert_hir_item (mapping.get_crate_num (), mapping.get_hirid (),

--- a/gcc/rust/hir/rust-ast-lower-pattern.h
+++ b/gcc/rust/hir/rust-ast-lower-pattern.h
@@ -45,7 +45,9 @@ public:
     translated
       = new HIR::IdentifierPattern (pattern.get_ident (), pattern.get_locus (),
 				    pattern.get_is_ref (),
-				    pattern.get_is_mut (), std::move (to_bind));
+				    pattern.get_is_mut () ? Mutability::Mut
+							  : Mutability::Imm,
+				    std::move (to_bind));
   }
 
 private:

--- a/gcc/rust/hir/rust-ast-lower-type.h
+++ b/gcc/rust/hir/rust-ast-lower-type.h
@@ -247,7 +247,9 @@ public:
 				   mappings->get_next_hir_id (crate_num),
 				   mappings->get_next_localdef_id (crate_num));
 
-    translated = new HIR::ReferenceType (mapping, type.get_has_mut (),
+    translated = new HIR::ReferenceType (mapping,
+					 type.get_has_mut () ? Mutability::Mut
+							     : Mutability::Imm,
 					 std::unique_ptr<HIR::Type> (base_type),
 					 type.get_locus (), lifetime);
 
@@ -268,7 +270,9 @@ public:
     translated
       = new HIR::RawPointerType (mapping,
 				 type.get_pointer_type ()
-				   == AST::RawPointerType::PointerType::MUT,
+				     == AST::RawPointerType::PointerType::MUT
+				   ? Mutability::Mut
+				   : Mutability::Imm,
 				 std::unique_ptr<HIR::Type> (base_type),
 				 type.get_locus ());
 

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -19,6 +19,7 @@
 #ifndef RUST_HIR_EXPR_H
 #define RUST_HIR_EXPR_H
 
+#include "rust-common.h"
 #include "rust-ast-full-decls.h"
 #include "rust-hir.h"
 #include "rust-hir-path.h"
@@ -171,23 +172,24 @@ public:
  * overloaded. */
 class BorrowExpr : public OperatorExpr
 {
-  bool is_mut;
+  Mutability mut;
   bool double_borrow;
 
 public:
   std::string as_string () const override;
 
   BorrowExpr (Analysis::NodeMapping mappings,
-	      std::unique_ptr<Expr> borrow_lvalue, bool is_mut_borrow,
+	      std::unique_ptr<Expr> borrow_lvalue, Mutability mut,
 	      bool is_double_borrow, AST::AttrVec outer_attribs, Location locus)
     : OperatorExpr (std::move (mappings), std::move (borrow_lvalue),
 		    std::move (outer_attribs), locus),
-      is_mut (is_mut_borrow), double_borrow (is_double_borrow)
+      mut (mut), double_borrow (is_double_borrow)
   {}
 
   void accept_vis (HIRVisitor &vis) override;
 
-  bool get_is_mut () const { return is_mut; }
+  Mutability get_mut () const { return mut; }
+  bool is_mut () const { return mut == Mutability::Mut; }
   bool get_is_double_borrow () const { return double_borrow; }
 
 protected:

--- a/gcc/rust/hir/tree/rust-hir-full-test.cc
+++ b/gcc/rust/hir/tree/rust-hir-full-test.cc
@@ -221,7 +221,7 @@ StaticItem::as_string () const
 
   str += indent_spaces (stay) + "static";
 
-  if (has_mut)
+  if (is_mut ())
     {
       str += " mut";
     }
@@ -1200,7 +1200,7 @@ BorrowExpr::as_string () const
       str += "&";
     }
 
-  if (is_mut)
+  if (is_mut ())
     {
       str += "mut ";
     }
@@ -2463,7 +2463,7 @@ StructPatternFieldIdent::as_string () const
       str += "ref ";
     }
 
-  if (has_mut)
+  if (is_mut ())
     {
       str += "mut ";
     }
@@ -2570,7 +2570,7 @@ ReferencePattern::as_string () const
       str += "&";
     }
 
-  if (is_mut)
+  if (is_mut ())
     {
       str += "mut ";
     }
@@ -2590,7 +2590,7 @@ IdentifierPattern::as_string () const
       str += "ref ";
     }
 
-  if (is_mut)
+  if (is_mut ())
     {
       str += "mut ";
     }
@@ -2776,7 +2776,7 @@ ReferenceType::as_string () const
       str += lifetime.as_string () + " ";
     }
 
-  if (has_mut)
+  if (is_mut ())
     {
       str += "mut ";
     }
@@ -3249,7 +3249,7 @@ ExternalStaticItem::as_string () const
 
   str += "static ";
 
-  if (has_mut)
+  if (is_mut ())
     {
       str += "mut ";
     }

--- a/gcc/rust/typecheck/rust-hir-dot-operator.h
+++ b/gcc/rust/typecheck/rust-hir-dot-operator.h
@@ -51,7 +51,7 @@ public:
 	// 2. try ref
 	TyTy::ReferenceType *r1
 	  = new TyTy::ReferenceType (r->get_ref (), TyTy::TyVar (r->get_ref ()),
-				     TyTy::TypeMutability::IMMUT);
+				     Mutability::Imm);
 	c = Try (candidates, r1);
 	if (c != nullptr)
 	  {
@@ -63,7 +63,7 @@ public:
 	// 3. try mut ref
 	TyTy::ReferenceType *r2
 	  = new TyTy::ReferenceType (r->get_ref (), TyTy::TyVar (r->get_ref ()),
-				     TyTy::TypeMutability::MUT);
+				     Mutability::Mut);
 	c = Try (candidates, r2);
 	if (c != nullptr)
 	  {

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -604,7 +604,7 @@ public:
 
 	  infered = new TyTy::ReferenceType (expr.get_mappings ().get_hirid (),
 					     TyTy::TyVar (base->get_ref ()),
-					     TyTy::TypeMutability::IMMUT);
+					     Mutability::Imm);
 	}
 	break;
 
@@ -651,7 +651,7 @@ public:
 
 	  infered = new TyTy::ReferenceType (expr.get_mappings ().get_hirid (),
 					     TyTy::TyVar (array->get_ref ()),
-					     TyTy::TypeMutability::IMMUT);
+					     Mutability::Imm);
 	}
 	break;
 
@@ -1094,9 +1094,7 @@ public:
 
     infered = new TyTy::ReferenceType (expr.get_mappings ().get_hirid (),
 				       TyTy::TyVar (resolved_base->get_ref ()),
-				       expr.get_is_mut ()
-					 ? TyTy::TypeMutability::MUT
-					 : TyTy::TypeMutability::IMMUT);
+				       expr.get_mut ());
   }
 
   void visit (HIR::DereferenceExpr &expr) override

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -101,7 +101,7 @@ public:
 	auto param_tyty = TypeCheckType::Resolve (param.get_type ().get ());
 
 	HIR::IdentifierPattern *param_pattern = new HIR::IdentifierPattern (
-	  param.get_param_name (), Location (), false, false,
+	  param.get_param_name (), Location (), false, Mutability::Imm,
 	  std::unique_ptr<HIR::Pattern> (nullptr));
 
 	params.push_back (
@@ -219,7 +219,7 @@ public:
 	HIR::SelfParam &self_param = function.get_self_param ();
 	HIR::IdentifierPattern *self_pattern = new HIR::IdentifierPattern (
 	  "self", self_param.get_locus (), self_param.is_ref (),
-	  self_param.is_mut (), std::unique_ptr<HIR::Pattern> (nullptr));
+	  self_param.get_mut (), std::unique_ptr<HIR::Pattern> (nullptr));
 
 	// might have a specified type
 	TyTy::BaseType *self_type = nullptr;
@@ -240,13 +240,13 @@ public:
 	      case HIR::SelfParam::IMM_REF:
 		self_type = new TyTy::ReferenceType (
 		  self_param.get_mappings ().get_hirid (),
-		  TyTy::TyVar (self->get_ref ()), TyTy::TypeMutability::IMMUT);
+		  TyTy::TyVar (self->get_ref ()), Mutability::Imm);
 		break;
 
 	      case HIR::SelfParam::MUT_REF:
 		self_type = new TyTy::ReferenceType (
 		  self_param.get_mappings ().get_hirid (),
-		  TyTy::TyVar (self->get_ref ()), TyTy::TypeMutability::MUT);
+		  TyTy::TyVar (self->get_ref ()), Mutability::Mut);
 		break;
 
 	      default:

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -129,9 +129,7 @@ public:
       = TypeCheckType::Resolve (type.get_base_type ().get ());
     translated = new TyTy::ReferenceType (type.get_mappings ().get_hirid (),
 					  TyTy::TyVar (base->get_ref ()),
-					  type.get_has_mut ()
-					    ? TyTy::TypeMutability::MUT
-					    : TyTy::TypeMutability::IMMUT);
+					  type.get_mut ());
   }
 
   void visit (HIR::RawPointerType &type) override
@@ -140,9 +138,7 @@ public:
       = TypeCheckType::Resolve (type.get_base_type ().get ());
     translated
       = new TyTy::PointerType (type.get_mappings ().get_hirid (),
-			       TyTy::TyVar (base->get_ref ()),
-			       type.is_mut () ? TyTy::TypeMutability::MUT
-					      : TyTy::TypeMutability::IMMUT);
+			       TyTy::TyVar (base->get_ref ()), type.get_mut ());
   }
 
   void visit (HIR::InferredType &type) override

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -526,7 +526,8 @@ TraitItemReference::get_type_from_fn (/*const*/ HIR::TraitItemFunc &fn) const
       HIR::IdentifierPattern *self_pattern
 	= new HIR::IdentifierPattern ("self", self_param.get_locus (),
 				      self_param.is_ref (),
-				      self_param.is_mut (),
+				      self_param.is_mut () ? Mutability::Mut
+							   : Mutability::Imm,
 				      std::unique_ptr<HIR::Pattern> (nullptr));
       // might have a specified type
       TyTy::BaseType *self_type = nullptr;
@@ -547,13 +548,13 @@ TraitItemReference::get_type_from_fn (/*const*/ HIR::TraitItemFunc &fn) const
 	    case HIR::SelfParam::IMM_REF:
 	      self_type = new TyTy::ReferenceType (
 		self_param.get_mappings ().get_hirid (),
-		TyTy::TyVar (self->get_ref ()), TyTy::TypeMutability::IMMUT);
+		TyTy::TyVar (self->get_ref ()), Mutability::Imm);
 	      break;
 
 	    case HIR::SelfParam::MUT_REF:
 	      self_type = new TyTy::ReferenceType (
 		self_param.get_mappings ().get_hirid (),
-		TyTy::TyVar (self->get_ref ()), TyTy::TypeMutability::MUT);
+		TyTy::TyVar (self->get_ref ()), Mutability::Mut);
 	      break;
 
 	    default:

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -24,6 +24,7 @@
 #include "rust-hir-full.h"
 #include "rust-diagnostics.h"
 #include "rust-abi.h"
+#include "rust-common.h"
 
 namespace Rust {
 
@@ -34,12 +35,6 @@ class AssociatedImplTrait;
 } // namespace Resolver
 
 namespace TyTy {
-
-enum TypeMutability
-{
-  IMMUT,
-  MUT
-};
 
 // https://rustc-dev-guide.rust-lang.org/type-inference.html#inference-variables
 // https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/enum.TyKind.html#variants
@@ -1558,12 +1553,12 @@ public:
 class ReferenceType : public BaseType
 {
 public:
-  ReferenceType (HirId ref, TyVar base, TypeMutability mut,
+  ReferenceType (HirId ref, TyVar base, Mutability mut,
 		 std::set<HirId> refs = std::set<HirId> ())
     : BaseType (ref, ref, TypeKind::REF, refs), base (base), mut (mut)
   {}
 
-  ReferenceType (HirId ref, HirId ty_ref, TyVar base, TypeMutability mut,
+  ReferenceType (HirId ref, HirId ty_ref, TyVar base, Mutability mut,
 		 std::set<HirId> refs = std::set<HirId> ())
     : BaseType (ref, ty_ref, TypeKind::REF, refs), base (base), mut (mut)
   {}
@@ -1593,24 +1588,24 @@ public:
 
   ReferenceType *handle_substitions (SubstitutionArgumentMappings mappings);
 
-  TypeMutability mutability () const { return mut; }
+  Mutability mutability () const { return mut; }
 
-  bool is_mutable () const { return mut == TypeMutability::MUT; }
+  bool is_mutable () const { return mut == Mutability::Mut; }
 
 private:
   TyVar base;
-  TypeMutability mut;
+  Mutability mut;
 };
 
 class PointerType : public BaseType
 {
 public:
-  PointerType (HirId ref, TyVar base, TypeMutability mut,
+  PointerType (HirId ref, TyVar base, Mutability mut,
 	       std::set<HirId> refs = std::set<HirId> ())
     : BaseType (ref, ref, TypeKind::POINTER, refs), base (base), mut (mut)
   {}
 
-  PointerType (HirId ref, HirId ty_ref, TyVar base, TypeMutability mut,
+  PointerType (HirId ref, HirId ty_ref, TyVar base, Mutability mut,
 	       std::set<HirId> refs = std::set<HirId> ())
     : BaseType (ref, ty_ref, TypeKind::POINTER, refs), base (base), mut (mut)
   {}
@@ -1640,15 +1635,15 @@ public:
 
   PointerType *handle_substitions (SubstitutionArgumentMappings mappings);
 
-  TypeMutability mutability () const { return mut; }
+  Mutability mutability () const { return mut; }
 
-  bool is_mutable () const { return mut == TypeMutability::MUT; }
+  bool is_mutable () const { return mut == Mutability::Mut; }
 
-  bool is_const () const { return mut == TypeMutability::IMMUT; }
+  bool is_const () const { return mut == Mutability::Imm; }
 
 private:
   TyVar base;
-  TypeMutability mut;
+  Mutability mut;
 };
 
 class StrType : public BaseType

--- a/gcc/rust/util/rust-common.h
+++ b/gcc/rust/util/rust-common.h
@@ -1,0 +1,34 @@
+// Copyright (C) 2021 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+// Common definitions useful throughout the Rust frontend.
+
+#ifndef RUST_COMMON
+#define RUST_COMMON
+
+namespace Rust {
+
+enum Mutability
+{
+  Imm,
+  Mut
+};
+
+} // namespace Rust
+
+#endif // RUST_COMMON


### PR DESCRIPTION
Introduce a new header rust/util/rust-common.h and move the enum
previously Rust::TyTy::TypeMutability there as Rust::Mutability.

Update the following objects to use Mutability enum rather than a bool:
- HIR::IdentifierPattern
- HIR::ReferencePattern
- HIR::StructPatternFieldIdent
- HIR::BorrowExpr
- HIR::RawPointerType
- HIR::ReferenceType
- HIR::StaticItem
- HIR::ExternalStaticItem

Also add a HIR::SelfParam::get_mut () helper, mapping its internal
custom mutability to the common Rust::Mutability.

Fixes: #731
