### PR TITLE
Add boiler plate for TyTy::ClosureType

### DIFF
--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -661,6 +661,8 @@ public:
     ctx->insert_compiled_type (type.get_ty_ref (), named_struct, &type);
   }
 
+  void visit (TyTy::ClosureType &type) override { gcc_unreachable (); }
+
 private:
   TyTyResolveCompile (Context *ctx, bool trait_object_mode)
     : ctx (ctx), trait_object_mode (trait_object_mode), translated (nullptr)

--- a/gcc/rust/backend/rust-compile-tyty.h
+++ b/gcc/rust/backend/rust-compile-tyty.h
@@ -239,6 +239,8 @@ public:
 
   void visit (TyTy::DynamicObjectType &) override { gcc_unreachable (); }
 
+  void visit (TyTy::ClosureType &) override { gcc_unreachable (); }
+
 private:
   TyTyCompile (::Backend *backend)
     : backend (backend), translated (nullptr),

--- a/gcc/rust/typecheck/rust-hir-const-fold.h
+++ b/gcc/rust/typecheck/rust-hir-const-fold.h
@@ -193,6 +193,8 @@ public:
 
   void visit (TyTy::DynamicObjectType &) override { gcc_unreachable (); }
 
+  void visit (TyTy::ClosureType &) override { gcc_unreachable (); }
+
 private:
   ConstFoldType (::Backend *backend)
     : backend (backend), translated (backend->error_type ())

--- a/gcc/rust/typecheck/rust-substitution-mapper.h
+++ b/gcc/rust/typecheck/rust-substitution-mapper.h
@@ -138,6 +138,7 @@ public:
   void visit (TyTy::StrType &) override { gcc_unreachable (); }
   void visit (TyTy::NeverType &) override { gcc_unreachable (); }
   void visit (TyTy::DynamicObjectType &) override { gcc_unreachable (); }
+  void visit (TyTy::ClosureType &) override { gcc_unreachable (); }
 
 private:
   SubstMapper (HirId ref, HIR::GenericArgs *generics, Location locus)
@@ -217,6 +218,11 @@ public:
     resolved = type.handle_substitions (mappings);
   }
 
+  void visit (TyTy::ClosureType &type) override
+  {
+    resolved = type.handle_substitions (mappings);
+  }
+
   // nothing to do for these
   void visit (TyTy::InferType &) override { gcc_unreachable (); }
   void visit (TyTy::FnPtr &) override { gcc_unreachable (); }
@@ -271,6 +277,14 @@ public:
     resolved = to_sub->handle_substitions (type.get_substitution_arguments ());
   }
 
+  void visit (TyTy::ClosureType &type) override
+  {
+    rust_assert (type.was_substituted ());
+
+    TyTy::ClosureType *to_sub = static_cast<TyTy::ClosureType *> (receiver);
+    resolved = to_sub->handle_substitions (type.get_substitution_arguments ());
+  }
+
   void visit (TyTy::InferType &) override { gcc_unreachable (); }
   void visit (TyTy::TupleType &) override { gcc_unreachable (); }
   void visit (TyTy::FnPtr &) override { gcc_unreachable (); }
@@ -319,6 +333,11 @@ public:
   }
 
   void visit (TyTy::ADTType &type) override
+  {
+    args = type.get_substitution_arguments ();
+  }
+
+  void visit (TyTy::ClosureType &type) override
   {
     args = type.get_substitution_arguments ();
   }

--- a/gcc/rust/typecheck/rust-tyty-call.h
+++ b/gcc/rust/typecheck/rust-tyty-call.h
@@ -65,6 +65,7 @@ public:
   // call fns
   void visit (FnType &type) override;
   void visit (FnPtr &type) override;
+  void visit (ClosureType &type) override { gcc_unreachable (); }
 
 private:
   TypeCheckCallExpr (HIR::CallExpr &c, Resolver::TypeCheckContext *context)
@@ -116,6 +117,7 @@ public:
 
   // call fns
   void visit (FnType &type) override;
+  void visit (ClosureType &type) override { gcc_unreachable (); }
 
 private:
   TypeCheckMethodCallExpr (HIR::MethodCallExpr &c,

--- a/gcc/rust/typecheck/rust-tyty-cast.h
+++ b/gcc/rust/typecheck/rust-tyty-cast.h
@@ -329,6 +329,17 @@ public:
 		   type.as_string ().c_str ());
   }
 
+  virtual void visit (ClosureType &type) override
+  {
+    Location ref_locus = mappings->lookup_location (type.get_ref ());
+    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
+    RichLocation r (ref_locus);
+    r.add_range (base_locus);
+    rust_error_at (r, "invalid cast [%s] to [%s]",
+		   get_base ()->as_string ().c_str (),
+		   type.as_string ().c_str ());
+  }
+
 protected:
   BaseCastRules (BaseType *base)
     : mappings (Analysis::Mappings::get ()),
@@ -590,6 +601,19 @@ public:
     BaseCastRules::visit (type);
   }
 
+  void visit (ClosureType &type) override
+  {
+    bool is_valid
+      = (base->get_infer_kind () == TyTy::InferType::InferTypeKind::GENERAL);
+    if (is_valid)
+      {
+	resolved = type.clone ();
+	return;
+      }
+
+    BaseCastRules::visit (type);
+  }
+
 private:
   BaseType *get_base () override { return base; }
 
@@ -747,6 +771,21 @@ private:
   BaseType *get_base () override { return base; }
 
   FnPtr *base;
+};
+
+class ClosureCastRules : public BaseCastRules
+{
+  using Rust::TyTy::BaseCastRules::visit;
+
+public:
+  ClosureCastRules (ClosureType *base) : BaseCastRules (base), base (base) {}
+
+  // TODO
+
+private:
+  BaseType *get_base () override { return base; }
+
+  ClosureType *base;
 };
 
 class ArrayCastRules : public BaseCastRules

--- a/gcc/rust/typecheck/rust-tyty-rules.h
+++ b/gcc/rust/typecheck/rust-tyty-rules.h
@@ -364,6 +364,17 @@ public:
 		   type.as_string ().c_str ());
   }
 
+  virtual void visit (ClosureType &type) override
+  {
+    Location ref_locus = mappings->lookup_location (type.get_ref ());
+    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
+    RichLocation r (ref_locus);
+    r.add_range (base_locus);
+    rust_error_at (r, "expected [%s] got [%s]",
+		   get_base ()->as_string ().c_str (),
+		   type.as_string ().c_str ());
+  }
+
 protected:
   BaseRules (BaseType *base)
     : mappings (Analysis::Mappings::get ()),
@@ -625,6 +636,19 @@ public:
     BaseRules::visit (type);
   }
 
+  void visit (ClosureType &type) override
+  {
+    bool is_valid
+      = (base->get_infer_kind () == TyTy::InferType::InferTypeKind::GENERAL);
+    if (is_valid)
+      {
+	resolved = type.clone ();
+	return;
+      }
+
+    BaseRules::visit (type);
+  }
+
 private:
   BaseType *get_base () override { return base; }
 
@@ -782,6 +806,21 @@ private:
   BaseType *get_base () override { return base; }
 
   FnPtr *base;
+};
+
+class ClosureRules : public BaseRules
+{
+  using Rust::TyTy::BaseRules::visit;
+
+public:
+  ClosureRules (ClosureType *base) : BaseRules (base), base (base) {}
+
+  // TODO
+
+private:
+  BaseType *get_base () override { return base; }
+
+  ClosureType *base;
 };
 
 class ArrayRules : public BaseRules

--- a/gcc/rust/typecheck/rust-tyty-visitor.h
+++ b/gcc/rust/typecheck/rust-tyty-visitor.h
@@ -49,6 +49,7 @@ public:
   virtual void visit (PlaceholderType &type) = 0;
   virtual void visit (ProjectionType &type) = 0;
   virtual void visit (DynamicObjectType &type) = 0;
+  virtual void visit (ClosureType &type) = 0;
 };
 
 class TyConstVisitor
@@ -76,6 +77,7 @@ public:
   virtual void visit (const PlaceholderType &type) = 0;
   virtual void visit (const ProjectionType &type) = 0;
   virtual void visit (const DynamicObjectType &type) = 0;
+  virtual void visit (const ClosureType &type) = 0;
 };
 
 } // namespace TyTy

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -1112,6 +1112,73 @@ FnPtr::clone () const
 }
 
 void
+ClosureType::accept_vis (TyVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+void
+ClosureType::accept_vis (TyConstVisitor &vis) const
+{
+  vis.visit (*this);
+}
+
+std::string
+ClosureType::as_string () const
+{
+  return "TODO";
+}
+
+BaseType *
+ClosureType::unify (BaseType *other)
+{
+  ClosureRules r (this);
+  return r.unify (other);
+}
+
+bool
+ClosureType::can_eq (const BaseType *other, bool emit_errors) const
+{
+  ClosureCmp r (this, emit_errors);
+  return r.can_eq (other);
+}
+
+BaseType *
+ClosureType::coerce (BaseType *other)
+{
+  ClosureCoercionRules r (this);
+  return r.coerce (other);
+}
+
+BaseType *
+ClosureType::cast (BaseType *other)
+{
+  ClosureCoercionRules r (this);
+  return r.coerce (other);
+}
+
+bool
+ClosureType::is_equal (const BaseType &other) const
+{
+  gcc_unreachable ();
+  return false;
+}
+
+BaseType *
+ClosureType::clone () const
+{
+  return new ClosureType (get_ref (), get_ty_ref (), id, parameter_types,
+			  result_type, clone_substs (), get_combined_refs ());
+}
+
+ClosureType *
+ClosureType::handle_substitions (SubstitutionArgumentMappings mappings)
+{
+  gcc_unreachable ();
+  return nullptr;
+}
+
+void
 ArrayType::accept_vis (TyVisitor &vis)
 {
   vis.visit (*this);

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -66,6 +66,7 @@ enum TypeKind
   PLACEHOLDER,
   PROJECTION,
   DYNAMIC,
+  CLOSURE,
   // there are more to add...
   ERROR
 };
@@ -139,6 +140,9 @@ public:
 
       case TypeKind::DYNAMIC:
 	return "Dynamic";
+
+      case TypeKind::CLOSURE:
+	return "Closure";
 
       case TypeKind::ERROR:
 	return "ERROR";
@@ -1276,6 +1280,73 @@ public:
 private:
   std::vector<TyVar> params;
   TyVar result_type;
+};
+
+class ClosureType : public BaseType, public SubstitutionRef
+{
+public:
+  ClosureType (HirId ref, DefId id, std::vector<TyVar> parameter_types,
+	       TyVar result_type,
+	       std::vector<SubstitutionParamMapping> subst_refs,
+	       std::set<HirId> refs = std::set<HirId> ())
+    : BaseType (ref, ref, TypeKind::CLOSURE, refs),
+      SubstitutionRef (std::move (subst_refs),
+		       SubstitutionArgumentMappings::error ()),
+      parameter_types (std::move (parameter_types)),
+      result_type (std::move (result_type)), id (id)
+  {
+    LocalDefId local_def_id = id & DEF_ID_LOCAL_DEF_MASK;
+    rust_assert (local_def_id != UNKNOWN_LOCAL_DEFID);
+  }
+
+  ClosureType (HirId ref, HirId ty_ref, DefId id,
+	       std::vector<TyVar> parameter_types, TyVar result_type,
+	       std::vector<SubstitutionParamMapping> subst_refs,
+	       std::set<HirId> refs = std::set<HirId> ())
+    : BaseType (ref, ty_ref, TypeKind::CLOSURE, refs),
+      SubstitutionRef (std::move (subst_refs),
+		       SubstitutionArgumentMappings::error ()),
+      parameter_types (std::move (parameter_types)),
+      result_type (std::move (result_type)), id (id)
+  {
+    LocalDefId local_def_id = id & DEF_ID_LOCAL_DEF_MASK;
+    rust_assert (local_def_id != UNKNOWN_LOCAL_DEFID);
+  }
+
+  void accept_vis (TyVisitor &vis) override;
+  void accept_vis (TyConstVisitor &vis) const override;
+
+  std::string as_string () const override;
+  std::string get_name () const override final { return as_string (); }
+
+  BaseType *unify (BaseType *other) override;
+  bool can_eq (const BaseType *other, bool emit_errors) const override final;
+  BaseType *coerce (BaseType *other) override;
+  BaseType *cast (BaseType *other) override;
+
+  bool is_equal (const BaseType &other) const override;
+
+  BaseType *clone () const final override;
+
+  bool needs_generic_substitutions () const override final
+  {
+    return needs_substitution ();
+  }
+
+  bool supports_substitutions () const override final { return true; }
+
+  bool has_subsititions_defined () const override final
+  {
+    return has_substitutions ();
+  }
+
+  ClosureType *
+  handle_substitions (SubstitutionArgumentMappings mappings) override final;
+
+private:
+  std::vector<TyVar> parameter_types;
+  TyVar result_type;
+  DefId id;
 };
 
 class ArrayType : public BaseType


### PR DESCRIPTION
This simply adds in the boilerplate for closure types for type-checking.
The closure branch is blocked until we get lang-item support in next.

Addresses #195
