### PR TITLE
Base v0 mangling grammar

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -88,6 +88,7 @@ GRS_OBJS = \
     rust/rust-lint-marklive.o \
     rust/rust-hir-type-check-path.o \
     rust/rust-compile-intrinsic.o \
+    rust/rust-base62.o \
     $(END)
 # removed object files from here
 

--- a/gcc/rust/backend/rust-mangle.cc
+++ b/gcc/rust/backend/rust-mangle.cc
@@ -1,5 +1,6 @@
 #include "rust-mangle.h"
 #include "fnv-hash.h"
+#include "rust-base62.h"
 #include <algorithm>
 
 // FIXME: Rename those to legacy_*
@@ -155,28 +156,6 @@ v0_simple_type_prefix (const TyTy::BaseType *ty)
   gcc_unreachable ();
 }
 
-// FIXME: Is this present somewhere in libbiberty already?
-static std::string
-v0_base62_integer (uint64_t x)
-{
-  const static std::string base_64
-    = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ@$";
-  std::string buffer (128, '\0');
-  size_t idx = 0;
-  size_t base = 62;
-
-  do
-    {
-      buffer[idx] = base_64[(x % base)];
-      idx++;
-      x = x / base;
-    }
-  while (x != 0);
-
-  std::reverse (buffer.begin (), buffer.begin () + idx);
-  return buffer.substr (0, idx);
-}
-
 // Add an underscore-terminated base62 integer to the mangling string.
 // This corresponds to the `<base-62-number>` grammar in the v0 mangling RFC:
 //  - 0 is encoded as "_"
@@ -185,7 +164,7 @@ static void
 v0_add_integer_62 (std::string &mangled, uint64_t x)
 {
   if (x > 0)
-    mangled.append (v0_base62_integer (x - 1));
+    mangled.append (base62_integer (x - 1));
 
   mangled.append ("_");
 }

--- a/gcc/rust/util/rust-base62.cc
+++ b/gcc/rust/util/rust-base62.cc
@@ -1,0 +1,48 @@
+// Copyright (C) 2020 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-base62.h"
+
+#include <algorithm>
+
+namespace Rust {
+
+std::string
+base62_integer (uint64_t value)
+{
+  const static std::string base_64
+    = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ@$";
+  std::string buffer (128, '\0');
+  size_t idx = 0;
+  size_t base = 62;
+
+  do
+    {
+      buffer[idx] = base_64[(value % base)];
+      idx++;
+      value = value / base;
+    }
+  while (value != 0);
+
+  std::reverse (buffer.begin (), buffer.begin () + idx);
+  return buffer.substr (0, idx);
+}
+
+} // namespace Rust
+
+// FIXME: Add unit testing using the selftest framework

--- a/gcc/rust/util/rust-base62.h
+++ b/gcc/rust/util/rust-base62.h
@@ -1,0 +1,34 @@
+// Copyright (C) 2020 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_BASE62_H
+#define RUST_BASE62_H
+
+#include <string>
+
+namespace Rust {
+
+/**
+ * Get the Base62 representation of an integer
+ */
+std::string
+base62_integer (uint64_t value);
+
+} // namespace Rust
+
+#endif /* !RUST_BASE62_H */


### PR DESCRIPTION
This PR adds base functions to deal with the v0 mangling grammar, [found here](https://rust-lang.github.io/rfcs/2603-rust-symbol-name-mangling-v0.html#syntax-of-mangled-names).

I have a few questions regarding this implementation:
1/ Is there any existing implementation for the base62 algorithm used here? This is directly adapted from [rustc's base_n module](https://github.com/rust-lang/rust/blob/6f53ddfa74ac3c10ceb63ad4a7a9c95e55853c87/compiler/rustc_data_structures/src/base_n.rs#L16) which I'm assuming is relatively standard and might already exist in the compiler. I haven't been able to find it however.
2/ gccrs cannot yet deal with unicode identifiers, as pointed out by @bjorn3 in #418. This means that a big chunk of the `v0_add_identifier` implementation is missing. Should it be added in this PR too?
3/ As mentionned in zulip, it would be great to be able to create unit tests for this piece of code. It would be quite easy to generate a bunch of base62 strings and ensure that the algorithm here matches with them.