### PR TITLE
Enable the usage of selftests

### DIFF
--- a/gcc/c-family/c-common.cc
+++ b/gcc/c-family/c-common.cc
@@ -9111,6 +9111,8 @@ c_family_tests (void)
   c_indentation_c_tests ();
   c_pretty_print_c_tests ();
   c_spellcheck_cc_tests ();
+  c_diagnostic_c_tests ();
+  c_opt_problem_cc_tests ();
 }
 
 } // namespace selftest

--- a/gcc/c-family/c-common.h
+++ b/gcc/c-family/c-common.h
@@ -1512,8 +1512,10 @@ extern tree braced_lists_to_strings (tree, tree);
 namespace selftest {
   /* Declarations for specific families of tests within c-family,
      by source file, in alphabetical order.  */
+  extern void c_diagnostic_c_tests (void);
   extern void c_format_c_tests (void);
   extern void c_indentation_c_tests (void);
+  extern void c_opt_problem_cc_tests (void);
   extern void c_pretty_print_c_tests (void);
   extern void c_spellcheck_cc_tests (void);
 

--- a/gcc/diagnostic.cc
+++ b/gcc/diagnostic.cc
@@ -2466,7 +2466,7 @@ test_num_digits ()
 /* Run all of the selftests within this file.  */
 
 void
-diagnostic_c_tests ()
+c_diagnostic_c_tests ()
 {
   test_print_escaped_string ();
   test_print_parseable_fixits_none ();

--- a/gcc/opt-problem.cc
+++ b/gcc/opt-problem.cc
@@ -324,7 +324,7 @@ test_opt_result_failure_at (const line_table_case &case_)
 /* Run all of the selftests within this file.  */
 
 void
-opt_problem_cc_tests ()
+c_opt_problem_cc_tests ()
 {
   test_opt_result_success ();
   for_each_line_table_case (test_opt_result_failure_at);

--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -209,8 +209,16 @@ rust.uninstall:
 	-rm -f $(RUST_ALL_OBJS)
 # ^those two are a maybe
 
-# No rust-specific selftests
-selftest-rust:
+# Enable selftests for the rust frontend
+selftest-rust: s-selftest-rust
+
+RUST_SELFTEST_FLAGS = -xrs $(SELFTEST_FLAGS)
+RUST_SELFTEST_DEPS = rust1$(exeext) $(SELFTEST_DEPS)
+
+# Run the rust selftests
+s-selftest-rust: $(RUST_SELFTEST_DEPS)
+	$(GCC_FOR_TARGET) $(RUST_SELFTEST_FLAGS)
+	$(STAMP) $@
 
 # Install info documentation for the front end, if it is present in the source directory. This target
 # should have dependencies on info files that should be installed.
@@ -319,4 +327,3 @@ rust/%.o: rust/typecheck/%.cc
 rust/%.o: rust/lint/%.cc
 	$(COMPILE) $(RUST_CXXFLAGS) $(RUST_INCLUDES) $<
 	$(POSTCOMPILE)
-

--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -32,6 +32,7 @@
 #include "convert.h"
 #include "langhooks.h"
 #include "langhooks-def.h"
+#include "selftest.h"
 
 #include <mpfr.h>
 // note: header files must be in this order or else forward declarations don't
@@ -433,6 +434,29 @@ rust_localize_identifier (const char *ident)
 #define LANG_HOOKS_GETDECLS grs_langhook_getdecls
 #define LANG_HOOKS_GIMPLIFY_EXPR grs_langhook_gimplify_expr
 #define LANG_HOOKS_EH_PERSONALITY grs_langhook_eh_personality
+
+#if CHECKING_P
+
+#undef LANG_HOOKS_RUN_LANG_SELFTESTS
+#define LANG_HOOKS_RUN_LANG_SELFTESTS selftest::run_rust_tests
+
+namespace selftest {
+
+static void
+simple_assert ()
+{
+  ASSERT_TRUE (true);
+}
+
+void
+run_rust_tests ()
+{
+  // Call tests for the rust frontend here
+  simple_assert ();
+}
+} // namespace selftest
+
+#endif /* !CHECKING_P */
 
 // Expands all LANG_HOOKS_x of GCC
 struct lang_hooks lang_hooks = LANG_HOOKS_INITIALIZER;

--- a/gcc/selftest-run-tests.cc
+++ b/gcc/selftest-run-tests.cc
@@ -76,7 +76,6 @@ selftest::run_tests ()
   json_cc_tests ();
   cgraph_c_tests ();
   optinfo_emit_json_cc_tests ();
-  opt_problem_cc_tests ();
   ordered_hash_map_tests_cc_tests ();
   splay_tree_cc_tests ();
 
@@ -95,7 +94,6 @@ selftest::run_tests ()
   /* Higher-level tests, or for components that other selftests don't
      rely on.  */
   diagnostic_show_locus_c_tests ();
-  diagnostic_c_tests ();
   diagnostic_format_json_cc_tests ();
   edit_context_c_tests ();
   fold_const_c_tests ();

--- a/gcc/selftest.h
+++ b/gcc/selftest.h
@@ -238,7 +238,6 @@ extern void hash_map_tests_c_tests ();
 extern void hash_set_tests_c_tests ();
 extern void input_c_tests ();
 extern void json_cc_tests ();
-extern void opt_problem_cc_tests ();
 extern void optinfo_emit_json_cc_tests ();
 extern void opts_c_tests ();
 extern void ordered_hash_map_tests_cc_tests ();


### PR DESCRIPTION
From what I can understand, self tests seem to only be used in the C family of languages and in no other gcc frontend. And for some reason one of the self test for the gccrs frontend seem to be the parsing of C code and C types, which fails, which is why this PR is a draft. Once this is fixed, selftests should be enabled for the frontend and we should be able to add some to the project.