### PR TITLE
Squash unused parameter warning.

### DIFF
--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -660,7 +660,7 @@ public:
     ctx->insert_compiled_type (type.get_ty_ref (), named_struct, &type);
   }
 
-  void visit (const TyTy::ClosureType &type) override { gcc_unreachable (); }
+  void visit (const TyTy::ClosureType &) override { gcc_unreachable (); }
 
 private:
   TyTyResolveCompile (Context *ctx, bool trait_object_mode)


### PR DESCRIPTION
This should fix out bootstrap build again.

Fixes #750
