### PR TITLE
Cleanup IR symbol names in gimple

### DIFF
--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -1982,6 +1982,20 @@ ParamType::as_string () const
   return lookup->as_string ();
 }
 
+std::string
+ParamType::get_name () const
+{
+  if (get_ref () == get_ty_ref ())
+    return get_symbol ();
+
+  auto context = Resolver::TypeCheckContext::get ();
+  BaseType *lookup = nullptr;
+  bool ok = context->lookup_type (get_ty_ref (), &lookup);
+  rust_assert (ok);
+
+  return lookup->get_name ();
+}
+
 BaseType *
 ParamType::unify (BaseType *other)
 {

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -545,7 +545,7 @@ public:
 
   BaseType *resolve () const;
 
-  std::string get_name () const override final { return as_string (); }
+  std::string get_name () const override final;
 
   bool is_equal (const BaseType &other) const override;
 
@@ -680,7 +680,7 @@ public:
     : generic (other.generic), param (other.param)
   {}
 
-  std::string as_string () const { return param->as_string (); }
+  std::string as_string () const { return param->get_name (); }
 
   bool fill_param_ty (BaseType &type, Location locus);
 


### PR DESCRIPTION
When we have generic code the full as_string is too verbose for symbol
names. This changes the ir_symbol_names to become the name of the types
not the full debug as_string version.

Fixes #745