### PR TITLE
gccrs: StructExprStructFields: remove `iterate` method

### DIFF
--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -1799,15 +1799,6 @@ public:
     return fields;
   }
 
-  void iterate (std::function<bool (StructExprField *)> cb)
-  {
-    for (auto &field : fields)
-      {
-	if (!cb (field.get ()))
-	  return;
-      }
-  }
-
   StructBase &get_struct_base () { return struct_base; }
   const StructBase &get_struct_base () const { return struct_base; }
 

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -546,13 +546,14 @@ public:
 	  = new HIR::StructBase (std::unique_ptr<HIR::Expr> (translated_base));
       }
 
+    auto const &in_fields = struct_expr.get_fields ();
     std::vector<std::unique_ptr<HIR::StructExprField> > fields;
-    struct_expr.iterate ([&] (AST::StructExprField *field) mutable -> bool {
-      HIR::StructExprField *translated
-	= ASTLowerStructExprField::translate (field);
-      fields.push_back (std::unique_ptr<HIR::StructExprField> (translated));
-      return true;
-    });
+    for (auto &field : in_fields)
+      {
+	HIR::StructExprField *translated
+	  = ASTLowerStructExprField::translate (field.get ());
+	fields.push_back (std::unique_ptr<HIR::StructExprField> (translated));
+      }
 
     auto crate_num = mappings->get_current_crate ();
     Analysis::NodeMapping mapping (crate_num, struct_expr.get_node_id (),

--- a/gcc/rust/resolve/rust-ast-resolve-expr.h
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.h
@@ -269,11 +269,12 @@ public:
 			 struct_expr.get_node_id ());
       }
 
-    struct_expr.iterate (
-      [&] (AST::StructExprField *struct_field) mutable -> bool {
-	ResolveStructExprField::go (struct_field, struct_expr.get_node_id ());
-	return true;
-      });
+    auto const &struct_fields = struct_expr.get_fields ();
+    for (auto &struct_field : struct_fields)
+      {
+	ResolveStructExprField::go (struct_field.get (),
+				    struct_expr.get_node_id ());
+      }
   }
 
   void visit (AST::GroupedExpr &expr) override


### PR DESCRIPTION
This provides a getter for the set of fields in a struct expression
rather than a visitor with a callback which is more complicated for
callers, especially static analysis.

Signed-off-by: Ben Boeckel <mathstuf@gmail.com>

Fixes: #721
