### PR TITLE
CompileExpr: fix copy pasta error message

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -317,8 +317,8 @@ public:
 	  if (!ctx->get_tyctx ()->lookup_type (
 		expr.get_mappings ().get_hirid (), &tyty))
 	    {
-	      rust_fatal_error (expr.get_locus (),
-				"did not resolve type for this array expr");
+	      rust_error_at (expr.get_locus (),
+			     "did not resolve type for this byte string");
 	      return;
 	    }
 


### PR DESCRIPTION
Also downgrade from a fatal error to a compilation error.

Signed-off-by: Ben Boeckel <mathstuf@gmail.com>

---
Fixes: #702 

Here is a checklist to help you with your PR.

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format` (letting CI handle this)
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/` (I don't see any existing tests that seem to test things like this; it's a gccrs internal error about lookup up the type it seems?)