### PR TITLE
LifetimeWhereClauseItem: store the location of the item

### DIFF
--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -190,13 +190,14 @@ class LifetimeWhereClauseItem : public WhereClauseItem
   // LifetimeBounds lifetime_bounds;
   std::vector<Lifetime> lifetime_bounds; // inlined lifetime bounds
 
-  // should this store location info?
+  Location locus;
 
 public:
   LifetimeWhereClauseItem (Lifetime lifetime,
-			   std::vector<Lifetime> lifetime_bounds)
+			   std::vector<Lifetime> lifetime_bounds,
+			   Location locus)
     : lifetime (std::move (lifetime)),
-      lifetime_bounds (std::move (lifetime_bounds))
+      lifetime_bounds (std::move (lifetime_bounds)), locus (locus)
   {}
 
   std::string as_string () const override;

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -165,13 +165,14 @@ class LifetimeWhereClauseItem : public WhereClauseItem
   // LifetimeBounds lifetime_bounds;
   std::vector<Lifetime> lifetime_bounds; // inlined lifetime bounds
 
-  // should this store location info?
+  Location locus;
 
 public:
   LifetimeWhereClauseItem (Lifetime lifetime,
-			   std::vector<Lifetime> lifetime_bounds)
+			   std::vector<Lifetime> lifetime_bounds,
+			   Location locus)
     : lifetime (std::move (lifetime)),
-      lifetime_bounds (std::move (lifetime_bounds))
+      lifetime_bounds (std::move (lifetime_bounds)), locus (locus)
   {}
 
   std::string as_string () const override;

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -3579,9 +3579,11 @@ Parser<ManagedTokenSource>::parse_lifetime_where_clause_item ()
   std::vector<AST::Lifetime> lifetime_bounds = parse_lifetime_bounds ();
   // TODO: have end token passed in?
 
+  Location locus = lifetime.get_locus ();
+
   return std::unique_ptr<AST::LifetimeWhereClauseItem> (
     new AST::LifetimeWhereClauseItem (std::move (lifetime),
-				      std::move (lifetime_bounds)));
+				      std::move (lifetime_bounds), locus));
 }
 
 // Parses a type bound where clause item.


### PR DESCRIPTION
Signed-off-by: Ben Boeckel <mathstuf@gmail.com>

---
Fixes: #765 

Here is a checklist to help you with your PR.

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format` (letting CI handle this)
- \[x] Added any relevant test cases to `gcc/testsuite/rust/`

I didn't find any ctor calls for the `HIR` type, but it's updated as well.