### PR TITLE
TraitImpl: track the polarity of the impl

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -520,13 +520,12 @@ public:
 	impl_item_ids.push_back (lowered->get_impl_mappings ().get_hirid ());
       }
 
-    HIR::ImplBlock *hir_impl_block
-      = new HIR::ImplBlock (mapping, std::move (impl_items),
-			    std::move (generic_params),
-			    std::unique_ptr<HIR::Type> (impl_type), nullptr,
-			    where_clause, vis, impl_block.get_inner_attrs (),
-			    impl_block.get_outer_attrs (),
-			    impl_block.get_locus ());
+    Polarity polarity = Positive;
+    HIR::ImplBlock *hir_impl_block = new HIR::ImplBlock (
+      mapping, std::move (impl_items), std::move (generic_params),
+      std::unique_ptr<HIR::Type> (impl_type), nullptr, where_clause, polarity,
+      vis, impl_block.get_inner_attrs (), impl_block.get_outer_attrs (),
+      impl_block.get_locus ());
     translated = hir_impl_block;
 
     mappings->insert_defid_mapping (mapping.get_defid (), translated);
@@ -689,14 +688,13 @@ public:
 	impl_item_ids.push_back (lowered->get_impl_mappings ().get_hirid ());
       }
 
-    HIR::ImplBlock *hir_impl_block
-      = new HIR::ImplBlock (mapping, std::move (impl_items),
-			    std::move (generic_params),
-			    std::unique_ptr<HIR::Type> (impl_type),
-			    std::unique_ptr<HIR::TypePath> (trait_ref),
-			    where_clause, vis, impl_block.get_inner_attrs (),
-			    impl_block.get_outer_attrs (),
-			    impl_block.get_locus ());
+    Polarity polarity = impl_block.is_exclam () ? Positive : Negative;
+    HIR::ImplBlock *hir_impl_block = new HIR::ImplBlock (
+      mapping, std::move (impl_items), std::move (generic_params),
+      std::unique_ptr<HIR::Type> (impl_type),
+      std::unique_ptr<HIR::TypePath> (trait_ref), where_clause, polarity, vis,
+      impl_block.get_inner_attrs (), impl_block.get_outer_attrs (),
+      impl_block.get_locus ());
     translated = hir_impl_block;
 
     mappings->insert_defid_mapping (mapping.get_defid (), translated);

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -2561,6 +2561,7 @@ class ImplBlock : public VisItem
   std::unique_ptr<Type> impl_type;
   std::unique_ptr<TypePath> trait_ref;
   WhereClause where_clause;
+  Polarity polarity;
   AST::AttrVec inner_attrs;
   Location locus;
   std::vector<std::unique_ptr<ImplItem>> impl_items;
@@ -2571,20 +2572,20 @@ public:
 	     std::vector<std::unique_ptr<GenericParam>> generic_params,
 	     std::unique_ptr<Type> impl_type,
 	     std::unique_ptr<TypePath> trait_ref, WhereClause where_clause,
-	     Visibility vis, AST::AttrVec inner_attrs, AST::AttrVec outer_attrs,
-	     Location locus)
+	     Polarity polarity, Visibility vis, AST::AttrVec inner_attrs,
+	     AST::AttrVec outer_attrs, Location locus)
     : VisItem (std::move (mappings), std::move (vis), std::move (outer_attrs)),
       generic_params (std::move (generic_params)),
       impl_type (std::move (impl_type)), trait_ref (std::move (trait_ref)),
-      where_clause (std::move (where_clause)),
+      where_clause (std::move (where_clause)), polarity (polarity),
       inner_attrs (std::move (inner_attrs)), locus (locus),
       impl_items (std::move (impl_items))
   {}
 
   ImplBlock (ImplBlock const &other)
     : VisItem (other), impl_type (other.impl_type->clone_type ()),
-      where_clause (other.where_clause), inner_attrs (other.inner_attrs),
-      locus (other.locus)
+      where_clause (other.where_clause), polarity (other.polarity),
+      inner_attrs (other.inner_attrs), locus (other.locus)
   {
     generic_params.reserve (other.generic_params.size ());
     for (const auto &e : other.generic_params)
@@ -2600,6 +2601,7 @@ public:
     VisItem::operator= (other);
     impl_type = other.impl_type->clone_type ();
     where_clause = other.where_clause;
+    polarity = other.polarity;
     inner_attrs = other.inner_attrs;
     locus = other.locus;
 
@@ -2639,6 +2641,9 @@ public:
 
   // Returns whether impl has where clause.
   bool has_where_clause () const { return !where_clause.is_empty (); }
+
+  // Returns the polarity of the impl.
+  Polarity get_polarity () const { return polarity; }
 
   // Returns whether impl has inner attributes.
   bool has_inner_attrs () const { return !inner_attrs.empty (); }

--- a/gcc/rust/util/rust-common.h
+++ b/gcc/rust/util/rust-common.h
@@ -35,6 +35,12 @@ enum Unsafety
   Normal
 };
 
+enum Polarity
+{
+  Positive,
+  Negative
+};
+
 } // namespace Rust
 
 #endif // RUST_COMMON


### PR DESCRIPTION
The internal representation now tracks whether a trait impl is a
positive or negative impl.

Signed-off-by: Ben Boeckel <mathstuf@gmail.com>

Fixes: #732 
