### PR TITLE
Converted FnType preprocessor defines into constants

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -111,9 +111,9 @@ public:
 	context->insert_type (param.get_mappings (), param_tyty);
       }
 
-    uint8_t flags = FNTYPE_IS_EXTERN_FLAG;
+    uint8_t flags = TyTy::FnType::FNTYPE_IS_EXTERN_FLAG;
     if (function.is_variadic ())
-      flags |= FNTYPE_IS_VARADIC_FLAG;
+      flags |= TyTy::FnType::FNTYPE_IS_VARADIC_FLAG;
 
     auto fnType = new TyTy::FnType (
       function.get_mappings ().get_hirid (),
@@ -272,11 +272,14 @@ public:
 	context->insert_type (param.get_mappings (), param_tyty);
       }
 
-    auto fnType = new TyTy::FnType (
-      function.get_mappings ().get_hirid (),
-      function.get_mappings ().get_defid (), function.get_function_name (),
-      function.is_method () ? FNTYPE_IS_METHOD_FLAG : FNTYPE_DEFAULT_FLAGS,
-      ABI::RUST, std::move (params), ret_type, std::move (substitutions));
+    auto fnType = new TyTy::FnType (function.get_mappings ().get_hirid (),
+				    function.get_mappings ().get_defid (),
+				    function.get_function_name (),
+				    function.is_method ()
+				      ? TyTy::FnType::FNTYPE_IS_METHOD_FLAG
+				      : TyTy::FnType::FNTYPE_DEFAULT_FLAGS,
+				    ABI::RUST, std::move (params), ret_type,
+				    std::move (substitutions));
 
     context->insert_type (function.get_mappings (), fnType);
   }

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.h
@@ -331,12 +331,12 @@ public:
 	context->insert_type (param.get_mappings (), param_tyty);
       }
 
-    auto fnType
-      = new TyTy::FnType (function.get_mappings ().get_hirid (),
-			  function.get_mappings ().get_defid (),
-			  function.get_function_name (), FNTYPE_DEFAULT_FLAGS,
-			  ABI::RUST, std::move (params), ret_type,
-			  std::move (substitutions));
+    auto fnType = new TyTy::FnType (function.get_mappings ().get_hirid (),
+				    function.get_mappings ().get_defid (),
+				    function.get_function_name (),
+				    TyTy::FnType::FNTYPE_DEFAULT_FLAGS,
+				    ABI::RUST, std::move (params), ret_type,
+				    std::move (substitutions));
     context->insert_type (function.get_mappings (), fnType);
 
     TyTy::FnType *resolved_fn_type = fnType;

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
@@ -290,12 +290,12 @@ public:
 	context->insert_type (param.get_mappings (), param_tyty);
       }
 
-    auto fnType
-      = new TyTy::FnType (function.get_mappings ().get_hirid (),
-			  function.get_mappings ().get_defid (),
-			  function.get_function_name (), FNTYPE_DEFAULT_FLAGS,
-			  ABI::RUST, std::move (params), ret_type,
-			  std::move (substitutions));
+    auto fnType = new TyTy::FnType (function.get_mappings ().get_hirid (),
+				    function.get_mappings ().get_defid (),
+				    function.get_function_name (),
+				    TyTy::FnType::FNTYPE_DEFAULT_FLAGS,
+				    ABI::RUST, std::move (params), ret_type,
+				    std::move (substitutions));
     context->insert_type (function.get_mappings (), fnType);
   }
 

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -583,8 +583,9 @@ TraitItemReference::get_type_from_fn (/*const*/ HIR::TraitItemFunc &fn) const
     = new TyTy::FnType (fn.get_mappings ().get_hirid (),
 			fn.get_mappings ().get_defid (),
 			function.get_function_name (),
-			function.is_method () ? FNTYPE_IS_METHOD_FLAG
-					      : FNTYPE_DEFAULT_FLAGS,
+			function.is_method ()
+			  ? TyTy::FnType::FNTYPE_IS_METHOD_FLAG
+			  : TyTy::FnType::FNTYPE_DEFAULT_FLAGS,
 			ABI::RUST, std::move (params), ret_type, substitutions);
 
   context->insert_type (fn.get_mappings (), resolved);

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -1138,11 +1138,10 @@ private:
 class FnType : public BaseType, public SubstitutionRef
 {
 public:
-  // FIXME these could be constants
-#define FNTYPE_DEFAULT_FLAGS 0x00
-#define FNTYPE_IS_METHOD_FLAG 0x01
-#define FNTYPE_IS_EXTERN_FLAG 0x02
-#define FNTYPE_IS_VARADIC_FLAG 0X04
+  static const uint8_t FNTYPE_DEFAULT_FLAGS = 0x00;
+  static const uint8_t FNTYPE_IS_METHOD_FLAG = 0x01;
+  static const uint8_t FNTYPE_IS_EXTERN_FLAG = 0x02;
+  static const uint8_t FNTYPE_IS_VARADIC_FLAG = 0X04;
 
   FnType (HirId ref, DefId id, std::string identifier, uint8_t flags, ABI abi,
 	  std::vector<std::pair<HIR::Pattern *, BaseType *>> params,


### PR DESCRIPTION
Fixes #737 

I have converted FnType preprocessor defines to static const of uint8_t. I did not change the variable case.
