### PR TITLE
Removed lambda in iterate_params within CallExpr and MethodCallExpr

### DIFF
--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -1916,15 +1916,6 @@ public:
   void mark_for_strip () override { function = nullptr; }
   bool is_marked_for_strip () const override { return function == nullptr; }
 
-  void iterate_params (std::function<bool (Expr *)> cb)
-  {
-    for (auto &param : params)
-      {
-	if (!cb (param.get ()))
-	  return;
-      }
-  }
-
   // TODO: this mutable getter seems really dodgy. Think up better way.
   const std::vector<std::unique_ptr<Expr> > &get_params () const
   {
@@ -2024,15 +2015,6 @@ public:
   // Invalid if receiver expr is null, so base stripping on that.
   void mark_for_strip () override { receiver = nullptr; }
   bool is_marked_for_strip () const override { return receiver == nullptr; }
-
-  void iterate_params (std::function<bool (Expr *)> cb)
-  {
-    for (auto &param : params)
-      {
-	if (!cb (param.get ()))
-	  return;
-      }
-  }
 
   // TODO: this mutable getter seems really dodgy. Think up better way.
   const std::vector<std::unique_ptr<Expr> > &get_params () const

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -192,12 +192,14 @@ public:
   {
     HIR::Expr *func
       = ASTLoweringExpr::translate (expr.get_function_expr ().get ());
+
+    auto const &in_params = expr.get_params ();
     std::vector<std::unique_ptr<HIR::Expr> > params;
-    expr.iterate_params ([&] (AST::Expr *p) mutable -> bool {
-      auto trans = ASTLoweringExpr::translate (p);
-      params.push_back (std::unique_ptr<HIR::Expr> (trans));
-      return true;
-    });
+    for (auto &param : in_params)
+      {
+	auto trans = ASTLoweringExpr::translate (param.get ());
+	params.push_back (std::unique_ptr<HIR::Expr> (trans));
+      }
 
     auto crate_num = mappings->get_current_crate ();
     Analysis::NodeMapping mapping (
@@ -217,12 +219,13 @@ public:
     HIR::Expr *receiver
       = ASTLoweringExpr::translate (expr.get_receiver_expr ().get ());
 
+    auto const &in_params = expr.get_params ();
     std::vector<std::unique_ptr<HIR::Expr> > params;
-    expr.iterate_params ([&] (AST::Expr *p) mutable -> bool {
-      auto trans = ASTLoweringExpr::translate (p);
-      params.push_back (std::unique_ptr<HIR::Expr> (trans));
-      return true;
-    });
+    for (auto &param : in_params)
+      {
+	auto trans = ASTLoweringExpr::translate (param.get ());
+	params.push_back (std::unique_ptr<HIR::Expr> (trans));
+      }
 
     auto crate_num = mappings->get_current_crate ();
     Analysis::NodeMapping mapping (crate_num, expr.get_node_id (),

--- a/gcc/rust/resolve/rust-ast-resolve-expr.h
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.h
@@ -101,10 +101,9 @@ public:
   void visit (AST::CallExpr &expr) override
   {
     ResolveExpr::go (expr.get_function_expr ().get (), expr.get_node_id ());
-    expr.iterate_params ([&] (AST::Expr *p) mutable -> bool {
-      ResolveExpr::go (p, expr.get_node_id ());
-      return true;
-    });
+    auto const &in_params = expr.get_params ();
+    for (auto &param : in_params)
+      ResolveExpr::go (param.get (), expr.get_node_id ());
   }
 
   void visit (AST::MethodCallExpr &expr) override
@@ -117,10 +116,9 @@ public:
 	ResolveTypeToCanonicalPath::type_resolve_generic_args (args);
       }
 
-    expr.iterate_params ([&] (AST::Expr *p) mutable -> bool {
-      ResolveExpr::go (p, expr.get_node_id ());
-      return true;
-    });
+    auto const &in_params = expr.get_params ();
+    for (auto &param : in_params)
+      ResolveExpr::go (param.get (), expr.get_node_id ());
   }
 
   void visit (AST::AssignmentExpr &expr) override


### PR DESCRIPTION
Signed-off-by: Nirmal Patel <npate012@gmail.com>

Removed iterate_params from AST::CallExpr and AST::MethodCallExpr.

Fixes #722 #723 
