### PR TITLE
Tag 'rust_fatal_error' as 'noreturn'

### DIFF
--- a/gcc/rust/rust-diagnostics.h
+++ b/gcc/rust/rust-diagnostics.h
@@ -57,7 +57,8 @@ rust_warning_at (const Location, int opt, const char *fmt, ...)
   RUST_ATTRIBUTE_GCC_DIAG (3, 4);
 extern void
 rust_fatal_error (const Location, const char *fmt, ...)
-  RUST_ATTRIBUTE_GCC_DIAG (2, 3);
+  RUST_ATTRIBUTE_GCC_DIAG (2, 3)
+  RUST_ATTRIBUTE_NORETURN;
 extern void
 rust_inform (const Location, const char *fmt, ...)
   RUST_ATTRIBUTE_GCC_DIAG (2, 3);
@@ -88,7 +89,8 @@ rust_be_error_at (const RichLocation &, const std::string &errmsg);
 extern void
 rust_be_warning_at (const Location, int opt, const std::string &warningmsg);
 extern void
-rust_be_fatal_error (const Location, const std::string &errmsg);
+rust_be_fatal_error (const Location, const std::string &errmsg)
+  RUST_ATTRIBUTE_NORETURN;
 extern void
 rust_be_inform (const Location, const std::string &infomsg);
 extern void

--- a/gcc/rust/rust-system.h
+++ b/gcc/rust/rust-system.h
@@ -59,6 +59,8 @@
 #include "diagnostic-core.h" /* For error_at and friends.  */
 #include "intl.h"	     /* For _().  */
 
+#define RUST_ATTRIBUTE_NORETURN ATTRIBUTE_NORETURN
+
 // File separator to use based on whether or not the OS we're working with is
 // DOS-based
 #if defined(HAVE_DOS_BASED_FILE_SYSTEM)


### PR DESCRIPTION
... like GCC's underlying 'fatal_error'.

By definition, we cannot continue, upon having run into a fatal error.
