### PR TITLE
Add location info in AST::TypeBoundWhereClauseItem and HIR::TypeBoundWhereClauseItem

### DIFF
--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -228,6 +228,7 @@ class TypeBoundWhereClauseItem : public WhereClauseItem
   std::unique_ptr<Type> bound_type;
   std::vector<std::unique_ptr<TypeParamBound>> type_param_bounds;
   NodeId node_id;
+  Location locus;
 
 public:
   // Returns whether the item has ForLifetimes
@@ -238,11 +239,12 @@ public:
 
   TypeBoundWhereClauseItem (
     std::vector<LifetimeParam> for_lifetimes, std::unique_ptr<Type> bound_type,
-    std::vector<std::unique_ptr<TypeParamBound>> type_param_bounds)
+    std::vector<std::unique_ptr<TypeParamBound>> type_param_bounds,
+    Location locus)
     : for_lifetimes (std::move (for_lifetimes)),
       bound_type (std::move (bound_type)),
       type_param_bounds (std::move (type_param_bounds)),
-      node_id (Analysis::Mappings::get ()->get_next_node_id ())
+      node_id (Analysis::Mappings::get ()->get_next_node_id ()), locus (locus)
   {}
 
   // Copy constructor requires clone
@@ -297,6 +299,8 @@ public:
   }
 
   NodeId get_node_id () const override final { return node_id; }
+
+  Location get_locus () const { return locus; }
 
 protected:
   // Clone function implementation as (not pure) virtual method

--- a/gcc/rust/hir/rust-ast-lower-type.h
+++ b/gcc/rust/hir/rust-ast-lower-type.h
@@ -479,7 +479,8 @@ public:
     translated
       = new HIR::TypeBoundWhereClauseItem (mapping, std::move (for_lifetimes),
 					   std::move (bound_type),
-					   std::move (type_param_bounds));
+					   std::move (type_param_bounds),
+					   item.get_locus ());
   }
 
 private:

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -218,6 +218,7 @@ class TypeBoundWhereClauseItem : public WhereClauseItem
   std::unique_ptr<Type> bound_type;
   std::vector<std::unique_ptr<TypeParamBound>> type_param_bounds;
   Analysis::NodeMapping mappings;
+  Location locus;
 
 public:
   // Returns whether the item has ForLifetimes
@@ -229,11 +230,12 @@ public:
   TypeBoundWhereClauseItem (
     Analysis::NodeMapping mappings, std::vector<LifetimeParam> for_lifetimes,
     std::unique_ptr<Type> bound_type,
-    std::vector<std::unique_ptr<TypeParamBound>> type_param_bounds)
+    std::vector<std::unique_ptr<TypeParamBound>> type_param_bounds,
+    Location locus)
     : for_lifetimes (std::move (for_lifetimes)),
       bound_type (std::move (bound_type)),
       type_param_bounds (std::move (type_param_bounds)),
-      mappings (std::move (mappings))
+      mappings (std::move (mappings)), locus (locus)
   {}
 
   // Copy constructor requires clone

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -3612,10 +3612,12 @@ Parser<ManagedTokenSource>::parse_type_bound_where_clause_item ()
   std::vector<std::unique_ptr<AST::TypeParamBound>> type_param_bounds
     = parse_type_param_bounds ();
 
+  Location locus = lexer.peek_token ()->get_locus ();
+
   return std::unique_ptr<AST::TypeBoundWhereClauseItem> (
     new AST::TypeBoundWhereClauseItem (std::move (for_lifetimes),
 				       std::move (type),
-				       std::move (type_param_bounds)));
+				       std::move (type_param_bounds), locus));
 }
 
 // Parses a for lifetimes clause, including the for keyword and angle brackets.


### PR DESCRIPTION
Location info has been added to AST::TypeBoundWhereClauseItem and HIR::TypeBoundWhereClauseItem. parse_type_bound_where_clause_item () has been modified to fetch location info and store it in AST::TypeBoundWhereClauseItem.

Fixes #766

Signed-off-by: Nirmal Patel <npate012@gmail.com>
