### PR TITLE
'rust_internal_error_at'

### DIFF
--- a/gcc/rust/backend/rust-compile-implitem.h
+++ b/gcc/rust/backend/rust-compile-implitem.h
@@ -46,12 +46,9 @@ public:
 
     if (is_query_mode
 	&& ctx->get_backend ()->is_error_expression (compiler.reference))
-      {
-	rust_error_at (ref_locus, "failed to compile impl item: %s",
-		       item->as_string ().c_str ());
-	rust_assert (
-	  !ctx->get_backend ()->is_error_expression (compiler.reference));
-      }
+      rust_internal_error_at (ref_locus, "failed to compile impl item: %s",
+			      item->as_string ().c_str ());
+
     return compiler.reference;
   }
 
@@ -339,12 +336,9 @@ public:
 
     if (is_query_mode
 	&& ctx->get_backend ()->is_error_expression (compiler.reference))
-      {
-	rust_error_at (ref_locus, "failed to compile trait item: %s",
-		       item->as_string ().c_str ());
-	rust_assert (
-	  !ctx->get_backend ()->is_error_expression (compiler.reference));
-      }
+      rust_internal_error_at (ref_locus, "failed to compile trait item: %s",
+			      item->as_string ().c_str ());
+
     return compiler.reference;
   }
 

--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -48,12 +48,9 @@ public:
 
     if (is_query_mode
 	&& ctx->get_backend ()->is_error_expression (compiler.reference))
-      {
-	rust_error_at (ref_locus, "failed to compile item: %s",
-		       item->as_string ().c_str ());
-	rust_assert (
-	  !ctx->get_backend ()->is_error_expression (compiler.reference));
-      }
+      rust_internal_error_at (ref_locus, "failed to compile item: %s",
+			      item->as_string ().c_str ());
+
     return compiler.reference;
   }
 

--- a/gcc/rust/rust-diagnostics.cc
+++ b/gcc/rust/rust-diagnostics.cc
@@ -147,6 +147,16 @@ rust_close_quote ()
 }
 
 void
+rust_internal_error_at (const Location location, const char *fmt, ...)
+{
+  va_list ap;
+
+  va_start (ap, fmt);
+  rust_be_internal_error_at (location, expand_message (fmt, ap));
+  va_end (ap);
+}
+
+void
 rust_error_at (const Location location, const char *fmt, ...)
 {
   va_list ap;

--- a/gcc/rust/rust-diagnostics.h
+++ b/gcc/rust/rust-diagnostics.h
@@ -50,6 +50,10 @@
 
 // simple location
 extern void
+rust_internal_error_at (const Location, const char *fmt, ...)
+  RUST_ATTRIBUTE_GCC_DIAG (2, 3)
+  RUST_ATTRIBUTE_NORETURN;
+extern void
 rust_error_at (const Location, const char *fmt, ...)
   RUST_ATTRIBUTE_GCC_DIAG (2, 3);
 extern void
@@ -81,6 +85,9 @@ rust_close_quote ();
 // instead use the equivalent routines above. The back end is required to
 // implement these routines.
 
+extern void
+rust_be_internal_error_at (const Location, const std::string &errmsg)
+  RUST_ATTRIBUTE_NORETURN;
 extern void
 rust_be_error_at (const Location, const std::string &errmsg);
 extern void

--- a/gcc/rust/rust-gcc-diagnostics.cc
+++ b/gcc/rust/rust-gcc-diagnostics.cc
@@ -24,6 +24,16 @@
 #include "options.h"
 
 void
+rust_be_internal_error_at (const Location location, const std::string &errmsg)
+{
+  std::string loc_str = Linemap::location_to_string (location);
+  if (loc_str.empty ())
+    internal_error ("%s", errmsg.c_str ());
+  else
+    internal_error ("at %s, %s", loc_str.c_str (), errmsg.c_str ());
+}
+
+void
 rust_be_error_at (const Location location, const std::string &errmsg)
 {
   location_t gcc_loc = location.gcc_location ();

--- a/gcc/rust/rust-system.h
+++ b/gcc/rust/rust-system.h
@@ -59,6 +59,8 @@
 #include "diagnostic-core.h" /* For error_at and friends.  */
 #include "intl.h"	     /* For _().  */
 
+#define RUST_ATTRIBUTE_NORETURN ATTRIBUTE_NORETURN
+
 // File separator to use based on whether or not the OS we're working with is
 // DOS-based
 #if defined(HAVE_DOS_BASED_FILE_SYSTEM)


### PR DESCRIPTION
... to be used for internal sanity checks, where in case of failure you'd like to provide/print more information than a plain 'rust_assert'.
