### PR TITLE
No side effects in 'assert' expressions

### DIFF
--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -53,11 +53,12 @@ public:
     for (auto it = builtins.begin (); it != builtins.end (); it++)
       {
 	HirId ref;
-	rust_assert (
-	  tyctx->lookup_type_by_node_id ((*it)->get_node_id (), &ref));
+	bool ok = tyctx->lookup_type_by_node_id ((*it)->get_node_id (), &ref);
+	rust_assert (ok);
 
 	TyTy::BaseType *lookup;
-	rust_assert (tyctx->lookup_type (ref, &lookup));
+	ok = tyctx->lookup_type (ref, &lookup);
+	rust_assert (ok);
 
 	Btype *compiled = TyTyCompile::compile (backend, lookup);
 	compiled_type_map.insert (std::pair<HirId, Btype *> (ref, compiled));

--- a/gcc/rust/backend/rust-compile-implitem.h
+++ b/gcc/rust/backend/rust-compile-implitem.h
@@ -67,9 +67,10 @@ public:
     Bexpression *value = CompileExpr::Compile (constant.get_expr (), ctx);
 
     const Resolver::CanonicalPath *canonical_path = nullptr;
-    rust_assert (ctx->get_mappings ()->lookup_canonical_path (
+    ok = ctx->get_mappings ()->lookup_canonical_path (
       constant.get_mappings ().get_crate_num (),
-      constant.get_mappings ().get_nodeid (), &canonical_path));
+      constant.get_mappings ().get_nodeid (), &canonical_path);
+    rust_assert (ok);
 
     std::string ident = canonical_path->get ();
     Bexpression *const_expr = ctx->get_backend ()->named_constant_expression (
@@ -148,9 +149,10 @@ public:
       flags |= Backend::function_is_visible;
 
     const Resolver::CanonicalPath *canonical_path = nullptr;
-    rust_assert (ctx->get_mappings ()->lookup_canonical_path (
+    bool ok = ctx->get_mappings ()->lookup_canonical_path (
       function.get_mappings ().get_crate_num (),
-      function.get_mappings ().get_nodeid (), &canonical_path));
+      function.get_mappings ().get_nodeid (), &canonical_path);
+    rust_assert (ok);
 
     std::string ir_symbol_name
       = canonical_path->get () + fntype->subst_as_string ();
@@ -260,7 +262,7 @@ public:
       }
 
     std::vector<Bvariable *> locals;
-    bool ok = compile_locals_for_block (*rib, fndecl, locals);
+    ok = compile_locals_for_block (*rib, fndecl, locals);
     rust_assert (ok);
 
     Bblock *enclosing_scope = NULL;
@@ -358,9 +360,10 @@ public:
       = CompileExpr::Compile (constant.get_expr ().get (), ctx);
 
     const Resolver::CanonicalPath *canonical_path = nullptr;
-    rust_assert (ctx->get_mappings ()->lookup_canonical_path (
+    bool ok = ctx->get_mappings ()->lookup_canonical_path (
       constant.get_mappings ().get_crate_num (),
-      constant.get_mappings ().get_nodeid (), &canonical_path));
+      constant.get_mappings ().get_nodeid (), &canonical_path);
+    rust_assert (ok);
 
     std::string ident = canonical_path->get ();
     Bexpression *const_expr = ctx->get_backend ()->named_constant_expression (
@@ -413,9 +416,10 @@ public:
     unsigned int flags = 0;
 
     const Resolver::CanonicalPath *canonical_path = nullptr;
-    rust_assert (ctx->get_mappings ()->lookup_canonical_path (
+    bool ok = ctx->get_mappings ()->lookup_canonical_path (
       func.get_mappings ().get_crate_num (), func.get_mappings ().get_nodeid (),
-      &canonical_path));
+      &canonical_path);
+    rust_assert (ok);
 
     std::string fn_identifier = canonical_path->get ();
     std::string asm_name = ctx->mangle_item (fntype, *canonical_path);
@@ -522,7 +526,7 @@ public:
       }
 
     std::vector<Bvariable *> locals;
-    bool ok = compile_locals_for_block (*rib, fndecl, locals);
+    ok = compile_locals_for_block (*rib, fndecl, locals);
     rust_assert (ok);
 
     Bblock *enclosing_scope = NULL;

--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -68,9 +68,10 @@ public:
     Bexpression *value = CompileExpr::Compile (var.get_expr (), ctx);
 
     const Resolver::CanonicalPath *canonical_path = nullptr;
-    rust_assert (ctx->get_mappings ()->lookup_canonical_path (
+    ok = ctx->get_mappings ()->lookup_canonical_path (
       var.get_mappings ().get_crate_num (), var.get_mappings ().get_nodeid (),
-      &canonical_path));
+      &canonical_path);
+    rust_assert (ok);
 
     std::string name = canonical_path->get ();
     std::string asm_name = ctx->mangle_item (resolved_type, *canonical_path);
@@ -103,9 +104,10 @@ public:
     Bexpression *value = CompileExpr::Compile (constant.get_expr (), ctx);
 
     const Resolver::CanonicalPath *canonical_path = nullptr;
-    rust_assert (ctx->get_mappings ()->lookup_canonical_path (
+    ok = ctx->get_mappings ()->lookup_canonical_path (
       constant.get_mappings ().get_crate_num (),
-      constant.get_mappings ().get_nodeid (), &canonical_path));
+      constant.get_mappings ().get_nodeid (), &canonical_path);
+    rust_assert (ok);
 
     std::string ident = canonical_path->get ();
     Bexpression *const_expr
@@ -186,9 +188,10 @@ public:
       flags |= Backend::function_is_visible;
 
     const Resolver::CanonicalPath *canonical_path = nullptr;
-    rust_assert (ctx->get_mappings ()->lookup_canonical_path (
+    bool ok = ctx->get_mappings ()->lookup_canonical_path (
       function.get_mappings ().get_crate_num (),
-      function.get_mappings ().get_nodeid (), &canonical_path));
+      function.get_mappings ().get_nodeid (), &canonical_path);
+    rust_assert (ok);
 
     std::string ir_symbol_name
       = canonical_path->get () + fntype->subst_as_string ();
@@ -259,7 +262,7 @@ public:
       }
 
     std::vector<Bvariable *> locals;
-    bool ok = compile_locals_for_block (*rib, fndecl, locals);
+    ok = compile_locals_for_block (*rib, fndecl, locals);
     rust_assert (ok);
 
     Bblock *enclosing_scope = NULL;

--- a/gcc/rust/backend/rust-compile-stmt.h
+++ b/gcc/rust/backend/rust-compile-stmt.h
@@ -60,9 +60,10 @@ public:
     Bexpression *value = CompileExpr::Compile (constant.get_expr (), ctx);
 
     const Resolver::CanonicalPath *canonical_path = nullptr;
-    rust_assert (ctx->get_mappings ()->lookup_canonical_path (
+    ok = ctx->get_mappings ()->lookup_canonical_path (
       constant.get_mappings ().get_crate_num (),
-      constant.get_mappings ().get_nodeid (), &canonical_path));
+      constant.get_mappings ().get_nodeid (), &canonical_path);
+    rust_assert (ok);
 
     std::string ident = canonical_path->get ();
     Bexpression *const_expr


### PR DESCRIPTION
Usually, if 'assert'ions are disabled, 'assert' expressions are not evaluated,
so in that case won't effect any side effects.

Via spurious ICEs/test suite FAILs, this may be observed in GCC/Rust, for
example, if configuring with '--enable-checking=no' and disabling a "more
forgiving" 'gcc/system.h:gcc_assert' definition, so that '0 && (EXPR)' gets
used:

     /* Use gcc_assert(EXPR) to test invariants.  */
     #if ENABLE_ASSERT_CHECKING
     #define gcc_assert(EXPR)                                               \
        ((void)(!(EXPR) ? fancy_abort (__FILE__, __LINE__, __FUNCTION__), 0 : 0))
    -#elif (GCC_VERSION >= 4005)
    +#elif (0) //GCC_VERSION >= 4005)
     #define gcc_assert(EXPR)                                               \
       ((void)(__builtin_expect (!(EXPR), 0) ? __builtin_unreachable (), 0 : 0))
     #else
     /* Include EXPR, so that unused variable warnings do not occur.  */
     #define gcc_assert(EXPR) ((void)(0 && (EXPR)))
     #endif

As that one does cause some issues in GCC proper (that I shall fix separately),
may use this change to 'gcc/rust/rust-system.h:rust_assert' instead:

    +#if 0
     #define rust_assert(EXPR) gcc_assert (EXPR)
    +#else
    +#define rust_assert(EXPR) ((void) (0 && (EXPR)))
    +#endif

To fix these, use the same pattern as is already used in a lot of existing
GCC/Rust code:

    bool ok = [expression with side effects];
    rust_assert (ok);

I've only done a quick manual review; maybe there is a tool for doing this?
