### PR TITLE
Get rid of lambda within `AST::TypePath` and provide a method to return a reference

### DIFF
--- a/gcc/rust/ast/rust-path.h
+++ b/gcc/rust/ast/rust-path.h
@@ -754,15 +754,6 @@ public:
   }
 
   size_t get_num_segments () const { return segments.size (); }
-
-  void iterate_segments (std::function<bool (TypePathSegment *)> cb)
-  {
-    for (auto it = segments.begin (); it != segments.end (); it++)
-      {
-	if (!cb ((*it).get ()))
-	  return;
-      }
-  }
 };
 
 struct QualifiedPathType
@@ -1029,15 +1020,6 @@ public:
   }
 
   Location get_locus () const override final { return locus; }
-
-  void iterate_segments (std::function<bool (TypePathSegment *)> cb)
-  {
-    for (auto it = segments.begin (); it != segments.end (); it++)
-      {
-	if (!cb ((*it).get ()))
-	  return;
-      }
-  }
 };
 } // namespace AST
 } // namespace Rust

--- a/gcc/rust/hir/rust-ast-lower-type.h
+++ b/gcc/rust/hir/rust-ast-lower-type.h
@@ -62,20 +62,18 @@ public:
   {
     std::vector<std::unique_ptr<HIR::TypePathSegment>> translated_segments;
 
-    path.iterate_segments ([&] (AST::TypePathSegment *seg) mutable -> bool {
-      translated_segment = nullptr;
-      seg->accept_vis (*this);
-      if (translated_segment == nullptr)
-	{
-	  rust_fatal_error (seg->get_locus (),
-			    "failed to translate AST TypePathSegment");
-	  return false;
-	}
-
-      translated_segments.push_back (
-	std::unique_ptr<HIR::TypePathSegment> (translated_segment));
-      return true;
-    });
+    for (auto &seg : path.get_segments ())
+      {
+	translated_segment = nullptr;
+	seg->accept_vis (*this);
+	if (translated_segment == nullptr)
+	  {
+	    rust_fatal_error (seg->get_locus (),
+			      "failed to translate AST TypePathSegment");
+	  }
+	translated_segments.push_back (
+	  std::unique_ptr<HIR::TypePathSegment> (translated_segment));
+      }
 
     auto crate_num = mappings->get_current_crate ();
     auto hirid = mappings->get_next_hir_id (crate_num);

--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -490,20 +490,18 @@ ASTLowerQualifiedPathInType::visit (AST::QualifiedPathInType &path)
   std::unique_ptr<HIR::TypePathSegment> associated_segment (translated_segment);
 
   std::vector<std::unique_ptr<HIR::TypePathSegment> > translated_segments;
-  path.iterate_segments ([&] (AST::TypePathSegment *seg) mutable -> bool {
-    translated_segment = nullptr;
-    seg->accept_vis (*this);
-    if (translated_segment == nullptr)
-      {
-	rust_fatal_error (seg->get_locus (),
-			  "failed to translate AST TypePathSegment");
-	return false;
-      }
-
-    translated_segments.push_back (
-      std::unique_ptr<HIR::TypePathSegment> (translated_segment));
-    return true;
-  });
+  for (auto &seg : path.get_segments ())
+    {
+      translated_segment = nullptr;
+      seg->accept_vis (*this);
+      if (translated_segment == nullptr)
+	{
+	  rust_fatal_error (seg->get_locus (),
+			    "failed to translte AST TypePathSegment");
+	}
+      translated_segments.push_back (
+	std::unique_ptr<HIR::TypePathSegment> (translated_segment));
+    }
 
   Analysis::NodeMapping mapping (crate_num, path.get_node_id (), hirid,
 				 mappings->get_next_localdef_id (crate_num));


### PR DESCRIPTION
## Related issue

This PR will fix <https://github.com/Rust-GCC/gccrs/issues/718>

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`
- \[x] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.

