### PR TITLE
gha: save `check-rust` results as artifacts

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -47,6 +47,12 @@ jobs:
       run: |
            cd gccrs-build; \
            make check-rust
+    - name: Archive check-rust results
+      uses: actions/upload-artifact@v2
+      with:
+        name: check-rust-logs
+        path: |
+          gccrs-build/gcc/testsuite/rust/
     - name: Check regressions
       run: |
            cd gccrs-build; \

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -52,6 +52,12 @@ jobs:
       run: |
            cd gccrs-build; \
            make check-rust
+    - name: Archive check-rust results
+      uses: actions/upload-artifact@v2
+      with:
+        name: check-rust-logs
+        path: |
+          gccrs-build/gcc/testsuite/rust/
     - name: Check regressions
       run: |
            cd gccrs-build; \


### PR DESCRIPTION
They will stick around for 90 days (as per GitHub default limits).

     https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts

Signed-off-by: Ben Boeckel <mathstuf@gmail.com>

Fixes: #634 
