### PR TITLE
Change DefId type from uint64_t to be struct

### DIFF
--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -1297,7 +1297,7 @@ public:
       params (std::move (params)), type (type), flags (flags),
       identifier (identifier), id (id), abi (abi)
   {
-    LocalDefId local_def_id = id & DEF_ID_LOCAL_DEF_MASK;
+    LocalDefId local_def_id = id.localDefId;
     rust_assert (local_def_id != UNKNOWN_LOCAL_DEFID);
   }
 
@@ -1312,7 +1312,7 @@ public:
       params (params), type (type), flags (flags), identifier (identifier),
       id (id), abi (abi)
   {
-    LocalDefId local_def_id = id & DEF_ID_LOCAL_DEF_MASK;
+    LocalDefId local_def_id = id.localDefId;
     rust_assert (local_def_id != UNKNOWN_LOCAL_DEFID);
   }
 
@@ -1471,7 +1471,7 @@ public:
       parameter_types (std::move (parameter_types)),
       result_type (std::move (result_type)), id (id)
   {
-    LocalDefId local_def_id = id & DEF_ID_LOCAL_DEF_MASK;
+    LocalDefId local_def_id = id.localDefId;
     rust_assert (local_def_id != UNKNOWN_LOCAL_DEFID);
   }
 
@@ -1485,7 +1485,7 @@ public:
       parameter_types (std::move (parameter_types)),
       result_type (std::move (result_type)), id (id)
   {
-    LocalDefId local_def_id = id & DEF_ID_LOCAL_DEF_MASK;
+    LocalDefId local_def_id = id.localDefId;
     rust_assert (local_def_id != UNKNOWN_LOCAL_DEFID);
   }
 

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -63,7 +63,7 @@ NodeMapping::get_defid () const
 DefId
 NodeMapping::get_defid (CrateNum crate_num, LocalDefId local_defid)
 {
-  return ((uint64_t) crate_num << 32) | local_defid;
+  return DefId{crate_num, local_defid};
 }
 
 std::string
@@ -209,8 +209,8 @@ Mappings::insert_hir_crate (HIR::Crate *crate)
 void
 Mappings::insert_defid_mapping (DefId id, HIR::Item *item)
 {
-  CrateNum crate_num = (id & DEF_ID_CRATE_MASK) >> 32;
-  LocalDefId local_def_id = id & DEF_ID_LOCAL_DEF_MASK;
+  CrateNum crate_num = id.crateNum;
+  LocalDefId local_def_id = id.localDefId;
 
   rust_assert (lookup_defid (id) == nullptr);
   rust_assert (lookup_local_defid (crate_num, local_def_id) == nullptr);

--- a/gcc/rust/util/rust-mapping-common.h
+++ b/gcc/rust/util/rust-mapping-common.h
@@ -31,17 +31,32 @@ typedef uint32_t NodeId;
 typedef uint32_t HirId;
 // refers to any top-level decl in HIR
 typedef uint32_t LocalDefId;
-// refers to <Crate><DefId>
-typedef uint64_t DefId;
 
-#define DEF_ID_CRATE_MASK 0xFFFFFFFF00000000
-#define DEF_ID_LOCAL_DEF_MASK 0x00000000FFFFFFFF
+struct DefId
+{
+  CrateNum crateNum;
+  LocalDefId localDefId;
+
+  bool operator== (const DefId &other) const
+  {
+    return this->crateNum == other.crateNum
+	   && this->localDefId == other.localDefId;
+  }
+
+  bool operator!= (const DefId &other) const { return !(*this == other); }
+
+  bool operator< (const DefId &other) const
+  {
+    return ((uint64_t) this->crateNum << 32 | this->localDefId)
+	   < ((uint64_t) other.crateNum << 32 | other.localDefId);
+  }
+};
 
 #define UNKNOWN_CREATENUM ((uint32_t) (0))
 #define UNKNOWN_NODEID ((uint32_t) (0))
 #define UNKNOWN_HIRID ((uint32_t) (0))
 #define UNKNOWN_LOCAL_DEFID ((uint32_t) (0))
-#define UNKNOWN_DEFID ((uint64_t) (0))
+#define UNKNOWN_DEFID (DefId{0, 0})
 
 } // namespace Rust
 


### PR DESCRIPTION
DefId was uint64_t previously but it has been changed to be a struct.
In order to reduce code breakage, ==, !=, and < operators have been implemented
for DefId. Since DefId is now a proper struct, bit manipulation code has been
removed with member accesses.

Fixes #439

Signed-off-by: Nirmal Patel <npate012@gmail.com>