### PR TITLE
Fix unhandled type bounds in TypeAlias

### DIFF
--- a/gcc/rust/ast/rust-type.h
+++ b/gcc/rust/ast/rust-type.h
@@ -162,10 +162,7 @@ public:
 class TraitObjectType : public Type
 {
   bool has_dyn;
-  // TypeParamBounds type_param_bounds;
-  std::vector<std::unique_ptr<TypeParamBound> >
-    type_param_bounds; // inlined form
-
+  std::vector<std::unique_ptr<TypeParamBound> > type_param_bounds;
   Location locus;
 
 protected:
@@ -179,7 +176,7 @@ protected:
 public:
   TraitObjectType (
     std::vector<std::unique_ptr<TypeParamBound> > type_param_bounds,
-    Location locus, bool is_dyn_dispatch = false)
+    Location locus, bool is_dyn_dispatch)
     : has_dyn (is_dyn_dispatch),
       type_param_bounds (std::move (type_param_bounds)), locus (locus)
   {}
@@ -214,6 +211,8 @@ public:
   Location get_locus () const override final { return locus; }
 
   void accept_vis (ASTVisitor &vis) override;
+
+  bool is_dyn () const { return has_dyn; }
 
   // TODO: mutable getter seems kinda dodgy
   std::vector<std::unique_ptr<TypeParamBound> > &get_type_param_bounds ()

--- a/gcc/rust/backend/rust-compile-base.h
+++ b/gcc/rust/backend/rust-compile-base.h
@@ -177,7 +177,6 @@ public:
   virtual void visit (HIR::TraitObjectType &type) {}
   virtual void visit (HIR::ParenthesisedType &type) {}
   virtual void visit (HIR::ImplTraitTypeOneBound &type) {}
-  virtual void visit (HIR::TraitObjectTypeOneBound &type) {}
   virtual void visit (HIR::TupleType &type) {}
   virtual void visit (HIR::NeverType &type) {}
   virtual void visit (HIR::RawPointerType &type) {}

--- a/gcc/rust/backend/rust-compile-base.h
+++ b/gcc/rust/backend/rust-compile-base.h
@@ -209,9 +209,12 @@ protected:
 				     const TyTy::DynamicObjectType *ty,
 				     Location locus);
 
-  Bexpression *
-  compute_address_for_trait_item (const Resolver::TraitItemReference *ref,
-				  const TyTy::BaseType *receiver);
+  Bexpression *compute_address_for_trait_item (
+    const Resolver::TraitItemReference *ref,
+    const TyTy::TypeBoundPredicate *predicate,
+    std::vector<std::pair<Resolver::TraitReference *, HIR::ImplBlock *>>
+      &receiver_bounds,
+    const TyTy::BaseType *receiver, const TyTy::BaseType *root, Location locus);
 };
 
 } // namespace Compile

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -367,6 +367,9 @@ public:
 
   void visit (const TyTy::ParamType &param) override
   {
+    recursion_count++;
+    rust_assert (recursion_count < kDefaultRecusionLimit);
+
     param.resolve ()->accept_vis (*this);
   }
 
@@ -670,12 +673,16 @@ public:
 
 private:
   TyTyResolveCompile (Context *ctx, bool trait_object_mode)
-    : ctx (ctx), trait_object_mode (trait_object_mode), translated (nullptr)
+    : ctx (ctx), trait_object_mode (trait_object_mode), translated (nullptr),
+      recursion_count (0)
   {}
 
   Context *ctx;
   bool trait_object_mode;
   ::Btype *translated;
+  size_t recursion_count;
+
+  static const size_t kDefaultRecusionLimit = 5;
 };
 
 } // namespace Compile

--- a/gcc/rust/backend/rust-compile-implitem.h
+++ b/gcc/rust/backend/rust-compile-implitem.h
@@ -331,7 +331,7 @@ class CompileTraitItem : public HIRCompileBase
   using Rust::Compile::HIRCompileBase::visit;
 
 public:
-  static Bexpression *Compile (TyTy::BaseType *self, HIR::TraitItem *item,
+  static Bexpression *Compile (const TyTy::BaseType *self, HIR::TraitItem *item,
 			       Context *ctx, TyTy::BaseType *concrete,
 			       bool is_query_mode = false,
 			       Location ref_locus = Location ())
@@ -575,14 +575,14 @@ public:
   }
 
 private:
-  CompileTraitItem (TyTy::BaseType *self, Context *ctx,
+  CompileTraitItem (const TyTy::BaseType *self, Context *ctx,
 		    TyTy::BaseType *concrete, Location ref_locus)
     : HIRCompileBase (ctx), self (self), concrete (concrete),
       reference (ctx->get_backend ()->error_expression ()),
       ref_locus (ref_locus)
   {}
 
-  TyTy::BaseType *self;
+  const TyTy::BaseType *self;
   TyTy::BaseType *concrete;
   Bexpression *reference;
   Location ref_locus;

--- a/gcc/rust/hir/rust-ast-lower-type.h
+++ b/gcc/rust/hir/rust-ast-lower-type.h
@@ -293,6 +293,8 @@ public:
 
   void visit (AST::TraitObjectTypeOneBound &type) override;
 
+  void visit (AST::TraitObjectType &type) override;
+
 private:
   ASTLoweringType () : ASTLoweringBase (), translated (nullptr) {}
 

--- a/gcc/rust/hir/tree/rust-hir-full-decls.h
+++ b/gcc/rust/hir/tree/rust-hir-full-decls.h
@@ -218,7 +218,6 @@ class ImplTraitType;
 class TraitObjectType;
 class ParenthesisedType;
 class ImplTraitTypeOneBound;
-class TraitObjectTypeOneBound;
 class TupleType;
 class NeverType;
 class RawPointerType;

--- a/gcc/rust/hir/tree/rust-hir-full-test.cc
+++ b/gcc/rust/hir/tree/rust-hir-full-test.cc
@@ -2893,25 +2893,6 @@ TypePathSegmentGeneric::as_string () const
 }
 
 std::string
-TraitObjectTypeOneBound::as_string () const
-{
-  std::string str ("TraitObjectTypeOneBound: \n Has dyn dispatch: ");
-
-  if (has_dyn)
-    {
-      str += "true";
-    }
-  else
-    {
-      str += "false";
-    }
-
-  str += "\n TraitBound: " + trait_bound.as_string ();
-
-  return str;
-}
-
-std::string
 TypePathFunction::as_string () const
 {
   std::string str ("(");
@@ -4457,12 +4438,6 @@ ParenthesisedType::accept_vis (HIRVisitor &vis)
 
 void
 ImplTraitTypeOneBound::accept_vis (HIRVisitor &vis)
-{
-  vis.visit (*this);
-}
-
-void
-TraitObjectTypeOneBound::accept_vis (HIRVisitor &vis)
 {
   vis.visit (*this);
 }

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -1122,6 +1122,11 @@ public:
   // Returns whether function has a where clause.
   bool has_where_clause () const { return !where_clause.is_empty (); }
 
+  ImplItemType get_impl_item_type () const override final
+  {
+    return ImplItem::ImplItemType::FUNCTION;
+  }
+
   // Mega-constructor with all possible fields
   Function (Analysis::NodeMapping mappings, Identifier function_name,
 	    FunctionQualifiers qualifiers,
@@ -1272,6 +1277,11 @@ public:
 
   // Returns whether type alias has a where clause.
   bool has_where_clause () const { return !where_clause.is_empty (); }
+
+  ImplItemType get_impl_item_type () const override final
+  {
+    return ImplItem::ImplItemType::TYPE_ALIAS;
+  }
 
   // Mega-constructor with all possible fields
   TypeAlias (Analysis::NodeMapping mappings, Identifier new_type_name,
@@ -2074,6 +2084,11 @@ public:
   {
     return get_mappings ();
   };
+
+  ImplItemType get_impl_item_type () const override final
+  {
+    return ImplItem::ImplItemType::CONSTANT;
+  }
 
 protected:
   /* Use covariance to implement clone function as returning this object

--- a/gcc/rust/hir/tree/rust-hir-type.h
+++ b/gcc/rust/hir/tree/rust-hir-type.h
@@ -145,10 +145,7 @@ public:
 class TraitObjectType : public Type
 {
   bool has_dyn;
-  // TypeParamBounds type_param_bounds;
-  std::vector<std::unique_ptr<TypeParamBound> >
-    type_param_bounds; // inlined form
-
+  std::vector<std::unique_ptr<TypeParamBound> > type_param_bounds;
   Location locus;
 
 protected:
@@ -163,7 +160,7 @@ public:
   TraitObjectType (
     Analysis::NodeMapping mappings,
     std::vector<std::unique_ptr<TypeParamBound> > type_param_bounds,
-    Location locus, bool is_dyn_dispatch = false)
+    Location locus, bool is_dyn_dispatch)
     : Type (mappings), has_dyn (is_dyn_dispatch),
       type_param_bounds (std::move (type_param_bounds)), locus (locus)
   {}
@@ -199,6 +196,17 @@ public:
   Location get_locus () const { return locus; }
 
   void accept_vis (HIRVisitor &vis) override;
+
+  std::vector<std::unique_ptr<TypeParamBound> > &get_type_param_bounds ()
+  {
+    return type_param_bounds;
+  }
+
+  const std::vector<std::unique_ptr<TypeParamBound> > &
+  get_type_param_bounds () const
+  {
+    return type_param_bounds;
+  }
 };
 
 // A type with parentheses around it, used to avoid ambiguity.
@@ -303,46 +311,6 @@ public:
   Location get_locus () const { return locus; }
 
   void accept_vis (HIRVisitor &vis) override;
-};
-
-/* A trait object with a single trait bound. The "trait bound" is really just
- * the trait. Basically like using an interface as a type in an OOP language. */
-class TraitObjectTypeOneBound : public TypeNoBounds
-{
-  bool has_dyn;
-  TraitBound trait_bound;
-  Location locus;
-
-protected:
-  /* Use covariance to implement clone function as returning this object rather
-   * than base */
-  TraitObjectTypeOneBound *clone_type_impl () const override
-  {
-    return new TraitObjectTypeOneBound (mappings, trait_bound, locus, has_dyn);
-  }
-
-  /* Use covariance to implement clone function as returning this object rather
-   * than base */
-  TraitObjectTypeOneBound *clone_type_no_bounds_impl () const override
-  {
-    return new TraitObjectTypeOneBound (mappings, trait_bound, locus, has_dyn);
-  }
-
-public:
-  TraitObjectTypeOneBound (Analysis::NodeMapping mappings,
-			   TraitBound trait_bound, Location locus,
-			   bool is_dyn_dispatch)
-    : TypeNoBounds (mappings), has_dyn (is_dyn_dispatch),
-      trait_bound (std::move (trait_bound)), locus (locus)
-  {}
-
-  std::string as_string () const override;
-
-  Location get_locus () const { return locus; }
-
-  void accept_vis (HIRVisitor &vis) override;
-
-  TraitBound &get_trait_bound () { return trait_bound; }
 };
 
 class TypePath; // definition moved to "rust-path.h"

--- a/gcc/rust/hir/tree/rust-hir-visitor.h
+++ b/gcc/rust/hir/tree/rust-hir-visitor.h
@@ -149,7 +149,6 @@ public:
   virtual void visit (TraitObjectType &type) = 0;
   virtual void visit (ParenthesisedType &type) = 0;
   virtual void visit (ImplTraitTypeOneBound &type) = 0;
-  virtual void visit (TraitObjectTypeOneBound &type) = 0;
   virtual void visit (TupleType &type) = 0;
   virtual void visit (NeverType &type) = 0;
   virtual void visit (RawPointerType &type) = 0;

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -642,11 +642,14 @@ public:
 
 class ImplItem
 {
-protected:
-  // Clone function implementation as pure virtual method
-  virtual ImplItem *clone_inherent_impl_item_impl () const = 0;
-
 public:
+  enum ImplItemType
+  {
+    FUNCTION,
+    TYPE_ALIAS,
+    CONSTANT
+  };
+
   virtual ~ImplItem () {}
 
   // Unique pointer custom clone function
@@ -662,6 +665,12 @@ public:
   virtual Analysis::NodeMapping get_impl_mappings () const = 0;
 
   virtual Location get_locus () const = 0;
+
+  virtual ImplItemType get_impl_item_type () const = 0;
+
+protected:
+  // Clone function implementation as pure virtual method
+  virtual ImplItem *clone_inherent_impl_item_impl () const = 0;
 };
 
 // A crate HIR object - holds all the data for a single compilation unit

--- a/gcc/rust/lint/rust-lint-marklive-base.h
+++ b/gcc/rust/lint/rust-lint-marklive-base.h
@@ -172,7 +172,6 @@ public:
   virtual void visit (HIR::TraitObjectType &) override {}
   virtual void visit (HIR::ParenthesisedType &) override {}
   virtual void visit (HIR::ImplTraitTypeOneBound &) override {}
-  virtual void visit (HIR::TraitObjectTypeOneBound &) override {}
   virtual void visit (HIR::TupleType &) override {}
   virtual void visit (HIR::NeverType &) override {}
   virtual void visit (HIR::RawPointerType &) override {}

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -9061,7 +9061,8 @@ Parser<ManagedTokenSource>::parse_type ()
 	  = parse_type_param_bounds ();
 
 	return std::unique_ptr<AST::TraitObjectType> (
-	  new AST::TraitObjectType (std::move (bounds), t->get_locus ()));
+	  new AST::TraitObjectType (std::move (bounds), t->get_locus (),
+				    false));
       }
     case IDENTIFIER:
     case SUPER:
@@ -9148,7 +9149,7 @@ Parser<ManagedTokenSource>::parse_type ()
 		}
 
 	      return std::unique_ptr<AST::TraitObjectType> (
-		new AST::TraitObjectType (std::move (bounds), locus));
+		new AST::TraitObjectType (std::move (bounds), locus, false));
 	    }
 	  default:
 	    // assume that this is a type path and not an error
@@ -9418,7 +9419,8 @@ Parser<ManagedTokenSource>::parse_paren_prefixed_type ()
 	    }
 
 	  return std::unique_ptr<AST::TraitObjectType> (
-	    new AST::TraitObjectType (std::move (bounds), left_delim_locus));
+	    new AST::TraitObjectType (std::move (bounds), left_delim_locus,
+				      false));
 	}
       else
 	{
@@ -9528,7 +9530,7 @@ Parser<ManagedTokenSource>::parse_for_prefixed_type ()
 	  }
 
 	return std::unique_ptr<AST::TraitObjectType> (
-	  new AST::TraitObjectType (std::move (bounds), for_locus));
+	  new AST::TraitObjectType (std::move (bounds), for_locus, false));
       }
     default:
       // error

--- a/gcc/rust/resolve/rust-ast-resolve-type.h
+++ b/gcc/rust/resolve/rust-ast-resolve-type.h
@@ -371,6 +371,8 @@ public:
 
   void visit (AST::TraitObjectTypeOneBound &type) override;
 
+  void visit (AST::TraitObjectType &type) override;
+
 private:
   ResolveType (NodeId parent, bool canonicalize_type_with_generics)
     : ResolverBase (parent),

--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -726,6 +726,17 @@ ResolveType::visit (AST::TraitObjectTypeOneBound &type)
   ok = bound_resolved_id != UNKNOWN_NODEID;
 }
 
+void
+ResolveType::visit (AST::TraitObjectType &type)
+{
+  ok = true;
+  for (auto &bound : type.get_type_param_bounds ())
+    {
+      /* NodeId bound_resolved_id = */
+      ResolveTypeBound::go (bound.get (), type.get_node_id ());
+    }
+}
+
 // rust-ast-resolve-item.h
 
 void

--- a/gcc/rust/typecheck/rust-hir-const-fold-base.h
+++ b/gcc/rust/typecheck/rust-hir-const-fold-base.h
@@ -175,7 +175,6 @@ public:
   virtual void visit (HIR::TraitObjectType &) override {}
   virtual void visit (HIR::ParenthesisedType &) override {}
   virtual void visit (HIR::ImplTraitTypeOneBound &) override {}
-  virtual void visit (HIR::TraitObjectTypeOneBound &) override {}
   virtual void visit (HIR::TupleType &) override {}
   virtual void visit (HIR::NeverType &) override {}
   virtual void visit (HIR::RawPointerType &) override {}

--- a/gcc/rust/typecheck/rust-hir-trait-ref.h
+++ b/gcc/rust/typecheck/rust-hir-trait-ref.h
@@ -91,9 +91,7 @@ public:
 
   TraitItemType get_trait_item_type () const { return type; }
 
-  const HIR::TraitItem *get_hir_trait_item () const { return hir_trait_item; }
-
-  HIR::TraitItem *get_hir_trait_item () { return hir_trait_item; }
+  HIR::TraitItem *get_hir_trait_item () const { return hir_trait_item; }
 
   Location get_locus () const { return locus; }
 

--- a/gcc/rust/typecheck/rust-hir-type-check-base.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.h
@@ -177,7 +177,6 @@ public:
   virtual void visit (HIR::TraitObjectType &) override {}
   virtual void visit (HIR::ParenthesisedType &) override {}
   virtual void visit (HIR::ImplTraitTypeOneBound &) override {}
-  virtual void visit (HIR::TraitObjectTypeOneBound &) override {}
   virtual void visit (HIR::TupleType &) override {}
   virtual void visit (HIR::NeverType &) override {}
   virtual void visit (HIR::RawPointerType &) override {}

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -536,9 +536,26 @@ TypeCheckType::visit (HIR::TraitObjectType &type)
 
       HIR::TypeParamBound &b = *bound.get ();
       HIR::TraitBound &trait_bound = static_cast<HIR::TraitBound &> (b);
-      TraitReference *trait = resolve_trait_path (trait_bound.get_path ());
+
+      auto &type_path = trait_bound.get_path ();
+      TraitReference *trait = resolve_trait_path (type_path);
       TyTy::TypeBoundPredicate predicate (trait->get_mappings ().get_defid (),
 					  trait_bound.get_locus ());
+      auto &final_seg = type_path.get_final_segment ();
+      if (final_seg->is_generic_segment ())
+	{
+	  auto final_generic_seg
+	    = static_cast<HIR::TypePathSegmentGeneric *> (final_seg.get ());
+	  if (final_generic_seg->has_generic_args ())
+	    {
+	      HIR::GenericArgs &generic_args
+		= final_generic_seg->get_generic_args ();
+
+	      // this is applying generic arguments to a trait
+	      // reference
+	      predicate.apply_generic_arguments (&generic_args);
+	    }
+	}
 
       if (predicate.is_object_safe (true, type.get_locus ()))
 	specified_bounds.push_back (std::move (predicate));

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -95,7 +95,7 @@ TypeCheckType::visit (HIR::TypePath &path)
 		     "TypePath %s declares generic arguments but "
 		     "the type %s does not have any",
 		     path.as_string ().c_str (),
-		     translated->as_string ().c_str ());
+		     path_type->as_string ().c_str ());
     }
   else
     {

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -147,7 +147,7 @@ public:
 				      TyTy::InferType::InferTypeKind::GENERAL);
   }
 
-  void visit (HIR::TraitObjectTypeOneBound &type) override;
+  void visit (HIR::TraitObjectType &type) override;
 
 private:
   TypeCheckType (std::vector<TyTy::SubstitutionParamMapping> *subst_mappings)

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -62,13 +62,9 @@ public:
 	   std::vector<TyTy::SubstitutionParamMapping> *subst_mappings
 	   = nullptr)
   {
-    TypeCheckType resolver (subst_mappings);
+    TypeCheckType resolver (type->get_mappings ().get_hirid (), subst_mappings);
     type->accept_vis (resolver);
-
-    if (resolver.translated == nullptr)
-      resolver.translated
-	= new TyTy::ErrorType (type->get_mappings ().get_hirid ());
-
+    rust_assert (resolver.translated != nullptr);
     resolver.context->insert_type (type->get_mappings (), resolver.translated);
     return resolver.translated;
   }
@@ -150,8 +146,10 @@ public:
   void visit (HIR::TraitObjectType &type) override;
 
 private:
-  TypeCheckType (std::vector<TyTy::SubstitutionParamMapping> *subst_mappings)
-    : TypeCheckBase (), subst_mappings (subst_mappings), translated (nullptr)
+  TypeCheckType (HirId id,
+		 std::vector<TyTy::SubstitutionParamMapping> *subst_mappings)
+    : TypeCheckBase (), subst_mappings (subst_mappings),
+      translated (new TyTy::ErrorType (id))
   {}
 
   void

--- a/gcc/rust/typecheck/rust-hir-type-check-util.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-util.h
@@ -170,7 +170,6 @@ public:
   virtual void visit (HIR::TraitObjectType &) override {}
   virtual void visit (HIR::ParenthesisedType &) override {}
   virtual void visit (HIR::ImplTraitTypeOneBound &) override {}
-  virtual void visit (HIR::TraitObjectTypeOneBound &) override {}
   virtual void visit (HIR::TupleType &) override {}
   virtual void visit (HIR::NeverType &) override {}
   virtual void visit (HIR::RawPointerType &) override {}

--- a/gcc/rust/typecheck/rust-tyty-bounds.cc
+++ b/gcc/rust/typecheck/rust-tyty-bounds.cc
@@ -70,7 +70,10 @@ namespace TyTy {
 std::string
 TypeBoundPredicate::as_string () const
 {
-  return get ()->as_string ();
+  return get ()->as_string ()
+	 + (has_generic_args ()
+	      ? std::string ("<") + args->as_string () + std::string (">")
+	      : "");
 }
 
 const Resolver::TraitReference *

--- a/gcc/rust/typecheck/rust-tyty-bounds.cc
+++ b/gcc/rust/typecheck/rust-tyty-bounds.cc
@@ -138,7 +138,8 @@ TypeBoundPredicate::lookup_associated_item (const std::string &search) const
 }
 
 BaseType *
-TypeBoundPredicateItem::get_tyty_for_receiver (const TyTy::BaseType *receiver)
+TypeBoundPredicateItem::get_tyty_for_receiver (
+  const TyTy::BaseType *receiver, const HIR::GenericArgs *bound_args)
 {
   TyTy::BaseType *trait_item_tyty = get_raw_item ()->get_tyty ();
   if (trait_item_tyty->get_kind () == TyTy::TypeKind::FNDEF)
@@ -169,7 +170,8 @@ TypeBoundPredicateItem::get_tyty_for_receiver (const TyTy::BaseType *receiver)
     return trait_item_tyty;
 
   // FIXME LEAK this should really be const
-  const HIR::GenericArgs *args = parent->get_generic_args ();
+  const HIR::GenericArgs *args
+    = (bound_args != nullptr) ? bound_args : parent->get_generic_args ();
   HIR::GenericArgs *generic_args = new HIR::GenericArgs (*args);
   TyTy::BaseType *resolved
     = Resolver::SubstMapper::Resolve (trait_item_tyty, parent->get_locus (),

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -585,6 +585,57 @@ SubstitutionRef::solve_mappings_from_receiver_for_self (
 				       mappings.get_locus ());
 }
 
+SubstitutionArgumentMappings
+SubstitutionRef::solve_missing_mappings_from_this (SubstitutionRef &ref,
+						   SubstitutionRef &to)
+{
+  rust_assert (!ref.needs_substitution ());
+  rust_assert (needs_substitution ());
+  rust_assert (get_num_substitutions () == ref.get_num_substitutions ());
+
+  Location locus = used_arguments.get_locus ();
+  std::vector<SubstitutionArg> resolved_mappings;
+
+  std::map<HirId, std::pair<ParamType *, BaseType *>> substs;
+  for (size_t i = 0; i < get_num_substitutions (); i++)
+    {
+      SubstitutionParamMapping &a = substitutions.at (i);
+      SubstitutionParamMapping &b = ref.substitutions.at (i);
+
+      if (a.need_substitution ())
+	{
+	  const BaseType *root = a.get_param_ty ()->resolve ()->get_root ();
+	  rust_assert (root->get_kind () == TyTy::TypeKind::PARAM);
+	  const ParamType *p = static_cast<const TyTy::ParamType *> (root);
+
+	  substs[p->get_ty_ref ()] = {static_cast<ParamType *> (p->clone ()),
+				      b.get_param_ty ()->resolve ()};
+	}
+    }
+
+  for (auto it = substs.begin (); it != substs.end (); it++)
+    {
+      HirId param_id = it->first;
+      BaseType *arg = it->second.second;
+
+      const SubstitutionParamMapping *associate_param = nullptr;
+      for (SubstitutionParamMapping &p : to.substitutions)
+	{
+	  if (p.get_param_ty ()->get_ty_ref () == param_id)
+	    {
+	      associate_param = &p;
+	      break;
+	    }
+	}
+
+      rust_assert (associate_param != nullptr);
+      SubstitutionArg argument (associate_param, arg);
+      resolved_mappings.push_back (std::move (argument));
+    }
+
+  return SubstitutionArgumentMappings (resolved_mappings, locus);
+}
+
 void
 ADTType::accept_vis (TyVisitor &vis)
 {
@@ -1988,7 +2039,7 @@ ParamType::as_string () const
   bool ok = context->lookup_type (get_ty_ref (), &lookup);
   rust_assert (ok);
 
-  return lookup->as_string ();
+  return get_symbol () + "=" + lookup->as_string ();
 }
 
 std::string
@@ -2513,10 +2564,13 @@ DynamicObjectType::is_equal (const BaseType &other) const
   return bounds_compatible (other, Location (), false);
 }
 
-const std::vector<const Resolver::TraitItemReference *>
+const std::vector<
+  std::pair<const Resolver::TraitItemReference *, const TypeBoundPredicate *>>
 DynamicObjectType::get_object_items () const
 {
-  std::vector<const Resolver::TraitItemReference *> items;
+  std::vector<
+    std::pair<const Resolver::TraitItemReference *, const TypeBoundPredicate *>>
+    items;
   for (auto &bound : get_specified_bounds ())
     {
       const Resolver::TraitReference *trait = bound.get ();
@@ -2525,7 +2579,7 @@ DynamicObjectType::get_object_items () const
 	  if (item.get_trait_item_type ()
 		== Resolver::TraitItemReference::TraitItemType::FN
 	      && item.is_object_safe ())
-	    items.push_back (&item);
+	    items.push_back ({&item, &bound});
 	}
 
       for (auto &super_trait : trait->get_super_traits ())
@@ -2535,7 +2589,7 @@ DynamicObjectType::get_object_items () const
 	      if (item.get_trait_item_type ()
 		    == Resolver::TraitItemReference::TraitItemType::FN
 		  && item.is_object_safe ())
-		items.push_back (&item);
+		items.push_back ({&item, &bound});
 	    }
 	}
     }

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -334,6 +334,16 @@ StructFieldType::clone () const
 }
 
 bool
+SubstitutionParamMapping::need_substitution () const
+{
+  if (!param->can_resolve ())
+    return true;
+
+  auto resolved = param->resolve ();
+  return !resolved->is_concrete ();
+}
+
+bool
 SubstitutionParamMapping::fill_param_ty (BaseType &type, Location locus)
 {
   auto context = Resolver::TypeCheckContext::get ();

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -166,11 +166,15 @@ public:
     return parent == nullptr || trait_item_ref == nullptr;
   }
 
-  BaseType *get_tyty_for_receiver (const TyTy::BaseType *receiver);
+  BaseType *get_tyty_for_receiver (const TyTy::BaseType *receiver,
+				   const HIR::GenericArgs *bound_args
+				   = nullptr);
 
   const Resolver::TraitItemReference *get_raw_item () const;
 
   bool needs_implementation () const;
+
+  const TypeBoundPredicate *get_parent () const { return parent; }
 
 private:
   const TypeBoundPredicate *parent;
@@ -992,6 +996,11 @@ public:
   SubstitutionArgumentMappings solve_mappings_from_receiver_for_self (
     SubstitutionArgumentMappings &mappings) const;
 
+  // TODO comment
+  SubstitutionArgumentMappings
+  solve_missing_mappings_from_this (SubstitutionRef &ref, SubstitutionRef &to);
+
+  // TODO comment
   BaseType *infer_substitions (Location locus)
   {
     std::vector<SubstitutionArg> args;
@@ -2228,7 +2237,8 @@ public:
   bool is_concrete () const override final { return true; }
 
   // this returns a flat list of items including super trait bounds
-  const std::vector<const Resolver::TraitItemReference *>
+  const std::vector<
+    std::pair<const Resolver::TraitItemReference *, const TypeBoundPredicate *>>
   get_object_items () const;
 };
 

--- a/gcc/testsuite/rust/compile/traits10.rs
+++ b/gcc/testsuite/rust/compile/traits10.rs
@@ -12,5 +12,4 @@ pub fn main() {
 
     let b: &dyn Bar = &a;
     // { dg-error "trait bound is not object safe" "" { target *-*-* } .-1 }
-    // { dg-error "expected" "" { target *-*-* } .-2 }
 }

--- a/gcc/testsuite/rust/compile/traits11.rs
+++ b/gcc/testsuite/rust/compile/traits11.rs
@@ -16,5 +16,4 @@ pub fn main() {
 
     let b: &dyn B = &a;
     // { dg-error "trait bound is not object safe" "" { target *-*-* } .-1 }
-    // { dg-error "expected" "" { target *-*-* } .-2 }
 }

--- a/gcc/testsuite/rust/execute/torture/trait12.rs
+++ b/gcc/testsuite/rust/execute/torture/trait12.rs
@@ -1,0 +1,41 @@
+/* { dg-output "3\n" } */
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+trait FnLike<A, R> {
+    fn call(&self, arg: A) -> R;
+    // { dg-warning "unused name .self." "" { target *-*-* } .-1 }
+    // { dg-warning "unused name .arg." "" { target *-*-* } .-2 }
+}
+
+type FnObject<'b> = dyn for<'a> FnLike<&'a isize, &'a isize> + 'b;
+
+struct Identity;
+
+impl<'a, T> FnLike<&'a T, &'a T> for Identity {
+    fn call(&self, arg: &'a T) -> &'a T {
+        // { dg-warning "unused name .self." "" { target *-*-* } .-1 }
+        // { dg-warning "unused name" "" { target *-*-* } .-2 }
+        arg
+    }
+}
+
+fn call_repeatedly(f: &FnObject) {
+    let x = 3;
+    let y = f.call(&x);
+
+    unsafe {
+        let a = "%i\n\0";
+        let b = a as *const str;
+        let c = b as *const i8;
+
+        printf(c, *y);
+    }
+}
+
+fn main() -> i32 {
+    call_repeatedly(&Identity);
+
+    0
+}

--- a/gcc/testsuite/rust/execute/torture/trait13.rs
+++ b/gcc/testsuite/rust/execute/torture/trait13.rs
@@ -1,0 +1,50 @@
+/* { dg-output "123\n456\n" } */
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+struct Foo(i32);
+trait Bar {
+    fn baz(&self);
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+
+    fn qux(&self) {
+        // { dg-warning "unused name" "" { target *-*-* } .-1 }
+        unsafe {
+            let a = "%i\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c, 456);
+        }
+    }
+}
+
+impl Bar for Foo {
+    fn baz(&self) {
+        // { dg-warning "unused name" "" { target *-*-* } .-1 }
+        unsafe {
+            let a = "%i\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c, self.0);
+        }
+    }
+}
+
+fn dynamic_dispatch(t: &dyn Bar) {
+    t.baz();
+    t.qux();
+}
+
+fn main() -> i32 {
+    let a;
+    a = Foo(123);
+
+    let b: &dyn Bar;
+    b = &a;
+    dynamic_dispatch(b);
+
+    0
+}


### PR DESCRIPTION
This adds support for trait-object-types and desugars HIR::TraitObjectTypeOneBound into a single
HIR::TraitObjectType. This also adds the missing cases of the generic arguments to the TypeBoundPredicates.

It also contains cleanup for helpers used during monomorphization and a recursion limiter which is likely set too
low but it is good enough for the test-cases we have now to get good back-traces. 

Fixes #786 