### PR TITLE
Handle forward declared items within blocks

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -822,6 +822,8 @@ public:
   virtual bool is_marked_for_strip () const = 0;
   NodeId get_node_id () const { return node_id; }
 
+  virtual bool is_item () const = 0;
+
 protected:
   Stmt () : node_id (Analysis::Mappings::get ()->get_next_node_id ()) {}
 
@@ -846,6 +848,8 @@ public:
   virtual void
   add_crate_name (std::vector<std::string> &names ATTRIBUTE_UNUSED) const
   {}
+
+  bool is_item () const override final { return true; }
 
 protected:
   // Clone function implementation as pure virtual method

--- a/gcc/rust/ast/rust-stmt.h
+++ b/gcc/rust/ast/rust-stmt.h
@@ -46,6 +46,8 @@ public:
   void mark_for_strip () override { marked_for_strip = true; }
   bool is_marked_for_strip () const override { return marked_for_strip; }
 
+  bool is_item () const override final { return false; }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */
@@ -169,6 +171,8 @@ public:
     return type;
   }
 
+  bool is_item () const override final { return false; }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */
@@ -185,6 +189,8 @@ class ExprStmt : public Stmt
 
 public:
   Location get_locus () const override final { return locus; }
+
+  bool is_item () const override final { return false; }
 
 protected:
   ExprStmt (Location locus) : locus (locus) {}

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -2007,15 +2007,6 @@ public:
 
   void accept_vis (HIRVisitor &vis) override;
 
-  void iterate_stmts (std::function<bool (Stmt *)> cb)
-  {
-    for (auto it = statements.begin (); it != statements.end (); it++)
-      {
-	if (!cb (it->get ()))
-	  return;
-      }
-  }
-
   bool is_final_stmt (Stmt *stmt) { return statements.back ().get () == stmt; }
 
   Location get_closing_locus ()

--- a/gcc/rust/hir/tree/rust-hir-stmt.h
+++ b/gcc/rust/hir/tree/rust-hir-stmt.h
@@ -41,6 +41,8 @@ public:
 
   void accept_vis (HIRVisitor &vis) override;
 
+  bool is_item () const override final { return false; }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */
@@ -119,6 +121,8 @@ public:
 
   HIR::Pattern *get_pattern () { return variables_pattern.get (); }
 
+  bool is_item () const override final { return false; }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */
@@ -135,6 +139,8 @@ class ExprStmt : public Stmt
 
 public:
   Location get_locus () const override final { return locus; }
+
+  bool is_item () const override final { return false; }
 
 protected:
   ExprStmt (Analysis::NodeMapping mappings, Location locus)

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -104,6 +104,8 @@ public:
 
   const Analysis::NodeMapping &get_mappings () const { return mappings; }
 
+  virtual bool is_item () const = 0;
+
 protected:
   Stmt (Analysis::NodeMapping mappings) : mappings (std::move (mappings)) {}
 
@@ -139,6 +141,8 @@ public:
 
   AST::AttrVec &get_outer_attrs () { return outer_attrs; }
   const AST::AttrVec &get_outer_attrs () const { return outer_attrs; }
+
+  bool is_item () const override final { return true; }
 
 protected:
   // Constructor

--- a/gcc/rust/lint/rust-lint-marklive.h
+++ b/gcc/rust/lint/rust-lint-marklive.h
@@ -97,10 +97,10 @@ public:
 
   void visit (HIR::BlockExpr &expr) override
   {
-    expr.iterate_stmts ([&] (HIR::Stmt *s) mutable -> bool {
-      s->accept_vis (*this);
-      return true;
-    });
+    for (auto &s : expr.get_statements ())
+      {
+	s->accept_vis (*this);
+      }
     if (expr.has_expr ())
       {
 	expr.get_final_expr ()->accept_vis (*this);

--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -349,7 +349,16 @@ ResolveExpr::visit (AST::BlockExpr &expr)
   resolver->push_new_label_rib (resolver->get_type_scope ().peek ());
 
   for (auto &s : expr.get_statements ())
-    ResolveStmt::go (s.get (), s->get_node_id ());
+    {
+      if (s->is_item ())
+	ResolveStmt::go (s.get (), s->get_node_id ());
+    }
+
+  for (auto &s : expr.get_statements ())
+    {
+      if (!s->is_item ())
+	ResolveStmt::go (s.get (), s->get_node_id ());
+    }
 
   if (expr.has_tail_expr ())
     ResolveExpr::go (expr.get_tail_expr ().get (), expr.get_node_id ());

--- a/gcc/rust/typecheck/rust-tycheck-dump.h
+++ b/gcc/rust/typecheck/rust-tycheck-dump.h
@@ -94,12 +94,12 @@ public:
   {
     indentation_level++;
 
-    expr.iterate_stmts ([&] (HIR::Stmt *s) mutable -> bool {
-      dump += indent ();
-      s->accept_vis (*this);
-      dump += ";\n";
-      return true;
-    });
+    for (auto &s : expr.get_statements ())
+      {
+	dump += indent ();
+	s->accept_vis (*this);
+	dump += ";\n";
+      }
 
     if (expr.has_expr ())
       {

--- a/gcc/testsuite/rust/compile/torture/forward_decl_5.rs
+++ b/gcc/testsuite/rust/compile/torture/forward_decl_5.rs
@@ -1,0 +1,19 @@
+pub fn main() {
+    let a;
+    a = foo { a: 123, b: 456f32 };
+
+    let mut a = 123;
+    a = bar(a);
+
+    let mut b = 456f32;
+    b = bar(b);
+
+    fn bar<T>(x: T) -> T {
+        x
+    }
+
+    struct foo {
+        a: i32,
+        b: f32,
+    };
+}


### PR DESCRIPTION
This changes the resolution in BlockExpr's to iterate the Items then Stmts
but we might want to handle this by desugaring the HIR BlockExpr to have
items then stmts to ensure we type resolve the items before the stmts.

Fixes #531