### PR TITLE
Added Remark markdown automation 

### DIFF
--- a/.github/workflows/Remark.yml
+++ b/.github/workflows/Remark.yml
@@ -1,0 +1,31 @@
+name: Remark
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches: 
+      - master
+
+jobs:
+  remark:
+    runs-on: ubuntu-latest
+
+    steps:
+    # Setup
+    - name: Checkout
+      uses: actions/checkout@v2.3.3
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v1.4.4
+      with:
+        node-version: '12.x'
+
+    - name: Install remark
+      run: npm install remark-cli remark-lint remark-lint-maximum-line-length remark-preset-lint-recommended remark-gfm
+
+    # Run
+    - name: Check *.md files
+      run: git ls-files -z *.md | xargs -0 -n 1 npx remark -u lint -f > /dev/null
+

--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,14 @@
+{
+  "plugins": [
+    "remark-preset-lint-recommended",
+    "remark-gfm",
+    ["remark-lint-maximum-line-length", 120],
+    ["remark-lint-list-item-indent", false],
+    ["remark-lint-no-literal-urls", false],
+    ["remark-lint-no-shortcut-reference-link", false]
+  ],
+  "settings": {
+    "commonmark": true
+  }
+}
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,9 @@
 
 * **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/Rust-GCC/gccrs/issues).
 
-* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/Rust-GCC/gccrs/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
+* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/Rust-GCC/gccrs/issues/new). 
+  Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample** 
+  or an **executable test case** demonstrating the expected behavior that is not occurring.
 
 #### **Do you want to submit a patch?**
 
@@ -12,16 +14,19 @@
 
 * Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
 
-* Before submitting, GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off. Please see the [Contributing to GCC](https://gcc.gnu.org/contribute.html) guide or [Developer's Certificate of Origin (DCO) Sign-off](https://gcc.gnu.org/dco.html) guide.
+* Before submitting, GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off.
+   Please see the [Contributing to GCC](https://gcc.gnu.org/contribute.html) guide or [Developer's Certificate of Origin (DCO) Sign-off](https://gcc.gnu.org/dco.html) guide.
 
 * Patches sent to the [`gcc-rust` mailing list](https://gcc.gnu.org/mailman/listinfo/gcc-rust) are likewise welcome.
-These will be imported into a GitHub PR to follow the normal review process, and the link to the GitHub PR sent to the submitter.
+These will be imported into a GitHub PR to follow the normal review process, 
+and the link to the GitHub PR sent to the submitter.
 
 #### **Do you intend to add a new feature or change an existing one?**
 
 * Suggest your change in the [Zulip](https://gcc-rust.zulipchat.com/) and start writing code.
 
-* Do not open an issue on GitHub until you have collected positive feedback about the change. GitHub issues are primarily intended for bug reports and fixes.
+* Do not open an issue on GitHub until you have collected positive feedback about the change. 
+  GitHub issues are primarily intended for bug reports and fixes.
 
 #### **Do you have questions about the source code?**
 
@@ -38,18 +43,21 @@ These will be imported into a GitHub PR to follow the normal review process, and
 
 * Avoid PR's with merge commit unless there's a good reason
 
-* Where possible please add test cases to `gcc/testsuite/rust/` for all PRs. Some issues may not be testable via dejagnu/automation such as debug dump changes.
+* Where possible please add test cases to `gcc/testsuite/rust/` for all PRs. 
+  Some issues may not be testable via dejagnu/automation such as debug dump changes.
 
 * Follow the [GCC coding style](https://gcc.gnu.org/codingconventions.html) (see `clang-format` below).
 
 * PRs won't be merged until the build and tests pass.
 
-* Please take the time to create good git commit messages. See the existing format of them in the git log or refer to something like: https://chris.beams.io/posts/git-commit/
+* Please take the time to create good git commit messages. 
+  See the existing format of them in the git log or refer to something like: https://chris.beams.io/posts/git-commit/
 
 #### Running `clang-format` locally
 
 * on all files using python scripts
-... corresponding to what the _Clang Format Lint_ (`.github/workflows/clang-format.yml`) is doing, with `clang-format-10` being available locally, and avoiding the Docker overhead.
+... corresponding to what the _Clang Format Lint_ (`.github/workflows/clang-format.yml`) 
+is doing, with `clang-format-10` being available locally, and avoiding the Docker overhead.
 
 ```shell
 $ wget 'https://github.com/DoozyX/clang-format-lint-action/raw/v0.11/run-clang-format.py'
@@ -114,7 +122,8 @@ index 9559374ce60..bd3043295ce 100644
  };
 ```
 
-Also note that you can use a given version of `clang-format` by using `git clang-format-10` if you have installed that particular version.
+Also note that you can use a given version of `clang-format` by using `git clang-format-10` if you have 
+installed that particular version.
 
 Thanks! :heart: :heart: :heart:
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ $ $HOME/gccrs-install/gccrs -g -O2 -c test.rs -o test.o
 $ $HOME/gccrs-install/gccrs -o test test.o
 ```
 
-You can also setup your shell to automatically find the installed compiler. For example for `bash`, add the following in your `$HOME/.bashrc`:
+You can also setup your shell to automatically find the installed compiler. For example for `bash`, 
+add the following in your `$HOME/.bashrc`:
 
 ```bash
 export PATH=$HOME/gccrs-install/bin:$PATH
@@ -125,7 +126,8 @@ test cases referencing any issues on Github.
 
 ### Enabling internal checks
 
-GCC has several internal checks that can be enabled during configuration. In the case of `gccrs`, you can enable the following:
+GCC has several internal checks that can be enabled during configuration. In the case of `gccrs`, 
+you can enable the following:
 ```bash
 $ ../gccrs/configure --prefix=$HOME/gccrs-install --disable-bootstrap --enable-multilib --enable-languages=rust --enable-checking=gimple,tree,types
 ```
@@ -143,7 +145,8 @@ $ gdb --args  /some/path/../../rust1 test.rs -quiet -dumpbase arithmetic_express
  -mtune=generic -march=x86-64 -O0 -w -version -fdiagnostics-color=never -fno-diagnostics-show-caret -fno-diagnostics-show-line-numbers -fdiagnostics-urls=never -fdiagnostics-path-format=separate-events -o test.s -L/lib/x86_64-linux-gnu -L/lib/../lib64 -L/usr/lib/x86_64-linux-gnu
 ```
 
-Or simply add the `-wrapper gdb,--args` option. This will call each subcommand in `gdb` and you simply have to break/debug in `rust1`:
+Or simply add the `-wrapper gdb,--args` option. 
+This will call each subcommand in `gdb` and you simply have to break/debug in `rust1`:
 ```bash
 $ gccrs test.rs -O0 -S -o arithmetic_expressions1.s -wrapper gdb,--args
 ```
@@ -192,16 +195,18 @@ To emit Rust front end debug output, you may add options like `-frust-debug`, `-
 
 If you want to contribute to GCC Rust, you can find more information in [CONTRIBUTING.md](https://github.com/Rust-GCC/gccrs/blob/master/CONTRIBUTING.md).
 
-Please be aware this project is designed to be pushed upstream to GCC when we reach some milestones, and this means we require
-copyright assignment or the Developer's Certificate of Origin sign-off. Please see the [Contributing to GCC](https://gcc.gnu.org/contribute.html) guide or [Developer's Certificate of Origin (DCO) Sign-off](https://gcc.gnu.org/dco.html) guide.
+Please be aware this project is designed to be pushed upstream to GCC when we reach some milestones, 
+and this means we require copyright assignment or the Developer's Certificate of Origin sign-off. 
+Please see the [Contributing to GCC](https://gcc.gnu.org/contribute.html) guide or [Developer's Certificate of Origin (DCO) Sign-off](https://gcc.gnu.org/dco.html) guide.
 
-Not all contributions must be code; we would love to see new test cases or bugs and issues to be reported. Feel free to add any comments on open PRs
+Not all contributions must be code; we would love to see new test cases or bugs and issues to be reported. 
+Feel free to add any comments on open PRs
 
 ## Community
 
 We can be found on all usual Rust channels such as Zulip, but we also have our own channels:
 
- * GCC Rust Zulip: https://gcc-rust.zulipchat.com/
- * Twitter: https://twitter.com/gcc_rust
- * GCC Mailing List: https://gcc.gnu.org/mailman/listinfo/gcc-rust
- * irc: irc.oftc.net - gccrust
+* GCC Rust Zulip: https://gcc-rust.zulipchat.com/
+* Twitter: https://twitter.com/gcc_rust
+* GCC Mailing List: https://gcc.gnu.org/mailman/listinfo/gcc-rust
+* irc: irc.oftc.net - gccrust


### PR DESCRIPTION
Fixes #487 
Remark.yml contains the workflow, and .remarkrc is the linter's config file. The configurations follow the same ones as shown in the reference repo specified by @philberty in the issue.

The linter works great, and the Test is shown as unsuccessful if a check fails. I also created a PR ( [here](https://github.com/mvvsmk/gccrs/pull/1) )in my fork to test this.  You can check the results out [here.](https://github.com/mvvsmk/gccrs/runs/4126281781?check_suite_focus=true) The test file's name is TEST.md .

Please note that the run mentioned above also shows errors in CONTRIBUTING.md and README.md, which were not part of the commit, but the linter goes over them regardless, as they are part of the Repository.

### The issues that still remain are :

- There are two files CONTRIBUTING.md and README.md which have a few errors, I could configure the linter to skip them, but it would be much easier to correct them.
- The trigger branch for the workflow was not specified. Hence I use master.
- Custom configurations/changes you would like me to add.

This is my first PR, so please let me know if I've missed anything! Thanks.

See: #487 

Signed-off-by: M V V S Manoj Kumar <mvvsmanojkumar@gmail.com>