### PR TITLE
Remove Btype, Bexpression, etc. abstractions over gcc trees

### DIFF
--- a/gcc/rust/backend/rust-compile-base.h
+++ b/gcc/rust/backend/rust-compile-base.h
@@ -200,16 +200,14 @@ protected:
   bool compile_locals_for_block (Resolver::Rib &rib, Bfunction *fndecl,
 				 std::vector<Bvariable *> &locals);
 
-  Bexpression *coercion_site (Bexpression *compiled_ref, TyTy::BaseType *actual,
-			      TyTy::BaseType *expected, Location locus);
+  tree coercion_site (tree compiled_ref, TyTy::BaseType *actual,
+		      TyTy::BaseType *expected, Location locus);
 
-  Bexpression *coerce_to_dyn_object (Bexpression *compiled_ref,
-				     const TyTy::BaseType *actual,
-				     const TyTy::BaseType *expected,
-				     const TyTy::DynamicObjectType *ty,
-				     Location locus);
+  tree coerce_to_dyn_object (tree compiled_ref, const TyTy::BaseType *actual,
+			     const TyTy::BaseType *expected,
+			     const TyTy::DynamicObjectType *ty, Location locus);
 
-  Bexpression *compute_address_for_trait_item (
+  tree compute_address_for_trait_item (
     const Resolver::TraitItemReference *ref,
     const TyTy::TypeBoundPredicate *predicate,
     std::vector<std::pair<Resolver::TraitReference *, HIR::ImplBlock *>>

--- a/gcc/rust/backend/rust-compile-base.h
+++ b/gcc/rust/backend/rust-compile-base.h
@@ -193,11 +193,11 @@ protected:
 
   Context *get_context () { return ctx; }
 
-  void compile_function_body (Bfunction *fndecl,
+  void compile_function_body (tree fndecl,
 			      std::unique_ptr<HIR::BlockExpr> &function_body,
 			      bool has_return_type);
 
-  bool compile_locals_for_block (Resolver::Rib &rib, Bfunction *fndecl,
+  bool compile_locals_for_block (Resolver::Rib &rib, tree fndecl,
 				 std::vector<Bvariable *> &locals);
 
   tree coercion_site (tree compiled_ref, TyTy::BaseType *actual,

--- a/gcc/rust/backend/rust-compile-block.h
+++ b/gcc/rust/backend/rust-compile-block.h
@@ -30,7 +30,7 @@ class CompileBlock : public HIRCompileBase
   using Rust::Compile::HIRCompileBase::visit;
 
 public:
-  static Bblock *compile (HIR::BlockExpr *expr, Context *ctx, Bvariable *result)
+  static tree compile (HIR::BlockExpr *expr, Context *ctx, Bvariable *result)
   {
     CompileBlock compiler (ctx, result);
     expr->accept_vis (compiler);
@@ -44,7 +44,7 @@ private:
     : HIRCompileBase (ctx), translated (nullptr), result (result)
   {}
 
-  Bblock *translated;
+  tree translated;
   Bvariable *result;
 };
 

--- a/gcc/rust/backend/rust-compile-block.h
+++ b/gcc/rust/backend/rust-compile-block.h
@@ -53,8 +53,7 @@ class CompileConditionalBlocks : public HIRCompileBase
   using Rust::Compile::HIRCompileBase::visit;
 
 public:
-  static Bstatement *compile (HIR::IfExpr *expr, Context *ctx,
-			      Bvariable *result)
+  static tree compile (HIR::IfExpr *expr, Context *ctx, Bvariable *result)
   {
     CompileConditionalBlocks resolver (ctx, result);
     expr->accept_vis (resolver);
@@ -72,7 +71,7 @@ private:
     : HIRCompileBase (ctx), translated (nullptr), result (result)
   {}
 
-  Bstatement *translated;
+  tree translated;
   Bvariable *result;
 };
 
@@ -81,8 +80,8 @@ class CompileExprWithBlock : public HIRCompileBase
   using Rust::Compile::HIRCompileBase::visit;
 
 public:
-  static Bstatement *compile (HIR::ExprWithBlock *expr, Context *ctx,
-			      Bvariable *result)
+  static tree compile (HIR::ExprWithBlock *expr, Context *ctx,
+		       Bvariable *result)
   {
     CompileExprWithBlock resolver (ctx, result);
     expr->accept_vis (resolver);
@@ -109,7 +108,7 @@ private:
     : HIRCompileBase (ctx), translated (nullptr), result (result)
   {}
 
-  Bstatement *translated;
+  tree translated;
   Bvariable *result;
 };
 

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -221,12 +221,9 @@ public:
     return true;
   }
 
-  void insert_label_decl (HirId id, ::Blabel *label)
-  {
-    compiled_labels[id] = label;
-  }
+  void insert_label_decl (HirId id, tree label) { compiled_labels[id] = label; }
 
-  bool lookup_label_decl (HirId id, ::Blabel **label)
+  bool lookup_label_decl (HirId id, tree *label)
   {
     auto it = compiled_labels.find (id);
     if (it == compiled_labels.end ())
@@ -278,16 +275,16 @@ public:
     return back;
   }
 
-  void push_loop_begin_label (Blabel *label)
+  void push_loop_begin_label (tree label)
   {
     loop_begin_labels.push_back (label);
   }
 
-  Blabel *peek_loop_begin_label () { return loop_begin_labels.back (); }
+  tree peek_loop_begin_label () { return loop_begin_labels.back (); }
 
-  Blabel *pop_loop_begin_label ()
+  tree pop_loop_begin_label ()
   {
-    Blabel *pop = loop_begin_labels.back ();
+    tree pop = loop_begin_labels.back ();
     loop_begin_labels.pop_back ();
     return pop;
   }
@@ -321,11 +318,11 @@ private:
   std::map<HirId, tree> compiled_type_map;
   std::map<HirId, tree> compiled_fn_map;
   std::map<HirId, tree> compiled_consts;
-  std::map<HirId, ::Blabel *> compiled_labels;
+  std::map<HirId, tree> compiled_labels;
   std::vector<::std::vector<tree>> statements;
   std::vector<tree> scope_stack;
   std::vector<::Bvariable *> loop_value_stack;
-  std::vector<::Blabel *> loop_begin_labels;
+  std::vector<tree> loop_begin_labels;
   std::map<const TyTy::BaseType *, std::pair<HirId, ::tree >> mono;
   std::map<DefId, std::vector<std::pair<const TyTy::BaseType *, tree>>>
     mono_fns;

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -35,7 +35,7 @@ namespace Compile {
 
 struct fncontext
 {
-  ::Bfunction *fndecl;
+  ::tree fndecl;
   ::Bvariable *ret_addr;
 };
 
@@ -161,7 +161,7 @@ public:
     return true;
   }
 
-  void insert_function_decl (const TyTy::FnType *ref, ::Bfunction *fn)
+  void insert_function_decl (const TyTy::FnType *ref, tree fn)
   {
     auto id = ref->get_ty_ref ();
     auto dId = ref->get_id ();
@@ -176,8 +176,7 @@ public:
     mono_fns[dId].push_back ({ref, fn});
   }
 
-  bool lookup_function_decl (HirId id, ::Bfunction **fn,
-			     DefId dId = UNKNOWN_DEFID,
+  bool lookup_function_decl (HirId id, tree *fn, DefId dId = UNKNOWN_DEFID,
 			     const TyTy::BaseType *ref = nullptr)
   {
     // for for any monomorphized fns
@@ -192,7 +191,7 @@ public:
 	for (auto &e : mono_fns[dId])
 	  {
 	    const TyTy::BaseType *r = e.first;
-	    ::Bfunction *f = e.second;
+	    tree f = e.second;
 	    if (ref->is_equal (*r))
 	      {
 		*fn = f;
@@ -237,7 +236,7 @@ public:
     return true;
   }
 
-  void push_fn (::Bfunction *fn, ::Bvariable *ret_addr)
+  void push_fn (tree fn, ::Bvariable *ret_addr)
   {
     fn_stack.push_back (fncontext{fn, ret_addr});
   }
@@ -247,7 +246,7 @@ public:
   void push_type (::tree t) { type_decls.push_back (t); }
   void push_var (::Bvariable *v) { var_decls.push_back (v); }
   void push_const (::tree c) { const_decls.push_back (c); }
-  void push_function (::Bfunction *f) { func_decls.push_back (f); }
+  void push_function (tree f) { func_decls.push_back (f); }
 
   void write_to_backend ()
   {
@@ -255,11 +254,11 @@ public:
 				       var_decls);
   }
 
-  bool function_completed (Bfunction *fn)
+  bool function_completed (tree fn)
   {
     for (auto it = func_decls.begin (); it != func_decls.end (); it++)
       {
-	Bfunction *i = (*it);
+	tree i = (*it);
 	if (i == fn)
 	  {
 	    return true;
@@ -320,7 +319,7 @@ private:
   std::vector<fncontext> fn_stack;
   std::map<HirId, ::Bvariable *> compiled_var_decls;
   std::map<HirId, tree> compiled_type_map;
-  std::map<HirId, ::Bfunction *> compiled_fn_map;
+  std::map<HirId, tree> compiled_fn_map;
   std::map<HirId, tree> compiled_consts;
   std::map<HirId, ::Blabel *> compiled_labels;
   std::vector<::std::vector<tree>> statements;
@@ -328,14 +327,14 @@ private:
   std::vector<::Bvariable *> loop_value_stack;
   std::vector<::Blabel *> loop_begin_labels;
   std::map<const TyTy::BaseType *, std::pair<HirId, ::tree >> mono;
-  std::map<DefId, std::vector<std::pair<const TyTy::BaseType *, ::Bfunction *>>>
+  std::map<DefId, std::vector<std::pair<const TyTy::BaseType *, tree>>>
     mono_fns;
 
   // To GCC middle-end
   std::vector<tree> type_decls;
   std::vector<::Bvariable *> var_decls;
   std::vector<tree> const_decls;
-  std::vector<::Bfunction *> func_decls;
+  std::vector<tree> func_decls;
 };
 
 class TyTyResolveCompile : public TyTy::TyConstVisitor

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -35,7 +35,7 @@ namespace Compile {
 
 struct fncontext
 {
-  ::tree fndecl;
+  tree fndecl;
   ::Bvariable *ret_addr;
 };
 
@@ -61,19 +61,19 @@ public:
 	rust_assert (ok);
 
 	tree compiled = TyTyCompile::compile (backend, lookup);
-	compiled_type_map.insert (std::pair<HirId, tree > (ref, compiled));
+	compiled_type_map.insert (std::pair<HirId, tree> (ref, compiled));
 	builtin_range.insert (ref);
       }
   }
 
-  bool lookup_compiled_types (HirId id, ::tree *type,
+  bool lookup_compiled_types (HirId id, tree *type,
 			      const TyTy::BaseType *ref = nullptr)
   {
     if (ref != nullptr)
       {
 	for (auto it = mono.begin (); it != mono.end (); it++)
 	  {
-	    std::pair<HirId, ::tree > &val = it->second;
+	    std::pair<HirId, tree> &val = it->second;
 	    const TyTy::BaseType *r = it->first;
 
 	    if (ref->is_equal (*r))
@@ -94,14 +94,14 @@ public:
     return true;
   }
 
-  void insert_compiled_type (HirId id, ::tree type,
+  void insert_compiled_type (HirId id, tree type,
 			     const TyTy::BaseType *ref = nullptr)
   {
     rust_assert (builtin_range.find (id) == builtin_range.end ());
-    compiled_type_map.insert (std::pair<HirId, tree > (id, type));
+    compiled_type_map.insert (std::pair<HirId, tree> (id, type));
     if (ref != nullptr)
       {
-	std::pair<HirId, ::tree > elem (id, type);
+	std::pair<HirId, tree> elem (id, type);
 	mono[ref] = std::move (elem);
       }
   }
@@ -209,9 +209,9 @@ public:
     return true;
   }
 
-  void insert_const_decl (HirId id, ::tree expr) { compiled_consts[id] = expr; }
+  void insert_const_decl (HirId id, tree expr) { compiled_consts[id] = expr; }
 
-  bool lookup_const_decl (HirId id, ::tree *expr)
+  bool lookup_const_decl (HirId id, tree *expr)
   {
     auto it = compiled_consts.find (id);
     if (it == compiled_consts.end ())
@@ -240,9 +240,9 @@ public:
   void pop_fn () { fn_stack.pop_back (); }
   fncontext peek_fn () { return fn_stack.back (); }
 
-  void push_type (::tree t) { type_decls.push_back (t); }
+  void push_type (tree t) { type_decls.push_back (t); }
   void push_var (::Bvariable *v) { var_decls.push_back (v); }
-  void push_const (::tree c) { const_decls.push_back (c); }
+  void push_const (tree c) { const_decls.push_back (c); }
   void push_function (tree f) { func_decls.push_back (f); }
 
   void write_to_backend ()
@@ -323,7 +323,7 @@ private:
   std::vector<tree> scope_stack;
   std::vector<::Bvariable *> loop_value_stack;
   std::vector<tree> loop_begin_labels;
-  std::map<const TyTy::BaseType *, std::pair<HirId, ::tree >> mono;
+  std::map<const TyTy::BaseType *, std::pair<HirId, tree>> mono;
   std::map<DefId, std::vector<std::pair<const TyTy::BaseType *, tree>>>
     mono_fns;
 
@@ -338,7 +338,7 @@ class TyTyResolveCompile : public TyTy::TyConstVisitor
 {
 public:
   static tree compile (Context *ctx, const TyTy::BaseType *ty,
-			   bool trait_object_mode = false)
+		       bool trait_object_mode = false)
   {
     TyTyResolveCompile compiler (ctx, trait_object_mode);
     ty->accept_vis (compiler);
@@ -410,7 +410,7 @@ public:
     tree result_type
       = TyTyResolveCompile::compile (ctx, type.get_return_type ());
 
-    std::vector<tree > parameters;
+    std::vector<tree> parameters;
     type.iterate_params ([&] (TyTy::BaseType *p) mutable -> bool {
       tree pty = TyTyResolveCompile::compile (ctx, p);
       parameters.push_back (pty);
@@ -440,8 +440,8 @@ public:
 	  = TyTyResolveCompile::compile (ctx, field->get_field_type ());
 
 	Backend::typed_identifier f (field->get_name (), compiled_field_ty,
-				      ctx->get_mappings ()->lookup_location (
-					type.get_ty_ref ()));
+				     ctx->get_mappings ()->lookup_location (
+				       type.get_ty_ref ()));
 	fields.push_back (std::move (f));
       }
 
@@ -488,9 +488,9 @@ public:
 	// approach makes it simpler to use a C-only debugger, or
 	// GDB's C mode, when debugging Rust.
 	Backend::typed_identifier f ("__" + std::to_string (i),
-				      compiled_field_ty,
-				      ctx->get_mappings ()->lookup_location (
-					type.get_ty_ref ()));
+				     compiled_field_ty,
+				     ctx->get_mappings ()->lookup_location (
+				       type.get_ty_ref ()));
 	fields.push_back (std::move (f));
       }
 
@@ -515,7 +515,7 @@ public:
 
   void visit (const TyTy::BoolType &type) override
   {
-    ::tree compiled_type = nullptr;
+    tree compiled_type = nullptr;
     bool ok = ctx->lookup_compiled_types (type.get_ty_ref (), &compiled_type);
     rust_assert (ok);
     translated = compiled_type;
@@ -523,7 +523,7 @@ public:
 
   void visit (const TyTy::IntType &type) override
   {
-    ::tree compiled_type = nullptr;
+    tree compiled_type = nullptr;
     bool ok = ctx->lookup_compiled_types (type.get_ty_ref (), &compiled_type);
     rust_assert (ok);
     translated = compiled_type;
@@ -531,7 +531,7 @@ public:
 
   void visit (const TyTy::UintType &type) override
   {
-    ::tree compiled_type = nullptr;
+    tree compiled_type = nullptr;
     bool ok = ctx->lookup_compiled_types (type.get_ty_ref (), &compiled_type);
     rust_assert (ok);
     translated = compiled_type;
@@ -539,7 +539,7 @@ public:
 
   void visit (const TyTy::FloatType &type) override
   {
-    ::tree compiled_type = nullptr;
+    tree compiled_type = nullptr;
     bool ok = ctx->lookup_compiled_types (type.get_ty_ref (), &compiled_type);
     rust_assert (ok);
     translated = compiled_type;
@@ -547,7 +547,7 @@ public:
 
   void visit (const TyTy::USizeType &type) override
   {
-    ::tree compiled_type = nullptr;
+    tree compiled_type = nullptr;
     bool ok = ctx->lookup_compiled_types (type.get_ty_ref (), &compiled_type);
     rust_assert (ok);
     translated = compiled_type;
@@ -555,7 +555,7 @@ public:
 
   void visit (const TyTy::ISizeType &type) override
   {
-    ::tree compiled_type = nullptr;
+    tree compiled_type = nullptr;
     bool ok = ctx->lookup_compiled_types (type.get_ty_ref (), &compiled_type);
     rust_assert (ok);
     translated = compiled_type;
@@ -563,7 +563,7 @@ public:
 
   void visit (const TyTy::CharType &type) override
   {
-    ::tree compiled_type = nullptr;
+    tree compiled_type = nullptr;
     bool ok = ctx->lookup_compiled_types (type.get_ty_ref (), &compiled_type);
     rust_assert (ok);
     translated = compiled_type;
@@ -601,7 +601,7 @@ public:
 
   void visit (const TyTy::StrType &type) override
   {
-    ::tree compiled_type = nullptr;
+    tree compiled_type = nullptr;
     bool ok = ctx->lookup_compiled_types (type.get_ty_ref (), &compiled_type);
     rust_assert (ok);
     translated = compiled_type;
@@ -633,8 +633,8 @@ public:
     tree uintptr_ty = ctx->get_backend ()->pointer_type (uint);
 
     Backend::typed_identifier f ("__receiver_trait_obj_ptr", uintptr_ty,
-				  ctx->get_mappings ()->lookup_location (
-				    type.get_ty_ref ()));
+				 ctx->get_mappings ()->lookup_location (
+				   type.get_ty_ref ()));
     fields.push_back (std::move (f));
 
     for (size_t i = 0; i < items.size (); i++)
@@ -645,8 +645,8 @@ public:
 	tree uintptr_ty = ctx->get_backend ()->pointer_type (uint);
 
 	Backend::typed_identifier f ("__" + std::to_string (i), uintptr_ty,
-				      ctx->get_mappings ()->lookup_location (
-					type.get_ty_ref ()));
+				     ctx->get_mappings ()->lookup_location (
+				       type.get_ty_ref ()));
 	fields.push_back (std::move (f));
       }
 
@@ -672,7 +672,7 @@ private:
 
   Context *ctx;
   bool trait_object_mode;
-  ::tree translated;
+  tree translated;
   size_t recursion_count;
 
   static const size_t kDefaultRecusionLimit = 5;

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -210,12 +210,9 @@ public:
     return true;
   }
 
-  void insert_const_decl (HirId id, ::Bexpression *expr)
-  {
-    compiled_consts[id] = expr;
-  }
+  void insert_const_decl (HirId id, ::tree expr) { compiled_consts[id] = expr; }
 
-  bool lookup_const_decl (HirId id, ::Bexpression **expr)
+  bool lookup_const_decl (HirId id, ::tree *expr)
   {
     auto it = compiled_consts.find (id);
     if (it == compiled_consts.end ())
@@ -249,7 +246,7 @@ public:
 
   void push_type (::tree t) { type_decls.push_back (t); }
   void push_var (::Bvariable *v) { var_decls.push_back (v); }
-  void push_const (::Bexpression *c) { const_decls.push_back (c); }
+  void push_const (::tree c) { const_decls.push_back (c); }
   void push_function (::Bfunction *f) { func_decls.push_back (f); }
 
   void write_to_backend ()
@@ -322,9 +319,9 @@ private:
   // state
   std::vector<fncontext> fn_stack;
   std::map<HirId, ::Bvariable *> compiled_var_decls;
-  std::map<HirId, ::tree > compiled_type_map;
+  std::map<HirId, tree> compiled_type_map;
   std::map<HirId, ::Bfunction *> compiled_fn_map;
-  std::map<HirId, ::Bexpression *> compiled_consts;
+  std::map<HirId, tree> compiled_consts;
   std::map<HirId, ::Blabel *> compiled_labels;
   std::vector<::std::vector<Bstatement *>> statements;
   std::vector<::Bblock *> scope_stack;
@@ -337,7 +334,7 @@ private:
   // To GCC middle-end
   std::vector<tree> type_decls;
   std::vector<::Bvariable *> var_decls;
-  std::vector<::Bexpression *> const_decls;
+  std::vector<tree> const_decls;
   std::vector<::Bfunction *> func_decls;
 };
 

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -112,13 +112,13 @@ public:
   Analysis::Mappings *get_mappings () { return mappings; }
   ConstFold::Context *get_const_ctx () { return const_ctx; }
 
-  void push_block (Bblock *scope)
+  void push_block (tree scope)
   {
     scope_stack.push_back (scope);
     statements.push_back ({});
   }
 
-  Bblock *pop_block ()
+  tree pop_block ()
   {
     auto block = scope_stack.back ();
     scope_stack.pop_back ();
@@ -131,7 +131,7 @@ public:
     return block;
   }
 
-  Bblock *peek_enclosing_scope ()
+  tree peek_enclosing_scope ()
   {
     if (scope_stack.size () == 0)
       return nullptr;
@@ -323,7 +323,7 @@ private:
   std::map<HirId, tree> compiled_consts;
   std::map<HirId, ::Blabel *> compiled_labels;
   std::vector<::std::vector<tree>> statements;
-  std::vector<::Bblock *> scope_stack;
+  std::vector<tree> scope_stack;
   std::vector<::Bvariable *> loop_value_stack;
   std::vector<::Blabel *> loop_begin_labels;
   std::map<const TyTy::BaseType *, std::pair<HirId, ::tree >> mono;

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -139,12 +139,12 @@ public:
     return scope_stack.back ();
   }
 
-  void add_statement_to_enclosing_scope (Bstatement *stmt)
+  void add_statement_to_enclosing_scope (tree stmt)
   {
     statements.at (statements.size () - 2).push_back (stmt);
   }
 
-  void add_statement (Bstatement *stmt) { statements.back ().push_back (stmt); }
+  void add_statement (tree stmt) { statements.back ().push_back (stmt); }
 
   void insert_var_decl (HirId id, ::Bvariable *decl)
   {
@@ -323,7 +323,7 @@ private:
   std::map<HirId, ::Bfunction *> compiled_fn_map;
   std::map<HirId, tree> compiled_consts;
   std::map<HirId, ::Blabel *> compiled_labels;
-  std::vector<::std::vector<Bstatement *>> statements;
+  std::vector<::std::vector<tree>> statements;
   std::vector<::Bblock *> scope_stack;
   std::vector<::Bvariable *> loop_value_stack;
   std::vector<::Blabel *> loop_begin_labels;

--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -86,7 +86,7 @@ CompileExpr::visit (HIR::CompoundAssignmentExpr &expr)
   auto operator_expr
     = ctx->get_backend ()->arithmetic_or_logical_expression (op, lhs, rhs,
 							     expr.get_locus ());
-  Bstatement *assignment
+  tree assignment
     = ctx->get_backend ()->assignment_statement (fn.fndecl, lhs, operator_expr,
 						 expr.get_locus ());
   ctx->add_statement (assignment);
@@ -178,7 +178,7 @@ CompileExpr::compile_dyn_dispatch_call (const TyTy::DynamicObjectType *dyn,
   fncontext fnctx = ctx->peek_fn ();
   Bblock *enclosing_scope = ctx->peek_enclosing_scope ();
   bool is_address_taken = false;
-  Bstatement *ret_var_stmt = nullptr;
+  tree ret_var_stmt = NULL_TREE;
   Bvariable *fn_convert_expr_tmp
     = ctx->get_backend ()->temporary_variable (fnctx.fndecl, enclosing_scope,
 					       expected_fntype, fn_convert_expr,

--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -150,7 +150,7 @@ CompileExpr::compile_dyn_dispatch_call (const TyTy::DynamicObjectType *dyn,
     {
       TyTy::ReferenceType *r = static_cast<TyTy::ReferenceType *> (receiver);
       auto indirect_ty = r->get_base ();
-      Btype *indrect_compiled_tyty
+      tree indrect_compiled_tyty
 	= TyTyResolveCompile::compile (ctx, indirect_ty);
 
       Bexpression *indirect
@@ -171,7 +171,7 @@ CompileExpr::compile_dyn_dispatch_call (const TyTy::DynamicObjectType *dyn,
 						    expr_locus);
 
   // cast it to the correct fntype
-  Btype *expected_fntype = TyTyResolveCompile::compile (ctx, fntype, true);
+  tree expected_fntype = TyTyResolveCompile::compile (ctx, fntype, true);
   Bexpression *fn_convert_expr
     = ctx->get_backend ()->convert_expression (expected_fntype,
 					       fn_vtable_access, expr_locus);
@@ -370,7 +370,7 @@ CompileExpr::resolve_operator_overload (
 	  break;
 
 	case Resolver::Adjustment::AdjustmentType::DEREF_REF:
-	  Btype *expected_type
+	  tree expected_type
 	    = TyTyResolveCompile::compile (ctx, adjustment.get_expected ());
 	  self
 	    = ctx->get_backend ()->indirect_expression (expected_type, self,

--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -209,7 +209,7 @@ CompileExpr::resolve_method_address (TyTy::FnType *fntype, HirId ref,
 				     Location expr_locus)
 {
   // lookup compiled functions since it may have already been compiled
-  Bfunction *fn = nullptr;
+  tree fn = NULL_TREE;
   if (ctx->lookup_function_decl (fntype->get_ty_ref (), &fn))
     {
       return ctx->get_backend ()->function_code_expression (fn, expr_locus);

--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -176,7 +176,7 @@ CompileExpr::compile_dyn_dispatch_call (const TyTy::DynamicObjectType *dyn,
 					       fn_vtable_access, expr_locus);
 
   fncontext fnctx = ctx->peek_fn ();
-  Bblock *enclosing_scope = ctx->peek_enclosing_scope ();
+  tree enclosing_scope = ctx->peek_enclosing_scope ();
   bool is_address_taken = false;
   tree ret_var_stmt = NULL_TREE;
   Bvariable *fn_convert_expr_tmp

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -204,7 +204,7 @@ public:
 	gcc_unreachable ();
       }
 
-    Bfunction *fn = nullptr;
+    tree fn = NULL_TREE;
     Bvariable *var = nullptr;
     if (ctx->lookup_const_decl (ref, &translated))
       {

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -514,7 +514,7 @@ public:
     if (needs_temp)
       {
 	fncontext fnctx = ctx->peek_fn ();
-	Bblock *enclosing_scope = ctx->peek_enclosing_scope ();
+	tree enclosing_scope = ctx->peek_enclosing_scope ();
 	tree block_type = TyTyResolveCompile::compile (ctx, if_type);
 
 	bool is_address_taken = false;
@@ -551,7 +551,7 @@ public:
     if (needs_temp)
       {
 	fncontext fnctx = ctx->peek_fn ();
-	Bblock *enclosing_scope = ctx->peek_enclosing_scope ();
+	tree enclosing_scope = ctx->peek_enclosing_scope ();
 	tree block_type = TyTyResolveCompile::compile (ctx, if_type);
 
 	bool is_address_taken = false;
@@ -587,7 +587,7 @@ public:
     if (needs_temp)
       {
 	fncontext fnctx = ctx->peek_fn ();
-	Bblock *enclosing_scope = ctx->peek_enclosing_scope ();
+	tree enclosing_scope = ctx->peek_enclosing_scope ();
 	tree block_type = TyTyResolveCompile::compile (ctx, block_tyty);
 
 	bool is_address_taken = false;
@@ -740,7 +740,7 @@ public:
     bool needs_temp = !block_tyty->is_unit ();
     if (needs_temp)
       {
-	Bblock *enclosing_scope = ctx->peek_enclosing_scope ();
+	tree enclosing_scope = ctx->peek_enclosing_scope ();
 	tree block_type = TyTyResolveCompile::compile (ctx, block_tyty);
 
 	bool is_address_taken = false;
@@ -773,7 +773,7 @@ public:
     ctx->add_statement (loop_begin_label_decl);
     ctx->push_loop_begin_label (loop_begin_label);
 
-    Bblock *code_block
+    tree code_block
       = CompileBlock::compile (expr.get_loop_block ().get (), ctx, nullptr);
     tree loop_expr
       = ctx->get_backend ()->loop_expression (code_block, expr.get_locus ());
@@ -811,8 +811,8 @@ public:
     Location start_location = expr.get_loop_block ()->get_locus ();
     Location end_location = expr.get_loop_block ()->get_locus (); // FIXME
 
-    Bblock *enclosing_scope = ctx->peek_enclosing_scope ();
-    Bblock *loop_block
+    tree enclosing_scope = ctx->peek_enclosing_scope ();
+    tree loop_block
       = ctx->get_backend ()->block (fnctx.fndecl, enclosing_scope, locals,
 				    start_location, end_location);
     ctx->push_block (loop_block);
@@ -832,7 +832,7 @@ public:
       = ctx->get_backend ()->expression_statement (fnctx.fndecl, exit_expr);
     ctx->add_statement (break_stmt);
 
-    Bblock *code_block
+    tree code_block
       = CompileBlock::compile (expr.get_loop_block ().get (), ctx, nullptr);
     tree code_block_stmt = ctx->get_backend ()->block_statement (code_block);
     ctx->add_statement (code_block_stmt);

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -755,7 +755,7 @@ public:
     if (expr.has_loop_label ())
       {
 	HIR::LoopLabel &loop_label = expr.get_loop_label ();
-	Blabel *label
+	tree label
 	  = ctx->get_backend ()->label (fnctx.fndecl,
 					loop_label.get_lifetime ().get_name (),
 					loop_label.get_locus ());
@@ -766,7 +766,7 @@ public:
 	  loop_label.get_lifetime ().get_mappings ().get_hirid (), label);
       }
 
-    Blabel *loop_begin_label
+    tree loop_begin_label
       = ctx->get_backend ()->label (fnctx.fndecl, "", expr.get_locus ());
     tree loop_begin_label_decl
       = ctx->get_backend ()->label_definition_statement (loop_begin_label);
@@ -796,7 +796,7 @@ public:
     if (expr.has_loop_label ())
       {
 	HIR::LoopLabel &loop_label = expr.get_loop_label ();
-	Blabel *label
+	tree label
 	  = ctx->get_backend ()->label (fnctx.fndecl,
 					loop_label.get_lifetime ().get_name (),
 					loop_label.get_locus ());
@@ -817,7 +817,7 @@ public:
 				    start_location, end_location);
     ctx->push_block (loop_block);
 
-    Blabel *loop_begin_label
+    tree loop_begin_label
       = ctx->get_backend ()->label (fnctx.fndecl, "", expr.get_locus ());
     tree loop_begin_label_decl
       = ctx->get_backend ()->label_definition_statement (loop_begin_label);
@@ -887,7 +887,7 @@ public:
 	    return;
 	  }
 
-	Blabel *label = nullptr;
+	tree label = NULL_TREE;
 	if (!ctx->lookup_label_decl (ref, &label))
 	  {
 	    rust_error_at (expr.get_label ().get_locus (),
@@ -912,7 +912,7 @@ public:
 
   void visit (HIR::ContinueExpr &expr) override
   {
-    Blabel *label = ctx->peek_loop_begin_label ();
+    tree label = ctx->peek_loop_begin_label ();
     if (expr.has_label ())
       {
 	NodeId resolved_node_id = UNKNOWN_NODEID;

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -379,7 +379,7 @@ public:
 
     rvalue = coercion_site (rvalue, actual, expected, expr.get_locus ());
 
-    Bstatement *assignment
+    tree assignment
       = ctx->get_backend ()->assignment_statement (fn.fndecl, lvalue, rvalue,
 						   expr.get_locus ());
 
@@ -518,7 +518,7 @@ public:
 	tree block_type = TyTyResolveCompile::compile (ctx, if_type);
 
 	bool is_address_taken = false;
-	Bstatement *ret_var_stmt = nullptr;
+	tree ret_var_stmt = nullptr;
 	tmp = ctx->get_backend ()->temporary_variable (
 	  fnctx.fndecl, enclosing_scope, block_type, NULL, is_address_taken,
 	  expr.get_locus (), &ret_var_stmt);
@@ -555,7 +555,7 @@ public:
 	tree block_type = TyTyResolveCompile::compile (ctx, if_type);
 
 	bool is_address_taken = false;
-	Bstatement *ret_var_stmt = nullptr;
+	tree ret_var_stmt = nullptr;
 	tmp = ctx->get_backend ()->temporary_variable (
 	  fnctx.fndecl, enclosing_scope, block_type, NULL, is_address_taken,
 	  expr.get_locus (), &ret_var_stmt);
@@ -591,7 +591,7 @@ public:
 	tree block_type = TyTyResolveCompile::compile (ctx, block_tyty);
 
 	bool is_address_taken = false;
-	Bstatement *ret_var_stmt = nullptr;
+	tree ret_var_stmt = nullptr;
 	tmp = ctx->get_backend ()->temporary_variable (
 	  fnctx.fndecl, enclosing_scope, block_type, NULL, is_address_taken,
 	  expr.get_locus (), &ret_var_stmt);
@@ -744,7 +744,7 @@ public:
 	tree block_type = TyTyResolveCompile::compile (ctx, block_tyty);
 
 	bool is_address_taken = false;
-	Bstatement *ret_var_stmt = nullptr;
+	tree ret_var_stmt = NULL_TREE;
 	tmp = ctx->get_backend ()->temporary_variable (
 	  fnctx.fndecl, enclosing_scope, block_type, NULL, is_address_taken,
 	  expr.get_locus (), &ret_var_stmt);
@@ -759,7 +759,7 @@ public:
 	  = ctx->get_backend ()->label (fnctx.fndecl,
 					loop_label.get_lifetime ().get_name (),
 					loop_label.get_locus ());
-	Bstatement *label_decl
+	tree label_decl
 	  = ctx->get_backend ()->label_definition_statement (label);
 	ctx->add_statement (label_decl);
 	ctx->insert_label_decl (
@@ -768,7 +768,7 @@ public:
 
     Blabel *loop_begin_label
       = ctx->get_backend ()->label (fnctx.fndecl, "", expr.get_locus ());
-    Bstatement *loop_begin_label_decl
+    tree loop_begin_label_decl
       = ctx->get_backend ()->label_definition_statement (loop_begin_label);
     ctx->add_statement (loop_begin_label_decl);
     ctx->push_loop_begin_label (loop_begin_label);
@@ -777,7 +777,7 @@ public:
       = CompileBlock::compile (expr.get_loop_block ().get (), ctx, nullptr);
     tree loop_expr
       = ctx->get_backend ()->loop_expression (code_block, expr.get_locus ());
-    Bstatement *loop_stmt
+    tree loop_stmt
       = ctx->get_backend ()->expression_statement (fnctx.fndecl, loop_expr);
     ctx->add_statement (loop_stmt);
 
@@ -800,7 +800,7 @@ public:
 	  = ctx->get_backend ()->label (fnctx.fndecl,
 					loop_label.get_lifetime ().get_name (),
 					loop_label.get_locus ());
-	Bstatement *label_decl
+	tree label_decl
 	  = ctx->get_backend ()->label_definition_statement (label);
 	ctx->add_statement (label_decl);
 	ctx->insert_label_decl (
@@ -819,7 +819,7 @@ public:
 
     Blabel *loop_begin_label
       = ctx->get_backend ()->label (fnctx.fndecl, "", expr.get_locus ());
-    Bstatement *loop_begin_label_decl
+    tree loop_begin_label_decl
       = ctx->get_backend ()->label_definition_statement (loop_begin_label);
     ctx->add_statement (loop_begin_label_decl);
     ctx->push_loop_begin_label (loop_begin_label);
@@ -828,14 +828,13 @@ public:
       = CompileExpr::Compile (expr.get_predicate_expr ().get (), ctx);
     tree exit_expr
       = ctx->get_backend ()->exit_expression (condition, expr.get_locus ());
-    Bstatement *break_stmt
+    tree break_stmt
       = ctx->get_backend ()->expression_statement (fnctx.fndecl, exit_expr);
     ctx->add_statement (break_stmt);
 
     Bblock *code_block
       = CompileBlock::compile (expr.get_loop_block ().get (), ctx, nullptr);
-    Bstatement *code_block_stmt
-      = ctx->get_backend ()->block_statement (code_block);
+    tree code_block_stmt = ctx->get_backend ()->block_statement (code_block);
     ctx->add_statement (code_block_stmt);
 
     ctx->pop_loop_begin_label ();
@@ -843,7 +842,7 @@ public:
 
     tree loop_expr
       = ctx->get_backend ()->loop_expression (loop_block, expr.get_locus ());
-    Bstatement *loop_stmt
+    tree loop_stmt
       = ctx->get_backend ()->expression_statement (fnctx.fndecl, loop_expr);
     ctx->add_statement (loop_stmt);
   }
@@ -860,7 +859,7 @@ public:
 	tree result_reference = ctx->get_backend ()->var_expression (
 	  loop_result_holder, expr.get_expr ()->get_locus ());
 
-	Bstatement *assignment = ctx->get_backend ()->assignment_statement (
+	tree assignment = ctx->get_backend ()->assignment_statement (
 	  fnctx.fndecl, result_reference, compiled_expr, expr.get_locus ());
 	ctx->add_statement (assignment);
       }
@@ -896,7 +895,7 @@ public:
 	    return;
 	  }
 
-	Bstatement *goto_label
+	tree goto_label
 	  = ctx->get_backend ()->goto_statement (label, expr.get_locus ());
 	ctx->add_statement (goto_label);
       }
@@ -905,7 +904,7 @@ public:
 	tree exit_expr = ctx->get_backend ()->exit_expression (
 	  ctx->get_backend ()->boolean_constant_expression (true),
 	  expr.get_locus ());
-	Bstatement *break_stmt
+	tree break_stmt
 	  = ctx->get_backend ()->expression_statement (fnctx.fndecl, exit_expr);
 	ctx->add_statement (break_stmt);
       }
@@ -945,7 +944,7 @@ public:
 	  }
       }
 
-    Bstatement *goto_label
+    tree goto_label
       = ctx->get_backend ()->goto_statement (label, expr.get_locus ());
     ctx->add_statement (goto_label);
   }

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -58,7 +58,7 @@ public:
 	TyTy::ReferenceType *r
 	  = static_cast<TyTy::ReferenceType *> (tuple_expr_ty);
 	TyTy::BaseType *tuple_type = r->get_base ();
-	Btype *tuple_tyty = TyTyResolveCompile::compile (ctx, tuple_type);
+	tree tuple_tyty = TyTyResolveCompile::compile (ctx, tuple_type);
 
 	Bexpression *indirect
 	  = ctx->get_backend ()->indirect_expression (tuple_tyty, receiver_ref,
@@ -88,7 +88,7 @@ public:
 	return;
       }
 
-    Btype *tuple_type = TyTyResolveCompile::compile (ctx, tyty);
+    tree tuple_type = TyTyResolveCompile::compile (ctx, tyty);
     rust_assert (tuple_type != nullptr);
 
     // this assumes all fields are in order from type resolution
@@ -259,7 +259,7 @@ public:
 	      return;
 	    }
 
-	  Btype *type = TyTyResolveCompile::compile (ctx, tyty);
+	  tree type = TyTyResolveCompile::compile (ctx, tyty);
 	  translated
 	    = ctx->get_backend ()->integer_constant_expression (type, ival);
 	}
@@ -285,7 +285,7 @@ public:
 	      return;
 	    }
 
-	  Btype *type = TyTyResolveCompile::compile (ctx, tyty);
+	  tree type = TyTyResolveCompile::compile (ctx, tyty);
 	  translated
 	    = ctx->get_backend ()->float_constant_expression (type, fval);
 	}
@@ -341,7 +341,7 @@ public:
 	      indexes.push_back (i);
 	    }
 
-	  Btype *array_type = TyTyResolveCompile::compile (ctx, array_tyty);
+	  tree array_type = TyTyResolveCompile::compile (ctx, array_tyty);
 	  Bexpression *constructed
 	    = ctx->get_backend ()->array_constructor_expression (
 	      array_type, indexes, vals, expr.get_locus ());
@@ -414,7 +414,7 @@ public:
     TyTy::ArrayType *array_tyty = static_cast<TyTy::ArrayType *> (tyty);
     capacity_expr = array_tyty->get_capacity ();
 
-    Btype *array_type = TyTyResolveCompile::compile (ctx, array_tyty);
+    tree array_type = TyTyResolveCompile::compile (ctx, array_tyty);
     rust_assert (array_type != nullptr);
 
     expr.get_internal_elements ()->accept_vis (*this);
@@ -517,7 +517,7 @@ public:
       {
 	fncontext fnctx = ctx->peek_fn ();
 	Bblock *enclosing_scope = ctx->peek_enclosing_scope ();
-	Btype *block_type = TyTyResolveCompile::compile (ctx, if_type);
+	tree block_type = TyTyResolveCompile::compile (ctx, if_type);
 
 	bool is_address_taken = false;
 	Bstatement *ret_var_stmt = nullptr;
@@ -554,7 +554,7 @@ public:
       {
 	fncontext fnctx = ctx->peek_fn ();
 	Bblock *enclosing_scope = ctx->peek_enclosing_scope ();
-	Btype *block_type = TyTyResolveCompile::compile (ctx, if_type);
+	tree block_type = TyTyResolveCompile::compile (ctx, if_type);
 
 	bool is_address_taken = false;
 	Bstatement *ret_var_stmt = nullptr;
@@ -590,7 +590,7 @@ public:
       {
 	fncontext fnctx = ctx->peek_fn ();
 	Bblock *enclosing_scope = ctx->peek_enclosing_scope ();
-	Btype *block_type = TyTyResolveCompile::compile (ctx, block_tyty);
+	tree block_type = TyTyResolveCompile::compile (ctx, block_tyty);
 
 	bool is_address_taken = false;
 	Bstatement *ret_var_stmt = nullptr;
@@ -640,7 +640,7 @@ public:
 	return;
       }
 
-    Btype *type = TyTyResolveCompile::compile (ctx, tyty);
+    tree type = TyTyResolveCompile::compile (ctx, tyty);
     rust_assert (type != nullptr);
 
     // this assumes all fields are in order from type resolution and if a base
@@ -705,7 +705,7 @@ public:
 					 &field_index);
 	rust_assert (ok);
 
-	Btype *adt_tyty = TyTyResolveCompile::compile (ctx, adt);
+	tree adt_tyty = TyTyResolveCompile::compile (ctx, adt);
 	Bexpression *indirect
 	  = ctx->get_backend ()->indirect_expression (adt_tyty, receiver_ref,
 						      true, expr.get_locus ());
@@ -743,7 +743,7 @@ public:
     if (needs_temp)
       {
 	Bblock *enclosing_scope = ctx->peek_enclosing_scope ();
-	Btype *block_type = TyTyResolveCompile::compile (ctx, block_tyty);
+	tree block_type = TyTyResolveCompile::compile (ctx, block_tyty);
 
 	bool is_address_taken = false;
 	Bstatement *ret_var_stmt = nullptr;
@@ -975,7 +975,7 @@ public:
 	return;
       }
 
-    Btype *expected_type = TyTyResolveCompile::compile (ctx, tyty);
+    tree expected_type = TyTyResolveCompile::compile (ctx, tyty);
     bool known_valid = true;
     translated
       = ctx->get_backend ()->indirect_expression (expected_type, main_expr,

--- a/gcc/rust/backend/rust-compile-extern.h
+++ b/gcc/rust/backend/rust-compile-extern.h
@@ -99,14 +99,14 @@ public:
 
     // items can be forward compiled which means we may not need to invoke this
     // code. We might also have already compiled this generic function as well.
-    Bfunction *lookup = nullptr;
+    tree lookup = NULL_TREE;
     if (ctx->lookup_function_decl (fntype->get_ty_ref (), &lookup,
 				   fntype->get_id (), fntype))
       {
 	// has this been added to the list then it must be finished
 	if (ctx->function_completed (lookup))
 	  {
-	    Bfunction *dummy = nullptr;
+	    tree dummy = NULL_TREE;
 	    if (!ctx->lookup_function_decl (fntype->get_ty_ref (), &dummy))
 	      ctx->insert_function_decl (fntype, lookup);
 
@@ -123,7 +123,7 @@ public:
     if (fntype->get_abi () == ABI::INTRINSIC)
       {
 	Intrinsics compile (ctx);
-	Bfunction *fndecl = compile.compile (fntype);
+	tree fndecl = compile.compile (fntype);
 	ctx->insert_function_decl (fntype, fndecl);
 	return;
       }
@@ -139,7 +139,7 @@ public:
     std::string ir_symbol_name = function.get_item_name ();
     std::string asm_name = function.get_item_name ();
 
-    Bfunction *fndecl
+    tree fndecl
       = ctx->get_backend ()->function (compiled_fn_type, ir_symbol_name,
 				       asm_name, flags, function.get_locus ());
     ctx->insert_function_decl (fntype, fndecl);

--- a/gcc/rust/backend/rust-compile-extern.h
+++ b/gcc/rust/backend/rust-compile-extern.h
@@ -55,7 +55,7 @@ public:
     // FIXME this is assuming C ABI
     std::string asm_name = name;
 
-    Btype *type = TyTyResolveCompile::compile (ctx, resolved_type);
+    tree type = TyTyResolveCompile::compile (ctx, resolved_type);
     bool is_external = true;
     bool is_hidden = false;
     bool in_unique_section = false;
@@ -128,7 +128,7 @@ public:
 	return;
       }
 
-    ::Btype *compiled_fn_type = TyTyResolveCompile::compile (ctx, fntype);
+    tree compiled_fn_type = TyTyResolveCompile::compile (ctx, fntype);
     compiled_fn_type
       = ctx->get_backend ()->specify_abi_attribute (compiled_fn_type,
 						    fntype->get_abi ());

--- a/gcc/rust/backend/rust-compile-fnparam.h
+++ b/gcc/rust/backend/rust-compile-fnparam.h
@@ -29,7 +29,7 @@ class CompileFnParam : public HIRCompileBase
   using Rust::Compile::HIRCompileBase::visit;
 
 public:
-  static Bvariable *compile (Context *ctx, Bfunction *fndecl,
+  static Bvariable *compile (Context *ctx, tree fndecl,
 			     HIR::FunctionParam *param, tree decl_type,
 			     Location locus)
   {
@@ -51,13 +51,12 @@ public:
   }
 
 private:
-  CompileFnParam (Context *ctx, ::Bfunction *fndecl, tree decl_type,
-		  Location locus)
+  CompileFnParam (Context *ctx, tree fndecl, tree decl_type, Location locus)
     : HIRCompileBase (ctx), fndecl (fndecl), decl_type (decl_type),
       locus (locus), translated (nullptr)
   {}
 
-  ::Bfunction *fndecl;
+  tree fndecl;
   tree decl_type;
   Location locus;
   ::Bvariable *translated;
@@ -66,9 +65,8 @@ private:
 class CompileSelfParam : public HIRCompileBase
 {
 public:
-  static Bvariable *compile (Context *ctx, Bfunction *fndecl,
-			     HIR::SelfParam &self, tree decl_type,
-			     Location locus)
+  static Bvariable *compile (Context *ctx, tree fndecl, HIR::SelfParam &self,
+			     tree decl_type, Location locus)
   {
     bool is_immutable
       = self.get_self_kind () == HIR::SelfParam::ImplicitSelfKind::IMM

--- a/gcc/rust/backend/rust-compile-fnparam.h
+++ b/gcc/rust/backend/rust-compile-fnparam.h
@@ -30,7 +30,7 @@ class CompileFnParam : public HIRCompileBase
 
 public:
   static Bvariable *compile (Context *ctx, Bfunction *fndecl,
-			     HIR::FunctionParam *param, Btype *decl_type,
+			     HIR::FunctionParam *param, tree decl_type,
 			     Location locus)
   {
     CompileFnParam compiler (ctx, fndecl, decl_type, locus);
@@ -51,14 +51,14 @@ public:
   }
 
 private:
-  CompileFnParam (Context *ctx, ::Bfunction *fndecl, ::Btype *decl_type,
+  CompileFnParam (Context *ctx, ::Bfunction *fndecl, tree decl_type,
 		  Location locus)
     : HIRCompileBase (ctx), fndecl (fndecl), decl_type (decl_type),
       locus (locus), translated (nullptr)
   {}
 
   ::Bfunction *fndecl;
-  ::Btype *decl_type;
+  tree decl_type;
   Location locus;
   ::Bvariable *translated;
 };
@@ -67,7 +67,7 @@ class CompileSelfParam : public HIRCompileBase
 {
 public:
   static Bvariable *compile (Context *ctx, Bfunction *fndecl,
-			     HIR::SelfParam &self, Btype *decl_type,
+			     HIR::SelfParam &self, tree decl_type,
 			     Location locus)
   {
     bool is_immutable

--- a/gcc/rust/backend/rust-compile-implitem.h
+++ b/gcc/rust/backend/rust-compile-implitem.h
@@ -34,11 +34,11 @@ class CompileInherentImplItem : public HIRCompileBase
   using Rust::Compile::HIRCompileBase::visit;
 
 public:
-  static Bexpression *Compile (const TyTy::BaseType *self, HIR::ImplItem *item,
-			       Context *ctx, bool compile_fns,
-			       TyTy::BaseType *concrete = nullptr,
-			       bool is_query_mode = false,
-			       Location ref_locus = Location ())
+  static tree Compile (const TyTy::BaseType *self, HIR::ImplItem *item,
+		       Context *ctx, bool compile_fns,
+		       TyTy::BaseType *concrete = nullptr,
+		       bool is_query_mode = false,
+		       Location ref_locus = Location ())
   {
     CompileInherentImplItem compiler (self, ctx, compile_fns, concrete,
 				      ref_locus);
@@ -61,7 +61,7 @@ public:
     rust_assert (ok);
 
     tree type = TyTyResolveCompile::compile (ctx, resolved_type);
-    Bexpression *value = CompileExpr::Compile (constant.get_expr (), ctx);
+    tree value = CompileExpr::Compile (constant.get_expr (), ctx);
 
     const Resolver::CanonicalPath *canonical_path = nullptr;
     ok = ctx->get_mappings ()->lookup_canonical_path (
@@ -70,7 +70,7 @@ public:
     rust_assert (ok);
 
     std::string ident = canonical_path->get ();
-    Bexpression *const_expr = ctx->get_backend ()->named_constant_expression (
+    tree const_expr = ctx->get_backend ()->named_constant_expression (
       type, constant.get_identifier (), value, constant.get_locus ());
 
     ctx->push_const (const_expr);
@@ -319,7 +319,7 @@ private:
   const TyTy::BaseType *self;
   bool compile_fns;
   TyTy::BaseType *concrete;
-  Bexpression *reference;
+  tree reference;
   Location ref_locus;
 };
 
@@ -328,10 +328,10 @@ class CompileTraitItem : public HIRCompileBase
   using Rust::Compile::HIRCompileBase::visit;
 
 public:
-  static Bexpression *Compile (const TyTy::BaseType *self, HIR::TraitItem *item,
-			       Context *ctx, TyTy::BaseType *concrete,
-			       bool is_query_mode = false,
-			       Location ref_locus = Location ())
+  static tree Compile (const TyTy::BaseType *self, HIR::TraitItem *item,
+		       Context *ctx, TyTy::BaseType *concrete,
+		       bool is_query_mode = false,
+		       Location ref_locus = Location ())
   {
     CompileTraitItem compiler (self, ctx, concrete, ref_locus);
     item->accept_vis (compiler);
@@ -350,8 +350,7 @@ public:
     TyTy::BaseType *resolved_type = concrete;
 
     tree type = TyTyResolveCompile::compile (ctx, resolved_type);
-    Bexpression *value
-      = CompileExpr::Compile (constant.get_expr ().get (), ctx);
+    tree value = CompileExpr::Compile (constant.get_expr ().get (), ctx);
 
     const Resolver::CanonicalPath *canonical_path = nullptr;
     bool ok = ctx->get_mappings ()->lookup_canonical_path (
@@ -360,7 +359,7 @@ public:
     rust_assert (ok);
 
     std::string ident = canonical_path->get ();
-    Bexpression *const_expr = ctx->get_backend ()->named_constant_expression (
+    tree const_expr = ctx->get_backend ()->named_constant_expression (
       type, constant.get_name (), value, constant.get_locus ());
 
     ctx->push_const (const_expr);
@@ -578,7 +577,7 @@ private:
 
   const TyTy::BaseType *self;
   TyTy::BaseType *concrete;
-  Bexpression *reference;
+  tree reference;
   Location ref_locus;
 };
 

--- a/gcc/rust/backend/rust-compile-implitem.h
+++ b/gcc/rust/backend/rust-compile-implitem.h
@@ -60,7 +60,7 @@ public:
 					&resolved_type);
     rust_assert (ok);
 
-    ::Btype *type = TyTyResolveCompile::compile (ctx, resolved_type);
+    tree type = TyTyResolveCompile::compile (ctx, resolved_type);
     Bexpression *value = CompileExpr::Compile (constant.get_expr (), ctx);
 
     const Resolver::CanonicalPath *canonical_path = nullptr;
@@ -136,7 +136,7 @@ public:
       }
 
     // convert to the actual function type
-    ::Btype *compiled_fn_type = TyTyResolveCompile::compile (ctx, fntype);
+    tree compiled_fn_type = TyTyResolveCompile::compile (ctx, fntype);
 
     unsigned int flags = 0;
 
@@ -178,7 +178,7 @@ public:
 	    return;
 	  }
 
-	Btype *self_type = TyTyResolveCompile::compile (ctx, self_tyty_lookup);
+	tree self_type = TyTyResolveCompile::compile (ctx, self_tyty_lookup);
 	if (self_type == nullptr)
 	  {
 	    rust_error_at (function.get_self_param ().get_locus (),
@@ -275,7 +275,7 @@ public:
     Bvariable *return_address = nullptr;
     if (function.has_function_return_type ())
       {
-	Btype *return_type = TyTyResolveCompile::compile (ctx, tyret);
+	tree return_type = TyTyResolveCompile::compile (ctx, tyret);
 
 	bool address_is_taken = false;
 	Bstatement *ret_var_stmt = nullptr;
@@ -349,7 +349,7 @@ public:
     rust_assert (concrete != nullptr);
     TyTy::BaseType *resolved_type = concrete;
 
-    ::Btype *type = TyTyResolveCompile::compile (ctx, resolved_type);
+    tree type = TyTyResolveCompile::compile (ctx, resolved_type);
     Bexpression *value
       = CompileExpr::Compile (constant.get_expr ().get (), ctx);
 
@@ -404,7 +404,7 @@ public:
       }
 
     // convert to the actual function type
-    ::Btype *compiled_fn_type = TyTyResolveCompile::compile (ctx, fntype);
+    tree compiled_fn_type = TyTyResolveCompile::compile (ctx, fntype);
 
     HIR::TraitFunctionDecl &function = func.get_decl ();
     unsigned int flags = 0;
@@ -440,7 +440,7 @@ public:
 	    return;
 	  }
 
-	Btype *self_type = TyTyResolveCompile::compile (ctx, self_tyty_lookup);
+	tree self_type = TyTyResolveCompile::compile (ctx, self_tyty_lookup);
 	if (self_type == nullptr)
 	  {
 	    rust_error_at (function.get_self ().get_locus (),
@@ -536,7 +536,7 @@ public:
     Bvariable *return_address = nullptr;
     if (function.has_return_type ())
       {
-	Btype *return_type = TyTyResolveCompile::compile (ctx, tyret);
+	tree return_type = TyTyResolveCompile::compile (ctx, tyret);
 
 	bool address_is_taken = false;
 	Bstatement *ret_var_stmt = nullptr;

--- a/gcc/rust/backend/rust-compile-implitem.h
+++ b/gcc/rust/backend/rust-compile-implitem.h
@@ -262,12 +262,12 @@ public:
     ok = compile_locals_for_block (*rib, fndecl, locals);
     rust_assert (ok);
 
-    Bblock *enclosing_scope = NULL;
+    tree enclosing_scope = NULL_TREE;
     HIR::BlockExpr *function_body = function.get_definition ().get ();
     Location start_location = function_body->get_locus ();
     Location end_location = function_body->get_closing_locus ();
 
-    Bblock *code_block
+    tree code_block
       = ctx->get_backend ()->block (fndecl, enclosing_scope, locals,
 				    start_location, end_location);
     ctx->push_block (code_block);
@@ -522,12 +522,12 @@ public:
     ok = compile_locals_for_block (*rib, fndecl, locals);
     rust_assert (ok);
 
-    Bblock *enclosing_scope = NULL;
+    tree enclosing_scope = NULL_TREE;
     HIR::BlockExpr *function_body = func.get_block_expr ().get ();
     Location start_location = function_body->get_locus ();
     Location end_location = function_body->get_closing_locus ();
 
-    Bblock *code_block
+    tree code_block
       = ctx->get_backend ()->block (fndecl, enclosing_scope, locals,
 				    start_location, end_location);
     ctx->push_block (code_block);

--- a/gcc/rust/backend/rust-compile-implitem.h
+++ b/gcc/rust/backend/rust-compile-implitem.h
@@ -110,14 +110,14 @@ public:
 
     // items can be forward compiled which means we may not need to invoke this
     // code. We might also have already compiled this generic function as well.
-    Bfunction *lookup = nullptr;
+    tree lookup = NULL_TREE;
     if (ctx->lookup_function_decl (fntype->get_ty_ref (), &lookup,
 				   fntype->get_id (), fntype))
       {
 	// has this been added to the list then it must be finished
 	if (ctx->function_completed (lookup))
 	  {
-	    Bfunction *dummy = nullptr;
+	    tree dummy = NULL_TREE;
 	    if (!ctx->lookup_function_decl (fntype->get_ty_ref (), &dummy))
 	      {
 		ctx->insert_function_decl (fntype, lookup);
@@ -156,7 +156,7 @@ public:
     std::string asm_name
       = ctx->mangle_impl_item (self, fntype, function.get_function_name ());
 
-    Bfunction *fndecl
+    tree fndecl
       = ctx->get_backend ()->function (compiled_fn_type, ir_symbol_name,
 				       asm_name, flags, function.get_locus ());
     ctx->insert_function_decl (fntype, fndecl);
@@ -377,14 +377,14 @@ public:
 
     // items can be forward compiled which means we may not need to invoke this
     // code. We might also have already compiled this generic function as well.
-    Bfunction *lookup = nullptr;
+    tree lookup = NULL_TREE;
     if (ctx->lookup_function_decl (fntype->get_ty_ref (), &lookup,
 				   fntype->get_id (), fntype))
       {
 	// has this been added to the list then it must be finished
 	if (ctx->function_completed (lookup))
 	  {
-	    Bfunction *dummy = nullptr;
+	    tree dummy = NULL_TREE;
 	    if (!ctx->lookup_function_decl (fntype->get_ty_ref (), &dummy))
 	      {
 		ctx->insert_function_decl (fntype, lookup);
@@ -417,7 +417,7 @@ public:
     std::string fn_identifier = canonical_path->get ();
     std::string asm_name = ctx->mangle_item (fntype, *canonical_path);
 
-    Bfunction *fndecl
+    tree fndecl
       = ctx->get_backend ()->function (compiled_fn_type, fn_identifier,
 				       asm_name, flags, func.get_locus ());
     ctx->insert_function_decl (fntype, fndecl);

--- a/gcc/rust/backend/rust-compile-implitem.h
+++ b/gcc/rust/backend/rust-compile-implitem.h
@@ -278,7 +278,7 @@ public:
 	tree return_type = TyTyResolveCompile::compile (ctx, tyret);
 
 	bool address_is_taken = false;
-	Bstatement *ret_var_stmt = nullptr;
+	tree ret_var_stmt = NULL_TREE;
 
 	return_address = ctx->get_backend ()->temporary_variable (
 	  fndecl, code_block, return_type, NULL, address_is_taken,
@@ -538,7 +538,7 @@ public:
 	tree return_type = TyTyResolveCompile::compile (ctx, tyret);
 
 	bool address_is_taken = false;
-	Bstatement *ret_var_stmt = nullptr;
+	tree ret_var_stmt = NULL_TREE;
 
 	return_address = ctx->get_backend ()->temporary_variable (
 	  fndecl, code_block, return_type, NULL, address_is_taken,

--- a/gcc/rust/backend/rust-compile-intrinsic.cc
+++ b/gcc/rust/backend/rust-compile-intrinsic.cc
@@ -21,7 +21,7 @@ namespace Compile {
 
 Intrinsics::Intrinsics (Context *ctx) : ctx (ctx) {}
 
-Bfunction *
+tree
 Intrinsics::compile (TyTy::FnType *fntype)
 {
   rust_assert (fntype->get_abi () == ABI::INTRINSIC);
@@ -77,7 +77,7 @@ Intrinsics::compile (TyTy::FnType *fntype)
   // };
   // Some(cx.get_intrinsic(&llvm_name))
 
-  Bfunction *builtin = ctx->get_backend ()->lookup_builtin_by_rust_name (
+  tree builtin = ctx->get_backend ()->lookup_builtin_by_rust_name (
     fntype->get_identifier ());
   if (builtin != nullptr)
     return builtin;

--- a/gcc/rust/backend/rust-compile-intrinsic.h
+++ b/gcc/rust/backend/rust-compile-intrinsic.h
@@ -27,7 +27,7 @@ class Intrinsics
 public:
   Intrinsics (Context *ctx);
 
-  Bfunction *compile (TyTy::FnType *fntype);
+  tree compile (TyTy::FnType *fntype);
 
 private:
   Context *ctx;

--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -61,7 +61,7 @@ public:
 					      &resolved_type);
     rust_assert (ok);
 
-    Btype *type = TyTyResolveCompile::compile (ctx, resolved_type);
+    tree type = TyTyResolveCompile::compile (ctx, resolved_type);
     Bexpression *value = CompileExpr::Compile (var.get_expr (), ctx);
 
     const Resolver::CanonicalPath *canonical_path = nullptr;
@@ -97,7 +97,7 @@ public:
 					&resolved_type);
     rust_assert (ok);
 
-    ::Btype *type = TyTyResolveCompile::compile (ctx, resolved_type);
+    tree type = TyTyResolveCompile::compile (ctx, resolved_type);
     Bexpression *value = CompileExpr::Compile (constant.get_expr (), ctx);
 
     const Resolver::CanonicalPath *canonical_path = nullptr;
@@ -174,7 +174,7 @@ public:
 	fntype->override_context ();
       }
 
-    ::Btype *compiled_fn_type = TyTyResolveCompile::compile (ctx, fntype);
+    tree compiled_fn_type = TyTyResolveCompile::compile (ctx, fntype);
 
     unsigned int flags = 0;
     bool is_main_fn = function.get_function_name ().compare ("main") == 0;
@@ -275,7 +275,7 @@ public:
     Bvariable *return_address = nullptr;
     if (function.has_function_return_type ())
       {
-	Btype *return_type = TyTyResolveCompile::compile (ctx, tyret);
+	tree return_type = TyTyResolveCompile::compile (ctx, tyret);
 
 	bool address_is_taken = false;
 	Bstatement *ret_var_stmt = nullptr;

--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -261,12 +261,12 @@ public:
     ok = compile_locals_for_block (*rib, fndecl, locals);
     rust_assert (ok);
 
-    Bblock *enclosing_scope = NULL;
+    tree enclosing_scope = NULL_TREE;
     HIR::BlockExpr *function_body = function.get_definition ().get ();
     Location start_location = function_body->get_locus ();
     Location end_location = function_body->get_closing_locus ();
 
-    Bblock *code_block
+    tree code_block
       = ctx->get_backend ()->block (fndecl, enclosing_scope, locals,
 				    start_location, end_location);
     ctx->push_block (code_block);

--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -37,11 +37,10 @@ protected:
   using Rust::Compile::HIRCompileBase::visit;
 
 public:
-  static Bexpression *compile (HIR::Item *item, Context *ctx,
-			       bool compile_fns = true,
-			       TyTy::BaseType *concrete = nullptr,
-			       bool is_query_mode = false,
-			       Location ref_locus = Location ())
+  static tree compile (HIR::Item *item, Context *ctx, bool compile_fns = true,
+		       TyTy::BaseType *concrete = nullptr,
+		       bool is_query_mode = false,
+		       Location ref_locus = Location ())
   {
     CompileItem compiler (ctx, compile_fns, concrete, ref_locus);
     item->accept_vis (compiler);
@@ -62,7 +61,7 @@ public:
     rust_assert (ok);
 
     tree type = TyTyResolveCompile::compile (ctx, resolved_type);
-    Bexpression *value = CompileExpr::Compile (var.get_expr (), ctx);
+    tree value = CompileExpr::Compile (var.get_expr (), ctx);
 
     const Resolver::CanonicalPath *canonical_path = nullptr;
     ok = ctx->get_mappings ()->lookup_canonical_path (
@@ -98,7 +97,7 @@ public:
     rust_assert (ok);
 
     tree type = TyTyResolveCompile::compile (ctx, resolved_type);
-    Bexpression *value = CompileExpr::Compile (constant.get_expr (), ctx);
+    tree value = CompileExpr::Compile (constant.get_expr (), ctx);
 
     const Resolver::CanonicalPath *canonical_path = nullptr;
     ok = ctx->get_mappings ()->lookup_canonical_path (
@@ -107,7 +106,7 @@ public:
     rust_assert (ok);
 
     std::string ident = canonical_path->get ();
-    Bexpression *const_expr
+    tree const_expr
       = ctx->get_backend ()->named_constant_expression (type, ident, value,
 							constant.get_locus ());
 
@@ -347,7 +346,7 @@ protected:
 
   bool compile_fns;
   TyTy::BaseType *concrete;
-  Bexpression *reference;
+  tree reference;
   Location ref_locus;
 };
 

--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -277,7 +277,7 @@ public:
 	tree return_type = TyTyResolveCompile::compile (ctx, tyret);
 
 	bool address_is_taken = false;
-	Bstatement *ret_var_stmt = nullptr;
+	tree ret_var_stmt = NULL_TREE;
 
 	return_address = ctx->get_backend ()->temporary_variable (
 	  fndecl, code_block, return_type, NULL, address_is_taken,

--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -147,14 +147,14 @@ public:
 
     // items can be forward compiled which means we may not need to invoke this
     // code. We might also have already compiled this generic function as well.
-    Bfunction *lookup = nullptr;
+    tree lookup = NULL_TREE;
     if (ctx->lookup_function_decl (fntype->get_ty_ref (), &lookup,
 				   fntype->get_id (), fntype))
       {
 	// has this been added to the list then it must be finished
 	if (ctx->function_completed (lookup))
 	  {
-	    Bfunction *dummy = nullptr;
+	    tree dummy = NULL_TREE;
 	    if (!ctx->lookup_function_decl (fntype->get_ty_ref (), &dummy))
 	      {
 		ctx->insert_function_decl (fntype, lookup);
@@ -201,7 +201,7 @@ public:
 	asm_name = ctx->mangle_item (fntype, *canonical_path);
       }
 
-    Bfunction *fndecl
+    tree fndecl
       = ctx->get_backend ()->function (compiled_fn_type, ir_symbol_name,
 				       asm_name, flags, function.get_locus ());
     ctx->insert_function_decl (fntype, fndecl);

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -40,7 +40,7 @@ ResolvePathRef::visit (HIR::PathInExpression &expr)
 		      expr.get_mappings (), expr.get_locus (), false);
 }
 
-Bexpression *
+tree
 ResolvePathRef::resolve (const HIR::PathIdentSegment &final_segment,
 			 const Analysis::NodeMapping &mappings,
 			 Location expr_locus, bool is_qualified_path)
@@ -76,7 +76,7 @@ ResolvePathRef::resolve (const HIR::PathIdentSegment &final_segment,
     }
 
   // might be a constant
-  Bexpression *constant_expr;
+  tree constant_expr;
   if (ctx->lookup_const_decl (ref, &constant_expr))
     return constant_expr;
 
@@ -104,7 +104,7 @@ ResolvePathRef::resolve (const HIR::PathIdentSegment &final_segment,
 			is_qualified_path);
 }
 
-Bexpression *
+tree
 ResolvePathRef::query_compile (HirId ref, TyTy::BaseType *lookup,
 			       const HIR::PathIdentSegment &final_segment,
 			       const Analysis::NodeMapping &mappings,

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -92,7 +92,7 @@ ResolvePathRef::resolve (const HIR::PathIdentSegment &final_segment,
   if (lookup->get_kind () == TyTy::TypeKind::FNDEF)
     {
       TyTy::FnType *fntype = static_cast<TyTy::FnType *> (lookup);
-      Bfunction *fn = nullptr;
+      tree fn = NULL_TREE;
       if (ctx->lookup_function_decl (fntype->get_ty_ref (), &fn))
 	{
 	  return ctx->get_backend ()->function_code_expression (fn, expr_locus);

--- a/gcc/rust/backend/rust-compile-resolve-path.h
+++ b/gcc/rust/backend/rust-compile-resolve-path.h
@@ -30,15 +30,14 @@ class ResolvePathRef : public HIRCompileBase
   using Rust::Compile::HIRCompileBase::visit;
 
 public:
-  static Bexpression *Compile (HIR::QualifiedPathInExpression &expr,
-			       Context *ctx)
+  static tree Compile (HIR::QualifiedPathInExpression &expr, Context *ctx)
   {
     ResolvePathRef resolver (ctx);
     expr.accept_vis (resolver);
     return resolver.resolved;
   }
 
-  static Bexpression *Compile (HIR::PathInExpression &expr, Context *ctx)
+  static tree Compile (HIR::PathInExpression &expr, Context *ctx)
   {
     ResolvePathRef resolver (ctx);
     expr.accept_vis (resolver);
@@ -54,16 +53,16 @@ private:
     : HIRCompileBase (ctx), resolved (ctx->get_backend ()->error_expression ())
   {}
 
-  Bexpression *resolve (const HIR::PathIdentSegment &final_segment,
-			const Analysis::NodeMapping &mappings, Location locus,
-			bool is_qualified_path);
+  tree resolve (const HIR::PathIdentSegment &final_segment,
+		const Analysis::NodeMapping &mappings, Location locus,
+		bool is_qualified_path);
 
-  Bexpression *query_compile (HirId ref, TyTy::BaseType *lookup,
-			      const HIR::PathIdentSegment &final_segment,
-			      const Analysis::NodeMapping &mappings,
-			      Location expr_locus, bool is_qualified_path);
+  tree query_compile (HirId ref, TyTy::BaseType *lookup,
+		      const HIR::PathIdentSegment &final_segment,
+		      const Analysis::NodeMapping &mappings,
+		      Location expr_locus, bool is_qualified_path);
 
-  Bexpression *resolved;
+  tree resolved;
 };
 
 } // namespace Compile

--- a/gcc/rust/backend/rust-compile-stmt.h
+++ b/gcc/rust/backend/rust-compile-stmt.h
@@ -118,7 +118,7 @@ public:
     auto fnctx = ctx->peek_fn ();
     if (ty->is_unit ())
       {
-	Bstatement *expr_stmt
+	tree expr_stmt
 	  = ctx->get_backend ()->expression_statement (fnctx.fndecl, init);
 	ctx->add_statement (expr_stmt);
       }

--- a/gcc/rust/backend/rust-compile-stmt.h
+++ b/gcc/rust/backend/rust-compile-stmt.h
@@ -31,7 +31,7 @@ class CompileStmt : public HIRCompileBase
   using Rust::Compile::HIRCompileBase::visit;
 
 public:
-  static Bexpression *Compile (HIR::Stmt *stmt, Context *ctx)
+  static tree Compile (HIR::Stmt *stmt, Context *ctx)
   {
     CompileStmt compiler (ctx);
     stmt->accept_vis (compiler);
@@ -57,7 +57,7 @@ public:
     rust_assert (ok);
 
     tree type = TyTyResolveCompile::compile (ctx, resolved_type);
-    Bexpression *value = CompileExpr::Compile (constant.get_expr (), ctx);
+    tree value = CompileExpr::Compile (constant.get_expr (), ctx);
 
     const Resolver::CanonicalPath *canonical_path = nullptr;
     ok = ctx->get_mappings ()->lookup_canonical_path (
@@ -66,7 +66,7 @@ public:
     rust_assert (ok);
 
     std::string ident = canonical_path->get ();
-    Bexpression *const_expr
+    tree const_expr
       = ctx->get_backend ()->named_constant_expression (type, ident, value,
 							constant.get_locus ());
 
@@ -101,7 +101,7 @@ public:
 	return;
       }
 
-    Bexpression *init = CompileExpr::Compile (stmt.get_init_expr (), ctx);
+    tree init = CompileExpr::Compile (stmt.get_init_expr (), ctx);
     // FIXME use error_mark_node, check that CompileExpr returns error_mark_node
     // on failure and make this an assertion
     if (init == nullptr)
@@ -132,7 +132,7 @@ public:
 private:
   CompileStmt (Context *ctx) : HIRCompileBase (ctx), translated (nullptr) {}
 
-  Bexpression *translated;
+  tree translated;
 };
 
 } // namespace Compile

--- a/gcc/rust/backend/rust-compile-stmt.h
+++ b/gcc/rust/backend/rust-compile-stmt.h
@@ -56,7 +56,7 @@ public:
 					&resolved_type);
     rust_assert (ok);
 
-    ::Btype *type = TyTyResolveCompile::compile (ctx, resolved_type);
+    tree type = TyTyResolveCompile::compile (ctx, resolved_type);
     Bexpression *value = CompileExpr::Compile (constant.get_expr (), ctx);
 
     const Resolver::CanonicalPath *canonical_path = nullptr;

--- a/gcc/rust/backend/rust-compile-struct-field-expr.h
+++ b/gcc/rust/backend/rust-compile-struct-field-expr.h
@@ -30,7 +30,7 @@ class CompileStructExprField : public HIRCompileBase
   using Rust::Compile::HIRCompileBase::visit;
 
 public:
-  static Bexpression *Compile (HIR::StructExprField *field, Context *ctx)
+  static tree Compile (HIR::StructExprField *field, Context *ctx)
   {
     CompileStructExprField compiler (ctx);
     field->accept_vis (compiler);
@@ -49,7 +49,7 @@ private:
     : HIRCompileBase (ctx), translated (nullptr)
   {}
 
-  Bexpression *translated;
+  tree translated;
 };
 
 } // namespace Compile

--- a/gcc/rust/backend/rust-compile-tyty.h
+++ b/gcc/rust/backend/rust-compile-tyty.h
@@ -34,7 +34,7 @@ namespace Compile {
 class TyTyCompile : public TyTy::TyVisitor
 {
 public:
-  static ::Btype *compile (::Backend *backend, TyTy::BaseType *ty)
+  static tree compile (::Backend *backend, TyTy::BaseType *ty)
   {
     TyTyCompile compiler (backend);
     ty->accept_vis (compiler);
@@ -72,15 +72,15 @@ public:
 
   void visit (TyTy::FnType &type) override
   {
-    Backend::Btyped_identifier receiver;
-    std::vector<Backend::Btyped_identifier> parameters;
-    std::vector<Backend::Btyped_identifier> results;
+    Backend::typed_identifier receiver;
+    std::vector<Backend::typed_identifier> parameters;
+    std::vector<Backend::typed_identifier> results;
 
     if (!type.get_return_type ()->is_unit ())
       {
 	auto hir_type = type.get_return_type ();
 	auto ret = TyTyCompile::compile (backend, hir_type);
-	results.push_back (Backend::Btyped_identifier (
+	results.push_back (Backend::typed_identifier (
 	  "_", ret, mappings->lookup_location (hir_type->get_ref ())));
       }
 
@@ -90,7 +90,7 @@ public:
 	auto param_tyty = params.second;
 	auto compiled_param_type = TyTyCompile::compile (backend, param_tyty);
 
-	auto compiled_param = Backend::Btyped_identifier (
+	auto compiled_param = Backend::typed_identifier (
 	  param_pattern->as_string (), compiled_param_type,
 	  mappings->lookup_location (param_tyty->get_ref ()));
 
@@ -227,7 +227,7 @@ public:
 
   void visit (TyTy::StrType &) override
   {
-    Btype *raw_str = backend->raw_str_type ();
+    tree raw_str = backend->raw_str_type ();
     translated
       = backend->named_type ("str", raw_str, Linemap::predeclared_location ());
   }
@@ -248,7 +248,7 @@ private:
   {}
 
   ::Backend *backend;
-  ::Btype *translated;
+  tree translated;
   Analysis::Mappings *mappings;
 };
 

--- a/gcc/rust/backend/rust-compile-var-decl.h
+++ b/gcc/rust/backend/rust-compile-var-decl.h
@@ -29,8 +29,7 @@ class CompileVarDecl : public HIRCompileBase
   using Rust::Compile::HIRCompileBase::visit;
 
 public:
-  static ::Bvariable *compile (::Bfunction *fndecl, HIR::Stmt *stmt,
-			       Context *ctx)
+  static ::Bvariable *compile (tree fndecl, HIR::Stmt *stmt, Context *ctx)
   {
     CompileVarDecl compiler (ctx, fndecl);
     stmt->accept_vis (compiler);
@@ -64,12 +63,12 @@ public:
   }
 
 private:
-  CompileVarDecl (Context *ctx, ::Bfunction *fndecl)
+  CompileVarDecl (Context *ctx, tree fndecl)
     : HIRCompileBase (ctx), fndecl (fndecl), translated_type (nullptr),
       translated (nullptr)
   {}
 
-  ::Bfunction *fndecl;
+  tree fndecl;
   tree translated_type;
   Location locus;
   ::Bvariable *translated;

--- a/gcc/rust/backend/rust-compile-var-decl.h
+++ b/gcc/rust/backend/rust-compile-var-decl.h
@@ -70,7 +70,7 @@ private:
   {}
 
   ::Bfunction *fndecl;
-  ::Btype *translated_type;
+  tree translated_type;
   Location locus;
   ::Bvariable *translated;
 };

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -338,10 +338,9 @@ CompileBlock::visit (HIR::BlockExpr &expr)
   bool ok = compile_locals_for_block (*rib, fndecl, locals);
   rust_assert (ok);
 
-  Bblock *enclosing_scope = ctx->peek_enclosing_scope ();
-  Bblock *new_block
-    = ctx->get_backend ()->block (fndecl, enclosing_scope, locals,
-				  start_location, end_location);
+  tree enclosing_scope = ctx->peek_enclosing_scope ();
+  tree new_block = ctx->get_backend ()->block (fndecl, enclosing_scope, locals,
+					       start_location, end_location);
   ctx->push_block (new_block);
 
   for (auto &s : expr.get_statements ())
@@ -395,8 +394,7 @@ CompileConditionalBlocks::visit (HIR::IfExpr &expr)
   fncontext fnctx = ctx->peek_fn ();
   tree fndecl = fnctx.fndecl;
   tree condition_expr = CompileExpr::Compile (expr.get_if_condition (), ctx);
-  Bblock *then_block
-    = CompileBlock::compile (expr.get_if_block (), ctx, result);
+  tree then_block = CompileBlock::compile (expr.get_if_block (), ctx, result);
 
   translated
     = ctx->get_backend ()->if_statement (fndecl, condition_expr, then_block,
@@ -409,10 +407,8 @@ CompileConditionalBlocks::visit (HIR::IfExprConseqElse &expr)
   fncontext fnctx = ctx->peek_fn ();
   tree fndecl = fnctx.fndecl;
   tree condition_expr = CompileExpr::Compile (expr.get_if_condition (), ctx);
-  Bblock *then_block
-    = CompileBlock::compile (expr.get_if_block (), ctx, result);
-  Bblock *else_block
-    = CompileBlock::compile (expr.get_else_block (), ctx, result);
+  tree then_block = CompileBlock::compile (expr.get_if_block (), ctx, result);
+  tree else_block = CompileBlock::compile (expr.get_else_block (), ctx, result);
 
   translated
     = ctx->get_backend ()->if_statement (fndecl, condition_expr, then_block,
@@ -425,17 +421,15 @@ CompileConditionalBlocks::visit (HIR::IfExprConseqIf &expr)
   fncontext fnctx = ctx->peek_fn ();
   tree fndecl = fnctx.fndecl;
   tree condition_expr = CompileExpr::Compile (expr.get_if_condition (), ctx);
-  Bblock *then_block
-    = CompileBlock::compile (expr.get_if_block (), ctx, result);
+  tree then_block = CompileBlock::compile (expr.get_if_block (), ctx, result);
 
   // else block
   std::vector<Bvariable *> locals;
   Location start_location = expr.get_conseq_if_expr ()->get_locus ();
   Location end_location = expr.get_conseq_if_expr ()->get_locus (); // FIXME
-  Bblock *enclosing_scope = ctx->peek_enclosing_scope ();
-  Bblock *else_block
-    = ctx->get_backend ()->block (fndecl, enclosing_scope, locals,
-				  start_location, end_location);
+  tree enclosing_scope = ctx->peek_enclosing_scope ();
+  tree else_block = ctx->get_backend ()->block (fndecl, enclosing_scope, locals,
+						start_location, end_location);
   ctx->push_block (else_block);
 
   tree else_stmt_decl
@@ -610,7 +604,7 @@ HIRCompileBase::coerce_to_dyn_object (tree compiled_ref,
 						   locus);
 
   fncontext fnctx = ctx->peek_fn ();
-  Bblock *enclosing_scope = ctx->peek_enclosing_scope ();
+  tree enclosing_scope = ctx->peek_enclosing_scope ();
   bool is_address_taken = false;
   tree ret_var_stmt = NULL_TREE;
 

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -72,7 +72,7 @@ CompileExpr::visit (HIR::CallExpr &expr)
     {
       rust_assert (tyty->get_kind () == TyTy::TypeKind::ADT);
       TyTy::ADTType *adt = static_cast<TyTy::ADTType *> (tyty);
-      Btype *compiled_adt_type = TyTyResolveCompile::compile (ctx, tyty);
+      tree compiled_adt_type = TyTyResolveCompile::compile (ctx, tyty);
 
       rust_assert (!adt->is_enum ());
       rust_assert (adt->number_of_variants () == 1);
@@ -275,7 +275,7 @@ CompileExpr::visit (HIR::MethodCallExpr &expr)
 	  break;
 
 	case Resolver::Adjustment::AdjustmentType::DEREF_REF:
-	  Btype *expected_type
+	  tree expected_type
 	    = TyTyResolveCompile::compile (ctx, adjustment.get_expected ());
 	  self = ctx->get_backend ()->indirect_expression (
 	    expected_type, self, true, /* known_valid*/
@@ -587,7 +587,7 @@ HIRCompileBase::coerce_to_dyn_object (Bexpression *compiled_ref,
 				      const TyTy::DynamicObjectType *ty,
 				      Location locus)
 {
-  Btype *dynamic_object = TyTyResolveCompile::compile (ctx, ty);
+  tree dynamic_object = TyTyResolveCompile::compile (ctx, ty);
 
   //' this assumes ordering and current the structure is
   // __trait_object_ptr

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -349,7 +349,7 @@ CompileBlock::visit (HIR::BlockExpr &expr)
       auto compiled_expr = CompileStmt::Compile (s.get (), ctx);
       if (compiled_expr != nullptr)
 	{
-	  Bstatement *compiled_stmt
+	  tree compiled_stmt
 	    = ctx->get_backend ()->expression_statement (fnctx.fndecl,
 							 compiled_expr);
 	  ctx->add_statement (compiled_stmt);
@@ -365,7 +365,7 @@ CompileBlock::visit (HIR::BlockExpr &expr)
 	{
 	  if (result == nullptr)
 	    {
-	      Bstatement *final_stmt
+	      tree final_stmt
 		= ctx->get_backend ()->expression_statement (fnctx.fndecl,
 							     compiled_expr);
 	      ctx->add_statement (final_stmt);
@@ -375,7 +375,7 @@ CompileBlock::visit (HIR::BlockExpr &expr)
 	      tree result_reference = ctx->get_backend ()->var_expression (
 		result, expr.get_final_expr ()->get_locus ());
 
-	      Bstatement *assignment
+	      tree assignment
 		= ctx->get_backend ()->assignment_statement (fnctx.fndecl,
 							     result_reference,
 							     compiled_expr,
@@ -438,7 +438,7 @@ CompileConditionalBlocks::visit (HIR::IfExprConseqIf &expr)
 				  start_location, end_location);
   ctx->push_block (else_block);
 
-  Bstatement *else_stmt_decl
+  tree else_stmt_decl
     = CompileConditionalBlocks::compile (expr.get_conseq_if_expr (), ctx,
 					 result);
   ctx->add_statement (else_stmt_decl);
@@ -486,7 +486,7 @@ HIRCompileBase::compile_function_body (
       auto compiled_expr = CompileStmt::Compile (s.get (), ctx);
       if (compiled_expr != nullptr)
 	{
-	  Bstatement *compiled_stmt
+	  tree compiled_stmt
 	    = ctx->get_backend ()->expression_statement (fndecl, compiled_expr);
 	  ctx->add_statement (compiled_stmt);
 	}
@@ -513,7 +513,7 @@ HIRCompileBase::compile_function_body (
 	    }
 	  else
 	    {
-	      Bstatement *final_stmt
+	      tree final_stmt
 		= ctx->get_backend ()->expression_statement (fndecl,
 							     compiled_expr);
 	      ctx->add_statement (final_stmt);
@@ -612,7 +612,7 @@ HIRCompileBase::coerce_to_dyn_object (tree compiled_ref,
   fncontext fnctx = ctx->peek_fn ();
   Bblock *enclosing_scope = ctx->peek_enclosing_scope ();
   bool is_address_taken = false;
-  Bstatement *ret_var_stmt = nullptr;
+  tree ret_var_stmt = NULL_TREE;
 
   Bvariable *dyn_tmp = ctx->get_backend ()->temporary_variable (
     fnctx.fndecl, enclosing_scope, dynamic_object, constructed_trait_object,

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -322,7 +322,7 @@ void
 CompileBlock::visit (HIR::BlockExpr &expr)
 {
   fncontext fnctx = ctx->peek_fn ();
-  Bfunction *fndecl = fnctx.fndecl;
+  tree fndecl = fnctx.fndecl;
   Location start_location = expr.get_locus ();
   Location end_location = expr.get_closing_locus ();
   auto body_mappings = expr.get_mappings ();
@@ -393,7 +393,7 @@ void
 CompileConditionalBlocks::visit (HIR::IfExpr &expr)
 {
   fncontext fnctx = ctx->peek_fn ();
-  Bfunction *fndecl = fnctx.fndecl;
+  tree fndecl = fnctx.fndecl;
   tree condition_expr = CompileExpr::Compile (expr.get_if_condition (), ctx);
   Bblock *then_block
     = CompileBlock::compile (expr.get_if_block (), ctx, result);
@@ -407,7 +407,7 @@ void
 CompileConditionalBlocks::visit (HIR::IfExprConseqElse &expr)
 {
   fncontext fnctx = ctx->peek_fn ();
-  Bfunction *fndecl = fnctx.fndecl;
+  tree fndecl = fnctx.fndecl;
   tree condition_expr = CompileExpr::Compile (expr.get_if_condition (), ctx);
   Bblock *then_block
     = CompileBlock::compile (expr.get_if_block (), ctx, result);
@@ -423,7 +423,7 @@ void
 CompileConditionalBlocks::visit (HIR::IfExprConseqIf &expr)
 {
   fncontext fnctx = ctx->peek_fn ();
-  Bfunction *fndecl = fnctx.fndecl;
+  tree fndecl = fnctx.fndecl;
   tree condition_expr = CompileExpr::Compile (expr.get_if_condition (), ctx);
   Bblock *then_block
     = CompileBlock::compile (expr.get_if_block (), ctx, result);
@@ -478,7 +478,7 @@ CompileStructExprField::visit (HIR::StructExprFieldIdentifier &field)
 
 void
 HIRCompileBase::compile_function_body (
-  Bfunction *fndecl, std::unique_ptr<HIR::BlockExpr> &function_body,
+  tree fndecl, std::unique_ptr<HIR::BlockExpr> &function_body,
   bool has_return_type)
 {
   for (auto &s : function_body->get_statements ())
@@ -523,7 +523,7 @@ HIRCompileBase::compile_function_body (
 }
 
 bool
-HIRCompileBase::compile_locals_for_block (Resolver::Rib &rib, Bfunction *fndecl,
+HIRCompileBase::compile_locals_for_block (Resolver::Rib &rib, tree fndecl,
 					  std::vector<Bvariable *> &locals)
 {
   rib.iterate_decls ([&] (NodeId n, Location) mutable -> bool {

--- a/gcc/rust/rust-backend.h
+++ b/gcc/rust/rust-backend.h
@@ -229,95 +229,12 @@ public:
   // Get an array type.
   virtual Btype *array_type (Btype *element_type, Bexpression *length) = 0;
 
-  // Create a placeholder pointer type.  This is used for a named
-  // pointer type, since in Go a pointer type may refer to itself.
-  // NAME is the name of the type, and the location is where the named
-  // type is defined.  This function is also used for unnamed function
-  // types with multiple results, in which case the type has no name
-  // and NAME will be empty.  FOR_FUNCTION is true if this is for a C
-  // pointer to function type.  A Go func type is represented as a
-  // pointer to a struct, and the first field of the struct is a C
-  // pointer to function.  The return value will later be passed as
-  // the first parameter to set_placeholder_pointer_type or
-  // set_placeholder_function_type.
-  virtual Btype *placeholder_pointer_type (const std::string &name, Location,
-					   bool for_function)
-    = 0;
-
-  // Fill in a placeholder pointer type as a pointer.  This takes a
-  // type returned by placeholder_pointer_type and arranges for it to
-  // point to the type that TO_TYPE points to (that is, PLACEHOLDER
-  // becomes the same type as TO_TYPE).  Returns true on success,
-  // false on failure.
-  virtual bool set_placeholder_pointer_type (Btype *placeholder, Btype *to_type)
-    = 0;
-
-  // Fill in a placeholder pointer type as a function.  This takes a
-  // type returned by placeholder_pointer_type and arranges for it to
-  // become a real Go function type (which corresponds to a C/C++
-  // pointer to function type).  FT will be something returned by the
-  // function_type method.  Returns true on success, false on failure.
-  virtual bool set_placeholder_function_type (Btype *placeholder, Btype *ft)
-    = 0;
-
-  // Create a placeholder struct type.  This is used for a named
-  // struct type, as with placeholder_pointer_type.  It is also used
-  // for interface types, in which case NAME will be the empty string.
-  virtual Btype *placeholder_struct_type (const std::string &name, Location)
-    = 0;
-
-  // Fill in a placeholder struct type.  This takes a type returned by
-  // placeholder_struct_type and arranges for it to become a real
-  // struct type.  The parameter is as for struct_type.  Returns true
-  // on success, false on failure.
-  virtual bool
-  set_placeholder_struct_type (Btype *placeholder,
-			       const std::vector<Btyped_identifier> &fields)
-    = 0;
-
-  // Create a placeholder array type.  This is used for a named array
-  // type, as with placeholder_pointer_type, to handle cases like
-  // type A []*A.
-  virtual Btype *placeholder_array_type (const std::string &name, Location) = 0;
-
-  // Fill in a placeholder array type.  This takes a type returned by
-  // placeholder_array_type and arranges for it to become a real array
-  // type.  The parameters are as for array_type.  Returns true on
-  // success, false on failure.
-  virtual bool set_placeholder_array_type (Btype *placeholder,
-					   Btype *element_type,
-					   Bexpression *length)
-    = 0;
-
   // Return a named version of a type.  The location is the location
   // of the type definition.  This will not be called for a type
   // created via placeholder_pointer_type, placeholder_struct_type, or
   // placeholder_array_type..  (It may be called for a pointer,
   // struct, or array type in a case like "type P *byte; type Q P".)
   virtual Btype *named_type (const std::string &name, Btype *, Location) = 0;
-
-  // Create a marker for a circular pointer type.  Go pointer and
-  // function types can refer to themselves in ways that are not
-  // permitted in C/C++.  When a circular type is found, this function
-  // is called for the circular reference.  This permits the backend
-  // to decide how to handle such a type.  PLACEHOLDER is the
-  // placeholder type which has already been created; if the backend
-  // is prepared to handle a circular pointer type, it may simply
-  // return PLACEHOLDER.  FOR_FUNCTION is true if this is for a
-  // function type.
-  //
-  // For "type P *P" the sequence of calls will be
-  //   bt1 = placeholder_pointer_type();
-  //   bt2 = circular_pointer_type(bt1, false);
-  //   set_placeholder_pointer_type(bt1, bt2);
-  virtual Btype *circular_pointer_type (Btype *placeholder, bool for_function)
-    = 0;
-
-  // Return whether the argument could be a special type created by
-  // circular_pointer_type.  This is used to introduce explicit type
-  // conversions where needed.  If circular_pointer_type returns its
-  // PLACEHOLDER parameter, this may safely always return false.
-  virtual bool is_circular_pointer_type (Btype *) = 0;
 
   // Return the size of a type.
   virtual int64_t type_size (Btype *) = 0;

--- a/gcc/rust/rust-backend.h
+++ b/gcc/rust/rust-backend.h
@@ -41,9 +41,6 @@ saw_errors (void);
 // frontend, and passed back to the backend.  The types must be
 // defined by the backend using these names.
 
-// The backend represention of an expression.
-class Bexpression;
-
 // The backend representation of a statement.
 class Bstatement;
 
@@ -87,7 +84,6 @@ public:
 
   // debug
   virtual void debug (tree) = 0;
-  virtual void debug (Bexpression *) = 0;
   virtual void debug (Bstatement *) = 0;
   virtual void debug (Bfunction *) = 0;
   virtual void debug (Bblock *) = 0;
@@ -95,9 +91,9 @@ public:
   virtual void debug (Blabel *) = 0;
 
   // const folder helpers
-  virtual bool const_size_cast (Bexpression *, size_t *) = 0;
-  virtual std::string const_size_val_to_string (Bexpression *) = 0;
-  virtual bool const_values_equal (Bexpression *, Bexpression *) = 0;
+  virtual bool const_size_cast (tree, size_t *) = 0;
+  virtual std::string const_size_val_to_string (tree) = 0;
+  virtual bool const_values_equal (tree, tree) = 0;
 
   static Rust::ABI get_abi_from_string (const std::string &abi, Location locus)
   {
@@ -226,7 +222,7 @@ public:
   virtual tree union_type (const std::vector<typed_identifier> &fields) = 0;
 
   // Get an array type.
-  virtual tree array_type (tree element_type, Bexpression *length) = 0;
+  virtual tree array_type (tree element_type, tree length) = 0;
 
   // Return a named version of a type.  The location is the location
   // of the type definition.  This will not be called for a type
@@ -255,165 +251,148 @@ public:
   // Return an expression for a zero value of the given type.  This is
   // used for cases such as local variable initialization and
   // converting nil to other types.
-  virtual Bexpression *zero_expression (tree) = 0;
+  virtual tree zero_expression (tree) = 0;
 
   // Create an error expression. This is used for cases which should
   // not occur in a correct program, in order to keep the compilation
   // going without crashing.
-  virtual Bexpression *error_expression () = 0;
+  virtual tree error_expression () = 0;
 
   // return whether this is error_mark_node
-  virtual bool is_error_expression (Bexpression *) = 0;
+  virtual bool is_error_expression (tree) = 0;
 
   // Create a nil pointer expression.
-  virtual Bexpression *nil_pointer_expression () = 0;
+  virtual tree nil_pointer_expression () = 0;
 
-  virtual Bexpression *unit_expression () = 0;
+  virtual tree unit_expression () = 0;
 
   // Create a reference to a variable.
-  virtual Bexpression *var_expression (Bvariable *var, Location) = 0;
+  virtual tree var_expression (Bvariable *var, Location) = 0;
 
   // Create an expression that indirects through the pointer expression EXPR
   // (i.e., return the expression for *EXPR). KNOWN_VALID is true if the pointer
   // is known to point to a valid memory location.  BTYPE is the expected type
   // of the indirected EXPR.
-  virtual Bexpression *indirect_expression (tree btype, Bexpression *expr,
-					    bool known_valid, Location)
+  virtual tree indirect_expression (tree btype, tree expr, bool known_valid,
+				    Location)
     = 0;
 
   // Return an expression that declares a constant named NAME with the
   // constant value VAL in BTYPE.
-  virtual Bexpression *named_constant_expression (tree btype,
-						  const std::string &name,
-						  Bexpression *val, Location)
+  virtual tree named_constant_expression (tree btype, const std::string &name,
+					  tree val, Location)
     = 0;
 
   // Return an expression for the multi-precision integer VAL in BTYPE.
-  virtual Bexpression *integer_constant_expression (tree btype, mpz_t val) = 0;
+  virtual tree integer_constant_expression (tree btype, mpz_t val) = 0;
 
   // Return an expression for the floating point value VAL in BTYPE.
-  virtual Bexpression *float_constant_expression (tree btype, mpfr_t val) = 0;
+  virtual tree float_constant_expression (tree btype, mpfr_t val) = 0;
 
   // Return an expression for the complex value VAL in BTYPE.
-  virtual Bexpression *complex_constant_expression (tree btype, mpc_t val) = 0;
+  virtual tree complex_constant_expression (tree btype, mpc_t val) = 0;
 
   // Return an expression for the string value VAL.
-  virtual Bexpression *string_constant_expression (const std::string &val) = 0;
+  virtual tree string_constant_expression (const std::string &val) = 0;
 
   // Get a char literal
-  virtual Bexpression *char_constant_expression (char c) = 0;
+  virtual tree char_constant_expression (char c) = 0;
 
   // Get a char literal
-  virtual Bexpression *wchar_constant_expression (wchar_t c) = 0;
+  virtual tree wchar_constant_expression (wchar_t c) = 0;
 
   // Return an expression for the boolean value VAL.
-  virtual Bexpression *boolean_constant_expression (bool val) = 0;
+  virtual tree boolean_constant_expression (bool val) = 0;
 
   // Return an expression for the real part of BCOMPLEX.
-  virtual Bexpression *real_part_expression (Bexpression *bcomplex, Location)
-    = 0;
+  virtual tree real_part_expression (tree bcomplex, Location) = 0;
 
   // Return an expression for the imaginary part of BCOMPLEX.
-  virtual Bexpression *imag_part_expression (Bexpression *bcomplex, Location)
-    = 0;
+  virtual tree imag_part_expression (tree bcomplex, Location) = 0;
 
   // Return an expression for the complex number (BREAL, BIMAG).
-  virtual Bexpression *complex_expression (Bexpression *breal,
-					   Bexpression *bimag, Location)
-    = 0;
+  virtual tree complex_expression (tree breal, tree bimag, Location) = 0;
 
   // Return an expression that converts EXPR to TYPE.
-  virtual Bexpression *convert_expression (tree type, Bexpression *expr,
-					   Location)
-    = 0;
+  virtual tree convert_expression (tree type, tree expr, Location) = 0;
 
   // Create an expression for the address of a function.  This is used to
   // get the address of the code for a function.
-  virtual Bexpression *function_code_expression (Bfunction *, Location) = 0;
+  virtual tree function_code_expression (Bfunction *, Location) = 0;
 
   // Create an expression that takes the address of an expression.
-  virtual Bexpression *address_expression (Bexpression *, Location) = 0;
+  virtual tree address_expression (tree, Location) = 0;
 
   // Return an expression for the field at INDEX in BSTRUCT.
-  virtual Bexpression *struct_field_expression (Bexpression *bstruct,
-						size_t index, Location)
+  virtual tree struct_field_expression (tree bstruct, size_t index, Location)
     = 0;
 
   // Create an expression that executes BSTAT before BEXPR.
-  virtual Bexpression *compound_expression (Bstatement *bstat,
-					    Bexpression *bexpr, Location)
+  virtual tree compound_expression (Bstatement *bstat, tree bexpr, Location)
     = 0;
 
   // Return an expression that executes THEN_EXPR if CONDITION is true, or
   // ELSE_EXPR otherwise and returns the result as type BTYPE, within the
   // specified function FUNCTION.  ELSE_EXPR may be NULL.  BTYPE may be NULL.
-  virtual Bexpression *conditional_expression (Bfunction *function, tree btype,
-					       Bexpression *condition,
-					       Bexpression *then_expr,
-					       Bexpression *else_expr, Location)
+  virtual tree conditional_expression (Bfunction *function, tree btype,
+				       tree condition, tree then_expr,
+				       tree else_expr, Location)
     = 0;
 
   // Return an expression for the negation operation OP EXPR.
   // Supported values of OP are enumerated in NegationOperator.
-  virtual Bexpression *negation_expression (NegationOperator op,
-					    Bexpression *expr, Location)
+  virtual tree negation_expression (NegationOperator op, tree expr, Location)
     = 0;
 
   // Return an expression for the operation LEFT OP RIGHT.
   // Supported values of OP are enumerated in ArithmeticOrLogicalOperator.
-  virtual Bexpression *
-  arithmetic_or_logical_expression (ArithmeticOrLogicalOperator op,
-				    Bexpression *left, Bexpression *right,
-				    Location)
+  virtual tree arithmetic_or_logical_expression (ArithmeticOrLogicalOperator op,
+						 tree left, tree right,
+						 Location)
     = 0;
 
   // Return an expression for the operation LEFT OP RIGHT.
   // Supported values of OP are enumerated in ComparisonOperator.
-  virtual Bexpression *comparison_expression (ComparisonOperator op,
-					      Bexpression *left,
-					      Bexpression *right, Location)
+  virtual tree comparison_expression (ComparisonOperator op, tree left,
+				      tree right, Location)
     = 0;
 
   // Return an expression for the operation LEFT OP RIGHT.
   // Supported values of OP are enumerated in LazyBooleanOperator.
-  virtual Bexpression *lazy_boolean_expression (LazyBooleanOperator op,
-						Bexpression *left,
-						Bexpression *right, Location)
+  virtual tree lazy_boolean_expression (LazyBooleanOperator op, tree left,
+					tree right, Location)
     = 0;
 
   // Return an expression that constructs BTYPE with VALS.  BTYPE must be the
   // backend representation a of struct.  VALS must be in the same order as the
   // corresponding fields in BTYPE.
-  virtual Bexpression *
-  constructor_expression (tree btype, const std::vector<Bexpression *> &vals,
-			  int, Location)
+  virtual tree constructor_expression (tree btype,
+				       const std::vector<tree> &vals, int,
+				       Location)
     = 0;
 
   // Return an expression that constructs an array of BTYPE with INDEXES and
   // VALS.  INDEXES and VALS must have the same amount of elements. Each index
   // in INDEXES must be in the same order as the corresponding value in VALS.
-  virtual Bexpression *array_constructor_expression (
-    tree btype, const std::vector<unsigned long> &indexes,
-    const std::vector<Bexpression *> &vals, Location)
+  virtual tree
+  array_constructor_expression (tree btype,
+				const std::vector<unsigned long> &indexes,
+				const std::vector<tree> &vals, Location)
     = 0;
 
   // Return an expression for the address of BASE[INDEX].
   // BASE has a pointer type.  This is used for slice indexing.
-  virtual Bexpression *pointer_offset_expression (Bexpression *base,
-						  Bexpression *index, Location)
-    = 0;
+  virtual tree pointer_offset_expression (tree base, tree index, Location) = 0;
 
   // Return an expression for ARRAY[INDEX] as an l-value.  ARRAY is a valid
   // fixed-length array, not a slice.
-  virtual Bexpression *array_index_expression (Bexpression *array,
-					       Bexpression *index, Location)
-    = 0;
+  virtual tree array_index_expression (tree array, tree index, Location) = 0;
 
   // Create an expression for a call to FN with ARGS, taking place within
   // caller CALLER.
-  virtual Bexpression *call_expression (Bfunction *caller, Bexpression *fn,
-					const std::vector<Bexpression *> &args,
-					Bexpression *static_chain, Location)
+  virtual tree call_expression (Bfunction *caller, tree fn,
+				const std::vector<tree> &args,
+				tree static_chain, Location)
     = 0;
 
   // Statements.
@@ -424,37 +403,36 @@ public:
   virtual Bstatement *error_statement () = 0;
 
   // Create an expression statement within the specified function.
-  virtual Bstatement *expression_statement (Bfunction *, Bexpression *) = 0;
+  virtual Bstatement *expression_statement (Bfunction *, tree) = 0;
 
   // Create a variable initialization statement in the specified
   // function.  This initializes a local variable at the point in the
   // program flow where it is declared.
-  virtual Bstatement *init_statement (Bfunction *, Bvariable *var,
-				      Bexpression *init)
+  virtual Bstatement *init_statement (Bfunction *, Bvariable *var, tree init)
     = 0;
 
   // Create an assignment statement within the specified function.
-  virtual Bstatement *assignment_statement (Bfunction *, Bexpression *lhs,
-					    Bexpression *rhs, Location)
+  virtual Bstatement *assignment_statement (Bfunction *, tree lhs, tree rhs,
+					    Location)
     = 0;
 
   // Create a return statement, passing the representation of the
   // function and the list of values to return.
-  virtual Bstatement *
-  return_statement (Bfunction *, const std::vector<Bexpression *> &, Location)
+  virtual Bstatement *return_statement (Bfunction *, const std::vector<tree> &,
+					Location)
     = 0;
 
   // Create an if statement within a function.  ELSE_BLOCK may be NULL.
-  virtual Bstatement *if_statement (Bfunction *, Bexpression *condition,
+  virtual Bstatement *if_statement (Bfunction *, tree condition,
 				    Bblock *then_block, Bblock *else_block,
 				    Location)
     = 0;
 
   // infinite loop expressions
-  virtual Bexpression *loop_expression (Bblock *body, Location) = 0;
+  virtual tree loop_expression (Bblock *body, Location) = 0;
 
   // exit expressions
-  virtual Bexpression *exit_expression (Bexpression *condition, Location) = 0;
+  virtual tree exit_expression (tree condition, Location) = 0;
 
   // Create a switch statement where the case values are constants.
   // CASES and STATEMENTS must have the same number of entries.  If
@@ -464,8 +442,8 @@ public:
   // STATEMENTS[i + 1].  CASES[i] is empty for the default clause,
   // which need not be last.  FUNCTION is the current function.
   virtual Bstatement *
-  switch_statement (Bfunction *function, Bexpression *value,
-		    const std::vector<std::vector<Bexpression *> > &cases,
+  switch_statement (Bfunction *function, tree value,
+		    const std::vector<std::vector<tree> > &cases,
 		    const std::vector<Bstatement *> &statements, Location)
     = 0;
 
@@ -543,7 +521,7 @@ public:
   // global_variable_set_init to set the initial value.  If this is
   // not called, the backend should initialize a global variable to 0.
   // The init function may then assign a value to it.
-  virtual void global_variable_set_init (Bvariable *, Bexpression *) = 0;
+  virtual void global_variable_set_init (Bvariable *, tree) = 0;
 
   // Create a local variable.  The frontend will create the local
   // variables first, and then create the block which contains them.
@@ -587,10 +565,10 @@ public:
   // variable, and may not be very useful.  This function should
   // return a variable which can be referenced later and should set
   // *PSTATEMENT to a statement which initializes the variable.
-  virtual Bvariable *
-  temporary_variable (Bfunction *, Bblock *, tree, Bexpression *init,
-		      bool address_is_taken, Location location,
-		      Bstatement **pstatement)
+  virtual Bvariable *temporary_variable (Bfunction *, Bblock *, tree, tree init,
+					 bool address_is_taken,
+					 Location location,
+					 Bstatement **pstatement)
     = 0;
 
   // Create an implicit variable that is compiler-defined.  This is
@@ -638,7 +616,7 @@ public:
   virtual void implicit_variable_set_init (Bvariable *, const std::string &name,
 					   tree type, bool is_hidden,
 					   bool is_constant, bool is_common,
-					   Bexpression *init)
+					   tree init)
     = 0;
 
   // Create a reference to a named implicit variable defined in some
@@ -693,8 +671,7 @@ public:
   // immutable_struct.
   virtual void immutable_struct_set_init (Bvariable *, const std::string &name,
 					  bool is_hidden, bool is_common,
-					  tree type, Location,
-					  Bexpression *initializer)
+					  tree type, Location, tree initializer)
     = 0;
 
   // Create a reference to a named immutable initialized data
@@ -725,7 +702,7 @@ public:
   // Create an expression for the address of a label.  This is used to
   // get the return address of a deferred function which may call
   // recover.
-  virtual Bexpression *label_address (Blabel *, Location) = 0;
+  virtual tree label_address (Blabel *, Location) = 0;
 
   // Functions.
 
@@ -782,9 +759,9 @@ public:
   // be a statement that looks like this in C++:
   //   finish:
   //     try { DEFER_RETURN; } catch { CHECK_DEFER; goto finish; }
-  virtual Bstatement *
-  function_defer_statement (Bfunction *function, Bexpression *undefer,
-			    Bexpression *check_defer, Location)
+  virtual Bstatement *function_defer_statement (Bfunction *function,
+						tree undefer, tree check_defer,
+						Location)
     = 0;
 
   // Record PARAM_VARS as the variables to use for the parameters of FUNCTION.
@@ -812,7 +789,7 @@ public:
   // FUNCTION_DECLS, and VARIABLE_DECLS declared globally.
   virtual void
   write_global_definitions (const std::vector<tree> &type_decls,
-			    const std::vector<Bexpression *> &constant_decls,
+			    const std::vector<tree> &constant_decls,
 			    const std::vector<Bfunction *> &function_decls,
 			    const std::vector<Bvariable *> &variable_decls)
     = 0;

--- a/gcc/rust/rust-backend.h
+++ b/gcc/rust/rust-backend.h
@@ -65,7 +65,7 @@ public:
     {}
 
     typed_identifier (const std::string &a_name, tree a_type,
-		       Location a_location)
+		      Location a_location)
       : name (a_name), type (a_type), location (a_location)
     {}
   };
@@ -180,11 +180,10 @@ public:
   // one result, RESULT_STRUCT is a struct type to hold the results,
   // and RESULTS may be ignored; if there are zero or one results,
   // RESULT_STRUCT is NULL.
-  virtual tree
-  function_type (const typed_identifier &receiver,
-		 const std::vector<typed_identifier> &parameters,
-		 const std::vector<typed_identifier> &results,
-		 tree result_struct, Location location)
+  virtual tree function_type (const typed_identifier &receiver,
+			      const std::vector<typed_identifier> &parameters,
+			      const std::vector<typed_identifier> &results,
+			      tree result_struct, Location location)
     = 0;
 
   virtual tree

--- a/gcc/rust/rust-backend.h
+++ b/gcc/rust/rust-backend.h
@@ -41,9 +41,6 @@ saw_errors (void);
 // frontend, and passed back to the backend.  The types must be
 // defined by the backend using these names.
 
-// The backend representation of a block.
-class Bblock;
-
 // The backend representation of a variable.
 class Bvariable;
 
@@ -78,7 +75,6 @@ public:
 
   // debug
   virtual void debug (tree) = 0;
-  virtual void debug (Bblock *) = 0;
   virtual void debug (Bvariable *) = 0;
   virtual void debug (Blabel *) = 0;
 
@@ -409,12 +405,12 @@ public:
   virtual tree return_statement (tree, const std::vector<tree> &, Location) = 0;
 
   // Create an if statement within a function.  ELSE_BLOCK may be NULL.
-  virtual tree if_statement (tree, tree condition, Bblock *then_block,
-			     Bblock *else_block, Location)
+  virtual tree if_statement (tree, tree condition, tree then_block,
+			     tree else_block, Location)
     = 0;
 
   // infinite loop expressions
-  virtual tree loop_expression (Bblock *body, Location) = 0;
+  virtual tree loop_expression (tree body, Location) = 0;
 
   // exit expressions
   virtual tree exit_expression (tree condition, Location) = 0;
@@ -458,20 +454,20 @@ public:
   // the initial curly brace.  END_LOCATION is the location of the end
   // of the block, more or less the location of the final curly brace.
   // The statements will be added after the block is created.
-  virtual Bblock *block (tree function, Bblock *enclosing,
-			 const std::vector<Bvariable *> &vars,
-			 Location start_location, Location end_location)
+  virtual tree block (tree function, tree enclosing,
+		      const std::vector<Bvariable *> &vars,
+		      Location start_location, Location end_location)
     = 0;
 
   // Add the statements to a block.  The block is created first.  Then
   // the statements are created.  Then the statements are added to the
   // block.  This will called exactly once per block.  The vector may
   // be empty if there are no statements.
-  virtual void block_add_statements (Bblock *, const std::vector<tree> &) = 0;
+  virtual void block_add_statements (tree, const std::vector<tree> &) = 0;
 
   // Return the block as a statement.  This is used to include a block
   // in a list of statements.
-  virtual tree block_statement (Bblock *) = 0;
+  virtual tree block_statement (tree) = 0;
 
   // Variables.
 
@@ -546,7 +542,7 @@ public:
   // variable, and may not be very useful.  This function should
   // return a variable which can be referenced later and should set
   // *PSTATEMENT to a statement which initializes the variable.
-  virtual Bvariable *temporary_variable (tree, Bblock *, tree, tree init,
+  virtual Bvariable *temporary_variable (tree, tree, tree, tree init,
 					 bool address_is_taken,
 					 Location location, tree *pstatement)
     = 0;

--- a/gcc/rust/rust-backend.h
+++ b/gcc/rust/rust-backend.h
@@ -44,9 +44,6 @@ saw_errors (void);
 // The backend representation of a variable.
 class Bvariable;
 
-// The backend representation of a label.
-class Blabel;
-
 // The backend interface.  This is a pure abstract class that a
 // specific backend will implement.
 
@@ -76,7 +73,6 @@ public:
   // debug
   virtual void debug (tree) = 0;
   virtual void debug (Bvariable *) = 0;
-  virtual void debug (Blabel *) = 0;
 
   // const folder helpers
   virtual bool const_size_cast (tree, size_t *) = 0;
@@ -665,20 +661,20 @@ public:
   // Create a new label.  NAME will be empty if this is a label
   // created by the frontend for a loop construct.  The location is
   // where the label is defined.
-  virtual Blabel *label (tree, const std::string &name, Location) = 0;
+  virtual tree label (tree, const std::string &name, Location) = 0;
 
   // Create a statement which defines a label.  This statement will be
   // put into the codestream at the point where the label should be
   // defined.
-  virtual tree label_definition_statement (Blabel *) = 0;
+  virtual tree label_definition_statement (tree) = 0;
 
   // Create a goto statement to a label.
-  virtual tree goto_statement (Blabel *, Location) = 0;
+  virtual tree goto_statement (tree, Location) = 0;
 
   // Create an expression for the address of a label.  This is used to
   // get the return address of a deferred function which may call
   // recover.
-  virtual tree label_address (Blabel *, Location) = 0;
+  virtual tree label_address (tree, Location) = 0;
 
   // Functions.
 

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -199,14 +199,14 @@ public:
   tree insert_type_attribute (tree, const std::string &);
 
   tree function_type (const typed_identifier &,
-			const std::vector<typed_identifier> &,
-			const std::vector<typed_identifier> &, tree,
-			const Location);
+		      const std::vector<typed_identifier> &,
+		      const std::vector<typed_identifier> &, tree,
+		      const Location);
 
   tree function_type_varadic (const typed_identifier &,
-				const std::vector<typed_identifier> &,
-				const std::vector<typed_identifier> &, tree,
-				const Location);
+			      const std::vector<typed_identifier> &,
+			      const std::vector<typed_identifier> &, tree,
+			      const Location);
 
   tree function_ptr_type (tree, const std::vector<tree> &, Location);
 
@@ -360,8 +360,8 @@ public:
   Bvariable *temporary_variable (tree, tree, tree, tree, bool, Location,
 				 tree *);
 
-  Bvariable *implicit_variable (const std::string &, const std::string &,
-				tree, bool, bool, bool, int64_t);
+  Bvariable *implicit_variable (const std::string &, const std::string &, tree,
+				bool, bool, bool, int64_t);
 
   void implicit_variable_set_init (Bvariable *, const std::string &, tree, bool,
 				   bool, bool, tree);
@@ -376,8 +376,7 @@ public:
 				  tree, Location, tree);
 
   Bvariable *immutable_struct_reference (const std::string &,
-					 const std::string &, tree,
-					 Location);
+					 const std::string &, tree, Location);
 
   // Labels.
 
@@ -416,7 +415,6 @@ public:
   void write_export_data (const char *bytes, unsigned int size);
 
 private:
-
   tree fill_in_fields (tree, const std::vector<typed_identifier> &);
 
   tree fill_in_array (tree, tree, tree);
@@ -1080,9 +1078,8 @@ Gcc_backend::fill_in_array (tree fill, tree element_type, tree length_tree)
     SET_TYPE_STRUCTURAL_EQUALITY (fill);
   else if (TYPE_CANONICAL (element_type) != element_type
 	   || TYPE_CANONICAL (index_type_tree) != index_type_tree)
-    TYPE_CANONICAL (fill)
-      = build_array_type (TYPE_CANONICAL (element_type),
-			  TYPE_CANONICAL (index_type_tree));
+    TYPE_CANONICAL (fill) = build_array_type (TYPE_CANONICAL (element_type),
+					      TYPE_CANONICAL (index_type_tree));
 
   return fill;
 }
@@ -1387,7 +1384,8 @@ Gcc_backend::convert_expression (tree type_tree, tree expr_tree,
     return this->error_expression ();
 
   tree ret;
-  if (this->type_size (type_tree) == 0 || TREE_TYPE (expr_tree) == void_type_node)
+  if (this->type_size (type_tree) == 0
+      || TREE_TYPE (expr_tree) == void_type_node)
     {
       // Do not convert zero-sized types.
       ret = expr_tree;

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -69,11 +69,6 @@ private:
 };
 
 // In gcc, types, expressions, and statements are all trees.
-class Btype : public Gcc_tree
-{
-public:
-  Btype (tree t) : Gcc_tree (t) {}
-};
 
 class Bexpression : public Gcc_tree
 {
@@ -159,7 +154,7 @@ class Gcc_backend : public Backend
 public:
   Gcc_backend ();
 
-  void debug (Btype *t) { debug_tree (t->get_tree ()); };
+  void debug (tree t) { debug_tree (t); };
   void debug (Bexpression *t) { debug_tree (t->get_tree ()); };
   void debug (Bstatement *t) { debug_tree (t->get_tree ()); };
   void debug (Bfunction *t) { debug_tree (t->get_tree ()); };
@@ -168,13 +163,13 @@ public:
   void debug (Blabel *t) { debug_tree (t->get_tree ()); };
 
   // Types.
-  Btype *error_type () { return this->make_type (error_mark_node); }
+  tree error_type () { return error_mark_node; }
 
-  Btype *void_type () { return this->make_type (void_type_node); }
+  tree void_type () { return void_type_node; }
 
-  Btype *unit_type ()
+  tree unit_type ()
   {
-    static Btype *unit_type;
+    static tree unit_type;
     if (unit_type == nullptr)
       {
 	auto unit_type_node = integer_type (true, 0);
@@ -185,9 +180,9 @@ public:
     return unit_type;
   }
 
-  Btype *bool_type () { return this->make_type (boolean_type_node); }
+  tree bool_type () { return boolean_type_node; }
 
-  Btype *char_type () { return this->make_type (char_type_node); }
+  tree char_type () { return char_type_node; }
 
   bool const_size_cast (Bexpression *expr, size_t *result)
   {
@@ -221,72 +216,71 @@ public:
 
   bool const_values_equal (Bexpression *a, Bexpression *b)
   {
-    return operand_equal_p (a->get_tree (), b->get_tree (),
-			    OEP_ONLY_CONST | OEP_PURE_SAME);
+    return operand_equal_p (a->get_tree (), b->get_tree (), OEP_ONLY_CONST | OEP_PURE_SAME);
     // printf ("comparing!\n");
     // debug_tree (a->get_tree ());
     // debug_tree (b->get_tree ());
     // printf ("ok = %s\n", ok ? "true" : "false");
   }
 
-  Btype *wchar_type ()
+  tree wchar_type ()
   {
     tree wchar = make_unsigned_type (32);
     TYPE_STRING_FLAG (wchar) = 1;
-    return this->make_type (wchar);
+    return wchar;
   }
 
   int get_pointer_size ();
 
-  Btype *raw_str_type ();
+  tree raw_str_type ();
 
-  Btype *integer_type (bool, int);
+  tree integer_type (bool, int);
 
-  Btype *float_type (int);
+  tree float_type (int);
 
-  Btype *complex_type (int);
+  tree complex_type (int);
 
-  Btype *pointer_type (Btype *);
+  tree pointer_type (tree);
 
-  Btype *reference_type (Btype *);
+  tree reference_type (tree);
 
-  Btype *immutable_type (Btype *);
+  tree immutable_type (tree);
 
-  Btype *specify_abi_attribute (Btype *, Rust::ABI);
+  tree specify_abi_attribute (tree, Rust::ABI);
 
-  Btype *insert_type_attribute (Btype *, const std::string &);
+  tree insert_type_attribute (tree, const std::string &);
 
-  Btype *function_type (const Btyped_identifier &,
-			const std::vector<Btyped_identifier> &,
-			const std::vector<Btyped_identifier> &, Btype *,
+  tree function_type (const typed_identifier &,
+			const std::vector<typed_identifier> &,
+			const std::vector<typed_identifier> &, tree,
 			const Location);
 
-  Btype *function_type_varadic (const Btyped_identifier &,
-				const std::vector<Btyped_identifier> &,
-				const std::vector<Btyped_identifier> &, Btype *,
+  tree function_type_varadic (const typed_identifier &,
+				const std::vector<typed_identifier> &,
+				const std::vector<typed_identifier> &, tree,
 				const Location);
 
-  Btype *function_ptr_type (Btype *, const std::vector<Btype *> &, Location);
+  tree function_ptr_type (tree, const std::vector<tree> &, Location);
 
-  Btype *struct_type (const std::vector<Btyped_identifier> &);
+  tree struct_type (const std::vector<typed_identifier> &);
 
-  Btype *union_type (const std::vector<Btyped_identifier> &);
+  tree union_type (const std::vector<typed_identifier> &);
 
-  Btype *array_type (Btype *, Bexpression *);
+  tree array_type (tree, Bexpression *);
 
-  Btype *named_type (const std::string &, Btype *, Location);
+  tree named_type (const std::string &, tree, Location);
 
-  int64_t type_size (Btype *);
+  int64_t type_size (tree);
 
-  int64_t type_alignment (Btype *);
+  int64_t type_alignment (tree);
 
-  int64_t type_field_alignment (Btype *);
+  int64_t type_field_alignment (tree);
 
-  int64_t type_field_offset (Btype *, size_t index);
+  int64_t type_field_offset (tree, size_t index);
 
   // Expressions.
 
-  Bexpression *zero_expression (Btype *);
+  Bexpression *zero_expression (tree);
 
   Bexpression *error_expression ()
   {
@@ -310,17 +304,17 @@ public:
 
   Bexpression *var_expression (Bvariable *var, Location);
 
-  Bexpression *indirect_expression (Btype *, Bexpression *expr,
+  Bexpression *indirect_expression (tree, Bexpression *expr,
 				    bool known_valid, Location);
 
-  Bexpression *named_constant_expression (Btype *btype, const std::string &name,
+  Bexpression *named_constant_expression (tree type, const std::string &name,
 					  Bexpression *val, Location);
 
-  Bexpression *integer_constant_expression (Btype *btype, mpz_t val);
+  Bexpression *integer_constant_expression (tree type, mpz_t val);
 
-  Bexpression *float_constant_expression (Btype *btype, mpfr_t val);
+  Bexpression *float_constant_expression (tree type, mpfr_t val);
 
-  Bexpression *complex_constant_expression (Btype *btype, mpc_t val);
+  Bexpression *complex_constant_expression (tree type, mpc_t val);
 
   Bexpression *string_constant_expression (const std::string &val);
 
@@ -337,7 +331,7 @@ public:
   Bexpression *complex_expression (Bexpression *breal, Bexpression *bimag,
 				   Location);
 
-  Bexpression *convert_expression (Btype *type, Bexpression *expr, Location);
+  Bexpression *convert_expression (tree type, Bexpression *expr, Location);
 
   Bexpression *function_code_expression (Bfunction *, Location);
 
@@ -347,7 +341,7 @@ public:
 
   Bexpression *compound_expression (Bstatement *, Bexpression *, Location);
 
-  Bexpression *conditional_expression (Bfunction *, Btype *, Bexpression *,
+  Bexpression *conditional_expression (Bfunction *, tree, Bexpression *,
 				       Bexpression *, Bexpression *, Location);
 
   Bexpression *negation_expression (NegationOperator op, Bexpression *expr,
@@ -364,11 +358,11 @@ public:
 					Bexpression *left, Bexpression *right,
 					Location);
 
-  Bexpression *constructor_expression (Btype *,
+  Bexpression *constructor_expression (tree,
 				       const std::vector<Bexpression *> &, int,
 				       Location);
 
-  Bexpression *array_constructor_expression (Btype *,
+  Bexpression *array_constructor_expression (tree,
 					     const std::vector<unsigned long> &,
 					     const std::vector<Bexpression *> &,
 					     Location);
@@ -434,41 +428,41 @@ public:
   Bvariable *error_variable () { return new Bvariable (error_mark_node); }
 
   Bvariable *global_variable (const std::string &var_name,
-			      const std::string &asm_name, Btype *btype,
+			      const std::string &asm_name, tree type,
 			      bool is_external, bool is_hidden,
 			      bool in_unique_section, Location location);
 
   void global_variable_set_init (Bvariable *, Bexpression *);
 
-  Bvariable *local_variable (Bfunction *, const std::string &, Btype *,
+  Bvariable *local_variable (Bfunction *, const std::string &, tree,
 			     Bvariable *, bool, Location);
 
-  Bvariable *parameter_variable (Bfunction *, const std::string &, Btype *,
+  Bvariable *parameter_variable (Bfunction *, const std::string &, tree,
 				 bool, Location);
 
-  Bvariable *static_chain_variable (Bfunction *, const std::string &, Btype *,
+  Bvariable *static_chain_variable (Bfunction *, const std::string &, tree,
 				    Location);
 
-  Bvariable *temporary_variable (Bfunction *, Bblock *, Btype *, Bexpression *,
+  Bvariable *temporary_variable (Bfunction *, Bblock *, tree, Bexpression *,
 				 bool, Location, Bstatement **);
 
   Bvariable *implicit_variable (const std::string &, const std::string &,
-				Btype *, bool, bool, bool, int64_t);
+				tree, bool, bool, bool, int64_t);
 
-  void implicit_variable_set_init (Bvariable *, const std::string &, Btype *,
+  void implicit_variable_set_init (Bvariable *, const std::string &, tree,
 				   bool, bool, bool, Bexpression *);
 
   Bvariable *implicit_variable_reference (const std::string &,
-					  const std::string &, Btype *);
+					  const std::string &, tree);
 
   Bvariable *immutable_struct (const std::string &, const std::string &, bool,
-			       bool, Btype *, Location);
+			       bool, tree, Location);
 
   void immutable_struct_set_init (Bvariable *, const std::string &, bool, bool,
-				  Btype *, Location, Bexpression *);
+				  tree, Location, Bexpression *);
 
   Bvariable *immutable_struct_reference (const std::string &,
-					 const std::string &, Btype *,
+					 const std::string &, tree,
 					 Location);
 
   // Labels.
@@ -485,7 +479,7 @@ public:
 
   Bfunction *error_function () { return this->make_function (error_mark_node); }
 
-  Bfunction *function (Btype *fntype, const std::string &name,
+  Bfunction *function (tree fntype, const std::string &name,
 		       const std::string &asm_name, unsigned int flags,
 		       Location);
 
@@ -502,7 +496,7 @@ public:
 
   Bfunction *lookup_builtin_by_rust_name (const std::string &);
 
-  void write_global_definitions (const std::vector<Btype *> &,
+  void write_global_definitions (const std::vector<tree> &,
 				 const std::vector<Bexpression *> &,
 				 const std::vector<Bfunction *> &,
 				 const std::vector<Bvariable *> &);
@@ -516,14 +510,11 @@ private:
   // Make a Bstatement from a tree.
   Bstatement *make_statement (tree t) { return new Bstatement (t); }
 
-  // Make a Btype from a tree.
-  Btype *make_type (tree t) { return new Btype (t); }
-
   Bfunction *make_function (tree t) { return new Bfunction (t); }
 
-  Btype *fill_in_fields (Btype *, const std::vector<Btyped_identifier> &);
+  tree fill_in_fields (tree, const std::vector<typed_identifier> &);
 
-  Btype *fill_in_array (Btype *, Btype *, Bexpression *);
+  tree fill_in_array (tree, tree, Bexpression *);
 
   tree non_zero_size_type (tree);
 
@@ -791,15 +782,15 @@ Gcc_backend::get_pointer_size ()
   return POINTER_SIZE;
 }
 
-Btype *
+tree
 Gcc_backend::raw_str_type ()
 {
   tree char_ptr = build_pointer_type (char_type_node);
   tree const_char_type = build_qualified_type (char_ptr, TYPE_QUAL_CONST);
-  return this->make_type (const_char_type);
+  return const_char_type;
 }
 
-Btype *
+tree
 Gcc_backend::integer_type (bool is_unsigned, int bits)
 {
   tree type;
@@ -829,12 +820,12 @@ Gcc_backend::integer_type (bool is_unsigned, int bits)
       else
 	type = make_signed_type (bits);
     }
-  return this->make_type (type);
+  return type;
 }
 
 // Get an unnamed float type.
 
-Btype *
+tree
 Gcc_backend::float_type (int bits)
 {
   tree type;
@@ -850,12 +841,12 @@ Gcc_backend::float_type (int bits)
       TYPE_PRECISION (type) = bits;
       layout_type (type);
     }
-  return this->make_type (type);
+  return type;
 }
 
 // Get an unnamed complex type.
 
-Btype *
+tree
 Gcc_backend::complex_type (int bits)
 {
   tree type;
@@ -872,49 +863,46 @@ Gcc_backend::complex_type (int bits)
       layout_type (type);
       type = build_complex_type (type);
     }
-  return this->make_type (type);
+  return type;
 }
 
 // Get a pointer type.
 
-Btype *
-Gcc_backend::pointer_type (Btype *to_type)
+tree
+Gcc_backend::pointer_type (tree to_type)
 {
-  tree to_type_tree = to_type->get_tree ();
-  if (to_type_tree == error_mark_node)
+  if (to_type == error_mark_node)
     return this->error_type ();
-  tree type = build_pointer_type (to_type_tree);
-  return this->make_type (type);
+  tree type = build_pointer_type (to_type);
+  return type;
 }
 
 // Get a reference type.
 
-Btype *
-Gcc_backend::reference_type (Btype *to_type)
+tree
+Gcc_backend::reference_type (tree to_type)
 {
-  tree to_type_tree = to_type->get_tree ();
-  if (to_type_tree == error_mark_node)
+  if (to_type == error_mark_node)
     return this->error_type ();
-  tree type = build_reference_type (to_type_tree);
-  return this->make_type (type);
+  tree type = build_reference_type (to_type);
+  return type;
 }
 
 // Get immutable type
 
-Btype *
-Gcc_backend::immutable_type (Btype *base)
+tree
+Gcc_backend::immutable_type (tree base)
 {
-  tree type_tree = base->get_tree ();
-  if (type_tree == error_mark_node)
+  if (base == error_mark_node)
     return this->error_type ();
-  tree constified = build_qualified_type (type_tree, TYPE_QUAL_CONST);
-  return this->make_type (constified);
+  tree constified = build_qualified_type (base, TYPE_QUAL_CONST);
+  return constified;
 }
 
 // ABI
 
-Btype *
-Gcc_backend::specify_abi_attribute (Btype *type, Rust::ABI abi)
+tree
+Gcc_backend::specify_abi_attribute (tree type, Rust::ABI abi)
 {
   std::string abi_string;
   switch (abi)
@@ -940,46 +928,46 @@ Gcc_backend::specify_abi_attribute (Btype *type, Rust::ABI abi)
   return insert_type_attribute (type, abi_string);
 }
 
-Btype *
-Gcc_backend::insert_type_attribute (Btype *type, const std::string &attrname)
+tree
+Gcc_backend::insert_type_attribute (tree type, const std::string &attrname)
 {
   tree ident = get_identifier (attrname.c_str ());
 
   tree attribs = NULL_TREE;
-  tree old_attrs = TYPE_ATTRIBUTES (type->get_tree ());
+  tree old_attrs = TYPE_ATTRIBUTES (type);
   if (old_attrs)
     attribs = merge_type_attributes (old_attrs,
 				     tree_cons (ident, NULL_TREE, NULL_TREE));
   else
     attribs = tree_cons (ident, NULL_TREE, NULL_TREE);
 
-  tree res = build_type_attribute_variant (type->get_tree (), attribs);
-  return this->make_type (res);
+  tree res = build_type_attribute_variant (type, attribs);
+  return res;
 }
 
 // Make a function type.
 
-Btype *
-Gcc_backend::function_type (const Btyped_identifier &receiver,
-			    const std::vector<Btyped_identifier> &parameters,
-			    const std::vector<Btyped_identifier> &results,
-			    Btype *result_struct, Location)
+tree
+Gcc_backend::function_type (const typed_identifier &receiver,
+			    const std::vector<typed_identifier> &parameters,
+			    const std::vector<typed_identifier> &results,
+			    tree result_struct, Location)
 {
   tree args = NULL_TREE;
   tree *pp = &args;
-  if (receiver.btype != NULL)
+  if (receiver.type != NULL_TREE)
     {
-      tree t = receiver.btype->get_tree ();
+      tree t = receiver.type;
       if (t == error_mark_node)
 	return this->error_type ();
       *pp = tree_cons (NULL_TREE, t, NULL_TREE);
       pp = &TREE_CHAIN (*pp);
     }
 
-  for (std::vector<Btyped_identifier>::const_iterator p = parameters.begin ();
+  for (std::vector<typed_identifier>::const_iterator p = parameters.begin ();
        p != parameters.end (); ++p)
     {
-      tree t = p->btype->get_tree ();
+      tree t = p->type;
       if (t == error_mark_node)
 	return this->error_type ();
       *pp = tree_cons (NULL_TREE, t, NULL_TREE);
@@ -994,11 +982,11 @@ Gcc_backend::function_type (const Btyped_identifier &receiver,
   if (results.empty ())
     result = void_type_node;
   else if (results.size () == 1)
-    result = results.front ().btype->get_tree ();
+    result = results.front ().type;
   else
     {
       gcc_assert (result_struct != NULL);
-      result = result_struct->get_tree ();
+      result = result_struct;
     }
   if (result == error_mark_node)
     return this->error_type ();
@@ -1015,32 +1003,32 @@ Gcc_backend::function_type (const Btyped_identifier &receiver,
   if (fntype == error_mark_node)
     return this->error_type ();
 
-  return this->make_type (build_pointer_type (fntype));
+  return build_pointer_type (fntype);
 }
 
-Btype *
+tree
 Gcc_backend::function_type_varadic (
-  const Btyped_identifier &receiver,
-  const std::vector<Btyped_identifier> &parameters,
-  const std::vector<Btyped_identifier> &results, Btype *result_struct, Location)
+  const typed_identifier &receiver,
+  const std::vector<typed_identifier> &parameters,
+  const std::vector<typed_identifier> &results, tree result_struct, Location)
 {
-  size_t n = parameters.size () + (receiver.btype != NULL ? 1 : 0);
+  size_t n = parameters.size () + (receiver.type != NULL_TREE ? 1 : 0);
   tree *args = XALLOCAVEC (tree, n);
   size_t offs = 0;
 
-  if (receiver.btype != NULL)
+  if (receiver.type != NULL_TREE)
     {
-      tree t = receiver.btype->get_tree ();
+      tree t = receiver.type;
       if (t == error_mark_node)
 	return this->error_type ();
 
       args[offs++] = t;
     }
 
-  for (std::vector<Btyped_identifier>::const_iterator p = parameters.begin ();
+  for (std::vector<typed_identifier>::const_iterator p = parameters.begin ();
        p != parameters.end (); ++p)
     {
-      tree t = p->btype->get_tree ();
+      tree t = p->type;
       if (t == error_mark_node)
 	return this->error_type ();
       args[offs++] = t;
@@ -1050,11 +1038,11 @@ Gcc_backend::function_type_varadic (
   if (results.empty ())
     result = void_type_node;
   else if (results.size () == 1)
-    result = results.front ().btype->get_tree ();
+    result = results.front ().type;
   else
     {
-      gcc_assert (result_struct != NULL);
-      result = result_struct->get_tree ();
+      gcc_assert (result_struct != NULL_TREE);
+      result = result_struct;
     }
   if (result == error_mark_node)
     return this->error_type ();
@@ -1071,12 +1059,12 @@ Gcc_backend::function_type_varadic (
   if (fntype == error_mark_node)
     return this->error_type ();
 
-  return this->make_type (build_pointer_type (fntype));
+  return build_pointer_type (fntype);
 }
 
-Btype *
-Gcc_backend::function_ptr_type (Btype *result_type,
-				const std::vector<Btype *> &parameters,
+tree
+Gcc_backend::function_ptr_type (tree result_type,
+				const std::vector<tree> &parameters,
 				Location /* locus */)
 {
   tree args = NULL_TREE;
@@ -1084,17 +1072,16 @@ Gcc_backend::function_ptr_type (Btype *result_type,
 
   for (auto &param : parameters)
     {
-      tree t = param->get_tree ();
-      if (t == error_mark_node)
+      if (param == error_mark_node)
 	return this->error_type ();
 
-      *pp = tree_cons (NULL_TREE, t, NULL_TREE);
+      *pp = tree_cons (NULL_TREE, param, NULL_TREE);
       pp = &TREE_CHAIN (*pp);
     }
 
   *pp = void_list_node;
 
-  tree result = result_type->get_tree ();
+  tree result = result_type;
   if (result != void_type_node && int_size_in_bytes (result) == 0)
     result = void_type_node;
 
@@ -1102,82 +1089,77 @@ Gcc_backend::function_ptr_type (Btype *result_type,
   if (fntype == error_mark_node)
     return this->error_type ();
 
-  return this->make_type (build_pointer_type (fntype));
+  return build_pointer_type (fntype);
 }
 
 // Make a struct type.
 
-Btype *
-Gcc_backend::struct_type (const std::vector<Btyped_identifier> &fields)
+tree
+Gcc_backend::struct_type (const std::vector<typed_identifier> &fields)
 {
-  return this->fill_in_fields (this->make_type (make_node (RECORD_TYPE)),
-			       fields);
+  return this->fill_in_fields (make_node (RECORD_TYPE), fields);
 }
 
 // Make a union type.
 
-Btype *
-Gcc_backend::union_type (const std::vector<Btyped_identifier> &fields)
+tree
+Gcc_backend::union_type (const std::vector<typed_identifier> &fields)
 {
-  return this->fill_in_fields (this->make_type (make_node (UNION_TYPE)),
-			       fields);
+  return this->fill_in_fields (make_node (UNION_TYPE), fields);
 }
 
 // Fill in the fields of a struct or union type.
 
-Btype *
-Gcc_backend::fill_in_fields (Btype *fill,
-			     const std::vector<Btyped_identifier> &fields)
+tree
+Gcc_backend::fill_in_fields (tree fill,
+			     const std::vector<typed_identifier> &fields)
 {
-  tree fill_tree = fill->get_tree ();
   tree field_trees = NULL_TREE;
   tree *pp = &field_trees;
-  for (std::vector<Btyped_identifier>::const_iterator p = fields.begin ();
+  for (std::vector<typed_identifier>::const_iterator p = fields.begin ();
        p != fields.end (); ++p)
     {
       tree name_tree = get_identifier_from_string (p->name);
-      tree type_tree = p->btype->get_tree ();
+      tree type_tree = p->type;
       if (type_tree == error_mark_node)
 	return this->error_type ();
       tree field = build_decl (p->location.gcc_location (), FIELD_DECL,
 			       name_tree, type_tree);
-      DECL_CONTEXT (field) = fill_tree;
+      DECL_CONTEXT (field) = fill;
       *pp = field;
       pp = &DECL_CHAIN (field);
     }
-  TYPE_FIELDS (fill_tree) = field_trees;
-  layout_type (fill_tree);
+  TYPE_FIELDS (fill) = field_trees;
+  layout_type (fill);
 
   // Because Rust permits converting between named struct types and
   // equivalent struct types, for which we use VIEW_CONVERT_EXPR, and
   // because we don't try to maintain TYPE_CANONICAL for struct types,
   // we need to tell the middle-end to use structural equality.
-  SET_TYPE_STRUCTURAL_EQUALITY (fill_tree);
+  SET_TYPE_STRUCTURAL_EQUALITY (fill);
 
   return fill;
 }
 
 // Make an array type.
 
-Btype *
-Gcc_backend::array_type (Btype *element_btype, Bexpression *length)
+tree
+Gcc_backend::array_type (tree element_type, Bexpression *length)
 {
-  return this->fill_in_array (this->make_type (make_node (ARRAY_TYPE)),
-			      element_btype, length);
+  return this->fill_in_array (make_node (ARRAY_TYPE), element_type, length);
 }
 
 // Fill in an array type.
 
-Btype *
-Gcc_backend::fill_in_array (Btype *fill, Btype *element_type,
+tree
+Gcc_backend::fill_in_array (tree fill, tree element_type,
 			    Bexpression *length)
 {
-  tree element_type_tree = element_type->get_tree ();
   tree length_tree = length->get_tree ();
-  if (element_type_tree == error_mark_node || length_tree == error_mark_node)
+  if (element_type == error_mark_node || length_tree == error_mark_node)
     return this->error_type ();
 
-  gcc_assert (TYPE_SIZE (element_type_tree) != NULL_TREE);
+  gcc_assert (TYPE_SIZE (element_type) != NULL_TREE);
 
   length_tree = fold_convert (sizetype, length_tree);
 
@@ -1186,18 +1168,17 @@ Gcc_backend::fill_in_array (Btype *fill, Btype *element_type,
   tree index_type_tree = build_index_type (
     fold_build2 (MINUS_EXPR, sizetype, length_tree, size_one_node));
 
-  tree fill_tree = fill->get_tree ();
-  TREE_TYPE (fill_tree) = element_type_tree;
-  TYPE_DOMAIN (fill_tree) = index_type_tree;
-  TYPE_ADDR_SPACE (fill_tree) = TYPE_ADDR_SPACE (element_type_tree);
-  layout_type (fill_tree);
+  TREE_TYPE (fill) = element_type;
+  TYPE_DOMAIN (fill) = index_type_tree;
+  TYPE_ADDR_SPACE (fill) = TYPE_ADDR_SPACE (element_type);
+  layout_type (fill);
 
-  if (TYPE_STRUCTURAL_EQUALITY_P (element_type_tree))
-    SET_TYPE_STRUCTURAL_EQUALITY (fill_tree);
-  else if (TYPE_CANONICAL (element_type_tree) != element_type_tree
+  if (TYPE_STRUCTURAL_EQUALITY_P (element_type))
+    SET_TYPE_STRUCTURAL_EQUALITY (fill);
+  else if (TYPE_CANONICAL (element_type) != element_type
 	   || TYPE_CANONICAL (index_type_tree) != index_type_tree)
-    TYPE_CANONICAL (fill_tree)
-      = build_array_type (TYPE_CANONICAL (element_type_tree),
+    TYPE_CANONICAL (fill)
+      = build_array_type (TYPE_CANONICAL (element_type),
 			  TYPE_CANONICAL (index_type_tree));
 
   return fill;
@@ -1205,11 +1186,9 @@ Gcc_backend::fill_in_array (Btype *fill, Btype *element_type,
 
 // Return a named version of a type.
 
-Btype *
-Gcc_backend::named_type (const std::string &name, Btype *btype,
-			 Location location)
+tree
+Gcc_backend::named_type (const std::string &name, tree type, Location location)
 {
-  tree type = btype->get_tree ();
   if (type == error_mark_node)
     return this->error_type ();
 
@@ -1225,7 +1204,7 @@ Gcc_backend::named_type (const std::string &name, Btype *btype,
       tree decl = build_decl (BUILTINS_LOCATION, TYPE_DECL,
 			      get_identifier_from_string (name), type);
       TYPE_NAME (type) = decl;
-      return this->make_type (type);
+      return type;
     }
 
   tree copy = build_variant_type_copy (type);
@@ -1233,15 +1212,14 @@ Gcc_backend::named_type (const std::string &name, Btype *btype,
 			  get_identifier_from_string (name), copy);
   DECL_ORIGINAL_TYPE (decl) = type;
   TYPE_NAME (copy) = decl;
-  return this->make_type (copy);
+  return copy;
 }
 
 // Return the size of a type.
 
 int64_t
-Gcc_backend::type_size (Btype *btype)
+Gcc_backend::type_size (tree t)
 {
-  tree t = btype->get_tree ();
   if (t == error_mark_node)
     return 1;
   if (t == void_type_node)
@@ -1258,9 +1236,8 @@ Gcc_backend::type_size (Btype *btype)
 // Return the alignment of a type.
 
 int64_t
-Gcc_backend::type_alignment (Btype *btype)
+Gcc_backend::type_alignment (tree t)
 {
-  tree t = btype->get_tree ();
   if (t == error_mark_node)
     return 1;
   return TYPE_ALIGN_UNIT (t);
@@ -1269,9 +1246,8 @@ Gcc_backend::type_alignment (Btype *btype)
 // Return the alignment of a struct field of type BTYPE.
 
 int64_t
-Gcc_backend::type_field_alignment (Btype *btype)
+Gcc_backend::type_field_alignment (tree t)
 {
-  tree t = btype->get_tree ();
   if (t == error_mark_node)
     return 1;
   return rust_field_alignment (t);
@@ -1280,9 +1256,8 @@ Gcc_backend::type_field_alignment (Btype *btype)
 // Return the offset of a field in a struct.
 
 int64_t
-Gcc_backend::type_field_offset (Btype *btype, size_t index)
+Gcc_backend::type_field_offset (tree struct_tree, size_t index)
 {
-  tree struct_tree = btype->get_tree ();
   if (struct_tree == error_mark_node)
     return 0;
   gcc_assert (TREE_CODE (struct_tree) == RECORD_TYPE);
@@ -1301,9 +1276,8 @@ Gcc_backend::type_field_offset (Btype *btype, size_t index)
 // Return the zero value for a type.
 
 Bexpression *
-Gcc_backend::zero_expression (Btype *btype)
+Gcc_backend::zero_expression (tree t)
 {
-  tree t = btype->get_tree ();
   tree ret;
   if (t == error_mark_node)
     ret = error_mark_node;
@@ -1326,11 +1300,10 @@ Gcc_backend::var_expression (Bvariable *var, Location location)
 // An expression that indirectly references an expression.
 
 Bexpression *
-Gcc_backend::indirect_expression (Btype *btype, Bexpression *expr,
+Gcc_backend::indirect_expression (tree type_tree, Bexpression *expr,
 				  bool known_valid, Location location)
 {
   tree expr_tree = expr->get_tree ();
-  tree type_tree = btype->get_tree ();
   if (expr_tree == error_mark_node || type_tree == error_mark_node)
     return this->error_expression ();
 
@@ -1351,10 +1324,9 @@ Gcc_backend::indirect_expression (Btype *btype, Bexpression *expr,
 // constant value VAL in BTYPE.
 
 Bexpression *
-Gcc_backend::named_constant_expression (Btype *btype, const std::string &name,
+Gcc_backend::named_constant_expression (tree type_tree, const std::string &name,
 					Bexpression *val, Location location)
 {
-  tree type_tree = btype->get_tree ();
   tree const_val = val->get_tree ();
   if (type_tree == error_mark_node || const_val == error_mark_node)
     return this->error_expression ();
@@ -1373,9 +1345,8 @@ Gcc_backend::named_constant_expression (Btype *btype, const std::string &name,
 // Return a typed value as a constant integer.
 
 Bexpression *
-Gcc_backend::integer_constant_expression (Btype *btype, mpz_t val)
+Gcc_backend::integer_constant_expression (tree t, mpz_t val)
 {
-  tree t = btype->get_tree ();
   if (t == error_mark_node)
     return this->error_expression ();
 
@@ -1386,9 +1357,8 @@ Gcc_backend::integer_constant_expression (Btype *btype, mpz_t val)
 // Return a typed value as a constant floating-point number.
 
 Bexpression *
-Gcc_backend::float_constant_expression (Btype *btype, mpfr_t val)
+Gcc_backend::float_constant_expression (tree t, mpfr_t val)
 {
-  tree t = btype->get_tree ();
   tree ret;
   if (t == error_mark_node)
     return this->error_expression ();
@@ -1404,9 +1374,8 @@ Gcc_backend::float_constant_expression (Btype *btype, mpfr_t val)
 // Return a typed real and imaginary value as a constant complex number.
 
 Bexpression *
-Gcc_backend::complex_constant_expression (Btype *btype, mpc_t val)
+Gcc_backend::complex_constant_expression (tree t, mpc_t val)
 {
-  tree t = btype->get_tree ();
   tree ret;
   if (t == error_mark_node)
     return this->error_expression ();
@@ -1444,14 +1413,14 @@ Gcc_backend::string_constant_expression (const std::string &val)
 Bexpression *
 Gcc_backend::wchar_constant_expression (wchar_t c)
 {
-  tree ret = build_int_cst (this->wchar_type ()->get_tree (), c);
+  tree ret = build_int_cst (this->wchar_type (), c);
   return this->make_expression (ret);
 }
 
 Bexpression *
 Gcc_backend::char_constant_expression (char c)
 {
-  tree ret = build_int_cst (this->char_type ()->get_tree (), c);
+  tree ret = build_int_cst (this->char_type (), c);
   return this->make_expression (ret);
 }
 
@@ -1516,17 +1485,16 @@ Gcc_backend::complex_expression (Bexpression *breal, Bexpression *bimag,
 // An expression that converts an expression to a different type.
 
 Bexpression *
-Gcc_backend::convert_expression (Btype *type, Bexpression *expr,
+Gcc_backend::convert_expression (tree type_tree, Bexpression *expr,
 				 Location location)
 {
-  tree type_tree = type->get_tree ();
   tree expr_tree = expr->get_tree ();
   if (type_tree == error_mark_node || expr_tree == error_mark_node
       || TREE_TYPE (expr_tree) == error_mark_node)
     return this->error_expression ();
 
   tree ret;
-  if (this->type_size (type) == 0 || TREE_TYPE (expr_tree) == void_type_node)
+  if (this->type_size (type_tree) == 0 || TREE_TYPE (expr_tree) == void_type_node)
     {
       // Do not convert zero-sized types.
       ret = expr_tree;
@@ -1628,12 +1596,11 @@ Gcc_backend::compound_expression (Bstatement *bstat, Bexpression *bexpr,
 // ELSE_EXPR otherwise.
 
 Bexpression *
-Gcc_backend::conditional_expression (Bfunction *, Btype *btype,
+Gcc_backend::conditional_expression (Bfunction *, tree type_tree,
 				     Bexpression *condition,
 				     Bexpression *then_expr,
 				     Bexpression *else_expr, Location location)
 {
-  tree type_tree = btype == NULL ? void_type_node : btype->get_tree ();
   tree cond_tree = condition->get_tree ();
   tree then_tree = then_expr->get_tree ();
   tree else_tree = else_expr == NULL ? NULL_TREE : else_expr->get_tree ();
@@ -1876,11 +1843,10 @@ Gcc_backend::lazy_boolean_expression (LazyBooleanOperator op, Bexpression *left,
 // Return an expression that constructs BTYPE with VALS.
 
 Bexpression *
-Gcc_backend::constructor_expression (Btype *btype,
+Gcc_backend::constructor_expression (tree type_tree,
 				     const std::vector<Bexpression *> &vals,
 				     int union_index, Location location)
 {
-  tree type_tree = btype->get_tree ();
   if (type_tree == error_mark_node)
     return this->error_expression ();
 
@@ -1965,10 +1931,9 @@ Gcc_backend::constructor_expression (Btype *btype,
 
 Bexpression *
 Gcc_backend::array_constructor_expression (
-  Btype *array_btype, const std::vector<unsigned long> &indexes,
+  tree type_tree, const std::vector<unsigned long> &indexes,
   const std::vector<Bexpression *> &vals, Location location)
 {
-  tree type_tree = array_btype->get_tree ();
   if (type_tree == error_mark_node)
     return this->error_expression ();
 
@@ -2674,11 +2639,10 @@ Gcc_backend::convert_tree (tree type_tree, tree expr_tree, Location location)
 
 Bvariable *
 Gcc_backend::global_variable (const std::string &var_name,
-			      const std::string &asm_name, Btype *btype,
+			      const std::string &asm_name, tree type_tree,
 			      bool is_external, bool is_hidden,
 			      bool in_unique_section, Location location)
 {
-  tree type_tree = btype->get_tree ();
   if (type_tree == error_mark_node)
     return this->error_variable ();
 
@@ -2742,10 +2706,9 @@ Gcc_backend::global_variable_set_init (Bvariable *var, Bexpression *expr)
 
 Bvariable *
 Gcc_backend::local_variable (Bfunction *function, const std::string &name,
-			     Btype *btype, Bvariable *decl_var,
+			     tree type_tree, Bvariable *decl_var,
 			     bool is_address_taken, Location location)
 {
-  tree type_tree = btype->get_tree ();
   if (type_tree == error_mark_node)
     return this->error_variable ();
   tree decl = build_decl (location.gcc_location (), VAR_DECL,
@@ -2767,10 +2730,9 @@ Gcc_backend::local_variable (Bfunction *function, const std::string &name,
 
 Bvariable *
 Gcc_backend::parameter_variable (Bfunction *function, const std::string &name,
-				 Btype *btype, bool is_address_taken,
+				 tree type_tree, bool is_address_taken,
 				 Location location)
 {
-  tree type_tree = btype->get_tree ();
   if (type_tree == error_mark_node)
     return this->error_variable ();
   tree decl = build_decl (location.gcc_location (), PARM_DECL,
@@ -2788,10 +2750,9 @@ Gcc_backend::parameter_variable (Bfunction *function, const std::string &name,
 
 Bvariable *
 Gcc_backend::static_chain_variable (Bfunction *function,
-				    const std::string &name, Btype *btype,
+				    const std::string &name, tree type_tree,
 				    Location location)
 {
-  tree type_tree = btype->get_tree ();
   if (type_tree == error_mark_node)
     return this->error_variable ();
   tree decl = build_decl (location.gcc_location (), PARM_DECL,
@@ -2823,13 +2784,12 @@ Gcc_backend::static_chain_variable (Bfunction *function,
 
 Bvariable *
 Gcc_backend::temporary_variable (Bfunction *function, Bblock *bblock,
-				 Btype *btype, Bexpression *binit,
+				 tree type_tree, Bexpression *binit,
 				 bool is_address_taken, Location location,
 				 Bstatement **pstatement)
 {
   gcc_assert (function != NULL);
   tree decl = function->get_tree ();
-  tree type_tree = btype->get_tree ();
   tree init_tree = binit == NULL ? NULL_TREE : binit->get_tree ();
   if (type_tree == error_mark_node || init_tree == error_mark_node
       || decl == error_mark_node)
@@ -2870,7 +2830,7 @@ Gcc_backend::temporary_variable (Bfunction *function, Bblock *bblock,
       BIND_EXPR_VARS (bind_tree) = BLOCK_VARS (block_tree);
     }
 
-  if (this->type_size (btype) != 0 && init_tree != NULL_TREE
+  if (this->type_size (type_tree) != 0 && init_tree != NULL_TREE
       && TREE_TYPE (init_tree) != void_type_node)
     DECL_INITIAL (var) = this->convert_tree (type_tree, init_tree, location);
 
@@ -2883,7 +2843,7 @@ Gcc_backend::temporary_variable (Bfunction *function, Bblock *bblock,
   // For a zero sized type, don't initialize VAR with BINIT, but still
   // evaluate BINIT for its side effects.
   if (init_tree != NULL_TREE
-      && (this->type_size (btype) == 0
+      && (this->type_size (type_tree) == 0
 	  || TREE_TYPE (init_tree) == void_type_node))
     *pstatement
       = this->compound_statement (this->expression_statement (function, binit),
@@ -2897,11 +2857,10 @@ Gcc_backend::temporary_variable (Bfunction *function, Bblock *bblock,
 
 Bvariable *
 Gcc_backend::implicit_variable (const std::string &name,
-				const std::string &asm_name, Btype *type,
+				const std::string &asm_name, tree type_tree,
 				bool is_hidden, bool is_constant,
 				bool is_common, int64_t alignment)
 {
-  tree type_tree = type->get_tree ();
   if (type_tree == error_mark_node)
     return this->error_variable ();
 
@@ -2952,7 +2911,7 @@ Gcc_backend::implicit_variable (const std::string &name,
 
 void
 Gcc_backend::implicit_variable_set_init (Bvariable *var, const std::string &,
-					 Btype *, bool, bool, bool is_common,
+					 tree, bool, bool, bool is_common,
 					 Bexpression *init)
 {
   tree decl = var->get_decl ();
@@ -2984,9 +2943,8 @@ Gcc_backend::implicit_variable_set_init (Bvariable *var, const std::string &,
 Bvariable *
 Gcc_backend::implicit_variable_reference (const std::string &name,
 					  const std::string &asm_name,
-					  Btype *btype)
+					  tree type_tree)
 {
-  tree type_tree = btype->get_tree ();
   if (type_tree == error_mark_node)
     return this->error_variable ();
 
@@ -3007,9 +2965,9 @@ Gcc_backend::implicit_variable_reference (const std::string &name,
 Bvariable *
 Gcc_backend::immutable_struct (const std::string &name,
 			       const std::string &asm_name, bool is_hidden,
-			       bool is_common, Btype *btype, Location location)
+			       bool is_common, tree type_tree,
+			       Location location)
 {
-  tree type_tree = btype->get_tree ();
   if (type_tree == error_mark_node)
     return this->error_variable ();
   gcc_assert (TREE_CODE (type_tree) == RECORD_TYPE);
@@ -3053,7 +3011,7 @@ Gcc_backend::immutable_struct (const std::string &name,
 
 void
 Gcc_backend::immutable_struct_set_init (Bvariable *var, const std::string &,
-					bool, bool is_common, Btype *, Location,
+					bool, bool is_common, tree, Location,
 					Bexpression *initializer)
 {
   tree decl = var->get_decl ();
@@ -3084,9 +3042,8 @@ Gcc_backend::immutable_struct_set_init (Bvariable *var, const std::string &,
 Bvariable *
 Gcc_backend::immutable_struct_reference (const std::string &name,
 					 const std::string &asm_name,
-					 Btype *btype, Location location)
+					 tree type_tree, Location location)
 {
-  tree type_tree = btype->get_tree ();
   if (type_tree == error_mark_node)
     return this->error_variable ();
   gcc_assert (TREE_CODE (type_tree) == RECORD_TYPE);
@@ -3173,11 +3130,10 @@ Gcc_backend::label_address (Blabel *label, Location location)
 // Declare or define a new function.
 
 Bfunction *
-Gcc_backend::function (Btype *fntype, const std::string &name,
+Gcc_backend::function (tree functype, const std::string &name,
 		       const std::string &asm_name, unsigned int flags,
 		       Location location)
 {
-  tree functype = fntype->get_tree ();
   if (functype != error_mark_node)
     {
       gcc_assert (FUNCTION_POINTER_TYPE_P (functype));
@@ -3330,7 +3286,7 @@ Gcc_backend::lookup_builtin_by_rust_name (const std::string &name)
 
 void
 Gcc_backend::write_global_definitions (
-  const std::vector<Btype *> &type_decls,
+  const std::vector<tree> &type_decls,
   const std::vector<Bexpression *> &constant_decls,
   const std::vector<Bfunction *> &function_decls,
   const std::vector<Bvariable *> &variable_decls)
@@ -3354,10 +3310,10 @@ Gcc_backend::write_global_definitions (
 	}
     }
 
-  for (std::vector<Btype *>::const_iterator p = type_decls.begin ();
+  for (std::vector<tree>::const_iterator p = type_decls.begin ();
        p != type_decls.end (); ++p)
     {
-      tree type_tree = (*p)->get_tree ();
+      tree type_tree = (*p);
       if (type_tree != error_mark_node && IS_TYPE_OR_DECL_P (type_tree))
 	{
 	  defs[i] = TYPE_NAME (type_tree);

--- a/gcc/rust/typecheck/rust-hir-const-fold-ctx.h
+++ b/gcc/rust/typecheck/rust-hir-const-fold-ctx.h
@@ -36,15 +36,15 @@ public:
 
   ::Backend *get_backend () { return backend; }
 
-  bool lookup_const (HirId id, Bexpression **expr);
+  bool lookup_const (HirId id, tree *expr);
 
-  void insert_const (HirId, Bexpression *expr);
+  void insert_const (HirId, tree expr);
 
 private:
   Context (::Backend *backend);
 
   ::Backend *backend;
-  std::map<HirId, Bexpression *> ctx;
+  std::map<HirId, tree> ctx;
 };
 
 } // namespace ConstFold

--- a/gcc/rust/typecheck/rust-hir-const-fold.cc
+++ b/gcc/rust/typecheck/rust-hir-const-fold.cc
@@ -41,7 +41,7 @@ Context::get ()
 }
 
 bool
-Context::lookup_const (HirId id, Bexpression **expr)
+Context::lookup_const (HirId id, tree *expr)
 {
   auto it = ctx.find (id);
   if (it == ctx.end ())
@@ -52,7 +52,7 @@ Context::lookup_const (HirId id, Bexpression **expr)
 }
 
 void
-Context::insert_const (HirId id, Bexpression *expr)
+Context::insert_const (HirId id, tree expr)
 {
   rust_assert (ctx.find (id) == ctx.end ());
   ctx[id] = expr;
@@ -75,7 +75,7 @@ ConstFoldArrayElems::visit (HIR::ArrayElemsValues &elems)
 {
   unsigned long index = 0;
   std::vector<unsigned long> indices;
-  std::vector<Bexpression *> values;
+  std::vector<tree> values;
 
   TyTy::BaseType *tyty = nullptr;
   if (!tyctx->lookup_type (expr.get_mappings ().get_hirid (), &tyty))
@@ -102,7 +102,7 @@ void
 ConstFoldArrayElems::visit (HIR::ArrayElemsCopied &elems)
 {
   std::vector<unsigned long> indices;
-  std::vector<Bexpression *> values;
+  std::vector<tree> values;
 
   TyTy::BaseType *tyty = nullptr;
   if (!tyctx->lookup_type (expr.get_mappings ().get_hirid (), &tyty))
@@ -113,11 +113,11 @@ ConstFoldArrayElems::visit (HIR::ArrayElemsCopied &elems)
     }
 
   tree type = ConstFoldType::fold (tyty, ctx->get_backend ());
-  Bexpression *elem = ConstFoldExpr::fold (elems.get_elem_to_copy ());
+  tree elem = ConstFoldExpr::fold (elems.get_elem_to_copy ());
 
   // num copies expr was already folded in rust-hir-type-check-expr; lookup the
   // earlier result
-  Bexpression *num_copies_expr = ctx->get_backend ()->error_expression ();
+  tree num_copies_expr = ctx->get_backend ()->error_expression ();
   ctx->lookup_const (elems.get_num_copies_expr ()->get_mappings ().get_hirid (),
 		     &num_copies_expr);
 

--- a/gcc/rust/typecheck/rust-hir-const-fold.cc
+++ b/gcc/rust/typecheck/rust-hir-const-fold.cc
@@ -85,7 +85,7 @@ ConstFoldArrayElems::visit (HIR::ArrayElemsValues &elems)
       return;
     }
 
-  Btype *btype = ConstFoldType::fold (tyty, ctx->get_backend ());
+  tree type = ConstFoldType::fold (tyty, ctx->get_backend ());
 
   for (auto &value : elems.get_values ())
     {
@@ -94,7 +94,7 @@ ConstFoldArrayElems::visit (HIR::ArrayElemsValues &elems)
     }
 
   folded
-    = ctx->get_backend ()->array_constructor_expression (btype, indices, values,
+    = ctx->get_backend ()->array_constructor_expression (type, indices, values,
 							 expr.get_locus ());
 }
 
@@ -112,7 +112,7 @@ ConstFoldArrayElems::visit (HIR::ArrayElemsCopied &elems)
       return;
     }
 
-  Btype *btype = ConstFoldType::fold (tyty, ctx->get_backend ());
+  tree type = ConstFoldType::fold (tyty, ctx->get_backend ());
   Bexpression *elem = ConstFoldExpr::fold (elems.get_elem_to_copy ());
 
   // num copies expr was already folded in rust-hir-type-check-expr; lookup the
@@ -132,7 +132,7 @@ ConstFoldArrayElems::visit (HIR::ArrayElemsCopied &elems)
     }
 
   folded
-    = ctx->get_backend ()->array_constructor_expression (btype, indices, values,
+    = ctx->get_backend ()->array_constructor_expression (type, indices, values,
 							 expr.get_locus ());
 }
 

--- a/gcc/rust/typecheck/rust-hir-const-fold.h
+++ b/gcc/rust/typecheck/rust-hir-const-fold.h
@@ -237,7 +237,7 @@ class ConstFoldItem : public ConstFoldBase
   using ConstFoldBase::visit;
 
 public:
-  static Bexpression *fold (HIR::Item &item)
+  static tree fold (HIR::Item &item)
   {
     ConstFoldItem folder;
     item.accept_vis (folder);
@@ -258,7 +258,7 @@ private:
     : ConstFoldBase (), folded (ctx->get_backend ()->error_expression ())
   {}
 
-  Bexpression *folded;
+  tree folded;
 };
 
 class ConstFoldArrayElems : public ConstFoldBase
@@ -266,7 +266,7 @@ class ConstFoldArrayElems : public ConstFoldBase
   using ConstFoldBase::visit;
 
 public:
-  static Bexpression *fold (HIR::ArrayExpr &expr)
+  static tree fold (HIR::ArrayExpr &expr)
   {
     ConstFoldArrayElems folder (expr);
     HIR::ArrayElems *elems = expr.get_internal_elements ();
@@ -283,7 +283,7 @@ private:
       expr (expr)
   {}
 
-  Bexpression *folded;
+  tree folded;
   HIR::ArrayExpr &expr;
 };
 
@@ -292,7 +292,7 @@ class ConstFoldExpr : public ConstFoldBase
   using ConstFoldBase::visit;
 
 public:
-  static Bexpression *fold (HIR::Expr *expr)
+  static tree fold (HIR::Expr *expr)
   {
     ConstFoldExpr folder;
     expr->accept_vis (folder);
@@ -453,8 +453,8 @@ public:
 
   void visit (HIR::ArrayIndexExpr &expr) override
   {
-    Bexpression *array = ConstFoldExpr::fold (expr.get_array_expr ());
-    Bexpression *index = ConstFoldExpr::fold (expr.get_index_expr ());
+    tree array = ConstFoldExpr::fold (expr.get_array_expr ());
+    tree index = ConstFoldExpr::fold (expr.get_index_expr ());
 
     folded = ctx->get_backend ()->array_index_expression (array, index,
 							  expr.get_locus ());
@@ -462,7 +462,7 @@ public:
 
   void visit (HIR::BorrowExpr &expr) override
   {
-    Bexpression *main_expr = ConstFoldExpr::fold (expr.get_expr ().get ());
+    tree main_expr = ConstFoldExpr::fold (expr.get_expr ().get ());
 
     folded
       = ctx->get_backend ()->address_expression (main_expr, expr.get_locus ());
@@ -470,7 +470,7 @@ public:
 
   void visit (HIR::DereferenceExpr &expr) override
   {
-    Bexpression *main_expr = ConstFoldExpr::fold (expr.get_expr ().get ());
+    tree main_expr = ConstFoldExpr::fold (expr.get_expr ().get ());
 
     TyTy::BaseType *tyty = nullptr;
     if (!tyctx->lookup_type (expr.get_mappings ().get_hirid (), &tyty))
@@ -497,7 +497,7 @@ private:
     : ConstFoldBase (), folded (ctx->get_backend ()->error_expression ())
   {}
 
-  Bexpression *folded;
+  tree folded;
 };
 
 } // namespace ConstFold

--- a/gcc/rust/typecheck/rust-hir-const-fold.h
+++ b/gcc/rust/typecheck/rust-hir-const-fold.h
@@ -28,7 +28,7 @@ namespace ConstFold {
 class ConstFoldType : public TyTy::TyVisitor
 {
 public:
-  static Btype *fold (TyTy::BaseType *type, ::Backend *backend)
+  static tree fold (TyTy::BaseType *type, ::Backend *backend)
   {
     ConstFoldType folder (backend);
     type->accept_vis (folder);
@@ -43,13 +43,13 @@ public:
 
   void visit (TyTy::ArrayType &type) override
   {
-    Btype *element_ty = ConstFoldType::fold (type.get_element_type (), backend);
+    tree element_ty = ConstFoldType::fold (type.get_element_type (), backend);
     translated = backend->array_type (element_ty, type.get_capacity ());
   }
 
   void visit (TyTy::ReferenceType &type) override
   {
-    Btype *base_compiled_type = ConstFoldType::fold (type.get_base (), backend);
+    tree base_compiled_type = ConstFoldType::fold (type.get_base (), backend);
     if (type.is_mutable ())
       {
 	translated = backend->reference_type (base_compiled_type);
@@ -63,7 +63,7 @@ public:
 
   void visit (TyTy::PointerType &type) override
   {
-    Btype *base_compiled_type = ConstFoldType::fold (type.get_base (), backend);
+    tree base_compiled_type = ConstFoldType::fold (type.get_base (), backend);
     if (type.is_mutable ())
       {
 	translated = backend->pointer_type (base_compiled_type);
@@ -212,7 +212,7 @@ public:
 
   void visit (TyTy::StrType &) override
   {
-    Btype *raw_str = backend->raw_str_type ();
+    tree raw_str = backend->raw_str_type ();
     translated
       = backend->named_type ("str", raw_str, Linemap::predeclared_location ());
   }
@@ -229,7 +229,7 @@ private:
   {}
 
   ::Backend *backend;
-  ::Btype *translated;
+  ::tree translated;
 };
 
 class ConstFoldItem : public ConstFoldBase
@@ -369,7 +369,7 @@ public:
 	      return;
 	    }
 
-	  Btype *type = ConstFoldType::fold (tyty, ctx->get_backend ());
+	  tree type = ConstFoldType::fold (tyty, ctx->get_backend ());
 	  folded
 	    = ctx->get_backend ()->integer_constant_expression (type, ival);
 	}
@@ -400,7 +400,7 @@ public:
 	      return;
 	    }
 
-	  Btype *type = ConstFoldType::fold (tyty, ctx->get_backend ());
+	  tree type = ConstFoldType::fold (tyty, ctx->get_backend ());
 	  folded = ctx->get_backend ()->float_constant_expression (type, fval);
 	}
 	return;
@@ -480,7 +480,7 @@ public:
 	return;
       }
 
-    Btype *expected_type = ConstFoldType::fold (tyty, ctx->get_backend ());
+    tree expected_type = ConstFoldType::fold (tyty, ctx->get_backend ());
     bool known_valid = true;
     folded = ctx->get_backend ()->indirect_expression (expected_type, main_expr,
 						       known_valid,

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -687,7 +687,7 @@ public:
 						  UNKNOWN_LOCAL_DEFID);
 
 	  /* Capacity is the size of the string (number of chars).
-	     It is a constant, but for fold it to get a Bexpression.  */
+	     It is a constant, but for fold it to get a tree.  */
 	  std::string capacity_str
 	    = std::to_string (expr.get_literal ()->as_string ().size ());
 	  HIR::LiteralExpr literal_capacity (capacity_mapping, capacity_str,
@@ -700,8 +700,7 @@ public:
 				new TyTy::USizeType (
 				  capacity_mapping.get_hirid ()));
 
-	  Bexpression *capacity
-	    = ConstFold::ConstFoldExpr::fold (&literal_capacity);
+	  tree capacity = ConstFold::ConstFoldExpr::fold (&literal_capacity);
 
 	  Analysis::NodeMapping array_mapping (crate_num, UNKNOWN_NODEID,
 					       mappings->get_next_hir_id (
@@ -1491,7 +1490,7 @@ private:
   /* The return value of visit(ArrayElemsValues&) and visit(ArrayElemsCopied&)
      Stores the type of array elements, if `expr` is ArrayExpr. */
   TyTy::BaseType *infered_array_elems;
-  Bexpression *folded_array_capacity;
+  tree folded_array_capacity;
   Location root_array_expr_locus;
 
   bool inside_loop;

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -1588,13 +1588,13 @@ private:
 class ArrayType : public BaseType
 {
 public:
-  ArrayType (HirId ref, Bexpression *capacity, TyVar base,
+  ArrayType (HirId ref, tree capacity, TyVar base,
 	     std::set<HirId> refs = std::set<HirId> ())
     : BaseType (ref, ref, TypeKind::ARRAY, refs), capacity (capacity),
       element_type (base)
   {}
 
-  ArrayType (HirId ref, HirId ty_ref, Bexpression *capacity, TyVar base,
+  ArrayType (HirId ref, HirId ty_ref, tree capacity, TyVar base,
 	     std::set<HirId> refs = std::set<HirId> ())
     : BaseType (ref, ty_ref, TypeKind::ARRAY, refs), capacity (capacity),
       element_type (base)
@@ -1615,7 +1615,7 @@ public:
 
   bool is_equal (const BaseType &other) const override;
 
-  Bexpression *get_capacity () const { return capacity; }
+  tree get_capacity () const { return capacity; }
   std::string capacity_string () const;
 
   BaseType *get_element_type () const;
@@ -1628,7 +1628,7 @@ public:
   }
 
 private:
-  Bexpression *capacity;
+  tree capacity;
   TyVar element_type;
 };
 


### PR DESCRIPTION
As discussed in #412, the Rust front end inherits an abstraction over gcc from the initial bootstrap via GCCGO. 
This is a cool idea, but adds overhead for the primary goal of gcc compiling Rust. It's not clear that the benefits of maintaining the abstraction are worth the potential extra headaches of maintaining it.

I figured for the sake of discussion, I'd draft an initial step towards removing this abstraction. 

The implementations of classes `Bytpe`, `Bexpression`, `Bstatement`, `Bfunction`, and `Bblock` are only wrappers around gcc's GENERIC `tree` structure, with no added functionality. This PR removes them, and changes all the functions for creating and manipulating these abstract types to just use/return `tree` instead. I also deleted a few functions that are vestiges from GCCGO port and aren't used.

Personally, I think the abstraction should be removed in favor of using `tree`s. This is more in line with the other gcc front ends and makes the interface between the frontend and the rest of gcc simpler.

I'm curious to hear other opinions on the matter :)

Addresses: #412 

