### PR TITLE
Remove implicit paths hack

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-implitem.h
+++ b/gcc/rust/resolve/rust-ast-resolve-implitem.h
@@ -54,9 +54,6 @@ public:
 	r.add_range (locus);
 	rust_error_at (r, "redefined multiple times");
       });
-    resolver->insert_new_definition (type.get_node_id (),
-				     Definition{type.get_node_id (),
-						type.get_node_id ()});
   }
 
   void visit (AST::ConstantItem &constant) override
@@ -181,16 +178,13 @@ public:
   {
     auto path
       = prefix.append (ResolveTraitItemTypeToCanonicalPath::resolve (type));
-    resolver->get_name_scope ().insert (
+    resolver->get_type_scope ().insert (
       path, type.get_node_id (), type.get_locus (), false,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (type.get_locus ());
 	r.add_range (locus);
 	rust_error_at (r, "redefined multiple times");
       });
-    resolver->insert_new_definition (type.get_node_id (),
-				     Definition{type.get_node_id (),
-						type.get_node_id ()});
   }
 
 private:

--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -771,17 +771,15 @@ ResolveType::visit (AST::TraitObjectType &type)
 // rust-ast-resolve-item.h
 
 void
-ResolveItem::resolve_impl_item (AST::TraitImplItem *item,
-				const CanonicalPath &self)
+ResolveItem::resolve_impl_item (AST::TraitImplItem *item)
 {
-  ResolveImplItems::go (item, self);
+  ResolveImplItems::go (item);
 }
 
 void
-ResolveItem::resolve_impl_item (AST::InherentImplItem *item,
-				const CanonicalPath &self)
+ResolveItem::resolve_impl_item (AST::InherentImplItem *item)
 {
-  ResolveImplItems::go (item, self);
+  ResolveImplItems::go (item);
 }
 
 void

--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -313,14 +313,12 @@ NameResolution::Resolve (AST::Crate &crate)
 void
 NameResolution::go (AST::Crate &crate)
 {
-  // setup parent scoping for names
-  resolver->get_name_scope ().push (crate.get_node_id ());
+  NodeId scope_node_id = crate.get_node_id ();
+  resolver->get_name_scope ().push (scope_node_id);
+  resolver->get_type_scope ().push (scope_node_id);
+  resolver->get_label_scope ().push (scope_node_id);
   resolver->push_new_name_rib (resolver->get_name_scope ().peek ());
-  // setup parent scoping for new types
-  resolver->get_type_scope ().push (mappings->get_next_node_id ());
   resolver->push_new_type_rib (resolver->get_type_scope ().peek ());
-  // setup label scope
-  resolver->get_label_scope ().push (mappings->get_next_node_id ());
   resolver->push_new_label_rib (resolver->get_type_scope ().peek ());
 
   // first gather the top-level namespace names then we drill down

--- a/gcc/rust/resolve/rust-name-resolver.h
+++ b/gcc/rust/resolve/rust-name-resolver.h
@@ -42,8 +42,8 @@ public:
     const CanonicalPath &path, NodeId id, Location locus, bool shadow,
     std::function<void (const CanonicalPath &, NodeId, Location)> dup_cb)
   {
-    auto it = mappings.find (path);
-    bool already_exists = it != mappings.end ();
+    auto it = path_mappings.find (path);
+    bool already_exists = it != path_mappings.end ();
     if (already_exists && !shadow)
       {
 	for (auto &decl : decls_within_rib)
@@ -58,8 +58,8 @@ public:
 	return;
       }
 
-    mappings[path] = id;
-    reverse_mappings.insert (std::pair<NodeId, CanonicalPath> (id, path));
+    path_mappings[path] = id;
+    reverse_path_mappings.insert (std::pair<NodeId, CanonicalPath> (id, path));
     decls_within_rib.insert (std::pair<NodeId, Location> (id, locus));
     references[id] = {};
 
@@ -69,8 +69,8 @@ public:
 
   bool lookup_name (const CanonicalPath &ident, NodeId *id)
   {
-    auto it = mappings.find (ident);
-    if (it == mappings.end ())
+    auto it = path_mappings.find (ident);
+    if (it == path_mappings.end ())
       return false;
 
     *id = it->second;
@@ -79,8 +79,8 @@ public:
 
   bool lookup_canonical_path (const NodeId &id, CanonicalPath *ident)
   {
-    auto it = reverse_mappings.find (id);
-    if (it == reverse_mappings.end ())
+    auto it = reverse_path_mappings.find (id);
+    if (it == reverse_path_mappings.end ())
       return false;
 
     *ident = it->second;
@@ -89,8 +89,8 @@ public:
 
   void clear_name (const CanonicalPath &ident, NodeId id)
   {
-    mappings.erase (ident);
-    reverse_mappings.erase (id);
+    path_mappings.erase (ident);
+    reverse_path_mappings.erase (id);
 
     for (auto &it : decls_within_rib)
       {
@@ -154,8 +154,8 @@ public:
 private:
   CrateNum crate_num;
   NodeId node_id;
-  std::map<CanonicalPath, NodeId> mappings;
-  std::map<NodeId, CanonicalPath> reverse_mappings;
+  std::map<CanonicalPath, NodeId> path_mappings;
+  std::map<NodeId, CanonicalPath> reverse_path_mappings;
   std::set<std::pair<NodeId, Location>> decls_within_rib;
   std::map<NodeId, std::set<NodeId>> references;
 };

--- a/gcc/rust/resolve/rust-name-resolver.h
+++ b/gcc/rust/resolve/rust-name-resolver.h
@@ -33,7 +33,8 @@ public:
   // Rust uses local_def_ids assigned by def_collector on the AST
   // lets use NodeId instead
   Rib (CrateNum crateNum, NodeId node_id)
-    : crate_num (crateNum), node_id (node_id)
+    : crate_num (crateNum), node_id (node_id),
+      mappings (Analysis::Mappings::get ())
   {}
 
   ~Rib () {}
@@ -59,8 +60,6 @@ public:
     reverse_path_mappings.insert (std::pair<NodeId, CanonicalPath> (id, path));
     decls_within_rib.insert (std::pair<NodeId, Location> (id, locus));
     references[id] = {};
-
-    auto mappings = Analysis::Mappings::get ();
     mappings->insert_canonical_path (mappings->get_current_crate (), id, path);
   }
 
@@ -155,6 +154,7 @@ private:
   std::map<NodeId, CanonicalPath> reverse_path_mappings;
   std::map<NodeId, Location> decls_within_rib;
   std::map<NodeId, std::set<NodeId>> references;
+  Analysis::Mappings *mappings;
 };
 
 class Scope

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -220,7 +220,7 @@ TypeCheckType::visit (HIR::QualifiedPathInType &path)
   bool fully_resolved = path.get_segments ().empty ();
   if (fully_resolved)
     {
-      resolver->insert_resolved_name (path.get_mappings ().get_nodeid (),
+      resolver->insert_resolved_type (path.get_mappings ().get_nodeid (),
 				      root_resolved_node_id);
       context->insert_receiver (path.get_mappings ().get_hirid (), root);
       return;
@@ -517,7 +517,7 @@ TypeCheckType::resolve_segments (
     }
   else
     {
-      resolver->insert_resolved_name (expr_mappings.get_nodeid (),
+      resolver->insert_resolved_type (expr_mappings.get_nodeid (),
 				      resolved_node_id);
     }
 


### PR DESCRIPTION
The name resolver also created a bunch of duplicates Self::associated_type
paths in the name resolver so associated types paths of this kind could be resolved
at name resolve time.

Addresses #739 