### PR TITLE
Support QualifiedPathInType's within the same Trait

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-bounds.h
+++ b/gcc/rust/typecheck/rust-hir-type-bounds.h
@@ -42,14 +42,22 @@ public:
   static bool is_bound_satisfied_for_type (TyTy::BaseType *receiver,
 					   TraitReference *ref)
   {
+    for (auto &bound : receiver->get_specified_bounds ())
+      {
+	const TraitReference *b = bound.get ();
+	if (b->is_equal (*ref))
+	  return true;
+      }
+
     std::vector<std::pair<TraitReference *, HIR::ImplBlock *>> bounds
       = Probe (receiver);
     for (auto &bound : bounds)
       {
-	TraitReference *b = bound.first;
-	if (b == ref)
+	const TraitReference *b = bound.first;
+	if (b->is_equal (*ref))
 	  return true;
       }
+
     return false;
   }
 

--- a/gcc/testsuite/rust/compile/torture/associated_types1.rs
+++ b/gcc/testsuite/rust/compile/torture/associated_types1.rs
@@ -1,0 +1,14 @@
+pub trait Foo {
+    type A;
+
+    fn boo(&self) -> <Self as Foo>::A;
+    // { dg-warning "unused name .self." "" { target *-*-* } .-1 }
+}
+
+fn foo2<I: Foo>(x: I) {
+    // { dg-warning "function is never used: .foo2." "" { target *-*-* } .-1 }
+    // { dg-warning "unused name .foo2." "" { target *-*-* } .-2 }
+    x.boo();
+}
+
+pub fn main() {}


### PR DESCRIPTION
The first implementation of qualified paths assumed that they only exist
within trait-impl blocks. Trait impl blocks have the same canonical paths
of <type as trait_path>::segment form but this type of path is more generic
than this.

see the commit for more details on the implementation.

Fixes #739
