### PR TITLE
Set TREE_ADDRESSABLE when we need to borrow any expression

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -86,6 +86,7 @@ GRS_OBJS = \
     rust/rust-hir-const-fold.o \
     rust/rust-hir-type-check-type.o \
     rust/rust-hir-type-check-struct.o \
+    rust/rust-hir-address-taken.o \
     rust/rust-substitution-mapper.o \
     rust/rust-lint-marklive.o \
     rust/rust-hir-type-check-path.o \

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -560,7 +560,7 @@ public:
 
   Type *get_type () { return type.get (); }
 
-  Analysis::NodeMapping &get_mappings () { return mappings; }
+  const Analysis::NodeMapping &get_mappings () const { return mappings; }
 };
 
 // Visibility of item - if the item has it, then it is some form of public

--- a/gcc/rust/typecheck/rust-hir-address-taken.cc
+++ b/gcc/rust/typecheck/rust-hir-address-taken.cc
@@ -1,0 +1,65 @@
+// Copyright (C) 2020-2021 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-hir-address-taken.h"
+#include "rust-hir-full.h"
+
+namespace Rust {
+namespace Resolver {
+
+AddressTakenContext *
+AddressTakenContext::get ()
+{
+  static AddressTakenContext *instance;
+  if (instance == nullptr)
+    instance = new AddressTakenContext ();
+
+  return instance;
+}
+
+AddressTakenContext::~AddressTakenContext () {}
+
+bool
+AddressTakenContext::lookup_addess_taken (HirId id, bool *address_taken) const
+{
+  const auto &it = ctx.find (id);
+  if (it == ctx.end ())
+    return false;
+
+  *address_taken = it->second;
+  return true;
+}
+
+void
+AddressTakenContext::insert_address_taken (HirId id, bool address_taken)
+{
+  const auto &it = ctx.find (id);
+  if (it != ctx.end ())
+    {
+      // assert that we never change a true result to a negative
+      if (it->second == true)
+	{
+	  rust_assert (address_taken != false);
+	}
+    }
+
+  ctx[id] = address_taken;
+}
+
+} // namespace Resolver
+} // namespace Rust

--- a/gcc/rust/typecheck/rust-hir-address-taken.h
+++ b/gcc/rust/typecheck/rust-hir-address-taken.h
@@ -1,0 +1,159 @@
+// Copyright (C) 2020-2021 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_HIR_ADDRESS_TAKEN
+#define RUST_HIR_ADDRESS_TAKEN
+
+#include "rust-hir-type-check-base.h"
+
+namespace Rust {
+namespace Resolver {
+
+class AddressTakenContext
+{
+public:
+  static AddressTakenContext *get ();
+
+  ~AddressTakenContext ();
+
+  bool lookup_addess_taken (HirId id, bool *address_taken) const;
+
+  void insert_address_taken (HirId id, bool address_taken);
+
+private:
+  std::map<HirId, bool> ctx;
+};
+
+class AddressTakenResolver : public TypeCheckBase
+{
+  using Rust::Resolver::TypeCheckBase::visit;
+
+public:
+  static void SetAddressTaken (HIR::Expr &expr)
+  {
+    AddressTakenResolver resolver;
+    expr.accept_vis (resolver);
+  }
+
+  void visit (HIR::IdentifierExpr &expr) override
+  {
+    NodeId ast_node_id = expr.get_mappings ().get_nodeid ();
+    NodeId ref_node_id = UNKNOWN_NODEID;
+    if (resolver->lookup_resolved_name (ast_node_id, &ref_node_id))
+      {
+	// these ref_node_ids will resolve to a pattern declaration but we are
+	// interested in the definition that this refers to get the parent id
+	Definition def;
+	if (!resolver->lookup_definition (ref_node_id, &def))
+	  {
+	    rust_error_at (expr.get_locus (),
+			   "unknown reference for resolved name");
+	    return;
+	  }
+	ref_node_id = def.parent;
+      }
+
+    if (ref_node_id == UNKNOWN_NODEID)
+      return;
+
+    // node back to HIR
+    HirId ref = UNKNOWN_HIRID;
+    bool reverse_lookup
+      = mappings->lookup_node_to_hir (expr.get_mappings ().get_crate_num (),
+				      ref_node_id, &ref);
+    rust_assert (reverse_lookup);
+    context->insert_address_taken (ref, true);
+  }
+
+  void visit (HIR::PathInExpression &expr) override
+  {
+    NodeId ast_node_id = expr.get_mappings ().get_nodeid ();
+    NodeId ref_node_id = UNKNOWN_NODEID;
+    if (resolver->lookup_resolved_name (ast_node_id, &ref_node_id))
+      {
+	// these ref_node_ids will resolve to a pattern declaration but we are
+	// interested in the definition that this refers to get the parent id
+	Definition def;
+	if (!resolver->lookup_definition (ref_node_id, &def))
+	  {
+	    rust_error_at (expr.get_locus (),
+			   "unknown reference for resolved name");
+	    return;
+	  }
+	ref_node_id = def.parent;
+      }
+
+    if (ref_node_id == UNKNOWN_NODEID)
+      return;
+
+    // node back to HIR
+    HirId ref = UNKNOWN_HIRID;
+    bool reverse_lookup
+      = mappings->lookup_node_to_hir (expr.get_mappings ().get_crate_num (),
+				      ref_node_id, &ref);
+    rust_assert (reverse_lookup);
+    context->insert_address_taken (ref, true);
+  }
+
+  void visit (HIR::QualifiedPathInExpression &expr) override
+  {
+    NodeId ast_node_id = expr.get_mappings ().get_nodeid ();
+    NodeId ref_node_id = UNKNOWN_NODEID;
+    if (resolver->lookup_resolved_name (ast_node_id, &ref_node_id))
+      {
+	// these ref_node_ids will resolve to a pattern declaration but we are
+	// interested in the definition that this refers to get the parent id
+	Definition def;
+	if (!resolver->lookup_definition (ref_node_id, &def))
+	  {
+	    rust_error_at (expr.get_locus (),
+			   "unknown reference for resolved name");
+	    return;
+	  }
+	ref_node_id = def.parent;
+      }
+
+    if (ref_node_id == UNKNOWN_NODEID)
+      return;
+
+    // node back to HIR
+    HirId ref = UNKNOWN_HIRID;
+    bool reverse_lookup
+      = mappings->lookup_node_to_hir (expr.get_mappings ().get_crate_num (),
+				      ref_node_id, &ref);
+    rust_assert (reverse_lookup);
+    context->insert_address_taken (ref, true);
+  }
+
+  void visit (HIR::DereferenceExpr &expr) override
+  {
+    expr.get_expr ()->accept_vis (*this);
+  }
+
+private:
+  AddressTakenResolver ()
+    : TypeCheckBase (), context (AddressTakenContext::get ())
+  {}
+
+  AddressTakenContext *context;
+};
+
+} // namespace Resolver
+} // namespace Rust
+
+#endif // RUST_HIR_ADDRESS_TAKEN

--- a/gcc/testsuite/rust/execute/torture/operator_overload_6.rs
+++ b/gcc/testsuite/rust/execute/torture/operator_overload_6.rs
@@ -1,0 +1,40 @@
+/* { dg-output "add_assign\n3\n" } */
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+#[lang = "add_assign"]
+pub trait AddAssign<Rhs = Self> {
+    fn add_assign(&mut self, rhs: Rhs);
+    // { dg-warning "unused name .self." "" { target *-*-* } .-1 }
+    // { dg-warning "unused name .rhs." "" { target *-*-* } .-2 }
+    // { dg-warning "unused name .AddAssign::add_assign." "" { target *-*-* } .-3 }
+}
+
+impl AddAssign for i32 {
+    fn add_assign(&mut self, other: i32) {
+        unsafe {
+            let a = "add_assign\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c);
+        }
+        *self += other
+    }
+}
+
+fn main() -> i32 {
+    let mut res = 1;
+    res += 2;
+
+    unsafe {
+        let a = "%i\n\0";
+        let b = a as *const str;
+        let c = b as *const i8;
+
+        printf(c, res);
+    }
+
+    0
+}


### PR DESCRIPTION
GCC requires VAR_DECL's and PARAM_DECL's to be marked with TREE_ADDRESSABLE
when the declaration will be used in borrow's ('&' getting the address).
This takes into account the implicit addresses when we do autoderef in
method resolution/operator-overloading.

If it is not set we end up in cases like this:

```c
i32 main ()
{
  i32 a.1;
  i32 D.86;
  i32 a;

  a = 1;
  a.1 = a; // this is wrong
  <i32 as AddAssign>::add_assign (&a.1, 2);
  D.86 = 0;
  return D.86;
}
```

You can see GCC will automatically make a copy of the VAR_DECL resulting bad code-generation.

Fixes #804
