### PR TITLE
Remove bad mutability check pass

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -390,10 +390,32 @@ public:
 
   void visit (HIR::ArrayIndexExpr &expr) override
   {
-    tree array = CompileExpr::Compile (expr.get_array_expr (), ctx);
+    tree array_reference = CompileExpr::Compile (expr.get_array_expr (), ctx);
     tree index = CompileExpr::Compile (expr.get_index_expr (), ctx);
+
+    // lets check if the array is a reference type then we can add an
+    // indirection if required
+    TyTy::BaseType *array_expr_ty = nullptr;
+    bool ok = ctx->get_tyctx ()->lookup_type (
+      expr.get_array_expr ()->get_mappings ().get_hirid (), &array_expr_ty);
+    rust_assert (ok);
+
+    // do we need to add an indirect reference
+    if (array_expr_ty->get_kind () == TyTy::TypeKind::REF)
+      {
+	TyTy::ReferenceType *r
+	  = static_cast<TyTy::ReferenceType *> (array_expr_ty);
+	TyTy::BaseType *tuple_type = r->get_base ();
+	tree array_tyty = TyTyResolveCompile::compile (ctx, tuple_type);
+
+	array_reference
+	  = ctx->get_backend ()->indirect_expression (array_tyty,
+						      array_reference, true,
+						      expr.get_locus ());
+      }
+
     translated
-      = ctx->get_backend ()->array_index_expression (array, index,
+      = ctx->get_backend ()->array_index_expression (array_reference, index,
 						     expr.get_locus ());
   }
 

--- a/gcc/rust/hir/rust-ast-lower-implitem.h
+++ b/gcc/rust/hir/rust-ast-lower-implitem.h
@@ -153,7 +153,7 @@ public:
 	  = HIR::FunctionParam (mapping, std::move (translated_pattern),
 				std::move (translated_type),
 				param.get_locus ());
-	function_params.push_back (hir_param);
+	function_params.push_back (std::move (hir_param));
       }
 
     bool terminated = false;
@@ -239,7 +239,7 @@ public:
 	  = HIR::FunctionParam (mapping, std::move (translated_pattern),
 				std::move (translated_type),
 				param.get_locus ());
-	function_params.push_back (hir_param);
+	function_params.push_back (std::move (hir_param));
       }
 
     bool terminated = false;
@@ -345,7 +345,7 @@ public:
 	  = HIR::FunctionParam (mapping, std::move (translated_pattern),
 				std::move (translated_type),
 				param.get_locus ());
-	function_params.push_back (hir_param);
+	function_params.push_back (std::move (hir_param));
       }
 
     HIR::TraitFunctionDecl decl (ref.get_identifier (), std::move (qualifiers),

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -465,7 +465,7 @@ public:
 	  = HIR::FunctionParam (mapping, std::move (translated_pattern),
 				std::move (translated_type),
 				param.get_locus ());
-	function_params.push_back (hir_param);
+	function_params.push_back (std::move (hir_param));
       }
 
     bool terminated = false;

--- a/gcc/rust/resolve/rust-ast-verify-assignee.h
+++ b/gcc/rust/resolve/rust-ast-verify-assignee.h
@@ -65,14 +65,6 @@ public:
     ok = true;
     // mark the assignment to the name
     resolver->mark_assignment_to_decl (resolved_node, parent);
-
-    // check is mutable
-    if (!resolver->decl_is_mutable (resolved_node))
-      {
-	// we only allow a single assignment to immutable decls
-	if (resolver->get_num_assignments_to_decl (resolved_node) > 1)
-	  rust_error_at (expr.get_locus (), "cannot assign to immutable");
-      }
   }
 
   void visit (AST::DereferenceExpr &expr) override

--- a/gcc/testsuite/rust/compile/array3.rs
+++ b/gcc/testsuite/rust/compile/array3.rs
@@ -1,0 +1,5 @@
+fn foo(state: &mut [u32; 16], a: usize) {
+    // { dg-warning "function is never used: .foo." "" { target *-*-* } .-1 }
+    // { dg-warning "unused name .foo." "" { target *-*-* } .-2 }
+    state[a] = 1;
+}

--- a/gcc/testsuite/rust/compile/immutable1.rs
+++ b/gcc/testsuite/rust/compile/immutable1.rs
@@ -1,5 +1,0 @@
-static x: i32 = 3;
-
-fn main() {
-    x = 1; /* { dg-error "cannot assign to immutable" } */
-}

--- a/gcc/testsuite/rust/compile/immutable2.rs
+++ b/gcc/testsuite/rust/compile/immutable2.rs
@@ -1,5 +1,0 @@
-const TEST_CONST: i32 = 10;
-
-fn main() {
-    TEST_CONST = 1; // { dg-error "cannot assign to immutable" }
-}

--- a/gcc/testsuite/rust/compile/immutable3.rs
+++ b/gcc/testsuite/rust/compile/immutable3.rs
@@ -1,4 +1,0 @@
-fn main() {
-    let a = 1;
-    a += 2; // { dg-error "cannot assign to immutable" }
-}

--- a/gcc/testsuite/rust/compile/immutable4.rs
+++ b/gcc/testsuite/rust/compile/immutable4.rs
@@ -1,4 +1,0 @@
-fn main() {
-    let array: [i32; 3] = [0; 3];
-    array[0] = 1; // { dg-error "cannot assign to immutable" }
-}

--- a/gcc/testsuite/rust/compile/immutable5.rs
+++ b/gcc/testsuite/rust/compile/immutable5.rs
@@ -1,6 +1,0 @@
-struct Foo(f32, i32);
-
-fn main() {
-    let a = Foo(1, 2);
-    a.0 = 22; // { dg-error "cannot assign to immutable" }
-}


### PR DESCRIPTION
This was an initial pass to try and ensure all assignments were valid
with respect to the binding mutability. This pass cannot be done at the
name resolution level and in rustc is achieved on mir as part of the borrow
checker. This patch removes this pass and associated test cases.

This set of patches also adds support for indirection around array index
expressions.

Fixes #815 