### PR TITLE
Deref operator overloading

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -979,26 +979,7 @@ public:
       = ctx->get_backend ()->address_expression (main_expr, expr.get_locus ());
   }
 
-  void visit (HIR::DereferenceExpr &expr) override
-  {
-    tree main_expr = CompileExpr::Compile (expr.get_expr ().get (), ctx);
-
-    TyTy::BaseType *tyty = nullptr;
-    if (!ctx->get_tyctx ()->lookup_type (expr.get_mappings ().get_hirid (),
-					 &tyty))
-      {
-	rust_fatal_error (expr.get_locus (),
-			  "did not resolve type for this TupleExpr");
-	return;
-      }
-
-    tree expected_type = TyTyResolveCompile::compile (ctx, tyty);
-    bool known_valid = true;
-    translated
-      = ctx->get_backend ()->indirect_expression (expected_type, main_expr,
-						  known_valid,
-						  expr.get_locus ());
-  }
+  void visit (HIR::DereferenceExpr &expr) override;
 
 protected:
   tree compile_dyn_dispatch_call (const TyTy::DynamicObjectType *dyn,

--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -51,6 +51,8 @@ public:
     DIV_ASSIGN,
     REM_ASSIGN,
 
+    DEREF,
+
     UNKNOWN,
   };
 
@@ -104,6 +106,10 @@ public:
       {
 	return ItemType::REM_ASSIGN;
       }
+    else if (item.compare ("deref") == 0)
+      {
+	return ItemType::DEREF;
+      }
 
     return ItemType::UNKNOWN;
   }
@@ -136,6 +142,8 @@ public:
 	return "div_assign";
       case REM_ASSIGN:
 	return "rem_assign";
+      case DEREF:
+	return "deref";
 
       case UNKNOWN:
 	break;

--- a/gcc/testsuite/rust/execute/torture/operator_overload_10.rs
+++ b/gcc/testsuite/rust/execute/torture/operator_overload_10.rs
@@ -1,0 +1,79 @@
+/* { dg-output "foo_deref\n123\n" } */
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+#[lang = "deref"]
+pub trait Deref {
+    type Target;
+
+    fn deref(&self) -> &Self::Target;
+    // { dg-warning "unused name .self." "" { target *-*-* } .-1 }
+    // { dg-warning "unused name .Deref::deref." "" { target *-*-* } .-2 }
+}
+
+impl<T> Deref for &T {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        // { dg-warning "unused name" "" { target *-*-* } .-1 }
+        unsafe {
+            let a = "imm_deref\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c);
+        }
+
+        *self
+    }
+}
+
+impl<T> Deref for &mut T {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        // { dg-warning "unused name" "" { target *-*-* } .-1 }
+        unsafe {
+            let a = "mut_deref\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c);
+        }
+
+        *self
+    }
+}
+
+struct Foo<T>(T);
+impl<T> Deref for Foo<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe {
+            let a = "foo_deref\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c);
+        }
+
+        &self.0
+    }
+}
+
+fn main() -> i32 {
+    let foo: Foo<i32> = Foo(123);
+    let bar: i32 = *foo;
+
+    unsafe {
+        let a = "%i\n\0";
+        let b = a as *const str;
+        let c = b as *const i8;
+
+        printf(c, bar);
+    }
+
+    0
+}

--- a/gcc/testsuite/rust/execute/torture/operator_overload_7.rs
+++ b/gcc/testsuite/rust/execute/torture/operator_overload_7.rs
@@ -1,0 +1,44 @@
+/* { dg-output "imm_deref\n123\n" } */
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+#[lang = "deref"]
+pub trait Deref {
+    type Target;
+
+    fn deref(&self) -> &Self::Target;
+    // { dg-warning "unused name .self." "" { target *-*-* } .-1 }
+    // { dg-warning "unused name .Deref::deref." "" { target *-*-* } .-2 }
+}
+
+impl<T> Deref for &T {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        unsafe {
+            let a = "imm_deref\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c);
+        }
+
+        *self
+    }
+}
+
+fn main() -> i32 {
+    let foo: &i32 = &123;
+    let res: i32 = *foo;
+
+    unsafe {
+        let a = "%i\n\0";
+        let b = a as *const str;
+        let c = b as *const i8;
+
+        printf(c, res);
+    }
+
+    0
+}

--- a/gcc/testsuite/rust/execute/torture/operator_overload_8.rs
+++ b/gcc/testsuite/rust/execute/torture/operator_overload_8.rs
@@ -1,0 +1,61 @@
+/* { dg-output "imm_deref\n123\n" } */
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+#[lang = "deref"]
+pub trait Deref {
+    type Target;
+
+    fn deref(&self) -> &Self::Target;
+    // { dg-warning "unused name .self." "" { target *-*-* } .-1 }
+    // { dg-warning "unused name .Deref::deref." "" { target *-*-* } .-2 }
+}
+
+impl<T> Deref for &T {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        unsafe {
+            let a = "imm_deref\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c);
+        }
+
+        *self
+    }
+}
+
+impl<T> Deref for &mut T {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        // { dg-warning "unused name" "" { target *-*-* } .-1 }
+        unsafe {
+            let a = "mut_deref\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c);
+        }
+
+        *self
+    }
+}
+
+fn main() -> i32 {
+    let foo: &i32 = &123;
+    let res: i32 = *foo;
+
+    unsafe {
+        let a = "%i\n\0";
+        let b = a as *const str;
+        let c = b as *const i8;
+
+        printf(c, res);
+    }
+
+    0
+}

--- a/gcc/testsuite/rust/execute/torture/operator_overload_9.rs
+++ b/gcc/testsuite/rust/execute/torture/operator_overload_9.rs
@@ -1,0 +1,61 @@
+/* { dg-output "mut_deref\n123\n" } */
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+#[lang = "deref"]
+pub trait Deref {
+    type Target;
+
+    fn deref(&self) -> &Self::Target;
+    // { dg-warning "unused name .self." "" { target *-*-* } .-1 }
+    // { dg-warning "unused name .Deref::deref." "" { target *-*-* } .-2 }
+}
+
+impl<T> Deref for &T {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        // { dg-warning "unused name" "" { target *-*-* } .-1 }
+        unsafe {
+            let a = "imm_deref\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c);
+        }
+
+        *self
+    }
+}
+
+impl<T> Deref for &mut T {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        unsafe {
+            let a = "mut_deref\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c);
+        }
+
+        *self
+    }
+}
+
+fn main() -> i32 {
+    let foo = &mut 123;
+    let res: i32 = *foo;
+
+    unsafe {
+        let a = "%i\n\0";
+        let b = a as *const str;
+        let c = b as *const i8;
+
+        printf(c, res);
+    }
+
+    0
+}


### PR DESCRIPTION
This adds initial support for dereferencing operator overloading. We need to be able
to use this as part of the autoderef cycle next.

It has two default impl's one for '&T' and '&mut T' to apply genericly.
The reason it is interesting is from the prototype the deref lang item
always returns &Self::Target in all cases regardless of mutability, the
lang item here is designed to wrap up any dereference such that when
applied it guarentees the type system you will get back an immutable
reference to something. The reason for doing this is more clear when
thinking about autoderef and method-resolution and how you apply
dereference operations to custom types and a test case is included for
that.


Fixes #809 