### PR TITLE
Bug fix mutability checks in can_eq for autoderef

### DIFF
--- a/gcc/rust/typecheck/rust-hir-dot-operator.h
+++ b/gcc/rust/typecheck/rust-hir-dot-operator.h
@@ -115,7 +115,7 @@ private:
 	    if (fn->is_method ())
 	      {
 		TyTy::BaseType *fn_self = fn->get_self_type ();
-		if (receiver->can_eq (fn_self, false, true))
+		if (fn_self->can_eq (receiver, false, true))
 		  {
 		    return &c;
 		  }
@@ -143,7 +143,7 @@ private:
 	    if (fn->is_method ())
 	      {
 		TyTy::BaseType *fn_self = fn->get_self_type ();
-		if (receiver->can_eq (fn_self, false, true))
+		if (fn_self->can_eq (receiver, false, true))
 		  {
 		    return &c;
 		  }
@@ -165,7 +165,7 @@ private:
 	    if (fn->is_method ())
 	      {
 		TyTy::BaseType *fn_self = fn->get_self_type ();
-		if (receiver->can_eq (fn_self, false, true))
+		if (fn_self->can_eq (receiver, false, true))
 		  {
 		    return &c;
 		  }

--- a/gcc/rust/typecheck/rust-tyty-cmp.h
+++ b/gcc/rust/typecheck/rust-tyty-cmp.h
@@ -1169,9 +1169,23 @@ public:
     auto base_type = base->get_base ();
     auto other_base_type = type.get_base ();
 
-    ok = base_type->can_eq (other_base_type, emit_error_flag,
-			    autoderef_mode_flag)
-	 && (base->is_mutable () == type.is_mutable ());
+    // rust is permissive about mutablity here you can always go from mutable to
+    // immutable but not the otherway round
+    bool mutability_ok = base->is_mutable () ? type.is_mutable () : true;
+    if (!mutability_ok)
+      {
+	BaseCmp::visit (type);
+	return;
+      }
+
+    if (!base_type->can_eq (other_base_type, emit_error_flag,
+			    autoderef_mode_flag))
+      {
+	BaseCmp::visit (type);
+	return;
+      }
+
+    ok = true;
   }
 
 private:
@@ -1193,9 +1207,23 @@ public:
     auto base_type = base->get_base ();
     auto other_base_type = type.get_base ();
 
-    ok = base_type->can_eq (other_base_type, emit_error_flag,
-			    autoderef_mode_flag)
-	 && (base->is_mutable () == type.is_mutable ());
+    // rust is permissive about mutablity here you can always go from mutable to
+    // immutable but not the otherway round
+    bool mutability_ok = base->is_mutable () ? type.is_mutable () : true;
+    if (!mutability_ok)
+      {
+	BaseCmp::visit (type);
+	return;
+      }
+
+    if (!base_type->can_eq (other_base_type, emit_error_flag,
+			    autoderef_mode_flag))
+      {
+	BaseCmp::visit (type);
+	return;
+      }
+
+    ok = true;
   }
 
 private:
@@ -1275,6 +1303,8 @@ public:
   void visit (const StrType &) override { ok = true; }
 
   void visit (const NeverType &) override { ok = true; }
+
+  void visit (const DynamicObjectType &) override { ok = true; }
 
   void visit (const PlaceholderType &type) override
   {

--- a/gcc/rust/typecheck/rust-tyty-rules.h
+++ b/gcc/rust/typecheck/rust-tyty-rules.h
@@ -1209,7 +1209,10 @@ public:
 	return;
       }
 
-    if (base->is_mutable () != type.is_mutable ())
+    // rust is permissive about mutablity here you can always go from mutable to
+    // immutable but not the otherway round
+    bool mutability_ok = base->is_mutable () ? type.is_mutable () : true;
+    if (!mutability_ok)
       {
 	BaseRules::visit (type);
 	return;
@@ -1246,7 +1249,10 @@ public:
 	return;
       }
 
-    if (base->is_mutable () != type.is_mutable ())
+    // rust is permissive about mutablity here you can always go from mutable to
+    // immutable but not the otherway round
+    bool mutability_ok = base->is_mutable () ? type.is_mutable () : true;
+    if (!mutability_ok)
       {
 	BaseRules::visit (type);
 	return;

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -2786,7 +2786,7 @@ TypeCheckCallExpr::visit (FnPtr &type)
 void
 TypeCheckMethodCallExpr::visit (FnType &type)
 {
-  adjusted_self->unify (type.get_self_type ());
+  type.get_self_type ()->unify (adjusted_self);
 
   // +1 for the receiver self
   size_t num_args_to_call = call.num_params () + 1;


### PR DESCRIPTION
Rust is permissive about mutablity in type checking for example, if we have
a function:

  fn foo(a:&bar) { ... }

  fn caller() {
    let a:&mut bar = ...;
    foo(a);
  }

This is valid since the mutable reference to bar is valid to be turned into
an immutable reference without any conversion. Like in C a non-const
pointer is valid to be passed to a const pointer inferface.
