### PR TITLE
Always update the type context for monoprhized items except type params

### DIFF
--- a/gcc/rust/typecheck/rust-substitution-mapper.cc
+++ b/gcc/rust/typecheck/rust-substitution-mapper.cc
@@ -31,10 +31,8 @@ SubstMapperInternal::Resolve (TyTy::BaseType *base,
   rust_assert (mapper.resolved != nullptr);
 
   // insert these new implict types into the context
-  bool is_fn = mapper.resolved->get_kind () == TyTy::TypeKind::FNDEF;
-  bool is_adt = mapper.resolved->get_kind () == TyTy::TypeKind::ADT;
   bool is_param = mapper.resolved->get_kind () == TyTy::TypeKind::PARAM;
-  if (!is_fn && !is_adt && !is_param)
+  if (!is_param)
     {
       auto context = TypeCheckContext::get ();
       context->insert_type (


### PR DESCRIPTION
We need to update the type context type with the newly monomorphized types
we guarded against ADT's and functions because they were never added before
though this does not work for generic reference's to ADT's this updates
the check accordingly.
