### PR TITLE
Constant folder now returns error_mark_node instead of nullptr

### DIFF
--- a/gcc/rust/typecheck/rust-hir-const-fold.cc
+++ b/gcc/rust/typecheck/rust-hir-const-fold.cc
@@ -64,8 +64,6 @@ void
 ConstFoldItem::visit (HIR::ConstantItem &item)
 {
   auto folded_expr = ConstFoldExpr::fold (item.get_expr ());
-  if (folded_expr == nullptr)
-    return;
 
   folded = folded_expr;
 }

--- a/gcc/rust/typecheck/rust-hir-const-fold.h
+++ b/gcc/rust/typecheck/rust-hir-const-fold.h
@@ -299,7 +299,7 @@ public:
     if (folder.ctx->get_backend ()->is_error_expression (folder.folded))
       {
 	rust_error_at (expr->get_locus (), "non const value");
-	return nullptr;
+	return folder.ctx->get_backend ()->error_expression ();
       }
 
     folder.ctx->insert_const (expr->get_mappings ().get_hirid (),
@@ -423,12 +423,7 @@ public:
   void visit (HIR::ArithmeticOrLogicalExpr &expr) override
   {
     auto lhs = ConstFoldExpr::fold (expr.get_lhs ());
-    if (lhs == nullptr)
-      return;
-
     auto rhs = ConstFoldExpr::fold (expr.get_rhs ());
-    if (rhs == nullptr)
-      return;
 
     auto op = expr.get_expr_type ();
     auto location = expr.get_locus ();
@@ -441,8 +436,6 @@ public:
   void visit (HIR::NegationExpr &expr) override
   {
     auto negated_expr = ConstFoldExpr::fold (expr.get_expr ().get ());
-    if (negated_expr == nullptr)
-      return;
 
     auto op = expr.get_expr_type ();
     auto location = expr.get_locus ();

--- a/gcc/rust/typecheck/rust-hir-type-check-enumitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-enumitem.h
@@ -74,8 +74,7 @@ public:
     auto backend = rust_get_backend ();
     auto folded_discriminant
       = ConstFold::ConstFoldExpr::fold (discriminant.get ());
-    if (folded_discriminant == nullptr
-	|| backend->is_error_expression (folded_discriminant))
+    if (backend->is_error_expression (folded_discriminant))
       return;
 
     size_t specified_discriminant;

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -151,8 +151,6 @@ TypeCheckType::visit (HIR::ArrayType &type)
     return;
 
   auto capacity = ConstFold::ConstFoldExpr::fold (type.get_size_expr ());
-  if (capacity == nullptr)
-    return;
 
   TyTy::BaseType *base = TypeCheckType::Resolve (type.get_element_type ());
   translated = new TyTy::ArrayType (type.get_mappings ().get_hirid (), capacity,


### PR DESCRIPTION
Removed nullptr checking on results from constant folder because when the
result is already error_mark_node, we no longer need to check if the result
is nullptr.

Fixes #692

Signed-off-by: Nirmal Patel <npate012@gmail.com>
