### PR TITLE
Cleanup lambdas within some AST types

### DIFF
--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -996,15 +996,6 @@ public:
 
   size_t get_num_values () const { return values.size (); }
 
-  void iterate (std::function<bool (Expr *)> cb)
-  {
-    for (auto it = values.begin (); it != values.end (); it++)
-      {
-	if (!cb ((*it).get ()))
-	  return;
-      }
-  }
-
 protected:
   ArrayElemsValues *clone_array_elems_impl () const override
   {

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -2472,15 +2472,6 @@ public:
   std::vector<StructField> &get_variants () { return variants; }
   const std::vector<StructField> &get_variants () const { return variants; }
 
-  void iterate (std::function<bool (StructField &)> cb)
-  {
-    for (auto &variant : variants)
-      {
-	if (!cb (variant))
-	  return;
-      }
-  }
-
   std::vector<std::unique_ptr<GenericParam>> &get_generic_params ()
   {
     return generic_params;

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -1975,15 +1975,6 @@ public:
   std::vector<StructField> &get_fields () { return fields; }
   const std::vector<StructField> &get_fields () const { return fields; }
 
-  void iterate (std::function<bool (StructField &)> cb)
-  {
-    for (auto &field : fields)
-      {
-	if (!cb (field))
-	  return;
-      }
-  }
-
 protected:
   /* Use covariance to implement clone function as returning this object
    * rather than base */

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -2110,15 +2110,6 @@ public:
   std::vector<TupleField> &get_fields () { return fields; }
   const std::vector<TupleField> &get_fields () const { return fields; }
 
-  void iterate (std::function<bool (TupleField &)> cb)
-  {
-    for (auto &field : fields)
-      {
-	if (!cb (field))
-	  return;
-      }
-  }
-
 protected:
   /* Use covariance to implement clone function as returning this object
    * rather than base */

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -303,11 +303,11 @@ public:
   void visit (AST::ArrayElemsValues &elems) override
   {
     std::vector<std::unique_ptr<HIR::Expr> > elements;
-    elems.iterate ([&] (AST::Expr *elem) mutable -> bool {
-      HIR::Expr *translated_elem = ASTLoweringExpr::translate (elem);
-      elements.push_back (std::unique_ptr<HIR::Expr> (translated_elem));
-      return true;
-    });
+    for (auto &elem : elems.get_values ())
+      {
+	HIR::Expr *translated_elem = ASTLoweringExpr::translate (elem.get ());
+	elements.push_back (std::unique_ptr<HIR::Expr> (translated_elem));
+      }
 
     translated_array_elems = new HIR::ArrayElemsValues (std::move (elements));
   }

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -325,28 +325,28 @@ public:
     HIR::Visibility vis = HIR::Visibility::create_public ();
 
     std::vector<HIR::StructField> variants;
-    union_decl.iterate ([&] (AST::StructField &variant) mutable -> bool {
-      HIR::Visibility vis = HIR::Visibility::create_public ();
-      HIR::Type *type
-	= ASTLoweringType::translate (variant.get_field_type ().get ());
+    for (AST::StructField &variant : union_decl.get_variants ())
+      {
+	HIR::Visibility vis = HIR::Visibility::create_public ();
+	HIR::Type *type
+	  = ASTLoweringType::translate (variant.get_field_type ().get ());
 
-      auto crate_num = mappings->get_current_crate ();
-      Analysis::NodeMapping mapping (crate_num, variant.get_node_id (),
-				     mappings->get_next_hir_id (crate_num),
-				     mappings->get_next_localdef_id (
-				       crate_num));
+	auto crate_num = mappings->get_current_crate ();
+	Analysis::NodeMapping mapping (crate_num, variant.get_node_id (),
+				       mappings->get_next_hir_id (crate_num),
+				       mappings->get_next_localdef_id (
+					 crate_num));
 
-      HIR::StructField translated_variant (mapping, variant.get_field_name (),
-					   std::unique_ptr<HIR::Type> (type),
-					   vis, variant.get_locus (),
-					   variant.get_outer_attrs ());
+	HIR::StructField translated_variant (mapping, variant.get_field_name (),
+					     std::unique_ptr<HIR::Type> (type),
+					     vis, variant.get_locus (),
+					     variant.get_outer_attrs ());
 
-      if (struct_field_name_exists (variants, translated_variant))
-	return false;
+	if (struct_field_name_exists (variants, translated_variant))
+	  break;
 
-      variants.push_back (std::move (translated_variant));
-      return true;
-    });
+	variants.push_back (std::move (translated_variant));
+      }
 
     auto crate_num = mappings->get_current_crate ();
     Analysis::NodeMapping mapping (crate_num, union_decl.get_node_id (),

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -215,28 +215,28 @@ public:
 
     bool is_unit = struct_decl.is_unit_struct ();
     std::vector<HIR::StructField> fields;
-    struct_decl.iterate ([&] (AST::StructField &field) mutable -> bool {
-      HIR::Visibility vis = HIR::Visibility::create_public ();
-      HIR::Type *type
-	= ASTLoweringType::translate (field.get_field_type ().get ());
+    for (AST::StructField &field : struct_decl.get_fields ())
+      {
+	HIR::Visibility vis = HIR::Visibility::create_public ();
+	HIR::Type *type
+	  = ASTLoweringType::translate (field.get_field_type ().get ());
 
-      auto crate_num = mappings->get_current_crate ();
-      Analysis::NodeMapping mapping (crate_num, field.get_node_id (),
-				     mappings->get_next_hir_id (crate_num),
-				     mappings->get_next_localdef_id (
-				       crate_num));
+	auto crate_num = mappings->get_current_crate ();
+	Analysis::NodeMapping mapping (crate_num, field.get_node_id (),
+				       mappings->get_next_hir_id (crate_num),
+				       mappings->get_next_localdef_id (
+					 crate_num));
 
-      HIR::StructField translated_field (mapping, field.get_field_name (),
-					 std::unique_ptr<HIR::Type> (type), vis,
-					 field.get_locus (),
-					 field.get_outer_attrs ());
+	HIR::StructField translated_field (mapping, field.get_field_name (),
+					   std::unique_ptr<HIR::Type> (type),
+					   vis, field.get_locus (),
+					   field.get_outer_attrs ());
 
-      if (struct_field_name_exists (fields, translated_field))
-	return false;
+	if (struct_field_name_exists (fields, translated_field))
+	  break;
 
-      fields.push_back (std::move (translated_field));
-      return true;
-    });
+	fields.push_back (std::move (translated_field));
+      }
 
     auto crate_num = mappings->get_current_crate ();
     Analysis::NodeMapping mapping (crate_num, struct_decl.get_node_id (),

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -154,24 +154,24 @@ public:
     HIR::Visibility vis = HIR::Visibility::create_public ();
 
     std::vector<HIR::TupleField> fields;
-    struct_decl.iterate ([&] (AST::TupleField &field) mutable -> bool {
-      HIR::Visibility vis = HIR::Visibility::create_public ();
-      HIR::Type *type
-	= ASTLoweringType::translate (field.get_field_type ().get ());
+    for (AST::TupleField &field : struct_decl.get_fields ())
+      {
+	HIR::Visibility vis = HIR::Visibility::create_public ();
+	HIR::Type *type
+	  = ASTLoweringType::translate (field.get_field_type ().get ());
 
-      auto crate_num = mappings->get_current_crate ();
-      Analysis::NodeMapping mapping (crate_num, field.get_node_id (),
-				     mappings->get_next_hir_id (crate_num),
-				     mappings->get_next_localdef_id (
-				       crate_num));
+	auto crate_num = mappings->get_current_crate ();
+	Analysis::NodeMapping mapping (crate_num, field.get_node_id (),
+				       mappings->get_next_hir_id (crate_num),
+				       mappings->get_next_localdef_id (
+					 crate_num));
 
-      HIR::TupleField translated_field (mapping,
-					std::unique_ptr<HIR::Type> (type), vis,
-					field.get_locus (),
-					field.get_outer_attrs ());
-      fields.push_back (std::move (translated_field));
-      return true;
-    });
+	HIR::TupleField translated_field (mapping,
+					  std::unique_ptr<HIR::Type> (type),
+					  vis, field.get_locus (),
+					  field.get_outer_attrs ());
+	fields.push_back (std::move (translated_field));
+      }
 
     auto crate_num = mappings->get_current_crate ();
     Analysis::NodeMapping mapping (crate_num, struct_decl.get_node_id (),

--- a/gcc/rust/hir/rust-ast-lower-stmt.h
+++ b/gcc/rust/hir/rust-ast-lower-stmt.h
@@ -203,28 +203,28 @@ public:
 
     bool is_unit = struct_decl.is_unit_struct ();
     std::vector<HIR::StructField> fields;
-    struct_decl.iterate ([&] (AST::StructField &field) mutable -> bool {
-      HIR::Visibility vis = HIR::Visibility::create_public ();
-      HIR::Type *type
-	= ASTLoweringType::translate (field.get_field_type ().get ());
+    for (AST::StructField &field : struct_decl.get_fields ())
+      {
+	HIR::Visibility vis = HIR::Visibility::create_public ();
+	HIR::Type *type
+	  = ASTLoweringType::translate (field.get_field_type ().get ());
 
-      auto crate_num = mappings->get_current_crate ();
-      Analysis::NodeMapping mapping (crate_num, field.get_node_id (),
-				     mappings->get_next_hir_id (crate_num),
-				     mappings->get_next_localdef_id (
-				       crate_num));
+	auto crate_num = mappings->get_current_crate ();
+	Analysis::NodeMapping mapping (crate_num, field.get_node_id (),
+				       mappings->get_next_hir_id (crate_num),
+				       mappings->get_next_localdef_id (
+					 crate_num));
 
-      HIR::StructField translated_field (mapping, field.get_field_name (),
-					 std::unique_ptr<HIR::Type> (type), vis,
-					 field.get_locus (),
-					 field.get_outer_attrs ());
+	HIR::StructField translated_field (mapping, field.get_field_name (),
+					   std::unique_ptr<HIR::Type> (type),
+					   vis, field.get_locus (),
+					   field.get_outer_attrs ());
 
-      if (struct_field_name_exists (fields, translated_field))
-	return false;
+	if (struct_field_name_exists (fields, translated_field))
+	  break;
 
-      fields.push_back (std::move (translated_field));
-      return true;
-    });
+	fields.push_back (std::move (translated_field));
+      }
 
     auto crate_num = mappings->get_current_crate ();
     Analysis::NodeMapping mapping (crate_num, struct_decl.get_node_id (),

--- a/gcc/rust/hir/rust-ast-lower-stmt.h
+++ b/gcc/rust/hir/rust-ast-lower-stmt.h
@@ -151,24 +151,24 @@ public:
     HIR::Visibility vis = HIR::Visibility::create_public ();
 
     std::vector<HIR::TupleField> fields;
-    struct_decl.iterate ([&] (AST::TupleField &field) mutable -> bool {
-      HIR::Visibility vis = HIR::Visibility::create_public ();
-      HIR::Type *type
-	= ASTLoweringType::translate (field.get_field_type ().get ());
+    for (AST::TupleField &field : struct_decl.get_fields ())
+      {
+	HIR::Visibility vis = HIR::Visibility::create_public ();
+	HIR::Type *type
+	  = ASTLoweringType::translate (field.get_field_type ().get ());
 
-      auto crate_num = mappings->get_current_crate ();
-      Analysis::NodeMapping mapping (crate_num, field.get_node_id (),
-				     mappings->get_next_hir_id (crate_num),
-				     mappings->get_next_localdef_id (
-				       crate_num));
+	auto crate_num = mappings->get_current_crate ();
+	Analysis::NodeMapping mapping (crate_num, field.get_node_id (),
+				       mappings->get_next_hir_id (crate_num),
+				       mappings->get_next_localdef_id (
+					 crate_num));
 
-      HIR::TupleField translated_field (mapping,
-					std::unique_ptr<HIR::Type> (type), vis,
-					field.get_locus (),
-					field.get_outer_attrs ());
-      fields.push_back (std::move (translated_field));
-      return true;
-    });
+	HIR::TupleField translated_field (mapping,
+					  std::unique_ptr<HIR::Type> (type),
+					  vis, field.get_locus (),
+					  field.get_outer_attrs ());
+	fields.push_back (std::move (translated_field));
+      }
 
     auto crate_num = mappings->get_current_crate ();
     Analysis::NodeMapping mapping (crate_num, struct_decl.get_node_id (),

--- a/gcc/rust/hir/rust-ast-lower-stmt.h
+++ b/gcc/rust/hir/rust-ast-lower-stmt.h
@@ -258,28 +258,28 @@ public:
     HIR::Visibility vis = HIR::Visibility::create_public ();
 
     std::vector<HIR::StructField> variants;
-    union_decl.iterate ([&] (AST::StructField &variant) mutable -> bool {
-      HIR::Visibility vis = HIR::Visibility::create_public ();
-      HIR::Type *type
-	= ASTLoweringType::translate (variant.get_field_type ().get ());
+    for (AST::StructField &variant : union_decl.get_variants ())
+      {
+	HIR::Visibility vis = HIR::Visibility::create_public ();
+	HIR::Type *type
+	  = ASTLoweringType::translate (variant.get_field_type ().get ());
 
-      auto crate_num = mappings->get_current_crate ();
-      Analysis::NodeMapping mapping (crate_num, variant.get_node_id (),
-				     mappings->get_next_hir_id (crate_num),
-				     mappings->get_next_localdef_id (
-				       crate_num));
+	auto crate_num = mappings->get_current_crate ();
+	Analysis::NodeMapping mapping (crate_num, variant.get_node_id (),
+				       mappings->get_next_hir_id (crate_num),
+				       mappings->get_next_localdef_id (
+					 crate_num));
 
-      HIR::StructField translated_variant (mapping, variant.get_field_name (),
-					   std::unique_ptr<HIR::Type> (type),
-					   vis, variant.get_locus (),
-					   variant.get_outer_attrs ());
+	HIR::StructField translated_variant (mapping, variant.get_field_name (),
+					     std::unique_ptr<HIR::Type> (type),
+					     vis, variant.get_locus (),
+					     variant.get_outer_attrs ());
 
-      if (struct_field_name_exists (variants, translated_variant))
-	return false;
+	if (struct_field_name_exists (variants, translated_variant))
+	  break;
 
-      variants.push_back (std::move (translated_variant));
-      return true;
-    });
+	variants.push_back (std::move (translated_variant));
+      }
 
     auto crate_num = mappings->get_current_crate ();
     Analysis::NodeMapping mapping (crate_num, union_decl.get_node_id (),

--- a/gcc/rust/resolve/rust-ast-resolve-expr.h
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.h
@@ -224,10 +224,8 @@ public:
 
   void visit (AST::ArrayElemsValues &elems) override
   {
-    elems.iterate ([&] (AST::Expr *elem) mutable -> bool {
-      ResolveExpr::go (elem, elems.get_node_id ());
-      return true;
-    });
+    for (auto &elem : elems.get_values ())
+      ResolveExpr::go (elem.get (), elems.get_node_id ());
   }
 
   void visit (AST::ArrayExpr &expr) override

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -331,11 +331,9 @@ public:
     if (union_decl.has_where_clause ())
       ResolveWhereClause::Resolve (union_decl.get_where_clause ());
 
-    union_decl.iterate ([&] (AST::StructField &field) mutable -> bool {
+    for (AST::StructField &field : union_decl.get_variants ())
       ResolveType::go (field.get_field_type ().get (),
 		       union_decl.get_node_id ());
-      return true;
-    });
 
     resolver->get_type_scope ().pop ();
   }

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -245,11 +245,9 @@ public:
     if (struct_decl.has_where_clause ())
       ResolveWhereClause::Resolve (struct_decl.get_where_clause ());
 
-    struct_decl.iterate ([&] (AST::TupleField &field) mutable -> bool {
+    for (AST::TupleField &field : struct_decl.get_fields ())
       ResolveType::go (field.get_field_type ().get (),
 		       struct_decl.get_node_id ());
-      return true;
-    });
 
     resolver->get_type_scope ().pop ();
   }

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -308,11 +308,9 @@ public:
     if (struct_decl.has_where_clause ())
       ResolveWhereClause::Resolve (struct_decl.get_where_clause ());
 
-    struct_decl.iterate ([&] (AST::StructField &field) mutable -> bool {
+    for (AST::StructField &field : struct_decl.get_fields ())
       ResolveType::go (field.get_field_type ().get (),
 		       struct_decl.get_node_id ());
-      return true;
-    });
 
     resolver->get_type_scope ().pop ();
   }

--- a/gcc/rust/resolve/rust-ast-resolve-stmt.h
+++ b/gcc/rust/resolve/rust-ast-resolve-stmt.h
@@ -267,11 +267,9 @@ public:
 	  }
       }
 
-    union_decl.iterate ([&] (AST::StructField &field) mutable -> bool {
+    for (AST::StructField &field : union_decl.get_variants ())
       ResolveType::go (field.get_field_type ().get (),
 		       union_decl.get_node_id ());
-      return true;
-    });
 
     resolver->get_type_scope ().pop ();
   }

--- a/gcc/rust/resolve/rust-ast-resolve-stmt.h
+++ b/gcc/rust/resolve/rust-ast-resolve-stmt.h
@@ -237,11 +237,9 @@ public:
 	  }
       }
 
-    struct_decl.iterate ([&] (AST::StructField &field) mutable -> bool {
+    for (AST::StructField &field : struct_decl.get_fields ())
       ResolveType::go (field.get_field_type ().get (),
 		       struct_decl.get_node_id ());
-      return true;
-    });
 
     resolver->get_type_scope ().pop ();
   }

--- a/gcc/rust/resolve/rust-ast-resolve-stmt.h
+++ b/gcc/rust/resolve/rust-ast-resolve-stmt.h
@@ -115,11 +115,9 @@ public:
 	  }
       }
 
-    struct_decl.iterate ([&] (AST::TupleField &field) mutable -> bool {
+    for (AST::TupleField &field : struct_decl.get_fields ())
       ResolveType::go (field.get_field_type ().get (),
 		       struct_decl.get_node_id ());
-      return true;
-    });
 
     resolver->get_type_scope ().pop ();
   }


### PR DESCRIPTION
Cleanup constructs like:
```C
    struct_decl.iterate ([&] (AST::TupleField &field) mutable -> bool {
        ... /* do stuff with field */
    });
```
For the following AST classes:
- AST::StructStruct
- AST::TupleStruct
- AST::Union
- AST::ArrayElemsValues

Fixes: #714
Fixes: #715
Fixes: #716
Fixes: #720
