### PR TITLE
Fix out-of-bounds in typechecking of ADTTypes

### DIFF
--- a/gcc/rust/typecheck/rust-tyty-cmp.h
+++ b/gcc/rust/typecheck/rust-tyty-cmp.h
@@ -1021,8 +1021,8 @@ public:
 
 	for (size_t j = 0; j < a->num_fields (); j++)
 	  {
-	    TyTy::StructFieldType *base_field = a->get_field_at_index (i);
-	    TyTy::StructFieldType *other_field = b->get_field_at_index (i);
+	    TyTy::StructFieldType *base_field = a->get_field_at_index (j);
+	    TyTy::StructFieldType *other_field = b->get_field_at_index (j);
 
 	    TyTy::BaseType *this_field_ty = base_field->get_field_type ();
 	    TyTy::BaseType *other_field_ty = other_field->get_field_type ();

--- a/gcc/rust/typecheck/rust-tyty-coercion.h
+++ b/gcc/rust/typecheck/rust-tyty-coercion.h
@@ -1031,8 +1031,8 @@ public:
 
 	for (size_t j = 0; j < a->num_fields (); j++)
 	  {
-	    TyTy::StructFieldType *base_field = a->get_field_at_index (i);
-	    TyTy::StructFieldType *other_field = b->get_field_at_index (i);
+	    TyTy::StructFieldType *base_field = a->get_field_at_index (j);
+	    TyTy::StructFieldType *other_field = b->get_field_at_index (j);
 
 	    TyTy::BaseType *this_field_ty = base_field->get_field_type ();
 	    TyTy::BaseType *other_field_ty = other_field->get_field_type ();

--- a/gcc/rust/typecheck/rust-tyty-rules.h
+++ b/gcc/rust/typecheck/rust-tyty-rules.h
@@ -1047,8 +1047,8 @@ public:
 
 	for (size_t j = 0; j < a->num_fields (); j++)
 	  {
-	    TyTy::StructFieldType *base_field = a->get_field_at_index (i);
-	    TyTy::StructFieldType *other_field = b->get_field_at_index (i);
+	    TyTy::StructFieldType *base_field = a->get_field_at_index (j);
+	    TyTy::StructFieldType *other_field = b->get_field_at_index (j);
 
 	    TyTy::BaseType *this_field_ty = base_field->get_field_type ();
 	    TyTy::BaseType *other_field_ty = other_field->get_field_type ();


### PR DESCRIPTION
In the case of an enum where there are more variants than the number of
fields within any variant we end up hitting an out of bounds exception
as we are using the wrong iterator on the fields during type checking.
This also means we were missing all possible fields in the case during
type checking. 