### PR TITLE
Add enum code generation

### DIFF
--- a/gcc/rust/backend/rust-compile-type.h
+++ b/gcc/rust/backend/rust-compile-type.h
@@ -35,6 +35,8 @@ public:
     return compiler.translated;
   }
 
+  static tree get_implicit_enumeral_node_type (Context *ctx);
+
   void visit (const TyTy::InferType &) override;
   void visit (const TyTy::ADTType &) override;
   void visit (const TyTy::TupleType &) override;

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -336,8 +336,8 @@ HIRCompileBase::coerce_to_dyn_object (tree compiled_ref,
     }
 
   tree constructed_trait_object
-    = ctx->get_backend ()->constructor_expression (dynamic_object, vals, -1,
-						   locus);
+    = ctx->get_backend ()->constructor_expression (dynamic_object, false, vals,
+						   -1, locus);
 
   fncontext fnctx = ctx->peek_fn ();
   tree enclosing_scope = ctx->peek_enclosing_scope ();

--- a/gcc/rust/rust-backend.h
+++ b/gcc/rust/rust-backend.h
@@ -122,6 +122,8 @@ public:
     return "unknown";
   }
 
+  virtual tree get_identifier_node (const std::string &str) = 0;
+
   // Types.
 
   // Produce an error type.  Actually the backend could probably just
@@ -348,7 +350,7 @@ public:
   // Return an expression that constructs BTYPE with VALS.  BTYPE must be the
   // backend representation a of struct.  VALS must be in the same order as the
   // corresponding fields in BTYPE.
-  virtual tree constructor_expression (tree btype,
+  virtual tree constructor_expression (tree btype, bool is_variant,
 				       const std::vector<tree> &vals, int,
 				       Location)
     = 0;

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -1268,15 +1268,21 @@ public:
     return false;
   }
 
-  bool lookup_variant_by_id (HirId id, VariantDef **found_variant) const
+  bool lookup_variant_by_id (HirId id, VariantDef **found_variant,
+			     int *index = nullptr) const
   {
+    int i = 0;
     for (auto &variant : variants)
       {
 	if (variant->get_id () == id)
 	  {
+	    if (index != nullptr)
+	      *index = i;
+
 	    *found_variant = variant;
 	    return true;
 	  }
+	i++;
       }
     return false;
   }

--- a/gcc/testsuite/rust/compile/torture/enum1.rs
+++ b/gcc/testsuite/rust/compile/torture/enum1.rs
@@ -1,0 +1,13 @@
+enum Foo {
+    A,
+    B,
+    C(char),
+    D { x: i64, y: i64 },
+}
+
+fn main() {
+    let _a = Foo::A;
+    let _b = Foo::B;
+    let _c = Foo::C('x');
+    let _d = Foo::D { x: 20, y: 80 };
+}


### PR DESCRIPTION
This adds a naieve first pass approach to enum type code generation. The
original idea was to use GCC's QUAL_UNION_TYPE but I have ran into issues
with the DECL_QUALIFIER as my understanding of how this works is incorrect.

This takes an enum such as:

```rust
enum AnEnum {
  A,
  B,
  C (char),
  D (x: i64, y: i64),
}
```

And turns this into one big union consisting of all fields as RECORD_TYPES.

```c
union AnEnum {
  record A { RUST$ENUM$DISR };
  record B { RUST$ENUM$DISR };
  record C { RUST$ENUM$DISR, char };
  record D { RUST$ENUM$DISR, i64, i64};
}
```

see: https://github.com/bminor/binutils-gdb/blob/527b8861cd472385fa9160a91dd6d65a25c41987/gdb/dwarf2/read.c#L9010-L9241

With the RUST$ENUM$DISR being the first field in all of the records this
means the alignment allows for indirect memory access of the struct to
use it as a qualifier field to figure out which variant is currently in
use. The data-less varients use their generated discriminat value during
type-checking the data variants use their HIR ID for their discriminant.

This will likely get redone to get improved GDB integration/updated to use
the QUAL_UNION_TYPE when we learn how to do this properly.

Fixes #79
