### PR TITLE
Add name-resolution and HIR lowering pass for MatchExpr

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -76,6 +76,7 @@ GRS_OBJS = \
     rust/rust-hir-full-test.o \
     rust/rust-hir-map.o \
     rust/rust-ast-lower.o \
+    rust/rust-ast-lower-pattern.o \
     rust/rust-ast-resolve.o \
     rust/rust-ast-resolve-pattern.o \
     rust/rust-hir-type-check.o \

--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -77,6 +77,7 @@ GRS_OBJS = \
     rust/rust-hir-map.o \
     rust/rust-ast-lower.o \
     rust/rust-ast-resolve.o \
+    rust/rust-ast-resolve-pattern.o \
     rust/rust-hir-type-check.o \
     rust/rust-tyty.o \
     rust/rust-tyctx.o \

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -4337,23 +4337,26 @@ struct MatchCase
 private:
   MatchArm arm;
   std::unique_ptr<Expr> expr;
+  NodeId node_id;
 
   /* TODO: does whether trailing comma exists need to be stored? currently
    * assuming it is only syntactical and has no effect on meaning. */
 
 public:
   MatchCase (MatchArm arm, std::unique_ptr<Expr> expr)
-    : arm (std::move (arm)), expr (std::move (expr))
+    : arm (std::move (arm)), expr (std::move (expr)),
+      node_id (Analysis::Mappings::get ()->get_next_node_id ())
   {}
 
   MatchCase (const MatchCase &other)
-    : arm (other.arm), expr (other.expr->clone_expr ())
+    : arm (other.arm), expr (other.expr->clone_expr ()), node_id (other.node_id)
   {}
 
   MatchCase &operator= (const MatchCase &other)
   {
     arm = other.arm;
     expr = other.expr->clone_expr ();
+    node_id = other.node_id;
 
     return *this;
   }
@@ -4378,6 +4381,8 @@ public:
     rust_assert (!arm.is_error ());
     return arm;
   }
+
+  NodeId get_node_id () const { return node_id; }
 };
 
 #if 0

--- a/gcc/rust/hir/rust-ast-lower-pattern.h
+++ b/gcc/rust/hir/rust-ast-lower-pattern.h
@@ -20,7 +20,6 @@
 #define RUST_AST_LOWER_PATTERN
 
 #include "rust-ast-lower-base.h"
-#include "rust-diagnostics.h"
 
 namespace Rust {
 namespace HIR {
@@ -34,12 +33,11 @@ public:
   {
     ASTLoweringPattern resolver;
     pattern->accept_vis (resolver);
+    rust_assert (resolver.translated != nullptr);
     return resolver.translated;
   }
 
-  virtual ~ASTLoweringPattern () override {}
-
-  void visit (AST::IdentifierPattern &pattern)
+  void visit (AST::IdentifierPattern &pattern) override
   {
     std::unique_ptr<Pattern> to_bind;
     translated
@@ -49,6 +47,12 @@ public:
 							  : Mutability::Imm,
 				    std::move (to_bind));
   }
+
+  void visit (AST::PathInExpression &pattern) override;
+
+  void visit (AST::StructPattern &pattern) override;
+
+  void visit (AST::TupleStructPattern &pattern) override;
 
 private:
   ASTLoweringPattern () : translated (nullptr) {}

--- a/gcc/rust/hir/tree/rust-hir-full-decls.h
+++ b/gcc/rust/hir/tree/rust-hir-full-decls.h
@@ -199,7 +199,6 @@ class StructPatternField;
 class StructPatternFieldTuplePat;
 class StructPatternFieldIdentPat;
 class StructPatternFieldIdent;
-struct StructPatternElements;
 class StructPattern;
 class TupleStructItems;
 class TupleStructItemsNoRange;

--- a/gcc/rust/hir/tree/rust-hir-full-test.cc
+++ b/gcc/rust/hir/tree/rust-hir-full-test.cc
@@ -2575,16 +2575,6 @@ StructPatternElements::as_string () const
 	}
     }
 
-  str += "\n  Etc: ";
-  if (has_struct_pattern_etc)
-    {
-      str += "true";
-    }
-  else
-    {
-      str += "false";
-    }
-
   return str;
 }
 

--- a/gcc/rust/hir/tree/rust-hir-pattern.h
+++ b/gcc/rust/hir/tree/rust-hir-pattern.h
@@ -377,26 +377,6 @@ protected:
   }
 };
 
-// aka StructPatternEtCetera; potential element in struct pattern
-struct StructPatternEtc
-{
-private:
-  AST::AttrVec outer_attrs;
-
-  // should this store location data?
-
-public:
-  StructPatternEtc (AST::AttrVec outer_attribs)
-    : outer_attrs (std::move (outer_attribs))
-  {}
-
-  // Creates an empty StructPatternEtc
-  static StructPatternEtc create_empty ()
-  {
-    return StructPatternEtc (AST::AttrVec ());
-  }
-};
-
 // Base class for a single field in a struct pattern - abstract
 class StructPatternField
 {
@@ -561,15 +541,7 @@ protected:
 struct StructPatternElements
 {
 private:
-  // bool has_struct_pattern_fields;
   std::vector<std::unique_ptr<StructPatternField> > fields;
-
-  bool has_struct_pattern_etc;
-  StructPatternEtc etc;
-
-  // must have at least one of the two and maybe both
-
-  // should this store location data?
 
 public:
   // Returns whether there are any struct pattern fields
@@ -577,29 +549,16 @@ public:
 
   /* Returns whether the struct pattern elements is entirely empty (no fields,
    * no etc). */
-  bool is_empty () const
-  {
-    return !has_struct_pattern_fields () && !has_struct_pattern_etc;
-  }
+  bool is_empty () const { return !has_struct_pattern_fields (); }
 
   // Constructor for StructPatternElements with both (potentially)
   StructPatternElements (
-    std::vector<std::unique_ptr<StructPatternField> > fields,
-    StructPatternEtc etc)
-    : fields (std::move (fields)), has_struct_pattern_etc (true),
-      etc (std::move (etc))
-  {}
-
-  // Constructor for StructPatternElements with no StructPatternEtc
-  StructPatternElements (
     std::vector<std::unique_ptr<StructPatternField> > fields)
-    : fields (std::move (fields)), has_struct_pattern_etc (false),
-      etc (StructPatternEtc::create_empty ())
+    : fields (std::move (fields))
   {}
 
   // Copy constructor with vector clone
   StructPatternElements (StructPatternElements const &other)
-    : has_struct_pattern_etc (other.has_struct_pattern_etc), etc (other.etc)
   {
     fields.reserve (other.fields.size ());
     for (const auto &e : other.fields)
@@ -609,9 +568,6 @@ public:
   // Overloaded assignment operator with vector clone
   StructPatternElements &operator= (StructPatternElements const &other)
   {
-    etc = other.etc;
-    has_struct_pattern_etc = other.has_struct_pattern_etc;
-
     fields.reserve (other.fields.size ());
     for (const auto &e : other.fields)
       fields.push_back (e->clone_struct_pattern_field ());
@@ -637,27 +593,15 @@ public:
 class StructPattern : public Pattern
 {
   PathInExpression path;
-
-  // bool has_struct_pattern_elements;
   StructPatternElements elems;
-
-  // TODO: should this store location data? Accessor uses path location data.
 
 public:
   std::string as_string () const override;
 
-  // Constructs a struct pattern from specified StructPatternElements
-  StructPattern (PathInExpression struct_path,
-		 StructPatternElements elems
-		 = StructPatternElements::create_empty ())
+  StructPattern (PathInExpression struct_path, StructPatternElements elems)
     : path (std::move (struct_path)), elems (std::move (elems))
   {}
 
-  /* TODO: constructor to construct via elements included in
-   * StructPatternElements */
-
-  /* Returns whether struct pattern has any struct pattern elements (if not, it
-   * is empty). */
   bool has_struct_pattern_elems () const { return !elems.is_empty (); }
 
   Location get_locus () const { return path.get_locus (); }

--- a/gcc/rust/resolve/rust-ast-resolve-pattern.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-pattern.cc
@@ -1,0 +1,104 @@
+// Copyright (C) 2020-2021 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-ast-resolve-pattern.h"
+#include "rust-ast-resolve-expr.h"
+
+namespace Rust {
+namespace Resolver {
+
+void
+PatternDeclaration::visit (AST::PathInExpression &pattern)
+{
+  ResolveExpr::go (&pattern, parent);
+}
+
+void
+PatternDeclaration::visit (AST::TupleStructPattern &pattern)
+{
+  ResolveExpr::go (&pattern.get_path (), parent);
+
+  std::unique_ptr<AST::TupleStructItems> &items = pattern.get_items ();
+  switch (items->get_item_type ())
+    {
+      case AST::TupleStructItems::RANGE: {
+	// TODO
+	gcc_unreachable ();
+      }
+      break;
+
+      case AST::TupleStructItems::NO_RANGE: {
+	AST::TupleStructItemsNoRange &items_no_range
+	  = static_cast<AST::TupleStructItemsNoRange &> (*items.get ());
+
+	for (auto &inner_pattern : items_no_range.get_patterns ())
+	  {
+	    PatternDeclaration::go (inner_pattern.get (),
+				    pattern.get_node_id ());
+	  }
+      }
+      break;
+    }
+}
+
+void
+PatternDeclaration::visit (AST::StructPattern &pattern)
+{
+  ResolveExpr::go (&pattern.get_path (), parent);
+
+  auto &struct_pattern_elems = pattern.get_struct_pattern_elems ();
+  for (auto &field : struct_pattern_elems.get_struct_pattern_fields ())
+    {
+      switch (field->get_item_type ())
+	{
+	  case AST::StructPatternField::ItemType::TUPLE_PAT: {
+	    // TODO
+	    gcc_unreachable ();
+	  }
+	  break;
+
+	  case AST::StructPatternField::ItemType::IDENT_PAT: {
+	    // TODO
+	    gcc_unreachable ();
+	  }
+	  break;
+
+	  case AST::StructPatternField::ItemType::IDENT: {
+	    AST::StructPatternFieldIdent &ident
+	      = static_cast<AST::StructPatternFieldIdent &> (*field.get ());
+
+	    resolver->get_name_scope ().insert (
+	      CanonicalPath::new_seg (ident.get_node_id (),
+				      ident.get_identifier ()),
+	      ident.get_node_id (), pattern.get_locus ());
+	    resolver->insert_new_definition (
+	      ident.get_node_id (),
+	      Definition{ident.get_node_id (), pattern.get_node_id ()});
+	    resolver->mark_decl_mutability (ident.get_node_id (),
+					    ident.is_mut ());
+	  }
+	  break;
+	}
+    }
+
+  // TODO
+  rust_assert (!struct_pattern_elems.has_etc ());
+}
+
+} // namespace Resolver
+} // namespace Rust

--- a/gcc/rust/resolve/rust-ast-resolve-pattern.h
+++ b/gcc/rust/resolve/rust-ast-resolve-pattern.h
@@ -83,6 +83,13 @@ public:
 				    pattern.get_is_mut ());
   }
 
+  // cases in a match expression
+  void visit (AST::PathInExpression &pattern) override;
+
+  void visit (AST::StructPattern &pattern) override;
+
+  void visit (AST::TupleStructPattern &pattern) override;
+
 private:
   PatternDeclaration (NodeId parent) : ResolverBase (parent) {}
 };


### PR DESCRIPTION
This adds the name-resolution and HIR lowering pass for the match-expr
the type checking pass patch needs some work to be split up but these are
two nice isolated commits which are easier to read.