### PR TITLE
BugFix NodeId skew on AST::Patterns

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -1037,7 +1037,6 @@ public:
   virtual ~Pattern () {}
 
   virtual std::string as_string () const = 0;
-
   virtual void accept_vis (ASTVisitor &vis) = 0;
 
   // as only one kind of pattern can be stripped, have default of nothing
@@ -1045,16 +1044,11 @@ public:
   virtual bool is_marked_for_strip () const { return false; }
 
   virtual Location get_locus () const = 0;
-
-  virtual NodeId get_node_id () const { return node_id; }
+  virtual NodeId get_pattern_node_id () const = 0;
 
 protected:
   // Clone pattern implementation as pure virtual method
   virtual Pattern *clone_pattern_impl () const = 0;
-
-  Pattern () : node_id (Analysis::Mappings::get ()->get_next_node_id ()) {}
-
-  NodeId node_id;
 };
 
 // forward decl for Type

--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -394,6 +394,11 @@ public:
     outer_attrs = std::move (new_attrs);
   }
 
+  NodeId get_pattern_node_id () const override final
+  {
+    return ExprWithoutBlock::get_node_id ();
+  }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */

--- a/gcc/rust/ast/rust-path.h
+++ b/gcc/rust/ast/rust-path.h
@@ -380,6 +380,8 @@ public:
     outer_attrs = std::move (new_attrs);
   }
 
+  NodeId get_pattern_node_id () const override final { return get_node_id (); }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */
@@ -901,6 +903,8 @@ public:
   }
 
   NodeId get_node_id () const override { return _node_id; }
+
+  NodeId get_pattern_node_id () const override final { return get_node_id (); }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -77,8 +77,8 @@ public:
 
 	// the mutability checker needs to verify for immutable decls the number
 	// of assignments are <1. This marks an implicit assignment
-	resolver->mark_assignment_to_decl (param.get_pattern ()->get_node_id (),
-					   param.get_node_id ());
+	resolver->mark_assignment_to_decl (
+	  param.get_pattern ()->get_pattern_node_id (), param.get_node_id ());
       }
 
     if (function.has_where_clause ())
@@ -143,8 +143,8 @@ public:
 
 	// the mutability checker needs to verify for immutable decls the number
 	// of assignments are <1. This marks an implicit assignment
-	resolver->mark_assignment_to_decl (param.get_pattern ()->get_node_id (),
-					   param.get_node_id ());
+	resolver->mark_assignment_to_decl (
+	  param.get_pattern ()->get_pattern_node_id (), param.get_node_id ());
       }
 
     if (function.has_where_clause ())
@@ -394,8 +394,8 @@ public:
 
 	// the mutability checker needs to verify for immutable decls the number
 	// of assignments are <1. This marks an implicit assignment
-	resolver->mark_assignment_to_decl (param.get_pattern ()->get_node_id (),
-					   param.get_node_id ());
+	resolver->mark_assignment_to_decl (
+	  param.get_pattern ()->get_pattern_node_id (), param.get_node_id ());
       }
 
     // resolve the function body
@@ -510,8 +510,8 @@ public:
 
 	// the mutability checker needs to verify for immutable decls the number
 	// of assignments are <1. This marks an implicit assignment
-	resolver->mark_assignment_to_decl (param.get_pattern ()->get_node_id (),
-					   param.get_node_id ());
+	resolver->mark_assignment_to_decl (
+	  param.get_pattern ()->get_pattern_node_id (), param.get_node_id ());
       }
 
     // resolve any where clause items

--- a/gcc/rust/resolve/rust-ast-resolve-stmt.h
+++ b/gcc/rust/resolve/rust-ast-resolve-stmt.h
@@ -82,8 +82,8 @@ public:
 	ResolveExpr::go (stmt.get_init_expr ().get (), stmt.get_node_id ());
 
 	// mark the assignment
-	resolver->mark_assignment_to_decl (stmt.get_pattern ()->get_node_id (),
-					   stmt.get_node_id ());
+	resolver->mark_assignment_to_decl (
+	  stmt.get_pattern ()->get_pattern_node_id (), stmt.get_node_id ());
       }
 
     PatternDeclaration::go (stmt.get_pattern ().get (), stmt.get_node_id ());
@@ -316,8 +316,8 @@ public:
 
 	// the mutability checker needs to verify for immutable decls the number
 	// of assignments are <1. This marks an implicit assignment
-	resolver->mark_assignment_to_decl (param.get_pattern ()->get_node_id (),
-					   param.get_node_id ());
+	resolver->mark_assignment_to_decl (
+	  param.get_pattern ()->get_pattern_node_id (), param.get_node_id ());
       }
 
     // resolve the function body


### PR DESCRIPTION
The AST constructors implicitly generate new NodeId's, their associated
copy/move constructors ensure that they preserve the NodeId correctly.
The AST::Pattern's here incorrectly had a constructor in the abstract
base class which was generating the NodeId's but when this is used
within AST::MatchArms the fields contain these patterns which can get
copied/moved to cause new NodeId's to be generated which then throws off
type checking as the NodeId changes during HIR lowering and thus each of the
ID's are all off by one during type checking.
