### PR TITLE
HIR::IdentifierPattern had all fields public

### DIFF
--- a/gcc/rust/backend/rust-compile-fnparam.h
+++ b/gcc/rust/backend/rust-compile-fnparam.h
@@ -48,10 +48,8 @@ public:
     address_taken_context->lookup_addess_taken (
       param.get_mappings ().get_hirid (), &address_taken);
 
-    compiled_param
-      = ctx->get_backend ()->parameter_variable (fndecl, pattern.variable_ident,
-						 decl_type, address_taken,
-						 locus);
+    compiled_param = ctx->get_backend ()->parameter_variable (
+      fndecl, pattern.get_identifier (), decl_type, address_taken, locus);
   }
 
 private:

--- a/gcc/rust/backend/rust-compile-var-decl.h
+++ b/gcc/rust/backend/rust-compile-var-decl.h
@@ -59,7 +59,7 @@ public:
       translated_type = ctx->get_backend ()->immutable_type (translated_type);
 
     compiled_variable
-      = ctx->get_backend ()->local_variable (fndecl, pattern.variable_ident,
+      = ctx->get_backend ()->local_variable (fndecl, pattern.get_identifier (),
 					     translated_type, NULL /*decl_var*/,
 					     address_taken, locus);
   }

--- a/gcc/rust/hir/tree/rust-hir-pattern.h
+++ b/gcc/rust/hir/tree/rust-hir-pattern.h
@@ -68,16 +68,13 @@ protected:
 // Identifier pattern HIR node (bind value matched to a variable)
 class IdentifierPattern : public Pattern
 {
-public:
   Identifier variable_ident;
   bool is_ref;
   Mutability mut;
-
-  // bool has_pattern;
   std::unique_ptr<Pattern> to_bind;
-
   Location locus;
 
+public:
   std::string as_string () const override;
 
   // Returns whether the IdentifierPattern has a pattern to bind.
@@ -125,6 +122,8 @@ public:
   bool is_mut () const { return mut == Mutability::Mut; }
 
   void accept_vis (HIRVisitor &vis) override;
+
+  Identifier get_identifier () const { return variable_ident; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather


### PR DESCRIPTION
This makes the fields private again and adds the missing getter for the
identifier.
