### PR TITLE
Add mssing mappings to HIR::Pattern

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-pattern.h
+++ b/gcc/rust/hir/rust-ast-lower-pattern.h
@@ -33,16 +33,32 @@ public:
   {
     ASTLoweringPattern resolver;
     pattern->accept_vis (resolver);
+
     rust_assert (resolver.translated != nullptr);
+
+    resolver.mappings->insert_hir_pattern (
+      resolver.translated->get_pattern_mappings ().get_crate_num (),
+      resolver.translated->get_pattern_mappings ().get_hirid (),
+      resolver.translated);
+    resolver.mappings->insert_location (
+      resolver.translated->get_pattern_mappings ().get_crate_num (),
+      resolver.translated->get_pattern_mappings ().get_hirid (),
+      pattern->get_locus ());
+
     return resolver.translated;
   }
 
   void visit (AST::IdentifierPattern &pattern) override
   {
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, pattern.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   UNKNOWN_LOCAL_DEFID);
+
     std::unique_ptr<Pattern> to_bind;
     translated
-      = new HIR::IdentifierPattern (pattern.get_ident (), pattern.get_locus (),
-				    pattern.get_is_ref (),
+      = new HIR::IdentifierPattern (mapping, pattern.get_ident (),
+				    pattern.get_locus (), pattern.get_is_ref (),
 				    pattern.get_is_mut () ? Mutability::Mut
 							  : Mutability::Imm,
 				    std::move (to_bind));

--- a/gcc/rust/hir/tree/rust-hir-path.h
+++ b/gcc/rust/hir/tree/rust-hir-path.h
@@ -330,6 +330,11 @@ public:
 	   == 0;
   }
 
+  Analysis::NodeMapping get_pattern_mappings () const override final
+  {
+    return get_mappings ();
+  }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */
@@ -823,6 +828,11 @@ public:
   QualifiedPathType &get_path_type () { return path_type; }
 
   Location get_locus () { return locus; }
+
+  Analysis::NodeMapping get_pattern_mappings () const override final
+  {
+    return get_mappings ();
+  }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -328,6 +328,8 @@ public:
 
   virtual void accept_vis (HIRVisitor &vis) = 0;
 
+  virtual Analysis::NodeMapping get_pattern_mappings () const = 0;
+
 protected:
   // Clone pattern implementation as pure virtual method
   virtual Pattern *clone_pattern_impl () const = 0;

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -100,8 +100,14 @@ public:
 	// get the name as well required for later on
 	auto param_tyty = TypeCheckType::Resolve (param.get_type ().get ());
 
+	// these are implicit mappings and not used
+	auto crate_num = mappings->get_current_crate ();
+	Analysis::NodeMapping mapping (crate_num, mappings->get_next_node_id (),
+				       mappings->get_next_hir_id (crate_num),
+				       UNKNOWN_LOCAL_DEFID);
+
 	HIR::IdentifierPattern *param_pattern = new HIR::IdentifierPattern (
-	  param.get_param_name (), Location (), false, Mutability::Imm,
+	  mapping, param.get_param_name (), Location (), false, Mutability::Imm,
 	  std::unique_ptr<HIR::Pattern> (nullptr));
 
 	params.push_back (
@@ -223,12 +229,18 @@ public:
     std::vector<std::pair<HIR::Pattern *, TyTy::BaseType *> > params;
     if (function.is_method ())
       {
+	// these are implicit mappings and not used
+	auto crate_num = mappings->get_current_crate ();
+	Analysis::NodeMapping mapping (crate_num, mappings->get_next_node_id (),
+				       mappings->get_next_hir_id (crate_num),
+				       UNKNOWN_LOCAL_DEFID);
+
 	// add the synthetic self param at the front, this is a placeholder for
 	// compilation to know parameter names. The types are ignored but we
 	// reuse the HIR identifier pattern which requires it
 	HIR::SelfParam &self_param = function.get_self_param ();
 	HIR::IdentifierPattern *self_pattern = new HIR::IdentifierPattern (
-	  "self", self_param.get_locus (), self_param.is_ref (),
+	  mapping, "self", self_param.get_locus (), self_param.is_ref (),
 	  self_param.get_mut (), std::unique_ptr<HIR::Pattern> (nullptr));
 
 	// might have a specified type

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -276,12 +276,19 @@ TraitItemReference::get_type_from_fn (/*const*/ HIR::TraitItemFunc &fn) const
   std::vector<std::pair<HIR::Pattern *, TyTy::BaseType *> > params;
   if (function.is_method ())
     {
+      // these are implicit mappings and not used
+      auto mappings = Analysis::Mappings::get ();
+      auto crate_num = mappings->get_current_crate ();
+      Analysis::NodeMapping mapping (crate_num, mappings->get_next_node_id (),
+				     mappings->get_next_hir_id (crate_num),
+				     UNKNOWN_LOCAL_DEFID);
+
       // add the synthetic self param at the front, this is a placeholder
       // for compilation to know parameter names. The types are ignored
       // but we reuse the HIR identifier pattern which requires it
       HIR::SelfParam &self_param = function.get_self ();
       HIR::IdentifierPattern *self_pattern
-	= new HIR::IdentifierPattern ("self", self_param.get_locus (),
+	= new HIR::IdentifierPattern (mapping, "self", self_param.get_locus (),
 				      self_param.is_ref (),
 				      self_param.is_mut () ? Mutability::Mut
 							   : Mutability::Imm,

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -566,6 +566,29 @@ Mappings::lookup_hir_struct_field (CrateNum crateNum, HirId id)
 }
 
 void
+Mappings::insert_hir_pattern (CrateNum crateNum, HirId id,
+			      HIR::Pattern *pattern)
+{
+  hirPatternMappings[crateNum][id] = pattern;
+  nodeIdToHirMappings[crateNum][pattern->get_pattern_mappings ().get_nodeid ()]
+    = id;
+}
+
+HIR::Pattern *
+Mappings::lookup_hir_pattern (CrateNum crateNum, HirId id)
+{
+  auto it = hirPatternMappings.find (crateNum);
+  if (it == hirPatternMappings.end ())
+    return nullptr;
+
+  auto iy = it->second.find (id);
+  if (iy == it->second.end ())
+    return nullptr;
+
+  return iy->second;
+}
+
+void
 Mappings::insert_local_defid_mapping (CrateNum crateNum, LocalDefId id,
 				      HIR::Item *item)
 {

--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -347,6 +347,9 @@ public:
 				HIR::StructExprField *type);
   HIR::StructExprField *lookup_hir_struct_field (CrateNum crateNum, HirId id);
 
+  void insert_hir_pattern (CrateNum crateNum, HirId id, HIR::Pattern *pattern);
+  HIR::Pattern *lookup_hir_pattern (CrateNum crateNum, HirId id);
+
   void walk_local_defids_for_crate (CrateNum crateNum,
 				    std::function<bool (HIR::Item *)> cb);
 
@@ -479,43 +482,44 @@ private:
   std::map<CrateNum, HIR::Crate *> hirCrateMappings;
 
   std::map<DefId, HIR::Item *> defIdMappings;
-  std::map<CrateNum, std::map<LocalDefId, HIR::Item *> > localDefIdMappings;
-  std::map<CrateNum, std::map<HirId, HIR::Module *> > hirModuleMappings;
-  std::map<CrateNum, std::map<HirId, HIR::Item *> > hirItemMappings;
-  std::map<CrateNum, std::map<HirId, HIR::Type *> > hirTypeMappings;
-  std::map<CrateNum, std::map<HirId, HIR::Expr *> > hirExprMappings;
-  std::map<CrateNum, std::map<HirId, HIR::Stmt *> > hirStmtMappings;
-  std::map<CrateNum, std::map<HirId, HIR::FunctionParam *> > hirParamMappings;
-  std::map<CrateNum, std::map<HirId, HIR::StructExprField *> >
+  std::map<CrateNum, std::map<LocalDefId, HIR::Item *>> localDefIdMappings;
+  std::map<CrateNum, std::map<HirId, HIR::Module *>> hirModuleMappings;
+  std::map<CrateNum, std::map<HirId, HIR::Item *>> hirItemMappings;
+  std::map<CrateNum, std::map<HirId, HIR::Type *>> hirTypeMappings;
+  std::map<CrateNum, std::map<HirId, HIR::Expr *>> hirExprMappings;
+  std::map<CrateNum, std::map<HirId, HIR::Stmt *>> hirStmtMappings;
+  std::map<CrateNum, std::map<HirId, HIR::FunctionParam *>> hirParamMappings;
+  std::map<CrateNum, std::map<HirId, HIR::StructExprField *>>
     hirStructFieldMappings;
-  std::map<CrateNum, std::map<HirId, std::pair<HirId, HIR::ImplItem *> > >
+  std::map<CrateNum, std::map<HirId, std::pair<HirId, HIR::ImplItem *>>>
     hirImplItemMappings;
-  std::map<CrateNum, std::map<HirId, HIR::SelfParam *> > hirSelfParamMappings;
+  std::map<CrateNum, std::map<HirId, HIR::SelfParam *>> hirSelfParamMappings;
   std::map<HirId, HIR::ImplBlock *> hirImplItemsToImplMappings;
-  std::map<CrateNum, std::map<HirId, HIR::ImplBlock *> > hirImplBlockMappings;
-  std::map<CrateNum, std::map<HirId, HIR::TraitItem *> > hirTraitItemMappings;
-  std::map<CrateNum, std::map<HirId, HIR::ExternalItem *> >
+  std::map<CrateNum, std::map<HirId, HIR::ImplBlock *>> hirImplBlockMappings;
+  std::map<CrateNum, std::map<HirId, HIR::TraitItem *>> hirTraitItemMappings;
+  std::map<CrateNum, std::map<HirId, HIR::ExternalItem *>>
     hirExternItemMappings;
-  std::map<CrateNum, std::map<HirId, HIR::PathExprSegment *> >
+  std::map<CrateNum, std::map<HirId, HIR::PathExprSegment *>>
     hirPathSegMappings;
-  std::map<CrateNum, std::map<HirId, HIR::GenericParam *> >
+  std::map<CrateNum, std::map<HirId, HIR::GenericParam *>>
     hirGenericParamMappings;
   std::map<HirId, HIR::Trait *> hirTraitItemsToTraitMappings;
+  std::map<CrateNum, std::map<HirId, HIR::Pattern *>> hirPatternMappings;
 
   // this maps the lang=<item_type> to DefId mappings
   std::map<RustLangItem::ItemType, DefId> lang_item_mappings;
 
   // canonical paths
-  std::map<CrateNum, std::map<NodeId, const Resolver::CanonicalPath> > paths;
+  std::map<CrateNum, std::map<NodeId, const Resolver::CanonicalPath>> paths;
 
   // location info
-  std::map<CrateNum, std::map<NodeId, Location> > locations;
+  std::map<CrateNum, std::map<NodeId, Location>> locations;
 
   // reverse mappings
-  std::map<CrateNum, std::map<NodeId, HirId> > nodeIdToHirMappings;
+  std::map<CrateNum, std::map<NodeId, HirId>> nodeIdToHirMappings;
 
   // all hirid nodes
-  std::map<CrateNum, std::set<HirId> > hirNodesWithinCrate;
+  std::map<CrateNum, std::set<HirId>> hirNodesWithinCrate;
 
   // crate names
   std::map<CrateNum, std::string> crate_names;


### PR DESCRIPTION
These mappings are missing within the HIR but are required
to complete typechecking of all patterns in match arms. As the
fields of structures must bind their associated field's types to new
names declared as part of the pattern, these mappings give access
to the associated name-resolved NodeId's to figure this out.