### PR TITLE
Add missing abstract method HIR::Pattern::get_locus() const

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-pattern.h
+++ b/gcc/rust/hir/tree/rust-hir-pattern.h
@@ -404,6 +404,8 @@ public:
     return mappings;
   }
 
+  Location get_locus () const override final { return locus; }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -330,6 +330,8 @@ public:
 
   virtual Analysis::NodeMapping get_pattern_mappings () const = 0;
 
+  virtual Location get_locus () const = 0;
+
 protected:
   // Clone pattern implementation as pure virtual method
   virtual Pattern *clone_pattern_impl () const = 0;


### PR DESCRIPTION
We have a missing locus here, there many places within the HIR where
we are missing location info such as HIR::MatchCase or HIR::MatchArm
come to mind. We also need to raise an issue to track CanonicalPath's and
location info within the TyTy module as part of a new Identifier structure which
will need to be raised in a separate PR+Issue.