### PR TITLE
Add support for enums on the match expression

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -94,6 +94,7 @@ GRS_OBJS = \
     rust/rust-lint-marklive.o \
     rust/rust-hir-type-check-path.o \
     rust/rust-compile-intrinsic.o \
+    rust/rust-compile-pattern.o \
     rust/rust-base62.o \
     rust/rust-compile-expr.o \
     rust/rust-compile-type.o \

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -233,6 +233,21 @@ public:
     return true;
   }
 
+  void insert_pattern_binding (HirId id, tree binding)
+  {
+    implicit_pattern_bindings[id] = binding;
+  }
+
+  bool lookup_pattern_binding (HirId id, tree *binding)
+  {
+    auto it = implicit_pattern_bindings.find (id);
+    if (it == implicit_pattern_bindings.end ())
+      return false;
+
+    *binding = it->second;
+    return true;
+  }
+
   void push_fn (tree fn, ::Bvariable *ret_addr)
   {
     fn_stack.push_back (fncontext{fn, ret_addr});
@@ -326,6 +341,7 @@ private:
   std::map<const TyTy::BaseType *, std::pair<HirId, tree>> mono;
   std::map<DefId, std::vector<std::pair<const TyTy::BaseType *, tree>>>
     mono_fns;
+  std::map<HirId, tree> implicit_pattern_bindings;
 
   // To GCC middle-end
   std::vector<tree> type_decls;

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -221,6 +221,10 @@ public:
 	translated
 	  = ctx->get_backend ()->var_expression (var, expr.get_locus ());
       }
+    else if (ctx->lookup_pattern_binding (ref, &translated))
+      {
+	return;
+      }
     else
       {
 	rust_fatal_error (expr.get_locus (),
@@ -1042,6 +1046,8 @@ public:
   }
 
   void visit (HIR::DereferenceExpr &expr) override;
+
+  void visit (HIR::MatchExpr &expr) override;
 
 protected:
   tree compile_dyn_dispatch_call (const TyTy::DynamicObjectType *dyn,

--- a/gcc/rust/backend/rust-compile-pattern.cc
+++ b/gcc/rust/backend/rust-compile-pattern.cc
@@ -1,0 +1,218 @@
+// Copyright (C) 2020-2021 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-compile-pattern.h"
+
+namespace Rust {
+namespace Compile {
+
+void
+CompilePatternCaseLabelExpr::visit (HIR::PathInExpression &pattern)
+{
+  // lookup the type
+  TyTy::BaseType *lookup = nullptr;
+  bool ok
+    = ctx->get_tyctx ()->lookup_type (pattern.get_mappings ().get_hirid (),
+				      &lookup);
+  rust_assert (ok);
+
+  // this must be an enum
+  rust_assert (lookup->get_kind () == TyTy::TypeKind::ADT);
+  TyTy::ADTType *adt = static_cast<TyTy::ADTType *> (lookup);
+  rust_assert (adt->is_enum ());
+
+  // lookup the variant
+  HirId variant_id;
+  ok = ctx->get_tyctx ()->lookup_variant_definition (
+    pattern.get_mappings ().get_hirid (), &variant_id);
+  rust_assert (ok);
+
+  TyTy::VariantDef *variant = nullptr;
+  ok = adt->lookup_variant_by_id (variant_id, &variant);
+  rust_assert (ok);
+
+  mpz_t disciminantl;
+  if (variant->get_variant_type () == TyTy::VariantDef::VariantType::NUM)
+    {
+      mpz_init_set_ui (disciminantl, variant->get_discriminant ());
+    }
+  else
+    {
+      HirId variant_id = variant->get_id ();
+      mpz_init_set_ui (disciminantl, variant_id);
+    }
+
+  tree t = TyTyResolveCompile::get_implicit_enumeral_node_type (ctx);
+  tree case_low
+    = double_int_to_tree (t, mpz_get_double_int (t, disciminantl, true));
+
+  case_label_expr
+    = build_case_label (case_low, NULL_TREE, associated_case_label);
+}
+
+void
+CompilePatternCaseLabelExpr::visit (HIR::StructPattern &pattern)
+{
+  CompilePatternCaseLabelExpr::visit (pattern.get_path ());
+}
+
+void
+CompilePatternCaseLabelExpr::visit (HIR::TupleStructPattern &pattern)
+{
+  CompilePatternCaseLabelExpr::visit (pattern.get_path ());
+}
+
+// setup the bindings
+
+void
+CompilePatternBindings::visit (HIR::TupleStructPattern &pattern)
+{
+  // lookup the type
+  TyTy::BaseType *lookup = nullptr;
+  bool ok = ctx->get_tyctx ()->lookup_type (
+    pattern.get_path ().get_mappings ().get_hirid (), &lookup);
+  rust_assert (ok);
+
+  // this must be an enum
+  rust_assert (lookup->get_kind () == TyTy::TypeKind::ADT);
+  TyTy::ADTType *adt = static_cast<TyTy::ADTType *> (lookup);
+  rust_assert (adt->is_enum ());
+
+  // lookup the variant
+  HirId variant_id;
+  ok = ctx->get_tyctx ()->lookup_variant_definition (
+    pattern.get_path ().get_mappings ().get_hirid (), &variant_id);
+  rust_assert (ok);
+
+  int variant_index = -1;
+  TyTy::VariantDef *variant = nullptr;
+  ok = adt->lookup_variant_by_id (variant_id, &variant, &variant_index);
+  rust_assert (ok);
+
+  rust_assert (variant->get_variant_type ()
+	       == TyTy::VariantDef::VariantType::TUPLE);
+
+  std::unique_ptr<HIR::TupleStructItems> &items = pattern.get_items ();
+  switch (items->get_item_type ())
+    {
+      case HIR::TupleStructItems::RANGE: {
+	// TODO
+	gcc_unreachable ();
+      }
+      break;
+
+      case HIR::TupleStructItems::NO_RANGE: {
+	HIR::TupleStructItemsNoRange &items_no_range
+	  = static_cast<HIR::TupleStructItemsNoRange &> (*items.get ());
+
+	rust_assert (items_no_range.get_patterns ().size ()
+		     == variant->num_fields ());
+
+	// we are offsetting by + 1 here since the first field in the record
+	// is always the discriminator
+	size_t tuple_field_index = 1;
+	for (auto &pattern : items_no_range.get_patterns ())
+	  {
+	    tree variant_accessor
+	      = ctx->get_backend ()->struct_field_expression (
+		match_scrutinee_expr, variant_index, pattern->get_locus ());
+
+	    tree binding = ctx->get_backend ()->struct_field_expression (
+	      variant_accessor, tuple_field_index++, pattern->get_locus ());
+
+	    ctx->insert_pattern_binding (
+	      pattern->get_pattern_mappings ().get_hirid (), binding);
+	  }
+      }
+      break;
+    }
+}
+
+void
+CompilePatternBindings::visit (HIR::StructPattern &pattern)
+{
+  // lookup the type
+  TyTy::BaseType *lookup = nullptr;
+  bool ok = ctx->get_tyctx ()->lookup_type (
+    pattern.get_path ().get_mappings ().get_hirid (), &lookup);
+  rust_assert (ok);
+
+  // this must be an enum
+  rust_assert (lookup->get_kind () == TyTy::TypeKind::ADT);
+  TyTy::ADTType *adt = static_cast<TyTy::ADTType *> (lookup);
+  rust_assert (adt->is_enum ());
+
+  // lookup the variant
+  HirId variant_id;
+  ok = ctx->get_tyctx ()->lookup_variant_definition (
+    pattern.get_path ().get_mappings ().get_hirid (), &variant_id);
+  rust_assert (ok);
+
+  int variant_index = -1;
+  TyTy::VariantDef *variant = nullptr;
+  ok = adt->lookup_variant_by_id (variant_id, &variant, &variant_index);
+  rust_assert (ok);
+
+  rust_assert (variant->get_variant_type ()
+	       == TyTy::VariantDef::VariantType::STRUCT);
+
+  auto &struct_pattern_elems = pattern.get_struct_pattern_elems ();
+  for (auto &field : struct_pattern_elems.get_struct_pattern_fields ())
+    {
+      switch (field->get_item_type ())
+	{
+	  case HIR::StructPatternField::ItemType::TUPLE_PAT: {
+	    // TODO
+	    gcc_unreachable ();
+	  }
+	  break;
+
+	  case HIR::StructPatternField::ItemType::IDENT_PAT: {
+	    // TODO
+	    gcc_unreachable ();
+	  }
+	  break;
+
+	  case HIR::StructPatternField::ItemType::IDENT: {
+	    HIR::StructPatternFieldIdent &ident
+	      = static_cast<HIR::StructPatternFieldIdent &> (*field.get ());
+
+	    tree variant_accessor
+	      = ctx->get_backend ()->struct_field_expression (
+		match_scrutinee_expr, variant_index, ident.get_locus ());
+
+	    size_t offs = 0;
+	    ok
+	      = variant->lookup_field (ident.get_identifier (), nullptr, &offs);
+	    rust_assert (ok);
+
+	    // we are offsetting by + 1 here since the first field in the record
+	    // is always the discriminator
+	    tree binding = ctx->get_backend ()->struct_field_expression (
+	      variant_accessor, offs + 1, ident.get_locus ());
+
+	    ctx->insert_pattern_binding (ident.get_mappings ().get_hirid (),
+					 binding);
+	  }
+	  break;
+	}
+    }
+}
+
+} // namespace Compile
+} // namespace Rust

--- a/gcc/rust/backend/rust-compile-pattern.h
+++ b/gcc/rust/backend/rust-compile-pattern.h
@@ -1,0 +1,78 @@
+// Copyright (C) 2020-2021 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-compile-base.h"
+
+namespace Rust {
+namespace Compile {
+
+class CompilePatternCaseLabelExpr : public HIRCompileBase
+{
+  using Rust::Compile::HIRCompileBase::visit;
+
+public:
+  static tree Compile (HIR::Pattern *pattern, tree associated_case_label,
+		       Context *ctx)
+  {
+    CompilePatternCaseLabelExpr compiler (ctx, associated_case_label);
+    pattern->accept_vis (compiler);
+    return compiler.case_label_expr;
+  }
+
+  void visit (HIR::PathInExpression &pattern) override;
+
+  void visit (HIR::StructPattern &pattern) override;
+
+  void visit (HIR::TupleStructPattern &pattern) override;
+
+private:
+  CompilePatternCaseLabelExpr (Context *ctx, tree associated_case_label)
+    : HIRCompileBase (ctx), case_label_expr (error_mark_node),
+      associated_case_label (associated_case_label)
+  {}
+
+  tree case_label_expr;
+  tree associated_case_label;
+};
+
+class CompilePatternBindings : public HIRCompileBase
+{
+  using Rust::Compile::HIRCompileBase::visit;
+
+public:
+  static void Compile (HIR::Pattern *pattern, tree match_scrutinee_expr,
+		       Context *ctx)
+  {
+    CompilePatternBindings compiler (ctx, match_scrutinee_expr);
+    pattern->accept_vis (compiler);
+  }
+
+  void visit (HIR::StructPattern &pattern) override;
+
+  void visit (HIR::TupleStructPattern &pattern) override;
+
+private:
+  CompilePatternBindings (Context *ctx, tree match_scrutinee_expr)
+    : HIRCompileBase (ctx), match_scrutinee_expr (match_scrutinee_expr)
+  {}
+
+  tree match_scrutinee_expr;
+};
+
+} // namespace Compile
+} // namespace Rust

--- a/gcc/testsuite/rust/execute/torture/match1.rs
+++ b/gcc/testsuite/rust/execute/torture/match1.rs
@@ -1,0 +1,58 @@
+// { dg-output "Foo::A\nFoo::B\nFoo::C x\nFoo::D 20 80\n" }
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+enum Foo {
+    A,
+    B,
+    C(char),
+    D { x: i64, y: i64 },
+}
+
+fn inspect(f: Foo) {
+    match f {
+        Foo::A => unsafe {
+            let a = "Foo::A\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c);
+        },
+        Foo::B => unsafe {
+            let a = "Foo::B\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c);
+        },
+        Foo::C(x) => unsafe {
+            let a = "Foo::C %c\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c, x);
+        },
+        Foo::D { x, y } => unsafe {
+            let a = "Foo::D %i %i\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c, x, y);
+        },
+    }
+}
+
+fn main() -> i32 {
+    let a = Foo::A;
+    let b = Foo::B;
+    let c = Foo::C('x');
+    let d = Foo::D { x: 20, y: 80 };
+
+    inspect(a);
+    inspect(b);
+    inspect(c);
+    inspect(d);
+
+    0
+}

--- a/gcc/testsuite/rust/execute/torture/match2.rs
+++ b/gcc/testsuite/rust/execute/torture/match2.rs
@@ -1,0 +1,42 @@
+// { dg-output "123\n80\n" }
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+enum Foo {
+    C(i32),
+    D { x: i32, y: i32 },
+}
+
+fn inspect(f: Foo) -> i32 {
+    match f {
+        Foo::C(x) => x,
+        Foo::D { x, y } => y,
+        // { dg-warning "unused name .x." "" { target *-*-* } .-1 }
+    }
+}
+
+fn main() -> i32 {
+    let a = Foo::C(123);
+    let b = Foo::D { x: 20, y: 80 };
+
+    let result = inspect(a);
+    unsafe {
+        let a = "%i\n\0";
+        let b = a as *const str;
+        let c = b as *const i8;
+
+        printf(c, result);
+    }
+
+    let result = inspect(b);
+    unsafe {
+        let a = "%i\n\0";
+        let b = a as *const str;
+        let c = b as *const i8;
+
+        printf(c, result);
+    }
+
+    0
+}


### PR DESCRIPTION
This adds in the initial support MatchExpression which allows us to start testing much
more complex rust code. Ideally we can now start targeing the #682 to find nasty bugs
early as possible.

This takes the MatchExpr and generates a SWITCH_EXPR with associated
CASE_LABEL_EXPR's for the variants that the qualifier contains.

To improve this support in order to take advantage of SWITCH_ALL_CASES_P
to add error checking for all cases being covered. This will require changes
to the enum data structure to use ENUMERAL_TYPES instead of the flat i64
so the enumerable type contains the list of all possible permutations.

This patch is the first pass at the MatchExpr as the patch is already pretty
large and serves as a base to move forward.

Fixes #190
