### PR TITLE
HIR::ImplBlock items should mangle based from their canonical path's

### DIFF
--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -310,14 +310,6 @@ public:
     return mangler.mangle_item (ty, path, mappings->get_current_crate_name ());
   }
 
-  std::string mangle_impl_item (const TyTy::BaseType *self,
-				const TyTy::BaseType *ty,
-				const std::string &name) const
-  {
-    return mangler.mangle_impl_item (self, ty, name,
-				     mappings->get_current_crate_name ());
-  }
-
 private:
   ::Backend *backend;
   Resolver::Resolver *resolver;

--- a/gcc/rust/backend/rust-compile-implitem.h
+++ b/gcc/rust/backend/rust-compile-implitem.h
@@ -153,8 +153,7 @@ public:
 
     std::string ir_symbol_name
       = canonical_path->get () + fntype->subst_as_string ();
-    std::string asm_name
-      = ctx->mangle_impl_item (self, fntype, function.get_function_name ());
+    std::string asm_name = ctx->mangle_item (fntype, *canonical_path);
 
     tree fndecl
       = ctx->get_backend ()->function (compiled_fn_type, ir_symbol_name,

--- a/gcc/rust/backend/rust-mangle.h
+++ b/gcc/rust/backend/rust-mangle.h
@@ -21,6 +21,7 @@
 
 namespace Rust {
 namespace Compile {
+
 class Mangler
 {
 public:
@@ -36,11 +37,6 @@ public:
 			   const Resolver::CanonicalPath &path,
 			   const std::string &crate_name) const;
 
-  std::string mangle_impl_item (const TyTy::BaseType *self,
-				const TyTy::BaseType *ty,
-				const std::string &name,
-				const std::string &crate_name) const;
-
   static void set_mangling (int frust_mangling_value)
   {
     version = static_cast<MangleVersion> (frust_mangling_value);
@@ -49,6 +45,8 @@ public:
 private:
   static enum MangleVersion version;
 };
+
 } // namespace Compile
 } // namespace Rust
+
 #endif // RUST_MANGLE_H

--- a/gcc/testsuite/rust/execute/torture/issue-845.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-845.rs
@@ -1,0 +1,47 @@
+// { dg-output "Foo::bar\n" }
+// { dg-additional-options "-w" }
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+struct Foo {}
+
+trait Bar {
+    fn bar(&self) {
+        unsafe {
+            let _a = "Bar::bar\n\0";
+            let _b = _a as *const str;
+            let _c = _b as *const i8;
+            printf(_c);
+        }
+    }
+}
+
+impl Foo {
+    fn bar(&self) {
+        unsafe {
+            let _a = "Foo::bar\n\0";
+            let _b = _a as *const str;
+            let _c = _b as *const i8;
+            printf(_c);
+        }
+    }
+}
+
+impl Bar for Foo {
+    fn bar(&self) {
+        unsafe {
+            let _a = "<Bar as Foo>::bar\n\0";
+            let _b = _a as *const str;
+            let _c = _b as *const i8;
+            printf(_c);
+        }
+    }
+}
+
+pub fn main() -> i32 {
+    let mut f = Foo {};
+    f.bar();
+
+    0
+}


### PR DESCRIPTION
Legacy mangling converts the '<', '>' from their canonical paths into '..'
this means we can simply reuse our normal mangle_item code for all types
of symbols. So we can now remove the mangle_impl_item code prior to having
the canonical path code in place.

Fixes #845
