### PR TITLE
Add missing bitwise lang items for operator overloading

### DIFF
--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -41,6 +41,11 @@ public:
     MULTIPLY,
     DIVIDE,
     REMAINDER,
+    BITAND,
+    BITOR,
+    BITXOR,
+    SHL,
+    SHR,
 
     NEGATION,
     NOT,
@@ -50,6 +55,11 @@ public:
     MUL_ASSIGN,
     DIV_ASSIGN,
     REM_ASSIGN,
+    BITAND_ASSIGN,
+    BITOR_ASSIGN,
+    BITXOR_ASSIGN,
+    SHL_ASSIGN,
+    SHR_ASSIGN,
 
     DEREF,
 
@@ -77,6 +87,26 @@ public:
     else if (item.compare ("rem") == 0)
       {
 	return ItemType::REMAINDER;
+      }
+    else if (item.compare ("bitand") == 0)
+      {
+	return ItemType::BITAND;
+      }
+    else if (item.compare ("bitor") == 0)
+      {
+	return ItemType::BITOR;
+      }
+    else if (item.compare ("bitxor") == 0)
+      {
+	return ItemType::BITXOR;
+      }
+    else if (item.compare ("shl") == 0)
+      {
+	return ItemType::SHL;
+      }
+    else if (item.compare ("shr") == 0)
+      {
+	return ItemType::SHR;
       }
     else if (item.compare ("neg") == 0)
       {
@@ -106,6 +136,26 @@ public:
       {
 	return ItemType::REM_ASSIGN;
       }
+    else if (item.compare ("bitand_assign") == 0)
+      {
+	return ItemType::BITAND_ASSIGN;
+      }
+    else if (item.compare ("bitor_assign") == 0)
+      {
+	return ItemType::BITOR_ASSIGN;
+      }
+    else if (item.compare ("bitxor_assign") == 0)
+      {
+	return ItemType::BITXOR_ASSIGN;
+      }
+    else if (item.compare ("shl_assign") == 0)
+      {
+	return ItemType::SHL_ASSIGN;
+      }
+    else if (item.compare ("shr_assign") == 0)
+      {
+	return ItemType::SHR_ASSIGN;
+      }
     else if (item.compare ("deref") == 0)
       {
 	return ItemType::DEREF;
@@ -128,6 +178,16 @@ public:
 	return "div";
       case REMAINDER:
 	return "rem";
+      case BITAND:
+	return "bitand";
+      case BITOR:
+	return "bitor";
+      case BITXOR:
+	return "bitxor";
+      case SHL:
+	return "shl";
+      case SHR:
+	return "shr";
       case NEGATION:
 	return "neg";
       case NOT:
@@ -142,11 +202,21 @@ public:
 	return "div_assign";
       case REM_ASSIGN:
 	return "rem_assign";
+      case BITAND_ASSIGN:
+	return "bitand_assign";
+      case BITOR_ASSIGN:
+	return "bitor_assign";
+      case BITXOR_ASSIGN:
+	return "bitxor_assign";
+      case SHL_ASSIGN:
+	return "shl_assign";
+      case SHR_ASSIGN:
+	return "shr_assign";
       case DEREF:
 	return "deref";
 
       case UNKNOWN:
-	break;
+	return "<UNKNOWN>";
       }
     return "<UNKNOWN>";
   }
@@ -165,9 +235,16 @@ public:
 	return ItemType::DIVIDE;
       case ArithmeticOrLogicalOperator::MODULUS:
 	return ItemType::REMAINDER;
-
-      default:
-	return ItemType::UNKNOWN;
+      case ArithmeticOrLogicalOperator::BITWISE_AND:
+	return ItemType::BITAND;
+      case ArithmeticOrLogicalOperator::BITWISE_OR:
+	return ItemType::BITOR;
+      case ArithmeticOrLogicalOperator::BITWISE_XOR:
+	return ItemType::BITXOR;
+      case ArithmeticOrLogicalOperator::LEFT_SHIFT:
+	return ItemType::SHL;
+      case ArithmeticOrLogicalOperator::RIGHT_SHIFT:
+	return ItemType::SHR;
       }
     return ItemType::UNKNOWN;
   }
@@ -187,9 +264,16 @@ public:
 	return ItemType::DIV_ASSIGN;
       case ArithmeticOrLogicalOperator::MODULUS:
 	return ItemType::REM_ASSIGN;
-
-      default:
-	return ItemType::UNKNOWN;
+      case ArithmeticOrLogicalOperator::BITWISE_AND:
+	return ItemType::BITAND_ASSIGN;
+      case ArithmeticOrLogicalOperator::BITWISE_OR:
+	return ItemType::BITOR_ASSIGN;
+      case ArithmeticOrLogicalOperator::BITWISE_XOR:
+	return ItemType::BITXOR_ASSIGN;
+      case ArithmeticOrLogicalOperator::LEFT_SHIFT:
+	return ItemType::SHL_ASSIGN;
+      case ArithmeticOrLogicalOperator::RIGHT_SHIFT:
+	return ItemType::SHR_ASSIGN;
       }
     return ItemType::UNKNOWN;
   }
@@ -202,9 +286,6 @@ public:
 	return ItemType::NEGATION;
       case NegationOperator::NOT:
 	return ItemType::NOT;
-
-      default:
-	return ItemType::UNKNOWN;
       }
     return ItemType::UNKNOWN;
   }

--- a/gcc/testsuite/rust/execute/torture/operator_overload_11.rs
+++ b/gcc/testsuite/rust/execute/torture/operator_overload_11.rs
@@ -1,0 +1,37 @@
+// { dg-output "1\n" }
+// { dg-additional-options "-w" }
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+#[lang = "bitand"]
+pub trait BitAnd<Rhs = Self> {
+    type Output;
+
+    fn bitand(self, rhs: Rhs) -> Self::Output;
+}
+
+impl BitAnd for i32 {
+    type Output = i32;
+
+    fn bitand(self, other: i32) -> i32 {
+        let res = self & other;
+
+        unsafe {
+            let a = "%i\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c, res);
+        }
+
+        res
+    }
+}
+
+fn main() -> i32 {
+    let a;
+    a = 1 & 1;
+
+    0
+}

--- a/gcc/testsuite/rust/execute/torture/operator_overload_12.rs
+++ b/gcc/testsuite/rust/execute/torture/operator_overload_12.rs
@@ -1,0 +1,31 @@
+// { dg-output "1\n" }
+// { dg-additional-options "-w" }
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+#[lang = "bitand_assign"]
+pub trait BitAndAssign<Rhs = Self> {
+    fn bitand_assign(&mut self, rhs: Rhs);
+}
+
+impl BitAndAssign for i32 {
+    fn bitand_assign(&mut self, other: i32) {
+        *self &= other;
+
+        unsafe {
+            let a = "%i\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c, *self);
+        }
+    }
+}
+
+fn main() -> i32 {
+    let mut a = 1;
+    a &= 1;
+
+    0
+}


### PR DESCRIPTION
This adds the missing bitwise lang items:

- bitand: libcore/ops/bit.rs
- bitor: libcore/ops/bit.rs
- bitxor: libcore/ops/bit.rs
- shl: libcore/ops/bit.rs
- shr: libcore/ops/bit.rs
- bitand_assign: libcore/ops/bit.rs
- bitor_assign: libcore/ops/bit.rs
- bitxor_assign: libcore/ops/bit.rs
- shl_assign: libcore/ops/bit.rs
- shr_assign: libcore/ops/bit.rs

Addresses #742
