### PR TITLE
Fix ICE in generic subsitution of enums containing dataless variants

### DIFF
--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -822,6 +822,9 @@ ADTType::handle_substitions (SubstitutionArgumentMappings subst_mappings)
 
   for (auto &variant : adt->get_variants ())
     {
+      if (variant->is_dataless_variant ())
+	continue;
+
       for (auto &field : variant->get_fields ())
 	{
 	  bool ok = ::Rust::TyTy::handle_substitions (subst_mappings, field);

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -1069,6 +1069,8 @@ public:
   HirId get_id () const { return id; }
 
   VariantType get_variant_type () const { return type; }
+  bool is_data_variant () const { return type != VariantType::NUM; }
+  bool is_dataless_variant () const { return type == VariantType::NUM; }
 
   std::string get_identifier () const { return identifier; }
   int get_discriminant () const { return discriminant; }

--- a/gcc/testsuite/rust/execute/torture/issue-851.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-851.rs
@@ -1,0 +1,35 @@
+/* { dg-output "Result: 123\n" } */
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+enum Foo<T> {
+    A,
+    B(T),
+}
+
+fn inspect(a: Foo<i32>) {
+    match a {
+        Foo::A => unsafe {
+            let a = "A\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c);
+        },
+        Foo::B(x) => unsafe {
+            let a = "Result: %i\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c, x);
+        },
+    }
+}
+
+fn main() -> i32 {
+    let a = Foo::B(123);
+    inspect(a);
+
+    0
+}


### PR DESCRIPTION
Dataless variants do not contain fields that can be substituted, which then
hits an assertion on access of the fields for the variant. This patch adds
a guard against the substitution of dataless variants. We could have
removed the assertion which would have also been a good fix but keeping the
assertion for now is very helpful in debugging issues.

Fixs #851
