### PR TITLE
Add overflow checking on LiteralExpression

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -95,7 +95,8 @@ public:
 
   void accept_vis (HIRFullVisitor &vis) override;
 
-  Literal *get_literal () { return &literal; }
+  Literal &get_literal () { return literal; }
+  const Literal &get_literal () const { return literal; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather

--- a/gcc/rust/typecheck/rust-hir-const-fold.h
+++ b/gcc/rust/typecheck/rust-hir-const-fold.h
@@ -354,7 +354,7 @@ public:
       {
 	case HIR::Literal::INT: {
 	  mpz_t ival;
-	  if (mpz_init_set_str (ival, literal_value->as_string ().c_str (), 10)
+	  if (mpz_init_set_str (ival, literal_value.as_string ().c_str (), 10)
 	      != 0)
 	    {
 	      rust_fatal_error (expr.get_locus (), "bad number in literal");
@@ -376,14 +376,14 @@ public:
 	return;
 
 	case HIR::Literal::BOOL: {
-	  bool bval = literal_value->as_string ().compare ("true") == 0;
+	  bool bval = literal_value.as_string ().compare ("true") == 0;
 	  folded = ctx->get_backend ()->boolean_constant_expression (bval);
 	}
 	return;
 
 	case HIR::Literal::FLOAT: {
 	  mpfr_t fval;
-	  if (mpfr_init_set_str (fval, literal_value->as_string ().c_str (), 10,
+	  if (mpfr_init_set_str (fval, literal_value.as_string ().c_str (), 10,
 				 MPFR_RNDN)
 	      != 0)
 	    {

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -604,7 +604,7 @@ public:
 	case HIR::Literal::LitType::INT: {
 	  bool ok = false;
 
-	  switch (expr.get_literal ()->get_type_hint ())
+	  switch (expr.get_literal ().get_type_hint ())
 	    {
 	    case CORETYPE_I8:
 	      ok = context->lookup_builtin ("i8", &infered);
@@ -639,11 +639,11 @@ public:
 	      break;
 
 	    case CORETYPE_F32:
-	      expr.get_literal ()->set_lit_type (HIR::Literal::LitType::FLOAT);
+	      expr.get_literal ().set_lit_type (HIR::Literal::LitType::FLOAT);
 	      ok = context->lookup_builtin ("f32", &infered);
 	      break;
 	    case CORETYPE_F64:
-	      expr.get_literal ()->set_lit_type (HIR::Literal::LitType::FLOAT);
+	      expr.get_literal ().set_lit_type (HIR::Literal::LitType::FLOAT);
 	      ok = context->lookup_builtin ("f64", &infered);
 	      break;
 
@@ -661,7 +661,7 @@ public:
 	case HIR::Literal::LitType::FLOAT: {
 	  bool ok = false;
 
-	  switch (expr.get_literal ()->get_type_hint ())
+	  switch (expr.get_literal ().get_type_hint ())
 	    {
 	    case CORETYPE_F32:
 	      ok = context->lookup_builtin ("f32", &infered);
@@ -727,7 +727,7 @@ public:
 	  /* Capacity is the size of the string (number of chars).
 	     It is a constant, but for fold it to get a tree.  */
 	  std::string capacity_str
-	    = std::to_string (expr.get_literal ()->as_string ().size ());
+	    = std::to_string (expr.get_literal ().as_string ().size ());
 	  HIR::LiteralExpr literal_capacity (capacity_mapping, capacity_str,
 					     HIR::Literal::LitType::INT,
 					     PrimitiveCoreType::CORETYPE_USIZE,

--- a/gcc/rust/typecheck/rust-tycheck-dump.h
+++ b/gcc/rust/typecheck/rust-tycheck-dump.h
@@ -141,7 +141,7 @@ public:
 
   void visit (HIR::LiteralExpr &expr) override
   {
-    dump += expr.get_literal ()->as_string () + ":"
+    dump += expr.get_literal ().as_string () + ":"
 	    + type_string (expr.get_mappings ());
   }
 

--- a/gcc/rust/typecheck/rust-tyty-cast.h
+++ b/gcc/rust/typecheck/rust-tyty-cast.h
@@ -444,7 +444,7 @@ public:
   void visit (FloatType &type) override
   {
     bool is_valid
-      = (base->get_infer_kind () == TyTy::InferType::InferTypeKind::GENERAL)
+      = (base->get_infer_kind () == TyTy::InferType::InferTypeKind::INTEGRAL)
 	|| (base->get_infer_kind () == TyTy::InferType::InferTypeKind::FLOAT);
     if (is_valid)
       {

--- a/gcc/testsuite/rust/compile/issue-635-1.rs
+++ b/gcc/testsuite/rust/compile/issue-635-1.rs
@@ -1,0 +1,5 @@
+// { dg-additional-options "-w" }
+fn test() -> i32 {
+    return 10000000000000000000000000000000000000000000;
+    // { dg-error "integer overflows the respective type .i32." "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/compile/issue-635-2.rs
+++ b/gcc/testsuite/rust/compile/issue-635-2.rs
@@ -1,0 +1,5 @@
+// { dg-additional-options "-w" }
+fn test() -> f32 {
+    return 10000000000000000000000000000000000000000000.0f32;
+    // { dg-error "decimal overflows the respective type .f32." "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
This checks that the literal value is within the bounds of their respective
types. I have omitted code fixing the other issue in the bug report that
overflow/max_val integers should be saturated to infinity when cast to
REAL_TYPE's this seems like something we really should have documentation
to reference in the code as to why this is the correct Rust behaviour.

Addresses #635
