### PR TITLE
Add support for Wildcard pattern binding

### DIFF
--- a/gcc/rust/backend/rust-compile-fnparam.h
+++ b/gcc/rust/backend/rust-compile-fnparam.h
@@ -52,6 +52,16 @@ public:
       fndecl, pattern.get_identifier (), decl_type, address_taken, locus);
   }
 
+  void visit (HIR::WildcardPattern &pattern) override
+  {
+    decl_type = ctx->get_backend ()->immutable_type (decl_type);
+
+    bool address_taken = false;
+    compiled_param
+      = ctx->get_backend ()->parameter_variable (fndecl, "_", decl_type,
+						 address_taken, locus);
+  }
+
 private:
   CompileFnParam (Context *ctx, tree fndecl, tree decl_type, Location locus,
 		  const HIR::FunctionParam &param)

--- a/gcc/rust/backend/rust-compile-var-decl.h
+++ b/gcc/rust/backend/rust-compile-var-decl.h
@@ -64,6 +64,15 @@ public:
 					     address_taken, locus);
   }
 
+  void visit (HIR::WildcardPattern &pattern) override
+  {
+    translated_type = ctx->get_backend ()->immutable_type (translated_type);
+    compiled_variable
+      = ctx->get_backend ()->local_variable (fndecl, "_", translated_type,
+					     NULL /*decl_var*/, address_taken,
+					     locus);
+  }
+
 private:
   CompileVarDecl (Context *ctx, tree fndecl)
     : HIRCompileBase (ctx), fndecl (fndecl),

--- a/gcc/rust/hir/rust-ast-lower-pattern.cc
+++ b/gcc/rust/hir/rust-ast-lower-pattern.cc
@@ -135,5 +135,16 @@ ASTLoweringPattern::visit (AST::StructPattern &pattern)
   translated = new HIR::StructPattern (mapping, *path, std::move (elems));
 }
 
+void
+ASTLoweringPattern::visit (AST::WildcardPattern &pattern)
+{
+  auto crate_num = mappings->get_current_crate ();
+  Analysis::NodeMapping mapping (crate_num, pattern.get_node_id (),
+				 mappings->get_next_hir_id (crate_num),
+				 UNKNOWN_LOCAL_DEFID);
+
+  translated = new HIR::WildcardPattern (mapping, pattern.get_locus ());
+}
+
 } // namespace HIR
 } // namespace Rust

--- a/gcc/rust/hir/rust-ast-lower-pattern.h
+++ b/gcc/rust/hir/rust-ast-lower-pattern.h
@@ -70,6 +70,8 @@ public:
 
   void visit (AST::TupleStructPattern &pattern) override;
 
+  void visit (AST::WildcardPattern &pattern) override;
+
 private:
   ASTLoweringPattern () : translated (nullptr) {}
 

--- a/gcc/rust/hir/tree/rust-hir-path.h
+++ b/gcc/rust/hir/tree/rust-hir-path.h
@@ -269,6 +269,11 @@ public:
   PathExprSegment &get_root_seg () { return segments.at (0); }
 
   PathExprSegment get_final_segment () const { return segments.back (); }
+
+  PatternType get_pattern_type () const override final
+  {
+    return PatternType::PATH;
+  }
 };
 
 /* HIR node representing a path-in-expression pattern (path that allows generic

--- a/gcc/rust/hir/tree/rust-hir-pattern.h
+++ b/gcc/rust/hir/tree/rust-hir-pattern.h
@@ -49,13 +49,18 @@ public:
       has_minus (has_minus), locus (locus), mappings (mappings)
   {}
 
-  Location get_locus () const { return locus; }
+  Location get_locus () const override { return locus; }
 
   void accept_vis (HIRFullVisitor &vis) override;
 
   Analysis::NodeMapping get_pattern_mappings () const override final
   {
     return mappings;
+  }
+
+  PatternType get_pattern_type () const override final
+  {
+    return PatternType::LITERAL;
   }
 
 protected:
@@ -122,7 +127,7 @@ public:
   IdentifierPattern (IdentifierPattern &&other) = default;
   IdentifierPattern &operator= (IdentifierPattern &&other) = default;
 
-  Location get_locus () const { return locus; }
+  Location get_locus () const override { return locus; }
 
   bool is_mut () const { return mut == Mutability::Mut; }
 
@@ -134,6 +139,11 @@ public:
   }
 
   Identifier get_identifier () const { return variable_ident; }
+
+  PatternType get_pattern_type () const override final
+  {
+    return PatternType::IDENTIFIER;
+  }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather
@@ -157,13 +167,18 @@ public:
     : locus (locus), mappings (mappings)
   {}
 
-  Location get_locus () const { return locus; }
+  Location get_locus () const override { return locus; }
 
   void accept_vis (HIRFullVisitor &vis) override;
 
   Analysis::NodeMapping get_pattern_mappings () const override final
   {
     return mappings;
+  }
+
+  PatternType get_pattern_type () const override final
+  {
+    return PatternType::WILDCARD;
   }
 
 protected:
@@ -335,13 +350,18 @@ public:
   RangePattern (RangePattern &&other) = default;
   RangePattern &operator= (RangePattern &&other) = default;
 
-  Location get_locus () const { return locus; }
+  Location get_locus () const override { return locus; }
 
   void accept_vis (HIRFullVisitor &vis) override;
 
   Analysis::NodeMapping get_pattern_mappings () const override final
   {
     return mappings;
+  }
+
+  PatternType get_pattern_type () const override final
+  {
+    return PatternType::RANGE;
   }
 
 protected:
@@ -405,6 +425,11 @@ public:
   }
 
   Location get_locus () const override final { return locus; }
+
+  PatternType get_pattern_type () const override final
+  {
+    return PatternType::REFERENCE;
+  }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather
@@ -671,7 +696,7 @@ public:
 
   bool has_struct_pattern_elems () const { return !elems.is_empty (); }
 
-  Location get_locus () const { return path.get_locus (); }
+  Location get_locus () const override { return path.get_locus (); }
 
   void accept_vis (HIRFullVisitor &vis) override;
 
@@ -681,6 +706,11 @@ public:
   Analysis::NodeMapping get_pattern_mappings () const override final
   {
     return mappings;
+  }
+
+  PatternType get_pattern_type () const override final
+  {
+    return PatternType::STRUCT;
   }
 
 protected:
@@ -894,7 +924,7 @@ public:
   TupleStructPattern (TupleStructPattern &&other) = default;
   TupleStructPattern &operator= (TupleStructPattern &&other) = default;
 
-  Location get_locus () const { return path.get_locus (); }
+  Location get_locus () const override { return path.get_locus (); }
 
   void accept_vis (HIRFullVisitor &vis) override;
 
@@ -905,6 +935,11 @@ public:
   Analysis::NodeMapping get_pattern_mappings () const override final
   {
     return mappings;
+  }
+
+  PatternType get_pattern_type () const override final
+  {
+    return PatternType::TUPLE_STRUCT;
   }
 
 protected:
@@ -939,41 +974,6 @@ protected:
   // pure virtual clone implementation
   virtual TuplePatternItems *clone_tuple_pattern_items_impl () const = 0;
 };
-
-// Class representing TuplePattern patterns where there is only a single pattern
-/*class TuplePatternItemsSingle : public TuplePatternItems {
-    // Pattern pattern;
-    std::unique_ptr<Pattern> pattern;
-
-  public:
-    TuplePatternItemsSingle(Pattern* pattern) : pattern(pattern) {}
-
-    // Copy constructor uses clone
-    TuplePatternItemsSingle(TuplePatternItemsSingle const& other) :
-      pattern(other.pattern->clone_pattern()) {}
-
-    // Destructor - define here if required
-
-    // Overload assignment operator to clone
-    TuplePatternItemsSingle& operator=(TuplePatternItemsSingle const& other) {
-	pattern = other.pattern->clone_pattern();
-
-	return *this;
-    }
-
-    // move constructors
-    TuplePatternItemsSingle(TuplePatternItemsSingle&& other) = default;
-    TuplePatternItemsSingle& operator=(TuplePatternItemsSingle&& other) =
-default;
-
-  protected:
-    // Use covariance to implement clone function as returning this object
-rather than base virtual TuplePatternItemsSingle*
-clone_tuple_pattern_items_impl() const override { return new
-TuplePatternItemsSingle(*this);
-    }
-};*/
-// removed in favour of single-element TuplePatternItemsMultiple
 
 // Class representing TuplePattern patterns where there are multiple patterns
 class TuplePatternItemsMultiple : public TuplePatternItems
@@ -1113,13 +1113,18 @@ public:
     return *this;
   }
 
-  Location get_locus () const { return locus; }
+  Location get_locus () const override { return locus; }
 
   void accept_vis (HIRFullVisitor &vis) override;
 
   Analysis::NodeMapping get_pattern_mappings () const override final
   {
     return mappings;
+  }
+
+  PatternType get_pattern_type () const override final
+  {
+    return PatternType::TUPLE;
   }
 
 protected:
@@ -1170,13 +1175,18 @@ public:
   GroupedPattern (GroupedPattern &&other) = default;
   GroupedPattern &operator= (GroupedPattern &&other) = default;
 
-  Location get_locus () const { return locus; }
+  Location get_locus () const override { return locus; }
 
   void accept_vis (HIRFullVisitor &vis) override;
 
   Analysis::NodeMapping get_pattern_mappings () const override final
   {
     return mappings;
+  }
+
+  PatternType get_pattern_type () const override final
+  {
+    return PatternType::GROUPED;
   }
 
 protected:
@@ -1229,13 +1239,18 @@ public:
   SlicePattern (SlicePattern &&other) = default;
   SlicePattern &operator= (SlicePattern &&other) = default;
 
-  Location get_locus () const { return locus; }
+  Location get_locus () const override { return locus; }
 
   void accept_vis (HIRFullVisitor &vis) override;
 
   Analysis::NodeMapping get_pattern_mappings () const override final
   {
     return mappings;
+  }
+
+  PatternType get_pattern_type () const override final
+  {
+    return PatternType::SLICE;
   }
 
 protected:

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -314,6 +314,21 @@ protected:
 class Pattern
 {
 public:
+  enum PatternType
+  {
+    PATH,
+    LITERAL,
+    IDENTIFIER,
+    WILDCARD,
+    RANGE,
+    REFERENCE,
+    STRUCT,
+    TUPLE_STRUCT,
+    TUPLE,
+    GROUPED,
+    SLICE,
+  };
+
   // Unique pointer custom clone function
   std::unique_ptr<Pattern> clone_pattern () const
   {
@@ -331,6 +346,8 @@ public:
   virtual Analysis::NodeMapping get_pattern_mappings () const = 0;
 
   virtual Location get_locus () const = 0;
+
+  virtual PatternType get_pattern_type () const = 0;
 
 protected:
   // Clone pattern implementation as pure virtual method

--- a/gcc/rust/resolve/rust-ast-resolve-pattern.h
+++ b/gcc/rust/resolve/rust-ast-resolve-pattern.h
@@ -83,6 +83,17 @@ public:
 				    pattern.get_is_mut ());
   }
 
+  void visit (AST::WildcardPattern &pattern) override
+  {
+    resolver->get_name_scope ().insert (
+      CanonicalPath::new_seg (pattern.get_node_id (), "_"),
+      pattern.get_node_id (), pattern.get_locus ());
+    resolver->insert_new_definition (pattern.get_node_id (),
+				     Definition{pattern.get_node_id (),
+						parent});
+    resolver->mark_decl_mutability (pattern.get_node_id (), false);
+  }
+
   // cases in a match expression
   void visit (AST::PathInExpression &pattern) override;
 

--- a/gcc/testsuite/rust/compile/issue-557.rs
+++ b/gcc/testsuite/rust/compile/issue-557.rs
@@ -1,0 +1,4 @@
+// { dg-additional-options "-w" }
+fn test(a: i32, _: i32) {
+    let _ = 42 + a;
+}


### PR DESCRIPTION
Wildcard bindings allow us to bind expression to be unused such as:

  let _ = 123;

They are more commonly used in destructuring of tuples such as:

  let my_tuple = (1,2);
  let (a,_) = my_tuple;

This is the initial basic support for the basic form of let _ = ...; and
it also allows us to ignore parameters within functions as well.

Fixes #557
