### PR TITLE
Track end locus of BlockExpr

### DIFF
--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -2326,7 +2326,8 @@ class BlockExpr : public ExprWithBlock
   std::vector<Attribute> inner_attrs;
   std::vector<std::unique_ptr<Stmt> > statements;
   std::unique_ptr<Expr> expr;
-  Location locus;
+  Location start_locus;
+  Location end_locus;
   bool marked_for_strip = false;
 
 public:
@@ -2341,18 +2342,19 @@ public:
   BlockExpr (std::vector<std::unique_ptr<Stmt> > block_statements,
 	     std::unique_ptr<Expr> block_expr,
 	     std::vector<Attribute> inner_attribs,
-	     std::vector<Attribute> outer_attribs, Location locus)
+	     std::vector<Attribute> outer_attribs, Location start_locus,
+	     Location end_locus)
     : outer_attrs (std::move (outer_attribs)),
       inner_attrs (std::move (inner_attribs)),
       statements (std::move (block_statements)), expr (std::move (block_expr)),
-      locus (locus)
+      start_locus (start_locus), end_locus (end_locus)
   {}
 
   // Copy constructor with clone
   BlockExpr (BlockExpr const &other)
     : ExprWithBlock (other), outer_attrs (other.outer_attrs),
-      inner_attrs (other.inner_attrs), locus (other.locus),
-      marked_for_strip (other.marked_for_strip)
+      inner_attrs (other.inner_attrs), start_locus (other.start_locus),
+      end_locus (other.end_locus), marked_for_strip (other.marked_for_strip)
   {
     // guard to protect from null pointer dereference
     if (other.expr != nullptr)
@@ -2368,7 +2370,8 @@ public:
   {
     ExprWithBlock::operator= (other);
     inner_attrs = other.inner_attrs;
-    locus = other.locus;
+    start_locus = other.start_locus;
+    end_locus = other.end_locus;
     marked_for_strip = other.marked_for_strip;
     outer_attrs = other.outer_attrs;
 
@@ -2395,7 +2398,10 @@ public:
     return std::unique_ptr<BlockExpr> (clone_block_expr_impl ());
   }
 
-  Location get_locus () const override final { return locus; }
+  Location get_locus () const override final { return start_locus; }
+
+  Location get_start_locus () const { return start_locus; }
+  Location get_end_locus () const { return end_locus; }
 
   void accept_vis (ASTVisitor &vis) override;
 

--- a/gcc/rust/backend/rust-compile-implitem.h
+++ b/gcc/rust/backend/rust-compile-implitem.h
@@ -264,7 +264,7 @@ public:
     tree enclosing_scope = NULL_TREE;
     HIR::BlockExpr *function_body = function.get_definition ().get ();
     Location start_location = function_body->get_locus ();
-    Location end_location = function_body->get_closing_locus ();
+    Location end_location = function_body->get_end_locus ();
 
     tree code_block
       = ctx->get_backend ()->block (fndecl, enclosing_scope, locals,
@@ -524,7 +524,7 @@ public:
     tree enclosing_scope = NULL_TREE;
     HIR::BlockExpr *function_body = func.get_block_expr ().get ();
     Location start_location = function_body->get_locus ();
-    Location end_location = function_body->get_closing_locus ();
+    Location end_location = function_body->get_end_locus ();
 
     tree code_block
       = ctx->get_backend ()->block (fndecl, enclosing_scope, locals,

--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -142,7 +142,7 @@ public:
 	HIR::BlockExpr *function_body
 	  = static_cast<HIR::BlockExpr *> (constant.get_expr ());
 	Location start_location = function_body->get_locus ();
-	Location end_location = function_body->get_closing_locus ();
+	Location end_location = function_body->get_end_locus ();
 
 	tree code_block
 	  = ctx->get_backend ()->block (fndecl, enclosing_scope, {},
@@ -341,7 +341,7 @@ public:
     tree enclosing_scope = NULL_TREE;
     HIR::BlockExpr *function_body = function.get_definition ().get ();
     Location start_location = function_body->get_locus ();
-    Location end_location = function_body->get_closing_locus ();
+    Location end_location = function_body->get_end_locus ();
 
     tree code_block
       = ctx->get_backend ()->block (fndecl, enclosing_scope, locals,

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -60,7 +60,7 @@ CompileBlock::visit (HIR::BlockExpr &expr)
   fncontext fnctx = ctx->peek_fn ();
   tree fndecl = fnctx.fndecl;
   Location start_location = expr.get_locus ();
-  Location end_location = expr.get_closing_locus ();
+  Location end_location = expr.get_end_locus ();
   auto body_mappings = expr.get_mappings ();
 
   Resolver::Rib *rib = nullptr;

--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -101,7 +101,8 @@ ASTLoweringBlock::visit (AST::BlockExpr &expr)
     = new HIR::BlockExpr (mapping, std::move (block_stmts),
 			  std::unique_ptr<HIR::ExprWithoutBlock> (tail_expr),
 			  tail_reachable, expr.get_inner_attrs (),
-			  expr.get_outer_attrs (), expr.get_locus ());
+			  expr.get_outer_attrs (), expr.get_start_locus (),
+			  expr.get_end_locus ());
 
   terminated = block_did_terminate;
 }

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -2069,7 +2069,8 @@ public:
   std::vector<std::unique_ptr<Stmt> > statements;
   std::unique_ptr<Expr> expr;
   bool tail_reachable;
-  Location locus;
+  Location start_locus;
+  Location end_locus;
 
   std::string as_string () const override;
 
@@ -2085,17 +2086,19 @@ public:
 	     std::vector<std::unique_ptr<Stmt> > block_statements,
 	     std::unique_ptr<Expr> block_expr, bool tail_reachable,
 	     AST::AttrVec inner_attribs, AST::AttrVec outer_attribs,
-	     Location locus)
+	     Location start_locus, Location end_locus)
     : ExprWithBlock (std::move (mappings), std::move (outer_attribs)),
       inner_attrs (std::move (inner_attribs)),
       statements (std::move (block_statements)), expr (std::move (block_expr)),
-      tail_reachable (tail_reachable), locus (locus)
+      tail_reachable (tail_reachable), start_locus (start_locus),
+      end_locus (end_locus)
   {}
 
   // Copy constructor with clone
   BlockExpr (BlockExpr const &other)
     : ExprWithBlock (other), /*statements(other.statements),*/
-      inner_attrs (other.inner_attrs), locus (other.locus)
+      inner_attrs (other.inner_attrs), start_locus (other.start_locus),
+      end_locus (other.end_locus)
   {
     // guard to protect from null pointer dereference
     if (other.expr != nullptr)
@@ -2113,7 +2116,8 @@ public:
     // statements = other.statements;
     expr = other.expr->clone_expr ();
     inner_attrs = other.inner_attrs;
-    locus = other.locus;
+    start_locus = other.end_locus;
+    end_locus = other.end_locus;
     // outer_attrs = other.outer_attrs;
 
     statements.reserve (other.statements.size ());
@@ -2133,19 +2137,15 @@ public:
     return std::unique_ptr<BlockExpr> (clone_block_expr_impl ());
   }
 
-  Location get_locus () const override final { return locus; }
+  Location get_locus () const override final { return start_locus; }
+
+  Location get_start_locus () const { return start_locus; }
+
+  Location get_end_locus () const { return end_locus; }
 
   void accept_vis (HIRFullVisitor &vis) override;
 
   bool is_final_stmt (Stmt *stmt) { return statements.back ().get () == stmt; }
-
-  Location get_closing_locus ()
-  {
-    if (statements.size () == 0)
-      return get_locus ();
-
-    return statements[statements.size () - 1]->get_locus ();
-  }
 
   std::unique_ptr<Expr> &get_final_expr () { return expr; }
 

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -7347,6 +7347,8 @@ Parser<ManagedTokenSource>::parse_block_expr (AST::AttrVec outer_attrs,
 	  return nullptr;
 	}
 
+      t = lexer.peek_token ();
+
       if (expr_or_stmt.stmt != nullptr)
 	{
 	  stmts.push_back (std::move (expr_or_stmt.stmt));
@@ -7357,9 +7359,9 @@ Parser<ManagedTokenSource>::parse_block_expr (AST::AttrVec outer_attrs,
 	  expr = std::move (expr_or_stmt.expr);
 	  break;
 	}
-
-      t = lexer.peek_token ();
     }
+
+  Location end_locus = t->get_locus ();
 
   if (!skip_token (RIGHT_CURLY))
     {
@@ -7378,8 +7380,8 @@ Parser<ManagedTokenSource>::parse_block_expr (AST::AttrVec outer_attrs,
 
   return std::unique_ptr<AST::BlockExpr> (
     new AST::BlockExpr (std::move (stmts), std::move (expr),
-			std::move (inner_attrs), std::move (outer_attrs),
-			locus));
+			std::move (inner_attrs), std::move (outer_attrs), locus,
+			end_locus));
 }
 
 /* Parses a "grouped" expression (expression in parentheses), used to control


### PR DESCRIPTION
Capture the closing locus of a block during parsing, and remove the old
hack to get the final statement locus within the block now that it is
properly tracked.

Fixes #864
