### PR TITLE
Record correct location when compiling ADT types

### DIFF
--- a/gcc/rust/backend/rust-compile-type.cc
+++ b/gcc/rust/backend/rust-compile-type.cc
@@ -281,7 +281,7 @@ TyTyResolveCompile::visit (const TyTy::ADTType &type)
   tree named_struct
     = ctx->get_backend ()->named_type (type.get_name (), type_record,
 				       ctx->get_mappings ()->lookup_location (
-					 type.get_ty_ref ()));
+					 type.get_ref ()));
 
   ctx->push_type (named_struct);
   translated = named_struct;

--- a/gcc/testsuite/rust/compile/torture/struct_decl.rs
+++ b/gcc/testsuite/rust/compile/torture/struct_decl.rs
@@ -1,0 +1,14 @@
+// { dg-additional-options -fdump-tree-gimple }
+
+struct Foo {
+  a: u16,
+// { dg-warning "field is never read" "" { target *-*-* } .-1 }
+  b: u8,
+// { dg-warning "field is never read" "" { target *-*-* } .-1 }
+}
+
+fn main() {
+  let my_foo = Foo { a: 1, b: 2 };
+  // { dg-warning "unused name" "" { target *-*-* } .-1 }
+  // { dg-final { scan-tree-dump-times {(?n)const struct Foo my_foo;$} 1 gimple } }
+}


### PR DESCRIPTION
When compiling struct and union types, we were using the wrong HirId
to lookup location information. The resulting GIMPLE nodes therefore
had no source location information, which made them indistinguishable
as user-declarations versus decls created by the compiler. As a result,
the type names were not shown in GIMPLE dumps, e.g. using
-fdump-tree-gimple.

Fix the location lookup, so these types are properly printed, and add a
simple test checking as much.

Fixes: #877

