### PR TITLE
Covariant types should respect the get_name

### DIFF
--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -1930,7 +1930,10 @@ public:
 
   std::string as_string () const override;
 
-  std::string get_name () const override final { return as_string (); }
+  std::string get_name () const override final
+  {
+    return "&" + get_base ()->get_name ();
+  }
 
   BaseType *unify (BaseType *other) override;
   bool can_eq (const BaseType *other, bool emit_errors,
@@ -1978,7 +1981,10 @@ public:
 
   std::string as_string () const override;
 
-  std::string get_name () const override final { return as_string (); }
+  std::string get_name () const override final
+  {
+    return "*" + get_base ()->get_name ();
+  }
 
   BaseType *unify (BaseType *other) override;
   bool can_eq (const BaseType *other, bool emit_errors,


### PR DESCRIPTION
This changes the Reference and Pointer types to respect the get_name
convention this means the canonical name for functions with their respective
substitutions string is properly formatted.