### PR TITLE
Add TraitItemKind to HIR TraitItems

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-full-test.cc
+++ b/gcc/rust/hir/tree/rust-hir-full-test.cc
@@ -3453,7 +3453,7 @@ TraitFunctionDecl::as_string () const
   str += "\n Function params: ";
   if (is_method ())
     {
-      str += self.as_string ();
+      str += self.as_string () + (has_params () ? ", " : "");
     }
 
   if (has_params ())
@@ -3463,7 +3463,7 @@ TraitFunctionDecl::as_string () const
 	  str += "\n  " + param.as_string ();
 	}
     }
-  else
+  else if (!is_method ())
     {
       str += "none";
     }

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -2346,6 +2346,11 @@ public:
     return decl.get_function_name ();
   }
 
+  TraitItemKind get_item_kind () const override final
+  {
+    return TraitItemKind::FUNC;
+  }
+
 protected:
   // Clone function implementation as (not pure) virtual method
   TraitItemFunc *clone_trait_item_impl () const override
@@ -2419,6 +2424,11 @@ public:
   }
 
   const std::string trait_identifier () const override final { return name; }
+
+  TraitItemKind get_item_kind () const override final
+  {
+    return TraitItemKind::CONST;
+  }
 
 protected:
   // Clone function implementation as (not pure) virtual method
@@ -2494,6 +2504,11 @@ public:
   }
 
   const std::string trait_identifier () const override final { return name; }
+
+  TraitItemKind get_item_kind () const override final
+  {
+    return TraitItemKind::TYPE;
+  }
 
 protected:
   // Clone function implementation as (not pure) virtual method

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -677,6 +677,14 @@ protected:
 // Item used in trait declarations - abstract base class
 class TraitItem
 {
+public:
+  enum TraitItemKind
+  {
+    FUNC,
+    CONST,
+    TYPE
+  };
+
 protected:
   // Constructor
   TraitItem (Analysis::NodeMapping mappings) : mappings (mappings) {}
@@ -701,6 +709,8 @@ public:
   virtual const std::string trait_identifier () const = 0;
 
   const Analysis::NodeMapping get_mappings () const { return mappings; }
+
+  virtual TraitItemKind get_item_kind () const = 0;
 };
 
 class ImplItem


### PR DESCRIPTION
This allows us to safely switch and cast between the items without the
need for visitors.
