### PR TITLE
Extract AsyncConstStatus to be a shared enum between AST and HIR

### DIFF
--- a/gcc/rust/ast/rust-ast-full-test.cc
+++ b/gcc/rust/ast/rust-ast-full-test.cc
@@ -2288,10 +2288,10 @@ FunctionQualifiers::as_string () const
     case NONE:
       // do nothing
       break;
-    case CONST:
+    case CONST_FN:
       str += "const ";
       break;
-    case ASYNC:
+    case ASYNC_FN:
       str += "async ";
       break;
     default:

--- a/gcc/rust/ast/rust-type.h
+++ b/gcc/rust/ast/rust-type.h
@@ -928,6 +928,8 @@ public:
     return return_type;
   }
 
+  FunctionQualifiers get_function_qualifiers () { return function_qualifiers; }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */

--- a/gcc/rust/hir/rust-ast-lower-implitem.h
+++ b/gcc/rust/hir/rust-ast-lower-implitem.h
@@ -118,8 +118,8 @@ public:
     // ignore for now and leave empty
     std::vector<std::unique_ptr<HIR::WhereClauseItem> > where_clause_items;
     HIR::WhereClause where_clause (std::move (where_clause_items));
-    HIR::FunctionQualifiers qualifiers (
-      HIR::FunctionQualifiers::AsyncConstStatus::NONE, Unsafety::Normal);
+    HIR::FunctionQualifiers qualifiers
+      = lower_qualifiers (function.get_qualifiers ());
     HIR::Visibility vis = HIR::Visibility::create_public ();
 
     // need
@@ -202,8 +202,8 @@ public:
     // ignore for now and leave empty
     std::vector<std::unique_ptr<HIR::WhereClauseItem> > where_clause_items;
     HIR::WhereClause where_clause (std::move (where_clause_items));
-    HIR::FunctionQualifiers qualifiers (
-      HIR::FunctionQualifiers::AsyncConstStatus::NONE, Unsafety::Normal);
+    HIR::FunctionQualifiers qualifiers
+      = lower_qualifiers (method.get_qualifiers ());
     HIR::Visibility vis = HIR::Visibility::create_public ();
 
     // need
@@ -314,8 +314,8 @@ public:
 
     std::vector<std::unique_ptr<HIR::WhereClauseItem> > where_clause_items;
     HIR::WhereClause where_clause (std::move (where_clause_items));
-    HIR::FunctionQualifiers qualifiers (
-      HIR::FunctionQualifiers::AsyncConstStatus::NONE, Unsafety::Normal);
+    HIR::FunctionQualifiers qualifiers
+      = lower_qualifiers (func.get_trait_function_decl ().get_qualifiers ());
 
     std::vector<std::unique_ptr<HIR::GenericParam> > generic_params;
     if (ref.has_generics ())
@@ -392,8 +392,8 @@ public:
 
     std::vector<std::unique_ptr<HIR::WhereClauseItem> > where_clause_items;
     HIR::WhereClause where_clause (std::move (where_clause_items));
-    HIR::FunctionQualifiers qualifiers (
-      HIR::FunctionQualifiers::AsyncConstStatus::NONE, Unsafety::Normal);
+    HIR::FunctionQualifiers qualifiers
+      = lower_qualifiers (method.get_trait_method_decl ().get_qualifiers ());
 
     std::vector<std::unique_ptr<HIR::GenericParam> > generic_params;
     if (ref.has_generics ())

--- a/gcc/rust/hir/rust-ast-lower-stmt.h
+++ b/gcc/rust/hir/rust-ast-lower-stmt.h
@@ -356,8 +356,8 @@ public:
     // ignore for now and leave empty
     std::vector<std::unique_ptr<HIR::WhereClauseItem>> where_clause_items;
     HIR::WhereClause where_clause (std::move (where_clause_items));
-    HIR::FunctionQualifiers qualifiers (
-      HIR::FunctionQualifiers::AsyncConstStatus::NONE, Unsafety::Normal);
+    HIR::FunctionQualifiers qualifiers
+      = lower_qualifiers (function.get_qualifiers ());
     HIR::Visibility vis = HIR::Visibility::create_public ();
 
     // need

--- a/gcc/rust/hir/rust-ast-lower-type.h
+++ b/gcc/rust/hir/rust-ast-lower-type.h
@@ -135,8 +135,8 @@ public:
   {
     bool is_variadic = false;
     std::vector<HIR::LifetimeParam> lifetime_params;
-    HIR::FunctionQualifiers qualifiers (
-      HIR::FunctionQualifiers::AsyncConstStatus::NONE, Unsafety::Normal);
+    HIR::FunctionQualifiers qualifiers
+      = lower_qualifiers (fntype.get_function_qualifiers ());
 
     std::vector<HIR::MaybeNamedParam> named_params;
     for (auto &param : fntype.get_function_params ())

--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -597,20 +597,6 @@ struct_field_name_exists (std::vector<HIR::StructField> &fields,
 HIR::FunctionQualifiers
 ASTLoweringBase::lower_qualifiers (const AST::FunctionQualifiers &qualifiers)
 {
-  HIR::FunctionQualifiers::AsyncConstStatus const_status;
-  switch (qualifiers.get_const_status ())
-    {
-    case AST::FunctionQualifiers::AsyncConstStatus::NONE:
-      const_status = HIR::FunctionQualifiers::AsyncConstStatus::NONE;
-      break;
-    case AST::FunctionQualifiers::AsyncConstStatus::CONST:
-      const_status = HIR::FunctionQualifiers::AsyncConstStatus::CONST;
-      break;
-    case AST::FunctionQualifiers::AsyncConstStatus::ASYNC:
-      const_status = HIR::FunctionQualifiers::AsyncConstStatus::ASYNC;
-      break;
-    }
-
   Unsafety unsafety
     = qualifiers.is_unsafe () ? Unsafety::Unsafe : Unsafety::Normal;
   bool has_extern = qualifiers.is_extern ();
@@ -618,8 +604,8 @@ ASTLoweringBase::lower_qualifiers (const AST::FunctionQualifiers &qualifiers)
   // FIXME turn this into the Rust::ABI enum
   std::string extern_abi = qualifiers.get_extern_abi ();
 
-  return HIR::FunctionQualifiers (const_status, unsafety, has_extern,
-				  extern_abi);
+  return HIR::FunctionQualifiers (qualifiers.get_const_status (), unsafety,
+				  has_extern, extern_abi);
 }
 
 } // namespace HIR

--- a/gcc/rust/hir/tree/rust-hir-full-test.cc
+++ b/gcc/rust/hir/tree/rust-hir-full-test.cc
@@ -2040,10 +2040,10 @@ FunctionQualifiers::as_string () const
     case NONE:
       // do nothing
       break;
-    case CONST:
+    case CONST_FN:
       str += "const ";
       break;
-    case ASYNC:
+    case ASYNC_FN:
       str += "async ";
       break;
     default:

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -477,24 +477,12 @@ public:
 // Qualifiers for function, i.e. const, unsafe, extern etc.
 struct FunctionQualifiers
 {
-public:
-  /* Whether the function is neither const nor async, const only, or async
-   * only. */
-  enum AsyncConstStatus
-  {
-    NONE,
-    CONST,
-    ASYNC
-  };
-
 private:
   AsyncConstStatus const_status;
   Unsafety unsafety;
   bool has_extern;
   std::string extern_abi; // e.g. extern "C" fn() -> i32 {}
   // TODO: maybe ensure that extern_abi only exists if extern exists?
-
-  // should this store location info?
 
 public:
   FunctionQualifiers (AsyncConstStatus const_status, Unsafety unsafety,
@@ -514,7 +502,7 @@ public:
 
   AsyncConstStatus get_status () const { return const_status; }
 
-  bool is_const () const { return const_status == AsyncConstStatus::CONST; }
+  bool is_const () const { return const_status == AsyncConstStatus::CONST_FN; }
 };
 
 // A function parameter

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -2602,8 +2602,7 @@ template <typename ManagedTokenSource>
 AST::FunctionQualifiers
 Parser<ManagedTokenSource>::parse_function_qualifiers ()
 {
-  AST::FunctionQualifiers::AsyncConstStatus const_status
-    = AST::FunctionQualifiers::NONE;
+  AsyncConstStatus const_status = NONE;
   // bool has_const = false;
   bool has_unsafe = false;
   bool has_extern = false;
@@ -2615,11 +2614,11 @@ Parser<ManagedTokenSource>::parse_function_qualifiers ()
     {
     case CONST:
       lexer.skip_token ();
-      const_status = AST::FunctionQualifiers::CONST;
+      const_status = CONST_FN;
       break;
     case ASYNC:
       lexer.skip_token ();
-      const_status = AST::FunctionQualifiers::ASYNC;
+      const_status = ASYNC_FN;
       break;
     default:
       // const status is still none

--- a/gcc/rust/util/rust-common.h
+++ b/gcc/rust/util/rust-common.h
@@ -41,6 +41,13 @@ enum Polarity
   Negative
 };
 
+enum AsyncConstStatus
+{
+  NONE,
+  CONST_FN,
+  ASYNC_FN
+};
+
 } // namespace Rust
 
 #endif // RUST_COMMON


### PR DESCRIPTION
This allows us to reuse the same enum and fix the uninitilized warning
as it has already been setup before hand in the AST.

Fixes #875