### PR TITLE
Improve error message for failure in Method resolution

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -299,17 +299,10 @@ public:
       = MethodResolution::Select (candidates, receiver_tyty, adjustments);
     if (resolved_candidate == nullptr)
       {
-	if (candidates.size () > 1)
-	  {
-	    // not sure if this is the correct error here
-	    ReportMultipleCandidateError::Report (
-	      candidates, expr.get_method_name ().get_segment (),
-	      expr.get_method_name ().get_locus ());
-	  }
-	else
-	  {
-	    rust_error_at (expr.get_locus (), "failed to resolve method");
-	  }
+	rust_error_at (
+	  expr.get_method_name ().get_locus (),
+	  "failed to resolve method for %<%s%>",
+	  expr.get_method_name ().get_segment ().as_string ().c_str ());
 	return;
       }
 

--- a/gcc/testsuite/rust/compile/method1.rs
+++ b/gcc/testsuite/rust/compile/method1.rs
@@ -8,6 +8,6 @@ pub fn main() {
     a = Foo(123);
 
     a.test();
-    // { dg-error "failed to resolve method" "" { target *-*-* } .-1 }
+    // { dg-error "failed to resolve method for .test." "" { target *-*-* } .-1 }
     // { dg-error {failed to type resolve expression} "" { target *-*-* } .-2 }
 }


### PR DESCRIPTION
Use the locus for the method name segment and print its name as part of the
error message improves the quality of the error handling in the method
resolution.

Fixes #861