### PR TITLE
[...]/gcc/rust/hir/rust-ast-lower.cc:622:45: error: ‘const_status’ may be used uninitialized in this function [-Werror=maybe-uninitialized] [#875]

### DIFF
--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -609,6 +609,8 @@ ASTLoweringBase::lower_qualifiers (const AST::FunctionQualifiers &qualifiers)
     case AST::FunctionQualifiers::AsyncConstStatus::ASYNC:
       const_status = HIR::FunctionQualifiers::AsyncConstStatus::ASYNC;
       break;
+    default:
+      gcc_unreachable ();
     }
 
   Unsafety unsafety


### PR DESCRIPTION
Use the standard hammer to get rid of:

    [...]/source-gcc/gcc/rust/hir/rust-ast-lower.cc: In member function ‘Rust::HIR::FunctionQualifiers Rust::HIR::ASTLoweringBase::lower_qualifiers(const Rust::AST::FunctionQualifiers&)’:
    [...]/source-gcc/gcc/rust/hir/rust-ast-lower.cc:622:45: error: ‘const_status’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
      622 |                                   extern_abi);
          |                                             ^
    [...]/source-gcc/gcc/rust/hir/rust-ast-lower.cc:600:45: note: ‘const_status’ was declared here
      600 |   HIR::FunctionQualifiers::AsyncConstStatus const_status;
          |                                             ^~~~~~~~~~~~

Fixes #875.
