### PR TITLE
Added location data to Match Arm and removed unused code

### DIFF
--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -4226,6 +4226,7 @@ private:
   std::unique_ptr<Expr> guard_expr;
 
   // TODO: should this store location data?
+  Location locus;
 
 public:
   // Returns whether the MatchArm has a match arm guard expression
@@ -4234,10 +4235,12 @@ public:
   // Constructor for match arm with a guard expression
   MatchArm (std::vector<std::unique_ptr<Pattern> > match_arm_patterns,
 	    std::unique_ptr<Expr> guard_expr = nullptr,
-	    std::vector<Attribute> outer_attrs = std::vector<Attribute> ())
+	    std::vector<Attribute> outer_attrs = std::vector<Attribute> (),
+      Location locus = Location ())
     : outer_attrs (std::move (outer_attrs)),
       match_arm_patterns (std::move (match_arm_patterns)),
-      guard_expr (std::move (guard_expr))
+      guard_expr (std::move (guard_expr)),
+      locus (locus)
   {}
 
   // Copy constructor with clone
@@ -4250,6 +4253,8 @@ public:
     match_arm_patterns.reserve (other.match_arm_patterns.size ());
     for (const auto &e : other.match_arm_patterns)
       match_arm_patterns.push_back (e->clone_pattern ());
+
+    locus = other.locus;  
   }
 
   ~MatchArm () = default;
@@ -4305,36 +4310,11 @@ public:
   {
     return match_arm_patterns;
   }
+
+  Location get_locus () const { return locus; }
+
 };
 
-/*
-// Base "match case" for a match expression - abstract
-class MatchCase
-{
-  MatchArm arm;
-
-protected:
-  MatchCase (MatchArm arm) : arm (std::move (arm)) {}
-
-  // Should not require copy constructor or assignment operator overloading
-
-  // Clone function implementation as pure virtual method
-  virtual MatchCase *clone_match_case_impl () const = 0;
-
-public:
-  virtual ~MatchCase () {}
-
-  // Unique pointer custom clone function
-  std::unique_ptr<MatchCase> clone_match_case () const
-  {
-    return std::unique_ptr<MatchCase> (clone_match_case_impl ());
-  }
-
-  virtual std::string as_string () const;
-
-  virtual void accept_vis (ASTVisitor &vis) = 0;
-};
-*/
 
 /* A "match case" - a correlated match arm and resulting expression. Not
  * abstract. */
@@ -4391,95 +4371,6 @@ public:
   NodeId get_node_id () const { return node_id; }
 };
 
-#if 0
-// Block expression match case
-class MatchCaseBlockExpr : public MatchCase
-{
-  std::unique_ptr<BlockExpr> block_expr;
-
-  // TODO: should this store location data?
-
-public:
-  MatchCaseBlockExpr (MatchArm arm, std::unique_ptr<BlockExpr> block_expr)
-    : MatchCase (std::move (arm)), block_expr (std::move (block_expr))
-  {}
-
-  // Copy constructor requires clone
-  MatchCaseBlockExpr (MatchCaseBlockExpr const &other)
-    : MatchCase (other), block_expr (other.block_expr->clone_block_expr ())
-  {}
-
-  // Overload assignment operator to have clone
-  MatchCaseBlockExpr &operator= (MatchCaseBlockExpr const &other)
-  {
-    MatchCase::operator= (other);
-    block_expr = other.block_expr->clone_block_expr ();
-    // arm = other.arm;
-
-    return *this;
-  }
-
-  // move constructors
-  MatchCaseBlockExpr (MatchCaseBlockExpr &&other) = default;
-  MatchCaseBlockExpr &operator= (MatchCaseBlockExpr &&other) = default;
-
-  std::string as_string () const override;
-
-  void accept_vis (ASTVisitor &vis) override;
-
-protected:
-  /* Use covariance to implement clone function as returning this object rather
-   * than base */
-  MatchCaseBlockExpr *clone_match_case_impl () const override
-  {
-    return new MatchCaseBlockExpr (*this);
-  }
-};
-
-// Expression (except block expression) match case
-class MatchCaseExpr : public MatchCase
-{
-  std::unique_ptr<Expr> expr;
-
-  // TODO: should this store location data?
-
-public:
-  MatchCaseExpr (MatchArm arm, std::unique_ptr<Expr> expr)
-    : MatchCase (std::move (arm)), expr (std::move (expr))
-  {}
-
-  // Copy constructor requires clone
-  MatchCaseExpr (MatchCaseExpr const &other)
-    : MatchCase (other), expr (other.expr->clone_expr ())
-  {}
-
-  // Overload assignment operator to have clone
-  MatchCaseExpr &operator= (MatchCaseExpr const &other)
-  {
-    MatchCase::operator= (other);
-    expr = other.expr->clone_expr ();
-    // arm = other.arm;
-
-    return *this;
-  }
-
-  // move constructors
-  MatchCaseExpr (MatchCaseExpr &&other) = default;
-  MatchCaseExpr &operator= (MatchCaseExpr &&other) = default;
-
-  std::string as_string () const override;
-
-  void accept_vis (ASTVisitor &vis) override;
-
-protected:
-  /* Use covariance to implement clone function as returning this object rather
-   * than base */
-  MatchCaseExpr *clone_match_case_impl () const override
-  {
-    return new MatchCaseExpr (*this);
-  }
-};
-#endif
 
 // Match expression AST node
 class MatchExpr : public ExprWithBlock

--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -274,7 +274,7 @@ CompileExpr::visit (HIR::MatchExpr &expr)
       rust_assert (kase_arm.get_patterns ().size () > 0);
 
       // generate implicit label
-      Location arm_locus = kase_arm.get_patterns ().at (0)->get_locus ();
+      Location arm_locus = kase_arm.get_locus();
       tree case_label = ctx->get_backend ()->label (
 	fndecl, "" /* empty creates an artificial label */, arm_locus);
 

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -3713,6 +3713,7 @@ private:
   AST::AttrVec outer_attrs;
   std::vector<std::unique_ptr<Pattern> > match_arm_patterns;
   std::unique_ptr<Expr> guard_expr;
+  Location locus;
 
 public:
   // Returns whether the MatchArm has a match arm guard expression
@@ -3721,10 +3722,12 @@ public:
   // Constructor for match arm with a guard expression
   MatchArm (std::vector<std::unique_ptr<Pattern> > match_arm_patterns,
 	    std::unique_ptr<Expr> guard_expr = nullptr,
-	    AST::AttrVec outer_attrs = AST::AttrVec ())
+	    AST::AttrVec outer_attrs = AST::AttrVec (),
+      Location locus = Location ())
     : outer_attrs (std::move (outer_attrs)),
       match_arm_patterns (std::move (match_arm_patterns)),
-      guard_expr (std::move (guard_expr))
+      guard_expr (std::move (guard_expr)),
+      locus (locus)
   {}
 
   // Copy constructor with clone
@@ -3737,6 +3740,8 @@ public:
     match_arm_patterns.reserve (other.match_arm_patterns.size ());
     for (const auto &e : other.match_arm_patterns)
       match_arm_patterns.push_back (e->clone_pattern ());
+    
+    locus = other.locus; 
   }
 
   ~MatchArm () = default;
@@ -3775,6 +3780,9 @@ public:
   {
     return match_arm_patterns;
   }
+
+  Location get_locus () const { return locus; }
+
 };
 
 /* A "match case" - a correlated match arm and resulting expression. Not
@@ -3819,95 +3827,7 @@ public:
   std::unique_ptr<Expr> &get_expr () { return expr; }
 };
 
-#if 0
-// Block expression match case
-class MatchCaseBlockExpr : public MatchCase
-{
-  std::unique_ptr<BlockExpr> block_expr;
 
-  // TODO: should this store location data?
-
-public:
-  MatchCaseBlockExpr (MatchArm arm, std::unique_ptr<BlockExpr> block_expr)
-    : MatchCase (std::move (arm)), block_expr (std::move (block_expr))
-  {}
-
-  // Copy constructor requires clone
-  MatchCaseBlockExpr (MatchCaseBlockExpr const &other)
-    : MatchCase (other), block_expr (other.block_expr->clone_block_expr ())
-  {}
-
-  // Overload assignment operator to have clone
-  MatchCaseBlockExpr &operator= (MatchCaseBlockExpr const &other)
-  {
-    MatchCase::operator= (other);
-    block_expr = other.block_expr->clone_block_expr ();
-    // arm = other.arm;
-
-    return *this;
-  }
-
-  // move constructors
-  MatchCaseBlockExpr (MatchCaseBlockExpr &&other) = default;
-  MatchCaseBlockExpr &operator= (MatchCaseBlockExpr &&other) = default;
-
-  std::string as_string () const override;
-
-  void accept_vis (HIRFullVisitor &vis) override;
-
-protected:
-  /* Use covariance to implement clone function as returning this object rather
-   * than base */
-  MatchCaseBlockExpr *clone_match_case_impl () const override
-  {
-    return new MatchCaseBlockExpr (*this);
-  }
-};
-
-// Expression (except block expression) match case
-class MatchCaseExpr : public MatchCase
-{
-  std::unique_ptr<Expr> expr;
-
-  // TODO: should this store location data?
-
-public:
-  MatchCaseExpr (MatchArm arm, std::unique_ptr<Expr> expr)
-    : MatchCase (std::move (arm)), expr (std::move (expr))
-  {}
-
-  // Copy constructor requires clone
-  MatchCaseExpr (MatchCaseExpr const &other)
-    : MatchCase (other), expr (other.expr->clone_expr ())
-  {}
-
-  // Overload assignment operator to have clone
-  MatchCaseExpr &operator= (MatchCaseExpr const &other)
-  {
-    MatchCase::operator= (other);
-    expr = other.expr->clone_expr ();
-    // arm = other.arm;
-
-    return *this;
-  }
-
-  // move constructors
-  MatchCaseExpr (MatchCaseExpr &&other) = default;
-  MatchCaseExpr &operator= (MatchCaseExpr &&other) = default;
-
-  std::string as_string () const override;
-
-  void accept_vis (HIRFullVisitor &vis) override;
-
-protected:
-  /* Use covariance to implement clone function as returning this object rather
-   * than base */
-  MatchCaseExpr *clone_match_case_impl () const override
-  {
-    return new MatchCaseExpr (*this);
-  }
-};
-#endif
 
 // Match expression HIR node
 class MatchExpr : public ExprWithBlock


### PR DESCRIPTION
Fixes #863

-  Added location data to Match arm in gcc/rust/ast/rust-expr.h and gcc/rust/hir/tree/rust-hir-expr.h
- Updated the respective constructors and copy constructors
- Updated location info for match arm in code generation in gcc/rust/backend/eust-compile-expr.cc
- Removed unused code in the above rust-expr.h and rust-gir-expr.h files as mentioned in the issue.

Note :
-  I also added a public member funtion for the class MatchArm
    ` Location get_locus ( ) const { return locus; } ` 

Do me know if I missed anything or could improve on something.

Signed-off-by : M V V S Manoj Kumar <mvvsmanojkumar@gmail.com>
