### PR TITLE
Update name-resolution to build up canonical-path with the crate-name

### DIFF
--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -304,7 +304,7 @@ public:
   std::string mangle_item (const TyTy::BaseType *ty,
 			   const Resolver::CanonicalPath &path) const
   {
-    return mangler.mangle_item (ty, path, mappings->get_current_crate_name ());
+    return mangler.mangle_item (ty, path);
   }
 
 private:

--- a/gcc/rust/backend/rust-mangle.cc
+++ b/gcc/rust/backend/rust-mangle.cc
@@ -252,12 +252,16 @@ legacy_mangle_item (const TyTy::BaseType *ty,
 static std::string
 v0_mangle_item (const TyTy::BaseType *ty, const Resolver::CanonicalPath &path)
 {
-  std::string mangled;
+  // we can get this from the canonical_path
+  auto mappings = Analysis::Mappings::get ();
+  std::string crate_name;
+  bool ok = mappings->get_crate_name (path.get_crate_num (), crate_name);
+  rust_assert (ok);
 
+  std::string mangled;
   // FIXME: Add real algorithm once all pieces are implemented
   auto ty_prefix = v0_type_prefix (ty);
-  // crate name must be assumed to be part of the canonical path
-  // v0_add_identifier (mangled, crate_name);
+  v0_add_identifier (mangled, crate_name);
   v0_add_disambiguator (mangled, 62);
 
   gcc_unreachable ();

--- a/gcc/rust/backend/rust-mangle.cc
+++ b/gcc/rust/backend/rust-mangle.cc
@@ -9,6 +9,9 @@ static const std::string kMangledSymbolDelim = "E";
 static const std::string kMangledGenericDelim = "$C$";
 static const std::string kMangledSubstBegin = "$LT$";
 static const std::string kMangledSubstEnd = "$GT$";
+static const std::string kMangledSpace = "$u20$";
+static const std::string kMangledRef = "$RF$";
+static const std::string kQualPathBegin = "_" + kMangledSubstBegin;
 
 namespace Rust {
 namespace Compile {
@@ -22,17 +25,35 @@ legacy_mangle_name (const std::string &name)
   //  <&T as core::fmt::Debug>::fmt:
   //  _ZN42_$LT$$RF$T$u20$as$u20$core..fmt..Debug$GT$3fmt17h6dac924c0051eef7E
   // replace all white space with $ and & with RF
-
+  //
+  // <example::Bar as example::A>::fooA:
+  // _ZN43_$LT$example..Bar$u20$as$u20$example..A$GT$4fooA17hfc615fa76c7db7a0E:
+  //
+  // example::Foo<T>::new:
+  // _ZN7example12Foo$LT$T$GT$3new17h9a2aacb7fd783515E:
   std::string buffer;
-  for (const auto &c : name)
+  for (size_t i = 0; i < name.size (); i++)
     {
       std::string m;
+      char c = name.at (i);
+
       if (c == ' ')
-	m = "$";
+	m = kMangledSpace;
       else if (c == '&')
-	m = "RF";
-      else if (c == '<' || c == '>')
-	m = "..";
+	m = kMangledRef;
+      else if (i == 0 && c == '<')
+	m = kQualPathBegin;
+      else if (c == '<')
+	m = kMangledSubstBegin;
+      else if (c == '>')
+	m = kMangledSubstEnd;
+      else if (c == ':')
+	{
+	  rust_assert (i + 1 < name.size ());
+	  rust_assert (name.at (i + 1) == ':');
+	  i++;
+	  m = "..";
+	}
       else
 	m.push_back (c);
 
@@ -46,10 +67,11 @@ static std::string
 legacy_mangle_canonical_path (const Resolver::CanonicalPath &path)
 {
   std::string buffer;
-  path.iterate_segs ([&] (const Resolver::CanonicalPath &p) -> bool {
-    buffer += legacy_mangle_name (p.get ());
-    return true;
-  });
+  for (size_t i = 0; i < path.size (); i++)
+    {
+      auto &seg = path.get_seg_at (i);
+      buffer += legacy_mangle_name (seg.second);
+    }
   return buffer;
 }
 
@@ -150,7 +172,8 @@ v0_simple_type_prefix (const TyTy::BaseType *ty)
 // Add an underscore-terminated base62 integer to the mangling string.
 // This corresponds to the `<base-62-number>` grammar in the v0 mangling RFC:
 //  - 0 is encoded as "_"
-//  - any other value is encoded as itself minus one in base 62, followed by "_"
+//  - any other value is encoded as itself minus one in base 62, followed by
+//  "_"
 static void
 v0_add_integer_62 (std::string &mangled, uint64_t x)
 {
@@ -188,11 +211,11 @@ v0_add_identifier (std::string &mangled, const std::string &identifier)
 {
   // FIXME: gccrs cannot handle unicode identifiers yet, so we never have to
   // create mangling for unicode values for now. However, this is handled
-  // by the v0 mangling scheme. The grammar for unicode identifier is contained
-  // in <undisambiguated-identifier>, right under the <identifier> one. If the
-  // identifier contains unicode values, then an extra "u" needs to be added
-  // to the mangling string and `punycode` must be used to encode the
-  // characters.
+  // by the v0 mangling scheme. The grammar for unicode identifier is
+  // contained in <undisambiguated-identifier>, right under the <identifier>
+  // one. If the identifier contains unicode values, then an extra "u" needs
+  // to be added to the mangling string and `punycode` must be used to encode
+  // the characters.
 
   mangled += std::to_string (identifier.size ());
 
@@ -217,25 +240,24 @@ v0_type_prefix (const TyTy::BaseType *ty)
 
 static std::string
 legacy_mangle_item (const TyTy::BaseType *ty,
-		    const Resolver::CanonicalPath &path,
-		    const std::string &crate_name)
+		    const Resolver::CanonicalPath &path)
 {
   const std::string hash = legacy_hash (ty->as_string ());
   const std::string hash_sig = legacy_mangle_name (hash);
 
-  return kMangledSymbolPrefix + legacy_mangle_name (crate_name)
-	 + legacy_mangle_canonical_path (path) + hash_sig + kMangledSymbolDelim;
+  return kMangledSymbolPrefix + legacy_mangle_canonical_path (path) + hash_sig
+	 + kMangledSymbolDelim;
 }
 
 static std::string
-v0_mangle_item (const TyTy::BaseType *ty, const Resolver::CanonicalPath &path,
-		const std::string &crate_name)
+v0_mangle_item (const TyTy::BaseType *ty, const Resolver::CanonicalPath &path)
 {
   std::string mangled;
 
   // FIXME: Add real algorithm once all pieces are implemented
   auto ty_prefix = v0_type_prefix (ty);
-  v0_add_identifier (mangled, crate_name);
+  // crate name must be assumed to be part of the canonical path
+  // v0_add_identifier (mangled, crate_name);
   v0_add_disambiguator (mangled, 62);
 
   gcc_unreachable ();
@@ -243,15 +265,14 @@ v0_mangle_item (const TyTy::BaseType *ty, const Resolver::CanonicalPath &path,
 
 std::string
 Mangler::mangle_item (const TyTy::BaseType *ty,
-		      const Resolver::CanonicalPath &path,
-		      const std::string &crate_name) const
+		      const Resolver::CanonicalPath &path) const
 {
   switch (version)
     {
     case Mangler::MangleVersion::LEGACY:
-      return legacy_mangle_item (ty, path, crate_name);
+      return legacy_mangle_item (ty, path);
     case Mangler::MangleVersion::V0:
-      return v0_mangle_item (ty, path, crate_name);
+      return v0_mangle_item (ty, path);
     default:
       gcc_unreachable ();
     }

--- a/gcc/rust/backend/rust-mangle.h
+++ b/gcc/rust/backend/rust-mangle.h
@@ -34,8 +34,7 @@ public:
 
   // this needs to support Legacy and V0 see github #429 or #305
   std::string mangle_item (const TyTy::BaseType *ty,
-			   const Resolver::CanonicalPath &path,
-			   const std::string &crate_name) const;
+			   const Resolver::CanonicalPath &path) const;
 
   static void set_mangling (int frust_mangling_value)
   {

--- a/gcc/rust/resolve/rust-ast-resolve-base.h
+++ b/gcc/rust/resolve/rust-ast-resolve-base.h
@@ -201,13 +201,14 @@ public:
 
 protected:
   ResolverBase (NodeId parent)
-    : resolver (Resolver::get ()), resolved_node (UNKNOWN_NODEID),
-      parent (parent), locus (Location ())
+    : resolver (Resolver::get ()), mappings (Analysis::Mappings::get ()),
+      resolved_node (UNKNOWN_NODEID), parent (parent), locus (Location ())
   {}
 
   bool resolved () const { return resolved_node != UNKNOWN_NODEID; }
 
   Resolver *resolver;
+  Analysis::Mappings *mappings;
   NodeId resolved_node;
   NodeId parent;
   Location locus;

--- a/gcc/rust/resolve/rust-ast-resolve-pattern.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-pattern.cc
@@ -25,13 +25,13 @@ namespace Resolver {
 void
 PatternDeclaration::visit (AST::PathInExpression &pattern)
 {
-  ResolveExpr::go (&pattern, parent);
+  ResolvePath::go (&pattern, parent);
 }
 
 void
 PatternDeclaration::visit (AST::TupleStructPattern &pattern)
 {
-  ResolveExpr::go (&pattern.get_path (), parent);
+  ResolvePath::go (&pattern.get_path (), parent);
 
   std::unique_ptr<AST::TupleStructItems> &items = pattern.get_items ();
   switch (items->get_item_type ())
@@ -59,7 +59,7 @@ PatternDeclaration::visit (AST::TupleStructPattern &pattern)
 void
 PatternDeclaration::visit (AST::StructPattern &pattern)
 {
-  ResolveExpr::go (&pattern.get_path (), parent);
+  ResolvePath::go (&pattern.get_path (), parent);
 
   auto &struct_pattern_elems = pattern.get_struct_pattern_elems ();
   for (auto &field : struct_pattern_elems.get_struct_pattern_fields ())

--- a/gcc/rust/resolve/rust-ast-resolve-struct-expr-field.h
+++ b/gcc/rust/resolve/rust-ast-resolve-struct-expr-field.h
@@ -32,9 +32,11 @@ class ResolveStructExprField : public ResolverBase
   using Rust::Resolver::ResolverBase::visit;
 
 public:
-  static void go (AST::StructExprField *field, NodeId parent)
+  static void go (AST::StructExprField *field, NodeId parent,
+		  const CanonicalPath &prefix,
+		  const CanonicalPath &canonical_prefix)
   {
-    ResolveStructExprField resolver (parent);
+    ResolveStructExprField resolver (parent, prefix, canonical_prefix);
     field->accept_vis (resolver);
   }
 
@@ -47,7 +49,14 @@ public:
   void visit (AST::StructExprFieldIdentifier &field) override;
 
 private:
-  ResolveStructExprField (NodeId parent) : ResolverBase (parent) {}
+  ResolveStructExprField (NodeId parent, const CanonicalPath &prefix,
+			  const CanonicalPath &canonical_prefix)
+    : ResolverBase (parent), prefix (prefix),
+      canonical_prefix (canonical_prefix)
+  {}
+
+  const CanonicalPath &prefix;
+  const CanonicalPath &canonical_prefix;
 };
 
 } // namespace Resolver

--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -314,9 +314,9 @@ void
 NameResolution::go (AST::Crate &crate)
 {
   // lookup current crate name
+  CrateNum cnum = mappings->get_current_crate ();
   std::string crate_name;
-  bool ok
-    = mappings->get_crate_name (mappings->get_current_crate (), crate_name);
+  bool ok = mappings->get_crate_name (cnum, crate_name);
   rust_assert (ok);
 
   // setup the ribs
@@ -331,10 +331,11 @@ NameResolution::go (AST::Crate &crate)
   // get the root segment
   CanonicalPath crate_prefix
     = CanonicalPath::new_seg (scope_node_id, crate_name);
+  crate_prefix.set_crate_num (cnum);
 
   // first gather the top-level namespace names then we drill down so this
-  // allows for resolving forward declarations since an impl block might have a
-  // Self type Foo which is defined after the impl block for example.
+  // allows for resolving forward declarations since an impl block might have
+  // a Self type Foo which is defined after the impl block for example.
   for (auto it = crate.items.begin (); it != crate.items.end (); it++)
     ResolveTopLevel::go (it->get (), CanonicalPath::create_empty (),
 			 crate_prefix);

--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -313,6 +313,13 @@ NameResolution::Resolve (AST::Crate &crate)
 void
 NameResolution::go (AST::Crate &crate)
 {
+  // lookup current crate name
+  std::string crate_name;
+  bool ok
+    = mappings->get_crate_name (mappings->get_current_crate (), crate_name);
+  rust_assert (ok);
+
+  // setup the ribs
   NodeId scope_node_id = crate.get_node_id ();
   resolver->get_name_scope ().push (scope_node_id);
   resolver->get_type_scope ().push (scope_node_id);
@@ -321,16 +328,24 @@ NameResolution::go (AST::Crate &crate)
   resolver->push_new_type_rib (resolver->get_type_scope ().peek ());
   resolver->push_new_label_rib (resolver->get_type_scope ().peek ());
 
-  // first gather the top-level namespace names then we drill down
-  for (auto it = crate.items.begin (); it != crate.items.end (); it++)
-    ResolveTopLevel::go (it->get ());
+  // get the root segment
+  CanonicalPath crate_prefix
+    = CanonicalPath::new_seg (scope_node_id, crate_name);
 
+  // first gather the top-level namespace names then we drill down so this
+  // allows for resolving forward declarations since an impl block might have a
+  // Self type Foo which is defined after the impl block for example.
+  for (auto it = crate.items.begin (); it != crate.items.end (); it++)
+    ResolveTopLevel::go (it->get (), CanonicalPath::create_empty (),
+			 crate_prefix);
+
+  // FIXME remove this
   if (saw_errors ())
     return;
 
   // next we can drill down into the items and their scopes
   for (auto it = crate.items.begin (); it != crate.items.end (); it++)
-    ResolveItem::go (it->get ());
+    ResolveItem::go (it->get (), CanonicalPath::create_empty (), crate_prefix);
 }
 
 // rust-ast-resolve-expr.h
@@ -349,17 +364,19 @@ ResolveExpr::visit (AST::BlockExpr &expr)
   for (auto &s : expr.get_statements ())
     {
       if (s->is_item ())
-	ResolveStmt::go (s.get (), s->get_node_id ());
+	ResolveStmt::go (s.get (), s->get_node_id (), prefix, canonical_prefix,
+			 CanonicalPath::create_empty ());
     }
 
   for (auto &s : expr.get_statements ())
     {
       if (!s->is_item ())
-	ResolveStmt::go (s.get (), s->get_node_id ());
+	ResolveStmt::go (s.get (), s->get_node_id (), prefix, canonical_prefix,
+			 CanonicalPath::create_empty ());
     }
 
   if (expr.has_tail_expr ())
-    ResolveExpr::go (expr.get_tail_expr ().get (), expr.get_node_id ());
+    resolve_expr (expr.get_tail_expr ().get (), expr.get_node_id ());
 
   resolver->get_name_scope ().pop ();
   resolver->get_type_scope ().pop ();
@@ -371,13 +388,15 @@ ResolveExpr::visit (AST::BlockExpr &expr)
 void
 ResolveStructExprField::visit (AST::StructExprFieldIdentifierValue &field)
 {
-  ResolveExpr::go (field.get_value ().get (), field.get_node_id ());
+  ResolveExpr::go (field.get_value ().get (), field.get_node_id (), prefix,
+		   canonical_prefix);
 }
 
 void
 ResolveStructExprField::visit (AST::StructExprFieldIndexValue &field)
 {
-  ResolveExpr::go (field.get_value ().get (), field.get_node_id ());
+  ResolveExpr::go (field.get_value ().get (), field.get_node_id (), prefix,
+		   canonical_prefix);
 }
 
 void
@@ -386,7 +405,7 @@ ResolveStructExprField::visit (AST::StructExprFieldIdentifier &field)
   AST::IdentifierExpr expr (field.get_field_name (), {}, field.get_locus ());
   expr.set_node_id (field.get_node_id ());
 
-  ResolveExpr::go (&expr, field.get_node_id ());
+  ResolveExpr::go (&expr, field.get_node_id (), prefix, canonical_prefix);
 }
 
 // rust-ast-resolve-type.h
@@ -746,7 +765,12 @@ void
 ResolveType::visit (AST::ArrayType &type)
 {
   type.get_elem_type ()->accept_vis (*this);
-  ResolveExpr::go (type.get_size_expr ().get (), type.get_node_id ());
+  // FIXME
+  // the capacity expr can contain block-expr with functions but these should be
+  // folded via constexpr code
+  ResolveExpr::go (type.get_size_expr ().get (), type.get_node_id (),
+		   CanonicalPath::create_empty (),
+		   CanonicalPath::create_empty ());
 }
 
 void
@@ -771,15 +795,19 @@ ResolveType::visit (AST::TraitObjectType &type)
 // rust-ast-resolve-item.h
 
 void
-ResolveItem::resolve_impl_item (AST::TraitImplItem *item)
+ResolveItem::resolve_impl_item (AST::TraitImplItem *item,
+				const CanonicalPath &prefix,
+				const CanonicalPath &canonical_prefix)
 {
-  ResolveImplItems::go (item);
+  ResolveImplItems::go (item, prefix, canonical_prefix);
 }
 
 void
-ResolveItem::resolve_impl_item (AST::InherentImplItem *item)
+ResolveItem::resolve_impl_item (AST::InherentImplItem *item,
+				const CanonicalPath &prefix,
+				const CanonicalPath &canonical_prefix)
 {
-  ResolveImplItems::go (item);
+  ResolveImplItems::go (item, prefix, canonical_prefix);
 }
 
 void

--- a/gcc/rust/resolve/rust-name-resolver.h
+++ b/gcc/rust/resolve/rust-name-resolver.h
@@ -39,6 +39,7 @@ public:
 
   ~Rib () {}
 
+  // this takes the relative paths of items within a compilation unit for lookup
   void insert_name (
     const CanonicalPath &path, NodeId id, Location locus, bool shadow,
     std::function<void (const CanonicalPath &, NodeId, Location)> dup_cb)
@@ -60,7 +61,6 @@ public:
     reverse_path_mappings.insert (std::pair<NodeId, CanonicalPath> (id, path));
     decls_within_rib.insert (std::pair<NodeId, Location> (id, locus));
     references[id] = {};
-    mappings->insert_canonical_path (mappings->get_current_crate (), id, path);
   }
 
   bool lookup_name (const CanonicalPath &ident, NodeId *id)

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -69,7 +69,7 @@ const char *kHIRDumpFile = "gccrs.hir.dump";
 const char *kHIRTypeResolutionDumpFile = "gccrs.type-resolution.dump";
 const char *kTargetOptionsDumpFile = "gccrs.target-options.dump";
 
-const std::string kDefaultCrateName = "TestCrate";
+const std::string kDefaultCrateName = "example";
 
 // Implicitly enable a target_feature (and recursively enable dependencies).
 void

--- a/gcc/rust/util/rust-canonical-path.h
+++ b/gcc/rust/util/rust-canonical-path.h
@@ -144,6 +144,17 @@ public:
     return segs.back ().first;
   }
 
+  const std::pair<NodeId, std::string> &get_seg_at (size_t index) const
+  {
+    rust_assert (index < size ());
+    return segs.at (index);
+  }
+
+  static bool segment_is_qualified_path (const std::string &seg)
+  {
+    return seg.find (" as ") != std::string::npos;
+  }
+
   bool is_equal (const CanonicalPath &b) const
   {
     return get ().compare (b.get ()) == 0;

--- a/gcc/rust/util/rust-canonical-path.h
+++ b/gcc/rust/util/rust-canonical-path.h
@@ -57,7 +57,8 @@ public:
   static CanonicalPath new_seg (NodeId id, const std::string &path)
   {
     rust_assert (!path.empty ());
-    return CanonicalPath ({std::pair<NodeId, std::string> (id, path)});
+    return CanonicalPath ({std::pair<NodeId, std::string> (id, path)},
+			  UNKNOWN_CREATENUM);
   }
 
   std::string get () const
@@ -77,7 +78,10 @@ public:
     return CanonicalPath::new_seg (id, "Self");
   }
 
-  static CanonicalPath create_empty () { return CanonicalPath ({}); }
+  static CanonicalPath create_empty ()
+  {
+    return CanonicalPath ({}, UNKNOWN_CREATENUM);
+  }
 
   bool is_empty () const { return segs.size () == 0; }
 
@@ -85,13 +89,13 @@ public:
   {
     rust_assert (!other.is_empty ());
     if (is_empty ())
-      return CanonicalPath (other.segs);
+      return CanonicalPath (other.segs, crate_num);
 
     std::vector<std::pair<NodeId, std::string>> copy (segs);
     for (auto &s : other.segs)
       copy.push_back (s);
 
-    return CanonicalPath (copy);
+    return CanonicalPath (copy, crate_num);
   }
 
   // if we have the path A::B::C this will give a callback for each segment
@@ -110,7 +114,7 @@ public:
     for (auto &seg : segs)
       {
 	buf.push_back (seg);
-	if (!cb (CanonicalPath (buf)))
+	if (!cb (CanonicalPath (buf, crate_num)))
 	  return;
       }
   }
@@ -131,7 +135,7 @@ public:
       {
 	std::vector<std::pair<NodeId, std::string>> buf;
 	buf.push_back ({seg.first, seg.second});
-	if (!cb (CanonicalPath (buf)))
+	if (!cb (CanonicalPath (buf, crate_num)))
 	  return;
       }
   }
@@ -150,14 +154,17 @@ public:
     return segs.at (index);
   }
 
-  static bool segment_is_qualified_path (const std::string &seg)
-  {
-    return seg.find (" as ") != std::string::npos;
-  }
-
   bool is_equal (const CanonicalPath &b) const
   {
     return get ().compare (b.get ()) == 0;
+  }
+
+  void set_crate_num (CrateNum n) { crate_num = n; }
+
+  CrateNum get_crate_num () const
+  {
+    rust_assert (crate_num != UNKNOWN_CREATENUM);
+    return crate_num;
   }
 
   bool operator== (const CanonicalPath &b) const { return is_equal (b); }
@@ -165,11 +172,13 @@ public:
   bool operator< (const CanonicalPath &b) const { return get () < b.get (); }
 
 private:
-  explicit CanonicalPath (std::vector<std::pair<NodeId, std::string>> path)
-    : segs (path)
+  explicit CanonicalPath (std::vector<std::pair<NodeId, std::string>> path,
+			  CrateNum crate_num)
+    : segs (path), crate_num (crate_num)
   {}
 
   std::vector<std::pair<NodeId, std::string>> segs;
+  CrateNum crate_num;
 };
 
 } // namespace Resolver

--- a/gcc/testsuite/rust/compile/canonical_paths1.rs
+++ b/gcc/testsuite/rust/compile/canonical_paths1.rs
@@ -1,0 +1,25 @@
+// { dg-additional-options "-w -fdump-tree-gimple" }
+struct Foo(i32);
+
+trait TR {
+    fn test(&self) -> i32;
+}
+
+mod A {
+    impl ::Foo {
+        pub fn test(self) {}
+        // { dg-final { scan-tree-dump-times {example::A::<impl example::Foo>::test} 2 gimple } }
+    }
+
+    impl ::TR for ::Foo {
+        fn test(&self) -> i32 {
+            // { dg-final { scan-tree-dump-times {example::A::<impl example::Foo as example::TR>::test} 1 gimple } }
+            self.0
+        }
+    }
+}
+
+pub fn test() {
+    let a = Foo(123);
+    a.test();
+}

--- a/gcc/testsuite/rust/compile/torture/mod3.rs
+++ b/gcc/testsuite/rust/compile/torture/mod3.rs
@@ -1,25 +1,22 @@
+// { dg-additional-options "-w" }
 mod A {
-    pub mod B {  // { dg-warning "unused name" }
-        pub mod C { // { dg-warning "unused name" }
+    pub mod B {
+        pub mod C {
             pub struct Foo {
                 pub f: i32,
             }
             impl Foo {
-                pub fn new() -> Self {  // { dg-warning "unused name" }
-                    Foo {
-                        f: 23i32,
-                    }
+                pub fn new() -> Self {
+                    Foo { f: 23i32 }
                 }
             }
         }
     }
 }
 
-fn main() ->i32 {
+fn main() -> i32 {
     let a = A::B::C::Foo::new();
-    let b = A::B::C::Foo {
-        f: -23i32,
-    };
+    let b = A::B::C::Foo { f: -23i32 };
 
     a.f - b.f
 }

--- a/gcc/testsuite/rust/compile/traits9.rs
+++ b/gcc/testsuite/rust/compile/traits9.rs
@@ -8,6 +8,6 @@ fn main() {
     a = Foo(123);
 
     let b: &dyn Bar = &a;
-    // { dg-error "bounds not satisfied for Foo .Bar. is not satisfied" "" { target *-*-* } .-1 }
+    // { dg-error "bounds not satisfied for Foo .example::Bar. is not satisfied" "" { target *-*-* } .-1 }
     // { dg-error "expected" "" { target *-*-* } .-2 }
 }


### PR DESCRIPTION
The name resolver there are two types of canonical-path object.
    
1. The relative canonical path to a type for name resolution
2. The full canonical-path including the crate-name (this-was-missing)
    
The lack of the crate-name being present in the canonical-path meant the
symbol mangling system was required to append it where appropriate but this
was going to be too messy to handle all cases. Such as module blocks
containing impl blocks requires a ```prefix::<impl crate::path>::item``` and
similarly for trait impl blocks.