### PR TITLE
Remove unused include

### DIFF
--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -24,7 +24,6 @@
 #include "rust-diagnostics.h"
 #include "rust-abi.h"
 #include "rust-common.h"
-#include "tree.h"
 
 namespace Rust {
 


### PR DESCRIPTION
We no longer need the tree within the type modules.