### PR TITLE
Add -frust-cfg=value option for adding config options

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -44,15 +44,6 @@ public:
   {
     ASTLoweringItem resolver;
     item->accept_vis (resolver);
-
-    // this is useful for debugging
-    // if (resolver.translated == nullptr)
-    //   {
-    //     rust_fatal_error (item->get_locus (), "failed to lower: %s",
-    //     		  item->as_string ().c_str ());
-    //     return nullptr;
-    //   }
-
     return resolver.translated;
   }
 
@@ -419,6 +410,9 @@ public:
 
   void visit (AST::Function &function) override
   {
+    if (function.is_marked_for_strip ())
+      return;
+
     std::vector<std::unique_ptr<HIR::WhereClauseItem>> where_clause_items;
     for (auto &item : function.get_where_clause ().get_items ())
       {

--- a/gcc/rust/lang.opt
+++ b/gcc/rust/lang.opt
@@ -59,6 +59,10 @@ Enum(frust_mangling) String(legacy) Value(0)
 EnumValue
 Enum(frust_mangling) String(v0) Value(1)
 
+frust-cfg=
+Rust Joined RejectNegative
+-frust-cfg=<name>             Set a config expansion option
+
 o
 Rust Joined Separate
 ; Documented in common.opt

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -362,6 +362,9 @@ public:
 
   void visit (AST::Function &function) override
   {
+    if (function.is_marked_for_strip ())
+      return;
+
     NodeId scope_node_id = function.get_node_id ();
     resolver->get_name_scope ().push (scope_node_id);
     resolver->get_type_scope ().push (scope_node_id);

--- a/gcc/rust/resolve/rust-ast-resolve-toplevel.h
+++ b/gcc/rust/resolve/rust-ast-resolve-toplevel.h
@@ -220,6 +220,9 @@ public:
 
   void visit (AST::Function &function) override
   {
+    if (function.is_marked_for_strip ())
+      return;
+
     auto path
       = prefix.append (ResolveFunctionItemToCanonicalPath::resolve (function));
     resolver->get_name_scope ().insert (

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -353,9 +353,11 @@ Session::handle_option (
     case OPT_I:
       // TODO: add search path
       break;
+
     case OPT_L:
       // TODO: add library link path or something
       break;
+
     case OPT_frust_crate_:
       // set the crate name
       if (arg != nullptr)
@@ -363,6 +365,7 @@ Session::handle_option (
       else
 	ret = false;
       break;
+
     case OPT_frust_dump_:
       // enable dump and return whether this was successful
       if (arg != nullptr)
@@ -374,15 +377,29 @@ Session::handle_option (
 	  ret = false;
 	}
       break;
+
     case OPT_frust_mangling_:
       Compile::Mangler::set_mangling (flag_rust_mangling);
-    // no option handling for -o
+      break;
+
+    case OPT_frust_cfg_:
+      ret = handle_cfg_option (std::string (arg));
+      break;
+
     default:
-      // return 1 to indicate option is valid
       break;
     }
 
   return ret;
+}
+
+bool
+Session::handle_cfg_option (const std::string &value)
+{
+  // rustc doesn't seem to error on any duplicate key
+  // TODO handle feature=bla and relevant error handling in parsing
+  options.target_data.insert_key (value);
+  return true;
 }
 
 /* Enables a certain dump depending on the name passed in. Returns true if name

--- a/gcc/rust/rust-session-manager.h
+++ b/gcc/rust/rust-session-manager.h
@@ -286,6 +286,9 @@ private:
    * macros, maybe build test harness in future, AST validation, maybe create
    * macro crate (if not rustdoc).*/
   void expansion (AST::Crate &crate);
+
+  // handle cfg_option
+  bool handle_cfg_option (const std::string &data);
 };
 } // namespace Rust
 

--- a/gcc/testsuite/rust/compile/cfg1.rs
+++ b/gcc/testsuite/rust/compile/cfg1.rs
@@ -1,0 +1,31 @@
+// { dg-additional-options "-w" }
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+#[cfg(A)]
+fn test() {
+    unsafe {
+        let a = "test1\n\0";
+        let b = a as *const str;
+        let c = b as *const i8;
+
+        printf(c);
+    }
+}
+
+#[cfg(B)]
+fn test() {
+    unsafe {
+        let a = "test2\n\0";
+        let b = a as *const str;
+        let c = b as *const i8;
+
+        printf(c);
+    }
+}
+
+fn main() {
+    test();
+    // { dg-error "Cannot find path .test. in this scope" "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/execute/torture/cfg1.rs
+++ b/gcc/testsuite/rust/execute/torture/cfg1.rs
@@ -1,0 +1,32 @@
+// { dg-additional-options "-w -frust-cfg=A" }
+// { dg-output "test1\n" }
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+#[cfg(A)]
+fn test() {
+    unsafe {
+        let a = "test1\n\0";
+        let b = a as *const str;
+        let c = b as *const i8;
+
+        printf(c);
+    }
+}
+
+#[cfg(B)]
+fn test() {
+    unsafe {
+        let a = "test2\n\0";
+        let b = a as *const str;
+        let c = b as *const i8;
+
+        printf(c);
+    }
+}
+
+fn main() -> i32 {
+    test();
+    0
+}


### PR DESCRIPTION
This adds the initial support for config expansion on custom config values
it need support for parsing options such as feature=test with apropriate
error handling withing Session::handle_cfg_option(const std::string&).

This also applies the mark_for_strip checks only on AST::Functions and
will need applied to the rest of the crate in #872.

Addresses #889
