### PR TITLE
Fix enum variant discriminant values

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -397,13 +397,11 @@ CompileExpr::visit (HIR::CallExpr &expr)
       std::vector<tree> ctor_arguments;
       if (adt->is_enum ())
 	{
-	  HirId variant_id = variant->get_id ();
-	  mpz_t val;
-	  mpz_init_set_ui (val, variant_id);
+	  HIR::Expr *discrim_expr = variant->get_discriminant ();
+	  tree discrim_expr_node = CompileExpr::Compile (discrim_expr, ctx);
+	  tree folded_discrim_expr = ConstCtx::fold (discrim_expr_node);
+	  tree qualifier = folded_discrim_expr;
 
-	  tree t = TyTyResolveCompile::get_implicit_enumeral_node_type (ctx);
-	  tree qualifier
-	    = double_int_to_tree (t, mpz_get_double_int (t, val, true));
 	  ctor_arguments.push_back (qualifier);
 	}
       for (auto &arg : arguments)

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -24,6 +24,7 @@
 #include "rust-compile-resolve-path.h"
 #include "rust-compile-block.h"
 #include "rust-compile-struct-field-expr.h"
+#include "rust-constexpr.h"
 
 namespace Rust {
 namespace Compile {
@@ -488,13 +489,10 @@ public:
     std::vector<tree> ctor_arguments;
     if (adt->is_enum ())
       {
-	HirId variant_id = variant->get_id ();
-	mpz_t val;
-	mpz_init_set_ui (val, variant_id);
-
-	tree t = TyTyResolveCompile::get_implicit_enumeral_node_type (ctx);
-	tree qualifier
-	  = double_int_to_tree (t, mpz_get_double_int (t, val, true));
+	HIR::Expr *discrim_expr = variant->get_discriminant ();
+	tree discrim_expr_node = CompileExpr::Compile (discrim_expr, ctx);
+	tree folded_discrim_expr = ConstCtx::fold (discrim_expr_node);
+	tree qualifier = folded_discrim_expr;
 
 	ctor_arguments.push_back (qualifier);
       }

--- a/gcc/rust/backend/rust-compile-pattern.cc
+++ b/gcc/rust/backend/rust-compile-pattern.cc
@@ -48,33 +48,10 @@ CompilePatternCaseLabelExpr::visit (HIR::PathInExpression &pattern)
   ok = adt->lookup_variant_by_id (variant_id, &variant);
   rust_assert (ok);
 
-  tree case_low = error_mark_node;
-  if (variant->is_specified_discriminant_node ())
-    {
-      auto discrim_node = variant->get_discriminant_node ();
-      auto &discrim_expr = discrim_node->get_discriminant_expression ();
-
-      tree discrim_expr_node = CompileExpr::Compile (discrim_expr.get (), ctx);
-      tree folded_discrim_expr = ConstCtx::fold (discrim_expr_node);
-      case_low = folded_discrim_expr;
-    }
-  else
-    {
-      mpz_t disciminantl;
-      if (variant->get_variant_type () == TyTy::VariantDef::VariantType::NUM)
-	{
-	  mpz_init_set_ui (disciminantl, variant->get_discriminant ());
-	}
-      else
-	{
-	  HirId variant_id = variant->get_id ();
-	  mpz_init_set_ui (disciminantl, variant_id);
-	}
-
-      tree t = TyTyResolveCompile::get_implicit_enumeral_node_type (ctx);
-      case_low
-	= double_int_to_tree (t, mpz_get_double_int (t, disciminantl, true));
-    }
+  HIR::Expr *discrim_expr = variant->get_discriminant ();
+  tree discrim_expr_node = CompileExpr::Compile (discrim_expr, ctx);
+  tree folded_discrim_expr = ConstCtx::fold (discrim_expr_node);
+  tree case_low = folded_discrim_expr;
 
   case_label_expr
     = build_case_label (case_low, NULL_TREE, associated_case_label);

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -340,6 +340,15 @@ public:
   }
 
   /* EnumItem doesn't need to be handled, no fields.  */
+  void visit (AST::EnumItem &item) override
+  {
+    auto decl
+      = CanonicalPath::new_seg (item.get_node_id (), item.get_identifier ());
+    auto path = prefix.append (decl);
+    auto cpath = canonical_prefix.append (decl);
+    mappings->insert_canonical_path (mappings->get_current_crate (),
+				     item.get_node_id (), cpath);
+  }
 
   void visit (AST::EnumItemTuple &item) override
   {

--- a/gcc/rust/typecheck/rust-hir-type-check-enumitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-enumitem.h
@@ -48,9 +48,30 @@ public:
     if (last_discriminant == INT64_MAX)
       rust_error_at (item.get_locus (), "discriminant too big");
 
-    variant
-      = new TyTy::VariantDef (item.get_mappings ().get_hirid (),
-			      item.get_identifier (), last_discriminant + 1);
+    Analysis::NodeMapping mapping (item.get_mappings ().get_crate_num (),
+				   item.get_mappings ().get_nodeid (),
+				   mappings->get_next_hir_id (
+				     item.get_mappings ().get_crate_num ()),
+				   item.get_mappings ().get_local_defid ());
+    HIR::LiteralExpr *discim_expr
+      = new HIR::LiteralExpr (mapping, std::to_string (last_discriminant),
+			      HIR::Literal::LitType::INT,
+			      PrimitiveCoreType::CORETYPE_I64,
+			      item.get_locus ());
+
+    TyTy::BaseType *isize = nullptr;
+    bool ok = context->lookup_builtin ("isize", &isize);
+    rust_assert (ok);
+    context->insert_type (mapping, isize);
+
+    const CanonicalPath *canonical_path = nullptr;
+    ok = mappings->lookup_canonical_path (item.get_mappings ().get_crate_num (),
+					  item.get_mappings ().get_nodeid (),
+					  &canonical_path);
+    rust_assert (ok);
+
+    variant = new TyTy::VariantDef (item.get_mappings ().get_hirid (),
+				    item.get_identifier (), discim_expr);
   }
 
   void visit (HIR::EnumItemDiscriminant &item) override
@@ -71,8 +92,16 @@ public:
     if (unified->get_kind () == TyTy::TypeKind::ERROR)
       return;
 
+    const CanonicalPath *canonical_path = nullptr;
+    bool ok
+      = mappings->lookup_canonical_path (item.get_mappings ().get_crate_num (),
+					 item.get_mappings ().get_nodeid (),
+					 &canonical_path);
+    rust_assert (ok);
+
     variant = new TyTy::VariantDef (item.get_mappings ().get_hirid (),
-				    item.get_identifier (), &item);
+				    item.get_identifier (),
+				    item.get_discriminant_expression ().get ());
   }
 
   void visit (HIR::EnumItemTuple &item) override
@@ -95,10 +124,32 @@ public:
 	idx++;
       }
 
-    variant
-      = new TyTy::VariantDef (item.get_mappings ().get_hirid (),
-			      item.get_identifier (),
-			      TyTy::VariantDef::VariantType::TUPLE, fields);
+    Analysis::NodeMapping mapping (item.get_mappings ().get_crate_num (),
+				   item.get_mappings ().get_nodeid (),
+				   mappings->get_next_hir_id (
+				     item.get_mappings ().get_crate_num ()),
+				   item.get_mappings ().get_local_defid ());
+    HIR::LiteralExpr *discim_expr
+      = new HIR::LiteralExpr (mapping, std::to_string (last_discriminant),
+			      HIR::Literal::LitType::INT,
+			      PrimitiveCoreType::CORETYPE_I64,
+			      item.get_locus ());
+
+    TyTy::BaseType *isize = nullptr;
+    bool ok = context->lookup_builtin ("isize", &isize);
+    rust_assert (ok);
+    context->insert_type (mapping, isize);
+
+    const CanonicalPath *canonical_path = nullptr;
+    ok = mappings->lookup_canonical_path (item.get_mappings ().get_crate_num (),
+					  item.get_mappings ().get_nodeid (),
+					  &canonical_path);
+    rust_assert (ok);
+
+    variant = new TyTy::VariantDef (item.get_mappings ().get_hirid (),
+				    item.get_identifier (),
+				    TyTy::VariantDef::VariantType::TUPLE,
+				    discim_expr, fields);
   }
 
   void visit (HIR::EnumItemStruct &item) override
@@ -119,10 +170,32 @@ public:
 			      ty_field->get_field_type ());
       }
 
-    variant
-      = new TyTy::VariantDef (item.get_mappings ().get_hirid (),
-			      item.get_identifier (),
-			      TyTy::VariantDef::VariantType::STRUCT, fields);
+    Analysis::NodeMapping mapping (item.get_mappings ().get_crate_num (),
+				   item.get_mappings ().get_nodeid (),
+				   mappings->get_next_hir_id (
+				     item.get_mappings ().get_crate_num ()),
+				   item.get_mappings ().get_local_defid ());
+    HIR::LiteralExpr *discrim_expr
+      = new HIR::LiteralExpr (mapping, std::to_string (last_discriminant),
+			      HIR::Literal::LitType::INT,
+			      PrimitiveCoreType::CORETYPE_I64,
+			      item.get_locus ());
+
+    TyTy::BaseType *isize = nullptr;
+    bool ok = context->lookup_builtin ("isize", &isize);
+    rust_assert (ok);
+    context->insert_type (mapping, isize);
+
+    const CanonicalPath *canonical_path = nullptr;
+    ok = mappings->lookup_canonical_path (item.get_mappings ().get_crate_num (),
+					  item.get_mappings ().get_nodeid (),
+					  &canonical_path);
+    rust_assert (ok);
+
+    variant = new TyTy::VariantDef (item.get_mappings ().get_hirid (),
+				    item.get_identifier (),
+				    TyTy::VariantDef::VariantType::STRUCT,
+				    discrim_expr, fields);
   }
 
 private:

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.h
@@ -171,7 +171,7 @@ public:
     std::vector<TyTy::VariantDef *> variants;
     variants.push_back (new TyTy::VariantDef (
       struct_decl.get_mappings ().get_hirid (), struct_decl.get_identifier (),
-      TyTy::VariantDef::VariantType::TUPLE, std::move (fields)));
+      TyTy::VariantDef::VariantType::TUPLE, nullptr, std::move (fields)));
 
     TyTy::BaseType *type
       = new TyTy::ADTType (struct_decl.get_mappings ().get_hirid (),
@@ -219,10 +219,8 @@ public:
 	TyTy::VariantDef *field_type
 	  = TypeCheckEnumItem::Resolve (variant.get (), discriminant_value);
 
+	discriminant_value++;
 	variants.push_back (field_type);
-	if (field_type->get_variant_type ()
-	    == TyTy::VariantDef::VariantType::NUM)
-	  discriminant_value = field_type->get_discriminant ();
       }
 
     TyTy::BaseType *type
@@ -281,7 +279,7 @@ public:
     std::vector<TyTy::VariantDef *> variants;
     variants.push_back (new TyTy::VariantDef (
       struct_decl.get_mappings ().get_hirid (), struct_decl.get_identifier (),
-      TyTy::VariantDef::VariantType::STRUCT, std::move (fields)));
+      TyTy::VariantDef::VariantType::STRUCT, nullptr, std::move (fields)));
 
     TyTy::BaseType *type
       = new TyTy::ADTType (struct_decl.get_mappings ().get_hirid (),
@@ -339,7 +337,7 @@ public:
     std::vector<TyTy::VariantDef *> variants;
     variants.push_back (new TyTy::VariantDef (
       union_decl.get_mappings ().get_hirid (), union_decl.get_identifier (),
-      TyTy::VariantDef::VariantType::STRUCT, std::move (fields)));
+      TyTy::VariantDef::VariantType::STRUCT, nullptr, std::move (fields)));
 
     TyTy::BaseType *type
       = new TyTy::ADTType (union_decl.get_mappings ().get_hirid (),

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
@@ -106,7 +106,7 @@ public:
     std::vector<TyTy::VariantDef *> variants;
     variants.push_back (new TyTy::VariantDef (
       struct_decl.get_mappings ().get_hirid (), struct_decl.get_identifier (),
-      TyTy::VariantDef::VariantType::TUPLE, std::move (fields)));
+      TyTy::VariantDef::VariantType::TUPLE, nullptr, std::move (fields)));
 
     TyTy::BaseType *type
       = new TyTy::ADTType (struct_decl.get_mappings ().get_hirid (),
@@ -175,7 +175,7 @@ public:
     std::vector<TyTy::VariantDef *> variants;
     variants.push_back (new TyTy::VariantDef (
       struct_decl.get_mappings ().get_hirid (), struct_decl.get_identifier (),
-      TyTy::VariantDef::VariantType::STRUCT, std::move (fields)));
+      TyTy::VariantDef::VariantType::STRUCT, nullptr, std::move (fields)));
 
     TyTy::BaseType *type
       = new TyTy::ADTType (struct_decl.get_mappings ().get_hirid (),
@@ -222,10 +222,8 @@ public:
 	TyTy::VariantDef *field_type
 	  = TypeCheckEnumItem::Resolve (variant.get (), discriminant_value);
 
+	discriminant_value++;
 	variants.push_back (field_type);
-	if (field_type->get_variant_type ()
-	    == TyTy::VariantDef::VariantType::NUM)
-	  discriminant_value = field_type->get_discriminant ();
       }
 
     TyTy::BaseType *type
@@ -288,7 +286,7 @@ public:
     std::vector<TyTy::VariantDef *> variants;
     variants.push_back (new TyTy::VariantDef (
       union_decl.get_mappings ().get_hirid (), union_decl.get_identifier (),
-      TyTy::VariantDef::VariantType::STRUCT, std::move (fields)));
+      TyTy::VariantDef::VariantType::STRUCT, nullptr, std::move (fields)));
 
     TyTy::BaseType *type
       = new TyTy::ADTType (union_decl.get_mappings ().get_hirid (),


### PR DESCRIPTION
Enum discriminants before this patch were either:

- The hir-id of the tuple/struct variant
- The expression of the specified discriminant
- Computed int64 of the dataless variant

Each of these had tree ways of computing the qualifier this patch changes
this to be more in line with rust to compute the values unless its a
specified discriminant value. In order to compile this we now create an
implicit HIR::LiteralExpr and feed this into our constexpr code so it
reuses the same path as the variants with a specified constant
discriminant.
