### PR TITLE
Add new RustIdent struct to track canonical-path and location info

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -187,9 +187,8 @@ Resolver::generate_builtins ()
   MKBUILTIN_TYPE ("str", builtins, str);
 
   // unit type ()
-
   TyTy::TupleType *unit_tyty
-    = new TyTy::TupleType (mappings->get_next_hir_id ());
+    = TyTy::TupleType::get_unit_type (mappings->get_next_hir_id ());
   std::vector<std::unique_ptr<AST::Type> > elems;
   AST::TupleType *unit_type
     = new AST::TupleType (std::move (elems), Linemap::predeclared_location ());

--- a/gcc/rust/typecheck/rust-hir-type-check-enumitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-enumitem.h
@@ -70,8 +70,9 @@ public:
 					  &canonical_path);
     rust_assert (ok);
 
+    RustIdent ident{*canonical_path, item.get_locus ()};
     variant = new TyTy::VariantDef (item.get_mappings ().get_hirid (),
-				    item.get_identifier (), discim_expr);
+				    item.get_identifier (), ident, discim_expr);
   }
 
   void visit (HIR::EnumItemDiscriminant &item) override
@@ -99,8 +100,9 @@ public:
 					 &canonical_path);
     rust_assert (ok);
 
+    RustIdent ident{*canonical_path, item.get_locus ()};
     variant = new TyTy::VariantDef (item.get_mappings ().get_hirid (),
-				    item.get_identifier (),
+				    item.get_identifier (), ident,
 				    item.get_discriminant_expression ().get ());
   }
 
@@ -146,8 +148,9 @@ public:
 					  &canonical_path);
     rust_assert (ok);
 
+    RustIdent ident{*canonical_path, item.get_locus ()};
     variant = new TyTy::VariantDef (item.get_mappings ().get_hirid (),
-				    item.get_identifier (),
+				    item.get_identifier (), ident,
 				    TyTy::VariantDef::VariantType::TUPLE,
 				    discim_expr, fields);
   }
@@ -192,8 +195,9 @@ public:
 					  &canonical_path);
     rust_assert (ok);
 
+    RustIdent ident{*canonical_path, item.get_locus ()};
     variant = new TyTy::VariantDef (item.get_mappings ().get_hirid (),
-				    item.get_identifier (),
+				    item.get_identifier (), ident,
 				    TyTy::VariantDef::VariantType::STRUCT,
 				    discrim_expr, fields);
   }

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
@@ -102,16 +102,26 @@ public:
 	idx++;
       }
 
-    // there is only a single variant
+    // get the path
+    const CanonicalPath *canonical_path = nullptr;
+    bool ok = mappings->lookup_canonical_path (
+      struct_decl.get_mappings ().get_crate_num (),
+      struct_decl.get_mappings ().get_nodeid (), &canonical_path);
+    rust_assert (ok);
+    RustIdent ident{*canonical_path, struct_decl.get_locus ()};
+
+    // its a single variant ADT
     std::vector<TyTy::VariantDef *> variants;
-    variants.push_back (new TyTy::VariantDef (
-      struct_decl.get_mappings ().get_hirid (), struct_decl.get_identifier (),
-      TyTy::VariantDef::VariantType::TUPLE, nullptr, std::move (fields)));
+    variants.push_back (
+      new TyTy::VariantDef (struct_decl.get_mappings ().get_hirid (),
+			    struct_decl.get_identifier (), ident,
+			    TyTy::VariantDef::VariantType::TUPLE, nullptr,
+			    std::move (fields)));
 
     TyTy::BaseType *type
       = new TyTy::ADTType (struct_decl.get_mappings ().get_hirid (),
 			   mappings->get_next_hir_id (),
-			   struct_decl.get_identifier (),
+			   struct_decl.get_identifier (), ident,
 			   TyTy::ADTType::ADTKind::TUPLE_STRUCT,
 			   std::move (variants), std::move (substitutions));
 
@@ -158,7 +168,6 @@ public:
       }
 
     std::vector<TyTy::StructFieldType *> fields;
-
     for (auto &field : struct_decl.get_fields ())
       {
 	TyTy::BaseType *field_type
@@ -171,16 +180,26 @@ public:
 			      ty_field->get_field_type ());
       }
 
-    // there is only a single variant
+    // get the path
+    const CanonicalPath *canonical_path = nullptr;
+    bool ok = mappings->lookup_canonical_path (
+      struct_decl.get_mappings ().get_crate_num (),
+      struct_decl.get_mappings ().get_nodeid (), &canonical_path);
+    rust_assert (ok);
+    RustIdent ident{*canonical_path, struct_decl.get_locus ()};
+
+    // its a single variant ADT
     std::vector<TyTy::VariantDef *> variants;
-    variants.push_back (new TyTy::VariantDef (
-      struct_decl.get_mappings ().get_hirid (), struct_decl.get_identifier (),
-      TyTy::VariantDef::VariantType::STRUCT, nullptr, std::move (fields)));
+    variants.push_back (
+      new TyTy::VariantDef (struct_decl.get_mappings ().get_hirid (),
+			    struct_decl.get_identifier (), ident,
+			    TyTy::VariantDef::VariantType::STRUCT, nullptr,
+			    std::move (fields)));
 
     TyTy::BaseType *type
       = new TyTy::ADTType (struct_decl.get_mappings ().get_hirid (),
 			   mappings->get_next_hir_id (),
-			   struct_decl.get_identifier (),
+			   struct_decl.get_identifier (), ident,
 			   TyTy::ADTType::ADTKind::STRUCT_STRUCT,
 			   std::move (variants), std::move (substitutions));
 
@@ -226,10 +245,19 @@ public:
 	variants.push_back (field_type);
       }
 
+    // get the path
+    const CanonicalPath *canonical_path = nullptr;
+    bool ok = mappings->lookup_canonical_path (
+      enum_decl.get_mappings ().get_crate_num (),
+      enum_decl.get_mappings ().get_nodeid (), &canonical_path);
+    rust_assert (ok);
+    RustIdent ident{*canonical_path, enum_decl.get_locus ()};
+
+    // multi variant ADT
     TyTy::BaseType *type
       = new TyTy::ADTType (enum_decl.get_mappings ().get_hirid (),
 			   mappings->get_next_hir_id (),
-			   enum_decl.get_identifier (),
+			   enum_decl.get_identifier (), ident,
 			   TyTy::ADTType::ADTKind::ENUM, std::move (variants),
 			   std::move (substitutions));
 
@@ -282,16 +310,26 @@ public:
 			      ty_variant->get_field_type ());
       }
 
+    // get the path
+    const CanonicalPath *canonical_path = nullptr;
+    bool ok = mappings->lookup_canonical_path (
+      union_decl.get_mappings ().get_crate_num (),
+      union_decl.get_mappings ().get_nodeid (), &canonical_path);
+    rust_assert (ok);
+    RustIdent ident{*canonical_path, union_decl.get_locus ()};
+
     // there is only a single variant
     std::vector<TyTy::VariantDef *> variants;
-    variants.push_back (new TyTy::VariantDef (
-      union_decl.get_mappings ().get_hirid (), union_decl.get_identifier (),
-      TyTy::VariantDef::VariantType::STRUCT, nullptr, std::move (fields)));
+    variants.push_back (
+      new TyTy::VariantDef (union_decl.get_mappings ().get_hirid (),
+			    union_decl.get_identifier (), ident,
+			    TyTy::VariantDef::VariantType::STRUCT, nullptr,
+			    std::move (fields)));
 
     TyTy::BaseType *type
       = new TyTy::ADTType (union_decl.get_mappings ().get_hirid (),
 			   mappings->get_next_hir_id (),
-			   union_decl.get_identifier (),
+			   union_decl.get_identifier (), ident,
 			   TyTy::ADTType::ADTKind::UNION, std::move (variants),
 			   std::move (substitutions));
 
@@ -350,7 +388,8 @@ public:
 
     TyTy::BaseType *ret_type = nullptr;
     if (!function.has_function_return_type ())
-      ret_type = new TyTy::TupleType (function.get_mappings ().get_hirid ());
+      ret_type = TyTy::TupleType::get_unit_type (
+	function.get_mappings ().get_hirid ());
     else
       {
 	auto resolved
@@ -379,9 +418,16 @@ public:
 	context->insert_type (param.get_mappings (), param_tyty);
       }
 
+    const CanonicalPath *canonical_path = nullptr;
+    bool ok = mappings->lookup_canonical_path (
+      function.get_mappings ().get_crate_num (),
+      function.get_mappings ().get_nodeid (), &canonical_path);
+    rust_assert (ok);
+
+    RustIdent ident{*canonical_path, function.get_locus ()};
     auto fnType = new TyTy::FnType (function.get_mappings ().get_hirid (),
 				    function.get_mappings ().get_defid (),
-				    function.get_function_name (),
+				    function.get_function_name (), ident,
 				    TyTy::FnType::FNTYPE_DEFAULT_FLAGS,
 				    ABI::RUST, std::move (params), ret_type,
 				    std::move (substitutions));

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -572,8 +572,10 @@ TypeCheckType::visit (HIR::TraitObjectType &type)
 	specified_bounds.push_back (std::move (predicate));
     }
 
-  translated = new TyTy::DynamicObjectType (type.get_mappings ().get_hirid (),
-					    std::move (specified_bounds));
+  RustIdent ident{CanonicalPath::create_empty (), type.get_locus ()};
+  translated
+    = new TyTy::DynamicObjectType (type.get_mappings ().get_hirid (), ident,
+				   std::move (specified_bounds));
 }
 
 void
@@ -594,7 +596,7 @@ TypeCheckType::visit (HIR::ArrayType &type)
 
   TyTy::BaseType *base = TypeCheckType::Resolve (type.get_element_type ());
   translated = new TyTy::ArrayType (type.get_mappings ().get_hirid (),
-				    *type.get_size_expr (),
+				    type.get_locus (), *type.get_size_expr (),
 				    TyTy::TyVar (base->get_ref ()));
 }
 

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -74,7 +74,8 @@ public:
     TyTy::BaseType *return_type
       = fntype.has_return_type ()
 	  ? TypeCheckType::Resolve (fntype.get_return_type ().get ())
-	  : new TyTy::TupleType (fntype.get_mappings ().get_hirid ());
+	  : TyTy::TupleType::get_unit_type (
+	    fntype.get_mappings ().get_hirid ());
 
     std::vector<TyTy::TyVar> params;
     for (auto &param : fntype.get_function_params ())
@@ -85,7 +86,7 @@ public:
       }
 
     translated = new TyTy::FnPtr (fntype.get_mappings ().get_hirid (),
-				  std::move (params),
+				  fntype.get_locus (), std::move (params),
 				  TyTy::TyVar (return_type->get_ref ()));
   }
 
@@ -109,8 +110,8 @@ public:
 	fields.push_back (TyTy::TyVar (field_ty->get_ref ()));
       }
 
-    translated
-      = new TyTy::TupleType (tuple.get_mappings ().get_hirid (), fields);
+    translated = new TyTy::TupleType (tuple.get_mappings ().get_hirid (),
+				      tuple.get_locus (), fields);
   }
 
   void visit (HIR::TypePath &path) override;
@@ -140,7 +141,8 @@ public:
   void visit (HIR::InferredType &type) override
   {
     translated = new TyTy::InferType (type.get_mappings ().get_hirid (),
-				      TyTy::InferType::InferTypeKind::GENERAL);
+				      TyTy::InferType::InferTypeKind::GENERAL,
+				      type.get_locus ());
   }
 
   void visit (HIR::TraitObjectType &type) override;
@@ -265,6 +267,7 @@ public:
       }
 
     resolved = new TyTy::ParamType (param.get_type_representation (),
+				    param.get_locus (),
 				    param.get_mappings ().get_hirid (), param,
 				    specified_bounds);
   }

--- a/gcc/rust/typecheck/rust-hir-type-check.h
+++ b/gcc/rust/typecheck/rust-hir-type-check.h
@@ -125,10 +125,11 @@ public:
       }
   }
 
-  void push_new_loop_context (HirId id)
+  void push_new_loop_context (HirId id, Location locus)
   {
     TyTy::BaseType *infer_var
-      = new TyTy::InferType (id, TyTy::InferType::InferTypeKind::GENERAL);
+      = new TyTy::InferType (id, TyTy::InferType::InferTypeKind::GENERAL,
+			     locus);
     loop_type_stack.push_back (infer_var);
   }
 

--- a/gcc/rust/typecheck/rust-tyty-cast.h
+++ b/gcc/rust/typecheck/rust-tyty-cast.h
@@ -806,9 +806,10 @@ public:
 	return;
       }
 
-    resolved = new ArrayType (type.get_ref (), type.get_ty_ref (),
-			      type.get_capacity_expr (),
-			      TyVar (base_resolved->get_ref ()));
+    resolved
+      = new ArrayType (type.get_ref (), type.get_ty_ref (),
+		       type.get_ident ().locus, type.get_capacity_expr (),
+		       TyVar (base_resolved->get_ref ()));
   }
 
 private:
@@ -1063,8 +1064,8 @@ public:
 	fields.push_back (TyVar (unified_ty->get_ref ()));
       }
 
-    resolved
-      = new TyTy::TupleType (type.get_ref (), type.get_ty_ref (), fields);
+    resolved = new TyTy::TupleType (type.get_ref (), type.get_ty_ref (),
+				    type.get_ident ().locus, fields);
   }
 
 private:

--- a/gcc/rust/typecheck/rust-tyty-coercion.h
+++ b/gcc/rust/typecheck/rust-tyty-coercion.h
@@ -824,9 +824,10 @@ public:
 	return;
       }
 
-    resolved = new ArrayType (type.get_ref (), type.get_ty_ref (),
-			      type.get_capacity_expr (),
-			      TyVar (base_resolved->get_ref ()));
+    resolved
+      = new ArrayType (type.get_ref (), type.get_ty_ref (),
+		       type.get_ident ().locus, type.get_capacity_expr (),
+		       TyVar (base_resolved->get_ref ()));
   }
 
 private:
@@ -1071,8 +1072,8 @@ public:
 	fields.push_back (TyVar (unified_ty->get_ref ()));
       }
 
-    resolved
-      = new TyTy::TupleType (type.get_ref (), type.get_ty_ref (), fields);
+    resolved = new TyTy::TupleType (type.get_ref (), type.get_ty_ref (),
+				    type.get_ident ().locus, fields);
   }
 
 private:

--- a/gcc/rust/typecheck/rust-tyty-rules.h
+++ b/gcc/rust/typecheck/rust-tyty-rules.h
@@ -838,9 +838,10 @@ public:
 	return;
       }
 
-    resolved = new ArrayType (type.get_ref (), type.get_ty_ref (),
-			      type.get_capacity_expr (),
-			      TyVar (base_resolved->get_ref ()));
+    resolved
+      = new ArrayType (type.get_ref (), type.get_ty_ref (),
+		       type.get_ident ().locus, type.get_capacity_expr (),
+		       TyVar (base_resolved->get_ref ()));
   }
 
 private:
@@ -1083,8 +1084,8 @@ public:
 	fields.push_back (TyVar (unified_ty->get_ref ()));
       }
 
-    resolved
-      = new TyTy::TupleType (type.get_ref (), type.get_ty_ref (), fields);
+    resolved = new TyTy::TupleType (type.get_ref (), type.get_ty_ref (),
+				    type.get_ident ().locus, fields);
   }
 
 private:

--- a/gcc/rust/util/rust-identifier.h
+++ b/gcc/rust/util/rust-identifier.h
@@ -1,0 +1,49 @@
+// Copyright (C) 2020-2022 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_IDENTIFIER
+#define RUST_IDENTIFIER
+
+#include "rust-canonical-path.h"
+#include "rust-location.h"
+
+namespace Rust {
+
+struct RustIdent
+{
+  Resolver::CanonicalPath path;
+  Location locus;
+
+  RustIdent (const Resolver::CanonicalPath &path, Location locus)
+    : path (path), locus (locus)
+  {}
+
+  RustIdent (const RustIdent &other) : path (other.path), locus (other.locus) {}
+
+  RustIdent &operator= (const RustIdent &other)
+  {
+    path = other.path;
+    locus = other.locus;
+
+    return *this;
+  }
+};
+
+} // namespace Rust
+
+#endif // RUST_IDENTIFIER

--- a/gcc/testsuite/rust/compile/torture/struct_decl.rs
+++ b/gcc/testsuite/rust/compile/torture/struct_decl.rs
@@ -1,14 +1,14 @@
 // { dg-additional-options -fdump-tree-gimple }
 
 struct Foo {
-  a: u16,
-// { dg-warning "field is never read" "" { target *-*-* } .-1 }
-  b: u8,
-// { dg-warning "field is never read" "" { target *-*-* } .-1 }
+    a: u16,
+    // { dg-warning "field is never read" "" { target *-*-* } .-1 }
+    b: u8,
+    // { dg-warning "field is never read" "" { target *-*-* } .-1 }
 }
 
 fn main() {
-  let my_foo = Foo { a: 1, b: 2 };
-  // { dg-warning "unused name" "" { target *-*-* } .-1 }
-  // { dg-final { scan-tree-dump-times {(?n)const struct Foo my_foo;$} 1 gimple } }
+    let my_foo = Foo { a: 1, b: 2 };
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+    // { dg-final { scan-tree-dump-times {(?n)const struct example::Foo my_foo;$} 1 gimple } }
 }


### PR DESCRIPTION
This refactors our TyTy type abstractions to contain their repspective
canonical-path and location info. This cleans up alot of location tracking
for example when we have generic structures we create implicit hirids which
may or may not have location info this now tracks the location info of
the declaration of the type avoiding any confustion.
