### PR TITLE
Apply the is_marked_for_strip check to the rest of the crate

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -147,6 +147,9 @@ public:
     std::vector<HIR::TupleField> fields;
     for (AST::TupleField &field : struct_decl.get_fields ())
       {
+	if (field.get_field_type ()->is_marked_for_strip ())
+	  continue;
+
 	HIR::Visibility vis = HIR::Visibility::create_public ();
 	HIR::Type *type
 	  = ASTLoweringType::translate (field.get_field_type ().get ());
@@ -208,6 +211,9 @@ public:
     std::vector<HIR::StructField> fields;
     for (AST::StructField &field : struct_decl.get_fields ())
       {
+	if (field.get_field_type ()->is_marked_for_strip ())
+	  continue;
+
 	HIR::Visibility vis = HIR::Visibility::create_public ();
 	HIR::Type *type
 	  = ASTLoweringType::translate (field.get_field_type ().get ());
@@ -272,6 +278,9 @@ public:
     std::vector<std::unique_ptr<HIR::EnumItem>> items;
     for (auto &variant : enum_decl.get_variants ())
       {
+	if (variant->is_marked_for_strip ())
+	  continue;
+
 	HIR::EnumItem *hir_item
 	  = ASTLoweringEnumItem::translate (variant.get ());
 	items.push_back (std::unique_ptr<HIR::EnumItem> (hir_item));
@@ -318,6 +327,9 @@ public:
     std::vector<HIR::StructField> variants;
     for (AST::StructField &variant : union_decl.get_variants ())
       {
+	if (variant.get_field_type ()->is_marked_for_strip ())
+	  continue;
+
 	HIR::Visibility vis = HIR::Visibility::create_public ();
 	HIR::Type *type
 	  = ASTLoweringType::translate (variant.get_field_type ().get ());
@@ -558,6 +570,9 @@ public:
     std::vector<HirId> impl_item_ids;
     for (auto &impl_item : impl_block.get_impl_items ())
       {
+	if (impl_item->is_marked_for_strip ())
+	  continue;
+
 	HIR::ImplItem *lowered
 	  = ASTLowerImplItem::translate (impl_item.get (),
 					 mapping.get_hirid ());
@@ -623,6 +638,9 @@ public:
     std::vector<HirId> trait_item_ids;
     for (auto &item : trait.get_trait_items ())
       {
+	if (item->is_marked_for_strip ())
+	  continue;
+
 	HIR::TraitItem *lowered = ASTLowerTraitItem::translate (item.get ());
 	trait_items.push_back (std::unique_ptr<HIR::TraitItem> (lowered));
 	trait_item_ids.push_back (lowered->get_mappings ().get_hirid ());
@@ -716,6 +734,9 @@ public:
     std::vector<HirId> impl_item_ids;
     for (auto &impl_item : impl_block.get_impl_items ())
       {
+	if (impl_item->is_marked_for_strip ())
+	  continue;
+
 	HIR::ImplItem *lowered
 	  = ASTLowerImplItem::translate (impl_item.get (),
 					 mapping.get_hirid ());
@@ -754,6 +775,9 @@ public:
     std::vector<std::unique_ptr<HIR::ExternalItem>> extern_items;
     for (auto &item : extern_block.get_extern_items ())
       {
+	if (item->is_marked_for_strip ())
+	  continue;
+
 	HIR::ExternalItem *lowered
 	  = ASTLoweringExternItem::translate (item.get ());
 	extern_items.push_back (std::unique_ptr<HIR::ExternalItem> (lowered));

--- a/gcc/rust/resolve/rust-ast-resolve-implitem.h
+++ b/gcc/rust/resolve/rust-ast-resolve-implitem.h
@@ -33,12 +33,18 @@ class ResolveToplevelImplItem : public ResolverBase
 public:
   static void go (AST::InherentImplItem *item, const CanonicalPath &prefix)
   {
+    if (item->is_marked_for_strip ())
+      return;
+
     ResolveToplevelImplItem resolver (prefix);
     item->accept_vis (resolver);
   }
 
   static void go (AST::TraitImplItem *item, const CanonicalPath &prefix)
   {
+    if (item->is_marked_for_strip ())
+      return;
+
     ResolveToplevelImplItem resolver (prefix);
     item->accept_vis (resolver);
   }

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -38,6 +38,9 @@ public:
   static void go (AST::TraitItem *item, const CanonicalPath &prefix,
 		  const CanonicalPath &canonical_prefix)
   {
+    if (item->is_marked_for_strip ())
+      return;
+
     ResolveTraitItems resolver (prefix, canonical_prefix);
     item->accept_vis (resolver);
   };
@@ -303,8 +306,13 @@ public:
       ResolveWhereClause::Resolve (struct_decl.get_where_clause ());
 
     for (AST::TupleField &field : struct_decl.get_fields ())
-      ResolveType::go (field.get_field_type ().get (),
-		       struct_decl.get_node_id ());
+      {
+	if (field.get_field_type ()->is_marked_for_strip ())
+	  continue;
+
+	ResolveType::go (field.get_field_type ().get (),
+			 struct_decl.get_node_id ());
+      }
 
     resolver->get_type_scope ().pop ();
   }
@@ -360,7 +368,12 @@ public:
 				     item.get_node_id (), cpath);
 
     for (auto &field : item.get_tuple_fields ())
-      ResolveType::go (field.get_field_type ().get (), item.get_node_id ());
+      {
+	if (field.get_field_type ()->is_marked_for_strip ())
+	  continue;
+
+	ResolveType::go (field.get_field_type ().get (), item.get_node_id ());
+      }
   }
 
   void visit (AST::EnumItemStruct &item) override
@@ -373,7 +386,12 @@ public:
 				     item.get_node_id (), cpath);
 
     for (auto &field : item.get_struct_fields ())
-      ResolveType::go (field.get_field_type ().get (), item.get_node_id ());
+      {
+	if (field.get_field_type ()->is_marked_for_strip ())
+	  continue;
+
+	ResolveType::go (field.get_field_type ().get (), item.get_node_id ());
+      }
   }
 
   void visit (AST::EnumItemDiscriminant &item) override
@@ -412,8 +430,13 @@ public:
       ResolveWhereClause::Resolve (struct_decl.get_where_clause ());
 
     for (AST::StructField &field : struct_decl.get_fields ())
-      ResolveType::go (field.get_field_type ().get (),
-		       struct_decl.get_node_id ());
+      {
+	if (field.get_field_type ()->is_marked_for_strip ())
+	  continue;
+
+	ResolveType::go (field.get_field_type ().get (),
+			 struct_decl.get_node_id ());
+      }
 
     resolver->get_type_scope ().pop ();
   }
@@ -442,8 +465,13 @@ public:
       ResolveWhereClause::Resolve (union_decl.get_where_clause ());
 
     for (AST::StructField &field : union_decl.get_variants ())
-      ResolveType::go (field.get_field_type ().get (),
-		       union_decl.get_node_id ());
+      {
+	if (field.get_field_type ()->is_marked_for_strip ())
+	  continue;
+
+	ResolveType::go (field.get_field_type ().get (),
+			 union_decl.get_node_id ());
+      }
 
     resolver->get_type_scope ().pop ();
   }
@@ -486,9 +514,6 @@ public:
 
   void visit (AST::Function &function) override
   {
-    if (function.is_marked_for_strip ())
-      return;
-
     auto decl = ResolveFunctionItemToCanonicalPath::resolve (function);
     auto path = prefix.append (decl);
     auto cpath = canonical_prefix.append (decl);
@@ -884,6 +909,9 @@ public:
   static void go (AST::InherentImplItem *item, const CanonicalPath &prefix,
 		  const CanonicalPath &canonical_prefix)
   {
+    if (item->is_marked_for_strip ())
+      return;
+
     ResolveImplItems resolver (prefix, canonical_prefix);
     item->accept_vis (resolver);
   };
@@ -891,6 +919,9 @@ public:
   static void go (AST::TraitImplItem *item, const CanonicalPath &prefix,
 		  const CanonicalPath &canonical_prefix)
   {
+    if (item->is_marked_for_strip ())
+      return;
+
     ResolveImplItems resolver (prefix, canonical_prefix);
     item->accept_vis (resolver);
   };

--- a/gcc/rust/resolve/rust-ast-resolve-stmt.h
+++ b/gcc/rust/resolve/rust-ast-resolve-stmt.h
@@ -37,6 +37,9 @@ public:
 		  const CanonicalPath &canonical_prefix,
 		  const CanonicalPath &enum_prefix)
   {
+    if (stmt->is_marked_for_strip ())
+      return;
+
     ResolveStmt resolver (parent, prefix, canonical_prefix, enum_prefix);
     stmt->accept_vis (resolver);
   };
@@ -208,7 +211,12 @@ public:
       });
 
     for (auto &field : item.get_tuple_fields ())
-      ResolveType::go (field.get_field_type ().get (), item.get_node_id ());
+      {
+	if (field.get_field_type ()->is_marked_for_strip ())
+	  continue;
+
+	ResolveType::go (field.get_field_type ().get (), item.get_node_id ());
+      }
   }
 
   void visit (AST::EnumItemStruct &item) override
@@ -229,7 +237,12 @@ public:
       });
 
     for (auto &field : item.get_struct_fields ())
-      ResolveType::go (field.get_field_type ().get (), item.get_node_id ());
+      {
+	if (field.get_field_type ()->is_marked_for_strip ())
+	  continue;
+
+	ResolveType::go (field.get_field_type ().get (), item.get_node_id ());
+      }
   }
 
   void visit (AST::EnumItemDiscriminant &item) override
@@ -282,8 +295,13 @@ public:
       }
 
     for (AST::StructField &field : struct_decl.get_fields ())
-      ResolveType::go (field.get_field_type ().get (),
-		       struct_decl.get_node_id ());
+      {
+	if (field.get_field_type ()->is_marked_for_strip ())
+	  continue;
+
+	ResolveType::go (field.get_field_type ().get (),
+			 struct_decl.get_node_id ());
+      }
 
     resolver->get_type_scope ().pop ();
   }
@@ -317,8 +335,13 @@ public:
       }
 
     for (AST::StructField &field : union_decl.get_variants ())
-      ResolveType::go (field.get_field_type ().get (),
-		       union_decl.get_node_id ());
+      {
+	if (field.get_field_type ()->is_marked_for_strip ())
+	  continue;
+
+	ResolveType::go (field.get_field_type ().get (),
+			 union_decl.get_node_id ());
+      }
 
     resolver->get_type_scope ().pop ();
   }

--- a/gcc/rust/resolve/rust-ast-resolve-toplevel.h
+++ b/gcc/rust/resolve/rust-ast-resolve-toplevel.h
@@ -36,6 +36,9 @@ public:
   static void go (AST::Item *item, const CanonicalPath &prefix,
 		  const CanonicalPath &canonical_prefix)
   {
+    if (item->is_marked_for_strip ())
+      return;
+
     ResolveTopLevel resolver (prefix, canonical_prefix);
     item->accept_vis (resolver);
   };
@@ -286,9 +289,6 @@ public:
 
   void visit (AST::Function &function) override
   {
-    if (function.is_marked_for_strip ())
-      return;
-
     auto decl = ResolveFunctionItemToCanonicalPath::resolve (function);
     auto path = prefix.append (decl);
     auto cpath = canonical_prefix.append (decl);

--- a/gcc/testsuite/rust/execute/torture/cfg2.rs
+++ b/gcc/testsuite/rust/execute/torture/cfg2.rs
@@ -1,0 +1,31 @@
+// { dg-additional-options "-w -frust-cfg=A" }
+// { dg-output "test1\n" }
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+fn test() {
+    #[cfg(A)]
+    unsafe {
+        let a = "test1\n\0";
+        let b = a as *const str;
+        let c = b as *const i8;
+
+        printf(c);
+    }
+
+    #[cfg(B)]
+    unsafe {
+        let a = "test2\n\0";
+        let b = a as *const str;
+        let c = b as *const i8;
+
+        printf(c);
+    }
+}
+
+fn main() -> i32 {
+    test();
+
+    0
+}

--- a/gcc/testsuite/rust/execute/torture/cfg3.rs
+++ b/gcc/testsuite/rust/execute/torture/cfg3.rs
@@ -1,0 +1,37 @@
+// { dg-additional-options "-w -frust-cfg=A" }
+// { dg-output "test1\n" }
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+struct Foo(i32);
+impl Foo {
+    #[cfg(A)]
+    fn test(&self) {
+        unsafe {
+            let a = "test1\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c);
+        }
+    }
+
+    #[cfg(B)]
+    fn test(&self) {
+        unsafe {
+            let a = "test2\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c);
+        }
+    }
+}
+
+fn main() -> i32 {
+    let a = Foo(123);
+    a.test();
+
+    0
+}


### PR DESCRIPTION
We need to apply this to all levels of the crate:

Item
  types
  impl-item
  trait-item
  Stmt
  expr's

Fixes #872 