### PR TITLE
Support cfg expansions predicates

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -816,7 +816,7 @@ class MetaWord;
 class MetaListPaths;
 
 // Forward decl - defined in rust-macro.h
-struct MetaListNameValueStr;
+class MetaListNameValueStr;
 
 /* Base statement abstract class. Note that most "statements" are not allowed in
  * top-level module scope - only a subclass of statements called "items" are. */

--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -610,6 +610,8 @@ class MetaListNameValueStr : public MetaItem
   Identifier ident;
   std::vector<MetaNameValueStr> strs;
 
+  // FIXME add location info
+
 public:
   MetaListNameValueStr (Identifier ident, std::vector<MetaNameValueStr> strs)
     : ident (std::move (ident)), strs (std::move (strs))
@@ -690,7 +692,7 @@ public:
 // Object that parses macros from a token stream.
 /* TODO: would "AttributeParser" be a better name? MetaItems are only for
  * attributes, I believe */
-struct MacroParser
+struct AttributeParser
 {
 private:
   // TODO: might as well rewrite to use lexer tokens
@@ -698,12 +700,12 @@ private:
   int stream_pos;
 
 public:
-  MacroParser (std::vector<std::unique_ptr<Token> > token_stream,
-	       int stream_start_pos = 0)
+  AttributeParser (std::vector<std::unique_ptr<Token> > token_stream,
+		   int stream_start_pos = 0)
     : token_stream (std::move (token_stream)), stream_pos (stream_start_pos)
   {}
 
-  ~MacroParser () = default;
+  ~AttributeParser () = default;
 
   std::vector<std::unique_ptr<MetaItemInner> > parse_meta_item_seq ();
 

--- a/gcc/testsuite/rust/compile/cfg2.rs
+++ b/gcc/testsuite/rust/compile/cfg2.rs
@@ -1,0 +1,13 @@
+// { dg-additional-options "-w -frust-cfg=A" }
+struct Foo;
+impl Foo {
+    #[cfg(not(A))]
+    fn test(&self) {}
+}
+
+fn main() {
+    let a = Foo;
+    a.test();
+    // { dg-error "failed to resolve method for .test." "" { target *-*-* } .-1 }
+    // { dg-error "failed to type resolve expression" "" { target *-*-* } .-2 }
+}

--- a/gcc/testsuite/rust/compile/cfg3.rs
+++ b/gcc/testsuite/rust/compile/cfg3.rs
@@ -1,0 +1,11 @@
+// { dg-additional-options "-w -frust-cfg=A -frust-cfg=B" }
+struct Foo;
+impl Foo {
+    #[cfg(all(A, B))]
+    fn test(&self) {}
+}
+
+fn main() {
+    let a = Foo;
+    a.test();
+}

--- a/gcc/testsuite/rust/compile/cfg4.rs
+++ b/gcc/testsuite/rust/compile/cfg4.rs
@@ -1,0 +1,11 @@
+// { dg-additional-options "-w -frust-cfg=A" }
+struct Foo;
+impl Foo {
+    #[cfg(any(A, B))]
+    fn test(&self) {}
+}
+
+fn main() {
+    let a = Foo;
+    a.test();
+}

--- a/gcc/testsuite/rust/execute/torture/cfg4.rs
+++ b/gcc/testsuite/rust/execute/torture/cfg4.rs
@@ -1,0 +1,38 @@
+// { dg-additional-options "-w -frust-cfg=A" }
+// { dg-output "test1\ntest2\n" }
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+struct Foo(i32);
+impl Foo {
+    #[cfg(A)]
+    fn test(&self) {
+        unsafe {
+            let a = "test1\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c);
+        }
+    }
+
+    #[cfg(not(B))]
+    fn test2(&self) {
+        unsafe {
+            let a = "test2\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c);
+        }
+    }
+}
+
+fn main() -> i32 {
+    let a = Foo(123);
+    a.test();
+    a.test2();
+
+    0
+}


### PR DESCRIPTION
Config expansion can be not, any, or all predicate to enforce the config
expansion logic.

This patch refactors the MacroParser to be named AttributeParser as it is
only used to parse attributes into MetaItems that we can work with and
do expansion logic upon. This handles the case of parsing the
inner-meta-item of not(A) to parse it into MetaListNameValueStr and tidies
up some of the code in the area.

Fixes #901
