### PR TITLE
Fix '-Wformat-diag' issue in 'TypeCheckPattern::visit (HIR::TupleStructPattern &pattern)'

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
@@ -58,7 +58,7 @@ TypeCheckPattern::visit (HIR::TupleStructPattern &pattern)
 
       rust_error_at (
 	pattern.get_locus (),
-	"expected tuple struct or tuple variant, found %s variant %s::%s",
+	"expected tuple struct or tuple variant, found %s variant %<%s::%s%>",
 	variant_type.c_str (), adt->get_name ().c_str (),
 	variant->get_identifier ().c_str ());
       return;

--- a/gcc/testsuite/rust/compile/match5.rs
+++ b/gcc/testsuite/rust/compile/match5.rs
@@ -10,6 +10,6 @@ fn inspect(f: Foo) {
         Foo::A => {}
         Foo::B => {}
         Foo::C(a) => {}
-        Foo::D(x, y) => {} // { dg-error "expected tuple struct or tuple variant, found struct variant Foo::D" }
+        Foo::D(x, y) => {} // { dg-error "expected tuple struct or tuple variant, found struct variant 'Foo::D'" }
     }
 }


### PR DESCRIPTION
It's alread now diagnosed, non-fatal warning:

    [...]/source-gcc/gcc/rust/typecheck/rust-hir-type-check-pattern.cc: In member function ‘virtual void Rust::Resolver::TypeCheckPattern::visit(Rust::HIR::TupleStructPattern&)’:
    [...]/source-gcc/gcc/rust/typecheck/rust-hir-type-check-pattern.cc:61:69: warning: unquoted operator ‘::’ in format [-Wformat-diag]
        61 |         "expected tuple struct or tuple variant, found %s variant %s::%s",
           |                                                                     ^~

A later merge from GCC upstream will bring in
commit 34ba4275dcf5162efb9b634e4665734766faf4e3
"Enable -Werror=format-diag during bootstrap", which then causes:

    [...]/source-gcc/gcc/rust/typecheck/rust-hir-type-check-pattern.cc: In member function ‘virtual void Rust::Resolver::TypeCheckPattern::visit(Rust::HIR::TupleStructPattern&)’:
    [...]/source-gcc/gcc/rust/typecheck/rust-hir-type-check-pattern.cc:61:69: error: unquoted operator ‘::’ in format [-Werror=format-diag]
       61 |         "expected tuple struct or tuple variant, found %s variant %s::%s",
          |                                                                     ^~
    cc1plus: all warnings being treated as errors
    make[3]: *** [rust/rust-hir-type-check-pattern.o] Error 1
