### PR TITLE
Add support for key = value pairs on -frust-cfg=

### DIFF
--- a/gcc/testsuite/rust/compile/cfg5.rs
+++ b/gcc/testsuite/rust/compile/cfg5.rs
@@ -1,0 +1,11 @@
+// { dg-additional-options "-w -frust-cfg=A=B" }
+struct Foo;
+impl Foo {
+    #[cfg(A = "B")]
+    fn test(&self) {}
+}
+
+fn main() {
+    let a = Foo;
+    a.test();
+}


### PR DESCRIPTION
This adds in a basic parser to parse out key value pairs for the config
option it needs to be tested poperly once the self-test framework is
merged in.

Fixes #889
