### PR TITLE
Support inline attribute by marking as DECL_DECLARED_INLINE_P

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -75,6 +75,7 @@ GRS_OBJS = \
     rust/rust-macro-expand.o \
     rust/rust-hir-full-test.o \
     rust/rust-hir-map.o \
+    rust/rust-abi.o \
     rust/rust-ast-lower.o \
     rust/rust-ast-lower-pattern.o \
     rust/rust-ast-resolve.o \
@@ -99,6 +100,7 @@ GRS_OBJS = \
     rust/rust-compile-expr.o \
     rust/rust-compile-type.o \
     rust/rust-constexpr.o \
+    rust/rust-compile-base.o \
     $(END)
 # removed object files from here
 

--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -1,0 +1,92 @@
+// Copyright (C) 2020-2022 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-compile-base.h"
+#include "stringpool.h"
+
+namespace Rust {
+namespace Compile {
+
+void
+HIRCompileBase::setup_attributes_on_fndecl (
+  tree fndecl, bool is_main_entry_point, bool has_visibility,
+  const HIR::FunctionQualifiers &qualifiers, const AST::AttrVec &attrs)
+{
+  // if its the main fn or pub visibility mark its as DECL_PUBLIC
+  // please see https://github.com/Rust-GCC/gccrs/pull/137
+  if (is_main_entry_point || has_visibility)
+    {
+      TREE_PUBLIC (fndecl) = 1;
+    }
+
+  // is it a const fn
+  if (qualifiers.is_const ())
+    {
+      TREE_READONLY (fndecl) = 1;
+    }
+
+  // is it inline?
+  for (const auto &attr : attrs)
+    {
+      bool is_inline = attr.get_path ().as_string ().compare ("inline") == 0;
+      if (is_inline)
+	{
+	  DECL_DECLARED_INLINE_P (fndecl) = 1;
+
+	  // do we want to force inline regardless of optimisation level?
+	  // https://gcc.gnu.org/onlinedocs/gcc/Inline.html
+	  //
+	  // /* Add attribute "always_inline": */
+	  // DECL_ATTRIBUTES (fndecl)
+	  //   = tree_cons (get_identifier ("always_inline"), NULL,
+	  //       	 DECL_ATTRIBUTES (fndecl));
+	}
+    }
+}
+
+void
+HIRCompileBase::setup_abi_options (tree fndecl, ABI abi)
+{
+  switch (abi)
+    {
+    case Rust::ABI::RUST:
+    case Rust::ABI::INTRINSIC:
+    case Rust::ABI::C:
+    case Rust::ABI::CDECL:
+      DECL_ATTRIBUTES (fndecl)
+	= tree_cons (get_identifier ("cdecl"), NULL, DECL_ATTRIBUTES (fndecl));
+      break;
+
+    case Rust::ABI::STDCALL:
+      DECL_ATTRIBUTES (fndecl) = tree_cons (get_identifier ("stdcall"), NULL,
+					    DECL_ATTRIBUTES (fndecl));
+      break;
+
+    case Rust::ABI::FASTCALL:
+      DECL_ATTRIBUTES (fndecl) = tree_cons (get_identifier ("fastcall"), NULL,
+					    DECL_ATTRIBUTES (fndecl));
+
+      break;
+
+    default:
+      break;
+    }
+}
+
+} // namespace Compile
+} // namespace Rust

--- a/gcc/rust/backend/rust-compile-base.h
+++ b/gcc/rust/backend/rust-compile-base.h
@@ -71,6 +71,12 @@ protected:
 
   tree resolve_deref_adjustment (Resolver::Adjustment &adjustment,
 				 tree expression, Location locus);
+
+  static void setup_attributes_on_fndecl (
+    tree fndecl, bool is_main_entry_point, bool has_visibility,
+    const HIR::FunctionQualifiers &qualifiers, const AST::AttrVec &attrs);
+
+  static void setup_abi_options (tree fndecl, ABI abi);
 };
 
 } // namespace Compile

--- a/gcc/rust/backend/rust-compile-extern.h
+++ b/gcc/rust/backend/rust-compile-extern.h
@@ -125,19 +125,16 @@ public:
       }
 
     tree compiled_fn_type = TyTyResolveCompile::compile (ctx, fntype);
-    compiled_fn_type
-      = ctx->get_backend ()->specify_abi_attribute (compiled_fn_type,
-						    fntype->get_abi ());
-
-    const unsigned int flags
-      = Backend::function_is_declaration | Backend::function_is_visible;
-
     std::string ir_symbol_name = function.get_item_name ();
     std::string asm_name = function.get_item_name ();
 
+    const unsigned int flags = Backend::function_is_declaration;
     tree fndecl
       = ctx->get_backend ()->function (compiled_fn_type, ir_symbol_name,
 				       asm_name, flags, function.get_locus ());
+    TREE_PUBLIC (fndecl) = 1;
+    setup_abi_options (fndecl, fntype->get_abi ());
+
     ctx->insert_function_decl (fntype, fndecl);
   }
 

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -2262,6 +2262,8 @@ public:
   }
 
   std::vector<FunctionParam> &get_function_params () { return function_params; }
+
+  const FunctionQualifiers &get_qualifiers () const { return qualifiers; }
 };
 
 // Actual trait item function declaration within traits
@@ -2338,6 +2340,8 @@ public:
   {
     return TraitItemKind::FUNC;
   }
+
+  AST::AttrVec get_outer_attrs () const { return outer_attrs; }
 
 protected:
   // Clone function implementation as (not pure) virtual method

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -126,14 +126,18 @@ public:
       CanonicalPath::new_seg (function.get_mappings ().get_nodeid (),
 			      function.get_item_name ()),
       function.get_locus ()};
-    auto fnType
-      = new TyTy::FnType (function.get_mappings ().get_hirid (),
-			  function.get_mappings ().get_defid (),
-			  function.get_item_name (), ident, flags,
-			  ::Backend::get_abi_from_string (parent.get_abi (),
-							  parent.get_locus ()),
-			  std::move (params), ret_type,
-			  std::move (substitutions));
+
+    auto abi = get_abi_from_string (parent.get_abi ());
+    if (abi == ABI::UNKNOWN)
+      {
+	rust_error_at (parent.get_locus (), "unknown abi");
+      }
+
+    auto fnType = new TyTy::FnType (function.get_mappings ().get_hirid (),
+				    function.get_mappings ().get_defid (),
+				    function.get_item_name (), ident, flags,
+				    abi, std::move (params), ret_type,
+				    std::move (substitutions));
 
     context->insert_type (function.get_mappings (), fnType);
   }

--- a/gcc/rust/util/rust-abi.cc
+++ b/gcc/rust/util/rust-abi.cc
@@ -1,0 +1,64 @@
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-abi.h"
+
+namespace Rust {
+
+Rust::ABI
+get_abi_from_string (const std::string &abi)
+{
+  if (abi.compare ("rust") == 0)
+    return Rust::ABI::C;
+  else if (abi.compare ("rust-intrinsic") == 0)
+    return Rust::ABI::INTRINSIC;
+  else if (abi.compare ("C") == 0)
+    return Rust::ABI::C;
+  else if (abi.compare ("cdecl") == 0)
+    return Rust::ABI::CDECL;
+  else if (abi.compare ("stdcall") == 0)
+    return Rust::ABI::STDCALL;
+  else if (abi.compare ("fastcall") == 0)
+    return Rust::ABI::FASTCALL;
+
+  return Rust::ABI::UNKNOWN;
+}
+
+std::string
+get_string_from_abi (Rust::ABI abi)
+{
+  switch (abi)
+    {
+    case Rust::ABI::RUST:
+      return "rust";
+    case Rust::ABI::INTRINSIC:
+      return "rust-intrinsic";
+    case Rust::ABI::C:
+      return "C";
+    case Rust::ABI::CDECL:
+      return "cdecl";
+    case Rust::ABI::STDCALL:
+      return "stdcall";
+    case Rust::ABI::FASTCALL:
+      return "fastcall";
+
+    case Rust::ABI::UNKNOWN:
+      return "unknown";
+    }
+  return "unknown";
+}
+
+} // namespace Rust

--- a/gcc/rust/util/rust-abi.h
+++ b/gcc/rust/util/rust-abi.h
@@ -17,6 +17,8 @@
 #ifndef RUST_ABI_OPTIONS_H
 #define RUST_ABI_OPTIONS_H
 
+#include <string>
+
 namespace Rust {
 
 enum ABI
@@ -29,6 +31,12 @@ enum ABI
   STDCALL,
   FASTCALL,
 };
+
+extern Rust::ABI
+get_abi_from_string (const std::string &abi);
+
+extern std::string
+get_string_from_abi (Rust::ABI abi);
 
 } // namespace Rust
 


### PR DESCRIPTION
This does a refactor by removing more flags for the fndecl construction
from the rust-gcc wrapper code in favour of using the tree api directly.
The ABI option attributes have also been refactored from the backend
interface in favour of their own package.

The gccgo wrapper tried to mark inline fns as extern inline but this
refactor allows us to control the inline options specificly for the
rust semantics.

Fixes #857
