### PR TITLE
Support inline never and always options

### DIFF
--- a/gcc/rust/backend/rust-compile-base.h
+++ b/gcc/rust/backend/rust-compile-base.h
@@ -71,8 +71,11 @@ protected:
 				       tree expression, Location locus);
 
   static void setup_attributes_on_fndecl (
-    tree fndecl, bool is_main_entry_point, bool has_visibility,
+    tree fndecl, bool is_main_entry_point, HIR::Visibility &visibility,
     const HIR::FunctionQualifiers &qualifiers, const AST::AttrVec &attrs);
+
+  static void handle_inline_attribute_on_fndecl (tree fndecl,
+						 const AST::Attribute &attr);
 
   static void setup_abi_options (tree fndecl, ABI abi);
 

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -632,6 +632,8 @@ public:
     return Visibility (IN_PATH, std::move (in_path));
   }
 
+  PublicVisType get_vis_type () const { return public_vis_type; }
+
   std::string as_string () const;
 
 protected:

--- a/gcc/testsuite/rust/compile/inline_1.rs
+++ b/gcc/testsuite/rust/compile/inline_1.rs
@@ -1,0 +1,15 @@
+#[inline]
+fn test_a() {}
+
+// { dg-final { scan-tree-dump-times {always_inline} 1 gimple } }
+#[inline(always)]
+fn test_b() {}
+
+#[inline(never)]
+fn test_c() {}
+
+fn main() {
+    test_a();
+    test_b();
+    test_c();
+}

--- a/gcc/testsuite/rust/compile/inline_2.rs
+++ b/gcc/testsuite/rust/compile/inline_2.rs
@@ -1,0 +1,6 @@
+// { dg-additional-options "-w" }
+#[inline(A)] // { dg-error "unknown inline option" }
+fn test_a() {}
+
+#[inline(A, B)] // { dg-error "invalid number of arguments" }
+fn test_b() {}


### PR DESCRIPTION
This maps over to DECL_UNINLINEABLE and to use the GCC attribute
always_inline.

Fixes #921