### PR TITLE
macros: Add multiple macro syntax tests

### DIFF
--- a/gcc/testsuite/rust/compile/macro1.rs
+++ b/gcc/testsuite/rust/compile/macro1.rs
@@ -1,0 +1,3 @@
+macro_rules! empty_parens {
+    () => ();
+}

--- a/gcc/testsuite/rust/compile/macro2.rs
+++ b/gcc/testsuite/rust/compile/macro2.rs
@@ -1,0 +1,3 @@
+macro_rules! empty_brackets {
+    [] => [];
+}

--- a/gcc/testsuite/rust/compile/macro3.rs
+++ b/gcc/testsuite/rust/compile/macro3.rs
@@ -1,0 +1,3 @@
+macro_rules! empty_curlies {
+    {} => {};
+}

--- a/gcc/testsuite/rust/compile/macro4.rs
+++ b/gcc/testsuite/rust/compile/macro4.rs
@@ -1,0 +1,3 @@
+macro_rules! one_keyword {
+    (kw) => {};
+}

--- a/gcc/testsuite/rust/compile/macro5.rs
+++ b/gcc/testsuite/rust/compile/macro5.rs
@@ -1,0 +1,3 @@
+macro_rules! rust_keyword {
+    (fn) => {};
+}

--- a/gcc/testsuite/rust/execute/xfail/macro1.rs
+++ b/gcc/testsuite/rust/execute/xfail/macro1.rs
@@ -1,0 +1,32 @@
+// { dg-output "macro\nmacro\nmacro\nmacro\n" }
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+fn f() {
+    let r_s = "macro\n\0";
+    let s_p = r_s as *const str;
+    let c_p = s_p as *const i8;
+
+    printf(c_p);
+}
+
+macro_rules! empty0 {
+    () => ( f() );
+}
+
+macro_rules! empty1 {
+    {} => { f() };
+}
+
+macro_rules! empty2 {
+    [] => [ f() ];
+}
+
+// using multiple parens/brackets/curlies variants allows us to make sure we
+// parse everything properly
+fn main() {
+    empty0!();
+    empty1!{};
+    empty2![];
+}

--- a/gcc/testsuite/rust/execute/xfail/macro2.rs
+++ b/gcc/testsuite/rust/execute/xfail/macro2.rs
@@ -1,0 +1,30 @@
+// { dg-output "arg\narg\n" }
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+fn f() {
+    let r_s = "arg\n\0";
+    let s_p = r_s as *const str;
+    let c_p = s_p as *const i8;
+
+    printf(c_p);
+}
+
+macro_rules! kw0 {
+    (keyword) => { f() };
+}
+
+macro_rules! kw1 {
+    (fn) => { f() };
+}
+
+macro_rules! kw2 {
+    (kw0 kw1 kw3) => { f() };
+}
+
+fn main() {
+    kw0!(keyword);
+    kw1!(fn);
+    kw2!(kw0 kw1 kw3);
+}

--- a/gcc/testsuite/rust/execute/xfail/macro3.rs
+++ b/gcc/testsuite/rust/execute/xfail/macro3.rs
@@ -1,0 +1,45 @@
+// { dg-output "invok\ninvok\ninvok\ninvok\ninvok\n" }
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+fn f() {
+    let r_s = "invok\n\0";
+    let s_p = r_s as *const str;
+    let c_p = s_p as *const i8;
+
+    printf(c_p);
+}
+
+macro_rules! invocation0 {
+    (valid) => { f() };
+    () => { };
+}
+
+macro_rules! invocation1 {
+    (valid) => { };
+    () => { f() };
+}
+
+macro_rules! invocation2 {
+    (valid) => { f() };
+    (invalid) => { };
+}
+
+macro_rules! invocation3 {
+    (this is a valid invocation) => { f() };
+    (not this one) => { };
+}
+
+macro_rules! invocation4 {
+    (fn f() {}) => { f() };
+    (not a keyword) => { };
+}
+
+fn main() {
+    invocation0!(valid);
+    invocation1!();
+    invocation2!(valid);
+    invocation3!(this is a valid invocation);
+    invocation4!(fn f() {});
+}


### PR DESCRIPTION
This PR adds test cases for macros, including parsing and execution.

I am unsure on how to check for proper execution: The solution I have chosen so far is to make sure that a correct amount of lines is printed, which I'm not entirely satisfied with. 

Another solution would be to increase a global integer to use when exiting, which we can then assert on using dejagnu, which is cleaner but relies on unsafe rust code.