### PR TITLE
Add location information to MacroRule

### DIFF
--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -20,6 +20,7 @@
 #define RUST_AST_MACRO_H
 
 #include "rust-ast.h"
+#include "rust-location.h"
 
 namespace Rust {
 namespace AST {
@@ -295,25 +296,27 @@ struct MacroRule
 private:
   MacroMatcher matcher;
   MacroTranscriber transcriber;
-
-  // TODO: should store location information?
+  Location locus;
 
 public:
-  MacroRule (MacroMatcher matcher, MacroTranscriber transcriber)
-    : matcher (std::move (matcher)), transcriber (std::move (transcriber))
+  MacroRule (MacroMatcher matcher, MacroTranscriber transcriber, Location locus)
+    : matcher (std::move (matcher)), transcriber (std::move (transcriber)),
+      locus (locus)
   {}
 
   // Returns whether macro rule is in error state.
   bool is_error () const { return matcher.is_error (); }
 
   // Creates an error state macro rule.
-  static MacroRule create_error ()
+  static MacroRule create_error (Location locus)
   {
-    // FIXME: Once #928 is merged, give location to MacroMatcher
-    return MacroRule (MacroMatcher::create_error (Location ()),
+    return MacroRule (MacroMatcher::create_error (locus),
 		      MacroTranscriber (DelimTokenTree::create_empty (),
-					Location ()));
+					Location ()),
+		      locus);
   }
+
+  Location get_locus () const { return locus; }
 
   std::string as_string () const;
 };

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -1678,23 +1678,25 @@ template <typename ManagedTokenSource>
 AST::MacroRule
 Parser<ManagedTokenSource>::parse_macro_rule ()
 {
+  Location locus = lexer.peek_token ()->get_locus ();
+
   // parse macro matcher
   AST::MacroMatcher matcher = parse_macro_matcher ();
 
   if (matcher.is_error ())
-    return AST::MacroRule::create_error ();
+    return AST::MacroRule::create_error (locus);
 
   if (!skip_token (MATCH_ARROW))
     {
       // skip after somewhere?
-      return AST::MacroRule::create_error ();
+      return AST::MacroRule::create_error (locus);
     }
 
   // parse transcriber (this is just a delim token tree)
   Location token_tree_loc = lexer.peek_token ()->get_locus ();
   AST::MacroTranscriber transcriber (parse_delim_token_tree (), token_tree_loc);
 
-  return AST::MacroRule (std::move (matcher), std::move (transcriber));
+  return AST::MacroRule (std::move (matcher), std::move (transcriber), locus);
 }
 
 // Parses a macro matcher (part of a macro rule definition).


### PR DESCRIPTION
Closes #930 

This PR adds location information to the `MacroRule` structure.

The location is from the beginning of the invokation pattern, so that errors look like so:
```rust
test.rs:2:5: error: ...
    2 |     ($a:expr, $b:expr) => { a + b }
      |     ^
```