### PR TITLE
macrotranscriber: Add location info

### DIFF
--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -277,15 +277,16 @@ struct MacroTranscriber
 {
 private:
   DelimTokenTree token_tree;
-
-  // TODO: should store location information?
+  Location locus;
 
 public:
-  MacroTranscriber (DelimTokenTree token_tree)
-    : token_tree (std::move (token_tree))
+  MacroTranscriber (DelimTokenTree token_tree, Location locus)
+    : token_tree (std::move (token_tree)), locus (locus)
   {}
 
   std::string as_string () const { return token_tree.as_string (); }
+
+  Location get_locus () const { return locus; }
 };
 
 // A macro rule? Matcher and transcriber pair?
@@ -310,7 +311,8 @@ public:
   {
     // FIXME: Once #928 is merged, give location to MacroMatcher
     return MacroRule (MacroMatcher::create_error (Location ()),
-		      MacroTranscriber (DelimTokenTree::create_empty ()));
+		      MacroTranscriber (DelimTokenTree::create_empty (),
+					Location ()));
   }
 
   std::string as_string () const;

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -1691,7 +1691,8 @@ Parser<ManagedTokenSource>::parse_macro_rule ()
     }
 
   // parse transcriber (this is just a delim token tree)
-  AST::MacroTranscriber transcriber (parse_delim_token_tree ());
+  Location token_tree_loc = lexer.peek_token ()->get_locus ();
+  AST::MacroTranscriber transcriber (parse_delim_token_tree (), token_tree_loc);
 
   return AST::MacroRule (std::move (matcher), std::move (transcriber));
 }


### PR DESCRIPTION
Closes #929 

Adds location info to the macro's transcriber. When generating a `MacroRule` error, this PR creates an empty location for the transcriber, since the error function is only called if no fat arrow is present or if there was an error parsing the macro's matcher. Please let me know if this is the expected behavior