### PR TITLE
macromatch: Add location to abstract MacroMatch class

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -111,6 +111,7 @@ public:
   virtual ~MacroMatch () {}
 
   virtual std::string as_string () const = 0;
+  virtual Location get_match_locus () const = 0;
 
   // Unique pointer custom clone function
   std::unique_ptr<MacroMatch> clone_macro_match () const
@@ -217,6 +218,7 @@ public:
   }
 
   std::string as_string () const override;
+  Location get_match_locus () const override { return tok_ref->get_locus (); };
 
   void accept_vis (ASTVisitor &vis) override;
 


### PR DESCRIPTION
Closes #928 

This adds location to the all child classes of the `MacroMatch` abstract class. The current locations are as follow, which I believe is what is expected but might be wrong.

```rust
test.rs:2:6: error: macro match fragment
    2 |     ($a:expr, $b:expr) => { $a + $b };
      |      ^
test.rs:2:15: error: macro match fragment
    2 |     ($a:expr, $b:expr) => { $a + $b };
      |               ^
test.rs:2:5: error: macro matcher
    2 |     ($a:expr, $b:expr) => { $a + $b };
      |     ^
test.rs:3:8: error: macro match fragment
    3 |     ($($i:ident)*) => { $($i)* }
      |        ^
test.rs:3:17: error: macro match repetition!
    3 |     ($($i:ident)*) => { $($i)* }
      |                 ^
test.rs:3:5: error: macro matcher
    3 |     ($($i:ident)*) => { $($i)* }
      |     ^
```

I think this should be rebased on #932 so that I can remove the FIXME 