### PR TITLE
Add more location info to AST structures

### DIFF
--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -1007,15 +1007,14 @@ class ArrayElemsCopied : public ArrayElems
 {
   std::unique_ptr<Expr> elem_to_copy;
   std::unique_ptr<Expr> num_copies;
-
-  // TODO: should this store location data?
+  Location locus;
 
 public:
   // Constructor requires pointers for polymorphism
   ArrayElemsCopied (std::unique_ptr<Expr> copied_elem,
-		    std::unique_ptr<Expr> copy_amount)
+		    std::unique_ptr<Expr> copy_amount, Location locus)
     : ArrayElems (), elem_to_copy (std::move (copied_elem)),
-      num_copies (std::move (copy_amount))
+      num_copies (std::move (copy_amount)), locus (locus)
   {}
 
   // Copy constructor required due to unique_ptr - uses custom clone

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -2134,8 +2134,7 @@ private:
 
   // bool has_type_given;
   std::unique_ptr<Type> type;
-
-  // TODO: should this store location data?
+  Location locus;
 
 public:
   // Returns whether the type of the parameter has been given.
@@ -2144,11 +2143,12 @@ public:
   bool has_outer_attrs () const { return !outer_attrs.empty (); }
 
   // Constructor for closure parameter
-  ClosureParam (std::unique_ptr<Pattern> param_pattern,
+  ClosureParam (std::unique_ptr<Pattern> param_pattern, Location locus,
 		std::unique_ptr<Type> param_type = nullptr,
 		std::vector<Attribute> outer_attrs = {})
     : outer_attrs (std::move (outer_attrs)),
-      pattern (std::move (param_pattern)), type (std::move (param_type))
+      pattern (std::move (param_pattern)), type (std::move (param_type)),
+      locus (locus)
   {}
 
   // Copy constructor required due to cloning as a result of unique_ptrs
@@ -2189,7 +2189,10 @@ public:
   bool is_error () const { return pattern == nullptr; }
 
   // Creates an error state closure parameter.
-  static ClosureParam create_error () { return ClosureParam (nullptr); }
+  static ClosureParam create_error ()
+  {
+    return ClosureParam (nullptr, Location ());
+  }
 
   std::string as_string () const;
 

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -1514,11 +1514,11 @@ struct StructBase
 {
 private:
   std::unique_ptr<Expr> base_struct;
+  Location locus;
 
 public:
-  // TODO: should this store location data?
-  StructBase (std::unique_ptr<Expr> base_struct_ptr)
-    : base_struct (std::move (base_struct_ptr))
+  StructBase (std::unique_ptr<Expr> base_struct_ptr, Location locus)
+    : base_struct (std::move (base_struct_ptr)), locus (locus)
   {}
 
   // Copy constructor requires clone
@@ -1550,7 +1550,7 @@ public:
   StructBase &operator= (StructBase &&other) = default;
 
   // Returns a null expr-ed StructBase - error state
-  static StructBase error () { return StructBase (nullptr); }
+  static StructBase error () { return StructBase (nullptr, Location ()); }
 
   // Returns whether StructBase is in error state
   bool is_invalid () const { return base_struct == nullptr; }

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -953,12 +953,11 @@ protected:
 class ArrayElemsValues : public ArrayElems
 {
   std::vector<std::unique_ptr<Expr> > values;
-
-  // TODO: should this store location data?
+  Location locus;
 
 public:
-  ArrayElemsValues (std::vector<std::unique_ptr<Expr> > elems)
-    : ArrayElems (), values (std::move (elems))
+  ArrayElemsValues (std::vector<std::unique_ptr<Expr> > elems, Location locus)
+    : ArrayElems (), values (std::move (elems)), locus (locus)
   {}
 
   // copy constructor with vector clone

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -3941,12 +3941,11 @@ private:
 
   std::unique_ptr<Type> param_type;
 
-  // TODO: should this store location data?
-
   // seemingly new since writing this node
   std::vector<Attribute> outer_attrs;
 
   NodeId node_id;
+  Location locus;
 
 public:
   /* Returns whether the named function parameter has a name (i.e. name is not
@@ -3967,14 +3966,14 @@ public:
   // Creates an error state named function parameter.
   static NamedFunctionParam create_error ()
   {
-    return NamedFunctionParam ("", nullptr, {});
+    return NamedFunctionParam ("", nullptr, {}, Location ());
   }
 
   NamedFunctionParam (std::string name, std::unique_ptr<Type> param_type,
-		      std::vector<Attribute> outer_attrs)
+		      std::vector<Attribute> outer_attrs, Location locus)
     : name (std::move (name)), param_type (std::move (param_type)),
       outer_attrs (std::move (outer_attrs)),
-      node_id (Analysis::Mappings::get ()->get_next_node_id ())
+      node_id (Analysis::Mappings::get ()->get_next_node_id ()), locus (locus)
   {}
 
   // Copy constructor

--- a/gcc/rust/ast/rust-path.h
+++ b/gcc/rust/ast/rust-path.h
@@ -541,11 +541,13 @@ private:
   // FIXME: think of better way to mark as invalid than taking up storage
   bool is_invalid;
 
-  // TODO: should this have location info?
+  Location locus;
 
 protected:
   // Constructor only used to create invalid type path functions.
-  TypePathFunction (bool is_invalid) : is_invalid (is_invalid) {}
+  TypePathFunction (bool is_invalid, Location locus)
+    : is_invalid (is_invalid), locus (locus)
+  {}
 
 public:
   // Returns whether the return type of the function has been specified.
@@ -558,13 +560,16 @@ public:
   bool is_error () const { return is_invalid; }
 
   // Creates an error state function.
-  static TypePathFunction create_error () { return TypePathFunction (true); }
+  static TypePathFunction create_error ()
+  {
+    return TypePathFunction (true, Location ());
+  }
 
   // Constructor
-  TypePathFunction (std::vector<std::unique_ptr<Type> > inputs,
+  TypePathFunction (std::vector<std::unique_ptr<Type> > inputs, Location locus,
 		    std::unique_ptr<Type> type = nullptr)
     : inputs (std::move (inputs)), return_type (std::move (type)),
-      is_invalid (false)
+      is_invalid (false), locus (locus)
   {}
 
   // Copy constructor with clone

--- a/gcc/rust/ast/rust-path.h
+++ b/gcc/rust/ast/rust-path.h
@@ -33,13 +33,12 @@ namespace AST {
 class PathIdentSegment
 {
   std::string segment_name;
-
-  // TODO: should this have location info stored?
+  Location locus;
 
   // only allow identifiers, "super", "self", "Self", "crate", or "$crate"
 public:
-  PathIdentSegment (std::string segment_name)
-    : segment_name (std::move (segment_name))
+  PathIdentSegment (std::string segment_name, Location locus)
+    : segment_name (std::move (segment_name)), locus (locus)
   {}
 
   /* TODO: insert check in constructor for this? Or is this a semantic error
@@ -49,7 +48,10 @@ public:
    * not entirely sure */
 
   // Creates an error PathIdentSegment.
-  static PathIdentSegment create_error () { return PathIdentSegment (""); }
+  static PathIdentSegment create_error ()
+  {
+    return PathIdentSegment ("", Location ());
+  }
 
   // Returns whether PathIdentSegment is in an error state.
   bool is_error () const { return segment_name.empty (); }
@@ -221,7 +223,7 @@ public:
   bool has_generic_args () const { return generic_args.has_generic_args (); }
 
   // Constructor for segment (from IdentSegment and GenericArgs)
-  PathExprSegment (PathIdentSegment segment_name, Location locus = Location (),
+  PathExprSegment (PathIdentSegment segment_name, Location locus,
 		   GenericArgs generic_args = GenericArgs::create_empty ())
     : segment_name (std::move (segment_name)),
       generic_args (std::move (generic_args)), locus (locus),
@@ -237,7 +239,7 @@ public:
 		   = std::vector<std::unique_ptr<Type> > (),
 		   std::vector<GenericArgsBinding> binding_args
 		   = std::vector<GenericArgsBinding> ())
-    : segment_name (PathIdentSegment (std::move (segment_name))),
+    : segment_name (PathIdentSegment (std::move (segment_name), locus)),
       generic_args (GenericArgs (std::move (lifetime_args),
 				 std::move (type_args),
 				 std::move (binding_args))),
@@ -250,7 +252,7 @@ public:
   // Creates an error-state path expression segment.
   static PathExprSegment create_error ()
   {
-    return PathExprSegment (PathIdentSegment::create_error ());
+    return PathExprSegment (PathIdentSegment::create_error (), Location ());
   }
 
   std::string as_string () const;
@@ -440,7 +442,7 @@ public:
 
   TypePathSegment (std::string segment_name,
 		   bool has_separating_scope_resolution, Location locus)
-    : ident_segment (PathIdentSegment (std::move (segment_name))),
+    : ident_segment (PathIdentSegment (std::move (segment_name), locus)),
       locus (locus),
       has_separating_scope_resolution (has_separating_scope_resolution),
       node_id (Analysis::Mappings::get ()->get_next_node_id ())

--- a/gcc/rust/ast/rust-pattern.h
+++ b/gcc/rust/ast/rust-pattern.h
@@ -848,18 +848,18 @@ class StructPattern : public Pattern
   // bool has_struct_pattern_elements;
   StructPatternElements elems;
 
-  // TODO: should this store location data? Accessor uses path location data.
   NodeId node_id;
+  Location locus;
 
 public:
   std::string as_string () const override;
 
   // Constructs a struct pattern from specified StructPatternElements
-  StructPattern (PathInExpression struct_path,
+  StructPattern (PathInExpression struct_path, Location locus,
 		 StructPatternElements elems
 		 = StructPatternElements::create_empty ())
     : path (std::move (struct_path)), elems (std::move (elems)),
-      node_id (Analysis::Mappings::get ()->get_next_node_id ())
+      node_id (Analysis::Mappings::get ()->get_next_node_id ()), locus (locus)
   {}
 
   /* TODO: constructor to construct via elements included in

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -706,29 +706,29 @@ Parser<ManagedTokenSource>::parse_path_ident_segment ()
     case IDENTIFIER:
       lexer.skip_token ();
 
-      return AST::PathIdentSegment (t->get_str ());
+      return AST::PathIdentSegment (t->get_str (), t->get_locus ());
     case SUPER:
       lexer.skip_token ();
 
-      return AST::PathIdentSegment ("super");
+      return AST::PathIdentSegment ("super", t->get_locus ());
     case SELF:
       lexer.skip_token ();
 
-      return AST::PathIdentSegment ("self");
+      return AST::PathIdentSegment ("self", t->get_locus ());
     case SELF_ALIAS:
       lexer.skip_token ();
 
-      return AST::PathIdentSegment ("Self");
+      return AST::PathIdentSegment ("Self", t->get_locus ());
     case CRATE:
       lexer.skip_token ();
 
-      return AST::PathIdentSegment ("crate");
+      return AST::PathIdentSegment ("crate", t->get_locus ());
     case DOLLAR_SIGN:
       if (lexer.peek_token (1)->get_id () == CRATE)
 	{
 	  lexer.skip_token (1);
 
-	  return AST::PathIdentSegment ("$crate");
+	  return AST::PathIdentSegment ("$crate", t->get_locus ());
 	}
       gcc_fallthrough ();
     default:
@@ -14613,8 +14613,10 @@ Parser<ManagedTokenSource>::parse_path_in_expression_pratt (const_TokenPtr tok)
 
       AST::GenericArgs generic_args = parse_path_generic_args ();
 
-      initial_segment = AST::PathExprSegment (initial_str, tok->get_locus (),
-					      std::move (generic_args));
+      initial_segment
+	= AST::PathExprSegment (AST::PathIdentSegment (initial_str,
+						       tok->get_locus ()),
+				tok->get_locus (), std::move (generic_args));
     }
   if (initial_segment.is_error ())
     {

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -6436,7 +6436,8 @@ Parser<ManagedTokenSource>::parse_type_path_segment ()
       }
       case LEFT_PAREN: {
 	// parse type path function
-	AST::TypePathFunction type_path_function = parse_type_path_function ();
+	AST::TypePathFunction type_path_function
+	  = parse_type_path_function (locus);
 
 	if (type_path_function.is_error ())
 	  {
@@ -6462,7 +6463,7 @@ Parser<ManagedTokenSource>::parse_type_path_segment ()
 // Parses a function call representation inside a type path.
 template <typename ManagedTokenSource>
 AST::TypePathFunction
-Parser<ManagedTokenSource>::parse_type_path_function ()
+Parser<ManagedTokenSource>::parse_type_path_function (Location id_location)
 {
   if (!skip_token (LEFT_PAREN))
     {
@@ -6508,7 +6509,8 @@ Parser<ManagedTokenSource>::parse_type_path_function ()
   std::unique_ptr<AST::Type> return_type = parse_function_return_type ();
 
   inputs.shrink_to_fit ();
-  return AST::TypePathFunction (std::move (inputs), std::move (return_type));
+  return AST::TypePathFunction (std::move (inputs), id_location,
+				std::move (return_type));
 }
 
 // Parses a path inside an expression that allows generic arguments.

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -8739,7 +8739,7 @@ Parser<ManagedTokenSource>::parse_array_expr (AST::AttrVec outer_attrs,
 
       std::vector<std::unique_ptr<AST::Expr>> exprs;
       auto array_elems
-	= Rust::make_unique<AST::ArrayElemsValues> (std::move (exprs));
+	= Rust::make_unique<AST::ArrayElemsValues> (std::move (exprs), locus);
       return Rust::make_unique<AST::ArrayExpr> (std::move (array_elems),
 						std::move (inner_attrs),
 						std::move (outer_attrs), locus);
@@ -8799,7 +8799,7 @@ Parser<ManagedTokenSource>::parse_array_expr (AST::AttrVec outer_attrs,
 	  skip_token (RIGHT_SQUARE);
 
 	  std::unique_ptr<AST::ArrayElemsValues> array_elems (
-	    new AST::ArrayElemsValues (std::move (exprs)));
+	    new AST::ArrayElemsValues (std::move (exprs), locus));
 	  return std::unique_ptr<AST::ArrayExpr> (
 	    new AST::ArrayExpr (std::move (array_elems),
 				std::move (inner_attrs),
@@ -8841,7 +8841,7 @@ Parser<ManagedTokenSource>::parse_array_expr (AST::AttrVec outer_attrs,
 	  exprs.shrink_to_fit ();
 
 	  std::unique_ptr<AST::ArrayElemsValues> array_elems (
-	    new AST::ArrayElemsValues (std::move (exprs)));
+	    new AST::ArrayElemsValues (std::move (exprs), locus));
 	  return std::unique_ptr<AST::ArrayExpr> (
 	    new AST::ArrayExpr (std::move (array_elems),
 				std::move (inner_attrs),

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -5993,6 +5993,7 @@ Parser<ManagedTokenSource>::parse_named_function_param (
   std::string name;
 
   const_TokenPtr t = lexer.peek_token ();
+  Location name_location = t->get_locus ();
   switch (t->get_id ())
     {
     case IDENTIFIER:
@@ -6028,7 +6029,7 @@ Parser<ManagedTokenSource>::parse_named_function_param (
     }
 
   return AST::NamedFunctionParam (std::move (name), std::move (param_type),
-				  std::move (outer_attrs));
+				  std::move (outer_attrs), name_location);
 }
 
 // Parses a statement (will further disambiguate any statement).

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -14441,6 +14441,7 @@ Parser<ManagedTokenSource>::parse_struct_expr_struct_partial (
 	AST::StructBase struct_base = AST::StructBase::error ();
 	if (lexer.peek_token ()->get_id () == DOT_DOT)
 	  {
+	    Location dot_dot_location = lexer.peek_token ()->get_locus ();
 	    lexer.skip_token ();
 
 	    // parse required struct base expr
@@ -14458,7 +14459,8 @@ Parser<ManagedTokenSource>::parse_struct_expr_struct_partial (
 	    // DEBUG:
 	    rust_debug ("struct/enum expr - parsed and validated base expr");
 
-	    struct_base = AST::StructBase (std::move (base_expr));
+	    struct_base
+	      = AST::StructBase (std::move (base_expr), dot_dot_location);
 
 	    // DEBUG:
 	    rust_debug ("assigned struct base to new struct base ");

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -8895,8 +8895,8 @@ Parser<ManagedTokenSource>::parse_closure_param ()
 	}
     }
 
-  return AST::ClosureParam (std::move (pattern), std::move (type),
-			    std::move (outer_attrs));
+  return AST::ClosureParam (std::move (pattern), pattern->get_locus (),
+			    std::move (type), std::move (outer_attrs));
 }
 
 // Parses a grouped or tuple expression (disambiguates).

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -8782,7 +8782,7 @@ Parser<ManagedTokenSource>::parse_array_expr (AST::AttrVec outer_attrs,
 
 	  std::unique_ptr<AST::ArrayElemsCopied> copied_array_elems (
 	    new AST::ArrayElemsCopied (std::move (initial_expr),
-				       std::move (copy_amount)));
+				       std::move (copy_amount), locus));
 	  return std::unique_ptr<AST::ArrayExpr> (
 	    new AST::ArrayExpr (std::move (copied_array_elems),
 				std::move (inner_attrs),

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -10603,7 +10603,8 @@ Parser<ManagedTokenSource>::parse_pattern ()
 		}
 
 	      return std::unique_ptr<AST::StructPattern> (
-		new AST::StructPattern (std::move (path), std::move (elems)));
+		new AST::StructPattern (std::move (path), t->get_locus (),
+					std::move (elems)));
 	    }
 	  default:
 	    // assume path in expression
@@ -11057,7 +11058,8 @@ Parser<ManagedTokenSource>::parse_ident_leading_pattern ()
 	rust_debug ("successfully parsed struct pattern");
 
 	return std::unique_ptr<AST::StructPattern> (
-	  new AST::StructPattern (std::move (path), std::move (elems)));
+	  new AST::StructPattern (std::move (path), initial_tok->get_locus (),
+				  std::move (elems)));
       }
     case DOT_DOT_EQ:
       case ELLIPSIS: {

--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -139,7 +139,7 @@ private:
   AST::PathIdentSegment parse_path_ident_segment ();
   AST::GenericArgs parse_path_generic_args ();
   AST::GenericArgsBinding parse_generic_args_binding ();
-  AST::TypePathFunction parse_type_path_function ();
+  AST::TypePathFunction parse_type_path_function (Location locus);
   AST::PathExprSegment parse_path_expr_segment ();
   AST::QualifiedPathInExpression
   // When given a pratt_parsed_loc, use it as the location of the

--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -26,7 +26,7 @@
 #define MKBUILTIN_TYPE(_X, _R, _TY)                                            \
   do                                                                           \
     {                                                                          \
-      AST::PathIdentSegment seg (_X);                                          \
+      AST::PathIdentSegment seg (_X, Linemap::predeclared_location ());        \
       auto typePath = ::std::unique_ptr<AST::TypePathSegment> (                \
 	new AST::TypePathSegment (::std::move (seg), false,                    \
 				  Linemap::predeclared_location ()));          \


### PR DESCRIPTION
Two classes still remain locus-less: `TupleStructItems` and `TuplePatternItems` as I do not believe they are constructed at the moment.