### PR TITLE
 Removed Lambda Function within AST::PathPattern

### DIFF
--- a/gcc/rust/ast/rust-path.h
+++ b/gcc/rust/ast/rust-path.h
@@ -303,15 +303,6 @@ public:
   // TODO: this seems kinda dodgy
   std::vector<PathExprSegment> &get_segments () { return segments; }
   const std::vector<PathExprSegment> &get_segments () const { return segments; }
-
-  void iterate_path_segments (std::function<bool (PathExprSegment &)> cb)
-  {
-    for (auto it = segments.begin (); it != segments.end (); it++)
-      {
-	if (!cb (*it))
-	  return;
-      }
-  }
 };
 
 /* AST node representing a path-in-expression pattern (path that allows generic

--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -263,17 +263,17 @@ void
 ASTLowerPathInExpression::visit (AST::PathInExpression &expr)
 {
   std::vector<HIR::PathExprSegment> path_segments;
-  expr.iterate_path_segments ([&] (AST::PathExprSegment &s) mutable -> bool {
-    path_segments.push_back (lower_path_expr_seg (s));
+  auto &segments = expr.get_segments ();
+  for (auto &s : segments)
+    {
+      path_segments.push_back (lower_path_expr_seg ((s)));
 
-    // insert the mappings for the segment
-    HIR::PathExprSegment *lowered_seg = &path_segments.back ();
-    mappings->insert_hir_path_expr_seg (
-      lowered_seg->get_mappings ().get_crate_num (),
-      lowered_seg->get_mappings ().get_hirid (), lowered_seg);
-    return true;
-  });
-
+      // insert the mappings for the segment
+      HIR::PathExprSegment *lowered_seg = &path_segments.back ();
+      mappings->insert_hir_path_expr_seg (
+	lowered_seg->get_mappings ().get_crate_num (),
+	lowered_seg->get_mappings ().get_hirid (), lowered_seg);
+    }
   auto crate_num = mappings->get_current_crate ();
   Analysis::NodeMapping mapping (crate_num, expr.get_node_id (),
 				 mappings->get_next_hir_id (crate_num),
@@ -311,16 +311,17 @@ ASTLowerQualPathInExpression::visit (AST::QualifiedPathInExpression &expr)
     = lower_qual_path_type (expr.get_qualified_path_type ());
 
   std::vector<HIR::PathExprSegment> path_segments;
-  expr.iterate_path_segments ([&] (AST::PathExprSegment &s) mutable -> bool {
-    path_segments.push_back (lower_path_expr_seg (s));
+  auto &segments = expr.get_segments ();
+  for (auto &s : segments)
+    {
+      path_segments.push_back (lower_path_expr_seg ((s)));
 
-    // insert the mappings for the segment
-    HIR::PathExprSegment *lowered_seg = &path_segments.back ();
-    mappings->insert_hir_path_expr_seg (
-      lowered_seg->get_mappings ().get_crate_num (),
-      lowered_seg->get_mappings ().get_hirid (), lowered_seg);
-    return true;
-  });
+      // insert the mappings for the segment
+      HIR::PathExprSegment *lowered_seg = &path_segments.back ();
+      mappings->insert_hir_path_expr_seg (
+	lowered_seg->get_mappings ().get_crate_num (),
+	lowered_seg->get_mappings ().get_hirid (), lowered_seg);
+    }
 
   auto crate_num = mappings->get_current_crate ();
   Analysis::NodeMapping mapping (crate_num, expr.get_node_id (),


### PR DESCRIPTION
Addresses issue #717 
1) Changed the rust-path.h and removed the iterate_path_segments
   fuction.
2) Removed the lambda fuction form rust-ast-lower.cc and replaced it
   with a for loop.

Do let me know if I missed anything or could improve on something.

Signed-off-by : M V V S Manoj Kumar <mvvsmanojkumar@gmail.com>

