### PR TITLE
parser: Add `clear_errors()` method

### DIFF
--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -603,6 +603,7 @@ private:
   bool done_end_of_file ();
 
   void add_error (Error error) { error_table.push_back (std::move (error)); }
+  void clear_errors () { error_table.clear (); }
 
 public:
   // Construct parser with specified "managed" token source.


### PR DESCRIPTION
Clears all errors from the error table so we can reuse the parser in later situations. I'm unsure whether or not the method should also emit all of the errors if present? In that case, we might want to rename it or add another wrapper that emits then clears