### PR TITLE
Substitute repetitions

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -204,6 +204,7 @@ public:
   std::vector<std::unique_ptr<Token> > to_token_stream () const override;
 
   TokenId get_id () const { return tok_ref->get_id (); }
+  const std::string &get_str () const { return tok_ref->get_str (); }
 
   Location get_locus () const { return tok_ref->get_locus (); }
 

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -57,10 +57,20 @@ struct MatchedFragment
   size_t match_amount;
 
   MatchedFragment (std::string identifier, size_t token_offset_begin,
-		   size_t token_offset_end, size_t match_amount = 0)
+		   size_t token_offset_end, size_t match_amount = 1)
     : fragment_ident (identifier), token_offset_begin (token_offset_begin),
       token_offset_end (token_offset_end), match_amount (match_amount)
   {}
+
+  /**
+   * Create a valid fragment matched zero times. This is useful for repetitions
+   * which allow the absence of a fragment, such as * and ?
+   */
+  static MatchedFragment zero (std::string identifier)
+  {
+    // We don't need offsets since there is "no match"
+    return MatchedFragment (identifier, 0, 0, 0);
+  }
 
   std::string as_string () const
   {

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -183,6 +183,40 @@ struct MacroExpander
 			size_t &match_amount, size_t lo_bound = 0,
 			size_t hi_bound = 0);
 
+  /**
+   * Substitute a metavariable by its given fragment in a transcribing context,
+   * i.e. replacing $var with the associated fragment.
+   *
+   * @param input Tokens given to the transcribing context
+   * @param fragments Fragments given to the macro substitution
+   * @param metavar Metavariable to try and replace
+   *
+   * @return A token containing the associated fragment expanded into tokens if
+   * any, or the cloned token if no fragment was associated
+   */
+  static std::vector<std::unique_ptr<AST::Token>>
+  substitute_metavar (std::vector<std::unique_ptr<AST::Token>> &input,
+		      std::map<std::string, MatchedFragment> &fragments,
+		      std::unique_ptr<AST::Token> &metavar);
+
+  /**
+   * Substitute a given token by its appropriate representation
+   *
+   * @param input Tokens given to the transcribing context
+   * @param fragments Fragments given to the macro substitution
+   * @param token Current token to try and substitute
+   *
+   * @return A token containing the associated fragment expanded into tokens if
+   * any, or the cloned token if no fragment was associated, as well as the
+   * amount of tokens that should be skipped before the next invocation. Since
+   * this function may consume more than just one token, it is important to skip
+   * ahead of the input to avoid mis-substitutions
+   */
+  static std::pair<std::vector<std::unique_ptr<AST::Token>>, size_t>
+  substitute_token (std::vector<std::unique_ptr<AST::Token>> &input,
+		    std::map<std::string, MatchedFragment> &fragments,
+		    std::unique_ptr<AST::Token> &token);
+
   static std::vector<std::unique_ptr<AST::Token>>
   substitute_tokens (std::vector<std::unique_ptr<AST::Token>> &input,
 		     std::vector<std::unique_ptr<AST::Token>> &macro,

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -204,14 +204,16 @@ struct MacroExpander
    *
    * @param input Tokens given to the transcribing context
    * @param fragments Fragments given to the macro substitution
-   * @param repetition Set of tokens to substitute and replace
+   * @param pattern_start Start index of the pattern tokens
+   * @param pattern_end Index  Amount of tokens in the pattern
    *
    * @return A vector containing the repeated pattern
    */
   static std::vector<std::unique_ptr<AST::Token>>
   substitute_repetition (std::vector<std::unique_ptr<AST::Token>> &input,
+			 std::vector<std::unique_ptr<AST::Token>> &macro,
 			 std::map<std::string, MatchedFragment> &fragments,
-			 std::vector<std::unique_ptr<AST::Token>> &pattern);
+			 size_t pattern_start, size_t pattern_end);
 
   /**
    * Substitute a given token by its appropriate representation
@@ -228,8 +230,8 @@ struct MacroExpander
    * ahead of the input to avoid mis-substitutions
    */
   static std::pair<std::vector<std::unique_ptr<AST::Token>>, size_t>
-  substitute_token (std::vector<std::unique_ptr<AST::Token>> &macro,
-		    std::vector<std::unique_ptr<AST::Token>> &input,
+  substitute_token (std::vector<std::unique_ptr<AST::Token>> &input,
+		    std::vector<std::unique_ptr<AST::Token>> &macro,
 		    std::map<std::string, MatchedFragment> &fragments,
 		    size_t token_idx);
 

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -200,8 +200,23 @@ struct MacroExpander
 		      std::unique_ptr<AST::Token> &metavar);
 
   /**
+   * Substitute a macro repetition by its given fragments
+   *
+   * @param input Tokens given to the transcribing context
+   * @param fragments Fragments given to the macro substitution
+   * @param repetition Set of tokens to substitute and replace
+   *
+   * @return A vector containing the repeated pattern
+   */
+  static std::vector<std::unique_ptr<AST::Token>>
+  substitute_repetition (std::vector<std::unique_ptr<AST::Token>> &input,
+			 std::map<std::string, MatchedFragment> &fragments,
+			 std::vector<std::unique_ptr<AST::Token>> &pattern);
+
+  /**
    * Substitute a given token by its appropriate representation
    *
+   * @param macro Tokens used in the macro declaration
    * @param input Tokens given to the transcribing context
    * @param fragments Fragments given to the macro substitution
    * @param token Current token to try and substitute
@@ -213,9 +228,10 @@ struct MacroExpander
    * ahead of the input to avoid mis-substitutions
    */
   static std::pair<std::vector<std::unique_ptr<AST::Token>>, size_t>
-  substitute_token (std::vector<std::unique_ptr<AST::Token>> &input,
+  substitute_token (std::vector<std::unique_ptr<AST::Token>> &macro,
+		    std::vector<std::unique_ptr<AST::Token>> &input,
 		    std::map<std::string, MatchedFragment> &fragments,
-		    std::unique_ptr<AST::Token> &token);
+		    size_t token_idx);
 
   static std::vector<std::unique_ptr<AST::Token>>
   substitute_tokens (std::vector<std::unique_ptr<AST::Token>> &input,

--- a/gcc/testsuite/rust/execute/torture/macros10.rs
+++ b/gcc/testsuite/rust/execute/torture/macros10.rs
@@ -1,0 +1,20 @@
+// { dg-output "18\n" }
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+fn print_int(value: i32) {
+    let s = "%d\n\0" as *const str as *const i8;
+    printf(s, value);
+}
+
+macro_rules! add_exprs {
+    ($($e:expr)*) => (0 $(+ $e)*)
+}
+
+fn main() -> i32 {
+    // 1 + 2 + 15 => 18
+    print_int(add_exprs!(1 2 15));
+
+    0
+}

--- a/gcc/testsuite/rust/execute/torture/macros11.rs
+++ b/gcc/testsuite/rust/execute/torture/macros11.rs
@@ -1,0 +1,22 @@
+// { dg-output "2" }
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+fn print_int(value: i32) {
+    let s = "%d\n\0";
+    let s_p = s as *const str;
+    let c_p = s_p as *const i8;
+    unsafe { printf(c_p, value); }
+}
+
+macro_rules! add_exprs {
+    ($($e:expr)?) => (0 $(+ $e)?)
+}
+
+fn main() -> i32 {
+    // 2
+    print_int(add_exprs!(2));
+
+    0
+}

--- a/gcc/testsuite/rust/execute/torture/macros12.rs
+++ b/gcc/testsuite/rust/execute/torture/macros12.rs
@@ -1,0 +1,20 @@
+// { dg-output "0\n" }
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+fn print_int(value: i32) {
+    let s = "%d\n\0" as *const str as *const i8;
+    printf(s, value);
+}
+
+macro_rules! add_exprs {
+    ($($e:expr)?) => (0 $(+ $e)?)
+}
+
+fn main() -> i32 {
+    // 0
+    print_int(add_exprs!());
+
+    0
+}

--- a/gcc/testsuite/rust/execute/torture/macros13.rs
+++ b/gcc/testsuite/rust/execute/torture/macros13.rs
@@ -1,0 +1,20 @@
+// { dg-output "18\n" }
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+fn print_int(value: i32) {
+    let s = "%d\n\0" as *const str as *const i8;
+    printf(s, value);
+}
+
+macro_rules! add_exprs {
+    ($($e:expr)+) => (0 $(+ $e)+)
+}
+
+fn main() -> i32 {
+    // 1 + 2 + 15 => 18
+    print_int(add_exprs!(1 2 15));
+
+    0
+}

--- a/gcc/testsuite/rust/execute/torture/macros14.rs
+++ b/gcc/testsuite/rust/execute/torture/macros14.rs
@@ -1,0 +1,20 @@
+// { dg-output "15\n" }
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+fn print_int(value: i32) {
+    let s = "%d\n\0" as *const str as *const i8;
+    printf(s, value);
+}
+
+macro_rules! add_exprs {
+    ($($e:expr)*) => (15 $(+ $e)*)
+}
+
+fn main() -> i32 {
+    // 15
+    print_int(add_exprs!());
+
+    0
+}


### PR DESCRIPTION
Needs #955 

This PR splits up the `substitute_tokens` function into multiple smaller functions. Still a draft until I can get repetitions working.

Closes #960 
Closes #961 