### PR TITLE
macro-invoc-lexer: Split implementation in its own file

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -74,6 +74,7 @@ GRS_OBJS = \
     rust/rust-mangle.o \
     rust/rust-compile-resolve-path.o \
     rust/rust-macro-expand.o \
+    rust/rust-macro-invoc-lexer.o \
     rust/rust-hir-full-test.o \
     rust/rust-hir-map.o \
     rust/rust-abi.o \

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -26,6 +26,7 @@
 #include "rust-macro.h"
 #include "rust-hir-map.h"
 #include "rust-name-resolver.h"
+#include "rust-macro-invoc-lexer.h"
 
 // Provides objects and method prototypes for macro expansion
 
@@ -46,52 +47,6 @@ struct ExpansionCfg
   bool should_test = false; // strip #[test] nodes if false
   bool keep_macs = false;   // keep macro definitions
   std::string crate_name = "";
-};
-
-class MacroInvocLexer
-{
-public:
-  MacroInvocLexer (std::vector<std::unique_ptr<AST::Token>> stream)
-    : offs (0), token_stream (std::move (stream))
-  {}
-
-  // Returns token n tokens ahead of current position.
-  const_TokenPtr peek_token (int n)
-  {
-    if ((offs + n) >= token_stream.size ())
-      return Token::make (END_OF_FILE, Location ());
-
-    return token_stream.at (offs + n)->get_tok_ptr ();
-  }
-  // Peeks the current token.
-  const_TokenPtr peek_token () { return peek_token (0); }
-
-  // Advances current token to n + 1 tokens ahead of current position.
-  void skip_token (int n) { offs += (n + 1); }
-
-  // Skips the current token.
-  void skip_token () { skip_token (0); }
-
-  // Splits the current token into two. Intended for use with nested generics
-  // closes (i.e. T<U<X>> where >> is wrongly lexed as one token). Note that
-  // this will only work with "simple" tokens like punctuation.
-  void split_current_token (TokenId /*new_left*/, TokenId /*new_right*/)
-  {
-    // FIXME
-    gcc_unreachable ();
-  }
-
-  std::string get_filename () const
-  {
-    gcc_unreachable ();
-    return "FIXME";
-  }
-
-  size_t get_offs () const { return offs; }
-
-private:
-  size_t offs;
-  std::vector<std::unique_ptr<AST::Token>> token_stream;
 };
 
 struct MatchedFragment

--- a/gcc/rust/expand/rust-macro-invoc-lexer.cc
+++ b/gcc/rust/expand/rust-macro-invoc-lexer.cc
@@ -1,0 +1,29 @@
+#include "rust-macro-invoc-lexer.h"
+
+namespace Rust {
+
+const_TokenPtr
+MacroInvocLexer::peek_token (int n)
+{
+  if ((offs + n) >= token_stream.size ())
+    return Token::make (END_OF_FILE, Location ());
+
+  return token_stream.at (offs + n)->get_tok_ptr ();
+}
+
+// Advances current token to n + 1 tokens ahead of current position.
+void
+MacroInvocLexer::skip_token (int n)
+{
+  offs += (n + 1);
+}
+
+void
+MacroInvocLexer::split_current_token (TokenId new_left __attribute__ ((unused)),
+				      TokenId new_right
+				      __attribute__ ((unused)))
+{
+  // FIXME
+  gcc_unreachable ();
+}
+} // namespace Rust

--- a/gcc/rust/expand/rust-macro-invoc-lexer.h
+++ b/gcc/rust/expand/rust-macro-invoc-lexer.h
@@ -1,0 +1,64 @@
+// Copyright (C) 2020-2022 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_MACRO_INVOC_LEXER_H
+#define RUST_MACRO_INVOC_LEXER_H
+
+#include "rust-ast.h"
+
+namespace Rust {
+class MacroInvocLexer
+{
+public:
+  MacroInvocLexer (std::vector<std::unique_ptr<AST::Token>> stream)
+    : offs (0), token_stream (std::move (stream))
+  {}
+
+  // Returns token n tokens ahead of current position.
+  const_TokenPtr peek_token (int n);
+
+  // Peeks the current token.
+  const_TokenPtr peek_token () { return peek_token (0); }
+
+  // Advances current token to n + 1 tokens ahead of current position.
+  void skip_token (int n);
+
+  // Skips the current token.
+  void skip_token () { skip_token (0); }
+
+  // Splits the current token into two. Intended for use with nested generics
+  // closes (i.e. T<U<X>> where >> is wrongly lexed as one token). Note that
+  // this will only work with "simple" tokens like punctuation.
+  void split_current_token (TokenId new_left, TokenId new_right);
+
+  std::string get_filename () const
+  {
+    // FIXME
+    gcc_unreachable ();
+    return "FIXME";
+  }
+
+  size_t get_offs () const { return offs; }
+
+private:
+  size_t offs;
+  std::vector<std::unique_ptr<AST::Token>> token_stream;
+};
+} // namespace Rust
+
+#endif // RUST_MACRO_INVOC_LEXER_H


### PR DESCRIPTION
Closes #949 