### PR TITLE
Implimented Soluion 1 and solution 2 for issue_734

### DIFF
--- a/gcc/rust/backend/rust-compile-type.cc
+++ b/gcc/rust/backend/rust-compile-type.cc
@@ -148,11 +148,13 @@ TyTyResolveCompile::visit (const TyTy::FnPtr &type)
   tree result_type = TyTyResolveCompile::compile (ctx, type.get_return_type ());
 
   std::vector<tree> parameters;
-  type.iterate_params ([&] (TyTy::BaseType *p) mutable -> bool {
-    tree pty = TyTyResolveCompile::compile (ctx, p);
-    parameters.push_back (pty);
-    return true;
-  });
+
+  auto &params = type.get_params ();
+  for (auto &p : params)
+    {
+      tree pty = TyTyResolveCompile::compile (ctx, p.get_tyty ());
+      parameters.push_back (pty);
+    }
 
   translated = ctx->get_backend ()->function_ptr_type (result_type, parameters,
 						       type.get_ident ().locus);

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -1294,10 +1294,13 @@ std::string
 FnPtr::as_string () const
 {
   std::string params_str;
-  iterate_params ([&] (BaseType *p) mutable -> bool {
-    params_str += p->as_string () + " ,";
-    return true;
-  });
+
+  auto &params = get_params ();
+  for (auto &p : params)
+    {
+      params_str += p.get_tyty ()->as_string () + " ,";
+    }
+
   return "fnptr (" + params_str + ") -> " + get_return_type ()->as_string ();
 }
 

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -1526,6 +1526,9 @@ public:
       }
   }
 
+  std::vector<TyVar> &get_params () { return params; }
+  const std::vector<TyVar> &get_params () const { return params; }
+
   bool is_concrete () const override final
   {
     for (auto &p : params)


### PR DESCRIPTION
Fixes #734 
Done :
- [x]  Remove iterate_params function
- [x] Create new get_params function

Solution 1
1) Created a new get_params function which returns the parameters.
2) Changed the references of the iterate_params to use get_params.

Solution 2
1) Added get_params2 which returns `std::vector<TyTy::BaseType*>`
2) Changed the references of the iterate_params to use get_params.

Status :  
Currently I have implemented the first solution. 

Signed-off-by : M V V S Manoj Kumar <mvvsmanojkumar@gmail.com>
