### PR TITLE
Parse macro!(); as MacroInvocation with semicolon

### DIFF
--- a/gcc/rust/ast/rust-ast-full-decls.h
+++ b/gcc/rust/ast/rust-ast-full-decls.h
@@ -54,7 +54,6 @@ class MacroItem;
 class TraitItem;
 class InherentImplItem;
 class TraitImplItem;
-class MacroInvocationSemi;
 struct Crate;
 class PathExpr;
 

--- a/gcc/rust/ast/rust-ast-full-test.cc
+++ b/gcc/rust/ast/rust-ast-full-test.cc
@@ -1275,19 +1275,6 @@ TypeAlias::as_string () const
   return str;
 }
 
-// FIXME: ARTHUR: Check if this is necessary for MacroInvocation
-// std::string
-// MacroInvocationSemi::as_string () const
-// {
-//   std::string str = "MacroInvocationSemi: ";
-//
-//   str += append_attributes (outer_attrs, OUTER);
-//
-//   str += "\n" + invoc_data.as_string ();
-//
-//   return str;
-// }
-
 std::string
 ExternBlock::as_string () const
 {

--- a/gcc/rust/ast/rust-ast-full-test.cc
+++ b/gcc/rust/ast/rust-ast-full-test.cc
@@ -1275,17 +1275,18 @@ TypeAlias::as_string () const
   return str;
 }
 
-std::string
-MacroInvocationSemi::as_string () const
-{
-  std::string str = "MacroInvocationSemi: ";
-
-  str += append_attributes (outer_attrs, OUTER);
-
-  str += "\n" + invoc_data.as_string ();
-
-  return str;
-}
+// FIXME: ARTHUR: Check if this is necessary for MacroInvocation
+// std::string
+// MacroInvocationSemi::as_string () const
+// {
+//   std::string str = "MacroInvocationSemi: ";
+//
+//   str += append_attributes (outer_attrs, OUTER);
+//
+//   str += "\n" + invoc_data.as_string ();
+//
+//   return str;
+// }
 
 std::string
 ExternBlock::as_string () const
@@ -1376,6 +1377,9 @@ MacroInvocation::as_string () const
   str += append_attributes (outer_attrs, OUTER);
 
   str += "\n " + invoc_data.as_string ();
+
+  str += "\n has semicolon: ";
+  str += has_semicolon () ? "true" : "false";
 
   return str;
 }
@@ -4917,12 +4921,6 @@ Lifetime::accept_vis (ASTVisitor &vis)
 
 void
 LifetimeParam::accept_vis (ASTVisitor &vis)
-{
-  vis.visit (*this);
-}
-
-void
-MacroInvocationSemi::accept_vis (ASTVisitor &vis)
 {
   vis.visit (*this);
 }

--- a/gcc/rust/ast/rust-ast-visitor.h
+++ b/gcc/rust/ast/rust-ast-visitor.h
@@ -52,7 +52,6 @@ public:
   // virtual void visit(TraitItem& trait_item) = 0;
   // virtual void visit(InherentImplItem& inherent_impl_item) = 0;
   // virtual void visit(TraitImplItem& trait_impl_item) = 0;
-  virtual void visit (MacroInvocationSemi &macro) = 0;
 
   // rust-path.h
   virtual void visit (PathInExpression &path) = 0;

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -28,7 +28,6 @@ namespace AST {
 // forward decls
 class BlockExpr;
 class TypePath;
-class MacroInvocationSemi;
 
 // TODO: inline?
 /*struct AbiName {
@@ -4306,7 +4305,6 @@ protected:
 
 // Replaced with forward decls - defined in "rust-macro.h"
 class MacroItem;
-class MacroInvocationSemi;
 class MacroRulesDefinition;
 } // namespace AST
 } // namespace Rust

--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -469,6 +469,8 @@ class MacroInvocation : public TypeNoBounds,
   // Important for when we actually expand the macro
   bool is_semi_coloned;
 
+  NodeId node_id;
+
 public:
   std::string as_string () const override;
 
@@ -477,7 +479,9 @@ public:
 		   bool is_semi_coloned = false)
     : outer_attrs (std::move (outer_attrs)),
       invoc_data (std::move (invoc_data)), locus (locus),
-      fragment (ASTFragment::create_empty ()), is_semi_coloned (is_semi_coloned)
+      fragment (ASTFragment::create_empty ()),
+      is_semi_coloned (is_semi_coloned),
+      node_id (Analysis::Mappings::get ()->get_next_node_id ())
   {}
 
   Location get_locus () const override final { return locus; }
@@ -503,6 +507,8 @@ public:
   {
     return ExprWithoutBlock::get_node_id ();
   }
+
+  NodeId get_macro_node_id () const { return node_id; }
 
   MacroInvocData &get_invoc_data () { return invoc_data; }
 
@@ -562,12 +568,9 @@ protected:
   }
 
   ExprWithoutBlock *to_stmt () const override
-  
-   
-   
-   
-  { 
-    auto new_impl  = clone_macro_invocation_impl();
+
+  {
+    auto new_impl = clone_macro_invocation_impl ();
     new_impl->is_semi_coloned = true;
 
     return new_impl;

--- a/gcc/rust/ast/rust-stmt.h
+++ b/gcc/rust/ast/rust-stmt.h
@@ -211,8 +211,9 @@ public:
   std::string as_string () const override;
 
   ExprStmtWithoutBlock (std::unique_ptr<ExprWithoutBlock> expr, Location locus)
-    : ExprStmt (locus), expr (std::move (expr))
+    : ExprStmt (locus), expr (std::move (expr->to_stmt ()))
   {}
+
   /*ExprStmtWithoutBlock (std::unique_ptr<Expr> expr, Location locus)
     : ExprStmt (locus), expr (std::move (expr))
   {}*/
@@ -336,9 +337,6 @@ protected:
   }
 };
 
-/* Replaced definition of MacroInvocationSemi with forward decl - defined in
- * rust-macro.h */
-class MacroInvocationSemi;
 } // namespace AST
 } // namespace Rust
 

--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -309,29 +309,32 @@ public:
   {
     // supposedly does not require - cfg does nothing
   }
-  void visit (AST::MacroInvocationSemi &macro_invoc) override
-  {
-    // initial strip test based on outer attrs
-    expander.expand_cfg_attrs (macro_invoc.get_outer_attrs ());
-    if (expander.fails_cfg_with_expand (macro_invoc.get_outer_attrs ()))
-      {
-	macro_invoc.mark_for_strip ();
-	return;
-      }
 
-    // can't strip simple path
+  // FIXME: ARTHUR: Check to see if necessary for MacroInvocation
+  // void visit (AST::MacroInvocationSemi &macro_invoc) override
+  // {
+  //   // initial strip test based on outer attrs
+  //   expander.expand_cfg_attrs (macro_invoc.get_outer_attrs ());
+  //   if (expander.fails_cfg_with_expand (macro_invoc.get_outer_attrs ()))
+  //     {
+  // macro_invoc.mark_for_strip ();
+  // return;
+  //     }
 
-    // I don't think any macro token trees can be stripped in any way
+  //   // can't strip simple path
 
-    // TODO: maybe have cfg! macro stripping behaviour here?
+  //   // I don't think any macro token trees can be stripped in any way
 
-    expander.expand_invoc_semi (macro_invoc);
+  //   // TODO: maybe have cfg! macro stripping behaviour here?
 
-    // we need to visit the expanded fragments since it may need cfg expansion
-    // and it may be recursive
-    for (auto &node : macro_invoc.get_fragment ().get_nodes ())
-      node.accept_vis (*this);
-  }
+  //   expander.expand_invoc_semi (macro_invoc);
+
+  //   // we need to visit the expanded fragments since it may need cfg
+  //   expansion
+  //   // and it may be recursive
+  //   for (auto &node : macro_invoc.get_fragment ().get_nodes ())
+  //     node.accept_vis (*this);
+  // }
 
   void visit (AST::PathInExpression &path) override
   {
@@ -3207,46 +3210,48 @@ MacroExpander::expand_invoc (AST::MacroInvocation &invoc)
   invoc.set_fragment (std::move (fragment));
 }
 
-void
-MacroExpander::expand_invoc_semi (AST::MacroInvocationSemi &invoc)
-{
-  if (depth_exceeds_recursion_limit ())
-    {
-      rust_error_at (invoc.get_locus (), "reached recursion limit");
-      return;
-    }
-
-  AST::MacroInvocData &invoc_data = invoc.get_invoc_data ();
-
-  // lookup the rules for this macro
-  NodeId resolved_node = UNKNOWN_NODEID;
-  bool found = resolver->get_macro_scope ().lookup (
-    Resolver::CanonicalPath::new_seg (invoc.get_macro_node_id (),
-				      invoc_data.get_path ().as_string ()),
-    &resolved_node);
-  if (!found)
-    {
-      rust_error_at (invoc.get_locus (), "unknown macro");
-      return;
-    }
-
-  // lookup the rules
-  AST::MacroRulesDefinition *rules_def = nullptr;
-  bool ok = mappings->lookup_macro_def (resolved_node, &rules_def);
-  rust_assert (ok);
-
-  auto fragment = AST::ASTFragment::create_empty ();
-
-  if (rules_def->is_builtin ())
-    fragment
-      = rules_def->get_builtin_transcriber () (invoc.get_locus (), invoc_data);
-  else
-    fragment
-      = expand_decl_macro (invoc.get_locus (), invoc_data, *rules_def, true);
-
-  // lets attach this fragment to the invocation
-  invoc.set_fragment (std::move (fragment));
-}
+// FIXME: ARTHUR: Check to see if necessary for MacroInvocation
+// void
+// MacroExpander::expand_invoc_semi (AST::MacroInvocationSemi &invoc)
+// {
+//   if (depth_exceeds_recursion_limit ())
+//     {
+//       rust_error_at (invoc.get_locus (), "reached recursion limit");
+//       return;
+//     }
+//
+//   AST::MacroInvocData &invoc_data = invoc.get_invoc_data ();
+//
+//   // lookup the rules for this macro
+//   NodeId resolved_node = UNKNOWN_NODEID;
+//   bool found = resolver->get_macro_scope ().lookup (
+//     Resolver::CanonicalPath::new_seg (invoc.get_macro_node_id (),
+// 				      invoc_data.get_path ().as_string ()),
+//     &resolved_node);
+//   if (!found)
+//     {
+//       rust_error_at (invoc.get_locus (), "unknown macro");
+//       return;
+//     }
+//
+//   // lookup the rules
+//   AST::MacroRulesDefinition *rules_def = nullptr;
+//   bool ok = mappings->lookup_macro_def (resolved_node, &rules_def);
+//   rust_assert (ok);
+//
+//   auto fragment = AST::ASTFragment::create_empty ();
+//
+//   if (rules_def->is_builtin ())
+//     fragment
+//       = rules_def->get_builtin_transcriber () (invoc.get_locus (),
+//       invoc_data);
+//   else
+//     fragment
+//       = expand_decl_macro (invoc.get_locus (), invoc_data, *rules_def, true);
+//
+//   // lets attach this fragment to the invocation
+//   invoc.set_fragment (std::move (fragment));
+// }
 
 /* Determines whether any cfg predicate is false and hence item with attributes
  * should be stripped. Note that attributes must be expanded before calling. */

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -150,7 +150,6 @@ struct MacroExpander
    * have similar duck-typed interface and use templates?*/
   // should this be public or private?
   void expand_invoc (AST::MacroInvocation &invoc);
-  void expand_invoc_semi (AST::MacroInvocationSemi &invoc);
 
   // Expands a single declarative macro.
   AST::ASTFragment expand_decl_macro (Location locus,

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -146,10 +146,11 @@ struct MacroExpander
   // Expands all macros in the crate passed in.
   void expand_crate ();
 
-  /* Expands a macro invocation (not macro invocation semi) - possibly make both
+  /* Expands a macro invocation - possibly make both
    * have similar duck-typed interface and use templates?*/
   // should this be public or private?
   void expand_invoc (AST::MacroInvocation &invoc);
+  void expand_invoc_semi (AST::MacroInvocation &invoc);
 
   // Expands a single declarative macro.
   AST::ASTFragment expand_decl_macro (Location locus,

--- a/gcc/rust/hir/rust-ast-lower-base.h
+++ b/gcc/rust/hir/rust-ast-lower-base.h
@@ -56,7 +56,6 @@ public:
   //  virtual void visit(TraitItem& trait_item) {}
   //  virtual void visit(InherentImplItem& inherent_impl_item) {}
   //  virtual void visit(TraitImplItem& trait_impl_item) {}
-  virtual void visit (AST::MacroInvocationSemi &macro) {}
 
   // rust-path.h
   virtual void visit (AST::PathInExpression &path) {}

--- a/gcc/rust/hir/rust-ast-lower-implitem.h
+++ b/gcc/rust/hir/rust-ast-lower-implitem.h
@@ -52,16 +52,18 @@ public:
     return resolver.translated;
   }
 
-  // FIXME: ARTHUR: See if this is necessary for MacroInvocation
-  // void visit (AST::MacroInvocationSemi &invoc) override
-  // {
-  //   AST::ASTFragment &fragment = invoc.get_fragment ();
+  void visit (AST::MacroInvocation &invoc) override
+  {
+    if (!invoc.has_semicolon ())
+      return;
 
-  //   // FIXME
-  //   // this assertion might go away, maybe on failure's to expand a macro?
-  //   rust_assert (!fragment.get_nodes ().empty ());
-  //   fragment.get_nodes ().at (0).accept_vis (*this);
-  // }
+    AST::ASTFragment &fragment = invoc.get_fragment ();
+
+    // FIXME
+    // this assertion might go away, maybe on failure's to expand a macro?
+    rust_assert (!fragment.get_nodes ().empty ());
+    fragment.get_nodes ().at (0).accept_vis (*this);
+  }
 
   void visit (AST::TypeAlias &alias) override
   {
@@ -319,16 +321,18 @@ public:
     return resolver.translated;
   }
 
-  // FIXME: ARTHUR: See if this is necessary for MacroInvocation
-  // void visit (AST::MacroInvocationSemi &invoc) override
-  // {
-  //   AST::ASTFragment &fragment = invoc.get_fragment ();
+  void visit (AST::MacroInvocation &invoc) override
+  {
+    if (!invoc.has_semicolon ())
+      return;
 
-  //   // FIXME
-  //   // this assertion might go away, maybe on failure's to expand a macro?
-  //   rust_assert (!fragment.get_nodes ().empty ());
-  //   fragment.get_nodes ().at (0).accept_vis (*this);
-  // }
+    AST::ASTFragment &fragment = invoc.get_fragment ();
+
+    // FIXME
+    // this assertion might go away, maybe on failure's to expand a macro?
+    rust_assert (!fragment.get_nodes ().empty ());
+    fragment.get_nodes ().at (0).accept_vis (*this);
+  }
 
   void visit (AST::TraitItemFunc &func) override
   {

--- a/gcc/rust/hir/rust-ast-lower-implitem.h
+++ b/gcc/rust/hir/rust-ast-lower-implitem.h
@@ -52,15 +52,16 @@ public:
     return resolver.translated;
   }
 
-  void visit (AST::MacroInvocationSemi &invoc) override
-  {
-    AST::ASTFragment &fragment = invoc.get_fragment ();
+  // FIXME: ARTHUR: See if this is necessary for MacroInvocation
+  // void visit (AST::MacroInvocationSemi &invoc) override
+  // {
+  //   AST::ASTFragment &fragment = invoc.get_fragment ();
 
-    // FIXME
-    // this assertion might go away, maybe on failure's to expand a macro?
-    rust_assert (!fragment.get_nodes ().empty ());
-    fragment.get_nodes ().at (0).accept_vis (*this);
-  }
+  //   // FIXME
+  //   // this assertion might go away, maybe on failure's to expand a macro?
+  //   rust_assert (!fragment.get_nodes ().empty ());
+  //   fragment.get_nodes ().at (0).accept_vis (*this);
+  // }
 
   void visit (AST::TypeAlias &alias) override
   {
@@ -318,15 +319,16 @@ public:
     return resolver.translated;
   }
 
-  void visit (AST::MacroInvocationSemi &invoc) override
-  {
-    AST::ASTFragment &fragment = invoc.get_fragment ();
+  // FIXME: ARTHUR: See if this is necessary for MacroInvocation
+  // void visit (AST::MacroInvocationSemi &invoc) override
+  // {
+  //   AST::ASTFragment &fragment = invoc.get_fragment ();
 
-    // FIXME
-    // this assertion might go away, maybe on failure's to expand a macro?
-    rust_assert (!fragment.get_nodes ().empty ());
-    fragment.get_nodes ().at (0).accept_vis (*this);
-  }
+  //   // FIXME
+  //   // this assertion might go away, maybe on failure's to expand a macro?
+  //   rust_assert (!fragment.get_nodes ().empty ());
+  //   fragment.get_nodes ().at (0).accept_vis (*this);
+  // }
 
   void visit (AST::TraitItemFunc &func) override
   {

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -51,15 +51,16 @@ public:
     return resolver.translated;
   }
 
-  void visit (AST::MacroInvocationSemi &invoc) override
-  {
-    AST::ASTFragment &fragment = invoc.get_fragment ();
+  // FIXME: ARTHUR: See if this is necessary for MacroInvocation
+  // void visit (AST::MacroInvocationSemi &invoc) override
+  // {
+  //   AST::ASTFragment &fragment = invoc.get_fragment ();
 
-    // FIXME
-    // this assertion might go away, maybe on failure's to expand a macro?
-    rust_assert (!fragment.get_nodes ().empty ());
-    fragment.get_nodes ().at (0).accept_vis (*this);
-  }
+  //   // FIXME
+  //   // this assertion might go away, maybe on failure's to expand a macro?
+  //   rust_assert (!fragment.get_nodes ().empty ());
+  //   fragment.get_nodes ().at (0).accept_vis (*this);
+  // }
 
   void visit (AST::Module &module) override
   {

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -51,16 +51,18 @@ public:
     return resolver.translated;
   }
 
-  // FIXME: ARTHUR: See if this is necessary for MacroInvocation
-  // void visit (AST::MacroInvocationSemi &invoc) override
-  // {
-  //   AST::ASTFragment &fragment = invoc.get_fragment ();
+  void visit (AST::MacroInvocation &invoc) override
+  {
+    if (!invoc.has_semicolon ())
+      return;
 
-  //   // FIXME
-  //   // this assertion might go away, maybe on failure's to expand a macro?
-  //   rust_assert (!fragment.get_nodes ().empty ());
-  //   fragment.get_nodes ().at (0).accept_vis (*this);
-  // }
+    AST::ASTFragment &fragment = invoc.get_fragment ();
+
+    // FIXME
+    // this assertion might go away, maybe on failure's to expand a macro?
+    rust_assert (!fragment.get_nodes ().empty ());
+    fragment.get_nodes ().at (0).accept_vis (*this);
+  }
 
   void visit (AST::Module &module) override
   {

--- a/gcc/rust/hir/rust-ast-lower-stmt.h
+++ b/gcc/rust/hir/rust-ast-lower-stmt.h
@@ -45,16 +45,18 @@ public:
     return resolver.translated;
   }
 
-  // FIXME: ARTHUR: See if this implementation is necessary for MacroInvocation
-  // void visit (AST::MacroInvocationSemi &invoc) override
-  // {
-  //   AST::ASTFragment &fragment = invoc.get_fragment ();
+  void visit (AST::MacroInvocation &invoc) override
+  {
+    if (!invoc.has_semicolon ())
+      return;
 
-  //   // FIXME
-  //   // this assertion might go away, maybe on failure's to expand a macro?
-  //   rust_assert (!fragment.get_nodes ().empty ());
-  //   fragment.get_nodes ().at (0).accept_vis (*this);
-  // }
+    AST::ASTFragment &fragment = invoc.get_fragment ();
+
+    // FIXME
+    // this assertion might go away, maybe on failure's to expand a macro?
+    rust_assert (!fragment.get_nodes ().empty ());
+    fragment.get_nodes ().at (0).accept_vis (*this);
+  }
 
   void visit (AST::ExprStmtWithBlock &stmt) override
   {

--- a/gcc/rust/hir/rust-ast-lower-stmt.h
+++ b/gcc/rust/hir/rust-ast-lower-stmt.h
@@ -45,15 +45,16 @@ public:
     return resolver.translated;
   }
 
-  void visit (AST::MacroInvocationSemi &invoc) override
-  {
-    AST::ASTFragment &fragment = invoc.get_fragment ();
+  // FIXME: ARTHUR: See if this implementation is necessary for MacroInvocation
+  // void visit (AST::MacroInvocationSemi &invoc) override
+  // {
+  //   AST::ASTFragment &fragment = invoc.get_fragment ();
 
-    // FIXME
-    // this assertion might go away, maybe on failure's to expand a macro?
-    rust_assert (!fragment.get_nodes ().empty ());
-    fragment.get_nodes ().at (0).accept_vis (*this);
-  }
+  //   // FIXME
+  //   // this assertion might go away, maybe on failure's to expand a macro?
+  //   rust_assert (!fragment.get_nodes ().empty ());
+  //   fragment.get_nodes ().at (0).accept_vis (*this);
+  // }
 
   void visit (AST::ExprStmtWithBlock &stmt) override
   {

--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -80,6 +80,7 @@ struct ParseRestrictions
    * like struct exprs being parsed from a dereference. */
   bool entered_from_unary = false;
   bool expr_can_be_null = false;
+  bool expr_can_be_stmt = false;
 };
 
 // Parser implementation for gccrs.
@@ -157,7 +158,7 @@ private:
   std::unique_ptr<AST::TokenTree> parse_token_tree ();
   std::unique_ptr<AST::MacroRulesDefinition>
   parse_macro_rules_def (AST::AttrVec outer_attrs);
-  std::unique_ptr<AST::MacroInvocationSemi>
+  std::unique_ptr<AST::MacroInvocation>
   parse_macro_invocation_semi (AST::AttrVec outer_attrs);
   std::unique_ptr<AST::MacroInvocation>
   parse_macro_invocation (AST::AttrVec outer_attrs);
@@ -468,9 +469,9 @@ private:
   parse_index_expr (const_TokenPtr tok, std::unique_ptr<AST::Expr> array_expr,
 		    AST::AttrVec outer_attrs,
 		    ParseRestrictions restrictions = ParseRestrictions ());
-  std::unique_ptr<AST::MacroInvocation>
-  parse_macro_invocation_partial (AST::PathInExpression path,
-				  AST::AttrVec outer_attrs);
+  std::unique_ptr<AST::MacroInvocation> parse_macro_invocation_partial (
+    AST::PathInExpression path, AST::AttrVec outer_attrs,
+    ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::StructExprStruct>
   parse_struct_expr_struct_partial (AST::PathInExpression path,
 				    AST::AttrVec outer_attrs);
@@ -490,7 +491,9 @@ private:
   std::unique_ptr<AST::ExprWithBlock>
   parse_expr_with_block (AST::AttrVec outer_attrs);
   std::unique_ptr<AST::ExprWithoutBlock>
-  parse_expr_without_block (AST::AttrVec outer_attrs = AST::AttrVec ());
+  parse_expr_without_block (AST::AttrVec outer_attrs = AST::AttrVec (),
+			    ParseRestrictions restrictions
+			    = ParseRestrictions ());
   // When given a pratt_parsed_loc, use it as the location of the
   // first token parsed in the expression (the parsing of that first
   // token should be skipped).

--- a/gcc/rust/resolve/rust-ast-resolve-base.h
+++ b/gcc/rust/resolve/rust-ast-resolve-base.h
@@ -38,7 +38,6 @@ public:
   void visit (AST::IdentifierExpr &) {}
   void visit (AST::Lifetime &) {}
   void visit (AST::LifetimeParam &) {}
-  void visit (AST::MacroInvocationSemi &) {}
   void visit (AST::PathInExpression &) {}
   void visit (AST::TypePathSegment &) {}
   void visit (AST::TypePathSegmentGeneric &) {}

--- a/gcc/rust/resolve/rust-ast-resolve-implitem.h
+++ b/gcc/rust/resolve/rust-ast-resolve-implitem.h
@@ -49,13 +49,15 @@ public:
     item->accept_vis (resolver);
   }
 
-  // FIXME: ARTHUR: See if this is necessary for MacroInvocation
-  // void visit (AST::MacroInvocationSemi &invoc) override
-  // {
-  //   AST::ASTFragment &fragment = invoc.get_fragment ();
-  //   for (auto &node : fragment.get_nodes ())
-  //     node.accept_vis (*this);
-  // }
+  void visit (AST::MacroInvocation &invoc) override
+  {
+    if (!invoc.has_semicolon ())
+      return;
+
+    AST::ASTFragment &fragment = invoc.get_fragment ();
+    for (auto &node : fragment.get_nodes ())
+      node.accept_vis (*this);
+  }
 
   void visit (AST::TypeAlias &type) override
   {
@@ -145,13 +147,15 @@ public:
     item->accept_vis (resolver);
   };
 
-  // FIXME: ARTHUR: See if this is necessary for MacroInvocation
-  // void visit (AST::MacroInvocationSemi &invoc) override
-  // {
-  //   AST::ASTFragment &fragment = invoc.get_fragment ();
-  //   for (auto &node : fragment.get_nodes ())
-  //     node.accept_vis (*this);
-  // }
+  void visit (AST::MacroInvocation &invoc) override
+  {
+    if (!invoc.has_semicolon ())
+      return;
+
+    AST::ASTFragment &fragment = invoc.get_fragment ();
+    for (auto &node : fragment.get_nodes ())
+      node.accept_vis (*this);
+  }
 
   void visit (AST::TraitItemFunc &function) override
   {
@@ -256,13 +260,15 @@ public:
     item->accept_vis (resolver);
   };
 
-  // FIXME: ARTHUR: See if this is necessary for MacroInvocation
-  // void visit (AST::MacroInvocationSemi &invoc) override
-  // {
-  //   AST::ASTFragment &fragment = invoc.get_fragment ();
-  //   for (auto &node : fragment.get_nodes ())
-  //     node.accept_vis (*this);
-  // }
+  void visit (AST::MacroInvocation &invoc) override
+  {
+    if (!invoc.has_semicolon ())
+      return;
+
+    AST::ASTFragment &fragment = invoc.get_fragment ();
+    for (auto &node : fragment.get_nodes ())
+      node.accept_vis (*this);
+  }
 
   void visit (AST::ExternalFunctionItem &function) override
   {

--- a/gcc/rust/resolve/rust-ast-resolve-implitem.h
+++ b/gcc/rust/resolve/rust-ast-resolve-implitem.h
@@ -49,12 +49,13 @@ public:
     item->accept_vis (resolver);
   }
 
-  void visit (AST::MacroInvocationSemi &invoc) override
-  {
-    AST::ASTFragment &fragment = invoc.get_fragment ();
-    for (auto &node : fragment.get_nodes ())
-      node.accept_vis (*this);
-  }
+  // FIXME: ARTHUR: See if this is necessary for MacroInvocation
+  // void visit (AST::MacroInvocationSemi &invoc) override
+  // {
+  //   AST::ASTFragment &fragment = invoc.get_fragment ();
+  //   for (auto &node : fragment.get_nodes ())
+  //     node.accept_vis (*this);
+  // }
 
   void visit (AST::TypeAlias &type) override
   {
@@ -144,12 +145,13 @@ public:
     item->accept_vis (resolver);
   };
 
-  void visit (AST::MacroInvocationSemi &invoc) override
-  {
-    AST::ASTFragment &fragment = invoc.get_fragment ();
-    for (auto &node : fragment.get_nodes ())
-      node.accept_vis (*this);
-  }
+  // FIXME: ARTHUR: See if this is necessary for MacroInvocation
+  // void visit (AST::MacroInvocationSemi &invoc) override
+  // {
+  //   AST::ASTFragment &fragment = invoc.get_fragment ();
+  //   for (auto &node : fragment.get_nodes ())
+  //     node.accept_vis (*this);
+  // }
 
   void visit (AST::TraitItemFunc &function) override
   {
@@ -254,12 +256,13 @@ public:
     item->accept_vis (resolver);
   };
 
-  void visit (AST::MacroInvocationSemi &invoc) override
-  {
-    AST::ASTFragment &fragment = invoc.get_fragment ();
-    for (auto &node : fragment.get_nodes ())
-      node.accept_vis (*this);
-  }
+  // FIXME: ARTHUR: See if this is necessary for MacroInvocation
+  // void visit (AST::MacroInvocationSemi &invoc) override
+  // {
+  //   AST::ASTFragment &fragment = invoc.get_fragment ();
+  //   for (auto &node : fragment.get_nodes ())
+  //     node.accept_vis (*this);
+  // }
 
   void visit (AST::ExternalFunctionItem &function) override
   {

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -45,13 +45,15 @@ public:
     item->accept_vis (resolver);
   };
 
-  // FIXME: ARTHUR: See if this is necessary for MacroInvocation
-  // void visit (AST::MacroInvocationSemi &invoc) override
-  // {
-  //   AST::ASTFragment &fragment = invoc.get_fragment ();
-  //   for (auto &node : fragment.get_nodes ())
-  //     node.accept_vis (*this);
-  // }
+  void visit (AST::MacroInvocation &invoc) override
+  {
+    if (!invoc.has_semicolon ())
+      return;
+
+    AST::ASTFragment &fragment = invoc.get_fragment ();
+    for (auto &node : fragment.get_nodes ())
+      node.accept_vis (*this);
+  }
 
   void visit (AST::TraitItemType &type) override
   {
@@ -235,13 +237,15 @@ public:
     item->accept_vis (resolver);
   };
 
-  // FIXME: ARTHUR: See if this is necessary for MacroInvocation
-  // void visit (AST::MacroInvocationSemi &invoc) override
-  // {
-  //   AST::ASTFragment &fragment = invoc.get_fragment ();
-  //   for (auto &node : fragment.get_nodes ())
-  //     node.accept_vis (*this);
-  // }
+  void visit (AST::MacroInvocation &invoc) override
+  {
+    if (!invoc.has_semicolon ())
+      return;
+
+    AST::ASTFragment &fragment = invoc.get_fragment ();
+    for (auto &node : fragment.get_nodes ())
+      node.accept_vis (*this);
+  }
 
   void visit (AST::TypeAlias &alias) override
   {

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -45,12 +45,13 @@ public:
     item->accept_vis (resolver);
   };
 
-  void visit (AST::MacroInvocationSemi &invoc) override
-  {
-    AST::ASTFragment &fragment = invoc.get_fragment ();
-    for (auto &node : fragment.get_nodes ())
-      node.accept_vis (*this);
-  }
+  // FIXME: ARTHUR: See if this is necessary for MacroInvocation
+  // void visit (AST::MacroInvocationSemi &invoc) override
+  // {
+  //   AST::ASTFragment &fragment = invoc.get_fragment ();
+  //   for (auto &node : fragment.get_nodes ())
+  //     node.accept_vis (*this);
+  // }
 
   void visit (AST::TraitItemType &type) override
   {
@@ -234,12 +235,13 @@ public:
     item->accept_vis (resolver);
   };
 
-  void visit (AST::MacroInvocationSemi &invoc) override
-  {
-    AST::ASTFragment &fragment = invoc.get_fragment ();
-    for (auto &node : fragment.get_nodes ())
-      node.accept_vis (*this);
-  }
+  // FIXME: ARTHUR: See if this is necessary for MacroInvocation
+  // void visit (AST::MacroInvocationSemi &invoc) override
+  // {
+  //   AST::ASTFragment &fragment = invoc.get_fragment ();
+  //   for (auto &node : fragment.get_nodes ())
+  //     node.accept_vis (*this);
+  // }
 
   void visit (AST::TypeAlias &alias) override
   {

--- a/gcc/rust/resolve/rust-ast-resolve-stmt.h
+++ b/gcc/rust/resolve/rust-ast-resolve-stmt.h
@@ -44,13 +44,14 @@ public:
     stmt->accept_vis (resolver);
   };
 
-  void visit (AST::MacroInvocationSemi &invoc) override
-  {
-    AST::ASTFragment &fragment = invoc.get_fragment ();
+  // FIXME: ARTHUR: See if this is necessary for MacroInvocation
+  // void visit (AST::MacroInvocationSemi &invoc) override
+  // {
+  //   AST::ASTFragment &fragment = invoc.get_fragment ();
 
-    for (auto &node : fragment.get_nodes ())
-      node.accept_vis (*this);
-  }
+  //   for (auto &node : fragment.get_nodes ())
+  //     node.accept_vis (*this);
+  // }
 
   void visit (AST::ExprStmtWithBlock &stmt) override
   {

--- a/gcc/rust/resolve/rust-ast-resolve-stmt.h
+++ b/gcc/rust/resolve/rust-ast-resolve-stmt.h
@@ -44,14 +44,16 @@ public:
     stmt->accept_vis (resolver);
   };
 
-  // FIXME: ARTHUR: See if this is necessary for MacroInvocation
-  // void visit (AST::MacroInvocationSemi &invoc) override
-  // {
-  //   AST::ASTFragment &fragment = invoc.get_fragment ();
+  void visit (AST::MacroInvocation &invoc) override
+  {
+    if (!invoc.has_semicolon ())
+      return;
 
-  //   for (auto &node : fragment.get_nodes ())
-  //     node.accept_vis (*this);
-  // }
+    AST::ASTFragment &fragment = invoc.get_fragment ();
+
+    for (auto &node : fragment.get_nodes ())
+      node.accept_vis (*this);
+  }
 
   void visit (AST::ExprStmtWithBlock &stmt) override
   {

--- a/gcc/rust/resolve/rust-ast-resolve-toplevel.h
+++ b/gcc/rust/resolve/rust-ast-resolve-toplevel.h
@@ -43,12 +43,13 @@ public:
     item->accept_vis (resolver);
   };
 
-  void visit (AST::MacroInvocationSemi &invoc) override
-  {
-    AST::ASTFragment &fragment = invoc.get_fragment ();
-    for (auto &node : fragment.get_nodes ())
-      node.accept_vis (*this);
-  }
+  // FIXME: ARTHUR: See if this is necessary for MacroInvocation
+  // void visit (AST::MacroInvocationSemi &invoc) override
+  // {
+  //   AST::ASTFragment &fragment = invoc.get_fragment ();
+  //   for (auto &node : fragment.get_nodes ())
+  //     node.accept_vis (*this);
+  // }
 
   void visit (AST::Module &module) override
   {

--- a/gcc/rust/resolve/rust-ast-resolve-toplevel.h
+++ b/gcc/rust/resolve/rust-ast-resolve-toplevel.h
@@ -43,13 +43,12 @@ public:
     item->accept_vis (resolver);
   };
 
-  // FIXME: ARTHUR: See if this is necessary for MacroInvocation
-  // void visit (AST::MacroInvocationSemi &invoc) override
-  // {
-  //   AST::ASTFragment &fragment = invoc.get_fragment ();
-  //   for (auto &node : fragment.get_nodes ())
-  //     node.accept_vis (*this);
-  // }
+  void visit (AST::MacroInvocation &invoc) override
+  {
+    AST::ASTFragment &fragment = invoc.get_fragment ();
+    for (auto &node : fragment.get_nodes ())
+      node.accept_vis (*this);
+  }
 
   void visit (AST::Module &module) override
   {


### PR DESCRIPTION
When parsing a macro invocation as a statement, the parser would parse
an expression and then try parsing a semicolon. Since no actual
lookahead was done (which is a good thing), we couldn't convert a
`MacroInvocation` to a `MacroInvocationSemi` after the fact.

Since, unlike function calls, macro invocations can act differently
based on whether or not they are followed by a semicolon, we actually
need to differentiate between the two up until expansion.

This commits adds a new virtual method for ExprWithoutBlock when
converting to ExprStmtWithoutBlock so that classes inheriting
ExprWithoutBlock can specify a new behavior. In the case of our
MacroInvocation class, it simply means toggling a boolean: If we're
converting a macro from an expression to a statement, it must mean that
it should contain a semicolon.

Closes #941 