### PR TITLE
Fix ICE on recursive macro invocation

### DIFF
--- a/gcc/rust/expand/rust-macro-substitute-ctx.cc
+++ b/gcc/rust/expand/rust-macro-substitute-ctx.cc
@@ -17,8 +17,8 @@ SubstituteCtx::substitute_metavar (std::unique_ptr<AST::Token> &metavar)
   else
     {
       // Replace
-      // We only care about the vector when expanding repetitions. Just access
-      // the first element of the vector.
+      // We only care about the vector when expanding repetitions.
+      // Just access the first element of the vector.
       // FIXME: Clean this up so it makes more sense
       auto &frag = it->second[0];
       for (size_t offs = frag.token_offset_begin; offs < frag.token_offset_end;
@@ -103,7 +103,13 @@ SubstituteCtx::substitute_repetition (size_t pattern_start, size_t pattern_end)
       for (auto &kv_match : fragments)
 	{
 	  std::vector<MatchedFragment> sub_vec;
-	  sub_vec.emplace_back (kv_match.second[i]);
+
+	  // FIXME: Hack: If a fragment is not repeated, how does it fit in the
+	  // submap? Do we really want to expand it? Is this normal behavior?
+	  if (kv_match.second.size () == 1)
+	    sub_vec.emplace_back (kv_match.second[0]);
+	  else
+	    sub_vec.emplace_back (kv_match.second[i]);
 
 	  sub_map.insert ({kv_match.first, sub_vec});
 	}
@@ -177,6 +183,7 @@ std::vector<std::unique_ptr<AST::Token>>
 SubstituteCtx::substitute_tokens ()
 {
   std::vector<std::unique_ptr<AST::Token>> replaced_tokens;
+  rust_debug ("expanding tokens");
 
   for (size_t i = 0; i < macro.size (); i++)
     {

--- a/gcc/testsuite/rust/execute/torture/macros16.rs
+++ b/gcc/testsuite/rust/execute/torture/macros16.rs
@@ -1,0 +1,14 @@
+macro_rules! add {
+    ($e:literal) => {
+        0 + $e
+    };
+    ($e:literal $($es:literal)*) => {
+        $e + add!($($es)*)
+    };
+}
+
+fn main() -> i32 {
+    let a = add!(1 2 3 10); // 16
+
+    a - 16
+}

--- a/gcc/testsuite/rust/execute/torture/macros17.rs
+++ b/gcc/testsuite/rust/execute/torture/macros17.rs
@@ -1,0 +1,17 @@
+macro_rules! two {
+    (2) => {
+        3
+    };
+}
+
+macro_rules! one {
+    (1) => {
+        two!(2)
+    };
+}
+
+fn main() -> i32 {
+    let a = one!(1);
+
+    a - 3
+}

--- a/gcc/testsuite/rust/execute/torture/macros18.rs
+++ b/gcc/testsuite/rust/execute/torture/macros18.rs
@@ -1,0 +1,14 @@
+macro_rules! add {
+    ($e:literal) => {
+        0 + $e
+    };
+    ($e:literal $($es:literal)*) => {
+        $e + add!($($es)*)
+    };
+}
+
+fn main() -> i32 {
+    let a = add!(3 4); // 7
+
+    a - 7
+}


### PR DESCRIPTION
Closes #982 

We can now do fancy lispy things!
```rust
macro_rules! add {
    ($e:literal) => {
        0 + $e
    };
    ($e:literal $($es:literal)*) => {
        $e + add!($($es)*)
    };
}
```

I've switched the order of the commits around so that the buildbot is happy