### PR TITLE
Add line!() macro

### DIFF
--- a/gcc/rust/expand/rust-macro-builtins.cc
+++ b/gcc/rust/expand/rust-macro-builtins.cc
@@ -49,4 +49,16 @@ MacroBuiltin::file (Location invoc_locus, AST::MacroInvocData &invoc)
 
   return AST::ASTFragment ({file_str});
 }
+
+AST::ASTFragment
+MacroBuiltin::line (Location invoc_locus, AST::MacroInvocData &invoc)
+{
+  auto current_line
+    = Session::get_instance ().linemap->location_line (invoc_locus);
+  auto inte = AST::SingleASTNode (std::unique_ptr<AST::Expr> (
+    new AST::LiteralExpr (std::to_string (current_line), AST::Literal::INT,
+			  PrimitiveCoreType::CORETYPE_U32, {}, invoc_locus)));
+
+  return AST::ASTFragment ({inte});
+}
 } // namespace Rust

--- a/gcc/rust/expand/rust-macro-builtins.h
+++ b/gcc/rust/expand/rust-macro-builtins.h
@@ -31,6 +31,9 @@ public:
 
   static AST::ASTFragment file (Location invoc_locus,
 				AST::MacroInvocData &invoc);
+
+  static AST::ASTFragment line (Location invoc_locus,
+				AST::MacroInvocData &invoc);
 };
 } // namespace Rust
 

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -750,6 +750,7 @@ Mappings::insert_macro_def (AST::MacroRulesDefinition *macro)
     builtin_macros = {
       {"assert", MacroBuiltin::assert},
       {"file", MacroBuiltin::file},
+      {"line", MacroBuiltin::line},
     };
 
   auto builtin = builtin_macros.find (macro->get_rule_name ());

--- a/gcc/testsuite/rust/execute/torture/builtin_macros2.rs
+++ b/gcc/testsuite/rust/execute/torture/builtin_macros2.rs
@@ -1,0 +1,24 @@
+// { dg-output "15\n19\n" }
+macro_rules! line {
+    () => {{}};
+}
+
+extern "C" {
+    fn printf(fmt: *const i8, ...);
+}
+
+fn print(s: u32) {
+    printf("%u\n\0" as *const str as *const i8, s);
+}
+
+fn main() -> i32 {
+    let line1 = line!();
+
+    print(line1);
+
+    let line2 = line!();
+
+    print(line2);
+
+    0
+}


### PR DESCRIPTION
Fixes #978 

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`
- \[x] Added any relevant test cases to `gcc/testsuite/rust/`
---
- Added the `line!()` macro

Signed-off-by: [54k1](mailto:54k1@protonmail.com)
