### PR TITLE
Match and expand macro separators properly

### DIFF
--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -207,6 +207,7 @@ public:
   }
 
   MacroRepOp get_op () const { return op; }
+  const std::unique_ptr<MacroRepSep> &get_sep () const { return sep; }
   std::vector<std::unique_ptr<MacroMatch> > &get_matches () { return matches; }
 
 protected:

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -192,7 +192,7 @@ struct MacroExpander
    * Match any amount of matches
    *
    * @param parser Parser to use for matching
-   * @param matches All consecutive matches to identify
+   * @param rep Repetition to try and match
    * @param match_amount Reference in which to store the ammount of succesful
    * and valid matches
    *
@@ -209,9 +209,8 @@ struct MacroExpander
    * otherwise
    */
   bool match_n_matches (Parser<MacroInvocLexer> &parser,
-			std::vector<std::unique_ptr<AST::MacroMatch>> &matches,
-			size_t &match_amount, size_t lo_bound = 0,
-			size_t hi_bound = 0);
+			AST::MacroMatchRepetition &rep, size_t &match_amount,
+			size_t lo_bound = 0, size_t hi_bound = 0);
 
   void push_context (ContextType t) { context.push_back (t); }
 

--- a/gcc/rust/expand/rust-macro-substitute-ctx.cc
+++ b/gcc/rust/expand/rust-macro-substitute-ctx.cc
@@ -17,8 +17,8 @@ SubstituteCtx::substitute_metavar (std::unique_ptr<AST::Token> &metavar)
   else
     {
       // Replace
-      // We only care about the vector when expanding repetitions. Just access
-      // the first element of the vector.
+      // We only care about the vector when expanding repetitions.
+      // Just access the first element of the vector.
       // FIXME: Clean this up so it makes more sense
       auto &frag = it->second[0];
       for (size_t offs = frag.token_offset_begin; offs < frag.token_offset_end;
@@ -103,7 +103,13 @@ SubstituteCtx::substitute_repetition (size_t pattern_start, size_t pattern_end)
       for (auto &kv_match : fragments)
 	{
 	  std::vector<MatchedFragment> sub_vec;
-	  sub_vec.emplace_back (kv_match.second[i]);
+
+	  // FIXME: Hack: If a fragment is not repeated, how does it fit in the
+	  // submap? Do we really want to expand it? Is this normal behavior?
+	  if (kv_match.second.size () == 1)
+	    sub_vec.emplace_back (kv_match.second[0]);
+	  else
+	    sub_vec.emplace_back (kv_match.second[i]);
 
 	  sub_map.insert ({kv_match.first, sub_vec});
 	}
@@ -177,6 +183,7 @@ std::vector<std::unique_ptr<AST::Token>>
 SubstituteCtx::substitute_tokens ()
 {
   std::vector<std::unique_ptr<AST::Token>> replaced_tokens;
+  rust_debug ("expanding tokens");
 
   for (size_t i = 0; i < macro.size (); i++)
     {

--- a/gcc/rust/expand/rust-macro-substitute-ctx.h
+++ b/gcc/rust/expand/rust-macro-substitute-ctx.h
@@ -49,12 +49,14 @@ public:
    * Substitute a macro repetition by its given fragments
    *
    * @param pattern_start Start index of the pattern tokens
-   * @param pattern_end Index  Amount of tokens in the pattern
+   * @param pattern_end End index of the patterns tokens
+   * @param separator Optional separator to include when expanding tokens
    *
    * @return A vector containing the repeated pattern
    */
   std::vector<std::unique_ptr<AST::Token>>
-  substitute_repetition (size_t pattern_start, size_t pattern_end);
+  substitute_repetition (size_t pattern_start, size_t pattern_end,
+			 std::unique_ptr<AST::Token> separator);
 
   /**
    * Substitute a given token by its appropriate representation

--- a/gcc/testsuite/rust/compile/macro9.rs
+++ b/gcc/testsuite/rust/compile/macro9.rs
@@ -1,0 +1,17 @@
+macro_rules! add {
+    ($e:expr, $($es:expr),*) => {
+        $e + add!($($es),*)
+    };
+    ($e:expr) => {
+        $e
+    };
+}
+
+fn main() -> i32 {
+    let a = add!(15 2 9); // { dg-error "Failed to match any rule within macro" }
+    let b = add!(15);
+    let b = add!(15 14); // { dg-error "Failed to match any rule within macro" }
+    let b = add!(15, 14,); // { dg-error "Failed to match any rule within macro" }
+
+    0
+}

--- a/gcc/testsuite/rust/execute/torture/macros16.rs
+++ b/gcc/testsuite/rust/execute/torture/macros16.rs
@@ -1,0 +1,14 @@
+macro_rules! add {
+    ($e:literal) => {
+        0 + $e
+    };
+    ($e:literal $($es:literal)*) => {
+        $e + add!($($es)*)
+    };
+}
+
+fn main() -> i32 {
+    let a = add!(1 2 3 10); // 16
+
+    a - 16
+}

--- a/gcc/testsuite/rust/execute/torture/macros17.rs
+++ b/gcc/testsuite/rust/execute/torture/macros17.rs
@@ -1,0 +1,17 @@
+macro_rules! two {
+    (2) => {
+        3
+    };
+}
+
+macro_rules! one {
+    (1) => {
+        two!(2)
+    };
+}
+
+fn main() -> i32 {
+    let a = one!(1);
+
+    a - 3
+}

--- a/gcc/testsuite/rust/execute/torture/macros18.rs
+++ b/gcc/testsuite/rust/execute/torture/macros18.rs
@@ -1,0 +1,14 @@
+macro_rules! add {
+    ($e:literal) => {
+        0 + $e
+    };
+    ($e:literal $($es:literal)*) => {
+        $e + add!($($es)*)
+    };
+}
+
+fn main() -> i32 {
+    let a = add!(3 4); // 7
+
+    a - 7
+}

--- a/gcc/testsuite/rust/execute/torture/macros19.rs
+++ b/gcc/testsuite/rust/execute/torture/macros19.rs
@@ -1,0 +1,14 @@
+macro_rules! add {
+    ($e:expr, $($es:expr),*) => {
+        $e + add!($($es),*)
+    };
+    ($e:expr) => {
+        $e
+    };
+}
+
+fn main() -> i32 {
+    let a = add!(15, 2, 9); // 26
+
+    a - 26
+}

--- a/gcc/testsuite/rust/execute/torture/macros20.rs
+++ b/gcc/testsuite/rust/execute/torture/macros20.rs
@@ -1,0 +1,14 @@
+macro_rules! add {
+    ($e:expr big_tok $($es:expr) big_tok *) => {
+        $e + add!($($es) big_tok *)
+    };
+    ($e:expr) => {
+        $e
+    };
+}
+
+fn main() -> i32 {
+    let a = add!(15 big_tok 2 big_tok 9); // 26
+
+    a - 26
+}


### PR DESCRIPTION
More nice recursive macros:
```rust
macro_rules! add {
    ($e:expr | $($es:expr) | *) => {
        $e + add!($($es) | *)
    };
    ($e:expr) => {
        $e
    };
}

add!(1 | 2 | 3 | 4 | 5 | 6);
```
Closes #968

This PR needs #986 to be merged first, as it depends on it for the test cases. You can skip reviewing the first two commits which are just from #986 