### PR TITLE
Parse macro expansion properly

### DIFF
--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -464,9 +464,6 @@ class MacroInvocation : public TypeNoBounds,
   MacroInvocData invoc_data;
   Location locus;
 
-  // this is the expanded macro
-  ASTFragment fragment;
-
   // Important for when we actually expand the macro
   bool is_semi_coloned;
 
@@ -480,7 +477,6 @@ public:
 		   bool is_semi_coloned = false)
     : outer_attrs (std::move (outer_attrs)),
       invoc_data (std::move (invoc_data)), locus (locus),
-      fragment (ASTFragment::create_empty ()),
       is_semi_coloned (is_semi_coloned),
       node_id (Analysis::Mappings::get ()->get_next_node_id ())
   {}
@@ -512,10 +508,6 @@ public:
   NodeId get_macro_node_id () const { return node_id; }
 
   MacroInvocData &get_invoc_data () { return invoc_data; }
-
-  ASTFragment &get_fragment () { return fragment; }
-
-  void set_fragment (ASTFragment &&f) { fragment = std::move (f); }
 
   bool has_semicolon () const { return is_semi_coloned; }
 

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -137,7 +137,9 @@ struct MacroExpander
 
   MacroExpander (AST::Crate &crate, ExpansionCfg cfg, Session &session)
     : cfg (cfg), crate (crate), session (session),
-      sub_stack (SubstitutionScope ()), resolver (Resolver::Resolver::get ()),
+      sub_stack (SubstitutionScope ()),
+      expanded_fragment (AST::ASTFragment::create_empty ()),
+      resolver (Resolver::Resolver::get ()),
       mappings (Analysis::Mappings::get ())
   {}
 
@@ -223,11 +225,25 @@ struct MacroExpander
 
   ContextType peek_context () { return context.back (); }
 
+  void set_expanded_fragment (AST::ASTFragment &&fragment)
+  {
+    expanded_fragment = std::move (fragment);
+  }
+
+  AST::ASTFragment take_expanded_fragment ()
+  {
+    AST::ASTFragment old_fragment = std::move (expanded_fragment);
+    expanded_fragment = AST::ASTFragment::create_empty ();
+
+    return old_fragment;
+  }
+
 private:
   AST::Crate &crate;
   Session &session;
   SubstitutionScope sub_stack;
   std::vector<ContextType> context;
+  AST::ASTFragment expanded_fragment;
 
 public:
   Resolver::Resolver *resolver;

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -102,12 +102,10 @@ public:
 
   void visit (AST::MacroInvocation &expr) override
   {
-    AST::ASTFragment &fragment = expr.get_fragment ();
-
-    // FIXME
-    // this assertion might go away, maybe on failure's to expand a macro?
-    rust_assert (!fragment.get_nodes ().empty ());
-    fragment.get_nodes ().at (0).accept_vis (*this);
+    rust_fatal_error (
+      expr.get_locus (),
+      "macro expansion failed: No macro invocation should get lowered to HIR "
+      "as they should disappear during expansion");
   }
 
   void visit (AST::TupleIndexExpr &expr) override

--- a/gcc/rust/hir/rust-ast-lower-implitem.h
+++ b/gcc/rust/hir/rust-ast-lower-implitem.h
@@ -54,15 +54,10 @@ public:
 
   void visit (AST::MacroInvocation &invoc) override
   {
-    if (!invoc.has_semicolon ())
-      return;
-
-    AST::ASTFragment &fragment = invoc.get_fragment ();
-
-    // FIXME
-    // this assertion might go away, maybe on failure's to expand a macro?
-    rust_assert (!fragment.get_nodes ().empty ());
-    fragment.get_nodes ().at (0).accept_vis (*this);
+    rust_fatal_error (
+      invoc.get_locus (),
+      "macro expansion failed: No macro invocation should get lowered to HIR "
+      "as they should disappear during expansion");
   }
 
   void visit (AST::TypeAlias &alias) override
@@ -323,15 +318,10 @@ public:
 
   void visit (AST::MacroInvocation &invoc) override
   {
-    if (!invoc.has_semicolon ())
-      return;
-
-    AST::ASTFragment &fragment = invoc.get_fragment ();
-
-    // FIXME
-    // this assertion might go away, maybe on failure's to expand a macro?
-    rust_assert (!fragment.get_nodes ().empty ());
-    fragment.get_nodes ().at (0).accept_vis (*this);
+    rust_fatal_error (
+      invoc.get_locus (),
+      "macro expansion failed: No macro invocation should get lowered to HIR "
+      "as they should disappear during expansion");
   }
 
   void visit (AST::TraitItemFunc &func) override

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -53,15 +53,10 @@ public:
 
   void visit (AST::MacroInvocation &invoc) override
   {
-    if (!invoc.has_semicolon ())
-      return;
-
-    AST::ASTFragment &fragment = invoc.get_fragment ();
-
-    // FIXME
-    // this assertion might go away, maybe on failure's to expand a macro?
-    rust_assert (!fragment.get_nodes ().empty ());
-    fragment.get_nodes ().at (0).accept_vis (*this);
+    rust_fatal_error (
+      invoc.get_locus (),
+      "macro expansion failed: No macro invocation should get lowered to HIR "
+      "as they should disappear during expansion");
   }
 
   void visit (AST::Module &module) override

--- a/gcc/rust/hir/rust-ast-lower-stmt.h
+++ b/gcc/rust/hir/rust-ast-lower-stmt.h
@@ -47,15 +47,10 @@ public:
 
   void visit (AST::MacroInvocation &invoc) override
   {
-    if (!invoc.has_semicolon ())
-      return;
-
-    AST::ASTFragment &fragment = invoc.get_fragment ();
-
-    // FIXME
-    // this assertion might go away, maybe on failure's to expand a macro?
-    rust_assert (!fragment.get_nodes ().empty ());
-    fragment.get_nodes ().at (0).accept_vis (*this);
+    rust_fatal_error (
+      invoc.get_locus (),
+      "macro expansion failed: No macro invocation should get lowered to HIR "
+      "as they should disappear during expansion");
   }
 
   void visit (AST::ExprStmtWithBlock &stmt) override

--- a/gcc/rust/resolve/rust-ast-resolve-expr.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.cc
@@ -35,14 +35,6 @@ ResolveExpr::go (AST::Expr *expr, NodeId parent, const CanonicalPath &prefix,
 }
 
 void
-ResolveExpr::visit (AST::MacroInvocation &expr)
-{
-  AST::ASTFragment &fragment = expr.get_fragment ();
-  for (auto &node : fragment.get_nodes ())
-    node.accept_vis (*this);
-}
-
-void
 ResolveExpr::visit (AST::TupleIndexExpr &expr)
 {
   resolve_expr (expr.get_tuple_expr ().get (), expr.get_node_id ());

--- a/gcc/rust/resolve/rust-ast-resolve-expr.h
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.h
@@ -62,8 +62,6 @@ public:
   static void go (AST::Expr *expr, NodeId parent, const CanonicalPath &prefix,
 		  const CanonicalPath &canonical_prefix);
 
-  void visit (AST::MacroInvocation &expr) override;
-
   void visit (AST::TupleIndexExpr &expr) override;
 
   void visit (AST::TupleExpr &expr) override;

--- a/gcc/rust/resolve/rust-ast-resolve-implitem.h
+++ b/gcc/rust/resolve/rust-ast-resolve-implitem.h
@@ -49,16 +49,6 @@ public:
     item->accept_vis (resolver);
   }
 
-  void visit (AST::MacroInvocation &invoc) override
-  {
-    if (!invoc.has_semicolon ())
-      return;
-
-    AST::ASTFragment &fragment = invoc.get_fragment ();
-    for (auto &node : fragment.get_nodes ())
-      node.accept_vis (*this);
-  }
-
   void visit (AST::TypeAlias &type) override
   {
     auto decl
@@ -146,16 +136,6 @@ public:
     ResolveTopLevelTraitItems resolver (prefix, canonical_prefix);
     item->accept_vis (resolver);
   };
-
-  void visit (AST::MacroInvocation &invoc) override
-  {
-    if (!invoc.has_semicolon ())
-      return;
-
-    AST::ASTFragment &fragment = invoc.get_fragment ();
-    for (auto &node : fragment.get_nodes ())
-      node.accept_vis (*this);
-  }
 
   void visit (AST::TraitItemFunc &function) override
   {
@@ -259,16 +239,6 @@ public:
     ResolveToplevelExternItem resolver (prefix);
     item->accept_vis (resolver);
   };
-
-  void visit (AST::MacroInvocation &invoc) override
-  {
-    if (!invoc.has_semicolon ())
-      return;
-
-    AST::ASTFragment &fragment = invoc.get_fragment ();
-    for (auto &node : fragment.get_nodes ())
-      node.accept_vis (*this);
-  }
 
   void visit (AST::ExternalFunctionItem &function) override
   {

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -45,16 +45,6 @@ public:
     item->accept_vis (resolver);
   };
 
-  void visit (AST::MacroInvocation &invoc) override
-  {
-    if (!invoc.has_semicolon ())
-      return;
-
-    AST::ASTFragment &fragment = invoc.get_fragment ();
-    for (auto &node : fragment.get_nodes ())
-      node.accept_vis (*this);
-  }
-
   void visit (AST::TraitItemType &type) override
   {
     auto decl = ResolveTraitItemTypeToCanonicalPath::resolve (type);
@@ -236,16 +226,6 @@ public:
     ResolveItem resolver (prefix, canonical_prefix);
     item->accept_vis (resolver);
   };
-
-  void visit (AST::MacroInvocation &invoc) override
-  {
-    if (!invoc.has_semicolon ())
-      return;
-
-    AST::ASTFragment &fragment = invoc.get_fragment ();
-    for (auto &node : fragment.get_nodes ())
-      node.accept_vis (*this);
-  }
 
   void visit (AST::TypeAlias &alias) override
   {

--- a/gcc/rust/resolve/rust-ast-resolve-stmt.h
+++ b/gcc/rust/resolve/rust-ast-resolve-stmt.h
@@ -44,17 +44,6 @@ public:
     stmt->accept_vis (resolver);
   };
 
-  void visit (AST::MacroInvocation &invoc) override
-  {
-    if (!invoc.has_semicolon ())
-      return;
-
-    AST::ASTFragment &fragment = invoc.get_fragment ();
-
-    for (auto &node : fragment.get_nodes ())
-      node.accept_vis (*this);
-  }
-
   void visit (AST::ExprStmtWithBlock &stmt) override
   {
     ResolveExpr::go (stmt.get_expr ().get (), stmt.get_node_id (), prefix,

--- a/gcc/rust/resolve/rust-ast-resolve-toplevel.h
+++ b/gcc/rust/resolve/rust-ast-resolve-toplevel.h
@@ -43,13 +43,6 @@ public:
     item->accept_vis (resolver);
   };
 
-  void visit (AST::MacroInvocation &invoc) override
-  {
-    AST::ASTFragment &fragment = invoc.get_fragment ();
-    for (auto &node : fragment.get_nodes ())
-      node.accept_vis (*this);
-  }
-
   void visit (AST::Module &module) override
   {
     auto mod

--- a/gcc/testsuite/rust/compile/macro11.rs
+++ b/gcc/testsuite/rust/compile/macro11.rs
@@ -1,0 +1,11 @@
+macro_rules! call_f {
+    ($($f:ident)*) => { $($f();)* }
+}
+
+fn f() {}
+
+// This is valid and should parse items
+fn main() {
+    call_f!(f f f f);
+}
+

--- a/gcc/testsuite/rust/compile/macro12.rs
+++ b/gcc/testsuite/rust/compile/macro12.rs
@@ -1,0 +1,8 @@
+// { dg-additional-options "-w" }
+macro_rules! define_vars {
+    ($($v:ident)*) => { $(let $v = 15;)* }
+}
+
+fn main() {
+    define_vars!(a0 b f __some_identifier);
+}

--- a/gcc/testsuite/rust/compile/macro13.rs
+++ b/gcc/testsuite/rust/compile/macro13.rs
@@ -1,0 +1,12 @@
+// { dg-additional-options "-w" }
+macro_rules! create_type {
+    ($s:ident) => {
+        struct $s;
+    };
+}
+
+fn main() {
+    create_type!(A);
+
+    let a = A;
+}

--- a/gcc/testsuite/rust/compile/macro14.rs
+++ b/gcc/testsuite/rust/compile/macro14.rs
@@ -1,0 +1,10 @@
+// { dg-additional-options "-w" }
+macro_rules! define_vars {
+    ($($v:ident)*) => { $(let $v = 15;)* }
+}
+
+fn main() -> i32 {
+    define_vars!(a0 b f __some_identifier);
+
+    b
+}

--- a/gcc/testsuite/rust/compile/macro15.rs
+++ b/gcc/testsuite/rust/compile/macro15.rs
@@ -1,0 +1,12 @@
+// { dg-additional-options "-w" }
+macro_rules! create_type {
+    ($s:ident) => {
+        struct $s;
+    };
+}
+
+create_type!(SomeOuterType);
+
+fn main() {
+    let a = SomeOuterType;
+}

--- a/gcc/testsuite/rust/compile/macro6.rs
+++ b/gcc/testsuite/rust/compile/macro6.rs
@@ -1,6 +1,6 @@
 macro_rules! zero_or_one {
     ($($a:literal)?) => { // { dg-error "invalid amount of matches for macro invocation. Expected between 0 and 1, got 2" }
-        f()
+        f();
     }
 }
 

--- a/gcc/testsuite/rust/compile/macro7.rs
+++ b/gcc/testsuite/rust/compile/macro7.rs
@@ -2,8 +2,8 @@ fn f() {}
 
 macro_rules! one_or_more {
     ($($a:literal)+) => { // { dg-error "invalid amount of matches for macro invocation" }
-        f()
-    }
+        f();
+    };
 }
 
 fn main() {

--- a/gcc/testsuite/rust/compile/macro8.rs
+++ b/gcc/testsuite/rust/compile/macro8.rs
@@ -2,8 +2,8 @@ fn f() {}
 
 macro_rules! expr {
     ($($a:expr)?) => {
-        f()
-    }
+        f();
+    };
 }
 
 fn main() {

--- a/gcc/testsuite/rust/execute/torture/macros11.rs
+++ b/gcc/testsuite/rust/execute/torture/macros11.rs
@@ -7,7 +7,9 @@ fn print_int(value: i32) {
     let s = "%d\n\0";
     let s_p = s as *const str;
     let c_p = s_p as *const i8;
-    unsafe { printf(c_p, value); }
+    unsafe {
+        printf(c_p, value);
+    }
 }
 
 macro_rules! add_exprs {
@@ -16,7 +18,8 @@ macro_rules! add_exprs {
 
 fn main() -> i32 {
     // 2
-    print_int(add_exprs!(2));
+    let a = add_exprs!(2);
+    print_int(a);
 
     0
 }

--- a/gcc/testsuite/rust/execute/torture/macros17.rs
+++ b/gcc/testsuite/rust/execute/torture/macros17.rs
@@ -5,9 +5,9 @@ macro_rules! two {
 }
 
 macro_rules! one {
-    (1) => {
+    (1) => {{
         two!(2)
-    };
+    }};
 }
 
 fn main() -> i32 {

--- a/gcc/testsuite/rust/execute/torture/macros2.rs
+++ b/gcc/testsuite/rust/execute/torture/macros2.rs
@@ -15,19 +15,19 @@ fn f() {
 
 macro_rules! kw0 {
     (keyword) => {
-        f()
+        f();
     };
 }
 
 macro_rules! kw1 {
     (fn) => {
-        f()
+        f();
     };
 }
 
 macro_rules! kw2 {
     (kw0 kw1 kw3) => {
-        f()
+        f();
     };
 }
 

--- a/gcc/testsuite/rust/execute/torture/macros22.rs
+++ b/gcc/testsuite/rust/execute/torture/macros22.rs
@@ -1,0 +1,23 @@
+// { dg-output "1\n2\nNaN\n3\n" }
+
+macro_rules! print_num {
+    ($l:literal) => {
+        printf("%d\n\0" as *const str as *const i8, $l);
+    };
+}
+
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+// Check to make sure that expanding macros does not break the flow of calls
+fn main() -> i32 {
+    print_num!(1);
+    print_num!(2);
+
+    printf("NaN\n\0" as *const str as *const i8);
+
+    print_num!(3);
+
+    0
+}

--- a/gcc/testsuite/rust/execute/torture/macros3.rs
+++ b/gcc/testsuite/rust/execute/torture/macros3.rs
@@ -15,7 +15,7 @@ fn f() {
 
 macro_rules! invocation0 {
     (valid) => {
-        f()
+        f();
     };
     () => {};
 }
@@ -23,27 +23,27 @@ macro_rules! invocation0 {
 macro_rules! invocation1 {
     (valid) => {};
     () => {
-        f()
+        f();
     };
 }
 
 macro_rules! invocation2 {
     (valid) => {
-        f()
+        f();
     };
     (invalid) => {};
 }
 
 macro_rules! invocation3 {
     (this is a valid invocation) => {
-        f()
+        f();
     };
     (not this one) => {};
 }
 
 macro_rules! invocation4 {
     (fn f() {}) => {
-        f()
+        f();
     };
     (not a keyword) => {};
 }

--- a/gcc/testsuite/rust/execute/torture/macros7.rs
+++ b/gcc/testsuite/rust/execute/torture/macros7.rs
@@ -8,13 +8,15 @@ fn f() {
     let s_p = r_s as *const str;
     let c_p = s_p as *const i8;
 
-    unsafe { printf(c_p); }
+    unsafe {
+        printf(c_p);
+    }
 }
 
 macro_rules! any {
     ($($a:expr)*) => {
-        f()
-    }
+        f();
+    };
 }
 
 fn main() -> i32 {

--- a/gcc/testsuite/rust/execute/torture/macros8.rs
+++ b/gcc/testsuite/rust/execute/torture/macros8.rs
@@ -8,13 +8,15 @@ fn f() {
     let s_p = r_s as *const str;
     let c_p = s_p as *const i8;
 
-    unsafe { printf(c_p); }
+    unsafe {
+        printf(c_p);
+    }
 }
 
 macro_rules! zero_or_one {
     ($($a:expr)?) => {
-        f()
-    }
+        f();
+    };
 }
 
 fn main() -> i32 {

--- a/gcc/testsuite/rust/execute/torture/macros9.rs
+++ b/gcc/testsuite/rust/execute/torture/macros9.rs
@@ -8,13 +8,15 @@ fn f() {
     let s_p = r_s as *const str;
     let c_p = s_p as *const i8;
 
-    unsafe { printf(c_p); }
+    unsafe {
+        printf(c_p);
+    }
 }
 
 macro_rules! one_or_more {
     ($($a:expr)+) => {
-        f()
-    }
+        f();
+    };
 }
 
 fn main() -> i32 {


### PR DESCRIPTION
This PR adds a base for trying to parse statements or items in macro invocations. We are now able to parse multiple items / expressions / statements properly, but do not lower them properly, which is the last remaining task in #943 

New macro parsing logic:
```mermaid
flowchart TD;
    has_semi -- Yes --> stmt;
    has_semi -- No --> invocation;
    invocation -- Is Parens --> expr;
    invocation -- Is Square --> expr;
    invocation -- Is Curly --> stmt;
```

Closes #943 
Closes #959 
Closes #952 