### PR TITLE
Add missing canonicalization of slices and raw pointer types

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-type.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-type.cc
@@ -168,6 +168,45 @@ ResolveTypeToCanonicalPath::visit (AST::ReferenceType &ref)
 }
 
 void
+ResolveTypeToCanonicalPath::visit (AST::RawPointerType &ref)
+{
+  auto inner_type
+    = ResolveTypeToCanonicalPath::resolve (*ref.get_type_pointed_to ().get (),
+					   include_generic_args_flag,
+					   type_resolve_generic_args_flag);
+
+  std::string segment_string ("*");
+  switch (ref.get_pointer_type ())
+    {
+    case AST::RawPointerType::PointerType::MUT:
+      segment_string += "mut ";
+      break;
+
+    case AST::RawPointerType::PointerType::CONST:
+      segment_string += "const ";
+      break;
+    }
+
+  segment_string += inner_type.get ();
+
+  auto ident_seg = CanonicalPath::new_seg (ref.get_node_id (), segment_string);
+  result = result.append (ident_seg);
+}
+
+void
+ResolveTypeToCanonicalPath::visit (AST::SliceType &slice)
+{
+  auto inner_type
+    = ResolveTypeToCanonicalPath::resolve (*slice.get_elem_type ().get (),
+					   include_generic_args_flag,
+					   type_resolve_generic_args_flag);
+  std::string segment_string = "[" + inner_type.get () + "]";
+  auto ident_seg
+    = CanonicalPath::new_seg (slice.get_node_id (), segment_string);
+  result = result.append (ident_seg);
+}
+
+void
 ResolveType::visit (AST::ReferenceType &type)
 {
   type.get_type_referenced ()->accept_vis (*this);

--- a/gcc/rust/resolve/rust-ast-resolve-type.h
+++ b/gcc/rust/resolve/rust-ast-resolve-type.h
@@ -122,6 +122,10 @@ public:
       }
   }
 
+  void visit (AST::SliceType &slice) override;
+
+  void visit (AST::RawPointerType &ptr) override;
+
   void visit (AST::ReferenceType &ref) override;
 
   void visit (AST::TypePathSegmentGeneric &seg) override;

--- a/gcc/testsuite/rust/compile/issue-1005.rs
+++ b/gcc/testsuite/rust/compile/issue-1005.rs
@@ -1,0 +1,4 @@
+// { dg-additional-options "-w" }
+impl<T> *const T {
+    fn test(self) {}
+}


### PR DESCRIPTION
This is part of my patch series for slices. This adds the missing visitors
for name canonicalization. More information in the patch, once we get
slice support in we need to start taking advantage of @dkm's HIR
visitor refactoring to avoid these issues with missing visitors making
simple bugs hard to track down.

Fixes #1005
