### PR TITLE
Add missing type resolution to slices and arrays

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-type.h
+++ b/gcc/rust/hir/tree/rust-hir-type.h
@@ -668,6 +668,8 @@ public:
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRTypeVisitor &vis) override;
 
+  std::unique_ptr<Type> &get_element_type () { return elem_type; }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -600,5 +600,15 @@ TypeCheckType::visit (HIR::ArrayType &type)
 				    TyTy::TyVar (base->get_ref ()));
 }
 
+void
+TypeCheckType::visit (HIR::SliceType &type)
+{
+  TyTy::BaseType *base
+    = TypeCheckType::Resolve (type.get_element_type ().get ());
+  translated
+    = new TyTy::SliceType (type.get_mappings ().get_hirid (), type.get_locus (),
+			   TyTy::TyVar (base->get_ref ()));
+}
+
 } // namespace Resolver
 } // namespace Rust

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -120,6 +120,8 @@ public:
 
   void visit (HIR::ArrayType &type) override;
 
+  void visit (HIR::SliceType &type) override;
+
   void visit (HIR::ReferenceType &type) override
   {
     TyTy::BaseType *base
@@ -338,8 +340,8 @@ public:
     binding->inherit_bounds (specified_bounds);
 
     // When we apply these bounds we must lookup which type this binding
-    // resolves to, as this is the type which will be used during resolution of
-    // the block.
+    // resolves to, as this is the type which will be used during resolution
+    // of the block.
     NodeId ast_node_id = binding_type_path->get_mappings ().get_nodeid ();
 
     // then lookup the reference_node_id

--- a/gcc/rust/typecheck/rust-substitution-mapper.h
+++ b/gcc/rust/typecheck/rust-substitution-mapper.h
@@ -221,11 +221,19 @@ public:
     resolved = type.handle_substitions (mappings);
   }
 
+  void visit (TyTy::ArrayType &type) override
+  {
+    resolved = type.handle_substitions (mappings);
+  }
+
+  void visit (TyTy::SliceType &type) override
+  {
+    resolved = type.handle_substitions (mappings);
+  }
+
   // nothing to do for these
   void visit (TyTy::InferType &) override { gcc_unreachable (); }
   void visit (TyTy::FnPtr &) override { gcc_unreachable (); }
-  void visit (TyTy::ArrayType &) override { gcc_unreachable (); }
-  void visit (TyTy::SliceType &) override { gcc_unreachable (); }
   void visit (TyTy::BoolType &) override { gcc_unreachable (); }
   void visit (TyTy::IntType &) override { gcc_unreachable (); }
   void visit (TyTy::UintType &) override { gcc_unreachable (); }

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -1508,6 +1508,22 @@ ArrayType::clone () const
 			element_type, get_combined_refs ());
 }
 
+ArrayType *
+ArrayType::handle_substitions (SubstitutionArgumentMappings mappings)
+{
+  auto mappings_table = Analysis::Mappings::get ();
+
+  ArrayType *ref = static_cast<ArrayType *> (clone ());
+  ref->set_ty_ref (mappings_table->get_next_hir_id ());
+
+  // might be &T or &ADT so this needs to be recursive
+  auto base = ref->get_element_type ();
+  BaseType *concrete = Resolver::SubstMapperInternal::Resolve (base, mappings);
+  ref->element_type = TyVar (concrete->get_ty_ref ());
+
+  return ref;
+}
+
 void
 SliceType::accept_vis (TyVisitor &vis)
 {
@@ -1579,6 +1595,22 @@ SliceType::clone () const
 {
   return new SliceType (get_ref (), get_ty_ref (), ident.locus, element_type,
 			get_combined_refs ());
+}
+
+SliceType *
+SliceType::handle_substitions (SubstitutionArgumentMappings mappings)
+{
+  auto mappings_table = Analysis::Mappings::get ();
+
+  SliceType *ref = static_cast<SliceType *> (clone ());
+  ref->set_ty_ref (mappings_table->get_next_hir_id ());
+
+  // might be &T or &ADT so this needs to be recursive
+  auto base = ref->get_element_type ();
+  BaseType *concrete = Resolver::SubstMapperInternal::Resolve (base, mappings);
+  ref->element_type = TyVar (concrete->get_ty_ref ());
+
+  return ref;
 }
 
 void

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -1665,6 +1665,8 @@ public:
 
   HIR::Expr &get_capacity_expr () const { return capacity_expr; }
 
+  ArrayType *handle_substitions (SubstitutionArgumentMappings mappings);
+
 private:
   TyVar element_type;
   HIR::Expr &capacity_expr;
@@ -1709,6 +1711,8 @@ public:
   {
     return get_element_type ()->is_concrete ();
   }
+
+  SliceType *handle_substitions (SubstitutionArgumentMappings mappings);
 
 private:
   TyVar element_type;


### PR DESCRIPTION
This adds in the missing type resolution for slices and generic slices
and arrays. Since Arrays and Slices are both covariant types just like
references and pointers for example they need to handle recursive
substitutions where their element type might be a generic type
that can bind substitution parameters such as functions and ADT's.

Addresses #849 