### PR TITLE
macros: Lower stmt macro definitions to empty statements

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-stmt.h
+++ b/gcc/rust/hir/rust-ast-lower-stmt.h
@@ -445,6 +445,19 @@ public:
     translated = fn;
   }
 
+  void visit (AST::MacroRulesDefinition &macro_def) override
+  {
+    // FIXME: This lowers macro definitions as statements (i.e. macros defined
+    // in blocks) as an empty statement: We actually need to perform
+    // lowering of the macro and figure out how to store it using rust's
+    // metadata formats: .rlib and .rmeta files
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, macro_def.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   UNKNOWN_LOCAL_DEFID);
+    translated = new HIR::EmptyStmt (mapping, macro_def.get_locus ());
+  }
+
 private:
   ASTLoweringStmt () : translated (nullptr), terminated (false) {}
 

--- a/gcc/testsuite/rust/compile/macro16.rs
+++ b/gcc/testsuite/rust/compile/macro16.rs
@@ -1,0 +1,11 @@
+fn main() {
+    macro_rules! create_type {
+        ($s:ident) => {
+            struct $s(i32);
+        };
+    }
+
+    create_type!(Wrapper);
+
+    let _ = Wrapper(15);
+}


### PR DESCRIPTION
This commit simply removes the ICE happening when lowering a macro
defined inside a block by lowering it to an empty statement. We do need
to figure out how to lower them properly to the corresponding .rlib and
.rmeta files later on

Fixes #1001 