### PR TITLE
attribute expansion: Fix spurious stripping of tail expression

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -249,7 +249,8 @@ public:
     BYTE_STRING,
     INT,
     FLOAT,
-    BOOL
+    BOOL,
+    ERROR
   };
 
 private:
@@ -274,11 +275,11 @@ public:
 
   static Literal create_error ()
   {
-    return Literal ("", CHAR, PrimitiveCoreType::CORETYPE_UNKNOWN);
+    return Literal ("", ERROR, PrimitiveCoreType::CORETYPE_UNKNOWN);
   }
 
   // Returns whether literal is in an invalid state.
-  bool is_error () const { return value_as_string == ""; }
+  bool is_error () const { return type == ERROR; }
 };
 
 /* Forward decl - definition moved to rust-expr.h as it requires LiteralExpr to

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -359,6 +359,10 @@ public:
       case AST::Literal::LitType::BOOL:
 	type = HIR::Literal::LitType::BOOL;
 	break;
+	// Error literals should have been stripped during expansion
+      case AST::Literal::LitType::ERROR:
+	gcc_unreachable ();
+	break;
       }
     auto crate_num = mappings->get_current_crate ();
     Analysis::NodeMapping mapping (crate_num, expr.get_node_id (),

--- a/gcc/testsuite/rust/compile/xfail/slice1.rs
+++ b/gcc/testsuite/rust/compile/xfail/slice1.rs
@@ -1,3 +1,5 @@
-fn foo (e: &str) -> &str {
-    &"" // { dg-bogus "cannot strip expression in this position - outer attributes not allowed" "#391" { xfail *-*-* } }
+// { dg-additional-options "-w" }
+
+fn foo(e: &str) -> &str { // { dg-bogus "expected" "#391" { xfail *-*-* } }
+    &"" // { dg-bogus "expected" "#391" { xfail *-*-* } }
 }


### PR DESCRIPTION
This commit fixes the issue reported in #391, but highlights another
one, which will be reported.

Closes #391 