### PR TITLE
Fix memory corruption in generation of builtin functions

### DIFF
--- a/gcc/rust/backend/rust-compile-intrinsic.cc
+++ b/gcc/rust/backend/rust-compile-intrinsic.cc
@@ -304,8 +304,6 @@ offset_intrinsic_handler (Context *ctx, TyTy::BaseType *fntype_tyty)
 
   gcc_assert (TREE_CODE (bind_tree) == BIND_EXPR);
   DECL_SAVED_TREE (fndecl) = bind_tree;
-
-  ctx->pop_fn ();
   ctx->push_function (fndecl);
 
   return fndecl;
@@ -393,8 +391,6 @@ sizeof_intrinsic_handler (Context *ctx, TyTy::BaseType *fntype_tyty)
 
   gcc_assert (TREE_CODE (bind_tree) == BIND_EXPR);
   DECL_SAVED_TREE (fndecl) = bind_tree;
-
-  ctx->pop_fn ();
   ctx->push_function (fndecl);
 
   return fndecl;

--- a/gcc/testsuite/rust/compile/torture/issue-1024.rs
+++ b/gcc/testsuite/rust/compile/torture/issue-1024.rs
@@ -1,0 +1,11 @@
+extern "rust-intrinsic" {
+    pub fn size_of<T>() -> usize;
+}
+
+fn test() -> usize {
+    unsafe { size_of::<i32>() }
+}
+
+fn main() {
+    let _a = test();
+}


### PR DESCRIPTION
This patch removes the pop_fn calls since no fncontext stack is required here for these intrinsic.
More context on the issues is in the commit message.

Fixes #1024