### PR TITLE
parser: Allow parsing stmts without closing semicolon

### DIFF
--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -479,7 +479,7 @@ MacroExpander::match_fragment (Parser<MacroInvocLexer> &parser,
       break;
 
     case AST::MacroFragSpec::STMT:
-      parser.parse_stmt ();
+      parser.parse_stmt (/* allow_no_semi */ true);
       break;
 
     case AST::MacroFragSpec::LIFETIME:
@@ -505,6 +505,9 @@ MacroExpander::match_fragment (Parser<MacroInvocLexer> &parser,
     case AST::MacroFragSpec::INVALID:
       return false;
     }
+
+  for (const auto &error : parser.get_errors ())
+    error.emit_error ();
 
   // it matches if the parser did not produce errors trying to parse that type
   // of item
@@ -825,7 +828,7 @@ transcribe_many_stmts (Parser<MacroInvocLexer> &parser, TokenId &delimiter)
   // transcriber is an expression, but since the macro call is followed by
   // a semicolon, it's a valid ExprStmt
   return parse_many (parser, delimiter, [&parser] () {
-    auto stmt = parser.parse_stmt ();
+    auto stmt = parser.parse_stmt (/* allow_no_semi */ true);
     return AST::SingleASTNode (std::move (stmt));
   });
 }

--- a/gcc/testsuite/rust/compile/macro18.rs
+++ b/gcc/testsuite/rust/compile/macro18.rs
@@ -1,0 +1,14 @@
+// { dg-additional-options "-w" }
+
+macro_rules! take_stmt {
+    ($s:stmt) => {
+        $s;
+    };
+}
+
+fn main() -> i32 {
+    take_stmt!(let complete = 15;);
+    take_stmt!(let lacking = 14);
+
+    0
+}

--- a/gcc/testsuite/rust/compile/macro19.rs
+++ b/gcc/testsuite/rust/compile/macro19.rs
@@ -1,0 +1,19 @@
+// { dg-additional-options "-w" }
+
+macro_rules! call_without_semi {
+    () => {
+        f()
+    };
+    (block) => {{
+        f()
+    }};
+}
+
+fn f() {}
+
+fn main() -> i32 {
+    call_without_semi!();
+    call_without_semi!(block);
+
+    0
+}

--- a/gcc/testsuite/rust/compile/macro9.rs
+++ b/gcc/testsuite/rust/compile/macro9.rs
@@ -12,6 +12,7 @@ fn main() -> i32 {
     let b = add!(15);
     let b = add!(15 14); // { dg-error "Failed to match any rule within macro" }
     let b = add!(15, 14,); // { dg-error "Failed to match any rule within macro" }
+                           // { dg-error "found unexpected token" "" { target *-*-* } .-1 }
 
     0
 }


### PR DESCRIPTION
In certain cases such as macro matching or macro expansion, it is
important to allow the parser to return a valid statement even if no
closing semicolon is given. This commit adds an optional parameter to
the concerned functions to allow a lack of semicolon those special cases

Closes #1011 
Closes #1010 