### PR TITLE
Add AST kind information

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -41,6 +41,7 @@ enum Kind
 {
   UNKNOWN,
   MACRO_RULES_DEFINITION,
+  MACRO_INVOCATION,
 };
 
 // Abstract base class for all AST elements
@@ -900,7 +901,7 @@ protected:
 class ExprWithoutBlock;
 
 // Base expression AST node - abstract
-class Expr
+class Expr : public Node
 {
 public:
   // Unique pointer custom clone function
@@ -1073,7 +1074,7 @@ protected:
 class TraitBound;
 
 // Base class for types as represented in AST - abstract
-class Type
+class Type : public Node
 {
 public:
   // Unique pointer custom clone function

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -36,6 +36,27 @@ namespace AST {
 class ASTVisitor;
 using AttrVec = std::vector<Attribute>;
 
+// The available kinds of AST Nodes
+enum Kind
+{
+  UNKNOWN,
+  MACRO_RULES_DEFINITION,
+};
+
+// Abstract base class for all AST elements
+class Node
+{
+public:
+  /**
+   * Get the kind of Node this is. This is used to differentiate various AST
+   * elements with very little overhead when extracting the derived type through
+   * static casting is not necessary.
+   */
+  // FIXME: Mark this as `= 0` in the future to make sure every node implements
+  // it
+  virtual Kind get_ast_kind () const { return Kind::UNKNOWN; }
+};
+
 // Delimiter types - used in macros and whatever.
 enum DelimType
 {
@@ -813,7 +834,7 @@ class MetaListNameValueStr;
 
 /* Base statement abstract class. Note that most "statements" are not allowed in
  * top-level module scope - only a subclass of statements called "items" are. */
-class Stmt
+class Stmt : public Node
 {
 public:
   // Unique pointer custom clone function

--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -507,6 +507,8 @@ public:
     return ExprWithoutBlock::get_node_id ();
   }
 
+  Kind get_ast_kind () const override { return Kind::MACRO_INVOCATION; }
+
   NodeId get_macro_node_id () const { return node_id; }
 
   MacroInvocData &get_invoc_data () { return invoc_data; }

--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -441,6 +441,8 @@ public:
     is_builtin_rule = true;
   }
 
+  Kind get_ast_kind () const override { return Kind::MACRO_RULES_DEFINITION; }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -100,14 +100,6 @@ public:
     return resolver.translated;
   }
 
-  void visit (AST::MacroInvocation &expr) override
-  {
-    rust_fatal_error (
-      expr.get_locus (),
-      "macro expansion failed: No macro invocation should get lowered to HIR "
-      "as they should disappear during expansion");
-  }
-
   void visit (AST::TupleIndexExpr &expr) override
   {
     HIR::Expr *tuple_expr

--- a/gcc/rust/hir/rust-ast-lower-implitem.h
+++ b/gcc/rust/hir/rust-ast-lower-implitem.h
@@ -52,14 +52,6 @@ public:
     return resolver.translated;
   }
 
-  void visit (AST::MacroInvocation &invoc) override
-  {
-    rust_fatal_error (
-      invoc.get_locus (),
-      "macro expansion failed: No macro invocation should get lowered to HIR "
-      "as they should disappear during expansion");
-  }
-
   void visit (AST::TypeAlias &alias) override
   {
     std::vector<std::unique_ptr<HIR::WhereClauseItem> > where_clause_items;
@@ -314,14 +306,6 @@ public:
     item->accept_vis (resolver);
     rust_assert (resolver.translated != nullptr);
     return resolver.translated;
-  }
-
-  void visit (AST::MacroInvocation &invoc) override
-  {
-    rust_fatal_error (
-      invoc.get_locus (),
-      "macro expansion failed: No macro invocation should get lowered to HIR "
-      "as they should disappear during expansion");
   }
 
   void visit (AST::TraitItemFunc &func) override

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -51,14 +51,6 @@ public:
     return resolver.translated;
   }
 
-  void visit (AST::MacroInvocation &invoc) override
-  {
-    rust_fatal_error (
-      invoc.get_locus (),
-      "macro expansion failed: No macro invocation should get lowered to HIR "
-      "as they should disappear during expansion");
-  }
-
   void visit (AST::Module &module) override
   {
     auto crate_num = mappings->get_current_crate ();

--- a/gcc/rust/hir/rust-ast-lower-stmt.h
+++ b/gcc/rust/hir/rust-ast-lower-stmt.h
@@ -45,14 +45,6 @@ public:
     return resolver.translated;
   }
 
-  void visit (AST::MacroInvocation &invoc) override
-  {
-    rust_fatal_error (
-      invoc.get_locus (),
-      "macro expansion failed: No macro invocation should get lowered to HIR "
-      "as they should disappear during expansion");
-  }
-
   void visit (AST::ExprStmtWithBlock &stmt) override
   {
     HIR::ExprWithBlock *expr

--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -67,6 +67,9 @@ ASTLoweringBlock::visit (AST::BlockExpr &expr)
 
   for (auto &s : expr.get_statements ())
     {
+      if (s->get_ast_kind () == AST::Kind::MACRO_RULES_DEFINITION)
+	continue;
+
       if (block_did_terminate)
 	rust_warning_at (s->get_locus (), 0, "unreachable statement");
 

--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -70,6 +70,13 @@ ASTLoweringBlock::visit (AST::BlockExpr &expr)
       if (s->get_ast_kind () == AST::Kind::MACRO_RULES_DEFINITION)
 	continue;
 
+      if (s->get_ast_kind () == AST::Kind::MACRO_INVOCATION)
+	rust_fatal_error (
+	  s->get_locus (),
+	  "macro invocations should not get lowered to HIR - At "
+	  "this point in "
+	  "the pipeline, they should all have been expanded");
+
       if (block_did_terminate)
 	rust_warning_at (s->get_locus (), 0, "unreachable statement");
 

--- a/gcc/testsuite/rust/compile/macro16.rs
+++ b/gcc/testsuite/rust/compile/macro16.rs
@@ -1,0 +1,11 @@
+fn main() {
+    macro_rules! create_type {
+        ($s:ident) => {
+            struct $s(i32);
+        };
+    }
+
+    create_type!(Wrapper);
+
+    let _ = Wrapper(15);
+}


### PR DESCRIPTION
Closes #1001 

This PR adds a base for adding node information to our AST types. It can be used when requiring to differentiate between multiple kinds of nodes, while not necessarily wanting to do a full static cast. This will open up a lot of cleanup issues and good first issues for Project Pineapple