### PR TITLE
Fix bad copy-paste in can equal interface for pointer types

### DIFF
--- a/gcc/rust/typecheck/rust-tyty-cmp.h
+++ b/gcc/rust/typecheck/rust-tyty-cmp.h
@@ -1240,7 +1240,7 @@ public:
     : BaseCmp (base, emit_errors), base (base)
   {}
 
-  void visit (const ReferenceType &type) override
+  void visit (const PointerType &type) override
   {
     auto base_type = base->get_base ();
     auto other_base_type = type.get_base ();

--- a/gcc/testsuite/rust/compile/issue-1031.rs
+++ b/gcc/testsuite/rust/compile/issue-1031.rs
@@ -1,0 +1,16 @@
+extern "rust-intrinsic" {
+    pub fn offset<T>(dst: *const T, offset: isize) -> *const T;
+}
+
+#[lang = "const_ptr"]
+impl<T> *const T {
+    pub const unsafe fn offset(self, count: isize) -> *const T {
+        // { dg-warning "associated function is never used" "" { target *-*-* } .-1 }
+        unsafe { offset(self, count) }
+    }
+
+    pub const unsafe fn add(self, count: usize) -> Self {
+        // { dg-warning "associated function is never used" "" { target *-*-* } .-1 }
+        unsafe { self.offset(count as isize) }
+    }
+}


### PR DESCRIPTION
When we perform method resolution we check if the self arguments can be
matched. Here the bug was that pointer types had a bad vistitor and only
could ever match reference types which is wrong and was a copy paste error.

Fixes #1031
Addresses #849 
