### PR TITLE
Handle -fsyntax-only

### DIFF
--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -542,6 +542,11 @@ Session::parse_file (const char *filename)
 
   rust_debug ("\033[0;31mSUCCESSFULLY PARSED CRATE \033[0m");
 
+  // If -fsyntax-only was passed, we can just skip the remaining passes.
+  // Parsing errors are already emitted in `parse_crate()`
+  if (flag_syntax_only)
+    return;
+
   // register plugins pipeline stage
   register_plugins (parsed_crate);
   rust_debug ("\033[0;31mSUCCESSFULLY REGISTERED PLUGINS \033[0m");

--- a/gcc/testsuite/rust/compile/syntax-only.rs
+++ b/gcc/testsuite/rust/compile/syntax-only.rs
@@ -1,0 +1,6 @@
+// { dg-additional-options "-fsyntax-only" }
+
+fn main() {
+    let mut a = 15;
+    a = true;
+}


### PR DESCRIPTION
Handle the -fsyntax-only properly from the rust frontend. This flag
allows checking for syntax and stopping after that, skipping further
passes of the pipeline.
The flag was accepted by the frontend, but was not used anywhere.