### PR TITLE
Support placeholders becoming slices

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -258,7 +258,6 @@ public:
     // Get the adjusted self
     Adjuster adj (receiver_tyty);
     TyTy::BaseType *adjusted_self = adj.adjust_type (candidate.adjustments);
-    adjusted_self->debug ();
 
     // store the adjustments for code-generation to know what to do
     context->insert_autoderef_mappings (expr.get_mappings ().get_hirid (),

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -440,8 +440,6 @@ public:
 
   void visit (HIR::TypeAlias &type) override
   {
-    // resolved_trait_item = trait_reference.lookup_trait_item (
-    //   type.get_new_type_name (), TraitItemReference::TraitItemType::TYPE);
     trait_reference.lookup_trait_item_by_type (
       type.get_new_type_name (), TraitItemReference::TraitItemType::TYPE,
       &resolved_trait_item);

--- a/gcc/rust/typecheck/rust-tyty-cmp.h
+++ b/gcc/rust/typecheck/rust-tyty-cmp.h
@@ -1444,6 +1444,8 @@ public:
 
   void visit (const NeverType &) override { ok = true; }
 
+  void visit (const SliceType &) override { ok = true; }
+
   void visit (const PlaceholderType &type) override
   {
     ok = base->get_symbol ().compare (type.get_symbol ()) == 0;

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -201,6 +201,7 @@ BaseType::inherit_bounds (
 const BaseType *
 BaseType::get_root () const
 {
+  // FIXME this needs to be it its own visitor class with a vector adjustments
   const TyTy::BaseType *root = this;
   if (get_kind () == TyTy::REF)
     {
@@ -212,6 +213,19 @@ BaseType::get_root () const
       const PointerType *r = static_cast<const PointerType *> (root);
       root = r->get_base ()->get_root ();
     }
+
+  // these are an unsize
+  else if (get_kind () == TyTy::SLICE)
+    {
+      const SliceType *r = static_cast<const SliceType *> (root);
+      root = r->get_element_type ()->get_root ();
+    }
+  // else if (get_kind () == TyTy::ARRAY)
+  //   {
+  //     const ArrayType *r = static_cast<const ArrayType *> (root);
+  //     root = r->get_element_type ()->get_root ();
+  //   }
+
   return root;
 }
 

--- a/gcc/testsuite/rust/compile/issue-1034.rs
+++ b/gcc/testsuite/rust/compile/issue-1034.rs
@@ -1,0 +1,16 @@
+trait Foo<T> {
+    type Output;
+
+    fn test(self, slice: &T) -> &Self::Output;
+}
+
+struct Bar<T>(T);
+// { dg-warning "struct is never constructed" "" { target *-*-* } .-1 }
+
+impl<T> Foo<[T]> for Bar<usize> {
+    type Output = [T];
+
+    fn test(self, slice: &[T]) -> &[T] {
+        slice
+    }
+}


### PR DESCRIPTION
When we setup trait-impls the type-alias are allowed to become any type
this interface was missing a visitor. We also need to support constraining
type-parameters behind slices.

The get_root interface is currently unsafe, it needs a flag for allowing
unsized and for keeping a map of adjustments along the way. This will
be added down the line when we support unsized method resolution.

Fixes #1034
Addresses #849 