### PR TITLE
Do not propagate parse errors in match repetitions

### DIFF
--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -505,9 +505,6 @@ MacroExpander::match_fragment (Parser<MacroInvocLexer> &parser,
       return false;
     }
 
-  for (const auto &error : parser.get_errors ())
-    error.emit_error ();
-
   // it matches if the parser did not produce errors trying to parse that type
   // of item
   return !parser.has_errors ();
@@ -714,7 +711,13 @@ MacroExpander::match_n_matches (Parser<MacroInvocLexer> &parser,
   bool did_meet_lo_bound = match_amount >= lo_bound;
   bool did_meet_hi_bound = hi_bound ? match_amount <= hi_bound : true;
 
-  return did_meet_lo_bound && did_meet_hi_bound;
+  // If the end-result is valid, then we can clear the parse errors: Since
+  // repetitions are parsed eagerly, it is okay to fail in some cases
+  auto res = did_meet_lo_bound && did_meet_hi_bound;
+  if (res)
+    parser.clear_errors ();
+
+  return res;
 }
 
 bool

--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -649,7 +649,6 @@ private:
   bool done_end_of_file ();
 
   void add_error (Error error) { error_table.push_back (std::move (error)); }
-  void clear_errors () { error_table.clear (); }
 
 public:
   // Construct parser with specified "managed" token source.
@@ -668,6 +667,8 @@ public:
 
   // Returns whether any parsing errors have occurred.
   bool has_errors () const { return !error_table.empty (); }
+  // Remove all parsing errors from the table
+  void clear_errors () { error_table.clear (); }
 
   // Get a reference to the list of errors encountered
   std::vector<Error> &get_errors () { return error_table; }

--- a/gcc/testsuite/rust/compile/macro25.rs
+++ b/gcc/testsuite/rust/compile/macro25.rs
@@ -1,0 +1,9 @@
+macro_rules! valid {
+    ($($a:literal)* $i:ident) => {{}};
+}
+
+fn main() {
+    valid!(1 one_lit);
+    valid!(identifier_only);
+    valid!(1 2 two_lits);
+}

--- a/gcc/testsuite/rust/compile/macro9.rs
+++ b/gcc/testsuite/rust/compile/macro9.rs
@@ -12,7 +12,6 @@ fn main() -> i32 {
     let b = add!(15);
     let b = add!(15 14); // { dg-error "Failed to match any rule within macro" }
     let b = add!(15, 14,); // { dg-error "Failed to match any rule within macro" }
-                           // { dg-error "found unexpected token" "" { target *-*-* } .-1 }
 
     0
 }


### PR DESCRIPTION
Since parsing repetitions is very eager, the parser might accumulate
bogus errors by trying to match more repetitions than there are. We can
avoid this by clearing the parsing errors if parsing repetitions
returned a valid result. This should not be an issue for previous
matchers erroring out, as they would immediately return upon failure and
not reach inside other match functions.

We need to figure out the best way to emit parser errors, as we do not always want to emit them in `match_fragment`. I think for now the easiest is to just *not* emit parse errors and simply error out with "failed to match macro rule". We will need to think about adding a bunch of hints too in order to make using macros easier.

Fixes #958 