### PR TITLE
macros: Only expand merged repetitions if they contain the same amount

### DIFF
--- a/gcc/rust/expand/rust-macro-substitute-ctx.h
+++ b/gcc/rust/expand/rust-macro-substitute-ctx.h
@@ -26,6 +26,17 @@ class SubstituteCtx
   std::vector<std::unique_ptr<AST::Token>> &macro;
   std::map<std::string, MatchedFragmentContainer> &fragments;
 
+  /**
+   * Find the repetition amount to use when expanding a repetition, and
+   * check that all fragments used respect that repetition amount
+   *
+   * @param pattern_start Start of the repetition pattern
+   * @param pattern_end End of the repetition pattern
+   * @param repeat_amount Reference to fill with the matched repetition amount
+   */
+  bool check_repetition_amount (size_t pattern_start, size_t pattern_end,
+				size_t &repeat_amount);
+
 public:
   SubstituteCtx (std::vector<std::unique_ptr<AST::Token>> &input,
 		 std::vector<std::unique_ptr<AST::Token>> &macro,

--- a/gcc/testsuite/rust/compile/macro26.rs
+++ b/gcc/testsuite/rust/compile/macro26.rs
@@ -1,0 +1,10 @@
+macro_rules! repeat {
+    ( $( $i:literal ),* ; $( $j:literal ),* ) => (( $( ($i,$j) ),* ))
+    // { dg-error "different amount of matches used in merged repetitions" "" { target *-*-* } .-1 }
+}
+
+fn main() -> i32 {
+    let _ = repeat!(1, 2, 3; 2, 3);
+
+    0
+}

--- a/gcc/testsuite/rust/execute/torture/macros24.rs
+++ b/gcc/testsuite/rust/execute/torture/macros24.rs
@@ -1,0 +1,9 @@
+macro_rules! repeat {
+    ( $( $i:literal ),* ; $( $j:literal ),* ) => (( $( ($i,$j) ),* ))
+}
+
+fn main() -> i32 {
+    let t = repeat!(1, 1; 2, 2);
+
+    t.0 .0 + t.0 .1 + t.1 .0 + t.1 .1 - 6
+}


### PR DESCRIPTION
Depends on #1040 
Fixes #948 