### PR TITLE
Add initial support for unsized method resolution

### DIFF
--- a/gcc/rust/backend/rust-compile-base.h
+++ b/gcc/rust/backend/rust-compile-base.h
@@ -72,6 +72,9 @@ protected:
   tree resolve_indirection_adjustment (Resolver::Adjustment &adjustment,
 				       tree expression, Location locus);
 
+  tree resolve_unsized_adjustment (Resolver::Adjustment &adjustment,
+				   tree expression, Location locus);
+
   static void setup_attributes_on_fndecl (
     tree fndecl, bool is_main_entry_point, HIR::Visibility &visibility,
     const HIR::FunctionQualifiers &qualifiers, const AST::AttrVec &attrs);

--- a/gcc/rust/typecheck/rust-autoderef.h
+++ b/gcc/rust/typecheck/rust-autoderef.h
@@ -36,6 +36,7 @@ public:
     DEREF,
     DEREF_MUT,
     INDIRECTION,
+    UNSIZE,
   };
 
   // ctor for all adjustments except derefs
@@ -78,6 +79,8 @@ public:
 	return "DEREF_MUT";
       case AdjustmentType::INDIRECTION:
 	return "INDIRECTION";
+      case AdjustmentType::UNSIZE:
+	return "UNSIZE";
       }
     gcc_unreachable ();
     return "";
@@ -134,6 +137,8 @@ public:
 		  Analysis::RustLangItem::ItemType deref_lang_item);
 
   static Adjustment try_raw_deref_type (const TyTy::BaseType *ty);
+
+  static Adjustment try_unsize_type (const TyTy::BaseType *ty);
 
 private:
   const TyTy::BaseType *base;

--- a/gcc/rust/typecheck/rust-hir-dot-operator.cc
+++ b/gcc/rust/typecheck/rust-hir-dot-operator.cc
@@ -40,6 +40,21 @@ MethodResolver::Probe (const TyTy::BaseType *receiver,
       if (autoderef_flag)
 	return MethodCandidate::get_error ();
 
+      // try unsize
+      Adjustment unsize = Adjuster::try_unsize_type (r);
+      if (!unsize.is_error ())
+	{
+	  adjustments.push_back (unsize);
+	  auto unsize_r = unsize.get_expected ();
+	  auto res = Try (unsize_r, segment_name, adjustments);
+	  if (!res.is_error ())
+	    {
+	      return res;
+	    }
+
+	  adjustments.pop_back ();
+	}
+
       Adjustment deref
 	= Adjuster::try_deref_type (r, Analysis::RustLangItem::ItemType::DEREF);
       if (!deref.is_error ())

--- a/gcc/rust/typecheck/rust-hir-type-check.h
+++ b/gcc/rust/typecheck/rust-hir-type-check.h
@@ -103,6 +103,7 @@ public:
 
   void insert_type (const Analysis::NodeMapping &mappings,
 		    TyTy::BaseType *type);
+  void insert_implicit_type (TyTy::BaseType *type);
   bool lookup_type (HirId id, TyTy::BaseType **type);
 
   void insert_implicit_type (HirId id, TyTy::BaseType *type);

--- a/gcc/rust/typecheck/rust-tyctx.cc
+++ b/gcc/rust/typecheck/rust-tyctx.cc
@@ -84,6 +84,13 @@ TypeCheckContext::insert_type (const Analysis::NodeMapping &mappings,
 }
 
 void
+TypeCheckContext::insert_implicit_type (TyTy::BaseType *type)
+{
+  rust_assert (type != nullptr);
+  resolved[type->get_ref ()] = type;
+}
+
+void
 TypeCheckContext::insert_implicit_type (HirId id, TyTy::BaseType *type)
 {
   rust_assert (type != nullptr);


### PR DESCRIPTION
In order to support slices, we end up with an operator overload call of:

```
impl<T, I> Index<I> for [T]
where
    I: SliceIndex<[T]>,
{
    type Output = I::Output;

    fn index(&self, index: I) -> &I::Output {
        index.index(self)
    }
}
```

So this means the self, in this case, is an array[T,capacity] and the index parameter is of type Range<usize>. In order to actually call this method
which has a self parameter of [T] we need to be able to 'unsize' the array
into a slice.

Addresses #849
