### PR TITLE
macros: Add remaining restrictions for follow-set restrictions

### DIFF
--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -128,19 +128,29 @@ public:
       }
   }
 
-  bool has_follow_set_restrictions ()
+  bool has_follow_set_restrictions () const
   {
     switch (kind)
       {
       case EXPR:
       case STMT:
-	// FIXME: Add the following cases once we can handle them properly
-	// in `is_match_compatible()`
-	// case PAT:
-	// // case PAT_PARAM: FIXME: Doesn't <metavar>:pat_param exist?
-	// case PATH:
-	// case TY:
-	// case VIS:
+      case PAT:
+      case PATH:
+      case TY:
+      case VIS:
+	return true;
+      default:
+	return false;
+      }
+  }
+
+  bool has_follow_set_fragment_restrictions () const
+  {
+    switch (kind)
+      {
+      case PAT:
+      case TY:
+      case VIS:
 	return true;
       default:
 	return false;
@@ -188,7 +198,7 @@ public:
   }
 
   Identifier get_ident () const { return ident; }
-  MacroFragSpec get_frag_spec () const { return frag_spec; }
+  const MacroFragSpec &get_frag_spec () const { return frag_spec; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather

--- a/gcc/rust/lex/rust-token.h
+++ b/gcc/rust/lex/rust-token.h
@@ -165,6 +165,7 @@ enum PrimitiveCoreType
   RS_TOKEN_KEYWORD (CONST, "const")                                            \
   RS_TOKEN_KEYWORD (CONTINUE, "continue")                                      \
   RS_TOKEN_KEYWORD (CRATE, "crate")                                            \
+  /* FIXME: Do we need to add $crate (DOLLAR_CRATE) as a reserved kw? */       \
   RS_TOKEN_KEYWORD (DO, "do") /* unused */                                     \
   RS_TOKEN_KEYWORD (DYN, "dyn")                                                \
   RS_TOKEN_KEYWORD (ELSE, "else")                                              \

--- a/gcc/testsuite/rust/compile/macro33.rs
+++ b/gcc/testsuite/rust/compile/macro33.rs
@@ -1,0 +1,5 @@
+macro_rules! forbidden_frag {
+    ($t:ty $not_block:ident) => {{}}; // { dg-error "fragment specifier .ident. is not allowed after .ty. fragments" }
+                                      // { dg-error "required first macro rule in macro rules definition could not be parsed" "" { target *-*-* } .-1 }
+                                      // { dg-error "failed to parse item in crate" "" { target *-*-* } .-2 }
+}

--- a/gcc/testsuite/rust/compile/macro34.rs
+++ b/gcc/testsuite/rust/compile/macro34.rs
@@ -1,0 +1,3 @@
+macro_rules! allowed_after_expr_matcher {
+    (($t:expr) bok) => {{}}; // follow-set restrictions do not apply after a matcher, but they do apply inside the matcher
+}

--- a/gcc/testsuite/rust/compile/macro35.rs
+++ b/gcc/testsuite/rust/compile/macro35.rs
@@ -1,0 +1,7 @@
+macro_rules! inside_matcher {
+    (($e:expr tok) tok) => {{}}; // { dg-error "token .tok. is not allowed after .expr. fragment" }
+                                 // { dg-error "failed to parse macro matcher" "" { target *-*-* } .-1 }
+                                 // { dg-error "failed to parse macro match" "" { target *-*-* } .-2 }
+                                 // { dg-error "required first macro rule" "" { target *-*-* } .-3 }
+                                 // { dg-error "failed to parse item in crate" "" { target *-*-* } .-4 }
+}

--- a/gcc/testsuite/rust/compile/macro36.rs
+++ b/gcc/testsuite/rust/compile/macro36.rs
@@ -1,0 +1,3 @@
+macro_rules! ty_allowed {
+    ($t:ty $b:block) => {{}};
+}


### PR DESCRIPTION
Adds the remaining restrictions for follow-set ambiguities in macros.
This means adding the remaining allowed tokens for all fragment
specifiers with follow-up restrictions, as well as handling allowed
fragment specifiers in certain cases. For example, :vis specifiers can
sometimes be followed by fragments, if they have the :ident, :ty or
:path specifier. Likewise for :path and :ty which can be followed by a
:block.

Finally, we also allow *any* fragment after a matcher: Since the matcher
is delimiter by parentheses, brackets or curlies, anything is allowed
afterwards.

Some edge cases or allowed tokens that we cannot handle yet remain, for which FIXMEs exist. I'll open up corresponding issues. 

Addresses #947 