### PR TITLE
Fix overzealous follow set ambiguity

### DIFF
--- a/gcc/testsuite/rust/compile/macro-issue1053-2.rs
+++ b/gcc/testsuite/rust/compile/macro-issue1053-2.rs
@@ -1,0 +1,5 @@
+macro_rules! m {
+    ($e:expr $(forbidden)*) => {{}}; // { dg-error "token .identifier. is not allowed after .expr. fragment" }
+                                     // { dg-error "required first macro rule in macro rules definition could not be parsed" "" { target *-*-* } .-1 }
+                                     // { dg-error "failed to parse item in crate" "" { target *-*-* } .-2 }
+}

--- a/gcc/testsuite/rust/compile/macro-issue1053.rs
+++ b/gcc/testsuite/rust/compile/macro-issue1053.rs
@@ -1,0 +1,3 @@
+macro_rules! m {
+    ($e:expr $(,)*) => {{}};
+}

--- a/gcc/testsuite/rust/compile/macro28.rs
+++ b/gcc/testsuite/rust/compile/macro28.rs
@@ -1,6 +1,6 @@
 macro_rules! m {
     ($a:expr $(tok $es:expr)*) => {
-        // { dg-error "fragment is not allowed after .expr. fragment" "" { target *-*-* } .-1 }
+        // { dg-error "token .identifier. is not allowed after .expr. fragment" "" { target *-*-* } .-1 }
         // { dg-error "required first macro rule in macro rules definition could not be parsed" "" { target *-*-* } .-2 }
         // { dg-error "failed to parse item in crate" "" { target *-*-* } .-3 }
         $a


### PR DESCRIPTION
When checking if a follow-up is valid, we previously always returned
false when comparing with MacroMatchRepetitions. This is however
invalid, as we should be comparing with the first match of the
repetition to be sure.

Closes #1053 
Addresses #947 