### PR TITLE
Fix '#include <algorithm>' [#159]

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -20,9 +20,9 @@ along with GCC; see the file COPYING3.  If not see
 /* DO NOT INCLUDE ANYWHERE - this is automatically included with rust-parse.h
  * This is also the reason why there are no include guards. */
 
+#define INCLUDE_ALGORITHM
 #include "rust-diagnostics.h"
 #include "util/rust-make-unique.h"
-#include <algorithm>
 
 namespace Rust {
 // Left binding powers of operations.


### PR DESCRIPTION
... recently introduced in #1044 commit 35ca685200830626e5abd623f65a850649beace2
"macros: Add base functions to check for follow-set ambiguities".

GCC doesn't like that:

    In file included from [...]
    ./mm_malloc.h:42:12: error: attempt to use poisoned "malloc"
         return malloc (__size);
                ^

See commit e7b3f654f2ab0400c95c0517387a9ad645a5c4cd, for example.
