### PR TITLE
Handle :meta fragments properly

### DIFF
--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -704,8 +704,9 @@ public:
 
   // Call OperatorExpr constructor to initialise left_expr
   AssignmentExpr (std::unique_ptr<Expr> value_to_assign_to,
-		  std::unique_ptr<Expr> value_to_assign, Location locus)
-    : OperatorExpr (std::move (value_to_assign_to), std::vector<Attribute> (),
+		  std::unique_ptr<Expr> value_to_assign,
+		  std::vector<Attribute> outer_attribs, Location locus)
+    : OperatorExpr (std::move (value_to_assign_to), std::move (outer_attribs),
 		    locus),
       right_expr (std::move (value_to_assign))
   {}

--- a/gcc/rust/expand/rust-attribute-visitor.cc
+++ b/gcc/rust/expand/rust-attribute-visitor.cc
@@ -628,8 +628,12 @@ AttrVisitor::visit (AST::TypeCastExpr &expr)
 void
 AttrVisitor::visit (AST::AssignmentExpr &expr)
 {
-  /* outer attributes never allowed before these. while cannot strip
-   * two direct descendant expressions, can strip ones below that */
+  expander.expand_cfg_attrs (expr.get_outer_attrs ());
+  if (expander.fails_cfg_with_expand (expr.get_outer_attrs ()))
+    {
+      expr.mark_for_strip ();
+      return;
+    }
 
   /* should have no possibility for outer attrs as would be parsed
    * with outer expr */

--- a/gcc/rust/expand/rust-attribute-visitor.h
+++ b/gcc/rust/expand/rust-attribute-visitor.h
@@ -71,8 +71,12 @@ public:
 	    it = values.erase (it);
 	    for (auto &node : fragment.get_nodes ())
 	      {
-		it = values.insert (it, extractor (node));
-		it++;
+		auto new_node = extractor (node);
+		if (new_node != nullptr && !new_node->is_marked_for_strip ())
+		  {
+		    it = values.insert (it, std::move (new_node));
+		    it++;
+		  }
 	      }
 	  }
 	else if (value->is_marked_for_strip ())

--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -490,11 +490,7 @@ MacroExpander::match_fragment (Parser<MacroInvocLexer> &parser,
 
       // is meta attributes?
     case AST::MacroFragSpec::META:
-      // parser.parse_inner_attribute ?
-      // parser.parse_outer_attribute ?
-      // parser.parse_attribute_body ?
-      // parser.parse_doc_comment ?
-      gcc_unreachable ();
+      parser.parse_attribute_body ();
       break;
 
     case AST::MacroFragSpec::TT:

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -11694,7 +11694,7 @@ Parser<ManagedTokenSource>::parse_stmt_or_expr_without_block ()
 	  {
 	    // should be expr without block
 	    std::unique_ptr<AST::ExprWithoutBlock> expr
-	      = parse_expr_without_block ();
+	      = parse_expr_without_block (std::move (outer_attrs));
 
 	    if (lexer.peek_token ()->get_id () == SEMICOLON)
 	      {
@@ -11739,7 +11739,7 @@ Parser<ManagedTokenSource>::parse_stmt_or_expr_without_block ()
 	  // FIXME: old code was good until composability was required
 	  // return parse_path_based_stmt_or_expr(std::move(outer_attrs));
 	  std::unique_ptr<AST::ExprWithoutBlock> expr
-	    = parse_expr_without_block ();
+	    = parse_expr_without_block (std::move (outer_attrs));
 
 	  if (lexer.peek_token ()->get_id () == SEMICOLON)
 	    {
@@ -11762,7 +11762,7 @@ Parser<ManagedTokenSource>::parse_stmt_or_expr_without_block ()
 	 * expression then make it statement if semi afterwards */
 
 	std::unique_ptr<AST::ExprWithoutBlock> expr
-	  = parse_expr_without_block ();
+	  = parse_expr_without_block (std::move (outer_attrs));
 
 	if (lexer.peek_token ()->get_id () == SEMICOLON)
 	  {
@@ -12437,7 +12437,7 @@ Parser<ManagedTokenSource>::parse_expr (int right_binding_power,
 
   // parse null denotation (unary part of expression)
   std::unique_ptr<AST::Expr> expr
-    = null_denotation (current_token, std::move (outer_attrs), restrictions);
+    = null_denotation (current_token, {}, restrictions);
 
   if (expr == nullptr)
     {
@@ -12452,8 +12452,8 @@ Parser<ManagedTokenSource>::parse_expr (int right_binding_power,
       current_token = lexer.peek_token ();
       lexer.skip_token ();
 
-      expr = left_denotation (current_token, std::move (expr), AST::AttrVec (),
-			      restrictions);
+      expr = left_denotation (current_token, std::move (expr),
+			      std::move (outer_attrs), restrictions);
 
       if (expr == nullptr)
 	{
@@ -13786,7 +13786,7 @@ template <typename ManagedTokenSource>
 std::unique_ptr<AST::AssignmentExpr>
 Parser<ManagedTokenSource>::parse_assig_expr (
   const_TokenPtr tok ATTRIBUTE_UNUSED, std::unique_ptr<AST::Expr> left,
-  AST::AttrVec outer_attrs ATTRIBUTE_UNUSED, ParseRestrictions restrictions)
+  AST::AttrVec outer_attrs, ParseRestrictions restrictions)
 {
   // parse RHS (as tok has already been consumed in parse_expression)
   std::unique_ptr<AST::Expr> right
@@ -13799,7 +13799,8 @@ Parser<ManagedTokenSource>::parse_assig_expr (
   Location locus = left->get_locus ();
 
   return std::unique_ptr<AST::AssignmentExpr> (
-    new AST::AssignmentExpr (std::move (left), std::move (right), locus));
+    new AST::AssignmentExpr (std::move (left), std::move (right),
+			     std::move (outer_attrs), locus));
 }
 
 /* Returns the left binding power for the given CompoundAssignmentExpr type.

--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -143,6 +143,7 @@ public:
   AST::Visibility parse_visibility ();
   std::unique_ptr<AST::IdentifierPattern> parse_identifier_pattern ();
   std::unique_ptr<AST::TokenTree> parse_token_tree ();
+  AST::Attribute parse_attribute_body ();
 
 private:
   void skip_after_semicolon ();
@@ -162,7 +163,6 @@ private:
   AST::Attribute parse_inner_attribute ();
   AST::AttrVec parse_outer_attributes ();
   AST::Attribute parse_outer_attribute ();
-  AST::Attribute parse_attribute_body ();
   std::unique_ptr<AST::AttrInput> parse_attr_input ();
   AST::Attribute parse_doc_comment ();
 

--- a/gcc/testsuite/rust/execute/torture/cfg5.rs
+++ b/gcc/testsuite/rust/execute/torture/cfg5.rs
@@ -1,0 +1,13 @@
+// { dg-additional-options "-w -frust-cfg=A" }
+
+fn main() -> i32 {
+    let mut a = 0;
+
+    #[cfg(A)]
+    a = 3;
+
+    #[cfg(B)]
+    a = 40;
+
+    a - 3
+}

--- a/gcc/testsuite/rust/execute/torture/macros27.rs
+++ b/gcc/testsuite/rust/execute/torture/macros27.rs
@@ -1,0 +1,24 @@
+// { dg-additional-options "-frust-cfg=A" }
+
+macro_rules! attr {
+    (#[$attr:meta] $s:stmt) => {
+        #[$attr]
+        $s;
+    };
+}
+
+fn main() -> i32 {
+    let mut a = 0;
+
+    attr! {
+    #[cfg(A)]
+        a = 3
+    };
+
+    attr! {
+    #[cfg(B)]
+        a = 40
+    };
+
+    a - 3
+}


### PR DESCRIPTION
This expands :meta fragments properly and allows us to strip assignment expressions