### PR TITLE
Handle :tt fragments properly

### DIFF
--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -497,10 +497,8 @@ MacroExpander::match_fragment (Parser<MacroInvocLexer> &parser,
       gcc_unreachable ();
       break;
 
-      // what is TT?
     case AST::MacroFragSpec::TT:
-      // parser.parse_token_tree() ?
-      gcc_unreachable ();
+      parser.parse_token_tree ();
       break;
 
       // i guess we just ignore invalid and just error out

--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -142,6 +142,7 @@ public:
   std::vector<std::unique_ptr<AST::LifetimeParam> > parse_lifetime_params ();
   AST::Visibility parse_visibility ();
   std::unique_ptr<AST::IdentifierPattern> parse_identifier_pattern ();
+  std::unique_ptr<AST::TokenTree> parse_token_tree ();
 
 private:
   void skip_after_semicolon ();
@@ -188,7 +189,6 @@ private:
 
   // Token tree or macro related
   AST::DelimTokenTree parse_delim_token_tree ();
-  std::unique_ptr<AST::TokenTree> parse_token_tree ();
   std::unique_ptr<AST::MacroRulesDefinition>
   parse_macro_rules_def (AST::AttrVec outer_attrs);
   std::unique_ptr<AST::MacroInvocation>

--- a/gcc/testsuite/rust/execute/torture/macros25.rs
+++ b/gcc/testsuite/rust/execute/torture/macros25.rs
@@ -1,0 +1,13 @@
+macro_rules! t {
+    ($t:tt) => {
+        $t
+    };
+}
+
+fn frob() -> i32 {
+    t!(15) + t!((14))
+}
+
+fn main() -> i32 {
+    frob() - 29
+}

--- a/gcc/testsuite/rust/execute/torture/macros26.rs
+++ b/gcc/testsuite/rust/execute/torture/macros26.rs
@@ -1,0 +1,12 @@
+macro_rules! count_tt {
+    ($t:tt) => { 1 };
+    ($t:tt $($ts:tt)*) => { 1 + count_tt!($($ts)*) };
+}
+
+fn main() -> i32 {
+    let count = count_tt!(1 2 let a = 15) + count_tt!(1 2 (let a = 15));
+    //                    ^ ^ ^^^ ^ ^ ^^              ^ ^ ^^^^^^^^^^^^
+    //                    6 token-trees               3 token-trees
+
+    count - 9
+}


### PR DESCRIPTION
:tt fragments stand for token trees, and are composed of either a token,
or a delimited token tree, which is a token tree surrounded by
delimiters (parentheses, curly brackets or square brackets).

This should allow us to handle a lot more macros, including extremely
powerful macro patterns such as TT munchers
