### PR TITLE
Handle macro invocations in type contexts

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -1800,7 +1800,7 @@ public:
       case IMPL:
 	return "Impl Item: " + impl_item->as_string ();
       case TRAIT_IMPL:
-	return "Trait Impl Item: " + impl_item->as_string ();
+	return "Trait Impl Item: " + trait_impl_item->as_string ();
       case TYPE:
 	return "Type: " + type->as_string ();
       }

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -1515,6 +1515,7 @@ public:
     TRAIT,
     IMPL,
     TRAIT_IMPL,
+    TYPE,
   };
 
 private:
@@ -1528,6 +1529,7 @@ private:
   std::unique_ptr<TraitItem> trait_item;
   std::unique_ptr<InherentImplItem> impl_item;
   std::unique_ptr<TraitImplItem> trait_impl_item;
+  std::unique_ptr<Type> type;
 
 public:
   SingleASTNode (std::unique_ptr<Expr> expr)
@@ -1556,6 +1558,10 @@ public:
 
   SingleASTNode (std::unique_ptr<TraitImplItem> trait_impl_item)
     : kind (TRAIT_IMPL), trait_impl_item (std::move (trait_impl_item))
+  {}
+
+  SingleASTNode (std::unique_ptr<Type> type)
+    : kind (TYPE), type (std::move (type))
   {}
 
   SingleASTNode (SingleASTNode const &other)
@@ -1589,6 +1595,10 @@ public:
 
       case TRAIT_IMPL:
 	trait_impl_item = other.trait_impl_item->clone_trait_impl_item ();
+	break;
+
+      case TYPE:
+	type = other.type->clone_type ();
 	break;
       }
   }
@@ -1624,6 +1634,10 @@ public:
 
       case TRAIT_IMPL:
 	trait_impl_item = other.trait_impl_item->clone_trait_impl_item ();
+	break;
+
+      case TYPE:
+	type = other.type->clone_type ();
 	break;
       }
     return *this;
@@ -1699,6 +1713,12 @@ public:
     return std::move (trait_impl_item);
   }
 
+  std::unique_ptr<Type> take_type ()
+  {
+    rust_assert (!is_error ());
+    return std::move (type);
+  }
+
   void accept_vis (ASTVisitor &vis)
   {
     switch (kind)
@@ -1730,6 +1750,10 @@ public:
       case TRAIT_IMPL:
 	trait_impl_item->accept_vis (vis);
 	break;
+
+      case TYPE:
+	type->accept_vis (vis);
+	break;
       }
   }
 
@@ -1751,6 +1775,8 @@ public:
 	return impl_item == nullptr;
       case TRAIT_IMPL:
 	return trait_impl_item == nullptr;
+      case TYPE:
+	return type == nullptr;
       }
 
     gcc_unreachable ();
@@ -1775,6 +1801,8 @@ public:
 	return "Impl Item: " + impl_item->as_string ();
       case TRAIT_IMPL:
 	return "Trait Impl Item: " + impl_item->as_string ();
+      case TYPE:
+	return "Type: " + type->as_string ();
       }
 
     gcc_unreachable ();

--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -909,6 +909,19 @@ transcribe_expression (Parser<MacroInvocLexer> &parser)
   return {AST::SingleASTNode (std::move (expr))};
 }
 
+/**
+ * Transcribe one type from a macro invocation
+ *
+ * @param parser Parser to extract statements from
+ */
+static std::vector<AST::SingleASTNode>
+transcribe_type (Parser<MacroInvocLexer> &parser)
+{
+  auto expr = parser.parse_type ();
+
+  return {AST::SingleASTNode (std::move (expr))};
+}
+
 static std::vector<AST::SingleASTNode>
 transcribe_on_delimiter (Parser<MacroInvocLexer> &parser, bool semicolon,
 			 AST::DelimType delimiter, TokenId last_token_id)
@@ -956,6 +969,9 @@ transcribe_context (MacroExpander::ContextType ctx,
       break;
     case MacroExpander::ContextType::EXTERN:
       return transcribe_many_ext (parser, last_token_id);
+      break;
+    case MacroExpander::ContextType::TYPE:
+      return transcribe_type (parser);
       break;
     default:
       return transcribe_on_delimiter (parser, semicolon, delimiter,

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -188,6 +188,7 @@ struct MacroExpander
     ITEM,
     BLOCK,
     EXTERN,
+    TYPE,
     TRAIT,
     IMPL,
     TRAIT_IMPL,

--- a/gcc/testsuite/rust/compile/macro40.rs
+++ b/gcc/testsuite/rust/compile/macro40.rs
@@ -1,0 +1,48 @@
+// { dg-additional-options "-w" }
+
+macro_rules! t {
+    () => {
+        i32
+    };
+}
+
+macro_rules! s {
+    () => {
+        *const i8
+    };
+}
+
+extern "C" {
+    fn printf(s: s!(), ...);
+}
+
+fn square(arg: t!()) -> t!() {
+    let input: t!() = arg;
+
+    input * input
+}
+
+trait Trait {
+    fn f() -> t!();
+    fn g(arg: t!());
+}
+
+struct Wrapper {
+    inner: t!(),
+}
+
+impl Trait for Wrapper {
+    fn f() -> t!() {
+        1
+    }
+
+    fn g(arg: t!()) {}
+}
+
+fn id<T>(arg: T) -> T {
+    arg
+}
+
+fn main() {
+    id::<t!()>(15);
+}

--- a/gcc/testsuite/rust/execute/torture/macros28.rs
+++ b/gcc/testsuite/rust/execute/torture/macros28.rs
@@ -1,0 +1,13 @@
+macro_rules! t {
+    () => {
+        i32
+    };
+}
+
+fn id<T>(arg: T) -> T {
+    arg
+}
+
+fn main() -> i32 {
+    id::<t!()>(15) - 15
+}


### PR DESCRIPTION
Closes #1067 

This highlighted two issues where parsing types is not entirely correct, which I'll raise. The code necessary to handle macro invocations in these two places should already be implemented. 