### PR TITLE
Allow transcribing of zero nodes in certain cases

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -1871,13 +1871,12 @@ public:
     return *this;
   }
 
-  static ASTFragment create_empty () { return ASTFragment ({}); }
   static ASTFragment create_error () { return ASTFragment ({}, true); }
 
   std::vector<SingleASTNode> &get_nodes () { return nodes; }
   bool is_error () const { return fragment_is_error; }
 
-  bool should_expand () const { return !is_error () && !nodes.empty (); }
+  bool should_expand () const { return !is_error (); }
 
   std::unique_ptr<Expr> take_expression_fragment ()
   {

--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -469,7 +469,7 @@ class MacroRulesDefinition : public MacroItem
   static ASTFragment dummy_builtin (Location, MacroInvocData &)
   {
     gcc_unreachable ();
-    return ASTFragment::create_empty ();
+    return ASTFragment::create_error ();
   }
 
   /* NOTE: in rustc, macro definitions are considered (and parsed as) a type

--- a/gcc/rust/expand/rust-macro-builtins.cc
+++ b/gcc/rust/expand/rust-macro-builtins.cc
@@ -141,7 +141,7 @@ MacroBuiltin::assert (Location invoc_locus, AST::MacroInvocData &invoc)
 {
   rust_debug ("assert!() called");
 
-  return AST::ASTFragment::create_empty ();
+  return AST::ASTFragment::create_error ();
 }
 
 AST::ASTFragment

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -200,7 +200,7 @@ struct MacroExpander
   MacroExpander (AST::Crate &crate, ExpansionCfg cfg, Session &session)
     : cfg (cfg), crate (crate), session (session),
       sub_stack (SubstitutionScope ()),
-      expanded_fragment (AST::ASTFragment::create_empty ()),
+      expanded_fragment (AST::ASTFragment::create_error ()),
       resolver (Resolver::Resolver::get ()),
       mappings (Analysis::Mappings::get ())
   {}
@@ -295,7 +295,7 @@ struct MacroExpander
   AST::ASTFragment take_expanded_fragment (AST::ASTVisitor &vis)
   {
     AST::ASTFragment old_fragment = std::move (expanded_fragment);
-    expanded_fragment = AST::ASTFragment::create_empty ();
+    expanded_fragment = AST::ASTFragment::create_error ();
 
     for (auto &node : old_fragment.get_nodes ())
       {

--- a/gcc/testsuite/rust/compile/macro41.rs
+++ b/gcc/testsuite/rust/compile/macro41.rs
@@ -1,0 +1,13 @@
+macro_rules! empty {
+    ($($t:tt)*) => {};
+}
+
+empty! {nothing}
+empty! {struct OuterItem;}
+empty! {}
+
+fn main() {
+    empty! {as statement};
+    empty! {any child item};
+    empty! {};
+}


### PR DESCRIPTION
When expanding AST fragments containing multiple nodes, we must be aware
that some cases allow expanding zero or more nodes. Any macro
transcription that gets parsed as many nodes (ie any transcriber function that calls `parse_many`) needs to be able to parse zero of those nodes and still get expanded properly (basically, removed).

Previously, this would cause a failure to lower the macro invocation which would remain as a child instead of getting stripped/erased.

