### PR TITLE
Add base for privacy visitor

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -89,6 +89,9 @@ GRS_OBJS = \
     rust/rust-ast-resolve-expr.o \
     rust/rust-ast-resolve-type.o \
     rust/rust-hir-type-check.o \
+    rust/rust-privacy-check.o \
+    rust/rust-privacy-ctx.o \
+    rust/rust-reachability.o \
     rust/rust-tyty.o \
     rust/rust-tyctx.o \
     rust/rust-tyty-bounds.o \
@@ -278,6 +281,7 @@ RUST_INCLUDES = -I $(srcdir)/rust \
 	-I $(srcdir)/rust/resolve \
 	-I $(srcdir)/rust/util \
 	-I $(srcdir)/rust/typecheck \
+	-I $(srcdir)/rust/privacy \
 	-I $(srcdir)/rust/lint
 
 # add files that require cross-folder includes - currently rust-lang.o, rust-lex.o
@@ -336,6 +340,11 @@ rust/%.o: rust/resolve/%.cc
 
 # build rust/typecheck files in rust folder
 rust/%.o: rust/typecheck/%.cc
+	$(COMPILE) $(RUST_CXXFLAGS) $(RUST_INCLUDES) $<
+	$(POSTCOMPILE)
+
+# build rust/privacy files in rust folder
+rust/%.o: rust/privacy/%.cc
 	$(COMPILE) $(RUST_CXXFLAGS) $(RUST_INCLUDES) $<
 	$(POSTCOMPILE)
 

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -1463,6 +1463,8 @@ public:
   Analysis::NodeMapping get_mappings () const { return mappings; }
 
   Location get_locus () { return locus; }
+
+  Visibility &get_visibility () { return visibility; }
 };
 
 // Rust struct declaration with true struct type HIR node

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -621,6 +621,8 @@ protected:
 public:
   using HIR::Stmt::accept_vis;
 
+  BaseKind get_hir_kind () override final { return VIS_ITEM; }
+
   /* Does the item have some kind of public visibility (non-default
    * visibility)? */
   bool has_visibility () const { return !visibility.is_error (); }
@@ -2744,7 +2746,7 @@ protected:
 };
 
 // Abstract base class for an item used inside an extern block
-class ExternalItem
+class ExternalItem : public Node
 {
   Analysis::NodeMapping mappings;
   AST::AttrVec outer_attrs;
@@ -2754,6 +2756,8 @@ class ExternalItem
 
 public:
   virtual ~ExternalItem () {}
+
+  BaseKind get_hir_kind () override final { return EXTERNAL; }
 
   // Returns whether item has outer attributes.
   bool has_outer_attrs () const { return !outer_attrs.empty (); }

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -576,6 +576,9 @@ public:
   // Returns whether visibility is in an error state.
   bool is_error () const { return vis_type == ERROR; }
 
+  // Does the current visibility refer to a simple `pub <item>` entirely public
+  bool is_public () const { return vis_type == PUBLIC; }
+
   // Creates an error visibility.
   static Visibility create_error ()
   {

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -45,33 +45,33 @@ class HIRTypeVisitor;
 // forward decl for use in token tree method
 class Token;
 
-// Kind for downcasting various HIR nodes to other base classes when visiting
-// them
-enum BaseKind
-{
-  /* class ExternalItem */
-  EXTERNAL,
-  /* class TraitItem */
-  TRAIT_ITEM,
-  /* class VisItem */
-  VIS_ITEM,
-  /* class Item */
-  ITEM,
-  /* class ImplItem */
-  IMPL,
-  /* class Type */
-  TYPE,
-  /* class Stmt */
-  STMT,
-  /* class Expr */
-  EXPR,
-  /* class Pattern */
-  PATTERN,
-};
-
 class Node
 {
 public:
+  // Kind for downcasting various HIR nodes to other base classes when visiting
+  // them
+  enum BaseKind
+  {
+    /* class ExternalItem */
+    EXTERNAL,
+    /* class TraitItem */
+    TRAIT_ITEM,
+    /* class VisItem */
+    VIS_ITEM,
+    /* class Item */
+    ITEM,
+    /* class ImplItem */
+    IMPL,
+    /* class Type */
+    TYPE,
+    /* class Stmt */
+    STMT,
+    /* class Expr */
+    EXPR,
+    /* class Pattern */
+    PATTERN,
+  };
+
   /**
    * Get the kind of HIR node we are dealing with. This is useful for
    * downcasting to more precise types when necessary, i.e going from an `Item*`

--- a/gcc/rust/privacy/rust-privacy-check.cc
+++ b/gcc/rust/privacy/rust-privacy-check.cc
@@ -33,7 +33,7 @@ Resolver::resolve (HIR::Crate &crate)
   const auto &items = crate.items;
   for (auto &item : items)
     {
-      if (item->get_hir_kind () == HIR::VIS_ITEM)
+      if (item->get_hir_kind () == HIR::Node::VIS_ITEM)
 	{
 	  auto vis_item = static_cast<HIR::VisItem *> (item.get ());
 	  vis_item->accept_vis (visitor);

--- a/gcc/rust/privacy/rust-privacy-check.cc
+++ b/gcc/rust/privacy/rust-privacy-check.cc
@@ -1,0 +1,47 @@
+// Copyright (C) 2020-2022 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-privacy-check.h"
+#include "rust-reachability.h"
+
+extern bool
+saw_errors (void);
+
+namespace Rust {
+namespace Privacy {
+void
+Resolver::resolve (HIR::Crate &crate)
+{
+  PrivacyContext ctx;
+  auto visitor = ReachabilityVisitor (ctx);
+
+  const auto &items = crate.items;
+  for (auto &item : items)
+    {
+      if (item->get_hir_kind () == HIR::VIS_ITEM)
+	{
+	  auto vis_item = static_cast<HIR::VisItem *> (item.get ());
+	  vis_item->accept_vis (visitor);
+	}
+    }
+
+  if (saw_errors ())
+    return;
+}
+} // namespace Privacy
+} // namespace Rust

--- a/gcc/rust/privacy/rust-privacy-check.cc
+++ b/gcc/rust/privacy/rust-privacy-check.cc
@@ -18,6 +18,7 @@
 
 #include "rust-privacy-check.h"
 #include "rust-reachability.h"
+#include "rust-hir-type-check.h"
 
 extern bool
 saw_errors (void);
@@ -28,7 +29,8 @@ void
 Resolver::resolve (HIR::Crate &crate)
 {
   PrivacyContext ctx;
-  auto visitor = ReachabilityVisitor (ctx);
+  auto ty_ctx = ::Rust::Resolver::TypeCheckContext::get ();
+  auto visitor = ReachabilityVisitor (ctx, *ty_ctx);
 
   const auto &items = crate.items;
   for (auto &item : items)

--- a/gcc/rust/privacy/rust-privacy-check.h
+++ b/gcc/rust/privacy/rust-privacy-check.h
@@ -24,6 +24,7 @@
 #include "rust-hir-expr.h"
 #include "rust-hir-stmt.h"
 #include "rust-hir-item.h"
+#include "rust-hir-type-check.h"
 
 namespace Rust {
 namespace Privacy {

--- a/gcc/rust/privacy/rust-privacy-check.h
+++ b/gcc/rust/privacy/rust-privacy-check.h
@@ -1,0 +1,44 @@
+// Copyright (C) 2020-2022 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_PRIVACY_CHECK_H
+#define RUST_PRIVACY_CHECK_H
+
+#include "rust-hir-map.h"
+#include "rust-hir.h"
+#include "rust-hir-expr.h"
+#include "rust-hir-stmt.h"
+#include "rust-hir-item.h"
+
+namespace Rust {
+namespace Privacy {
+class Resolver
+{
+public:
+  /**
+   * Perform the full privacy resolving pass on a crate.
+   *
+   * This resolver first computes the reachability of all items in a crate,
+   * before checking for privacy violations.
+   */
+  static void resolve (HIR::Crate &crate);
+};
+} // namespace Privacy
+} // namespace Rust
+
+#endif // !RUST_PRIVACY_CHECK_H

--- a/gcc/rust/privacy/rust-privacy-ctx.cc
+++ b/gcc/rust/privacy/rust-privacy-ctx.cc
@@ -21,6 +21,7 @@
 
 namespace Rust {
 namespace Privacy {
+
 static ReachLevel
 insert_if_higher (ReachLevel new_level,
 		  std::unordered_map<HirId, ReachLevel>::iterator &existing)

--- a/gcc/rust/privacy/rust-privacy-ctx.cc
+++ b/gcc/rust/privacy/rust-privacy-ctx.cc
@@ -24,7 +24,7 @@ namespace Privacy {
 
 static ReachLevel
 insert_if_higher (ReachLevel new_level,
-		  std::unordered_map<HirId, ReachLevel>::iterator &existing)
+		  std::unordered_map<DefId, ReachLevel>::iterator &existing)
 {
   if (new_level > existing->second)
     existing->second = new_level;
@@ -36,18 +36,19 @@ ReachLevel
 PrivacyContext::update_reachability (const Analysis::NodeMapping &mapping,
 				     ReachLevel reach)
 {
-  auto existing_reach = reachability_map.find (mapping.get_hirid ());
+  auto def_id = mapping.get_defid ();
+  auto existing_reach = reachability_map.find (def_id);
   if (existing_reach != reachability_map.end ())
     return insert_if_higher (reach, existing_reach);
 
-  reachability_map.insert ({mapping.get_hirid (), reach});
+  reachability_map.insert ({def_id, reach});
   return reach;
 }
 
 const ReachLevel *
 PrivacyContext::lookup_reachability (const Analysis::NodeMapping &mapping)
 {
-  auto existing_reach = reachability_map.find (mapping.get_hirid ());
+  auto existing_reach = reachability_map.find (mapping.get_defid ());
   if (existing_reach == reachability_map.end ())
     return nullptr;
 

--- a/gcc/rust/privacy/rust-privacy-ctx.cc
+++ b/gcc/rust/privacy/rust-privacy-ctx.cc
@@ -1,0 +1,35 @@
+// Copyright (C) 2020-2022 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-privacy-ctx.h"
+
+namespace Rust {
+namespace Privacy {
+void
+PrivacyContext::insert_reachability (const Analysis::NodeMapping &mapping,
+				     ReachLevel reach)
+{}
+
+const ReachLevel *
+PrivacyContext::lookup_reachability (const Analysis::NodeMapping &mapping)
+{
+  return nullptr;
+}
+
+} // namespace Privacy
+} // namespace Rust

--- a/gcc/rust/privacy/rust-privacy-ctx.h
+++ b/gcc/rust/privacy/rust-privacy-ctx.h
@@ -16,6 +16,9 @@
 // along with GCC; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
+#ifndef RUST_PRIVACY_CTX_H
+#define RUST_PRIVACY_CTX_H
+
 #include "rust-hir-map.h"
 #include "rust-privacy-check.h"
 
@@ -36,13 +39,19 @@ class PrivacyContext
 {
 public:
   /**
-   * Insert a new resolved visibility for a given node
+   * Insert a new resolved visibility for a given node. If the node is already
+   * present in the reachability map, then its visibility will only be updated
+   * if the given visibility is higher.
    *
    * @param mappings Mappings of the node to store the reach level for
    * @param reach Level of reachability for the given node
+   *
+   * @return The new reachability level for this node. If this was the first
+   * time inserting this node, then return `reach`. Otherwise, return `reach` or
+   * the existing reach level if it was higher.
    */
-  void insert_reachability (const Analysis::NodeMapping &mapping,
-			    ReachLevel reach);
+  ReachLevel update_reachability (const Analysis::NodeMapping &mapping,
+				  ReachLevel reach);
 
   /**
    * Lookup the visibility of an already declared Node
@@ -59,3 +68,12 @@ private:
 };
 } // namespace Privacy
 } // namespace Rust
+
+#if CHECKING_P
+namespace selftest {
+void
+rust_privacy_ctx_test (void);
+}
+#endif // !CHECKING_P
+
+#endif // !RUST_PRIVACY_CTX_H

--- a/gcc/rust/privacy/rust-privacy-ctx.h
+++ b/gcc/rust/privacy/rust-privacy-ctx.h
@@ -1,0 +1,61 @@
+// Copyright (C) 2020-2022 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-hir-map.h"
+#include "rust-privacy-check.h"
+
+namespace Rust {
+namespace Privacy {
+
+/**
+ * Reachability levels of HIR nodes. These levels are computed through the
+ * `ReachabilityVisitor` visitor.
+ */
+enum ReachLevel
+{
+  Private,
+  Public,
+};
+
+class PrivacyContext
+{
+public:
+  /**
+   * Insert a new resolved visibility for a given node
+   *
+   * @param mappings Mappings of the node to store the reach level for
+   * @param reach Level of reachability for the given node
+   */
+  void insert_reachability (const Analysis::NodeMapping &mapping,
+			    ReachLevel reach);
+
+  /**
+   * Lookup the visibility of an already declared Node
+   *
+   * @param mapping Mappings of the node to fetch the reach level of
+   *
+   * @return `nullptr` if the reach level for the current node has not been
+   * added, a valid pointer otherwise
+   */
+  const ReachLevel *lookup_reachability (const Analysis::NodeMapping &mapping);
+
+private:
+  std::unordered_map<HirId, ReachLevel> reachability_map;
+};
+} // namespace Privacy
+} // namespace Rust

--- a/gcc/rust/privacy/rust-privacy-ctx.h
+++ b/gcc/rust/privacy/rust-privacy-ctx.h
@@ -28,8 +28,8 @@ namespace Privacy {
  */
 enum ReachLevel
 {
-  Private,
-  Public,
+  Unreachable,
+  Reachable,
 };
 
 class PrivacyContext

--- a/gcc/rust/privacy/rust-privacy-ctx.h
+++ b/gcc/rust/privacy/rust-privacy-ctx.h
@@ -64,7 +64,7 @@ public:
   const ReachLevel *lookup_reachability (const Analysis::NodeMapping &mapping);
 
 private:
-  std::unordered_map<HirId, ReachLevel> reachability_map;
+  std::unordered_map<DefId, ReachLevel> reachability_map;
 };
 } // namespace Privacy
 } // namespace Rust

--- a/gcc/rust/privacy/rust-reachability.cc
+++ b/gcc/rust/privacy/rust-reachability.cc
@@ -24,7 +24,7 @@ namespace Privacy {
 static HIR::VisItem *
 maybe_get_vis_item (std::unique_ptr<HIR::Item> &item)
 {
-  if (item->get_hir_kind () != HIR::VIS_ITEM)
+  if (item->get_hir_kind () != HIR::Node::VIS_ITEM)
     return nullptr;
 
   return static_cast<HIR::VisItem *> (item.get ());

--- a/gcc/rust/privacy/rust-reachability.cc
+++ b/gcc/rust/privacy/rust-reachability.cc
@@ -1,0 +1,108 @@
+// Copyright (C) 2020-2022 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-reachability.h"
+
+namespace Rust {
+namespace Privacy {
+void
+ReachabilityVisitor::visit (HIR::Module &mod)
+{
+  for (auto &item : mod.get_items ())
+    {
+      // FIXME: How do we refactor this pattern into something more ergonomic?
+      // FIXME: Add helper functions
+      // FIXME: Is that what we want to do? Yes? Only visit the items with
+      // visibility?
+      if (item->get_hir_kind () == HIR::VIS_ITEM)
+	{
+	  auto vis_item = static_cast<HIR::VisItem *> (item.get ());
+	  vis_item->accept_vis (*this);
+	}
+    }
+}
+
+void
+ReachabilityVisitor::visit (HIR::ExternCrate &crate)
+{}
+
+void
+ReachabilityVisitor::visit (HIR::UseDeclaration &use_decl)
+{}
+
+void
+ReachabilityVisitor::visit (HIR::Function &func)
+{}
+
+void
+ReachabilityVisitor::visit (HIR::TypeAlias &type_alias)
+{}
+
+void
+ReachabilityVisitor::visit (HIR::StructStruct &struct_item)
+{
+  auto struct_reach = ReachLevel::Private;
+  // FIXME: This feels very wrong. Should we check for `has_visibility`
+  // beforehand? Is it just private otherwise? Should the `HIR::Visibility` also
+  // keep variants for private items?
+  if (struct_item.get_visibility ().get_vis_type () == HIR::Visibility::NONE)
+    struct_reach = ReachLevel::Public;
+
+  // FIXME: Here we want to update only if the visibility is higher
+  ctx.insert_reachability (struct_item.get_mappings (), struct_reach);
+
+  for (auto &field : struct_item.get_fields ())
+    ctx.insert_reachability (field.get_mappings (), struct_reach);
+
+  // FIXME: How do we get the constructor from `struct_item`? We need to update
+  // its visibility as well. Probably by keeping a reference to the TypeCtx?
+}
+
+void
+ReachabilityVisitor::visit (HIR::TupleStruct &tuple_struct)
+{}
+
+void
+ReachabilityVisitor::visit (HIR::Enum &enum_item)
+{}
+
+void
+ReachabilityVisitor::visit (HIR::Union &union_item)
+{}
+
+void
+ReachabilityVisitor::visit (HIR::ConstantItem &const_item)
+{}
+
+void
+ReachabilityVisitor::visit (HIR::StaticItem &static_item)
+{}
+
+void
+ReachabilityVisitor::visit (HIR::Trait &trait)
+{}
+
+void
+ReachabilityVisitor::visit (HIR::ImplBlock &impl)
+{}
+
+void
+ReachabilityVisitor::visit (HIR::ExternBlock &block)
+{}
+} // namespace Privacy
+} // namespace Rust

--- a/gcc/rust/privacy/rust-reachability.cc
+++ b/gcc/rust/privacy/rust-reachability.cc
@@ -110,14 +110,11 @@ ReachabilityVisitor::visit (HIR::StructStruct &struct_item)
 	    }
 	}
 
-      // for (auto &field : struct_item.get_fields ())
-      // if (field.get_visibility ().is_public ())
-      // FIXME: How do we visit these fields with the reachability
-      // visitor?
+      for (auto &field : struct_item.get_fields ())
+	if (field.get_visibility ().is_public ())
+	  ctx.update_reachability (field.get_field_type ()->get_mappings (),
+				   struct_reach);
     }
-
-  // FIXME: How do we get the constructor from `struct_item`? We need to update
-  // its visibility as well. Probably by keeping a reference to the TypeCtx?
 
   current_level = old_level;
 }

--- a/gcc/rust/privacy/rust-reachability.cc
+++ b/gcc/rust/privacy/rust-reachability.cc
@@ -65,17 +65,14 @@ void
 ReachabilityVisitor::visit (HIR::StructStruct &struct_item)
 {
   auto struct_reach = ReachLevel::Unreachable;
-  // FIXME: This feels very wrong. Should we check for `has_visibility`
-  // beforehand? Is it just private otherwise? Should the `HIR::Visibility` also
-  // keep variants for private items?
   if (struct_item.get_visibility ().is_public ())
-    struct_reach = ReachLevel::Reachable;
+    struct_reach = current_level;
 
   struct_reach
     = ctx.update_reachability (struct_item.get_mappings (), struct_reach);
 
-  // FIXME: We need to also visit the fields as they might have their own set
-  // of reachability levels
+  // FIXME: Do we need to also visit the fields as they might have their own set
+  // of reachability levels? Can they?
 
   for (auto &field : struct_item.get_fields ())
     ctx.update_reachability (field.get_mappings (), struct_reach);

--- a/gcc/rust/privacy/rust-reachability.cc
+++ b/gcc/rust/privacy/rust-reachability.cc
@@ -56,15 +56,18 @@ ReachabilityVisitor::visit (HIR::TypeAlias &type_alias)
 void
 ReachabilityVisitor::visit (HIR::StructStruct &struct_item)
 {
-  auto struct_reach = ReachLevel::Private;
+  auto struct_reach = ReachLevel::Unreachable;
   // FIXME: This feels very wrong. Should we check for `has_visibility`
   // beforehand? Is it just private otherwise? Should the `HIR::Visibility` also
   // keep variants for private items?
   if (struct_item.get_visibility ().get_vis_type () == HIR::Visibility::NONE)
-    struct_reach = ReachLevel::Public;
+    struct_reach = ReachLevel::Reachable;
 
   // FIXME: Here we want to update only if the visibility is higher
   ctx.insert_reachability (struct_item.get_mappings (), struct_reach);
+
+  // FIXME: We need to also visit the fields as they might have their own set
+  // of reachability levels
 
   for (auto &field : struct_item.get_fields ())
     ctx.insert_reachability (field.get_mappings (), struct_reach);

--- a/gcc/rust/privacy/rust-reachability.cc
+++ b/gcc/rust/privacy/rust-reachability.cc
@@ -63,14 +63,14 @@ ReachabilityVisitor::visit (HIR::StructStruct &struct_item)
   if (struct_item.get_visibility ().get_vis_type () == HIR::Visibility::NONE)
     struct_reach = ReachLevel::Reachable;
 
-  // FIXME: Here we want to update only if the visibility is higher
-  ctx.insert_reachability (struct_item.get_mappings (), struct_reach);
+  struct_reach
+    = ctx.update_reachability (struct_item.get_mappings (), struct_reach);
 
   // FIXME: We need to also visit the fields as they might have their own set
   // of reachability levels
 
   for (auto &field : struct_item.get_fields ())
-    ctx.insert_reachability (field.get_mappings (), struct_reach);
+    ctx.update_reachability (field.get_mappings (), struct_reach);
 
   // FIXME: How do we get the constructor from `struct_item`? We need to update
   // its visibility as well. Probably by keeping a reference to the TypeCtx?

--- a/gcc/rust/privacy/rust-reachability.cc
+++ b/gcc/rust/privacy/rust-reachability.cc
@@ -71,14 +71,32 @@ ReachabilityVisitor::visit (HIR::StructStruct &struct_item)
   struct_reach
     = ctx.update_reachability (struct_item.get_mappings (), struct_reach);
 
-  // FIXME: Do we need to also visit the fields as they might have their own set
-  // of reachability levels? Can they?
+  auto old_level = current_level;
+  current_level = struct_reach;
 
-  for (auto &field : struct_item.get_fields ())
-    ctx.update_reachability (field.get_mappings (), struct_reach);
+  if (struct_reach != ReachLevel::Unreachable)
+    {
+      for (auto &field : struct_item.get_fields ())
+	if (field.get_visibility ().is_public ())
+	  ctx.update_reachability (field.get_mappings (), struct_reach);
+
+      // for (auto &generic : struct_item.get_generic_params ())
+      // FIXME: How do we visit these generics's predicates with the
+      // reachability visitor?
+
+      // FIXME: How do we get each generic's predicates from here?
+      // TypeContext?
+
+      // for (auto &field : struct_item.get_fields ())
+      // if (field.get_visibility ().is_public ())
+      // FIXME: How do we visit these fields with the reachability
+      // visitor?
+    }
 
   // FIXME: How do we get the constructor from `struct_item`? We need to update
   // its visibility as well. Probably by keeping a reference to the TypeCtx?
+
+  current_level = old_level;
 }
 
 void
@@ -112,5 +130,8 @@ ReachabilityVisitor::visit (HIR::ImplBlock &impl)
 void
 ReachabilityVisitor::visit (HIR::ExternBlock &block)
 {}
+
+// FIXME: How can we visit Blocks in the current configuration? Have a full
+// visitor?
 } // namespace Privacy
 } // namespace Rust

--- a/gcc/rust/privacy/rust-reachability.h
+++ b/gcc/rust/privacy/rust-reachability.h
@@ -37,7 +37,7 @@ class ReachabilityVisitor : public HIR::HIRVisItemVisitor
 {
 public:
   ReachabilityVisitor (PrivacyContext &ctx)
-    : current_level (ReachLevel::Private), ctx (ctx)
+    : current_level (ReachLevel::Unreachable), ctx (ctx)
   {}
 
   virtual void visit (HIR::Module &mod);

--- a/gcc/rust/privacy/rust-reachability.h
+++ b/gcc/rust/privacy/rust-reachability.h
@@ -33,11 +33,15 @@ namespace Privacy {
 // to reach more and more nodes until nothing has changed anymore.
 // Do we need to reproduce this behavior? How long does it take to do this?
 
+/**
+ * The ReachabilityVisitor tries to reach all items possible in the crate,
+ * according to their privacy level.
+ */
 class ReachabilityVisitor : public HIR::HIRVisItemVisitor
 {
 public:
   ReachabilityVisitor (PrivacyContext &ctx)
-    : current_level (ReachLevel::Unreachable), ctx (ctx)
+    : current_level (ReachLevel::Reachable), ctx (ctx)
   {}
 
   virtual void visit (HIR::Module &mod);

--- a/gcc/rust/privacy/rust-reachability.h
+++ b/gcc/rust/privacy/rust-reachability.h
@@ -25,6 +25,7 @@
 #include "rust-hir-expr.h"
 #include "rust-hir-stmt.h"
 #include "rust-hir-item.h"
+#include "rust-hir-type-check.h"
 
 namespace Rust {
 namespace Privacy {
@@ -40,8 +41,9 @@ namespace Privacy {
 class ReachabilityVisitor : public HIR::HIRVisItemVisitor
 {
 public:
-  ReachabilityVisitor (PrivacyContext &ctx)
-    : current_level (ReachLevel::Reachable), ctx (ctx)
+  ReachabilityVisitor (PrivacyContext &ctx,
+		       const ::Rust::Resolver::TypeCheckContext &ty_ctx)
+    : current_level (ReachLevel::Reachable), ctx (ctx), ty_ctx (ty_ctx)
   {}
 
   virtual void visit (HIR::Module &mod);
@@ -62,6 +64,7 @@ public:
 private:
   ReachLevel current_level;
   PrivacyContext &ctx;
+  const ::Rust::Resolver::TypeCheckContext &ty_ctx;
 };
 } // namespace Privacy
 } // namespace Rust

--- a/gcc/rust/privacy/rust-reachability.h
+++ b/gcc/rust/privacy/rust-reachability.h
@@ -1,0 +1,65 @@
+// Copyright (C) 2020-2022 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_REACHABILITY_H
+#define RUST_REACHABILITY_H
+
+#include "rust-privacy-ctx.h"
+#include "rust-hir-visitor.h"
+#include "rust-hir.h"
+#include "rust-hir-expr.h"
+#include "rust-hir-stmt.h"
+#include "rust-hir-item.h"
+
+namespace Rust {
+namespace Privacy {
+
+// FIXME: The EmbargoVisitor from rustc is a fixed-point visitor which tries
+// to reach more and more nodes until nothing has changed anymore.
+// Do we need to reproduce this behavior? How long does it take to do this?
+
+class ReachabilityVisitor : public HIR::HIRVisItemVisitor
+{
+public:
+  ReachabilityVisitor (PrivacyContext &ctx)
+    : current_level (ReachLevel::Private), ctx (ctx)
+  {}
+
+  virtual void visit (HIR::Module &mod);
+  virtual void visit (HIR::ExternCrate &crate);
+  virtual void visit (HIR::UseDeclaration &use_decl);
+  virtual void visit (HIR::Function &func);
+  virtual void visit (HIR::TypeAlias &type_alias);
+  virtual void visit (HIR::StructStruct &struct_item);
+  virtual void visit (HIR::TupleStruct &tuple_struct);
+  virtual void visit (HIR::Enum &enum_item);
+  virtual void visit (HIR::Union &union_item);
+  virtual void visit (HIR::ConstantItem &const_item);
+  virtual void visit (HIR::StaticItem &static_item);
+  virtual void visit (HIR::Trait &trait);
+  virtual void visit (HIR::ImplBlock &impl);
+  virtual void visit (HIR::ExternBlock &block);
+
+private:
+  ReachLevel current_level;
+  PrivacyContext &ctx;
+};
+} // namespace Privacy
+} // namespace Rust
+
+#endif // !RUST_REACHABILITY_H

--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -32,8 +32,10 @@
 #include "convert.h"
 #include "langhooks.h"
 #include "langhooks-def.h"
+
 #include "selftest.h"
 #include "rust-cfg-parser.h"
+#include "rust-privacy-ctx.h"
 
 #include <mpfr.h>
 // note: header files must be in this order or else forward declarations don't
@@ -455,6 +457,7 @@ run_rust_tests ()
   // Call tests for the rust frontend here
   simple_assert ();
   rust_cfg_parser_test ();
+  rust_privacy_ctx_test ();
 }
 } // namespace selftest
 

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -25,6 +25,7 @@
 #include "rust-ast-resolve.h"
 #include "rust-ast-lower.h"
 #include "rust-hir-type-check.h"
+#include "rust-privacy-check.h"
 #include "rust-tycheck-dump.h"
 #include "rust-compile.h"
 #include "rust-cfg-parser.h"
@@ -608,6 +609,9 @@ Session::parse_file (const char *filename)
 
   if (saw_errors ())
     return;
+
+  // privacy pass
+  Privacy::Resolver::resolve (hir);
 
   // do compile to gcc generic
   Compile::Context ctx (backend);

--- a/gcc/rust/typecheck/rust-hir-type-check.h
+++ b/gcc/rust/typecheck/rust-hir-type-check.h
@@ -104,7 +104,7 @@ public:
   void insert_type (const Analysis::NodeMapping &mappings,
 		    TyTy::BaseType *type);
   void insert_implicit_type (TyTy::BaseType *type);
-  bool lookup_type (HirId id, TyTy::BaseType **type);
+  bool lookup_type (HirId id, TyTy::BaseType **type) const;
 
   void insert_implicit_type (HirId id, TyTy::BaseType *type);
 

--- a/gcc/rust/typecheck/rust-tyctx.cc
+++ b/gcc/rust/typecheck/rust-tyctx.cc
@@ -98,7 +98,7 @@ TypeCheckContext::insert_implicit_type (HirId id, TyTy::BaseType *type)
 }
 
 bool
-TypeCheckContext::lookup_type (HirId id, TyTy::BaseType **type)
+TypeCheckContext::lookup_type (HirId id, TyTy::BaseType **type) const
 {
   auto it = resolved.find (id);
   if (it == resolved.end ())

--- a/gcc/rust/util/rust-mapping-common.h
+++ b/gcc/rust/util/rust-mapping-common.h
@@ -69,4 +69,17 @@ struct DefId
 
 } // namespace Rust
 
+namespace std {
+template <> struct hash<Rust::DefId>
+{
+  size_t operator() (const Rust::DefId &id) const noexcept
+  {
+    // TODO: Check if we can improve performance by having a better hash
+    // algorithm for `DefId`s
+    return hash<uint32_t> () (hash<uint32_t> () (id.crateNum)
+			      + hash<uint32_t> () (id.localDefId));
+  }
+};
+} // namespace std
+
 #endif // RUST_MAPPING_COMMON


### PR DESCRIPTION
This PR is extremely early and implements some building blocks for privacy visitors. I'd like to get some feedback on the architecture and, if satisfactory, merge this first "visitor" which only takes care of visiting HIR struct definitions, to make reviewing easier. We could also merge it to a different branch for now, in order to not add an incomplete pass to the compiler.

Thanks!