### PR TITLE
bugfix: fix several minor issues

### DIFF
--- a/gcc/rust/ast/rust-ast-full-test.cc
+++ b/gcc/rust/ast/rust-ast-full-test.cc
@@ -311,7 +311,7 @@ Visibility::as_string () const
     case NONE:
       return std::string ("pub");
     case CRATE:
-      return std::string ("ub(crate)");
+      return std::string ("pub(crate)");
     case SELF:
       return std::string ("pub(self)");
     case SUPER:

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -311,8 +311,9 @@ Session::init ()
   // setup backend to GCC GIMPLE
   backend = rust_get_backend ();
 
-  // set the default crate name
-  options.set_crate_name (kDefaultCrateName);
+  // set the default crate name if crate name was unset
+  if (options.crate_name.empty ())
+    options.set_crate_name (kDefaultCrateName);
 }
 
 /* Initialise default options. Actually called before handle_option, unlike init


### PR DESCRIPTION
- Fixed `-frust-crate= option` got incorrectly overridden by a default value (`example`)
- Fix a minor typo in `gcc/rust/ast/rust-ast-full-test.cc`