### PR TITLE
Use loop to initialize repeat arrays

### DIFF
--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -250,6 +250,10 @@ public:
     fn_stack.push_back (fncontext{fn, ret_addr});
   }
   void pop_fn () { fn_stack.pop_back (); }
+
+  bool in_fn () { return fn_stack.size () != 0; }
+
+  // Note: it is undefined behavior to call peek_fn () if fn_stack is empty.
   fncontext peek_fn () { return fn_stack.back (); }
 
   void push_type (tree t) { type_decls.push_back (t); }
@@ -301,6 +305,14 @@ public:
     return pop;
   }
 
+  void push_const_context (void) { const_context++; }
+  void pop_const_context (void)
+  {
+    if (const_context > 0)
+      const_context--;
+  }
+  bool const_context_p (void) { return (const_context > 0); }
+
   std::string mangle_item (const TyTy::BaseType *ty,
 			   const Resolver::CanonicalPath &path) const
   {
@@ -341,6 +353,9 @@ private:
   std::vector<::Bvariable *> var_decls;
   std::vector<tree> const_decls;
   std::vector<tree> func_decls;
+
+  // Nonzero iff we are currently compiling something inside a constant context.
+  unsigned int const_context = 0;
 };
 
 } // namespace Compile

--- a/gcc/rust/backend/rust-compile-item.cc
+++ b/gcc/rust/backend/rust-compile-item.cc
@@ -92,9 +92,11 @@ CompileItem::visit (HIR::ConstantItem &constant)
   rust_assert (ok);
 
   HIR::Expr *const_value_expr = constant.get_expr ();
+  ctx->push_const_context ();
   tree const_expr
     = compile_constant_item (ctx, resolved_type, canonical_path,
 			     const_value_expr, constant.get_locus ());
+  ctx->pop_const_context ();
 
   ctx->push_const (const_expr);
   ctx->insert_const_decl (constant.get_mappings ().get_hirid (), const_expr);

--- a/gcc/rust/rust-backend.h
+++ b/gcc/rust/rust-backend.h
@@ -275,6 +275,10 @@ public:
 				const std::vector<tree> &vals, Location)
     = 0;
 
+  virtual tree array_initializer (tree, tree, tree, tree, tree, tree *,
+				  Location)
+    = 0;
+
   // Return an expression for ARRAY[INDEX] as an l-value.  ARRAY is a valid
   // fixed-length array, not a slice.
   virtual tree array_index_expression (tree array, tree index, Location) = 0;

--- a/gcc/testsuite/rust/compile/torture/arrays5.rs
+++ b/gcc/testsuite/rust/compile/torture/arrays5.rs
@@ -1,0 +1,6 @@
+
+// Checks that we don't try to allocate a 4TB array during compilation
+fn main () {
+    let x = [0; 4 * 1024 * 1024 * 1024 * 1024];
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/compile/torture/arrays6.rs
+++ b/gcc/testsuite/rust/compile/torture/arrays6.rs
@@ -1,0 +1,10 @@
+
+// Checks that we don't try to allocate a 4TB array during compilation
+fn foo() -> [u8; 4 * 1024 * 1024 * 1024 * 1024] {
+    [0; 4 * 1024 * 1024 * 1024 * 1024]
+}
+
+fn main () {
+    let x = foo ();
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
This PR changes how we compile initializers for arrays of repeating elements. I use the same approach outlined in the comments of the linked issue, with some tweaks. It is very similar to how the D language front-end compiles, the new function `Gcc_backend::array_initializer` is heavily inspired by the D front-end's `build_array_set`

This fixes the issue where the compiler tries to allocate a vec containing all elements of the array to be constructed, and therefore explodes on huge constructions (e.g. `let x = [0u8; 4 * 1024 * 1024 * 1024 * 1024]`)

However, we can only initialize non-const arrays in this way. For arrays in const contexts we must initialize them at compile time, and therefore continue using the old method.

Fixes: #1068 
