### PR TITLE
macros: add concat! macro

### DIFF
--- a/gcc/rust/expand/rust-macro-builtins.h
+++ b/gcc/rust/expand/rust-macro-builtins.h
@@ -80,6 +80,9 @@ public:
 
   static AST::ASTFragment compile_error (Location invoc_locus,
 					 AST::MacroInvocData &invoc);
+
+  static AST::ASTFragment concat (Location invoc_locus,
+				  AST::MacroInvocData &invoc);
 };
 } // namespace Rust
 

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -754,6 +754,7 @@ Mappings::insert_macro_def (AST::MacroRulesDefinition *macro)
       {"include_bytes", MacroBuiltin::include_bytes},
       {"include_str", MacroBuiltin::include_str},
       {"compile_error", MacroBuiltin::compile_error},
+      {"concat", MacroBuiltin::concat},
     };
 
   auto builtin = builtin_macros.find (macro->get_rule_name ());

--- a/gcc/testsuite/rust/compile/builtin_macro_concat.rs
+++ b/gcc/testsuite/rust/compile/builtin_macro_concat.rs
@@ -1,0 +1,15 @@
+macro_rules! concat {
+  () => {{}};
+}
+
+fn main () {
+  let not_literal = "identifier";
+  concat! ();
+  concat! (,); // { dg-error "argument must be a constant literal" }
+  concat! (not_literal); // { dg-error "argument must be a constant literal" }
+  concat! ("message");
+  concat! ("message",);
+  concat! ("message",1, true, false, 1.0, 10usize, 2000u64);
+  concat! ("message",1, true, false, 1.0, 10usize, 2000u64,);
+  concat! ("m", not_literal); // { dg-error "argument must be a constant literal" }
+}

--- a/gcc/testsuite/rust/execute/torture/builtin_macro_concat.rs
+++ b/gcc/testsuite/rust/execute/torture/builtin_macro_concat.rs
@@ -1,0 +1,23 @@
+// { dg-output "\ntest10btrue2.15\ntest10bfalse2.151\n" }
+macro_rules! concat {
+    () => {{}};
+}
+
+extern "C" {
+    fn printf(fmt: *const i8, ...);
+}
+
+fn print(s: &str) {
+    printf("%s\n" as *const str as *const i8, s as *const str as *const i8);
+}
+
+fn main() -> i32 {
+    let a = concat!();
+    let b = concat!("test", 10, 'b', true, 2.15);
+    let c = concat!("test", 10, 'b', false, 2.15, 1u64);
+    print(a);
+    print(b);
+    print(c);
+
+    0
+}


### PR DESCRIPTION
- extracts parenthesis-matching logic into a function
- adds `concat!` macro