### PR TITLE
gcc/rust/Make-lang.in: add missing rust compiler driver

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -140,7 +140,7 @@ check_rust_parallelize = 10
 # was specified as a configure option.
 rust.srcextra:
 
-rust.all.cross:
+rust.all.cross: gccrs$(exeext)
 
 # idk what this does but someone used it
 rust.start.encap: gccrs$(exeext)


### PR DESCRIPTION
When building gccrs with Buildroot toolchain infrastructure, the gccrs
compiler driver is missing when intalling gcc.

This is due to missing depedency on gccrs$(exeext) in rust.all.cross
target.

With that fixed, the gcc toolchain with Rust support is correctly installed into Buildroot:

$ ./test/gccrs/host/bin/aarch64-linux-gccrs --version
aarch64-linux-gccrs (Buildroot 2022.02-442-g54d638fbd1-dirty) 12.0.1 20220118 (experimental)

Note: We probably needs gccrs-cross target like other supported languages.

Copyright assignment signed between Smile and the FSF to contribute to GNU tools.