### PR TITLE
Ensure unsize method resolutions actually unsize

### DIFF
--- a/gcc/rust/typecheck/rust-autoderef.cc
+++ b/gcc/rust/typecheck/rust-autoderef.cc
@@ -116,7 +116,7 @@ Adjuster::try_unsize_type (const TyTy::BaseType *ty)
 			   TyTy::TyVar (slice_elem->get_ref ()));
   context->insert_implicit_type (slice);
 
-  return Adjustment (Adjustment::AdjustmentType::INDIRECTION, slice);
+  return Adjustment (Adjustment::AdjustmentType::UNSIZE, slice);
 }
 
 static bool


### PR DESCRIPTION
This was a typo when unsized method resolution was added, where the
adjustment was wrongly marked as an indirection. The enum is required so
that the code generation adjustment takes place.

Addresses #849