### PR TITLE
Add known lang item const_slice_ptr mappings

### DIFF
--- a/gcc/rust/util/rust-lang-item.h
+++ b/gcc/rust/util/rust-lang-item.h
@@ -70,6 +70,7 @@ public:
 
     // https://github.com/rust-lang/rust/blob/master/library/core/src/ptr/const_ptr.rs
     CONST_PTR,
+    CONST_SLICE_PTR,
 
     UNKNOWN,
   };
@@ -208,6 +209,10 @@ public:
       {
 	return ItemType::CONST_PTR;
       }
+    else if (item.compare ("const_slice_ptr") == 0)
+      {
+	return ItemType::CONST_SLICE_PTR;
+      }
 
     return ItemType::UNKNOWN;
   }
@@ -282,6 +287,8 @@ public:
 	return "RangeToInclusive";
       case CONST_PTR:
 	return "const_ptr";
+      case CONST_SLICE_PTR:
+	return "const_slice_ptr";
 
       case UNKNOWN:
 	return "<UNKNOWN>";


### PR DESCRIPTION
This will allow us to define the const_slice_ptr lang item attribute
without erroring out as an unknown lang item.

Addresses #849 