### PR TITLE
Lower AST::Visibility to HIR::Visibility properly

### DIFF
--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -632,7 +632,7 @@ public:
     : public_vis_type (public_vis_type), in_path (std::move (in_path))
   {}
 
-  PublicVisType get_public_vis_type () { return public_vis_type; }
+  PublicVisType get_public_vis_type () const { return public_vis_type; }
 
   // Returns whether visibility is in an error state.
   bool is_error () const
@@ -884,6 +884,8 @@ public:
 
   FunctionQualifiers get_qualifiers () { return qualifiers; }
 
+  const Visibility &get_visibility () const { return vis; }
+
 protected:
   /* Use covariance to implement clone function as returning this object
    * rather than base */
@@ -941,8 +943,8 @@ public:
   std::string as_string () const override;
 
   // TODO: this mutable getter seems really dodgy. Think up better way.
-  Visibility &get_vis () { return visibility; }
-  const Visibility &get_vis () const { return visibility; }
+  Visibility &get_visibility () { return visibility; }
+  const Visibility &get_visibility () const { return visibility; }
 
   std::vector<Attribute> &get_outer_attrs () { return outer_attrs; }
   const std::vector<Attribute> &get_outer_attrs () const { return outer_attrs; }
@@ -1896,7 +1898,7 @@ public:
     return field_type;
   }
 
-  Visibility get_visibility () const { return visibility; }
+  const Visibility &get_visibility () const { return visibility; }
 
   NodeId get_node_id () const { return node_id; }
 };
@@ -2029,6 +2031,8 @@ public:
   std::string as_string () const;
 
   NodeId get_node_id () const { return node_id; }
+
+  const Visibility &get_visibility () const { return visibility; }
 
   Location get_locus () const { return locus; }
 
@@ -3921,6 +3925,8 @@ public:
 
   Identifier get_identifier () const { return item_name; }
 
+  const Visibility &get_visibility () const { return visibility; }
+
   bool is_mut () const { return has_mut; }
 
 protected:
@@ -4082,6 +4088,8 @@ public:
   }
 
   Location get_locus () const { return locus; }
+
+  const Visibility &get_visibility () const { return visibility; }
 
   ExternalFunctionItem (
     Identifier item_name,

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -632,6 +632,8 @@ public:
     : public_vis_type (public_vis_type), in_path (std::move (in_path))
   {}
 
+  PublicVisType get_public_vis_type () { return public_vis_type; }
+
   // Returns whether visibility is in an error state.
   bool is_error () const
   {
@@ -684,6 +686,7 @@ public:
   }
 
   std::string as_string () const;
+  const SimplePath &get_path () const { return in_path; }
 
 protected:
   // Clone function implementation - not currently virtual but may be if

--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -37,8 +37,7 @@ HIRCompileBase::setup_attributes_on_fndecl (
 {
   // if its the main fn or pub visibility mark its as DECL_PUBLIC
   // please see https://github.com/Rust-GCC/gccrs/pull/137
-  bool is_pub
-    = visibility.get_vis_type () != HIR::Visibility::PublicVisType::NONE;
+  bool is_pub = visibility.get_vis_type () == HIR::Visibility::VisType::PUBLIC;
   if (is_main_entry_point || is_pub)
     {
       TREE_PUBLIC (fndecl) = 1;

--- a/gcc/rust/backend/rust-compile-implitem.cc
+++ b/gcc/rust/backend/rust-compile-implitem.cc
@@ -84,9 +84,8 @@ CompileTraitItem::visit (HIR::TraitItemFunc &func)
     &canonical_path);
   rust_assert (ok);
 
-  // FIXME
-  HIR::Visibility vis (HIR::Visibility::PublicVisType::NONE,
-		       AST::SimplePath::create_empty ());
+  // FIXME: Get from lowering the item's visibility instead
+  auto vis = HIR::Visibility::create_public ();
   HIR::TraitFunctionDecl &function = func.get_decl ();
   tree fndecl
     = compile_function (ctx, function.get_function_name (),

--- a/gcc/rust/backend/rust-compile-implitem.cc
+++ b/gcc/rust/backend/rust-compile-implitem.cc
@@ -84,8 +84,8 @@ CompileTraitItem::visit (HIR::TraitItemFunc &func)
     &canonical_path);
   rust_assert (ok);
 
-  // FIXME: Get from lowering the item's visibility instead
-  auto vis = HIR::Visibility::create_public ();
+  // FIXME: How do we get the proper visibility here?
+  auto vis = HIR::Visibility (HIR::Visibility::VisType::PUBLIC);
   HIR::TraitFunctionDecl &function = func.get_decl ();
   tree fndecl
     = compile_function (ctx, function.get_function_name (),

--- a/gcc/rust/hir/rust-ast-lower-enumitem.h
+++ b/gcc/rust/hir/rust-ast-lower-enumitem.h
@@ -19,6 +19,7 @@
 #ifndef RUST_AST_LOWER_ENUMITEM
 #define RUST_AST_LOWER_ENUMITEM
 
+#include "rust-ast-lower.h"
 #include "rust-diagnostics.h"
 
 #include "rust-ast-lower-base.h"
@@ -51,7 +52,7 @@ public:
     if (item.has_visibility ())
       rust_error_at (item.get_locus (),
 		     "visibility qualifier %qs not allowed on enum item",
-		     item.get_vis ().as_string ().c_str ());
+		     item.get_visibility ().as_string ().c_str ());
 
     translated = new HIR::EnumItem (mapping, item.get_identifier (),
 				    item.get_outer_attrs (), item.get_locus ());
@@ -73,12 +74,12 @@ public:
     if (item.has_visibility ())
       rust_error_at (item.get_locus (),
 		     "visibility qualifier %qs not allowed on enum item",
-		     item.get_vis ().as_string ().c_str ());
+		     item.get_visibility ().as_string ().c_str ());
 
     std::vector<HIR::TupleField> fields;
     for (auto &field : item.get_tuple_fields ())
       {
-	HIR::Visibility vis = HIR::Visibility::create_public ();
+	HIR::Visibility vis = translate_visibility (field.get_visibility ());
 	HIR::Type *type
 	  = ASTLoweringType::translate (field.get_field_type ().get ());
 
@@ -117,12 +118,12 @@ public:
     if (item.has_visibility ())
       rust_error_at (item.get_locus (),
 		     "visibility qualifier %qs not allowed on enum item",
-		     item.get_vis ().as_string ().c_str ());
+		     item.get_visibility ().as_string ().c_str ());
 
     std::vector<HIR::StructField> fields;
     for (auto &field : item.get_struct_fields ())
       {
-	HIR::Visibility vis = HIR::Visibility::create_public ();
+	HIR::Visibility vis = translate_visibility (field.get_visibility ());
 	HIR::Type *type
 	  = ASTLoweringType::translate (field.get_field_type ().get ());
 
@@ -165,7 +166,7 @@ public:
     if (item.has_visibility ())
       rust_error_at (item.get_locus (),
 		     "visibility qualifier %qs not allowed on enum item",
-		     item.get_vis ().as_string ().c_str ());
+		     item.get_visibility ().as_string ().c_str ());
 
     HIR::Expr *expr = ASTLoweringExpr::translate (item.get_expr ().get ());
     translated

--- a/gcc/rust/hir/rust-ast-lower-extern.h
+++ b/gcc/rust/hir/rust-ast-lower-extern.h
@@ -21,6 +21,7 @@
 
 #include "rust-ast-lower-base.h"
 #include "rust-ast-lower-type.h"
+#include "rust-ast-lower.h"
 
 namespace Rust {
 namespace HIR {
@@ -39,7 +40,7 @@ public:
 
   void visit (AST::ExternalStaticItem &item) override
   {
-    HIR::Visibility vis = HIR::Visibility::create_public ();
+    HIR::Visibility vis = translate_visibility (item.get_visibility ());
     HIR::Type *static_type
       = ASTLoweringType::translate (item.get_type ().get ());
 
@@ -65,7 +66,7 @@ public:
   {
     std::vector<std::unique_ptr<HIR::WhereClauseItem> > where_clause_items;
     HIR::WhereClause where_clause (std::move (where_clause_items));
-    HIR::Visibility vis = HIR::Visibility::create_public ();
+    HIR::Visibility vis = translate_visibility (function.get_visibility ());
 
     std::vector<std::unique_ptr<HIR::GenericParam> > generic_params;
     if (function.has_generics ())

--- a/gcc/rust/hir/rust-ast-lower-implitem.h
+++ b/gcc/rust/hir/rust-ast-lower-implitem.h
@@ -56,7 +56,7 @@ public:
   {
     std::vector<std::unique_ptr<HIR::WhereClauseItem> > where_clause_items;
     HIR::WhereClause where_clause (std::move (where_clause_items));
-    HIR::Visibility vis = HIR::Visibility::create_public ();
+    HIR::Visibility vis = translate_visibility (alias.get_visibility ());
 
     std::vector<std::unique_ptr<HIR::GenericParam> > generic_params;
     if (alias.has_generics ())
@@ -87,7 +87,7 @@ public:
 
   void visit (AST::ConstantItem &constant) override
   {
-    HIR::Visibility vis = HIR::Visibility::create_public ();
+    HIR::Visibility vis = translate_visibility (constant.get_visibility ());
 
     HIR::Type *type = ASTLoweringType::translate (constant.get_type ().get ());
     HIR::Expr *expr = ASTLoweringExpr::translate (constant.get_expr ().get ());
@@ -120,7 +120,7 @@ public:
     HIR::WhereClause where_clause (std::move (where_clause_items));
     HIR::FunctionQualifiers qualifiers
       = lower_qualifiers (function.get_qualifiers ());
-    HIR::Visibility vis = HIR::Visibility::create_public ();
+    HIR::Visibility vis = translate_visibility (function.get_visibility ());
 
     // need
     std::vector<std::unique_ptr<HIR::GenericParam> > generic_params;
@@ -204,7 +204,7 @@ public:
     HIR::WhereClause where_clause (std::move (where_clause_items));
     HIR::FunctionQualifiers qualifiers
       = lower_qualifiers (method.get_qualifiers ());
-    HIR::Visibility vis = HIR::Visibility::create_public ();
+    HIR::Visibility vis = translate_visibility (method.get_visibility ());
 
     // need
     std::vector<std::unique_ptr<HIR::GenericParam> > generic_params;

--- a/gcc/rust/hir/rust-ast-lower-stmt.h
+++ b/gcc/rust/hir/rust-ast-lower-stmt.h
@@ -85,7 +85,7 @@ public:
 
   void visit (AST::ConstantItem &constant) override
   {
-    HIR::Visibility vis = HIR::Visibility::create_public ();
+    HIR::Visibility vis = translate_visibility (constant.get_visibility ());
 
     HIR::Type *type = ASTLoweringType::translate (constant.get_type ().get ());
     HIR::Expr *expr = ASTLoweringExpr::translate (constant.get_expr ().get ());
@@ -148,12 +148,12 @@ public:
 
     std::vector<std::unique_ptr<HIR::WhereClauseItem>> where_clause_items;
     HIR::WhereClause where_clause (std::move (where_clause_items));
-    HIR::Visibility vis = HIR::Visibility::create_public ();
+    HIR::Visibility vis = translate_visibility (struct_decl.get_visibility ());
 
     std::vector<HIR::TupleField> fields;
     for (AST::TupleField &field : struct_decl.get_fields ())
       {
-	HIR::Visibility vis = HIR::Visibility::create_public ();
+	HIR::Visibility vis = translate_visibility (field.get_visibility ());
 	HIR::Type *type
 	  = ASTLoweringType::translate (field.get_field_type ().get ());
 
@@ -199,13 +199,13 @@ public:
 
     std::vector<std::unique_ptr<HIR::WhereClauseItem>> where_clause_items;
     HIR::WhereClause where_clause (std::move (where_clause_items));
-    HIR::Visibility vis = HIR::Visibility::create_public ();
+    HIR::Visibility vis = translate_visibility (struct_decl.get_visibility ());
 
     bool is_unit = struct_decl.is_unit_struct ();
     std::vector<HIR::StructField> fields;
     for (AST::StructField &field : struct_decl.get_fields ())
       {
-	HIR::Visibility vis = HIR::Visibility::create_public ();
+	HIR::Visibility vis = translate_visibility (field.get_visibility ());
 	HIR::Type *type
 	  = ASTLoweringType::translate (field.get_field_type ().get ());
 
@@ -255,12 +255,12 @@ public:
 
     std::vector<std::unique_ptr<HIR::WhereClauseItem>> where_clause_items;
     HIR::WhereClause where_clause (std::move (where_clause_items));
-    HIR::Visibility vis = HIR::Visibility::create_public ();
+    HIR::Visibility vis = translate_visibility (union_decl.get_visibility ());
 
     std::vector<HIR::StructField> variants;
     for (AST::StructField &variant : union_decl.get_variants ())
       {
-	HIR::Visibility vis = HIR::Visibility::create_public ();
+	HIR::Visibility vis = translate_visibility (variant.get_visibility ());
 	HIR::Type *type
 	  = ASTLoweringType::translate (variant.get_field_type ().get ());
 
@@ -308,7 +308,7 @@ public:
 
     std::vector<std::unique_ptr<HIR::WhereClauseItem>> where_clause_items;
     HIR::WhereClause where_clause (std::move (where_clause_items));
-    HIR::Visibility vis = HIR::Visibility::create_public ();
+    HIR::Visibility vis = translate_visibility (enum_decl.get_visibility ());
 
     // bool is_unit = enum_decl.is_zero_variant ();
     std::vector<std::unique_ptr<HIR::EnumItem>> items;
@@ -358,7 +358,7 @@ public:
     HIR::WhereClause where_clause (std::move (where_clause_items));
     HIR::FunctionQualifiers qualifiers
       = lower_qualifiers (function.get_qualifiers ());
-    HIR::Visibility vis = HIR::Visibility::create_public ();
+    HIR::Visibility vis = translate_visibility (function.get_visibility ());
 
     // need
     std::vector<std::unique_ptr<HIR::GenericParam>> generic_params;

--- a/gcc/rust/hir/rust-ast-lower.h
+++ b/gcc/rust/hir/rust-ast-lower.h
@@ -32,6 +32,14 @@ namespace HIR {
 bool
 struct_field_name_exists (std::vector<HIR::StructField> &fields,
 			  HIR::StructField &new_field);
+
+/**
+ * Lowers a Visibility from the AST into an HIR Visibility, desugaring it in
+ * the process
+ */
+Visibility
+translate_visibility (const AST::Visibility &vis);
+
 class ASTLowering
 {
 public:

--- a/gcc/rust/hir/tree/rust-hir-full-test.cc
+++ b/gcc/rust/hir/tree/rust-hir-full-test.cc
@@ -118,18 +118,12 @@ Crate::as_string () const
 std::string
 Visibility::as_string () const
 {
-  switch (public_vis_type)
+  switch (vis_type)
     {
-    case NONE:
-      return std::string ("pub");
-    case CRATE:
-      return std::string ("pub(crate)");
-    case SELF:
-      return std::string ("pub(self)");
-    case SUPER:
-      return std::string ("pub(super)");
-    case IN_PATH:
-      return std::string ("pub(in ") + in_path.as_string () + std::string (")");
+    case PRIVATE:
+      return std::string ("private");
+    case PUBLIC:
+      return std::string ("pub(in ") + path.as_string () + std::string (")");
     default:
       gcc_unreachable ();
     }

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -582,14 +582,6 @@ public:
     return Visibility (ERROR, AST::SimplePath::create_empty ());
   }
 
-  // Creates a public visibility.
-  // FIXME: Remove this function: We should not be calling it anymore and
-  // instead we should be using `translate_visibility`
-  static Visibility create_public ()
-  {
-    return Visibility (ERROR, AST::SimplePath::create_empty ());
-  }
-
   VisType get_vis_type () const { return vis_type; }
 
   std::string as_string () const;

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -553,91 +553,46 @@ public:
 struct Visibility
 {
 public:
-  enum PublicVisType
+  enum VisType
   {
-    NONE,
-    CRATE,
-    SELF,
-    SUPER,
-    IN_PATH
+    PRIVATE,
+    PUBLIC,
+    ERROR,
   };
 
 private:
-  // if vis is public, one of these
-  PublicVisType public_vis_type;
-  // Only assigned if public_vis_type is IN_PATH
-  AST::SimplePath in_path;
+  VisType vis_type;
+  AST::SimplePath path;
 
   // should this store location info?
 
 public:
   // Creates a Visibility - TODO make constructor protected or private?
-  Visibility (PublicVisType public_vis_type, AST::SimplePath in_path)
-    : public_vis_type (public_vis_type), in_path (std::move (in_path))
+  Visibility (VisType vis_type,
+	      AST::SimplePath path = AST::SimplePath::create_empty ())
+    : vis_type (vis_type), path (std::move (path))
   {}
 
   // Returns whether visibility is in an error state.
-  bool is_error () const
-  {
-    return public_vis_type == IN_PATH && in_path.is_empty ();
-  }
+  bool is_error () const { return vis_type == ERROR; }
 
   // Creates an error visibility.
   static Visibility create_error ()
   {
-    return Visibility (IN_PATH, AST::SimplePath::create_empty ());
+    return Visibility (ERROR, AST::SimplePath::create_empty ());
   }
 
-  // Unique pointer custom clone function
-  /*std::unique_ptr<Visibility> clone_visibility() const {
-      return std::unique_ptr<Visibility>(clone_visibility_impl());
-  }*/
-
-  /* TODO: think of a way to only allow valid Visibility states - polymorphism
-   * is one idea but may be too resource-intensive. */
-
-  // Creates a public visibility with no further features/arguments.
+  // Creates a public visibility.
+  // FIXME: Remove this function: We should not be calling it anymore and
+  // instead we should be using `translate_visibility`
   static Visibility create_public ()
   {
-    return Visibility (NONE, AST::SimplePath::create_empty ());
+    return Visibility (ERROR, AST::SimplePath::create_empty ());
   }
 
-  // Creates a public visibility with crate-relative paths or whatever.
-  static Visibility create_crate ()
-  {
-    return Visibility (CRATE, AST::SimplePath::create_empty ());
-  }
-
-  // Creates a public visibility with self-relative paths or whatever.
-  static Visibility create_self ()
-  {
-    return Visibility (SELF, AST::SimplePath::create_empty ());
-  }
-
-  // Creates a public visibility with parent module-relative paths or
-  // whatever.
-  static Visibility create_super ()
-  {
-    return Visibility (SUPER, AST::SimplePath::create_empty ());
-  }
-
-  // Creates a public visibility with a given path or whatever.
-  static Visibility create_in_path (AST::SimplePath in_path)
-  {
-    return Visibility (IN_PATH, std::move (in_path));
-  }
-
-  PublicVisType get_vis_type () const { return public_vis_type; }
+  VisType get_vis_type () const { return vis_type; }
 
   std::string as_string () const;
-
-protected:
-  // Clone function implementation - not currently virtual but may be if
-  // polymorphism used
-  /*virtual*/ Visibility *clone_visibility_impl () const
-  {
-    return new Visibility (*this);
-  }
 };
 
 // Item that supports visibility - abstract base class


### PR DESCRIPTION
Fixes #1093

This should cover every case since the previous code simply created public HIR visibilities.

The PR refactors the HIR::Visibility struct to be tinier and a desugared version of the AST one.