### PR TITLE
macros: fix an infinite loop in `concat!` macro parser

### DIFF
--- a/gcc/rust/expand/rust-macro-builtins.cc
+++ b/gcc/rust/expand/rust-macro-builtins.cc
@@ -287,9 +287,12 @@ MacroBuiltin::concat (Location invoc_locus, AST::MacroInvocData &invoc)
 	}
       else
 	{
-	  rust_error_at (parser.peek_current_token ()->get_locus (),
+	  auto current_token = parser.peek_current_token ();
+	  rust_error_at (current_token->get_locus (),
 			 "argument must be a constant literal");
 	  has_error = true;
+	  // Just crash if the current token can't be skipped
+	  rust_assert (parser.skip_token (current_token->get_id ()));
 	}
       parser.maybe_skip_token (COMMA);
     }

--- a/gcc/testsuite/rust/compile/builtin_macro_concat.rs
+++ b/gcc/testsuite/rust/compile/builtin_macro_concat.rs
@@ -3,13 +3,14 @@ macro_rules! concat {
 }
 
 fn main() {
-    // let not_literal = "identifier";
+    let not_literal = "identifier";
     concat!();
-    // concat! (,); // { error "argument must be a constant literal" }
-    // concat!(not_literal); // { error "argument must be a constant literal" }
+    concat! (,); // { dg-error "argument must be a constant literal" }
+    concat!(not_literal); // { dg-error "argument must be a constant literal" }
     concat!("message");
     concat!("message",);
     concat!("message", 1, true, false, 1.0, 10usize, 2000u64);
     concat!("message", 1, true, false, 1.0, 10usize, 2000u64,);
-    // concat! ("m", not_literal); // { error "argument must be a constant literal" }
+    concat! ("m", not_literal); // { dg-error "argument must be a constant literal" }
+    concat!(not_literal invalid 'm' !!,); // { dg-error "argument must be a constant literal" }
 }


### PR DESCRIPTION
- Fix concat macro parser issue which caused an infinite loop when invalid token is encountered
