### PR TITLE
tests: Improve timeout handling

### DIFF
--- a/gcc/testsuite/lib/rust.exp
+++ b/gcc/testsuite/lib/rust.exp
@@ -166,6 +166,10 @@ proc rust_target_compile { source dest type options } {
     global gluefile wrap_flags
     global ALWAYS_RUSTFLAGS
     global RUST_UNDER_TEST
+    global individual_timeout
+
+    # HACK: guard against infinite loops in the compiler
+    set individual_timeout 10
 
     if { [target_info needs_status_wrapper] != "" && [info exists gluefile] } {
 	lappend options "libs=${gluefile}"

--- a/gcc/testsuite/rust/compile/xfail/macro_return.rs
+++ b/gcc/testsuite/rust/compile/xfail/macro_return.rs
@@ -1,0 +1,10 @@
+// { dg-excess-errors "...." { xfail *-*-*-* } }
+
+macro_rules! add {
+    ($a:expr) => { $a };
+    ($a:expr, $($b:expr),+) => { $a + add!($($b),*) }
+}
+
+fn main() -> i32 {
+    add!(add!(1, 2))
+}


### PR DESCRIPTION
- add a 10-second timeout for individual compile test
- add a xfail test case to ensure the timeout mechanism is working 