### PR TITLE
Add Reachability visitors for items with generics

### DIFF
--- a/gcc/rust/privacy/rust-reachability.h
+++ b/gcc/rust/privacy/rust-reachability.h
@@ -46,6 +46,14 @@ public:
     : current_level (ReachLevel::Reachable), ctx (ctx), ty_ctx (ty_ctx)
   {}
 
+  /**
+   * Visit all the predicates of all the generic types of a given item, marking
+   * them as reachable or not.
+   */
+  void visit_generic_predicates (
+    const std::vector<std::unique_ptr<HIR::GenericParam>> &generics,
+    ReachLevel item_reach);
+
   virtual void visit (HIR::Module &mod);
   virtual void visit (HIR::ExternCrate &crate);
   virtual void visit (HIR::UseDeclaration &use_decl);

--- a/gcc/rust/privacy/rust-reachability.h
+++ b/gcc/rust/privacy/rust-reachability.h
@@ -54,6 +54,11 @@ public:
     const std::vector<std::unique_ptr<HIR::GenericParam>> &generics,
     ReachLevel item_reach);
 
+  /**
+   * Get the initial reach level for an item based on its visibility.
+   */
+  ReachLevel get_reachability_level (const HIR::Visibility &item_visibility);
+
   virtual void visit (HIR::Module &mod);
   virtual void visit (HIR::ExternCrate &crate);
   virtual void visit (HIR::UseDeclaration &use_decl);


### PR DESCRIPTION
This factors generics' predicates visiting in the `ReachabilityVisitor` and calls the function in other items with generic parameters