### PR TITLE
Add AST Private Visibilities

### DIFF
--- a/gcc/rust/ast/rust-ast-full-test.cc
+++ b/gcc/rust/ast/rust-ast-full-test.cc
@@ -306,17 +306,19 @@ SimplePath::as_string () const
 std::string
 Visibility::as_string () const
 {
-  switch (public_vis_type)
+  switch (vis_type)
     {
-    case NONE:
+    case PRIV:
+      return std::string ("");
+    case PUB:
       return std::string ("pub");
-    case CRATE:
+    case PUB_CRATE:
       return std::string ("pub(crate)");
-    case SELF:
+    case PUB_SELF:
       return std::string ("pub(self)");
-    case SUPER:
+    case PUB_SUPER:
       return std::string ("pub(super)");
-    case IN_PATH:
+    case PUB_IN_PATH:
       return std::string ("pub(in ") + in_path.as_string () + std::string (")");
     default:
       gcc_unreachable ();

--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -36,24 +36,21 @@ translate_visibility (const AST::Visibility &vis)
   if (vis.is_error ())
     return Visibility::create_error ();
 
-  // FIXME: ... And then use this?
-  // if (vis.is_private ())
-  //   return Visibility::create_private ();
-
   switch (vis.get_public_vis_type ())
     {
-    case AST::Visibility::NONE:
+    case AST::Visibility::PUB:
       return Visibility (Visibility::VisType::PUBLIC);
-    case AST::Visibility::SELF:
+    case AST::Visibility::PRIV:
+    case AST::Visibility::PUB_SELF:
       return Visibility (Visibility::VisType::PRIVATE);
     // Desugar pub(crate) into pub(in crate) and so on
-    case AST::Visibility::CRATE:
+    case AST::Visibility::PUB_CRATE:
       return Visibility (Visibility::PUBLIC,
 			 AST::SimplePath::from_str ("crate"));
-    case AST::Visibility::SUPER:
+    case AST::Visibility::PUB_SUPER:
       return Visibility (Visibility::PUBLIC,
 			 AST::SimplePath::from_str ("super"));
-    case AST::Visibility::IN_PATH:
+    case AST::Visibility::PUB_IN_PATH:
       return Visibility (Visibility::VisType::PUBLIC, vis.get_path ());
       break;
     }

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -2121,7 +2121,7 @@ Parser<ManagedTokenSource>::parse_visibility ()
   // check for no visibility
   if (lexer.peek_token ()->get_id () != PUB)
     {
-      return AST::Visibility::create_error ();
+      return AST::Visibility::create_private ();
     }
 
   lexer.skip_token ();


### PR DESCRIPTION
When parsing a visibility in `parse_visibility`, it is not an error to
not have a pub token: It simply means we want to create a private
visibility. If we had C++14 or another language, we could instead
represent all visibilities as an optional<AST::Visibility> where the
Visibility class would not need to change. But I think the best course
of action for our case is to instead keep visibilities even when they
are private and have a special case in the `VisKind` enumeration.

This also enables HIR lowering of visibilities to be performed properly for private items