### PR TITLE
macros: Add env! macro

### DIFF
--- a/gcc/rust/expand/rust-macro-builtins.h
+++ b/gcc/rust/expand/rust-macro-builtins.h
@@ -89,6 +89,9 @@ public:
 
   static AST::ASTFragment concat (Location invoc_locus,
 				  AST::MacroInvocData &invoc);
+
+  static AST::ASTFragment env (Location invoc_locus,
+			       AST::MacroInvocData &invoc);
 };
 } // namespace Rust
 

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -755,6 +755,7 @@ Mappings::insert_macro_def (AST::MacroRulesDefinition *macro)
       {"include_str", MacroBuiltin::include_str},
       {"compile_error", MacroBuiltin::compile_error},
       {"concat", MacroBuiltin::concat},
+      {"env", MacroBuiltin::env},
     };
 
   auto builtin = builtin_macros.find (macro->get_rule_name ());

--- a/gcc/testsuite/rust/compile/builtin_macro_env.rs
+++ b/gcc/testsuite/rust/compile/builtin_macro_env.rs
@@ -1,0 +1,19 @@
+macro_rules! env {
+  () => {{}};
+}
+
+fn main () {
+  let message = "error message";
+  env! (message); // { dg-error "argument must be a string literal" "" }
+  env! (); // { dg-error "env! takes 1 or 2 arguments" "" }
+  env! (,); // { dg-error "argument must be a string literal" "" }
+  env! (1); // { dg-error "argument must be a string literal" "" }
+  env! ("NOT_DEFINED"); // { dg-error "environment variable 'NOT_DEFINED' not defined" "" }
+  env! ("NOT_DEFINED",); // { dg-error "environment variable 'NOT_DEFINED' not defined" "" }
+  env! ("NOT_DEFINED", 1); // { dg-error "argument must be a string literal" "" }
+  env! ("NOT_DEFINED", "two", "three"); // { dg-error "env! takes 1 or 2 arguments" "" }
+  env! ("NOT_DEFINED" "expected error message"); // { dg-error "expected token: ','" "" }
+  env! ("NOT_DEFINED", "expected error message"); // { dg-error "expected error message" "" }
+  env! ("NOT_DEFINED", "expected error message",); // { dg-error "expected error message" "" }
+  env! (1, "two"); // { dg-error "argument must be a string literal" "" }
+}

--- a/gcc/testsuite/rust/execute/torture/builtin_macro_env.rs
+++ b/gcc/testsuite/rust/execute/torture/builtin_macro_env.rs
@@ -1,0 +1,26 @@
+// { dg-output "VALUE\nVALUE\n" }
+// { dg-set-compiler-env-var ENV_MACRO_TEST "VALUE" }
+
+macro_rules! env {
+    () => {{}};
+}
+
+extern "C" {
+    fn printf(fmt: *const i8, ...);
+}
+
+fn print(s: &str) {
+    printf("%s\n" as *const str as *const i8, s as *const str as *const i8);
+}
+
+fn main() -> i32 {
+    let val0 = env!("ENV_MACRO_TEST");
+
+    print(val0);
+
+    let val1 = env!("ENV_MACRO_TEST",);
+
+    print(val1);
+
+    0
+}


### PR DESCRIPTION
Added the `env!()` macro and relevant test cases

Fixes: #977 

Signed-off-by: Ondřej Machota <ondrejmachota@gmail.com>