### PR TITLE
rust: Use -Otarget when building and logging warnings

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -51,7 +51,7 @@ jobs:
       shell: bash
       run: |
            cd gccrs-build; \
-           make -j $(nproc) 2>&1 | tee log
+           make -Otarget -j $(nproc) 2>&1 | tee log
 
     - name: Check for new warnings
       run: |


### PR DESCRIPTION
This will provide some synchronization for output lines, and so will
make comparisons with known warnings as part of CI more reliable.

