### PR TITLE
Move `cfg!()` macro to builtins. Fixes #1039

### DIFF
--- a/gcc/rust/expand/rust-macro-builtins.h
+++ b/gcc/rust/expand/rust-macro-builtins.h
@@ -92,6 +92,9 @@ public:
 
   static AST::ASTFragment env (Location invoc_locus,
 			       AST::MacroInvocData &invoc);
+
+  static AST::ASTFragment cfg (Location invoc_locus,
+			       AST::MacroInvocData &invoc);
 };
 } // namespace Rust
 

--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -25,50 +25,6 @@
 #include "rust-attribute-visitor.h"
 
 namespace Rust {
-void
-MacroExpander::parse_macro_to_meta_item (AST::MacroInvocData &invoc)
-{
-  // only parse if not already parsed
-  if (invoc.is_parsed ())
-    return;
-
-  std::unique_ptr<AST::AttrInputMetaItemContainer> converted_input (
-    invoc.get_delim_tok_tree ().parse_to_meta_item ());
-
-  if (converted_input == nullptr)
-    {
-      rust_debug ("DEBUG: failed to parse macro to meta item");
-      // TODO: do something now? is this an actual error?
-    }
-  else
-    {
-      std::vector<std::unique_ptr<AST::MetaItemInner>> meta_items (
-	std::move (converted_input->get_items ()));
-      invoc.set_meta_item_output (std::move (meta_items));
-    }
-}
-
-AST::Literal
-MacroExpander::expand_cfg_macro (AST::MacroInvocData &invoc)
-{
-  // only allow on cfg macros
-  if (invoc.get_path () != "cfg")
-    return AST::Literal::create_error ();
-
-  parse_macro_to_meta_item (invoc);
-
-  /* TODO: assuming that cfg! macros can only have one meta item inner, like cfg
-   * attributes */
-  if (invoc.get_meta_items ().size () != 1)
-    return AST::Literal::create_error ();
-
-  bool result = invoc.get_meta_items ()[0]->check_cfg_predicate (session);
-  if (result)
-    return AST::Literal ("true", AST::Literal::BOOL, CORETYPE_BOOL);
-  else
-    return AST::Literal ("false", AST::Literal::BOOL, CORETYPE_BOOL);
-}
-
 AST::ASTFragment
 MacroExpander::expand_decl_macro (Location invoc_locus,
 				  AST::MacroInvocData &invoc,

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -226,11 +226,6 @@ struct MacroExpander
   bool fails_cfg (const AST::AttrVec &attr) const;
   bool fails_cfg_with_expand (AST::AttrVec &attrs) const;
 
-  // Expand the data of a cfg! macro.
-  void parse_macro_to_meta_item (AST::MacroInvocData &invoc);
-  // Get the literal representation of a cfg! macro.
-  AST::Literal expand_cfg_macro (AST::MacroInvocData &invoc);
-
   bool depth_exceeds_recursion_limit () const;
 
   bool try_match_rule (AST::MacroRule &match_rule,

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -756,6 +756,7 @@ Mappings::insert_macro_def (AST::MacroRulesDefinition *macro)
       {"compile_error", MacroBuiltin::compile_error},
       {"concat", MacroBuiltin::concat},
       {"env", MacroBuiltin::env},
+      {"cfg", MacroBuiltin::cfg},
     };
 
   auto builtin = builtin_macros.find (macro->get_rule_name ());


### PR DESCRIPTION
Fixes #1039

Hey team, I need help understanding why the test fails.

Compilation succeeds, all the existing tests pass. However the test that I've added fails with the error:
```
FAIL: rust/compile/cfg_macro.rs (test for excess errors)
Excess errors:
/Users/anton/Documents/projects/gcc2/gccrs/gcc/testsuite/rust/compile/cfg_macro.rs:17:8: fatal error: Failed to lower expr: [MacroInvocation: 
 outer attributes: none
 cfg!((A))
 has semicolon: false]
compilation terminated.
```
I tried to understand what's happening using a debugger. The only thing that I understood is that the `MacroBuiltin::cfg` function runs.

Appreciate any feedback.

Thank you. 