### PR TITLE
Add reachability visitor to Enum variants

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-full-test.cc
+++ b/gcc/rust/hir/tree/rust-hir-full-test.cc
@@ -3108,6 +3108,22 @@ EnumItem::as_string () const
 {
   std::string str = Item::as_string ();
   str += variant_name;
+  str += " ";
+  switch (get_enum_item_kind ())
+    {
+    case Named:
+      str += "[Named variant]";
+      break;
+    case Tuple:
+      str += "[Tuple variant]";
+      break;
+    case Struct:
+      str += "[Struct variant]";
+      break;
+    case Discriminant:
+      str += "[Discriminant variant]";
+      break;
+    }
 
   return str;
 }

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -1588,7 +1588,7 @@ public:
 
   std::string as_string () const;
 
-  Analysis::NodeMapping get_mappings () { return mappings; }
+  Analysis::NodeMapping get_mappings () const { return mappings; }
 
   Location get_locus () const { return locus; }
 
@@ -1644,11 +1644,18 @@ protected:
 class EnumItem : public Item
 {
   Identifier variant_name;
-
   Location locus;
 
 public:
   virtual ~EnumItem () {}
+
+  enum EnumItemKind
+  {
+    Named,
+    Tuple,
+    Struct,
+    Discriminant,
+  };
 
   EnumItem (Analysis::NodeMapping mappings, Identifier variant_name,
 	    AST::AttrVec outer_attrs, Location locus)
@@ -1663,6 +1670,7 @@ public:
   }
 
   virtual std::string as_string () const override;
+  virtual EnumItemKind get_enum_item_kind () const { return Named; };
 
   // not pure virtual as not abstract
   void accept_vis (HIRFullVisitor &vis) override;
@@ -1686,6 +1694,11 @@ class EnumItemTuple : public EnumItem
 public:
   // Returns whether tuple enum item has tuple fields.
   bool has_tuple_fields () const { return !tuple_fields.empty (); }
+
+  EnumItemKind get_enum_item_kind () const override
+  {
+    return EnumItemKind::Tuple;
+  }
 
   EnumItemTuple (Analysis::NodeMapping mappings, Identifier variant_name,
 		 std::vector<TupleField> tuple_fields, AST::AttrVec outer_attrs,
@@ -1719,6 +1732,11 @@ class EnumItemStruct : public EnumItem
 public:
   // Returns whether struct enum item has struct fields.
   bool has_struct_fields () const { return !struct_fields.empty (); }
+
+  EnumItemKind get_enum_item_kind () const override
+  {
+    return EnumItemKind::Struct;
+  }
 
   EnumItemStruct (Analysis::NodeMapping mappings, Identifier variant_name,
 		  std::vector<StructField> struct_fields,
@@ -1776,6 +1794,11 @@ public:
   // move constructors
   EnumItemDiscriminant (EnumItemDiscriminant &&other) = default;
   EnumItemDiscriminant &operator= (EnumItemDiscriminant &&other) = default;
+
+  EnumItemKind get_enum_item_kind () const override
+  {
+    return EnumItemKind::Discriminant;
+  }
 
   std::string as_string () const override;
 

--- a/gcc/rust/privacy/rust-reachability.cc
+++ b/gcc/rust/privacy/rust-reachability.cc
@@ -69,6 +69,9 @@ ReachabilityVisitor::visit_generic_predicates (
 void
 ReachabilityVisitor::visit (HIR::Module &mod)
 {
+  auto reach = get_reachability_level (mod.get_visibility ());
+  reach = ctx.update_reachability (mod.get_mappings (), reach);
+
   for (auto &item : mod.get_items ())
     {
       // FIXME: Is that what we want to do? Yes? Only visit the items with
@@ -83,11 +86,17 @@ ReachabilityVisitor::visit (HIR::Module &mod)
 
 void
 ReachabilityVisitor::visit (HIR::ExternCrate &crate)
-{}
+{
+  auto reach = get_reachability_level (crate.get_visibility ());
+  reach = ctx.update_reachability (crate.get_mappings (), reach);
+}
 
 void
 ReachabilityVisitor::visit (HIR::UseDeclaration &use_decl)
-{}
+{
+  auto reach = get_reachability_level (use_decl.get_visibility ());
+  reach = ctx.update_reachability (use_decl.get_mappings (), reach);
+}
 
 void
 ReachabilityVisitor::visit (HIR::Function &func)
@@ -155,11 +164,17 @@ ReachabilityVisitor::visit (HIR::Union &union_item)
 
 void
 ReachabilityVisitor::visit (HIR::ConstantItem &const_item)
-{}
+{
+  auto reach = get_reachability_level (const_item.get_visibility ());
+  reach = ctx.update_reachability (const_item.get_mappings (), reach);
+}
 
 void
 ReachabilityVisitor::visit (HIR::StaticItem &static_item)
-{}
+{
+  auto reach = get_reachability_level (static_item.get_visibility ());
+  reach = ctx.update_reachability (static_item.get_mappings (), reach);
+}
 
 void
 ReachabilityVisitor::visit (HIR::Trait &trait)


### PR DESCRIPTION
This visits all of an enum's variants and their fields if present. To do that properly, this adds a new `EnumItemKind` enum which allows static casting when visiting each variant of the enum (kept as an `EnumItem` class which is derived three times)