### PR TITLE
Add a test for the cfg!() macro

### DIFF
--- a/gcc/testsuite/rust/execute/torture/builtin_macro_cfg.rs
+++ b/gcc/testsuite/rust/execute/torture/builtin_macro_cfg.rs
@@ -1,0 +1,27 @@
+// { dg-additional-options "-w -frust-cfg=A" }
+// { dg-output "A\n" }
+macro_rules! cfg {
+    () => {{}};
+}
+
+extern "C" {
+    fn printf(fmt: *const i8, ...);
+}
+
+fn print(s: &str) {
+    printf("%s\n" as *const str as *const i8, s as *const str as *const i8);
+}
+
+
+fn main() -> i32 {
+    let cfg = cfg!(A);
+    if cfg {
+        print("A");
+    }
+    let cfg = cfg!(B);
+    if cfg {
+        print("B");
+    }
+
+    0
+}


### PR DESCRIPTION
See #1116 and #1039

Adding a test for the cfg!() macro. The compilation of the test fails with the message:

```
fatal error: Failed to lower expr: [MacroInvocation: 
 outer attributes: none
 cfg!((A))
 has semicolon: false]
compilation terminated.
```
