### PR TITLE
Fix bad projection substitution

### DIFF
--- a/gcc/rust/typecheck/rust-hir-trait-ref.h
+++ b/gcc/rust/typecheck/rust-hir-trait-ref.h
@@ -137,9 +137,9 @@ public:
   // the trait will not be stored in its own map yet
   void on_resolved ();
 
-  void associated_type_set (TyTy::BaseType *ty);
+  void associated_type_set (TyTy::BaseType *ty) const;
 
-  void associated_type_reset ();
+  void associated_type_reset () const;
 
   bool is_object_safe () const;
 
@@ -286,6 +286,24 @@ public:
   bool lookup_trait_item_by_type (const std::string &ident,
 				  TraitItemReference::TraitItemType type,
 				  TraitItemReference **ref)
+  {
+    for (auto &item : item_refs)
+      {
+	if (item.get_trait_item_type () != type)
+	  continue;
+
+	if (ident.compare (item.get_identifier ()) == 0)
+	  {
+	    *ref = &item;
+	    return true;
+	  }
+      }
+    return false;
+  }
+
+  bool lookup_trait_item_by_type (const std::string &ident,
+				  TraitItemReference::TraitItemType type,
+				  const TraitItemReference **ref) const
   {
     for (auto &item : item_refs)
       {

--- a/gcc/rust/typecheck/rust-hir-trait-resolve.cc
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.cc
@@ -128,7 +128,7 @@ TraitItemReference::resolve_item (HIR::TraitItemFunc &func)
 }
 
 void
-TraitItemReference::associated_type_set (TyTy::BaseType *ty)
+TraitItemReference::associated_type_set (TyTy::BaseType *ty) const
 {
   rust_assert (get_trait_item_type () == TraitItemType::TYPE);
 
@@ -141,7 +141,7 @@ TraitItemReference::associated_type_set (TyTy::BaseType *ty)
 }
 
 void
-TraitItemReference::associated_type_reset ()
+TraitItemReference::associated_type_reset () const
 {
   rust_assert (get_trait_item_type () == TraitItemType::TYPE);
 

--- a/gcc/rust/typecheck/rust-hir-type-check-item.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.h
@@ -78,9 +78,9 @@ public:
 	trait_reference = TraitResolver::Resolve (*ref.get ());
 	rust_assert (!trait_reference->is_error ());
 
+	// we don't error out here see: gcc/testsuite/rust/compile/traits2.rs
+	// for example
 	specified_bound = get_predicate_from_bound (*ref.get ());
-	// FIXME error out maybe?
-	// if specified_Bound == TyTy::TypeBoundPredicate::error() ?
       }
 
     TyTy::BaseType *self = nullptr;
@@ -120,9 +120,9 @@ public:
 	    auto trait_item_ref
 	      = TypeCheckImplItemWithTrait::Resolve (&impl_block,
 						     impl_item.get (), self,
-						     *trait_reference,
+						     specified_bound,
 						     substitutions);
-	    trait_item_refs.push_back (trait_item_ref);
+	    trait_item_refs.push_back (trait_item_ref.get_raw_item ());
 	  }
       }
 
@@ -134,7 +134,7 @@ public:
 	// filter the missing impl_items
 	std::vector<std::reference_wrapper<const TraitItemReference>>
 	  missing_trait_items;
-	for (auto &trait_item_ref : trait_reference->get_trait_items ())
+	for (const auto &trait_item_ref : trait_reference->get_trait_items ())
 	  {
 	    bool found = false;
 	    for (auto implemented_trait_item : trait_item_refs)

--- a/gcc/rust/typecheck/rust-hir-type-check.h
+++ b/gcc/rust/typecheck/rust-hir-type-check.h
@@ -211,8 +211,8 @@ public:
   void clear_associated_type_mapping (HirId id)
   {
     auto it = associated_type_mappings.find (id);
-    rust_assert (it != associated_type_mappings.end ());
-    associated_type_mappings.erase (it);
+    if (it != associated_type_mappings.end ())
+      associated_type_mappings.erase (it);
   }
 
   // lookup any associated type mappings, the out parameter of mapping is

--- a/gcc/rust/typecheck/rust-substitution-mapper.h
+++ b/gcc/rust/typecheck/rust-substitution-mapper.h
@@ -208,7 +208,14 @@ public:
   void visit (TyTy::PlaceholderType &type) override
   {
     rust_assert (type.can_resolve ());
-    resolved = SubstMapperInternal::Resolve (type.resolve (), mappings);
+    if (mappings.trait_item_mode ())
+      {
+	resolved = type.resolve ();
+      }
+    else
+      {
+	resolved = SubstMapperInternal::Resolve (type.resolve (), mappings);
+      }
   }
 
   void visit (TyTy::ProjectionType &type) override

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -480,7 +480,7 @@ SubstitutionParamMapping::fill_param_ty (
 
   if (type.get_kind () == TypeKind::PARAM)
     {
-      delete param;
+      // delete param;
       param = static_cast<ParamType *> (type.clone ());
     }
   else
@@ -643,8 +643,9 @@ SubstitutionRef::adjust_mappings_for_this (
   if (resolved_mappings.empty ())
     return SubstitutionArgumentMappings::error ();
 
-  return SubstitutionArgumentMappings (resolved_mappings,
-				       mappings.get_locus ());
+  return SubstitutionArgumentMappings (resolved_mappings, mappings.get_locus (),
+				       mappings.get_subst_cb (),
+				       mappings.trait_item_mode ());
 }
 
 bool
@@ -2699,6 +2700,13 @@ ProjectionType::clone () const
 ProjectionType *
 ProjectionType::handle_substitions (SubstitutionArgumentMappings subst_mappings)
 {
+  // // do we really need to substitute this?
+  // if (base->needs_generic_substitutions () || base->contains_type_parameters
+  // ())
+  //   {
+  //     return this;
+  //   }
+
   ProjectionType *projection = static_cast<ProjectionType *> (clone ());
   projection->set_ty_ref (mappings->get_next_hir_id ());
   projection->used_arguments = subst_mappings;
@@ -2755,9 +2763,7 @@ ProjectionType::handle_substitions (SubstitutionArgumentMappings subst_mappings)
 	  return nullptr;
 	}
 
-      auto new_field = concrete->clone ();
-      new_field->set_ref (fty->get_ref ());
-      projection->base = new_field;
+      projection->base = concrete;
     }
 
   return projection;

--- a/gcc/testsuite/rust/compile/traits9.rs
+++ b/gcc/testsuite/rust/compile/traits9.rs
@@ -1,4 +1,3 @@
-// { dg-additional-options -frust-crate=example }
 struct Foo(i32);
 trait Bar {
     fn baz(&self);
@@ -9,6 +8,6 @@ fn main() {
     a = Foo(123);
 
     let b: &dyn Bar = &a;
-    // { dg-error "bounds not satisfied for Foo .example::Bar. is not satisfied" "" { target *-*-* } .-1 }
+    // { dg-error "bounds not satisfied for Foo .Bar. is not satisfied" "" { target *-*-* } .-1 }
     // { dg-error "expected" "" { target *-*-* } .-2 }
 }

--- a/gcc/testsuite/rust/execute/torture/issue-1120.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-1120.rs
@@ -1,0 +1,123 @@
+// { dg-additional-options "-w" }
+extern "rust-intrinsic" {
+    pub fn offset<T>(dst: *const T, offset: isize) -> *const T;
+}
+
+struct FatPtr<T> {
+    data: *const T,
+    len: usize,
+}
+
+pub union Repr<T> {
+    rust: *const [T],
+    rust_mut: *mut [T],
+    raw: FatPtr<T>,
+}
+
+pub enum Option<T> {
+    None,
+    Some(T),
+}
+
+#[lang = "Range"]
+pub struct Range<Idx> {
+    pub start: Idx,
+    pub end: Idx,
+}
+
+#[lang = "const_slice_ptr"]
+impl<T> *const [T] {
+    pub const fn len(self) -> usize {
+        let a = unsafe { Repr { rust: self }.raw };
+        a.len
+    }
+
+    pub const fn as_ptr(self) -> *const T {
+        self as *const T
+    }
+}
+
+#[lang = "const_ptr"]
+impl<T> *const T {
+    pub const unsafe fn offset(self, count: isize) -> *const T {
+        unsafe { offset(self, count) }
+    }
+
+    pub const unsafe fn add(self, count: usize) -> Self {
+        unsafe { self.offset(count as isize) }
+    }
+
+    pub const fn as_ptr(self) -> *const T {
+        self as *const T
+    }
+}
+
+const fn slice_from_raw_parts<T>(data: *const T, len: usize) -> *const [T] {
+    unsafe {
+        Repr {
+            raw: FatPtr { data, len },
+        }
+        .rust
+    }
+}
+
+#[lang = "index"]
+trait Index<Idx> {
+    type Output;
+
+    fn index(&self, index: Idx) -> &Self::Output;
+}
+
+pub unsafe trait SliceIndex<T> {
+    type Output;
+
+    fn get(self, slice: &T) -> Option<&Self::Output>;
+
+    unsafe fn get_unchecked(self, slice: *const T) -> *const Self::Output;
+
+    fn index(self, slice: &T) -> &Self::Output;
+}
+
+unsafe impl<T> SliceIndex<[T]> for Range<usize> {
+    type Output = [T];
+
+    fn get(self, slice: &[T]) -> Option<&[T]> {
+        if self.start > self.end
+        /* || self.end > slice.len() */
+        {
+            Option::None
+        } else {
+            unsafe { Option::Some(&*self.get_unchecked(slice)) }
+        }
+    }
+
+    unsafe fn get_unchecked(self, slice: *const [T]) -> *const [T] {
+        unsafe {
+            let a: *const T = slice.as_ptr();
+            let b: *const T = a.add(self.start);
+            slice_from_raw_parts(b, self.end - self.start)
+        }
+    }
+
+    fn index(self, slice: &[T]) -> &[T] {
+        unsafe { &*self.get_unchecked(slice) }
+    }
+}
+
+impl<T, I> Index<I> for [T]
+where
+    I: SliceIndex<[T]>,
+{
+    type Output = I::Output;
+
+    fn index(&self, index: I) -> &I::Output {
+        index.index(self)
+    }
+}
+
+fn main() -> i32 {
+    let a = [1, 2, 3, 4, 5];
+    let b = &a[1..3];
+
+    0
+}


### PR DESCRIPTION
When we have a Trait such as:

```
pub unsafe trait SliceIndex<T> {
    type Output;

    fn index(self, slice: &T) -> &Self::Output;
}

unsafe impl<T> SliceIndex<[T]> for Range<usize> {
    type Output = [T];

    fn index(self, slice: &[T]) -> &[T] {
        unsafe { &*self.get_unchecked(slice) }
    }
}

```

When we need to verify that the impl index is compatible fir SliceIndex we
get the Type info for the trait-item which is:

  fn<Self, T> index(self: Self, slice: &T)
        -> &<placeholder=projection<T>=[T]>

This projection gets setup and the types are substituted with
Self=Range<usize> and T=[T] which ended up substituting the projection
twice resulting in a recursive slice [T=[T]]. In this case the associated
type is already setup for the placeholder and does not require generic
substitution. This means we added a flag to the substitution generic
arguments mappings to handle this case.

This patch also addressed memory corruption with the TypeBoundPredicate
as part of the debugging of this issue which resulted in a segv when
trying to debug the mappings. The issue was the copy constructors needed
to update the used argument mappings each time since the substitution param
mappings are copied and the addresses no longer exist, valgrind was great
here to find this issue.

Fixes #1120
