### PR TITLE
testsuite/rust: fix test case failure on macOS

### DIFF
--- a/gcc/testsuite/rust/compile/xfail/macro_return.rs
+++ b/gcc/testsuite/rust/compile/xfail/macro_return.rs
@@ -1,4 +1,4 @@
-// { dg-excess-errors "...." { xfail *-*-*-* } }
+// { dg-excess-errors "...." { xfail *-*-*-* *-*-* } }
 
 macro_rules! add {
     ($a:expr) => { $a };


### PR DESCRIPTION
- extent `macro_return` xfail targets to three-segment triples