### PR TITLE
Don't ICE on traits' `Self` generic parameters

### DIFF
--- a/gcc/rust/privacy/rust-reachability.cc
+++ b/gcc/rust/privacy/rust-reachability.cc
@@ -53,6 +53,7 @@ ReachabilityVisitor::visit_generic_predicates (
 	  TyTy::BaseType *generic_ty = nullptr;
 	  auto ok = ty_ctx.lookup_type (generic->get_mappings ().get_hirid (),
 					&generic_ty);
+
 	  rust_assert (ok);
 	  rust_assert (generic_ty->get_kind () == TyTy::PARAM);
 

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -189,6 +189,8 @@ public:
 	return nullptr;
       }
 
+    resolver.context->insert_type (param->get_mappings (), resolver.resolved);
+
     return resolver.resolved;
   }
 

--- a/gcc/testsuite/rust/compile/1128-ice-reachability.rs
+++ b/gcc/testsuite/rust/compile/1128-ice-reachability.rs
@@ -1,0 +1,13 @@
+trait Hasher {
+    fn write(&mut self, bytes: &[u8]);
+    fn write_u8(&mut self, i: u8) {
+        self.write(&[i])
+    }
+}
+
+pub trait PubHasher {
+    fn p_write(&mut self, bytes: &[u8]);
+    fn p_write_u8(&mut self, i: u8) {
+        self.write(&[i])
+    }
+}


### PR DESCRIPTION
The `Self` type of a Trait is part of its generic parameter list. This
fails lookup since it's not a properly defined type. We need to be able
to identify `Self` parameters and skip them in the reachability pass.

Closes #1128 