### PR TITLE
Fix generic param redefined bug

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -955,6 +955,15 @@ public:
 
   void visit (AST::ExternalFunctionItem &function) override
   {
+    NodeId scope_node_id = function.get_node_id ();
+    resolver->get_name_scope ().push (scope_node_id);
+    resolver->get_type_scope ().push (scope_node_id);
+    resolver->get_label_scope ().push (scope_node_id);
+    resolver->push_new_name_rib (resolver->get_name_scope ().peek ());
+    resolver->push_new_type_rib (resolver->get_type_scope ().peek ());
+    resolver->push_new_label_rib (resolver->get_type_scope ().peek ());
+
+    // resolve the generics
     if (function.has_generics ())
       {
 	for (auto &generic : function.get_generic_params ())
@@ -971,6 +980,11 @@ public:
       {
 	ResolveType::go (param.get_type ().get (), param.get_node_id ());
       }
+
+    // done
+    resolver->get_name_scope ().pop ();
+    resolver->get_type_scope ().pop ();
+    resolver->get_label_scope ().pop ();
   }
 
   void visit (AST::ExternalStaticItem &item) override

--- a/gcc/testsuite/rust/compile/issue-1131.rs
+++ b/gcc/testsuite/rust/compile/issue-1131.rs
@@ -1,0 +1,4 @@
+extern "rust-intrinsic" {
+    fn size_of<T>() -> usize;
+    fn offset<T>(dst: *const T, offset: isize) -> *const T;
+}


### PR DESCRIPTION
When we name-resolve generic parameters their declaration gets inserted in
to the upper-most rib on the stack. Then when this is referenced we lookup
the relevant binding starting from the uppermost rib this lead to the 2nd
extern item adding the same binding into the same rib which caused this
clash. To fix this we need to have a seperate rib for each declaration
so as reusing the same names don't clash with each other.

Fixes #1131
