### PR TITLE
Add missing coercion rule from array to slice

### DIFF
--- a/gcc/rust/typecheck/rust-tyty-coercion.h
+++ b/gcc/rust/typecheck/rust-tyty-coercion.h
@@ -886,6 +886,22 @@ public:
 			      TyVar (base_resolved->get_ref ()));
   }
 
+  void visit (ArrayType &type) override
+  {
+    // check base type
+    auto base_resolved
+      = base->get_element_type ()->unify (type.get_element_type ());
+    if (base_resolved == nullptr)
+      {
+	BaseCoercionRules::visit (type);
+	return;
+      }
+
+    resolved = new SliceType (type.get_ref (), type.get_ty_ref (),
+			      type.get_ident ().locus,
+			      TyVar (base_resolved->get_ref ()));
+  }
+
 private:
   BaseType *get_base () override { return base; }
 

--- a/gcc/testsuite/rust/compile/issue-1129-1.rs
+++ b/gcc/testsuite/rust/compile/issue-1129-1.rs
@@ -1,0 +1,4 @@
+// { dg-additional-options "-w" }
+fn write_u8(i: u8) {
+    let x: &[u8] = &[i];
+}

--- a/gcc/testsuite/rust/compile/issue-1129-2.rs
+++ b/gcc/testsuite/rust/compile/issue-1129-2.rs
@@ -1,0 +1,22 @@
+// { dg-additional-options "-w" }
+pub trait Hasher {
+    fn finish(&self) -> u64;
+    fn write(&mut self, bytes: &[u8]);
+    fn write_u8(&mut self, i: u8) {
+        self.write(&[i])
+    }
+}
+
+struct SipHasher;
+
+impl Hasher for SipHasher {
+    #[inline]
+    fn write(&mut self, msg: &[u8]) {
+        loop {}
+    }
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        0
+    }
+}


### PR DESCRIPTION
Arrays are coercible into slices, this adds the missing type-resolution
the rule which works for now. The other part of this fix is described in #1146 
for coercion_site to be recursive and reuse the adjustment classes so that
we reuse as much code as possible and handle complex coercion sites.

Fixes #1129
