### PR TITLE
Add support for isize and usize type-hints

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-base.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.cc
@@ -133,6 +133,14 @@ TypeCheckBase::resolve_literal (const Analysis::NodeMapping &expr_mappings,
 	    ok = context->lookup_builtin ("f64", &infered);
 	    break;
 
+	  case CORETYPE_ISIZE:
+	    ok = context->lookup_builtin ("isize", &infered);
+	    break;
+
+	  case CORETYPE_USIZE:
+	    ok = context->lookup_builtin ("usize", &infered);
+	    break;
+
 	  default:
 	    ok = true;
 	    infered

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -619,6 +619,8 @@ public:
 	    = (negated_expr_ty->get_kind () == TyTy::TypeKind::INT)
 	      || (negated_expr_ty->get_kind () == TyTy::TypeKind::UINT)
 	      || (negated_expr_ty->get_kind () == TyTy::TypeKind::FLOAT)
+	      || (negated_expr_ty->get_kind () == TyTy::TypeKind::ISIZE)
+	      || (negated_expr_ty->get_kind () == TyTy::TypeKind::USIZE)
 	      || (negated_expr_ty->get_kind () == TyTy::TypeKind::INFER
 		  && (((TyTy::InferType *) negated_expr_ty)->get_infer_kind ()
 		      == TyTy::InferType::INTEGRAL))

--- a/gcc/testsuite/rust/compile/issue-1152.rs
+++ b/gcc/testsuite/rust/compile/issue-1152.rs
@@ -1,0 +1,8 @@
+fn test() {
+    let f = [0; -4_isize];
+    // { dg-error "expected .usize. got .isize." "" { target *-*-* } .-1 }
+    // { dg-error "failed to type resolve expression" "" { target *-*-* } .-2 }
+    let f = [0_usize; -1_isize];
+    // { dg-error "expected .usize. got .isize." "" { target *-*-* } .-1 }
+    // { dg-error "failed to type resolve expression" "" { target *-*-* } .-2 }
+}


### PR DESCRIPTION
This bug turned out to be that we expected a usize for the array capacity
but the specified capacity turned out to be an integer inference variable
which will default to a signed integer. The type resolution was missing
handling the type-hints of isize and usize

Fixes #1152
