### PR TITLE
tests/attr_cold: fix a typo

### DIFF
--- a/gcc/testsuite/rust/compile/attr_cold.rs
+++ b/gcc/testsuite/rust/compile/attr_cold.rs
@@ -1,11 +1,11 @@
-// { dg-additional-options "-fdump-tree-gimple }
+// { dg-additional-options "-fdump-tree-gimple" }
 #[cold]
 fn cold_function() -> i32 {
     42
 }
 
 fn main() -> i32 {
-    // { dg-final { scan-tree-dump-times {__attribute__((cdecl, cold))} 1 gimple } }
+    // { dg-final { scan-tree-dump-times {__attribute__\(\(cdecl, cold\)\)} 1 gimple } }
     cold_function();
 
     0


### PR DESCRIPTION
- fix a typo in the `rust/compile/attr_cold.rs` file