### PR TITLE
Resolve remaining simple visibilites

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -633,6 +633,7 @@ public:
   virtual void accept_vis (HIRVisItemVisitor &vis) = 0;
 
   Visibility &get_visibility () { return visibility; }
+  const Visibility &get_visibility () const { return visibility; }
 
   std::string as_string () const override;
 };

--- a/gcc/rust/privacy/rust-visibility-resolver.h
+++ b/gcc/rust/privacy/rust-visibility-resolver.h
@@ -53,6 +53,14 @@ public:
 			   ModuleVisibility &to_resolve);
 
   /**
+   * Resolve the visibility of an item and updates it. This is useful for
+   * vis-items who need to be resolved but do not care about their module
+   * visibility - const items, static items, etc. For items with an impact on
+   * their children (enums, traits), this cannot be used
+   */
+  void resolve_and_update (const HIR::VisItem *item);
+
+  /**
    * Get the DefId of the parent module we are currently visiting.
    *
    * @return UNKNOWN_DEFID if the module stack is empty, a valid `DefId`


### PR DESCRIPTION
Based on #1155, so you can review just the last commit.

This adds the remaining simple visitors for visibility resolving, as well as a helper method for doing so.