### PR TITLE
CI: catch malformed test cases

### DIFF
--- a/.github/emit_test_errors.pl
+++ b/.github/emit_test_errors.pl
@@ -1,0 +1,25 @@
+#!/bin/perl -n
+
+sub analyze_errors() {
+    /^(FAIL|ERROR|XPASS):\s([^:\s]+):?\s+(.+)/;
+
+    my $type     = $1;
+    my $filename = $2;
+    my $message  = $3;
+    my $line;
+
+    if ( !$type ) { return; }
+
+    if ( $message =~ /(at line (\d+))?.+(test for \w+, line (\d+))/g ) {
+        $line = $2 || $4;
+    }
+
+    my $command = "::error file=gcc/testsuite/$filename";
+    if ($line) {
+        $command = "$command,line=$line";
+    }
+
+    print "$command,title=Test failure ($type)::$message\n";
+}
+
+analyze_errors();

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -77,9 +77,10 @@ jobs:
     - name: Check regressions
       run: |
            cd gccrs-build; \
-           if grep -e "unexpected" -e "unresolved" gcc/testsuite/rust/rust.sum;\
+           if grep -e "unexpected" -e "unresolved" -e "ERROR:" gcc/testsuite/rust/rust.sum;\
            then \
-              echo "some tests are not correct"; \
+              echo "::error title=Regression test failed::some tests are not correct"; \
+              perl -n ../.github/emit_test_errors.pl < gcc/testsuite/rust/rust.sum; \
               exit 1; \
             else \
               exit 0; \
@@ -142,9 +143,9 @@ jobs:
     - name: Check regressions
       run: |
            cd gccrs-build; \
-           if grep -e "unexpected" -e "unresolved" gcc/testsuite/rust/rust.sum;\
+           if grep -e "unexpected" -e "unresolved" -e "ERROR:" gcc/testsuite/rust/rust.sum;\
            then \
-              echo "some tests are not correct"; \
+              echo "::error title=Regression test failed::some tests are not correct"; \
               exit 1; \
             else \
               exit 0; \
@@ -196,9 +197,9 @@ jobs:
     - name: Check regressions
       run: |
            cd gccrs-build; \
-           if grep -e "unexpected" -e "unresolved" gcc/testsuite/rust/rust.sum;\
+           if grep -e "unexpected" -e "unresolved" -e "ERROR:" gcc/testsuite/rust/rust.sum;\
            then \
-              echo "some tests are not correct"; \
+              echo "::error title=Regression test failed::some tests are not correct"; \
               exit 1; \
             else \
               exit 0; \


### PR DESCRIPTION
- catch malformed test cases and use GitHub Actions' annotation feature to mark the failures