### PR TITLE
Add `NodeId`s to `SimplePath{Segment}`s

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -325,12 +325,14 @@ class SimplePathSegment : public PathSegment
 {
   std::string segment_name;
   Location locus;
+  NodeId node_id;
 
   // only allow identifiers, "super", "self", "crate", or "$crate"
 public:
   // TODO: put checks in constructor to enforce this rule?
   SimplePathSegment (std::string segment_name, Location locus = Location ())
-    : segment_name (std::move (segment_name)), locus (locus)
+    : segment_name (std::move (segment_name)), locus (locus),
+      node_id (Analysis::Mappings::get ()->get_next_node_id ())
   {}
 
   /* Returns whether simple path segment is in an invalid state (currently, if
@@ -346,6 +348,7 @@ public:
   std::string as_string () const override;
 
   Location get_locus () const { return locus; }
+  NodeId get_node_id () const { return node_id; }
 
   // TODO: visitor pattern?
 };
@@ -356,6 +359,7 @@ class SimplePath
   bool has_opening_scope_resolution;
   std::vector<SimplePathSegment> segments;
   Location locus;
+  NodeId node_id;
 
 public:
   // Constructor
@@ -363,7 +367,8 @@ public:
 	      bool has_opening_scope_resolution = false,
 	      Location locus = Location ())
     : has_opening_scope_resolution (has_opening_scope_resolution),
-      segments (std::move (path_segments)), locus (locus)
+      segments (std::move (path_segments)), locus (locus),
+      node_id (Analysis::Mappings::get ()->get_next_node_id ())
   {}
 
   // Creates an empty SimplePath.
@@ -378,6 +383,7 @@ public:
   std::string as_string () const;
 
   Location get_locus () const { return locus; }
+  NodeId get_node_id () const { return node_id; }
 
   // does this need visitor if not polymorphic? probably not
 

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -640,6 +640,9 @@ public:
     return vis_type == PUB_IN_PATH && in_path.is_empty ();
   }
 
+  // Returns whether a visibility has a path
+  bool has_path () const { return !(is_error ()) && vis_type == PUB_IN_PATH; }
+
   // Returns whether visibility is public or not.
   bool is_public () const { return vis_type != PRIV && !is_error (); }
 


### PR DESCRIPTION
This is a necessary first step which addresses #1158

I am working on the visibility resolver and simple-path name resolver in parallel and will need those changes. 

I'm not sure if the `has_path` method is necessary since we will have `HIR::Visibilities` in the visibility resolver, which will be desugared. Maybe I am doing this wrong and we should be working on `AST::Visibilities` instead?