### PR TITLE
Support inference of generic parameters on paths behind reference's

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -12591,16 +12591,6 @@ Parser<ManagedTokenSource>::null_denotation (const_TokenPtr tok,
 	      // struct/enum expr struct
 	      if (!restrictions.can_be_struct_expr && !not_a_block)
 		{
-		  // assume path is returned if not single segment
-		  if (path.is_single_segment ())
-		    {
-		      // have to return an identifier expression or something
-		      /* HACK: may have to become permanent, but this is my
-		       * current identifier expression */
-		      return std::unique_ptr<AST::IdentifierExpr> (
-			new AST::IdentifierExpr (tok->get_str (), {},
-						 tok->get_locus ()));
-		    }
 		  // HACK: add outer attrs to path
 		  path.set_outer_attrs (std::move (outer_attrs));
 		  return std::unique_ptr<AST::PathInExpression> (
@@ -12613,16 +12603,6 @@ Parser<ManagedTokenSource>::null_denotation (const_TokenPtr tok,
 	    // struct/enum expr tuple
 	    if (!restrictions.can_be_struct_expr)
 	      {
-		// assume path is returned if not single segment
-		if (path.is_single_segment ())
-		  {
-		    // have to return an identifier expression or something, idk
-		    /* HACK: may have to become permanent, but this is my
-		     * current identifier expression */
-		    return std::unique_ptr<AST::IdentifierExpr> (
-		      new AST::IdentifierExpr (tok->get_str (), {},
-					       tok->get_locus ()));
-		  }
 		// HACK: add outer attrs to path
 		path.set_outer_attrs (std::move (outer_attrs));
 		return std::unique_ptr<AST::PathInExpression> (

--- a/gcc/testsuite/rust/compile/issue-1165.rs
+++ b/gcc/testsuite/rust/compile/issue-1165.rs
@@ -1,0 +1,5 @@
+struct Foo<T>(T);
+
+fn main() {
+    &Foo(123);
+}


### PR DESCRIPTION
We used a hack in the parser to turn simple cases such as &Foo(..) into:

  BorrowExpr
    CallExpr(
      IdentifierExpr + <Argument-expressions>))

The IdentifierExpr here is parsed as a PathExpression but to simplify
things at the time it seemed logic to see these as identifier expressions
but this is actually a Path and we need to be careful about generic
arguments here. Identifiers are simply identifiers and must not be changed
or coherence of inference variables will become a jumble of inference
variables trying to infer one another inside purely generic code.

This patch leaves the PathInExpressions as Path's instead of trying to be
clever and turn them into identifiers.

Fixes #1165
