### PR TITLE
Fix nullptr when resolving the root of a path expression

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-path.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-path.cc
@@ -178,7 +178,7 @@ TypeCheckExpr::resolve_root_path (HIR::PathInExpression &expr, size_t *offset,
       HIR::PathExprSegment &seg = expr.get_segments ().at (i);
 
       bool have_more_segments = (expr.get_num_segments () - 1 != i);
-      bool is_root = *offset == 0;
+      bool is_root = *offset == 0 || root_tyty == nullptr;
       NodeId ast_node_id = seg.get_mappings ().get_nodeid ();
 
       // then lookup the reference_node_id


### PR DESCRIPTION
When we resolve paths we don't have a _type_, in this scenario there is a
bug in our resolution of this generic function so this means the root_tyty
is nullptr but the offset is non zero so we return nullptr.

Addresses #1132

This test case no longer ICE's but still fails. I have a fix in progress for this

```rust
mod mem {
    extern "rust-intrinsic" {
        fn transmute<U, V>(_: U) -> V;
    }
}

pub trait Hasher {
    fn write(&mut self, bytes: &[u8]);
    fn write_u16(&mut self, i: u16) {
        self.write(&mem::transmute::<_, [u8; 2]>(i))
    }
}

pub struct SipHasher;

impl Hasher for SipHasher {
    #[inline]
    fn write(&mut self, msg: &[u8]) {}
}

```