### PR TITLE
Implement macro expansion in `IfExpr`, `IfExprConseqElse`, `IfExprConseqIf`, `IfExprConseqIfLet`.

### DIFF
--- a/gcc/rust/expand/rust-attribute-visitor.cc
+++ b/gcc/rust/expand/rust-attribute-visitor.cc
@@ -1630,6 +1630,9 @@ AttrVisitor::visit (AST::IfExpr &expr)
   // can't strip condition expr itself, but can strip sub-expressions
   auto &condition_expr = expr.get_condition_expr ();
   condition_expr->accept_vis (*this);
+  auto cond_fragment = expander.take_expanded_fragment (*this);
+  if (cond_fragment.should_expand ())
+    condition_expr = cond_fragment.take_expression_fragment ();
   if (condition_expr->is_marked_for_strip ())
     rust_error_at (condition_expr->get_locus (),
 		   "cannot strip expression in this position - outer "
@@ -1657,6 +1660,9 @@ AttrVisitor::visit (AST::IfExprConseqElse &expr)
   // can't strip condition expr itself, but can strip sub-expressions
   auto &condition_expr = expr.get_condition_expr ();
   condition_expr->accept_vis (*this);
+  auto cond_fragment = expander.take_expanded_fragment (*this);
+  if (cond_fragment.should_expand ())
+    condition_expr = cond_fragment.take_expression_fragment ();
   if (condition_expr->is_marked_for_strip ())
     rust_error_at (condition_expr->get_locus (),
 		   "cannot strip expression in this position - outer "
@@ -1692,6 +1698,9 @@ AttrVisitor::visit (AST::IfExprConseqIf &expr)
   // can't strip condition expr itself, but can strip sub-expressions
   auto &condition_expr = expr.get_condition_expr ();
   condition_expr->accept_vis (*this);
+  auto cond_fragment = expander.take_expanded_fragment (*this);
+  if (cond_fragment.should_expand ())
+    condition_expr = cond_fragment.take_expression_fragment ();
   if (condition_expr->is_marked_for_strip ())
     rust_error_at (condition_expr->get_locus (),
 		   "cannot strip expression in this position - outer "
@@ -1727,6 +1736,9 @@ AttrVisitor::visit (AST::IfExprConseqIfLet &expr)
   // can't strip condition expr itself, but can strip sub-expressions
   auto &condition_expr = expr.get_condition_expr ();
   condition_expr->accept_vis (*this);
+  auto cond_fragment = expander.take_expanded_fragment (*this);
+  if (cond_fragment.should_expand ())
+    condition_expr = cond_fragment.take_expression_fragment ();
   if (condition_expr->is_marked_for_strip ())
     rust_error_at (condition_expr->get_locus (),
 		   "cannot strip expression in this position - outer "

--- a/gcc/testsuite/rust/compile/macro42.rs
+++ b/gcc/testsuite/rust/compile/macro42.rs
@@ -1,0 +1,31 @@
+// { dg-additional-options "-w -frust-cfg=A" }
+macro_rules! cfg {
+    () => {{}};
+}
+
+fn main() -> i32 {
+    let mut res = 0;
+    if cfg!(A) {
+        res = 1;
+    }
+
+    if cfg!(A) {
+        res = 2;
+    } else {
+        res = 3;
+    }
+
+    if cfg!(A) {
+        res = 4;
+    } else if cfg!(A) {
+        res = 5;
+    }
+
+    let res = if cfg!(A) {
+        6
+    } else {
+        7
+    };
+
+    return res;
+}


### PR DESCRIPTION
Addresses #1141. Following up on #1161.

This change adds support for the macros inside the `if` condition expressions.

Things to note:
1. Judging by my research, the `IfExprConseqIfLet` isn't used. The parser treats the syntax `let var = if ...` as a `let` expression followed by `if` expression:
![Screen Shot 2022-04-26 at 9 47 29 am](https://user-images.githubusercontent.com/1451467/165258060-6a42f918-2585-4aef-9da5-9d60d69ca248.png)
2. I didn't add the macro expansion to the `IfLetExpr...` family of expressions because I wasn't able to write a test case reproducing the missing macro expansion. I've tried the following code
```rust
fn main() -> i32 {
    let mut res = 0;

    enum E {
        X(u8),
        Y(u8),
        Z(u8),
    }
    let v = E::Y(12);
    if let E::Y(n) = v {
        res = 1;
    }

    0
}
```
which caused the compiler error
```
FAIL: rust/compile/macro43.rs (internal compiler error: in append_reference_for_def, at rust/resolve/rust-name-resolver.h:227)
```

