### PR TITLE
Dockerfile: change base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest AS gcc-builder
+FROM debian:11 AS gcc-builder
 
 RUN apt-get update; \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
@@ -67,7 +67,7 @@ RUN /bin/sh -c set -ex; \
     dpkg-divert --divert /usr/bin/g++.orig --rename /usr/bin/g++; \
     update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 999
 
-FROM rust
+FROM rust:latest
 COPY --from=gcc-builder /usr/ /usr/
 RUN cargo install --git https://github.com/Rust-GCC/cargo-gccrs cargo-gccrs
 


### PR DESCRIPTION
- Dockerfile: change base image

This commit fixes a recent Docker building error where the GLibc version mismatches.