### PR TITLE
Remove default location for `SimplePath`s

### DIFF
--- a/gcc/rust/ast/rust-ast-full-test.cc
+++ b/gcc/rust/ast/rust-ast-full-test.cc
@@ -4695,7 +4695,10 @@ MetaNameValueStr::to_attribute () const
 {
   LiteralExpr lit_expr (str, Literal::LitType::STRING,
 			PrimitiveCoreType::CORETYPE_UNKNOWN, {}, Location ());
-  return Attribute (SimplePath::from_str (ident),
+  // FIXME: What location do we put here? Is the literal above supposed to have
+  // an empty location as well?
+  // Should MetaNameValueStr keep a location?
+  return Attribute (SimplePath::from_str (ident, Location ()),
 		    std::unique_ptr<AttrInputLiteral> (
 		      new AttrInputLiteral (std::move (lit_expr))));
 }
@@ -4722,7 +4725,8 @@ MetaItemSeq::to_attribute () const
 Attribute
 MetaWord::to_attribute () const
 {
-  return Attribute (SimplePath::from_str (ident), nullptr);
+  // FIXME: How do we get a location here?
+  return Attribute (SimplePath::from_str (ident, Location ()), nullptr);
 }
 
 Attribute
@@ -4740,7 +4744,8 @@ MetaListPaths::to_attribute () const
 
   std::unique_ptr<AttrInputMetaItemContainer> new_seq_container (
     new AttrInputMetaItemContainer (std::move (new_seq)));
-  return Attribute (SimplePath::from_str (ident),
+  // FIXME: How do we get a location here?
+  return Attribute (SimplePath::from_str (ident, Location ()),
 		    std::move (new_seq_container));
 }
 
@@ -4755,7 +4760,8 @@ MetaListNameValueStr::to_attribute () const
 
   std::unique_ptr<AttrInputMetaItemContainer> new_seq_container (
     new AttrInputMetaItemContainer (std::move (new_seq)));
-  return Attribute (SimplePath::from_str (ident),
+  // FIXME: How do we get a location here?
+  return Attribute (SimplePath::from_str (ident, Location ()),
 		    std::move (new_seq_container));
 }
 

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -330,7 +330,7 @@ class SimplePathSegment : public PathSegment
   // only allow identifiers, "super", "self", "crate", or "$crate"
 public:
   // TODO: put checks in constructor to enforce this rule?
-  SimplePathSegment (std::string segment_name, Location locus = Location ())
+  SimplePathSegment (std::string segment_name, Location locus)
     : segment_name (std::move (segment_name)), locus (locus),
       node_id (Analysis::Mappings::get ()->get_next_node_id ())
   {}
@@ -342,7 +342,7 @@ public:
   // Creates an error SimplePathSegment
   static SimplePathSegment create_error ()
   {
-    return SimplePathSegment (std::string (""));
+    return SimplePathSegment (std::string (""), Location ());
   }
 
   std::string as_string () const override;
@@ -398,10 +398,10 @@ public:
    * ensure that this is a valid identifier in path, so be careful. Also, this
    * will have no location data.
    * TODO have checks? */
-  static SimplePath from_str (std::string str)
+  static SimplePath from_str (std::string str, Location locus)
   {
     std::vector<AST::SimplePathSegment> single_segments
-      = {AST::SimplePathSegment (std::move (str))};
+      = {AST::SimplePathSegment (std::move (str), locus)};
     return SimplePath (std::move (single_segments));
   }
 };

--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -44,12 +44,13 @@ translate_visibility (const AST::Visibility &vis)
     case AST::Visibility::PUB_SELF:
       return Visibility (Visibility::VisType::PRIVATE);
     // Desugar pub(crate) into pub(in crate) and so on
+    // FIXME: How do we get a location for the SimplePath here?
     case AST::Visibility::PUB_CRATE:
       return Visibility (Visibility::PUBLIC,
-			 AST::SimplePath::from_str ("crate"));
+			 AST::SimplePath::from_str ("crate", Location ()));
     case AST::Visibility::PUB_SUPER:
       return Visibility (Visibility::PUBLIC,
-			 AST::SimplePath::from_str ("super"));
+			 AST::SimplePath::from_str ("super", Location ()));
     case AST::Visibility::PUB_IN_PATH:
       return Visibility (Visibility::VisType::PUBLIC, vis.get_path ());
       break;

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -870,7 +870,8 @@ Session::injection (AST::Crate &crate)
     {
       // create "macro use" attribute for use on extern crate item to enable
       // loading macros from it
-      AST::Attribute attr (AST::SimplePath::from_str ("macro_use"), nullptr);
+      AST::Attribute attr (AST::SimplePath::from_str ("macro_use", Location ()),
+			   nullptr);
 
       // create "extern crate" item with the name
       std::unique_ptr<AST::ExternCrate> extern_crate (
@@ -885,13 +886,15 @@ Session::injection (AST::Crate &crate)
   // create use tree path
   // prelude is injected_crate_name
   std::vector<AST::SimplePathSegment> segments
-    = {AST::SimplePathSegment (injected_crate_name),
-       AST::SimplePathSegment ("prelude"), AST::SimplePathSegment ("v1")};
+    = {AST::SimplePathSegment (injected_crate_name, Location ()),
+       AST::SimplePathSegment ("prelude", Location ()),
+       AST::SimplePathSegment ("v1", Location ())};
   // create use tree and decl
   std::unique_ptr<AST::UseTreeGlob> use_tree (
     new AST::UseTreeGlob (AST::UseTreeGlob::PATH_PREFIXED,
 			  AST::SimplePath (std::move (segments)), Location ()));
-  AST::Attribute prelude_attr (AST::SimplePath::from_str ("prelude_import"),
+  AST::Attribute prelude_attr (AST::SimplePath::from_str ("prelude_import",
+							  Location ()),
 			       nullptr);
   std::unique_ptr<AST::UseDeclaration> use_decl (
     new AST::UseDeclaration (std::move (use_tree),


### PR DESCRIPTION
This removes the default argument for the locus of `SimplePath`s. Addresses #1159 

There are a lot of places in the code where it is not possible to insert a "correct" location for these `SimplePath`s: namely, when creating the use statement for the standard library's prelude, or when creating the `SimplePath`s of attributes. I've left a few FIXMEs in these cases because I'm unsure about the proper course of action.