### PR TITLE
Fix bad name resolution on path with generic segments

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-path.h
+++ b/gcc/rust/hir/tree/rust-hir-path.h
@@ -262,6 +262,8 @@ public:
 
   std::vector<PathExprSegment> &get_segments () { return segments; }
 
+  const std::vector<PathExprSegment> &get_segments () const { return segments; }
+
   PathExprSegment &get_root_seg () { return segments.at (0); }
 
   PathExprSegment get_final_segment () const { return segments.back (); }

--- a/gcc/rust/resolve/rust-ast-resolve-type.h
+++ b/gcc/rust/resolve/rust-ast-resolve-type.h
@@ -169,13 +169,8 @@ public:
 	return CanonicalPath::create_empty ();
       }
 
-    std::string generics
-      = ResolveTypeToCanonicalPath::canonicalize_generic_args (
-	seg.get_generic_args ());
-
     return CanonicalPath::new_seg (seg.get_node_id (),
-				   seg.get_ident_segment ().as_string ()
-				     + "::" + generics);
+				   seg.get_ident_segment ().as_string ());
   }
 };
 

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -221,13 +221,6 @@ public:
 
     infered
       = TyTy::TypeCheckCallExpr::go (function_tyty, expr, variant, context);
-    if (infered == nullptr)
-      {
-	rust_error_at (expr.get_locus (), "failed to lookup type to CallExpr");
-	return;
-      }
-
-    infered->set_ref (expr.get_mappings ().get_hirid ());
   }
 
   void visit (HIR::MethodCallExpr &expr) override
@@ -1076,7 +1069,6 @@ private:
     : TypeCheckBase (), infered (nullptr), inside_loop (inside_loop)
   {}
 
-  // Beware: currently returns Tyty::ErrorType or nullptr in case of error.
   TyTy::BaseType *resolve_root_path (HIR::PathInExpression &expr,
 				     size_t *offset,
 				     NodeId *root_resolved_node_id);

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -54,18 +54,11 @@ TypeResolution::Resolve (HIR::Crate &crate)
 
   // default inference variables if possible
   context->iterate ([&] (HirId id, TyTy::BaseType *ty) mutable -> bool {
-    if (ty->get_kind () == TyTy::TypeKind::ERROR)
-      {
-	rust_error_at (mappings->lookup_location (id),
-		       "failure in type resolution for %u", id);
-	return false;
-      }
-
     // nothing to do
     if (ty->get_kind () != TyTy::TypeKind::INFER)
       return true;
 
-    TyTy::InferType *infer_var = (TyTy::InferType *) ty;
+    TyTy::InferType *infer_var = static_cast<TyTy::InferType *> (ty);
     TyTy::BaseType *default_type;
     bool ok = infer_var->default_type (&default_type);
     if (!ok)

--- a/gcc/rust/typecheck/rust-tyty-rules.h
+++ b/gcc/rust/typecheck/rust-tyty-rules.h
@@ -89,6 +89,11 @@ public:
     for (auto ref : other->get_combined_refs ())
       resolved->append_reference (ref);
 
+    other->append_reference (resolved->get_ref ());
+    other->append_reference (get_base ()->get_ref ());
+    get_base ()->append_reference (resolved->get_ref ());
+    get_base ()->append_reference (other->get_ref ());
+
     bool result_resolved = resolved->get_kind () != TyTy::TypeKind::INFER;
     bool result_is_infer_var = resolved->get_kind () == TyTy::TypeKind::INFER;
     bool results_is_non_general_infer_var

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -955,12 +955,23 @@ public:
   BaseType *infer_substitions (Location locus)
   {
     std::vector<SubstitutionArg> args;
+    std::map<std::string, BaseType *> argument_mappings;
     for (auto &p : get_substs ())
       {
 	if (p.needs_substitution ())
 	  {
-	    TyVar infer_var = TyVar::get_implicit_infer_var (locus);
-	    args.push_back (SubstitutionArg (&p, infer_var.get_tyty ()));
+	    const std::string &symbol = p.get_param_ty ()->get_symbol ();
+	    auto it = argument_mappings.find (symbol);
+	    if (it == argument_mappings.end ())
+	      {
+		TyVar infer_var = TyVar::get_implicit_infer_var (locus);
+		args.push_back (SubstitutionArg (&p, infer_var.get_tyty ()));
+		argument_mappings[symbol] = infer_var.get_tyty ();
+	      }
+	    else
+	      {
+		args.push_back (SubstitutionArg (&p, it->second));
+	      }
 	  }
 	else
 	  {

--- a/gcc/testsuite/rust/compile/issue-1173.rs
+++ b/gcc/testsuite/rust/compile/issue-1173.rs
@@ -1,0 +1,20 @@
+// { dg-additional-options "-w" }
+mod mem {
+    extern "rust-intrinsic" {
+        fn transmute<U, V>(_: U) -> V;
+    }
+}
+
+pub trait Hasher {
+    fn write(&mut self, bytes: &[u8]);
+    fn write_u16(&mut self, i: u16) {
+        self.write(&mem::transmute::<_, [u8; 2]>(i))
+    }
+}
+
+pub struct SipHasher;
+
+impl Hasher for SipHasher {
+    #[inline]
+    fn write(&mut self, msg: &[u8]) {}
+}

--- a/gcc/testsuite/rust/compile/torture/issue-893-2.rs
+++ b/gcc/testsuite/rust/compile/torture/issue-893-2.rs
@@ -24,7 +24,7 @@ impl Baz<i32, f32> {
 
 pub fn main() {
     let a = Foo::<i32>::new::<f32>(123, 456f32);
-    let b = Foo::new::<f32>(123, 456f32);
+    // let b = Foo::new::<f32>(123, 456f32);
 
     let c = Bar::<i32>(123);
     let d = Bar::baz(c);

--- a/gcc/testsuite/rust/compile/torture/issue-893-2.rs
+++ b/gcc/testsuite/rust/compile/torture/issue-893-2.rs
@@ -24,7 +24,7 @@ impl Baz<i32, f32> {
 
 pub fn main() {
     let a = Foo::<i32>::new::<f32>(123, 456f32);
-    // let b = Foo::new::<f32>(123, 456f32);
+    let b = Foo::new::<f32>(123, 456f32);
 
     let c = Bar::<i32>(123);
     let d = Bar::baz(c);


### PR DESCRIPTION
This fix breaks down into two commits the first commit fixes the issue directly
then the second one fixes the regression that was introduced in the first.

The TLDR for this patch set is that when we resolve the path here:

  module::transmute

The name-resolver wronly added the specified generic arguments into the canonical
path meaning that the root segment could not be name-resolved such that during
type resolution we iterate and apply the generic arguments appropriately to the root
segment.

In fixing this it introduced a regression exposing a few more complex issues with
inference variables but for a more complete explanation about that please read the
commit message from ea38a59ee8329bb7b309400a7de57d53ad7bde31

Fixes #1173 