### PR TITLE
Support align and packed repr layout on structs

### DIFF
--- a/gcc/rust/backend/rust-compile-type.cc
+++ b/gcc/rust/backend/rust-compile-type.cc
@@ -280,6 +280,26 @@ TyTyResolveCompile::visit (const TyTy::ADTType &type)
       type_record = ctx->get_backend ()->union_type (enum_fields);
     }
 
+  // Handle repr options
+  // TODO: "packed" should only narrow type alignment and "align" should only
+  // widen it. Do we need to check and enforce this here, or is it taken care of
+  // later on in the gcc middle-end?
+  TyTy::ADTType::ReprOptions repr = type.get_repr_options ();
+  if (repr.pack)
+    {
+      TYPE_PACKED (type_record);
+      if (repr.pack > 1)
+	{
+	  SET_TYPE_ALIGN (type_record, repr.pack * 8);
+	  TYPE_USER_ALIGN (type_record) = 1;
+	}
+    }
+  else if (repr.align)
+    {
+      SET_TYPE_ALIGN (type_record, repr.align * 8);
+      TYPE_USER_ALIGN (type_record) = 1;
+    }
+
   std::string named_struct_str
     = type.get_ident ().path.get () + type.subst_as_string ();
   tree named_struct

--- a/gcc/rust/typecheck/rust-hir-type-check-base.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.h
@@ -58,6 +58,9 @@ protected:
   TyTy::BaseType *resolve_literal (const Analysis::NodeMapping &mappings,
 				   HIR::Literal &literal, Location locus);
 
+  TyTy::ADTType::ReprOptions parse_repr_options (const AST::AttrVec &attrs,
+						 Location locus);
+
   Analysis::Mappings *mappings;
   Resolver *resolver;
   TypeCheckContext *context;

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.h
@@ -185,12 +185,18 @@ public:
 			    TyTy::VariantDef::VariantType::TUPLE, nullptr,
 			    std::move (fields)));
 
+    // Process #[repr(...)] attribute, if any
+    const AST::AttrVec &attrs = struct_decl.get_outer_attrs ();
+    TyTy::ADTType::ReprOptions repr
+      = parse_repr_options (attrs, struct_decl.get_locus ());
+
     TyTy::BaseType *type
       = new TyTy::ADTType (struct_decl.get_mappings ().get_hirid (),
 			   mappings->get_next_hir_id (),
 			   struct_decl.get_identifier (), ident,
 			   TyTy::ADTType::ADTKind::TUPLE_STRUCT,
-			   std::move (variants), std::move (substitutions));
+			   std::move (variants), std::move (substitutions),
+			   repr);
 
     context->insert_type (struct_decl.get_mappings (), type);
     infered = type;
@@ -311,12 +317,18 @@ public:
 			    TyTy::VariantDef::VariantType::STRUCT, nullptr,
 			    std::move (fields)));
 
+    // Process #[repr(...)] attribute, if any
+    const AST::AttrVec &attrs = struct_decl.get_outer_attrs ();
+    TyTy::ADTType::ReprOptions repr
+      = parse_repr_options (attrs, struct_decl.get_locus ());
+
     TyTy::BaseType *type
       = new TyTy::ADTType (struct_decl.get_mappings ().get_hirid (),
 			   mappings->get_next_hir_id (),
 			   struct_decl.get_identifier (), ident,
 			   TyTy::ADTType::ADTKind::STRUCT_STRUCT,
-			   std::move (variants), std::move (substitutions));
+			   std::move (variants), std::move (substitutions),
+			   repr);
 
     context->insert_type (struct_decl.get_mappings (), type);
     infered = type;

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
@@ -118,12 +118,18 @@ public:
 			    TyTy::VariantDef::VariantType::TUPLE, nullptr,
 			    std::move (fields)));
 
+    // Process #[repr(X)] attribute, if any
+    const AST::AttrVec &attrs = struct_decl.get_outer_attrs ();
+    TyTy::ADTType::ReprOptions repr
+      = parse_repr_options (attrs, struct_decl.get_locus ());
+
     TyTy::BaseType *type
       = new TyTy::ADTType (struct_decl.get_mappings ().get_hirid (),
 			   mappings->get_next_hir_id (),
 			   struct_decl.get_identifier (), ident,
 			   TyTy::ADTType::ADTKind::TUPLE_STRUCT,
-			   std::move (variants), std::move (substitutions));
+			   std::move (variants), std::move (substitutions),
+			   repr);
 
     context->insert_type (struct_decl.get_mappings (), type);
   }
@@ -196,12 +202,18 @@ public:
 			    TyTy::VariantDef::VariantType::STRUCT, nullptr,
 			    std::move (fields)));
 
+    // Process #[repr(X)] attribute, if any
+    const AST::AttrVec &attrs = struct_decl.get_outer_attrs ();
+    TyTy::ADTType::ReprOptions repr
+      = parse_repr_options (attrs, struct_decl.get_locus ());
+
     TyTy::BaseType *type
       = new TyTy::ADTType (struct_decl.get_mappings ().get_hirid (),
 			   mappings->get_next_hir_id (),
 			   struct_decl.get_identifier (), ident,
 			   TyTy::ADTType::ADTKind::STRUCT_STRUCT,
-			   std::move (variants), std::move (substitutions));
+			   std::move (variants), std::move (substitutions),
+			   repr);
 
     context->insert_type (struct_decl.get_mappings (), type);
   }

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -960,7 +960,8 @@ ADTType::clone () const
 
   return new ADTType (get_ref (), get_ty_ref (), identifier, ident,
 		      get_adt_kind (), cloned_variants, clone_substs (),
-		      used_arguments, get_combined_refs ());
+		      get_repr_options (), used_arguments,
+		      get_combined_refs ());
 }
 
 static bool

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -1254,6 +1254,20 @@ public:
     ENUM
   };
 
+  // Representation options, specified via attributes e.g. #[repr(packed)]
+  struct ReprOptions
+  {
+    // bool is_c;
+    // bool is_transparent;
+    //...
+
+    // For align and pack: 0 = unspecified. Nonzero = byte alignment.
+    // It is an error for both to be nonzero, this should be caught when
+    // parsing the #[repr] attribute.
+    unsigned char align = 0;
+    unsigned char pack = 0;
+  };
+
   ADTType (HirId ref, std::string identifier, RustIdent ident, ADTKind adt_kind,
 	   std::vector<VariantDef *> variants,
 	   std::vector<SubstitutionParamMapping> subst_refs,
@@ -1276,7 +1290,20 @@ public:
       identifier (identifier), variants (variants), adt_kind (adt_kind)
   {}
 
+  ADTType (HirId ref, HirId ty_ref, std::string identifier, RustIdent ident,
+	   ADTKind adt_kind, std::vector<VariantDef *> variants,
+	   std::vector<SubstitutionParamMapping> subst_refs, ReprOptions repr,
+	   SubstitutionArgumentMappings generic_arguments
+	   = SubstitutionArgumentMappings::error (),
+	   std::set<HirId> refs = std::set<HirId> ())
+    : BaseType (ref, ty_ref, TypeKind::ADT, ident, refs),
+      SubstitutionRef (std::move (subst_refs), std::move (generic_arguments)),
+      identifier (identifier), variants (variants), adt_kind (adt_kind),
+      repr (repr)
+  {}
+
   ADTKind get_adt_kind () const { return adt_kind; }
+  ReprOptions get_repr_options () const { return repr; }
 
   bool is_struct_struct () const { return adt_kind == STRUCT_STRUCT; }
   bool is_tuple_struct () const { return adt_kind == TUPLE_STRUCT; }
@@ -1385,6 +1412,7 @@ private:
   std::string identifier;
   std::vector<VariantDef *> variants;
   ADTType::ADTKind adt_kind;
+  ReprOptions repr;
 };
 
 class FnType : public BaseType, public SubstitutionRef

--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -33,6 +33,7 @@ static const BuiltinAttrDefinition __definitions[] = {
   {"lang", HIR_LOWERING},
   {"link_section", CODE_GENERATION},
   {"no_mangle", CODE_GENERATION},
+  {"repr", CODE_GENERATION},
 };
 
 BuiltinAttributeMappings *

--- a/gcc/testsuite/rust/compile/struct_align1.rs
+++ b/gcc/testsuite/rust/compile/struct_align1.rs
@@ -1,0 +1,19 @@
+#[repr(align(8))]
+struct Foo {
+    x: i16,
+    // { dg-warning "field is never read" "" { target *-*-* } .-1 }
+    y: i8,
+    // { dg-warning "field is never read" "" { target *-*-* } .-1 }
+    z: i32,
+    // { dg-warning "field is never read" "" { target *-*-* } .-1 }
+}
+
+#[repr(align(8))]
+struct Bar(i8, i32);
+
+fn main () {
+    let f = Foo { x: 5, y: 2, z: 13 };
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+    let b = Bar (7, 262);
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/compile/struct_align2.rs
+++ b/gcc/testsuite/rust/compile/struct_align2.rs
@@ -1,0 +1,18 @@
+
+fn main () {
+
+    #[repr(align(8))]
+    struct Baz {
+        x: u16,
+        y: u32,
+    };
+
+    #[repr(align(4))]
+    struct Qux (u8, i16);
+
+    let b = Baz { x: 5, y: 1984 };
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+
+    let c = Qux (1, 2);
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/compile/struct_pack1.rs
+++ b/gcc/testsuite/rust/compile/struct_pack1.rs
@@ -1,0 +1,19 @@
+#[repr(packed(2))]
+struct Foo {
+    x: i16,
+    // { dg-warning "field is never read" "" { target *-*-* } .-1 }
+    y: i8,
+    // { dg-warning "field is never read" "" { target *-*-* } .-1 }
+    z: i32,
+    // { dg-warning "field is never read" "" { target *-*-* } .-1 }
+}
+
+#[repr(packed)]
+struct Bar(i8, i32);
+
+fn main () {
+    let f = Foo { x: 5, y: 2, z: 13 };
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+    let b = Bar (7, 262);
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/compile/struct_pack2.rs
+++ b/gcc/testsuite/rust/compile/struct_pack2.rs
@@ -1,0 +1,18 @@
+
+fn main () {
+
+    #[repr(packed(2))]
+    struct Baz {
+        x: u16,
+        y: u32,
+    };
+
+    #[repr(packed)]
+    struct Qux (u8, i16);
+
+    let b = Baz { x: 5, y: 1984 };
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+
+    let c = Qux (1, 2);
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
This is a start at handling the various layout options supported by Rust, beginning with `#[repr(align(N))]` and `#[repr(packed(N))]`, on structs and tuple structs.

There are several other layout options which remain to be supported such as `#[repr(C)]`, `#[repr(transparent)]`, combinations e.g. `#[repr(C, packed(2))]`, as well as layouts on union and enum types.

Fixes: #915 