### PR TITLE
Fix ICE in reachability class and refactor associated types code

### DIFF
--- a/gcc/rust/backend/rust-compile-implitem.cc
+++ b/gcc/rust/backend/rust-compile-implitem.cc
@@ -52,6 +52,7 @@ CompileTraitItem::visit (HIR::TraitItemFunc &func)
 
   rust_assert (concrete->get_kind () == TyTy::TypeKind::FNDEF);
   TyTy::FnType *fntype = static_cast<TyTy::FnType *> (concrete);
+  fntype->monomorphize ();
 
   // items can be forward compiled which means we may not need to invoke this
   // code. We might also have already compiled this generic function as well.

--- a/gcc/rust/backend/rust-compile-item.cc
+++ b/gcc/rust/backend/rust-compile-item.cc
@@ -127,6 +127,7 @@ CompileItem::visit (HIR::Function &function)
 	{
 	  rust_assert (concrete->get_kind () == TyTy::TypeKind::FNDEF);
 	  fntype = static_cast<TyTy::FnType *> (concrete);
+	  fntype->monomorphize ();
 	}
     }
 

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -251,21 +251,6 @@ HIRCompileBase::query_compile (HirId ref, TyTy::BaseType *lookup,
 	      rust_assert (ok);				    // found
 	      rust_assert (trait_item_ref->is_optional ()); // has definition
 
-	      Analysis::NodeMapping trait_mappings
-		= trait_item_ref->get_parent_trait_mappings ();
-
-	      HirId associated_impl_id;
-	      ok = ctx->get_tyctx ()->lookup_associated_impl_mapping_for_self (
-		trait_mappings.get_hirid (), receiver, &associated_impl_id);
-	      rust_assert (ok);
-
-	      Resolver::AssociatedImplTrait *associated = nullptr;
-	      bool found_associated_trait_impl
-		= ctx->get_tyctx ()->lookup_associated_trait_impl (
-		  associated_impl_id, &associated);
-	      rust_assert (found_associated_trait_impl);
-	      associated->setup_associated_types ();
-
 	      return CompileTraitItem::Compile (
 		trait_item_ref->get_hir_trait_item (), ctx, lookup, true,
 		expr_locus);

--- a/gcc/rust/typecheck/rust-hir-path-probe.h
+++ b/gcc/rust/typecheck/rust-hir-path-probe.h
@@ -326,18 +326,6 @@ protected:
       }
 
     TyTy::BaseType *trait_item_tyty = trait_item_ref->get_tyty ();
-    if (impl != nullptr && !is_reciever_generic ())
-
-      {
-	HirId impl_block_id = impl->get_mappings ().get_hirid ();
-	AssociatedImplTrait *lookup_associated = nullptr;
-	bool found_impl_trait
-	  = context->lookup_associated_trait_impl (impl_block_id,
-						   &lookup_associated);
-	// see testsuite/rust/compile/torture/traits10.rs this can be false
-	if (found_impl_trait)
-	  lookup_associated->setup_associated_types ();
-      }
 
     // we can substitute the Self with the receiver here
     if (trait_item_tyty->get_kind () == TyTy::TypeKind::FNDEF)

--- a/gcc/rust/typecheck/rust-hir-trait-ref.h
+++ b/gcc/rust/typecheck/rust-hir-trait-ref.h
@@ -454,17 +454,10 @@ public:
 
   TyTy::BaseType *get_self () { return self; }
 
-  void setup_associated_types ();
-
-  void setup_associated_types2 (const TyTy::BaseType *self,
-				const TyTy::TypeBoundPredicate &bound);
+  void setup_associated_types (const TyTy::BaseType *self,
+			       const TyTy::TypeBoundPredicate &bound);
 
   void reset_associated_types ();
-
-  TyTy::BaseType *get_projected_type (const TraitItemReference *trait_item_ref,
-				      TyTy::BaseType *reciever, HirId ref,
-				      HIR::GenericArgs &trait_generics,
-				      Location expr_locus);
 
 private:
   TraitReference *trait;

--- a/gcc/rust/typecheck/rust-hir-trait-resolve.cc
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.cc
@@ -61,7 +61,198 @@ ResolveTraitItemToRef::visit (HIR::TraitItemFunc &fn)
 				 self, std::move (substitutions), locus);
 }
 
+ResolveTraitItemToRef::ResolveTraitItemToRef (
+  TyTy::BaseType *self,
+  std::vector<TyTy::SubstitutionParamMapping> &&substitutions)
+  : TypeCheckBase (), resolved (TraitItemReference::error ()), self (self),
+    substitutions (std::move (substitutions))
+{}
+
 // TraitItemReference items
+
+TraitReference *
+TraitResolver::Resolve (HIR::TypePath &path)
+{
+  TraitResolver resolver;
+  return resolver.go (path);
+}
+
+TraitReference *
+TraitResolver::Lookup (HIR::TypePath &path)
+{
+  TraitResolver resolver;
+  return resolver.lookup_path (path);
+}
+
+TraitResolver::TraitResolver () : TypeCheckBase () {}
+
+TraitReference *
+TraitResolver::go (HIR::TypePath &path)
+{
+  NodeId ref;
+  if (!resolver->lookup_resolved_type (path.get_mappings ().get_nodeid (),
+				       &ref))
+    {
+      rust_error_at (path.get_locus (), "Failed to resolve path to node-id");
+      return &TraitReference::error_node ();
+    }
+
+  HirId hir_node = UNKNOWN_HIRID;
+  if (!mappings->lookup_node_to_hir (mappings->get_current_crate (), ref,
+				     &hir_node))
+    {
+      rust_error_at (path.get_locus (), "Failed to resolve path to hir-id");
+      return &TraitReference::error_node ();
+    }
+
+  HIR::Item *resolved_item
+    = mappings->lookup_hir_item (mappings->get_current_crate (), hir_node);
+
+  rust_assert (resolved_item != nullptr);
+  resolved_item->accept_vis (*this);
+  rust_assert (trait_reference != nullptr);
+
+  TraitReference *tref = &TraitReference::error_node ();
+  if (context->lookup_trait_reference (
+	trait_reference->get_mappings ().get_defid (), &tref))
+    {
+      return tref;
+    }
+
+  TyTy::BaseType *self = nullptr;
+  std::vector<TyTy::SubstitutionParamMapping> substitutions;
+  for (auto &generic_param : trait_reference->get_generic_params ())
+    {
+      switch (generic_param.get ()->get_kind ())
+	{
+	case HIR::GenericParam::GenericKind::LIFETIME:
+	  // Skipping Lifetime completely until better handling.
+	  break;
+
+	  case HIR::GenericParam::GenericKind::TYPE: {
+	    auto param_type
+	      = TypeResolveGenericParam::Resolve (generic_param.get ());
+	    context->insert_type (generic_param->get_mappings (), param_type);
+
+	    auto &typaram = static_cast<HIR::TypeParam &> (*generic_param);
+	    substitutions.push_back (
+	      TyTy::SubstitutionParamMapping (typaram, param_type));
+
+	    if (typaram.get_type_representation ().compare ("Self") == 0)
+	      {
+		self = param_type;
+	      }
+	  }
+	  break;
+	}
+    }
+  rust_assert (self != nullptr);
+
+  // Check if there is a super-trait, and apply this bound to the Self
+  // TypeParam
+  std::vector<TyTy::TypeBoundPredicate> specified_bounds;
+
+  // copy the substitition mappings
+  std::vector<TyTy::SubstitutionParamMapping> self_subst_copy;
+  for (auto &sub : substitutions)
+    self_subst_copy.push_back (sub.clone ());
+
+  // They also inherit themselves as a bound this enables a trait item to
+  // reference other Self::trait_items
+  auto self_hrtb
+    = TyTy::TypeBoundPredicate (trait_reference->get_mappings ().get_defid (),
+				std::move (self_subst_copy),
+				trait_reference->get_locus ());
+  specified_bounds.push_back (self_hrtb);
+
+  // look for any
+  std::vector<const TraitReference *> super_traits;
+  if (trait_reference->has_type_param_bounds ())
+    {
+      for (auto &bound : trait_reference->get_type_param_bounds ())
+	{
+	  if (bound->get_bound_type ()
+	      == HIR::TypeParamBound::BoundType::TRAITBOUND)
+	    {
+	      HIR::TraitBound *b
+		= static_cast<HIR::TraitBound *> (bound.get ());
+
+	      // FIXME this might be recursive we need a check for that
+	      auto predicate = get_predicate_from_bound (b->get_path ());
+	      specified_bounds.push_back (predicate);
+	      super_traits.push_back (predicate.get ());
+	    }
+	}
+    }
+  self->inherit_bounds (specified_bounds);
+
+  std::vector<TraitItemReference> item_refs;
+  for (auto &item : trait_reference->get_trait_items ())
+    {
+      // make a copy of the substs
+      std::vector<TyTy::SubstitutionParamMapping> item_subst;
+      for (auto &sub : substitutions)
+	item_subst.push_back (sub.clone ());
+
+      TraitItemReference trait_item_ref
+	= ResolveTraitItemToRef::Resolve (*item.get (), self,
+					  std::move (item_subst));
+      item_refs.push_back (std::move (trait_item_ref));
+    }
+
+  TraitReference trait_object (trait_reference, item_refs,
+			       std::move (super_traits),
+			       std::move (substitutions));
+  context->insert_trait_reference (
+    trait_reference->get_mappings ().get_defid (), std::move (trait_object));
+
+  tref = &TraitReference::error_node ();
+  bool ok = context->lookup_trait_reference (
+    trait_reference->get_mappings ().get_defid (), &tref);
+  rust_assert (ok);
+
+  // hook to allow the trait to resolve its optional item blocks, we cant
+  // resolve the blocks of functions etc because it can end up in a recursive
+  // loop of trying to resolve traits as required by the types
+  tref->on_resolved ();
+
+  return tref;
+}
+
+TraitReference *
+TraitResolver::lookup_path (HIR::TypePath &path)
+{
+  NodeId ref;
+  if (!resolver->lookup_resolved_type (path.get_mappings ().get_nodeid (),
+				       &ref))
+    {
+      rust_error_at (path.get_locus (), "Failed to resolve path to node-id");
+      return &TraitReference::error_node ();
+    }
+
+  HirId hir_node = UNKNOWN_HIRID;
+  if (!mappings->lookup_node_to_hir (mappings->get_current_crate (), ref,
+				     &hir_node))
+    {
+      rust_error_at (path.get_locus (), "Failed to resolve path to hir-id");
+      return &TraitReference::error_node ();
+    }
+
+  HIR::Item *resolved_item
+    = mappings->lookup_hir_item (mappings->get_current_crate (), hir_node);
+
+  rust_assert (resolved_item != nullptr);
+  resolved_item->accept_vis (*this);
+  rust_assert (trait_reference != nullptr);
+
+  TraitReference *tref = &TraitReference::error_node ();
+  if (context->lookup_trait_reference (
+	trait_reference->get_mappings ().get_defid (), &tref))
+    {
+      return tref;
+    }
+  return &TraitReference::error_node ();
+}
 
 void
 TraitItemReference::on_resolved ()

--- a/gcc/rust/typecheck/rust-hir-trait-resolve.h
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.h
@@ -66,19 +66,23 @@ class TraitResolver : public TypeCheckBase
 public:
   static TraitReference *Resolve (HIR::TypePath &path);
 
+  static TraitReference *Resolve (HIR::Trait &trait);
+
   static TraitReference *Lookup (HIR::TypePath &path);
 
 private:
   TraitResolver ();
 
-  TraitReference *go (HIR::TypePath &path);
+  TraitReference *resolve_path (HIR::TypePath &path);
+
+  TraitReference *resolve_trait (HIR::Trait *trait_reference);
 
   TraitReference *lookup_path (HIR::TypePath &path);
 
-  HIR::Trait *trait_reference;
+  HIR::Trait *resolved_trait_reference;
 
 public:
-  void visit (HIR::Trait &trait) override { trait_reference = &trait; }
+  void visit (HIR::Trait &trait) override { resolved_trait_reference = &trait; }
 };
 
 } // namespace Resolver

--- a/gcc/rust/typecheck/rust-hir-trait-resolve.h
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.h
@@ -52,10 +52,7 @@ public:
 private:
   ResolveTraitItemToRef (
     TyTy::BaseType *self,
-    std::vector<TyTy::SubstitutionParamMapping> &&substitutions)
-    : TypeCheckBase (), resolved (TraitItemReference::error ()), self (self),
-      substitutions (std::move (substitutions))
-  {}
+    std::vector<TyTy::SubstitutionParamMapping> &&substitutions);
 
   TraitItemReference resolved;
   TyTy::BaseType *self;
@@ -67,186 +64,16 @@ class TraitResolver : public TypeCheckBase
   using Rust::Resolver::TypeCheckBase::visit;
 
 public:
-  static TraitReference *Resolve (HIR::TypePath &path)
-  {
-    TraitResolver resolver;
-    return resolver.go (path);
-  }
+  static TraitReference *Resolve (HIR::TypePath &path);
 
-  static TraitReference *Lookup (HIR::TypePath &path)
-  {
-    TraitResolver resolver;
-    return resolver.lookup_path (path);
-  }
+  static TraitReference *Lookup (HIR::TypePath &path);
 
 private:
-  TraitResolver () : TypeCheckBase () {}
+  TraitResolver ();
 
-  TraitReference *go (HIR::TypePath &path)
-  {
-    NodeId ref;
-    if (!resolver->lookup_resolved_type (path.get_mappings ().get_nodeid (),
-					 &ref))
-      {
-	rust_error_at (path.get_locus (), "Failed to resolve path to node-id");
-	return &TraitReference::error_node ();
-      }
+  TraitReference *go (HIR::TypePath &path);
 
-    HirId hir_node = UNKNOWN_HIRID;
-    if (!mappings->lookup_node_to_hir (mappings->get_current_crate (), ref,
-				       &hir_node))
-      {
-	rust_error_at (path.get_locus (), "Failed to resolve path to hir-id");
-	return &TraitReference::error_node ();
-      }
-
-    HIR::Item *resolved_item
-      = mappings->lookup_hir_item (mappings->get_current_crate (), hir_node);
-
-    rust_assert (resolved_item != nullptr);
-    resolved_item->accept_vis (*this);
-    rust_assert (trait_reference != nullptr);
-
-    TraitReference *tref = &TraitReference::error_node ();
-    if (context->lookup_trait_reference (
-	  trait_reference->get_mappings ().get_defid (), &tref))
-      {
-	return tref;
-      }
-
-    TyTy::BaseType *self = nullptr;
-    std::vector<TyTy::SubstitutionParamMapping> substitutions;
-    for (auto &generic_param : trait_reference->get_generic_params ())
-      {
-	switch (generic_param.get ()->get_kind ())
-	  {
-	  case HIR::GenericParam::GenericKind::LIFETIME:
-	    // Skipping Lifetime completely until better handling.
-	    break;
-
-	    case HIR::GenericParam::GenericKind::TYPE: {
-	      auto param_type
-		= TypeResolveGenericParam::Resolve (generic_param.get ());
-	      context->insert_type (generic_param->get_mappings (), param_type);
-
-	      auto &typaram = static_cast<HIR::TypeParam &> (*generic_param);
-	      substitutions.push_back (
-		TyTy::SubstitutionParamMapping (typaram, param_type));
-
-	      if (typaram.get_type_representation ().compare ("Self") == 0)
-		{
-		  self = param_type;
-		}
-	    }
-	    break;
-	  }
-      }
-    rust_assert (self != nullptr);
-
-    // Check if there is a super-trait, and apply this bound to the Self
-    // TypeParam
-    std::vector<TyTy::TypeBoundPredicate> specified_bounds;
-
-    // copy the substitition mappings
-    std::vector<TyTy::SubstitutionParamMapping> self_subst_copy;
-    for (auto &sub : substitutions)
-      self_subst_copy.push_back (sub.clone ());
-
-    // They also inherit themselves as a bound this enables a trait item to
-    // reference other Self::trait_items
-    auto self_hrtb
-      = TyTy::TypeBoundPredicate (trait_reference->get_mappings ().get_defid (),
-				  std::move (self_subst_copy),
-				  trait_reference->get_locus ());
-    specified_bounds.push_back (self_hrtb);
-
-    // look for any
-    std::vector<const TraitReference *> super_traits;
-    if (trait_reference->has_type_param_bounds ())
-      {
-	for (auto &bound : trait_reference->get_type_param_bounds ())
-	  {
-	    if (bound->get_bound_type ()
-		== HIR::TypeParamBound::BoundType::TRAITBOUND)
-	      {
-		HIR::TraitBound *b
-		  = static_cast<HIR::TraitBound *> (bound.get ());
-
-		// FIXME this might be recursive we need a check for that
-		auto predicate = get_predicate_from_bound (b->get_path ());
-		specified_bounds.push_back (predicate);
-		super_traits.push_back (predicate.get ());
-	      }
-	  }
-      }
-    self->inherit_bounds (specified_bounds);
-
-    std::vector<TraitItemReference> item_refs;
-    for (auto &item : trait_reference->get_trait_items ())
-      {
-	// make a copy of the substs
-	std::vector<TyTy::SubstitutionParamMapping> item_subst;
-	for (auto &sub : substitutions)
-	  item_subst.push_back (sub.clone ());
-
-	TraitItemReference trait_item_ref
-	  = ResolveTraitItemToRef::Resolve (*item.get (), self,
-					    std::move (item_subst));
-	item_refs.push_back (std::move (trait_item_ref));
-      }
-
-    TraitReference trait_object (trait_reference, item_refs,
-				 std::move (super_traits),
-				 std::move (substitutions));
-    context->insert_trait_reference (
-      trait_reference->get_mappings ().get_defid (), std::move (trait_object));
-
-    tref = &TraitReference::error_node ();
-    bool ok = context->lookup_trait_reference (
-      trait_reference->get_mappings ().get_defid (), &tref);
-    rust_assert (ok);
-
-    // hook to allow the trait to resolve its optional item blocks, we cant
-    // resolve the blocks of functions etc because it can end up in a recursive
-    // loop of trying to resolve traits as required by the types
-    tref->on_resolved ();
-
-    return tref;
-  }
-
-  TraitReference *lookup_path (HIR::TypePath &path)
-  {
-    NodeId ref;
-    if (!resolver->lookup_resolved_type (path.get_mappings ().get_nodeid (),
-					 &ref))
-      {
-	rust_error_at (path.get_locus (), "Failed to resolve path to node-id");
-	return &TraitReference::error_node ();
-      }
-
-    HirId hir_node = UNKNOWN_HIRID;
-    if (!mappings->lookup_node_to_hir (mappings->get_current_crate (), ref,
-				       &hir_node))
-      {
-	rust_error_at (path.get_locus (), "Failed to resolve path to hir-id");
-	return &TraitReference::error_node ();
-      }
-
-    HIR::Item *resolved_item
-      = mappings->lookup_hir_item (mappings->get_current_crate (), hir_node);
-
-    rust_assert (resolved_item != nullptr);
-    resolved_item->accept_vis (*this);
-    rust_assert (trait_reference != nullptr);
-
-    TraitReference *tref = &TraitReference::error_node ();
-    if (context->lookup_trait_reference (
-	  trait_reference->get_mappings ().get_defid (), &tref))
-      {
-	return tref;
-      }
-    return &TraitReference::error_node ();
-  }
+  TraitReference *lookup_path (HIR::TypePath &path);
 
   HIR::Trait *trait_reference;
 

--- a/gcc/rust/typecheck/rust-hir-type-check-item.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.h
@@ -224,6 +224,8 @@ public:
       TypeCheckItem::Resolve (item.get ());
   }
 
+  void visit (HIR::Trait &trait) override { TraitResolver::Resolve (trait); }
+
 private:
   TypeCheckItem () : TypeCheckBase () {}
 };

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -142,31 +142,35 @@ TypeCheckType::visit (HIR::QualifiedPathInType &path)
       return;
     }
 
+  // get the predicate for the bound
+  auto specified_bound
+    = get_predicate_from_bound (*qual_path_type.get_trait ().get ());
+  if (specified_bound.is_error ())
+    return;
+
+  // inherit the bound
+  root->inherit_bounds ({specified_bound});
+
+  // lookup the associated item from the specified bound
   std::unique_ptr<HIR::TypePathSegment> &item_seg
     = path.get_associated_segment ();
-  const TraitItemReference *trait_item_ref = nullptr;
-  bool ok
-    = trait_ref->lookup_trait_item (item_seg->get_ident_segment ().as_string (),
-				    &trait_item_ref);
-  if (!ok)
+  HIR::PathIdentSegment item_seg_identifier = item_seg->get_ident_segment ();
+  TyTy::TypeBoundPredicateItem item
+    = specified_bound.lookup_associated_item (item_seg_identifier.as_string ());
+  if (item.is_error ())
     {
       rust_error_at (item_seg->get_locus (), "unknown associated item");
       return;
     }
 
-  // this will be the placeholder from the trait but we may be able to project
-  // it based on the impl block
-  translated = trait_item_ref->get_tyty ();
-
-  // this is the associated generics we need to potentially apply
-  HIR::GenericArgs trait_generics = qual_path_type.trait_has_generic_args ()
-				      ? qual_path_type.get_trait_generic_args ()
-				      : HIR::GenericArgs::create_empty ();
+  // infer the root type
+  translated = item.get_tyty_for_receiver (root);
 
   // we need resolve to the impl block
   NodeId impl_resolved_id = UNKNOWN_NODEID;
   bool have_associated_impl = resolver->lookup_resolved_name (
     qual_path_type.get_mappings ().get_nodeid (), &impl_resolved_id);
+  AssociatedImplTrait *lookup_associated = nullptr;
   if (have_associated_impl)
     {
       HirId impl_block_id;
@@ -175,30 +179,16 @@ TypeCheckType::visit (HIR::QualifiedPathInType &path)
 					impl_resolved_id, &impl_block_id);
       rust_assert (ok);
 
-      AssociatedImplTrait *lookup_associated = nullptr;
       bool found_impl_trait
 	= context->lookup_associated_trait_impl (impl_block_id,
 						 &lookup_associated);
-      rust_assert (found_impl_trait);
-
-      // project
-      lookup_associated->setup_associated_types ();
-      translated = lookup_associated->get_projected_type (
-	trait_item_ref, root, item_seg->get_mappings ().get_hirid (),
-	trait_generics, item_seg->get_locus ());
-    }
-
-  if (translated->get_kind () == TyTy::TypeKind::PLACEHOLDER)
-    {
-      // lets grab the actual projection type
-      TyTy::PlaceholderType *p
-	= static_cast<TyTy::PlaceholderType *> (translated);
-      if (p->can_resolve ())
+      if (found_impl_trait)
 	{
-	  translated = p->resolve ();
+	  lookup_associated->setup_associated_types (root, specified_bound);
 	}
     }
 
+  // turbo-fish segment path::<ty>
   if (item_seg->get_type () == HIR::TypePathSegment::SegmentType::GENERIC)
     {
       HIR::TypePathSegmentGeneric &generic_seg
@@ -222,6 +212,7 @@ TypeCheckType::visit (HIR::QualifiedPathInType &path)
     }
 
   // continue on as a path-in-expression
+  const TraitItemReference *trait_item_ref = item.get_raw_item ();
   NodeId root_resolved_node_id = trait_item_ref->get_mappings ().get_nodeid ();
   bool fully_resolved = path.get_segments ().empty ();
   if (fully_resolved)
@@ -448,22 +439,6 @@ TypeCheckType::resolve_segments (
 	{
 	  resolved_node_id
 	    = candidate.item.trait.item_ref->get_mappings ().get_nodeid ();
-
-	  // lookup the associated-impl-trait
-	  HIR::ImplBlock *impl = candidate.item.trait.impl;
-	  if (impl != nullptr && !reciever_is_generic)
-	    {
-	      AssociatedImplTrait *lookup_associated = nullptr;
-	      bool found_impl_trait = context->lookup_associated_trait_impl (
-		impl->get_mappings ().get_hirid (), &lookup_associated);
-	      rust_assert (found_impl_trait);
-
-	      lookup_associated->setup_associated_types ();
-
-	      // we need a new ty_ref_id for this trait item
-	      tyseg = tyseg->clone ();
-	      tyseg->set_ty_ref (mappings->get_next_hir_id ());
-	    }
 	}
 
       if (seg->is_generic_segment ())

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -826,22 +826,23 @@ SubstitutionRef::monomorphize ()
 	      bool found_impl_trait
 		= context->lookup_associated_trait_impl (impl_block_id,
 							 &associated);
-	      rust_assert (found_impl_trait);
-
-	      bool found_trait
-		= specified_bound_ref->is_equal (*bound_trait_ref);
-	      bool found_self
-		= associated->get_self ()->can_eq (binding, false);
-	      if (found_trait && found_self)
+	      if (found_impl_trait)
 		{
-		  associated_impl_trait = associated;
-		  break;
+		  bool found_trait
+		    = specified_bound_ref->is_equal (*bound_trait_ref);
+		  bool found_self
+		    = associated->get_self ()->can_eq (binding, false);
+		  if (found_trait && found_self)
+		    {
+		      associated_impl_trait = associated;
+		      break;
+		    }
 		}
 	    }
 
 	  if (associated_impl_trait != nullptr)
 	    {
-	      associated_impl_trait->setup_associated_types2 (binding, bound);
+	      associated_impl_trait->setup_associated_types (binding, bound);
 	    }
 	}
     }
@@ -2974,6 +2975,7 @@ TypeCheckCallExpr::visit (ADTType &type)
 void
 TypeCheckCallExpr::visit (FnType &type)
 {
+  type.monomorphize ();
   if (call.num_params () != type.num_params ())
     {
       if (type.is_varadic ())

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -1230,6 +1230,19 @@ FnType::is_equal (const BaseType &other) const
     {
       if (get_num_substitutions () != other2.get_num_substitutions ())
 	return false;
+
+      const FnType &ofn = static_cast<const FnType &> (other);
+      for (size_t i = 0; i < get_num_substitutions (); i++)
+	{
+	  const SubstitutionParamMapping &a = get_substs ().at (i);
+	  const SubstitutionParamMapping &b = ofn.get_substs ().at (i);
+
+	  const ParamType *pa = a.get_param_ty ();
+	  const ParamType *pb = b.get_param_ty ();
+
+	  if (!pa->is_equal (*pb))
+	    return false;
+	}
     }
 
   if (num_params () != other2.num_params ())

--- a/gcc/testsuite/rust/compile/issue-1128.rs
+++ b/gcc/testsuite/rust/compile/issue-1128.rs
@@ -1,0 +1,6 @@
+pub trait Hasher {
+    fn write(&mut self, bytes: &[u8]);
+    fn write_u8(&mut self, i: u8) {
+        self.write(&[i])
+    }
+}


### PR DESCRIPTION
There are several fixes going on to solve these issues which overlap with one
another so it seemed best to pack them within the same PR.

The main issue for #1128 was that we did not resolve a trait when it was unused
leading to us hitting the ICE in the privacy pass. Since the type check context was
empty for the trait since it was not resolved. To fix this we needed to refactor the
trait resolver to resolve the trait as part of iterating the crate. This resulted in some
regressions in the testsuite so this is why we need the the other commits. Which
required us to finally perform the refactor specified in #1105 to fix these.

Fixes #1105 #1128 #1132