### PR TITLE
Resolve simple paths in use items

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -410,6 +410,8 @@ public:
   {
     return segments;
   }
+
+  std::vector<SimplePathSegment> &get_segments () { return segments; }
 };
 
 // path-to-string inverse comparison operator

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -26,6 +26,7 @@
 #include "rust-ast-resolve-type.h"
 #include "rust-ast-resolve-pattern.h"
 #include "rust-ast-resolve-stmt.h"
+#include "config.h"
 
 namespace Rust {
 namespace Resolver {
@@ -81,6 +82,7 @@ public:
   void visit (AST::TraitImpl &impl_block) override;
   void visit (AST::Trait &trait) override;
   void visit (AST::ExternBlock &extern_block) override;
+  void visit (AST::UseDeclaration &) override;
 
 protected:
   void resolve_impl_item (AST::TraitImplItem *item, const CanonicalPath &prefix,
@@ -135,5 +137,14 @@ private:
 
 } // namespace Resolver
 } // namespace Rust
+
+#if CHECKING_P
+
+namespace selftest {
+extern void
+rust_simple_path_resolve_test (void);
+} // namespace selftest
+
+#endif // CHECKING_P
 
 #endif // RUST_AST_RESOLVE_ITEM_H

--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -36,6 +36,7 @@
 #include "selftest.h"
 #include "rust-cfg-parser.h"
 #include "rust-privacy-ctx.h"
+#include "rust-ast-resolve-item.h"
 
 #include <mpfr.h>
 // note: header files must be in this order or else forward declarations don't
@@ -459,6 +460,7 @@ run_rust_tests ()
   rust_cfg_parser_test ();
   rust_privacy_ctx_test ();
   rust_crate_name_validation_test ();
+  rust_simple_path_resolve_test ();
 }
 } // namespace selftest
 

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -932,23 +932,25 @@ Session::injection (AST::Crate &crate)
 
   // create use tree path
   // prelude is injected_crate_name
-  std::vector<AST::SimplePathSegment> segments
-    = {AST::SimplePathSegment (injected_crate_name, Location ()),
-       AST::SimplePathSegment ("prelude", Location ()),
-       AST::SimplePathSegment ("v1", Location ())};
-  // create use tree and decl
-  std::unique_ptr<AST::UseTreeGlob> use_tree (
-    new AST::UseTreeGlob (AST::UseTreeGlob::PATH_PREFIXED,
-			  AST::SimplePath (std::move (segments)), Location ()));
-  AST::Attribute prelude_attr (AST::SimplePath::from_str ("prelude_import",
-							  Location ()),
-			       nullptr);
-  std::unique_ptr<AST::UseDeclaration> use_decl (
-    new AST::UseDeclaration (std::move (use_tree),
-			     AST::Visibility::create_error (),
-			     {std::move (prelude_attr)}, Location ()));
+  // FIXME: Once we do want to include the standard library, add the prelude
+  // use item
+  // std::vector<AST::SimplePathSegment> segments
+  //   = {AST::SimplePathSegment (injected_crate_name, Location ()),
+  //      AST::SimplePathSegment ("prelude", Location ()),
+  //      AST::SimplePathSegment ("v1", Location ())};
+  // // create use tree and decl
+  // std::unique_ptr<AST::UseTreeGlob> use_tree (
+  //   new AST::UseTreeGlob (AST::UseTreeGlob::PATH_PREFIXED,
+  //     		  AST::SimplePath (std::move (segments)), Location ()));
+  // AST::Attribute prelude_attr (AST::SimplePath::from_str ("prelude_import",
+  //     						  Location ()),
+  //     		       nullptr);
+  // std::unique_ptr<AST::UseDeclaration> use_decl (
+  //   new AST::UseDeclaration (std::move (use_tree),
+  //     		     AST::Visibility::create_error (),
+  //     		     {std::move (prelude_attr)}, Location ()));
 
-  crate.items.insert (crate.items.begin (), std::move (use_decl));
+  // crate.items.insert (crate.items.begin (), std::move (use_decl));
 
   /* TODO: potentially add checking attribute crate type? I can't figure out
    * what this does currently comment says "Unconditionally collect crate

--- a/gcc/testsuite/rust/compile/torture/cfg_attr.rs
+++ b/gcc/testsuite/rust/compile/torture/cfg_attr.rs
@@ -1,4 +1,4 @@
-use std::env; // Add one line so gccrs doesn't believe we're parsing a shebang
+mod fake {} // Add one line so gccrs doesn't believe we're parsing a shebang
 
 #[cfg_attr(feature = "somefeature", attribute = "someattr")]
 struct Feature;

--- a/gcc/testsuite/rust/compile/use_1.rs
+++ b/gcc/testsuite/rust/compile/use_1.rs
@@ -1,0 +1,16 @@
+mod frob {}
+
+use foo::bar::baz; // { dg-error "cannot find simple path segment .foo." }
+use frob::ulator; // { dg-error "cannot find simple path segment .ulator." }
+
+mod sain {
+    mod doux {}
+
+    mod dron {}
+}
+
+use not_sain::*; // { dg-error "cannot find simple path segment .not_sain." }
+
+use sain::*;
+use sain::{doux, dron};
+use sain::{doux, dron, graal}; // { dg-error "cannot find simple path segment .graal." }


### PR DESCRIPTION
In order to resolve `SimplePath`s, we have to expand all paths present
in a `UseDeclaration` and resolve them. For example, we want to resolve
two paths with the following statement `use foo::bar::{baz, bul}`:
`foo::bar::baz` and `foo::bar::bul`
This also removes the prelude inclusion (`use std::prelude::v1::*`)
since we cannot resolve it (yet!)

Needs #1172 to compile
Adresses #1159 
Adresses #1187 