### PR TITLE
Remove unused parameter caller from generating Call expressions

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -497,10 +497,8 @@ CompileExpr::visit (HIR::CallExpr &expr)
 
   // must be a call to a function
   auto fn_address = CompileExpr::Compile (expr.get_fnexpr (), ctx);
-  auto fncontext = ctx->peek_fn ();
-  translated
-    = ctx->get_backend ()->call_expression (fncontext.fndecl, fn_address, args,
-					    nullptr, expr.get_locus ());
+  translated = ctx->get_backend ()->call_expression (fn_address, args, nullptr,
+						     expr.get_locus ());
 }
 
 void
@@ -610,10 +608,8 @@ CompileExpr::visit (HIR::MethodCallExpr &expr)
       args.push_back (rvalue);
     }
 
-  auto fncontext = ctx->peek_fn ();
-  translated
-    = ctx->get_backend ()->call_expression (fncontext.fndecl, fn_expr, args,
-					    nullptr, expr.get_locus ());
+  translated = ctx->get_backend ()->call_expression (fn_expr, args, nullptr,
+						     expr.get_locus ());
 }
 
 tree
@@ -696,8 +692,8 @@ CompileExpr::compile_dyn_dispatch_call (const TyTy::DynamicObjectType *dyn,
   tree fn_expr
     = ctx->get_backend ()->var_expression (fn_convert_expr_tmp, expr_locus);
 
-  return ctx->get_backend ()->call_expression (fnctx.fndecl, fn_expr, args,
-					       nullptr, expr_locus);
+  return ctx->get_backend ()->call_expression (fn_expr, args, nullptr,
+					       expr_locus);
 }
 
 tree
@@ -866,9 +862,8 @@ CompileExpr::resolve_operator_overload (
   if (rhs != nullptr)	 // can be null for negation_expr (unary ones)
     args.push_back (rhs);
 
-  auto fncontext = ctx->peek_fn ();
-  return ctx->get_backend ()->call_expression (fncontext.fndecl, fn_expr, args,
-					       nullptr, expr.get_locus ());
+  return ctx->get_backend ()->call_expression (fn_expr, args, nullptr,
+					       expr.get_locus ());
 }
 
 tree
@@ -1289,10 +1284,8 @@ HIRCompileBase::resolve_deref_adjustment (Resolver::Adjustment &adjustment,
     }
 
   // make the call
-  auto fncontext = ctx->peek_fn ();
-  return ctx->get_backend ()->call_expression (fncontext.fndecl, fn_address,
-					       {adjusted_argument}, nullptr,
-					       locus);
+  return ctx->get_backend ()->call_expression (fn_address, {adjusted_argument},
+					       nullptr, locus);
 }
 
 tree

--- a/gcc/rust/rust-backend.h
+++ b/gcc/rust/rust-backend.h
@@ -285,8 +285,7 @@ public:
 
   // Create an expression for a call to FN with ARGS, taking place within
   // caller CALLER.
-  virtual tree call_expression (tree caller, tree fn,
-				const std::vector<tree> &args,
+  virtual tree call_expression (tree fn, const std::vector<tree> &args,
 				tree static_chain, Location)
     = 0;
 

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -250,7 +250,7 @@ public:
 
   tree array_index_expression (tree array, tree index, Location);
 
-  tree call_expression (tree caller, tree fn, const std::vector<tree> &args,
+  tree call_expression (tree fn, const std::vector<tree> &args,
 			tree static_chain, Location);
 
   // Statements.
@@ -1794,8 +1794,7 @@ Gcc_backend::array_index_expression (tree array_tree, tree index_tree,
 
 // Create an expression for a call to FN_EXPR with FN_ARGS.
 tree
-Gcc_backend::call_expression (tree, // containing fcn for call
-			      tree fn, const std::vector<tree> &fn_args,
+Gcc_backend::call_expression (tree fn, const std::vector<tree> &fn_args,
 			      tree chain_expr, Location location)
 {
   if (fn == error_mark_node || TREE_TYPE (fn) == error_mark_node)


### PR DESCRIPTION
Within const context the fncontext maybe empty which in turn results in a
segv for generating const calls which will be evaluated by the const-expr
code anyway.

Addresses #1130
