### PR TITLE
Support recursive coercion sites

### DIFF
--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -317,7 +317,7 @@ HIRCompileBase::mark_addressable (tree exp, Location locus)
 }
 
 tree
-HIRCompileBase::address_expression (tree expr, Location location)
+HIRCompileBase::address_expression (tree expr, tree ptrtype, Location location)
 {
   if (expr == error_mark_node)
     return error_mark_node;
@@ -325,7 +325,8 @@ HIRCompileBase::address_expression (tree expr, Location location)
   if (!mark_addressable (expr, location))
     return error_mark_node;
 
-  return build_fold_addr_expr_loc (location.gcc_location (), expr);
+  return build_fold_addr_expr_with_type_loc (location.gcc_location (), expr,
+					     ptrtype);
 }
 
 std::vector<Bvariable *>

--- a/gcc/rust/backend/rust-compile-base.h
+++ b/gcc/rust/backend/rust-compile-base.h
@@ -98,7 +98,7 @@ protected:
 
   static void setup_abi_options (tree fndecl, ABI abi);
 
-  static tree address_expression (tree, Location);
+  static tree address_expression (tree expr, tree ptrtype, Location locus);
 
   static bool mark_addressable (tree, Location);
 

--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -677,17 +677,6 @@ CompileExpr::compile_dyn_dispatch_call (const TyTy::DynamicObjectType *dyn,
     = ctx->get_backend ()->convert_expression (expected_fntype,
 					       fn_vtable_access, expr_locus);
 
-  fncontext fnctx = ctx->peek_fn ();
-  tree enclosing_scope = ctx->peek_enclosing_scope ();
-  bool is_address_taken = false;
-  tree ret_var_stmt = NULL_TREE;
-  Bvariable *fn_convert_expr_tmp
-    = ctx->get_backend ()->temporary_variable (fnctx.fndecl, enclosing_scope,
-					       expected_fntype, fn_convert_expr,
-					       is_address_taken, expr_locus,
-					       &ret_var_stmt);
-  ctx->add_statement (ret_var_stmt);
-
   std::vector<tree> args;
   args.push_back (self_argument);
   for (auto &argument : arguments)
@@ -696,10 +685,7 @@ CompileExpr::compile_dyn_dispatch_call (const TyTy::DynamicObjectType *dyn,
       args.push_back (compiled_expr);
     }
 
-  tree fn_expr
-    = ctx->get_backend ()->var_expression (fn_convert_expr_tmp, expr_locus);
-
-  return ctx->get_backend ()->call_expression (fn_expr, args, nullptr,
+  return ctx->get_backend ()->call_expression (fn_convert_expr, args, nullptr,
 					       expr_locus);
 }
 

--- a/gcc/rust/backend/rust-compile-implitem.cc
+++ b/gcc/rust/backend/rust-compile-implitem.cc
@@ -68,7 +68,10 @@ CompileTraitItem::visit (HIR::TraitItemFunc &func)
 	    {
 	      ctx->insert_function_decl (fntype, lookup);
 	    }
-	  reference = address_expression (lookup, ref_locus);
+	  reference
+	    = address_expression (lookup,
+				  build_pointer_type (TREE_TYPE (lookup)),
+				  ref_locus);
 	  return;
 	}
     }
@@ -95,7 +98,9 @@ CompileTraitItem::visit (HIR::TraitItemFunc &func)
 			func.get_outer_attrs (), func.get_locus (),
 			func.get_block_expr ().get (), canonical_path, fntype,
 			function.has_return_type ());
-  reference = address_expression (fndecl, ref_locus);
+  reference
+    = address_expression (fndecl, build_pointer_type (TREE_TYPE (fndecl)),
+			  ref_locus);
 }
 
 } // namespace Compile

--- a/gcc/rust/backend/rust-compile-item.cc
+++ b/gcc/rust/backend/rust-compile-item.cc
@@ -146,7 +146,10 @@ CompileItem::visit (HIR::Function &function)
 	      ctx->insert_function_decl (fntype, lookup);
 	    }
 
-	  reference = address_expression (lookup, ref_locus);
+	  reference
+	    = address_expression (lookup,
+				  build_pointer_type (TREE_TYPE (lookup)),
+				  ref_locus);
 	  return;
 	}
     }
@@ -171,7 +174,9 @@ CompileItem::visit (HIR::Function &function)
 			function.get_outer_attrs (), function.get_locus (),
 			function.get_definition ().get (), canonical_path,
 			fntype, function.has_function_return_type ());
-  reference = address_expression (fndecl, ref_locus);
+  reference
+    = address_expression (fndecl, build_pointer_type (TREE_TYPE (fndecl)),
+			  ref_locus);
 }
 
 void

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -141,14 +141,16 @@ ResolvePathRef::resolve (const HIR::PathIdentSegment &final_segment,
       if (ctx->lookup_function_decl (fntype->get_ty_ref (), &fn))
 	{
 	  TREE_USED (fn) = 1;
-	  return address_expression (fn, expr_locus);
+	  return address_expression (fn, build_pointer_type (TREE_TYPE (fn)),
+				     expr_locus);
 	}
       else if (fntype->get_abi () == ABI::INTRINSIC)
 	{
 	  Intrinsics compile (ctx);
 	  fn = compile.compile (fntype);
 	  TREE_USED (fn) = 1;
-	  return address_expression (fn, expr_locus);
+	  return address_expression (fn, build_pointer_type (TREE_TYPE (fn)),
+				     expr_locus);
 	}
     }
 

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -299,8 +299,9 @@ HIRCompileBase::coerce_to_dyn_object (tree compiled_ref,
 	  || it->get_type () == Resolver::Adjustment::AdjustmentType::MUT_REF;
       rust_assert (ok);
 
-      resulting_dyn_object_ref
-	= address_expression (resulting_dyn_object_ref, locus);
+      resulting_dyn_object_ref = address_expression (
+	resulting_dyn_object_ref,
+	build_reference_type (TREE_TYPE (resulting_dyn_object_ref)), locus);
     }
   return resulting_dyn_object_ref;
 }


### PR DESCRIPTION
There are two changes are part of this PR one where we update the address_expression
helper to take a ptrtype tree. Since the default build_address_expr_loc was automatically
building a pointer type of the TREE_TYPE of the operand which is not correct since we
sometimes want REFERENCE_TYPES instead of POINTER_TYPES. 

The 2nd commit enhances the coercion_site code to recursively walk the tree and their
types to handle coercions to dyn traits or do array bounds checking etc. This gets rid of
the get_root hack used and cleans up the code in general.


Fixes #1146 