### PR TITLE
Add new as_name interface for Dynamic types

### DIFF
--- a/gcc/rust/typecheck/rust-tyty-bounds.cc
+++ b/gcc/rust/typecheck/rust-tyty-bounds.cc
@@ -215,6 +215,12 @@ TypeBoundPredicate::as_string () const
   return get ()->as_string () + subst_as_string ();
 }
 
+std::string
+TypeBoundPredicate::as_name () const
+{
+  return get ()->get_name () + subst_as_string ();
+}
+
 const Resolver::TraitReference *
 TypeBoundPredicate::get () const
 {
@@ -430,6 +436,20 @@ std::string
 TypeBoundsMappings::bounds_as_string () const
 {
   return "bounds:[" + raw_bounds_as_string () + "]";
+}
+
+std::string
+TypeBoundsMappings::raw_bounds_as_name () const
+{
+  std::string buf;
+  for (size_t i = 0; i < specified_bounds.size (); i++)
+    {
+      const TypeBoundPredicate &b = specified_bounds.at (i);
+      bool has_next = (i + 1) < specified_bounds.size ();
+      buf += b.as_name () + (has_next ? " + " : "");
+    }
+
+  return buf;
 }
 
 void

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -2867,8 +2867,7 @@ DynamicObjectType::clone () const
 std::string
 DynamicObjectType::get_name () const
 {
-  std::string bounds = "[" + raw_bounds_as_string () + "]";
-  return "dyn " + bounds;
+  return "dyn [" + raw_bounds_as_name () + "]";
 }
 
 bool

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -124,6 +124,8 @@ public:
 
   std::string bounds_as_string () const;
 
+  std::string raw_bounds_as_name () const;
+
 protected:
   void add_bound (TypeBoundPredicate predicate);
 
@@ -1018,6 +1020,8 @@ public:
   static TypeBoundPredicate error ();
 
   std::string as_string () const;
+
+  std::string as_name () const;
 
   const Resolver::TraitReference *get () const;
 


### PR DESCRIPTION
The Gimple names of our dyn trait objects were looking like:

  const struct dyn [HIR Trait: FnLike->[C: 0 Nid: 31 Hid: 38 Lid: 13] [(FN call ), ]<Self, &isize, &isize>] & const f

This is a horrible name but useful for debugging this patch fixes this so
we have a seperate naming for generating the type. So now it looks like:

  const struct dyn [FnLike<Self, &isize, &isize>] & const f
