### PR TITLE
Remove duplicated code for expansions of types and expressions

### DIFF
--- a/gcc/rust/expand/rust-attribute-visitor.h
+++ b/gcc/rust/expand/rust-attribute-visitor.h
@@ -25,6 +25,8 @@ class AttrVisitor : public AST::ASTVisitor
 {
 private:
   MacroExpander &expander;
+  void maybe_expand_expr (std::unique_ptr<AST::Expr> &expr);
+  void maybe_expand_type (std::unique_ptr<AST::Type> &expr);
 
 public:
   AttrVisitor (MacroExpander &expander) : expander (expander) {}


### PR DESCRIPTION
Following up on the comment https://github.com/Rust-GCC/gccrs/pull/1161#pullrequestreview-951665285
