### PR TITLE
Take advantage of OBJ_TYPE_REF'S in dyn calls

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -789,11 +789,13 @@ public:
   void visit (HIR::AsyncBlockExpr &) override {}
 
 protected:
-  tree compile_dyn_dispatch_call (const TyTy::DynamicObjectType *dyn,
-				  TyTy::BaseType *receiver,
-				  TyTy::FnType *fntype, tree receiver_ref,
-				  std::vector<HIR::Expr *> &arguments,
-				  Location expr_locus);
+  tree get_fn_addr_from_dyn (const TyTy::DynamicObjectType *dyn,
+			     TyTy::BaseType *receiver, TyTy::FnType *fntype,
+			     tree receiver_ref, Location expr_locus);
+
+  tree get_receiver_from_dyn (const TyTy::DynamicObjectType *dyn,
+			      TyTy::BaseType *receiver, TyTy::FnType *fntype,
+			      tree receiver_ref, Location expr_locus);
 
   tree resolve_method_address (TyTy::FnType *fntype, HirId ref,
 			       TyTy::BaseType *receiver,

--- a/gcc/rust/backend/rust-compile-type.cc
+++ b/gcc/rust/backend/rust-compile-type.cc
@@ -532,25 +532,19 @@ TyTyResolveCompile::visit (const TyTy::DynamicObjectType &type)
 
   tree uint = ctx->get_backend ()->integer_type (
     true, ctx->get_backend ()->get_pointer_size ());
-  tree uintptr_ty = ctx->get_backend ()->pointer_type (uint);
+  tree uintptr_ty = build_pointer_type (uint);
 
-  Backend::typed_identifier f ("__receiver_trait_obj_ptr", uintptr_ty,
+  Backend::typed_identifier f ("pointer", uintptr_ty,
 			       ctx->get_mappings ()->lookup_location (
 				 type.get_ty_ref ()));
   fields.push_back (std::move (f));
 
-  for (size_t i = 0; i < items.size (); i++)
-    {
-      // mrustc seems to make a vtable consisting of uintptr's
-      tree uint = ctx->get_backend ()->integer_type (
-	true, ctx->get_backend ()->get_pointer_size ());
-      tree uintptr_ty = ctx->get_backend ()->pointer_type (uint);
-
-      Backend::typed_identifier f ("__" + std::to_string (i), uintptr_ty,
-				   ctx->get_mappings ()->lookup_location (
-				     type.get_ty_ref ()));
-      fields.push_back (std::move (f));
-    }
+  tree vtable_size = build_int_cst (size_type_node, items.size ());
+  tree vtable_type = ctx->get_backend ()->array_type (uintptr_ty, vtable_size);
+  Backend::typed_identifier vtf ("vtable", vtable_type,
+				 ctx->get_mappings ()->lookup_location (
+				   type.get_ty_ref ()));
+  fields.push_back (std::move (vtf));
 
   tree type_record = ctx->get_backend ()->struct_type (fields);
   tree named_struct


### PR DESCRIPTION
OBJ_TYPE_REF's are the gcc nodes that signify that this is a virtual call
which gives a hint to the optimizers for devirtualization. This patch also enhaces
the dyn object to hold an array of pointers instead of multiple name fields of addresses.

Fixes #996