### PR TITLE
Allow match on boolean expressions

### DIFF
--- a/gcc/rust/backend/rust-compile-pattern.cc
+++ b/gcc/rust/backend/rust-compile-pattern.cc
@@ -80,6 +80,20 @@ CompilePatternCaseLabelExpr::visit (HIR::WildcardPattern &pattern)
     = build_case_label (NULL_TREE, NULL_TREE, associated_case_label);
 }
 
+void
+CompilePatternCaseLabelExpr::visit (HIR::LiteralPattern &pattern)
+{
+  // Compile the literal
+  HIR::LiteralExpr *litexpr
+    = new HIR::LiteralExpr (pattern.get_pattern_mappings (),
+			    pattern.get_literal (), pattern.get_locus (),
+			    std::vector<AST::Attribute> ());
+
+  tree lit = CompileExpr::Compile (litexpr, ctx);
+
+  case_label_expr = build_case_label (lit, NULL_TREE, associated_case_label);
+}
+
 // setup the bindings
 
 void

--- a/gcc/rust/backend/rust-compile-pattern.h
+++ b/gcc/rust/backend/rust-compile-pattern.h
@@ -41,7 +41,7 @@ public:
   // Empty visit for unused Pattern HIR nodes.
   void visit (HIR::GroupedPattern &) override {}
   void visit (HIR::IdentifierPattern &) override {}
-  void visit (HIR::LiteralPattern &) override {}
+  void visit (HIR::LiteralPattern &) override;
   void visit (HIR::QualifiedPathInExpression &) override {}
   void visit (HIR::RangePattern &) override {}
   void visit (HIR::ReferencePattern &) override {}

--- a/gcc/testsuite/rust/execute/torture/match_bool1.rs
+++ b/gcc/testsuite/rust/execute/torture/match_bool1.rs
@@ -1,0 +1,44 @@
+// { dg-output "182 is more than 100\n55 is less than 100\n" }
+
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+fn foo (x: bool) -> i32 {
+    match x {
+        true => { return 182; },
+        false => { return 55; },
+    }
+}
+
+fn bar (y: i32) {
+
+    match y < 100 {
+        true => {
+            let a = "%i is less than 100\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf (c, y);
+        }
+        _ => {
+            let a = "%i is more than 100\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf (c, y);
+        }
+    }
+}
+
+
+fn main () -> i32 {
+
+    let a = foo (true);
+    let b = foo (false);
+
+    bar (a);
+    bar (b);
+
+    0
+}


### PR DESCRIPTION
Enables compiling `match` expressions where the scrutinee is a boolean expression. Also enable compiling match arms with Literal patterns, since `true` and `false` literals are commonly used with matches on boolean expressions.

Fixes: #1207 