### PR TITLE
Preserve inside_loop context when type checking match

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -1027,7 +1027,7 @@ public:
 
 	// check the kase type
 	TyTy::BaseType *kase_block_ty
-	  = TypeCheckExpr::Resolve (kase.get_expr ().get (), false);
+	  = TypeCheckExpr::Resolve (kase.get_expr ().get (), inside_loop);
 	kase_block_tys.push_back (kase_block_ty);
       }
 

--- a/gcc/testsuite/rust/execute/torture/match_loop1.rs
+++ b/gcc/testsuite/rust/execute/torture/match_loop1.rs
@@ -1,0 +1,51 @@
+// { dg-output "E::One\nE::Two\nbreak!\n" }
+
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+enum E {
+    One,
+    Two,
+    Other
+}
+
+fn foo () {
+    let mut x = E::One;
+
+    loop {
+        match x {
+            E::One => {
+                let a = "E::One\n\0";
+                let b = a as *const str;
+                let c = b as *const i8;
+                printf (c);
+
+                x = E::Two;
+            }
+            E::Two => {
+                let a = "E::Two\n\0";
+                let b = a as *const str;
+                let c = b as *const i8;
+                printf (c);
+
+                x = E::Other;
+            }
+            _ => {
+                let a = "break!\n\0";
+                let b = a as *const str;
+                let c = b as *const i8;
+                printf (c);
+
+                break;
+            }
+        }
+    }
+}
+
+
+fn main () -> i32 {
+    foo ();
+
+    0
+}


### PR DESCRIPTION
Previously, we would lose the context of being inside a loop when compiling a `match`.
This would lead to incorrect error messages like "cannot 'break' outside of a loop" when
trying to break out of a loop from within a `match` expression.

Fixes: #1196 
