### PR TITLE
Replace SSH cloning with HTTPS cloning in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ apt install build-essential libgmp3-dev libmpfr-dev libmpc-dev flex bison auto
 Clone the repository
 
 ```bash
-$ git clone git@github.com:Rust-GCC/gccrs.git
+$ git clone https://github.com/Rust-GCC/gccrs
 ```
 
 #### Linux


### PR DESCRIPTION
HTTPS cloning is the standard across many projects as well as being simpler and more beginner-friendly.

Signed-off-by: Maximilian Downey Twiss <creatorsmithmdt@gmail.com>