### PR TITLE
Destructure our generics, placeholers or projections during coercion

### DIFF
--- a/gcc/rust/backend/rust-compile-base.h
+++ b/gcc/rust/backend/rust-compile-base.h
@@ -40,8 +40,8 @@ protected:
 protected:
   Context *get_context () { return ctx; }
 
-  tree coercion_site (tree rvalue, TyTy::BaseType *actual,
-		      TyTy::BaseType *expected, Location lvalue_locus,
+  tree coercion_site (tree rvalue, const TyTy::BaseType *actual,
+		      const TyTy::BaseType *expected, Location lvalue_locus,
 		      Location rvalue_locus);
 
   tree coerce_to_dyn_object (tree compiled_ref, const TyTy::BaseType *actual,

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -198,12 +198,15 @@ CompileStructExprField::visit (HIR::StructExprFieldIdentifier &field)
 // Shared methods in compilation
 
 tree
-HIRCompileBase::coercion_site (tree rvalue, TyTy::BaseType *actual,
-			       TyTy::BaseType *expected, Location lvalue_locus,
-			       Location rvalue_locus)
+HIRCompileBase::coercion_site (tree rvalue, const TyTy::BaseType *rval,
+			       const TyTy::BaseType *lval,
+			       Location lvalue_locus, Location rvalue_locus)
 {
   if (rvalue == error_mark_node)
     return error_mark_node;
+
+  const TyTy::BaseType *actual = rval->destructure ();
+  const TyTy::BaseType *expected = lval->destructure ();
 
   if (expected->get_kind () == TyTy::TypeKind::REF)
     {
@@ -211,8 +214,10 @@ HIRCompileBase::coercion_site (tree rvalue, TyTy::BaseType *actual,
       if (actual->get_kind () != TyTy::TypeKind::REF)
 	return error_mark_node;
 
-      TyTy::ReferenceType *exp = static_cast<TyTy::ReferenceType *> (expected);
-      TyTy::ReferenceType *act = static_cast<TyTy::ReferenceType *> (actual);
+      const TyTy::ReferenceType *exp
+	= static_cast<const TyTy::ReferenceType *> (expected);
+      const TyTy::ReferenceType *act
+	= static_cast<const TyTy::ReferenceType *> (actual);
 
       tree expected_type = TyTyResolveCompile::compile (ctx, act->get_base ());
       tree deref_rvalue
@@ -235,20 +240,22 @@ HIRCompileBase::coercion_site (tree rvalue, TyTy::BaseType *actual,
       if (!valid_coercion)
 	return error_mark_node;
 
-      TyTy::ReferenceType *exp = static_cast<TyTy::ReferenceType *> (expected);
+      const TyTy::ReferenceType *exp
+	= static_cast<const TyTy::ReferenceType *> (expected);
 
       TyTy::BaseType *actual_base = nullptr;
       tree expected_type = error_mark_node;
       if (actual->get_kind () == TyTy::TypeKind::REF)
 	{
-	  TyTy::ReferenceType *act
-	    = static_cast<TyTy::ReferenceType *> (actual);
+	  const TyTy::ReferenceType *act
+	    = static_cast<const TyTy::ReferenceType *> (actual);
 	  actual_base = act->get_base ();
 	  expected_type = TyTyResolveCompile::compile (ctx, act->get_base ());
 	}
       else if (actual->get_kind () == TyTy::TypeKind::POINTER)
 	{
-	  TyTy::PointerType *act = static_cast<TyTy::PointerType *> (actual);
+	  const TyTy::PointerType *act
+	    = static_cast<const TyTy::PointerType *> (actual);
 	  actual_base = act->get_base ();
 	  expected_type = TyTyResolveCompile::compile (ctx, act->get_base ());
 	}

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -229,6 +229,38 @@ BaseType::get_root () const
   return root;
 }
 
+const BaseType *
+BaseType::destructure () const
+{
+  switch (get_kind ())
+    {
+      case TyTy::TypeKind::PARAM: {
+	const TyTy::ParamType *p = static_cast<const TyTy::ParamType *> (this);
+	return p->resolve ();
+      }
+      break;
+
+      case TyTy::TypeKind::PLACEHOLDER: {
+	const TyTy::PlaceholderType *p
+	  = static_cast<const TyTy::PlaceholderType *> (this);
+	rust_assert (p->can_resolve ());
+	return p->resolve ();
+      }
+      break;
+
+      case TyTy::TypeKind::PROJECTION: {
+	const TyTy::ProjectionType *p
+	  = static_cast<const TyTy::ProjectionType *> (this);
+	return p->get ();
+      }
+
+    default:
+      return this;
+    }
+
+  return this;
+}
+
 TyVar::TyVar (HirId ref) : ref (ref)
 {
   // ensure this reference is defined within the context

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -253,7 +253,12 @@ public:
 		debug_str ().c_str ());
   }
 
+  // FIXME this will eventually go away
   const BaseType *get_root () const;
+
+  // This will get the monomorphized type from Params, Placeholders or
+  // Projections if available or error
+  const BaseType *destructure () const;
 
   const RustIdent &get_ident () const { return ident; }
 


### PR DESCRIPTION
When we coerce types we need to destructure from the generics in order to
apply these coercion rules correctly or we end up returning a bad
error_mark_node.

This was found while fixing https://github.com/Rust-GCC/gccrs/pull/1220