### PR TITLE
macros: Error out when repeating metavars which refer to repetitions

### DIFF
--- a/gcc/rust/expand/rust-macro-substitute-ctx.cc
+++ b/gcc/rust/expand/rust-macro-substitute-ctx.cc
@@ -16,6 +16,21 @@ SubstituteCtx::substitute_metavar (std::unique_ptr<AST::Token> &metavar)
     }
   else
     {
+      // If we are expanding a metavar which has a lof of matches, we are
+      // currently expanding a repetition metavar - not a simple metavar. We
+      // need to error out and inform the user.
+      // Associated test case for an example: compile/macro-issue1224.rs
+      if (it->second.get_match_amount () != 1)
+	{
+	  rust_error_at (metavar->get_locus (),
+			 "metavariable is still repeating at this depth");
+	  rust_inform (
+	    metavar->get_locus (),
+	    "you probably forgot the repetition operator: %<%s%s%s%>", "$(",
+	    metavar->as_string ().c_str (), ")*");
+	  return expanded;
+	}
+
       // We only care about the vector when expanding repetitions.
       // Just access the first element of the vector.
       auto &frag = it->second.get_single_fragment ();

--- a/gcc/testsuite/rust/compile/macro-issue1224.rs
+++ b/gcc/testsuite/rust/compile/macro-issue1224.rs
@@ -1,0 +1,9 @@
+macro_rules! impl_uint {
+    ($($ty:ident),*) => {
+        impl $ty {} // { dg-error "metavariable is still repeating at this depth" }
+                    // { dg-error "unrecognised token" "" { target *-*-* } .-1 } // Spurious
+                    // { dg-error "could not parse type" "" { target *-*-* } .-2 } // Spurious
+    };
+}
+
+impl_uint!(u8, u16, u32, u64, u128);


### PR DESCRIPTION
In the case were a repeting metavar was used as a regular metavar ($var
instead of $($var)* for example), the compiler would crash on an
assertion that $var was only repeating once. We should instead error out
and point to the user that this is probably not what they intended to
do.

Some spurious errors are emitted, but improving them requires a major refactor of the SubstitutionContext file to report error states before.

Closes #1224 

Thanks to @bjorn3 for pointing this out.