### PR TITLE
Fix match tests on 32bit systems

### DIFF
--- a/gcc/testsuite/rust/execute/torture/match1.rs
+++ b/gcc/testsuite/rust/execute/torture/match1.rs
@@ -7,7 +7,7 @@ enum Foo {
     A,
     B,
     C(char),
-    D { x: i64, y: i64 },
+    D { x: i32, y: i32 },
 }
 
 fn inspect(f: Foo) {

--- a/gcc/testsuite/rust/execute/torture/match3.rs
+++ b/gcc/testsuite/rust/execute/torture/match3.rs
@@ -7,7 +7,7 @@ enum Foo {
     A,
     B,
     C(char),
-    D { x: i64, y: i64 },
+    D { x: i32, y: i32 },
 }
 
 fn inspect(f: Foo) {


### PR DESCRIPTION
Printing i64's on 32bit systems requires the proper format specifier
this amends these testcases to 32bit integers so %i works as expected.
I was able to use gdb to verify that these values are computed properly
from the structure.
