### PR TITLE
Assigning members to structures is a coercion site

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-struct.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-struct.cc
@@ -44,7 +44,7 @@ TypeCheckStructExpr::visit (HIR::StructExprStructFields &struct_expr)
 	= TypeCheckExpr::Resolve (struct_expr.struct_base->base_struct.get (),
 				  false);
       struct_def
-	= (TyTy::ADTType *) struct_path_resolved->unify (base_resolved);
+	= (TyTy::ADTType *) struct_path_resolved->coerce (base_resolved);
       if (struct_def == nullptr)
 	{
 	  rust_fatal_error (struct_expr.struct_base->base_struct->get_locus (),
@@ -222,7 +222,7 @@ TypeCheckStructExpr::visit (HIR::StructExprFieldIdentifierValue &field)
     }
 
   TyTy::BaseType *value = TypeCheckExpr::Resolve (field.get_value (), false);
-  resolved_field_value_expr = field_type->get_field_type ()->unify (value);
+  resolved_field_value_expr = field_type->get_field_type ()->coerce (value);
   if (resolved_field_value_expr != nullptr)
     {
       fields_assigned.insert (field.field_name);
@@ -251,7 +251,7 @@ TypeCheckStructExpr::visit (HIR::StructExprFieldIndexValue &field)
     }
 
   TyTy::BaseType *value = TypeCheckExpr::Resolve (field.get_value (), false);
-  resolved_field_value_expr = field_type->get_field_type ()->unify (value);
+  resolved_field_value_expr = field_type->get_field_type ()->coerce (value);
   if (resolved_field_value_expr != nullptr)
     {
       fields_assigned.insert (field_name);
@@ -285,7 +285,7 @@ TypeCheckStructExpr::visit (HIR::StructExprFieldIdentifier &field)
 			    field.get_locus ());
   TyTy::BaseType *value = TypeCheckExpr::Resolve (&expr, false);
 
-  resolved_field_value_expr = field_type->get_field_type ()->unify (value);
+  resolved_field_value_expr = field_type->get_field_type ()->coerce (value);
   if (resolved_field_value_expr != nullptr)
 
     {

--- a/gcc/testsuite/rust/compile/issue-1235.rs
+++ b/gcc/testsuite/rust/compile/issue-1235.rs
@@ -1,0 +1,21 @@
+// { dg-additional-options "-w" }
+struct FatPtr<T> {
+    data: *const T,
+    len: usize,
+}
+
+pub union Repr<T> {
+    rust: *const [T],
+    rust_mut: *mut [T],
+    raw: FatPtr<T>,
+}
+
+impl<T> [T] {
+    pub const fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub const fn len(&self) -> usize {
+        unsafe { Repr { rust: self }.raw.len }
+    }
+}


### PR DESCRIPTION
Fix missing coercion site call which allows the coecion of a reference to
a pointer type.

Fixes #1235
