### PR TITLE
Change Artihmetic Operation to be a cast type operation

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -555,7 +555,17 @@ public:
 	return;
       }
 
-    infered = lhs->unify (rhs);
+    switch (expr.get_expr_type ())
+      {
+      case ArithmeticOrLogicalOperator::LEFT_SHIFT:
+      case ArithmeticOrLogicalOperator::RIGHT_SHIFT:
+	infered = rhs->cast (lhs);
+	break;
+
+      default:
+	infered = lhs->unify (rhs);
+	break;
+      }
   }
 
   void visit (HIR::ComparisonExpr &expr) override

--- a/gcc/testsuite/rust/compile/issue-1234.rs
+++ b/gcc/testsuite/rust/compile/issue-1234.rs
@@ -1,0 +1,4 @@
+fn foo() -> u8 {
+    // { dg-warning "function is never used" "" { target *-*-* } .-1 }
+    1u8 << 2u32
+}


### PR DESCRIPTION
Arithmetic operations like this need a cast to support the range of integer
types which are allow here.

Fixes #1234
