### PR TITLE
Implement name resolution for the IfLet expression.

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-expr.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.cc
@@ -199,6 +199,31 @@ ResolveExpr::visit (AST::IfExprConseqIf &expr)
 }
 
 void
+ResolveExpr::visit (AST::IfLetExpr &expr)
+{
+  resolve_expr (expr.get_value_expr ().get (), expr.get_node_id ());
+
+  NodeId scope_node_id = expr.get_node_id ();
+  resolver->get_name_scope ().push (scope_node_id);
+  resolver->get_type_scope ().push (scope_node_id);
+  resolver->get_label_scope ().push (scope_node_id);
+  resolver->push_new_name_rib (resolver->get_name_scope ().peek ());
+  resolver->push_new_type_rib (resolver->get_type_scope ().peek ());
+  resolver->push_new_label_rib (resolver->get_type_scope ().peek ());
+
+  for (auto &pattern : expr.get_patterns ())
+    {
+      PatternDeclaration::go (pattern.get (), expr.get_node_id ());
+    }
+
+  resolve_expr (expr.get_if_block ().get (), expr.get_node_id ());
+
+  resolver->get_name_scope ().pop ();
+  resolver->get_type_scope ().pop ();
+  resolver->get_label_scope ().pop ();
+}
+
+void
 ResolveExpr::visit (AST::BlockExpr &expr)
 {
   NodeId scope_node_id = expr.get_node_id ();

--- a/gcc/rust/resolve/rust-ast-resolve-expr.h
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.h
@@ -69,6 +69,8 @@ public:
 
   void visit (AST::IfExprConseqIf &expr) override;
 
+  void visit (AST::IfLetExpr &expr) override;
+
   void visit (AST::BlockExpr &expr) override;
 
   void visit (AST::UnsafeBlockExpr &expr) override;


### PR DESCRIPTION
Addresses #1177.

Guidance from the ticket #1177:

> You should be able to copy how we do name resolution for the if blocks from that file. Though if let statements add a new binding and scope level so you need to declare the pattern so you should be able to see how that is done from rust-ast-resolve-stmt.

I don't understand how to modify the block expression resolution so that it can handle the `IfLet` expression. For now, I copied the code from the `MatchExpr` resolution. Not sure how to test it either and what is the desired expected result of the name resolution so I just hope that reviewers will spot the errors.

I created this PR in order to get some guidance about how to proceed with it. Thanks!

