### PR TITLE
Remove undefined behavior in context vector

### DIFF
--- a/gcc/rust/expand/rust-attribute-visitor.cc
+++ b/gcc/rust/expand/rust-attribute-visitor.cc
@@ -1193,7 +1193,6 @@ AttrVisitor::visit (AST::BlockExpr &expr)
   if (expander.fails_cfg_with_expand (expr.get_outer_attrs ()))
     {
       expr.mark_for_strip ();
-      expander.pop_context ();
       return;
     }
 
@@ -1203,7 +1202,6 @@ AttrVisitor::visit (AST::BlockExpr &expr)
   if (expander.fails_cfg_with_expand (expr.get_inner_attrs ()))
     {
       expr.mark_for_strip ();
-      expander.pop_context ();
       return;
     }
 

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -275,8 +275,11 @@ struct MacroExpander
 
   ContextType pop_context ()
   {
+    rust_assert (!context.empty ());
+
     ContextType t = context.back ();
     context.pop_back ();
+
     return t;
   }
 

--- a/gcc/testsuite/rust/compile/macro-issue1233.rs
+++ b/gcc/testsuite/rust/compile/macro-issue1233.rs
@@ -1,0 +1,22 @@
+// { dg-additional-options "-w" }
+
+macro_rules! impl_uint {
+    ($($ty:ident = $lang:literal),*) => {
+        $(
+            impl $ty {
+                pub fn to_le(self) -> Self {
+                    #[cfg(not(target_endian = "little"))]
+                    {
+                        self
+                    }
+                    #[cfg(target_endian = "little")]
+                    {
+                        self
+                    }
+                }
+            }
+        )*
+    }
+}
+
+impl_uint!(u8 = "u8", u16 = "u16", u32 = "u32");


### PR DESCRIPTION
This also fixes the undefined behavior. Once again we are hurt by
`std::vector<T>::back()` returning references and not
pointers/`std::optional<T>`s!

The cause of the bug was some overzealous popping from the context
vector in block expressions. The amount of calls to `pop_context` is now
the same as the amount of calls to `push_context`

Closes #1233 