### PR TITLE
Allow cast of integers to pointers

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -903,7 +903,6 @@ CompileExpr::compile_integer_literal (const HIR::LiteralExpr &expr,
   const auto literal_value = expr.get_literal ();
 
   tree type = TyTyResolveCompile::compile (ctx, tyty);
-  rust_assert (TREE_CODE (type) == INTEGER_TYPE);
 
   mpz_t ival;
   if (mpz_init_set_str (ival, literal_value.as_string ().c_str (), 10) != 0)

--- a/gcc/rust/backend/rust-constexpr.cc
+++ b/gcc/rust/backend/rust-constexpr.cc
@@ -59,17 +59,7 @@ ConstCtx::constexpr_expression (tree t)
     {
       if (TREE_OVERFLOW (t))
 	{
-	  rust_error_at (Location (loc), "overflow in constant expression");
-	  return t;
-	}
-
-      if (TREE_CODE (t) == INTEGER_CST && TYPE_PTR_P (TREE_TYPE (t))
-	  && !integer_zerop (t))
-	{
-	  // FIXME check does this actually work to print out tree types
-	  rust_error_at (Location (loc),
-			 "value %qE of type %qT is not a constant expression",
-			 t, TREE_TYPE (t));
+	  error_at (loc, "overflow in constant expression");
 	  return t;
 	}
 

--- a/gcc/rust/typecheck/rust-tyty-cast.h
+++ b/gcc/rust/typecheck/rust-tyty-cast.h
@@ -588,8 +588,11 @@ public:
 
   void visit (PointerType &type) override
   {
-    bool is_valid
-      = (base->get_infer_kind () == TyTy::InferType::InferTypeKind::GENERAL);
+    bool is_general_infer_var
+      = base->get_infer_kind () == TyTy::InferType::InferTypeKind::GENERAL;
+    bool is_integral_infer_var
+      = base->get_infer_kind () == TyTy::InferType::InferTypeKind::INTEGRAL;
+    bool is_valid = is_general_infer_var || is_integral_infer_var;
     if (is_valid)
       {
 	resolved = type.clone ();
@@ -939,6 +942,8 @@ public:
 
   void visit (ISizeType &type) override { resolved = type.clone (); }
 
+  void visit (PointerType &type) override { resolved = type.clone (); }
+
 private:
   BaseType *get_base () override { return base; }
 
@@ -974,6 +979,8 @@ public:
   void visit (USizeType &type) override { resolved = type.clone (); }
 
   void visit (ISizeType &type) override { resolved = type.clone (); }
+
+  void visit (PointerType &type) override { resolved = type.clone (); }
 
   void visit (CharType &type) override
   {

--- a/gcc/testsuite/rust/compile/issue-1226.rs
+++ b/gcc/testsuite/rust/compile/issue-1226.rs
@@ -1,0 +1,6 @@
+// { dg-additional-options "-w" }
+const TEST: *mut u8 = 123 as *mut u8;
+
+fn test() {
+    let a = TEST;
+}


### PR DESCRIPTION
This adds the cast rules of integer types and integer inference variables
to pointers. The code-generation needed to remove the bad assertion that
all integer literals were always going to be of type integer. This also
needed a tweak to a bad port from the cp/constexpr.cc code which assumed
that all integer_cst of pointer types would be a zero pointer which was
used to detect cases of bad method pointers in CPP which we does not apply
here.

see gcc/cp/constexpr.cc:6564-6488

Fixes #1226