### PR TITLE
Allow match on integer and char types

### DIFF
--- a/gcc/rust/backend/rust-compile-pattern.cc
+++ b/gcc/rust/backend/rust-compile-pattern.cc
@@ -89,6 +89,17 @@ CompilePatternCaseLabelExpr::visit (HIR::LiteralPattern &pattern)
 			    pattern.get_literal (), pattern.get_locus (),
 			    std::vector<AST::Attribute> ());
 
+  // Note: Floating point literals are currently accepted but will likely be
+  // forbidden in LiteralPatterns in a future version of Rust.
+  // See: https://github.com/rust-lang/rust/issues/41620
+  // For now, we cannot compile them anyway as CASE_LABEL_EXPR does not support
+  // floating point types.
+  if (pattern.get_literal ().get_lit_type () == HIR::Literal::LitType::FLOAT)
+    {
+      sorry_at (pattern.get_locus ().gcc_location (),
+		"floating-point literal in pattern");
+    }
+
   tree lit = CompileExpr::Compile (litexpr, ctx);
 
   case_label_expr = build_case_label (lit, NULL_TREE, associated_case_label);

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -114,6 +114,26 @@ TypeKindFormat::to_string (TypeKind kind)
 }
 
 bool
+is_primitive_type_kind (TypeKind kind)
+{
+  switch (kind)
+    {
+    case TypeKind::BOOL:
+    case TypeKind::CHAR:
+    case TypeKind::INT:
+    case TypeKind::UINT:
+    case TypeKind::ISIZE:
+    case TypeKind::USIZE:
+    case TypeKind::FLOAT:
+    case TypeKind::NEVER:
+    case TypeKind::STR:
+      return true;
+    default:
+      return false;
+    }
+}
+
+bool
 BaseType::satisfies_bound (const TypeBoundPredicate &predicate) const
 {
   const Resolver::TraitReference *query = predicate.get ();

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -67,6 +67,9 @@ enum TypeKind
   ERROR
 };
 
+extern bool
+is_primitive_type_kind (TypeKind kind);
+
 class TypeKindFormat
 {
 public:

--- a/gcc/testsuite/rust/execute/torture/match_byte1.rs
+++ b/gcc/testsuite/rust/execute/torture/match_byte1.rs
@@ -1,0 +1,49 @@
+// { dg-output "a\nseven\nquote\nelse" }
+
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+fn foo (x: u8) {
+    match x {
+        b'a' => {
+            let a = "a\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+            printf (c);
+        }
+
+        b'\x07' => {
+            let a = "seven\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+            printf (c);
+        }
+
+        b'\'' => {
+            let a = "quote\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+            printf (c);
+        }
+
+        _ => {
+            let a = "else\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+            printf (c);
+        }
+    }
+}
+
+fn main () -> i32 {
+
+    let x: u8 = 7;
+
+    foo (b'a');
+    foo (x);
+    foo (b'\'');
+    foo (b'\\');
+
+    0
+}

--- a/gcc/testsuite/rust/execute/torture/match_char1.rs
+++ b/gcc/testsuite/rust/execute/torture/match_char1.rs
@@ -1,0 +1,49 @@
+// { dg-output "amazing\nwildcard\ncompiler\nproductivity\n" }
+
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+fn foo (x: char) {
+    match x {
+        'a' => {
+            let a = "amazing\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+            printf (c);
+        }
+
+        'c' => {
+            let a = "compiler\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+            printf (c);
+        }
+
+        'p' => {
+            let a = "productivity\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+            printf (c);
+        }
+
+        _ => {
+            let a = "wildcard\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+            printf (c);
+        }
+    }
+}
+
+fn main () -> i32 {
+
+    let p = 'p';
+
+    foo ('a');
+    foo ('b');
+    foo ('c');
+    foo (p);
+
+    0
+}

--- a/gcc/testsuite/rust/execute/torture/match_int1.rs
+++ b/gcc/testsuite/rust/execute/torture/match_int1.rs
@@ -1,0 +1,94 @@
+// { dg-output "other!\nother!\nother!\nfifteen!\nfifteen!\nother!\nother!\nfifteen!\n" }
+
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+fn foo_i32 (x: i32) {
+    match x {
+        15 => {
+            let a = "fifteen!\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+            printf (c);
+        }
+
+        _ => {
+            let a = "other!\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+            printf (c);
+        }
+    }
+}
+
+fn foo_isize (x: isize) {
+    match x {
+        15 => {
+            let a = "fifteen!\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+            printf (c);
+        }
+
+        _ => {
+            let a = "other!\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+            printf (c);
+        }
+    }
+}
+
+fn foo_u32 (x: u32) {
+    match x {
+        15 => {
+            let a = "fifteen!\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+            printf (c);
+        }
+
+        _ => {
+            let a = "other!\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+            printf (c);
+        }
+    }
+}
+
+fn foo_usize (x: usize) {
+    match x {
+        15 => {
+            let a = "fifteen!\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+            printf (c);
+        }
+
+        _ => {
+            let a = "other!\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+            printf (c);
+        }
+    }
+}
+
+
+fn main () -> i32 {
+    let x = -2;
+    foo_i32 (x);
+    foo_i32 (334);
+    foo_isize (-4768);
+    foo_isize (15);
+
+    let y = 127;
+    foo_u32 (15);
+    foo_u32 (y);
+    foo_usize (2394);
+    foo_usize (15);
+
+    0
+}


### PR DESCRIPTION
Enable compiling match expressions on other primitive types like `i32`, `usize` and `char`.
