### PR TITLE
Support extern-blocks defined within blocks

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -94,6 +94,7 @@ GRS_OBJS = \
     rust/rust-ast-resolve-expr.o \
     rust/rust-ast-resolve-type.o \
     rust/rust-ast-resolve-path.o \
+    rust/rust-ast-resolve-stmt.o \
     rust/rust-hir-type-check.o \
     rust/rust-privacy-check.o \
     rust/rust-privacy-ctx.o \

--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -343,8 +343,12 @@ HIRCompileBase::compile_locals_for_block (Context *ctx, Resolver::Rib &rib,
       rust_assert (ok);
 
       HIR::Stmt *decl = nullptr;
-      ok = ctx->get_mappings ()->resolve_nodeid_to_stmt (d.parent, &decl);
-      rust_assert (ok);
+      if (!ctx->get_mappings ()->resolve_nodeid_to_stmt (d.parent, &decl))
+	{
+	  // might be an extern block see fix for
+	  // https://github.com/Rust-GCC/gccrs/issues/976
+	  continue;
+	}
 
       // if its a function we extract this out side of this fn context
       // and it is not a local to this function

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -23,8 +23,7 @@
 #include "rust-compile-expr.h"
 #include "rust-hir-trait-resolve.h"
 #include "rust-hir-path-probe.h"
-
-#include "print-tree.h"
+#include "rust-compile-extern.h"
 
 namespace Rust {
 namespace Compile {
@@ -172,7 +171,11 @@ HIRCompileBase::query_compile (HirId ref, TyTy::BaseType *lookup,
 {
   HIR::Item *resolved_item
     = ctx->get_mappings ()->lookup_hir_item (mappings.get_crate_num (), ref);
+  HIR::ExternalItem *resolved_extern_item
+    = ctx->get_mappings ()->lookup_hir_extern_item (mappings.get_crate_num (),
+						    ref);
   bool is_hir_item = resolved_item != nullptr;
+  bool is_hir_extern_item = resolved_extern_item != nullptr;
   if (is_hir_item)
     {
       if (!lookup->has_subsititions_defined ())
@@ -181,6 +184,15 @@ HIRCompileBase::query_compile (HirId ref, TyTy::BaseType *lookup,
       else
 	return CompileItem::compile (resolved_item, ctx, lookup, true,
 				     expr_locus);
+    }
+  else if (is_hir_extern_item)
+    {
+      if (!lookup->has_subsititions_defined ())
+	return CompileExternItem::compile (resolved_extern_item, ctx, nullptr,
+					   true, expr_locus);
+      else
+	return CompileExternItem::compile (resolved_extern_item, ctx, lookup,
+					   true, expr_locus);
     }
   else
     {

--- a/gcc/rust/hir/rust-ast-lower-base.h
+++ b/gcc/rust/hir/rust-ast-lower-base.h
@@ -286,6 +286,8 @@ protected:
   lower_range_pattern_bound (AST::RangePatternBound *bound);
 
   HIR::Literal lower_literal (const AST::Literal &literal);
+
+  HIR::ExternBlock *lower_extern_block (AST::ExternBlock &extern_block);
 };
 
 } // namespace HIR

--- a/gcc/rust/hir/rust-ast-lower-stmt.h
+++ b/gcc/rust/hir/rust-ast-lower-stmt.h
@@ -437,6 +437,11 @@ public:
     translated = fn;
   }
 
+  void visit (AST::ExternBlock &extern_block) override
+  {
+    translated = lower_extern_block (extern_block);
+  }
+
 private:
   ASTLoweringStmt () : translated (nullptr), terminated (false) {}
 

--- a/gcc/rust/resolve/rust-ast-resolve-stmt.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-stmt.cc
@@ -1,0 +1,38 @@
+// Copyright (C) 2020-2022 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-ast-resolve-item.h"
+#include "rust-ast-resolve-stmt.h"
+
+namespace Rust {
+namespace Resolver {
+
+void
+ResolveStmt::visit (AST::ExternBlock &extern_block)
+{
+  resolve_visibility (extern_block.get_visibility ());
+  for (auto &item : extern_block.get_extern_items ())
+    {
+      ResolveToplevelExternItem::go (item.get (),
+				     CanonicalPath::create_empty ());
+      ResolveExternItem::go (item.get ());
+    }
+}
+
+} // namespace Resolver
+} // namespace Rust

--- a/gcc/rust/resolve/rust-ast-resolve-stmt.h
+++ b/gcc/rust/resolve/rust-ast-resolve-stmt.h
@@ -406,6 +406,8 @@ public:
     resolver->get_label_scope ().pop ();
   }
 
+  void visit (AST::ExternBlock &extern_block) override;
+
 private:
   ResolveStmt (NodeId parent, const CanonicalPath &prefix,
 	       const CanonicalPath &canonical_prefix,

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.h
@@ -24,6 +24,7 @@
 #include "rust-hir-type-check-type.h"
 #include "rust-hir-type-check-expr.h"
 #include "rust-hir-type-check-enumitem.h"
+#include "rust-hir-type-check-implitem.h"
 
 namespace Rust {
 namespace Resolver {
@@ -54,6 +55,14 @@ public:
   {
     infered
       = TyTy::TupleType::get_unit_type (stmt.get_mappings ().get_hirid ());
+  }
+
+  void visit (HIR::ExternBlock &extern_block) override
+  {
+    for (auto &item : extern_block.get_extern_items ())
+      {
+	TypeCheckTopLevelExternItem::Resolve (item.get (), extern_block);
+      }
   }
 
   void visit (HIR::ConstantItem &constant) override

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -90,12 +90,7 @@ TypeCheckExpr::visit (HIR::BlockExpr &expr)
       if (!s->is_item ())
 	continue;
 
-      auto resolved = TypeCheckStmt::Resolve (s.get (), inside_loop);
-      if (resolved == nullptr)
-	{
-	  rust_error_at (s->get_locus (), "failure to resolve type");
-	  return;
-	}
+      TypeCheckStmt::Resolve (s.get (), inside_loop);
     }
 
   for (auto &s : expr.get_statements ())

--- a/gcc/testsuite/rust/execute/torture/issue-976.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-976.rs
@@ -1,0 +1,14 @@
+/* { dg-output "hi" } */
+fn main() -> i32 {
+    {
+        extern "C" {
+            fn puts(s: *const i8);
+        }
+
+        unsafe {
+            puts("hi\0" as *const str as *const i8);
+        }
+    }
+
+    0
+}


### PR DESCRIPTION
This adds support for declaring extern blocks within blocks. So this adds
the missing name resolution visitor for the statement context. Then we
extract out a common extern block hir lowering function for both contexts.

The type resolution step needs to be updated to be like the code-generation
step so that we can solve these paths in a query rather than a top-down
approach but this is a known issue.

The final step was to support query-based compilation to extern functions.

Fixes #976