### PR TITLE
privacy: Handle calls to functions defined in previous ancestors

### DIFF
--- a/gcc/testsuite/rust/compile/privacy2.rs
+++ b/gcc/testsuite/rust/compile/privacy2.rs
@@ -1,0 +1,13 @@
+// { dg-additional-options "-w" }
+
+mod orange {
+    fn tangerine() {}
+
+    mod green {
+        mod blue {
+            fn berry() {
+                tangerine();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Previously, we would only check if `current_module` was a direct
descendant of the item's module. However, we also need to visit each of this
item's module's children recursively.
