### PR TITLE
issue #1233: Do not rely on the endianness for testing

### DIFF
--- a/gcc/testsuite/rust/compile/macro-issue1233.rs
+++ b/gcc/testsuite/rust/compile/macro-issue1233.rs
@@ -1,15 +1,15 @@
-// { dg-additional-options "-w" }
+// { dg-additional-options "-frust-cfg=A -w" }
 
 macro_rules! impl_uint {
     ($($ty:ident = $lang:literal),*) => {
         $(
             impl $ty {
                 pub fn to_le(self) -> Self {
-                    #[cfg(not(target_endian = "little"))]
+                    #[cfg(not(A))]
                     {
                         self
                     }
-                    #[cfg(target_endian = "little")]
+                    #[cfg(A)]
                     {
                         self
                     }


### PR DESCRIPTION
This testcase uncovered a very interesting bug requiring a refactor of
our `AST::Block` class (#1253), but should still be fixed/adapted in the
meantime so that the BE builds on our buildbot do not fail.

I've tested this newtestcase with a compiler from 74e836599ce80a11b1fe28065ed7aae6ffa3b7e2, which was the commit pointed out in #1233. The same ICE would still trigger, so I can safely say that this is a different exemple showing the same underlying issue. I'll work on fixing #1253 but it is a refactor we need to think about a little.

This should make all the architectures on buildbot happy again!