### PR TITLE
Privacy report expressions

### DIFF
--- a/gcc/testsuite/rust/compile/privacy3.rs
+++ b/gcc/testsuite/rust/compile/privacy3.rs
@@ -1,0 +1,28 @@
+mod orange {
+    mod green {
+        fn sain_void() {}
+        fn sain() -> bool {
+            false
+        }
+        pub fn doux() {}
+    }
+
+    fn brown() {
+        if green::sain() {
+            // { dg-error "definition is private in this context" "" { target *-*-* } .-1 }
+            green::doux();
+        }
+
+        {
+            green::sain();
+            // { dg-error "definition is private in this context" "" { target *-*-* } .-1 }
+            green::sain();
+            // { dg-error "definition is private in this context" "" { target *-*-* } .-1 }
+            green::sain_void()
+            // { dg-error "definition is private in this context" "" { target *-*-* } .-1 }
+        }
+
+        let a = green::sain();
+        // { dg-error "definition is private in this context" "" { target *-*-* } .-1 }
+    }
+}

--- a/gcc/testsuite/rust/compile/privacy4.rs
+++ b/gcc/testsuite/rust/compile/privacy4.rs
@@ -1,0 +1,19 @@
+mod orange {
+    mod green {
+        fn bean<T>(value: T) -> T {
+            value
+        }
+    }
+
+    fn brown() {
+        green::bean::<bool>(false);
+        // { dg-error "definition is private in this context" "" { target *-*-* } .-1 }
+        let a = green::bean::<i32>(15);
+        // { dg-error "definition is private in this context" "" { target *-*-* } .-1 }
+
+        struct S;
+
+        let s = green::bean(S);
+        // { dg-error "definition is private in this context" "" { target *-*-* } .-1 }
+    }
+}


### PR DESCRIPTION
This adds privacy reporting to all expression types inside our HIR. It also restricts the `PrivacyReporter` visitor to `HIR::Expression`s and `HIR::Stmt`s as a lot of the previous types did not need to be visited.