### PR TITLE
Make TyTy::BaseType::destructure recursive

### DIFF
--- a/gcc/rust/backend/rust-compile-type.cc
+++ b/gcc/rust/backend/rust-compile-type.cc
@@ -112,9 +112,15 @@ TyTyResolveCompile::visit (const TyTy::PlaceholderType &type)
 void
 TyTyResolveCompile::visit (const TyTy::ParamType &param)
 {
-  // FIXME make this reuse the same machinery from constexpr code
-  recursion_count++;
-  rust_assert (recursion_count < kDefaultRecusionLimit);
+  if (recurisve_ops++ >= rust_max_recursion_depth)
+    {
+      rust_error_at (Location (),
+		     "%<recursion depth%> count exceeds limit of %i (use "
+		     "%<frust-max-recursion-depth=%> to increase the limit)",
+		     rust_max_recursion_depth);
+      translated = error_mark_node;
+      return;
+    }
 
   param.resolve ()->accept_vis (*this);
 }

--- a/gcc/rust/backend/rust-compile-type.h
+++ b/gcc/rust/backend/rust-compile-type.h
@@ -63,16 +63,13 @@ public:
 private:
   TyTyResolveCompile (Context *ctx, bool trait_object_mode)
     : ctx (ctx), trait_object_mode (trait_object_mode),
-      translated (error_mark_node), recursion_count (0)
+      translated (error_mark_node), recurisve_ops (0)
   {}
 
   Context *ctx;
   bool trait_object_mode;
   tree translated;
-
-  // FIXME this needs to be derived from the gcc config option
-  size_t recursion_count;
-  static const size_t kDefaultRecusionLimit = 5;
+  int recurisve_ops;
 };
 
 } // namespace Compile

--- a/gcc/rust/lang.opt
+++ b/gcc/rust/lang.opt
@@ -66,6 +66,10 @@ frust-dump-
 Rust Joined RejectNegative
 -frust-dump-<type>	Dump Rust frontend internal information.
 
+frust-max-recursion-depth=
+Rust RejectNegative Type(int) Var(rust_max_recursion_depth) Init(64)
+-frust-max-recursion-depth=integer
+
 frust-mangling=
 Rust Joined RejectNegative Enum(frust_mangling) Var(flag_rust_mangling)
 -frust-mangling=[legacy|v0]     Choose which version to use for name mangling


### PR DESCRIPTION
In the case of Generic Associated Types we end up

  placeholders->projections->generic-param->i32

This means we need to keep destructuring the TyTy object until we finally
get the real type at the end. In order to do this safely we need to ensure
we add in recursion limits and apply this where it matters such as
compiling types in general too.
