### PR TITLE
Remove old hack to handle type inferencing in untyped decalred bindings

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -384,46 +384,7 @@ public:
     auto lhs = TypeCheckExpr::Resolve (expr.get_lhs (), false);
     auto rhs = TypeCheckExpr::Resolve (expr.get_rhs (), false);
 
-    auto result = lhs->coerce (rhs);
-    if (result->get_kind () == TyTy::TypeKind::ERROR)
-      return;
-
-    // in the case of declare first for an ADT Type:
-    //
-    // let a;
-    // a = Foo{..}
-    // let b = a.field;
-    //
-    // The lhs will have a TyTy of INFER and so when the declaration is
-    // referenced it will still have an unknown type so we will fail to resolve
-    // FieldAccessExpr
-
-    NodeId ast_node_id = expr.get_lhs ()->get_mappings ().get_nodeid ();
-    NodeId ref_node_id;
-    if (!resolver->lookup_resolved_name (ast_node_id, &ref_node_id))
-      return;
-
-    Definition def;
-    if (!resolver->lookup_definition (ref_node_id, &def))
-      {
-	rust_error_at (expr.get_locus (),
-		       "assignment infer - unknown reference");
-	return;
-      }
-
-    HirId ref;
-    if (!mappings->lookup_node_to_hir (expr.get_mappings ().get_crate_num (),
-				       def.parent, &ref))
-      {
-	rust_error_at (expr.get_locus (),
-		       "assignment infer - reverse lookup failure");
-	return;
-      }
-
-    context->insert_type (
-      Analysis::NodeMapping (expr.get_lhs ()->get_mappings ().get_crate_num (),
-			     ref_node_id, ref, UNKNOWN_LOCAL_DEFID),
-      result->clone ());
+    lhs->coerce (rhs);
   }
 
   void visit (HIR::CompoundAssignmentExpr &expr) override


### PR DESCRIPTION
This reverts the code fix for 89631998d2ffda0c0c05066c148c6fc19398da5c
but keeps the test-case proving that we have not regressed. More info in
the commit message.

Fixes #1274 #1273
