### PR TITLE
Wrapup testing code within CHECKING_P guards

### DIFF
--- a/gcc/rust/util/rust-optional-test.cc
+++ b/gcc/rust/util/rust-optional-test.cc
@@ -21,6 +21,8 @@
 #include "config.h"
 #include "selftest.h"
 
+#if CHECKING_P
+
 static void
 rust_optional_create ()
 {
@@ -93,12 +95,17 @@ rust_optional_reference ()
   ASSERT_EQ (opt->at (2), "gcc");
 }
 
+#endif /* #if CHECKING_P */
+
 void
 rust_optional_test ()
 {
+#if CHECKING_P
   rust_optional_create ();
   rust_optional_operators ();
   rust_optional_take ();
   rust_optional_map ();
   rust_optional_reference ();
+
+#endif /* #if CHECKING_P */
 }


### PR DESCRIPTION
I seem to be having build issues locally with missing ASSERT macros but works when they are wrapped in CHECKING_P guards.