### PR TITLE
Reuse index_expr_ty type

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -291,8 +291,7 @@ TypeCheckExpr::visit (HIR::ArrayIndexExpr &expr)
   bool ok = context->lookup_builtin ("usize", &size_ty);
   rust_assert (ok);
 
-  auto resolved_index_expr
-    = size_ty->unify (TypeCheckExpr::Resolve (expr.get_index_expr (), false));
+  auto resolved_index_expr = size_ty->unify (index_expr_ty);
   if (resolved_index_expr->get_kind () == TyTy::TypeKind::ERROR)
     return;
 


### PR DESCRIPTION
This is a small refactor to remove duplicating the work in type checking
the index expression.