### PR TITLE
Implement type checking for the `IfLet` expression.

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -3477,6 +3477,19 @@ public:
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRExpressionVisitor &vis) override;
 
+  std::unique_ptr<Expr> &get_scrutinee_expr ()
+  {
+    rust_assert (value != nullptr);
+    return value;
+  }
+
+  std::vector<std::unique_ptr<Pattern> > &get_patterns ()
+  {
+    return match_arm_patterns;
+  }
+
+  BlockExpr *get_if_block () { return if_block.get (); }
+
   ExprType get_expression_type () const final override
   {
     return ExprType::IfLet;


### PR DESCRIPTION
This change implements the type check for the `IfLet` expression. This is the adapted type checking code from the `MatchExpr`.

Tested on this code
```
enum E {
    X(u8),
}

fn main() -> i32 {
    let mut res = 0;
    let v = E::X(4);
    if let E::X(n) = v {
        res = n;
    }

    0
}
```
Compilation finishes without errors.

Next is the implementation of the code generation but I'll need help to find where it's located.

Addresses #192 #1177