### PR TITLE
Str's have the same layout as [T]

### DIFF
--- a/gcc/rust/backend/rust-compile-type.h
+++ b/gcc/rust/backend/rust-compile-type.h
@@ -62,6 +62,7 @@ public:
 
 protected:
   tree create_slice_type_record (const TyTy::SliceType &type);
+  tree create_str_type_record (const TyTy::StrType &type);
 
 private:
   TyTyResolveCompile (Context *ctx, bool trait_object_mode);

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -974,6 +974,26 @@ public:
     TyTy::BaseType *resolved_base
       = TypeCheckExpr::Resolve (expr.get_expr ().get (), false);
 
+    // In Rust this is valid because of DST's
+    //
+    // fn test() {
+    //     let a:&str = "TEST 1";
+    //     let b:&str = &"TEST 2";
+    // }
+    if (resolved_base->get_kind () == TyTy::TypeKind::REF)
+      {
+	const TyTy::ReferenceType *ref
+	  = static_cast<const TyTy::ReferenceType *> (resolved_base);
+
+	// this might end up being a more generic is_dyn object check but lets
+	// double check dyn traits type-layout first
+	if (ref->is_dyn_str_type ())
+	  {
+	    infered = resolved_base;
+	    return;
+	  }
+      }
+
     if (expr.get_is_double_borrow ())
       {
 	// FIXME double_reference

--- a/gcc/rust/typecheck/rust-tycheck-dump.h
+++ b/gcc/rust/typecheck/rust-tycheck-dump.h
@@ -98,6 +98,7 @@ public:
 
   void visit (HIR::BlockExpr &expr) override
   {
+    dump += "{\n";
     indentation_level++;
 
     for (auto &s : expr.get_statements ())
@@ -115,6 +116,13 @@ public:
       }
 
     indentation_level--;
+    dump += "}\n";
+  }
+
+  void visit (HIR::UnsafeBlockExpr &expr) override
+  {
+    dump += "unsafe ";
+    expr.get_block_expr ()->accept_vis (*this);
   }
 
   void visit (HIR::LetStmt &stmt) override

--- a/gcc/testsuite/rust/compile/issue-1023.rs
+++ b/gcc/testsuite/rust/compile/issue-1023.rs
@@ -1,0 +1,4 @@
+// { dg-additional-options "-w" }
+fn foo(e: &str) -> &str {
+    &""
+}

--- a/gcc/testsuite/rust/compile/issue-1271.rs
+++ b/gcc/testsuite/rust/compile/issue-1271.rs
@@ -1,0 +1,5 @@
+// { dg-additional-options "-w" }
+fn test() {
+    let a: &str = "TEST 1";
+    let b: &str = &"TEST 2";
+}

--- a/gcc/testsuite/rust/compile/xfail/slice1.rs
+++ b/gcc/testsuite/rust/compile/xfail/slice1.rs
@@ -1,5 +1,0 @@
-// { dg-additional-options "-w" }
-
-fn foo(e: &str) -> &str { // { dg-bogus "expected" "#391" { xfail *-*-* } }
-    &"" // { dg-bogus "expected" "#391" { xfail *-*-* } }
-}

--- a/gcc/testsuite/rust/execute/torture/str-layout1.rs
+++ b/gcc/testsuite/rust/execute/torture/str-layout1.rs
@@ -1,0 +1,56 @@
+// { dg-additional-options "-w" }
+// { dg-output "t1sz=5 t2sz=10" }
+mod mem {
+    extern "rust-intrinsic" {
+        fn transmute<T, U>(_: T) -> U;
+    }
+}
+
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+struct FatPtr<T> {
+    data: *const T,
+    len: usize,
+}
+
+pub union Repr<T> {
+    rust: *const [T],
+    rust_mut: *mut [T],
+    raw: FatPtr<T>,
+}
+
+impl<T> [T] {
+    pub const fn len(&self) -> usize {
+        unsafe { Repr { rust: self }.raw.len }
+    }
+}
+
+impl str {
+    pub const fn len(&self) -> usize {
+        self.as_bytes().len()
+    }
+
+    pub const fn as_bytes(&self) -> &[u8] {
+        unsafe { mem::transmute(self) }
+    }
+}
+
+fn main() -> i32 {
+    let t1: &str = "TEST1";
+    let t2: &str = &"TEST_12345";
+
+    let t1sz = t1.len();
+    let t2sz = t2.len();
+
+    unsafe {
+        let a = "t1sz=%i t2sz=%i\n";
+        let b = a as *const str;
+        let c = b as *const i8;
+
+        printf(c, t1sz as i32, t2sz as i32);
+    }
+
+    0
+}


### PR DESCRIPTION
Raw strings have a very specific type layout which maps over to Slices. It
also has very specific type checking rules so for example:

    let a:&str = "TEST 1";
    let b:&str = &"TEST 2";

Are both the same type this is likely to be for all DST's but lets do one
rule at a time.

Fixes #1023 #1271