### PR TITLE
Add testcase to prove bug is fixed

### DIFF
--- a/gcc/testsuite/rust/compile/issue-1237.rs
+++ b/gcc/testsuite/rust/compile/issue-1237.rs
@@ -1,0 +1,23 @@
+// { dg-additional-options "-w" }
+mod intrinsics {
+    extern "rust-intrinsic" {
+        pub fn offset<T>(ptr: *const T, count: isize) -> *const T;
+    }
+}
+
+impl<T> *const T {
+    pub unsafe fn offset(self, count: isize) -> *const T {
+        unsafe { intrinsics::offset(self, count) }
+    }
+}
+
+impl<T> [T] {
+    pub unsafe fn get_unchecked(&self, index: usize) -> &T {
+        unsafe { &*(self as *const [T] as *const T).offset(index as isize) }
+    }
+}
+
+#[inline]
+unsafe fn u8to64_le(buf: &[u8], start: usize, len: usize) -> u64 {
+    (unsafe { *buf.get_unchecked(start) } as u64)
+}


### PR DESCRIPTION
This bug was fixed in commit cb4d935508def8b250345ba5205a90ad9e177ab4
with related PR #1223

The issue is that associated types get updated depending on the context
they are used so we need to monomorphize the types when we can so that we
don't then throw off the rest of type checking with bogus errors like this.

Fixes #1237