### PR TITLE
const folding in gccrs: remove ConstCtx class.

### DIFF
--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -555,7 +555,7 @@ HIRCompileBase::compile_constant_item (
   if (!is_block_expr)
     {
       tree value = CompileExpr::Compile (const_value_expr, ctx);
-      folded_expr = ConstCtx::fold (value);
+      folded_expr = fold_expr (value);
     }
   else
     {
@@ -605,7 +605,7 @@ HIRCompileBase::compile_constant_item (
       // lets fold it into a call expr
       tree call = build_call_array_loc (locus.gcc_location (), const_type,
 					fndecl, 0, NULL);
-      folded_expr = ConstCtx::fold (call);
+      folded_expr = fold_expr (call);
     }
 
   return named_constant_expression (const_type, ident, folded_expr, locus);

--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -449,7 +449,7 @@ CompileExpr::visit (HIR::CallExpr &expr)
 	{
 	  HIR::Expr *discrim_expr = variant->get_discriminant ();
 	  tree discrim_expr_node = CompileExpr::Compile (discrim_expr, ctx);
-	  tree folded_discrim_expr = ConstCtx::fold (discrim_expr_node);
+	  tree folded_discrim_expr = fold_expr (discrim_expr_node);
 	  tree qualifier = folded_discrim_expr;
 
 	  ctor_arguments.push_back (qualifier);

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -492,7 +492,7 @@ public:
       {
 	HIR::Expr *discrim_expr = variant->get_discriminant ();
 	tree discrim_expr_node = CompileExpr::Compile (discrim_expr, ctx);
-	tree folded_discrim_expr = ConstCtx::fold (discrim_expr_node);
+	tree folded_discrim_expr = fold_expr (discrim_expr_node);
 	tree qualifier = folded_discrim_expr;
 
 	ctor_arguments.push_back (qualifier);

--- a/gcc/rust/backend/rust-compile-pattern.cc
+++ b/gcc/rust/backend/rust-compile-pattern.cc
@@ -52,7 +52,7 @@ CompilePatternCaseLabelExpr::visit (HIR::PathInExpression &pattern)
 
   HIR::Expr *discrim_expr = variant->get_discriminant ();
   tree discrim_expr_node = CompileExpr::Compile (discrim_expr, ctx);
-  tree folded_discrim_expr = ConstCtx::fold (discrim_expr_node);
+  tree folded_discrim_expr = fold_expr (discrim_expr_node);
   tree case_low = folded_discrim_expr;
 
   case_label_expr
@@ -132,7 +132,7 @@ compile_range_pattern_bound (HIR::RangePatternBound *bound,
 	result = ResolvePathRef::Compile (ref.get_path (), ctx);
 
 	// If the path resolves to a const expression, fold it.
-	result = ConstCtx::fold (result);
+	result = fold_expr (result);
       }
       break;
 
@@ -143,7 +143,7 @@ compile_range_pattern_bound (HIR::RangePatternBound *bound,
 	result = ResolvePathRef::Compile (ref.get_qualified_path (), ctx);
 
 	// If the path resolves to a const expression, fold it.
-	result = ConstCtx::fold (result);
+	result = fold_expr (result);
       }
     }
 

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -99,7 +99,7 @@ ResolvePathRef::resolve (const HIR::PathIdentSegment &final_segment,
       // make the ctor for the union
       HIR::Expr *discrim_expr = variant->get_discriminant ();
       tree discrim_expr_node = CompileExpr::Compile (discrim_expr, ctx);
-      tree folded_discrim_expr = ConstCtx::fold (discrim_expr_node);
+      tree folded_discrim_expr = fold_expr (discrim_expr_node);
       tree qualifier = folded_discrim_expr;
 
       return ctx->get_backend ()->constructor_expression (compiled_adt_type,

--- a/gcc/rust/backend/rust-compile-type.cc
+++ b/gcc/rust/backend/rust-compile-type.cc
@@ -371,7 +371,7 @@ TyTyResolveCompile::visit (const TyTy::ArrayType &type)
   tree element_type
     = TyTyResolveCompile::compile (ctx, type.get_element_type ());
   tree capacity_expr = CompileExpr::Compile (&type.get_capacity_expr (), ctx);
-  tree folded_capacity_expr = ConstCtx::fold (capacity_expr);
+  tree folded_capacity_expr = fold_expr (capacity_expr);
 
   translated
     = ctx->get_backend ()->array_type (element_type, folded_capacity_expr);

--- a/gcc/rust/backend/rust-constexpr.h
+++ b/gcc/rust/backend/rust-constexpr.h
@@ -23,22 +23,7 @@
 namespace Rust {
 namespace Compile {
 
-class ConstCtx
-{
-public:
-  static tree fold (tree);
-
-  tree constexpr_expression (tree);
-  tree eval_binary_expression (tree);
-  tree eval_call_expression (tree);
-  tree constexpr_fn_retval (tree);
-  tree eval_store_expression (tree);
-
-private:
-  ConstCtx ();
-
-  HOST_WIDE_INT constexpr_ops_count;
-};
+extern tree fold_expr (tree);
 
 } // namespace Compile
 } // namespace Rust


### PR DESCRIPTION
Card: [Link](https://github.com/Rust-GCC/gccrs/projects/16#card-82300522)

This class had potential to hinder porting further const folding code from C++. This edit makes it easy to copy code from constexpr.cc to rust-constexpr.cc and so on.

Structs `constexpr_ctx` and `constexpr_global_ctx` have been copied as well as to keep `constexpr_ops_count` after removing the class. These structs will be filled further as the port carries on. The prototypes inside ConstCtx have been copied over to rust-constexpr.cc as static prototypes.
