### PR TITLE
Marklive: support arrayindex

### DIFF
--- a/gcc/rust/lint/rust-lint-marklive.h
+++ b/gcc/rust/lint/rust-lint-marklive.h
@@ -78,6 +78,12 @@ public:
     expr.get_internal_elements ()->accept_vis (*this);
   }
 
+  void visit (HIR::ArrayIndexExpr &expr) override
+  {
+    expr.get_array_expr ()->accept_vis (*this);
+    expr.get_index_expr ()->accept_vis (*this);
+  }
+
   void visit (HIR::ArrayElemsValues &expr) override
   {
     for (auto &elem : expr.get_values ())

--- a/gcc/testsuite/rust/compile/torture/arrays_index3.rs
+++ b/gcc/testsuite/rust/compile/torture/arrays_index3.rs
@@ -1,0 +1,15 @@
+fn foo() -> usize {
+    1
+}
+    
+fn bar() -> [i32; 1] {
+    [0]
+}
+    
+    
+        
+fn main() -> () {
+    let a = [10];
+    let _b = a[foo()];
+    let _c = bar()[foo()];
+}


### PR DESCRIPTION
This makes `MarkLive` support `HIR::ArrayIndex` and adds a related test case.