### PR TITLE
Add AST dump visitor

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -69,6 +69,7 @@ GRS_OBJS = \
     rust/rust-cfg-parser.o \
     rust/rust-parse.o \
     rust/rust-ast-full-test.o \
+    rust/rust-ast-dump.o \
     rust/rust-session-manager.o \
     rust/rust-compile.o \
     rust/rust-mangle.o \

--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -1,0 +1,648 @@
+// Copyright (C) 2020-2022 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-ast-dump.h"
+
+namespace Rust {
+namespace AST {
+
+void
+Dump::visit (Token &tok)
+{}
+
+void
+Dump::visit (DelimTokenTree &delim_tok_tree)
+{}
+
+void
+Dump::visit (AttrInputMetaItemContainer &input)
+{}
+
+void
+Dump::visit (IdentifierExpr &ident_expr)
+{}
+
+void
+Dump::visit (Lifetime &lifetime)
+{}
+
+void
+Dump::visit (LifetimeParam &lifetime_param)
+{}
+
+// rust-path.h
+void
+Dump::visit (PathInExpression &path)
+{}
+
+void
+Dump::visit (TypePathSegment &segment)
+{}
+
+void
+Dump::visit (TypePathSegmentGeneric &segment)
+{}
+
+void
+Dump::visit (TypePathSegmentFunction &segment)
+{}
+
+void
+Dump::visit (TypePath &path)
+{}
+
+void
+Dump::visit (QualifiedPathInExpression &path)
+{}
+
+void
+Dump::visit (QualifiedPathInType &path)
+{}
+
+// rust-expr.h
+void
+Dump::visit (LiteralExpr &expr)
+{}
+
+void
+Dump::visit (AttrInputLiteral &attr_input)
+{}
+
+void
+Dump::visit (MetaItemLitExpr &meta_item)
+{}
+
+void
+Dump::visit (MetaItemPathLit &meta_item)
+{}
+
+void
+Dump::visit (BorrowExpr &expr)
+{}
+
+void
+Dump::visit (DereferenceExpr &expr)
+{}
+
+void
+Dump::visit (ErrorPropagationExpr &expr)
+{}
+
+void
+Dump::visit (NegationExpr &expr)
+{}
+
+void
+Dump::visit (ArithmeticOrLogicalExpr &expr)
+{}
+
+void
+Dump::visit (ComparisonExpr &expr)
+{}
+
+void
+Dump::visit (LazyBooleanExpr &expr)
+{}
+
+void
+Dump::visit (TypeCastExpr &expr)
+{}
+
+void
+Dump::visit (AssignmentExpr &expr)
+{}
+
+void
+Dump::visit (CompoundAssignmentExpr &expr)
+{}
+
+void
+Dump::visit (GroupedExpr &expr)
+{}
+
+void
+Dump::visit (ArrayElemsValues &elems)
+{}
+
+void
+Dump::visit (ArrayElemsCopied &elems)
+{}
+
+void
+Dump::visit (ArrayExpr &expr)
+{}
+
+void
+Dump::visit (ArrayIndexExpr &expr)
+{}
+
+void
+Dump::visit (TupleExpr &expr)
+{}
+
+void
+Dump::visit (TupleIndexExpr &expr)
+{}
+
+void
+Dump::visit (StructExprStruct &expr)
+{}
+
+void
+Dump::visit (StructExprFieldIdentifier &field)
+{}
+
+void
+Dump::visit (StructExprFieldIdentifierValue &field)
+{}
+
+void
+Dump::visit (StructExprFieldIndexValue &field)
+{}
+
+void
+Dump::visit (StructExprStructFields &expr)
+{}
+
+void
+Dump::visit (StructExprStructBase &expr)
+{}
+
+void
+Dump::visit (CallExpr &expr)
+{}
+
+void
+Dump::visit (MethodCallExpr &expr)
+{}
+
+void
+Dump::visit (FieldAccessExpr &expr)
+{}
+
+void
+Dump::visit (ClosureExprInner &expr)
+{}
+
+void
+Dump::visit (BlockExpr &expr)
+{}
+
+void
+Dump::visit (ClosureExprInnerTyped &expr)
+{}
+
+void
+Dump::visit (ContinueExpr &expr)
+{}
+
+void
+Dump::visit (BreakExpr &expr)
+{}
+
+void
+Dump::visit (RangeFromToExpr &expr)
+{}
+
+void
+Dump::visit (RangeFromExpr &expr)
+{}
+
+void
+Dump::visit (RangeToExpr &expr)
+{}
+
+void
+Dump::visit (RangeFullExpr &expr)
+{}
+
+void
+Dump::visit (RangeFromToInclExpr &expr)
+{}
+
+void
+Dump::visit (RangeToInclExpr &expr)
+{}
+
+void
+Dump::visit (ReturnExpr &expr)
+{}
+
+void
+Dump::visit (UnsafeBlockExpr &expr)
+{}
+
+void
+Dump::visit (LoopExpr &expr)
+{}
+
+void
+Dump::visit (WhileLoopExpr &expr)
+{}
+
+void
+Dump::visit (WhileLetLoopExpr &expr)
+{}
+
+void
+Dump::visit (ForLoopExpr &expr)
+{}
+
+void
+Dump::visit (IfExpr &expr)
+{}
+
+void
+Dump::visit (IfExprConseqElse &expr)
+{}
+
+void
+Dump::visit (IfExprConseqIf &expr)
+{}
+
+void
+Dump::visit (IfExprConseqIfLet &expr)
+{}
+
+void
+Dump::visit (IfLetExpr &expr)
+{}
+
+void
+Dump::visit (IfLetExprConseqElse &expr)
+{}
+
+void
+Dump::visit (IfLetExprConseqIf &expr)
+{}
+
+void
+Dump::visit (IfLetExprConseqIfLet &expr)
+{}
+
+void
+Dump::visit (MatchExpr &expr)
+{}
+
+void
+Dump::visit (AwaitExpr &expr)
+{}
+
+void
+Dump::visit (AsyncBlockExpr &expr)
+{}
+
+// rust-item.h
+void
+Dump::visit (TypeParam &param)
+{}
+
+void
+Dump::visit (LifetimeWhereClauseItem &item)
+{}
+
+void
+Dump::visit (TypeBoundWhereClauseItem &item)
+{}
+
+void
+Dump::visit (Method &method)
+{}
+
+void
+Dump::visit (Module &module)
+{}
+
+void
+Dump::visit (ExternCrate &crate)
+{}
+
+void
+Dump::visit (UseTreeGlob &use_tree)
+{}
+
+void
+Dump::visit (UseTreeList &use_tree)
+{}
+
+void
+Dump::visit (UseTreeRebind &use_tree)
+{}
+
+void
+Dump::visit (UseDeclaration &use_decl)
+{}
+
+void
+Dump::visit (Function &function)
+{}
+
+void
+Dump::visit (TypeAlias &type_alias)
+{}
+
+void
+Dump::visit (StructStruct &struct_item)
+{}
+
+void
+Dump::visit (TupleStruct &tuple_struct)
+{}
+
+void
+Dump::visit (EnumItem &item)
+{}
+
+void
+Dump::visit (EnumItemTuple &item)
+{}
+
+void
+Dump::visit (EnumItemStruct &item)
+{}
+
+void
+Dump::visit (EnumItemDiscriminant &item)
+{}
+
+void
+Dump::visit (Enum &enum_item)
+{}
+
+void
+Dump::visit (Union &union_item)
+{}
+
+void
+Dump::visit (ConstantItem &const_item)
+{}
+
+void
+Dump::visit (StaticItem &static_item)
+{}
+
+void
+Dump::visit (TraitItemFunc &item)
+{}
+
+void
+Dump::visit (TraitItemMethod &item)
+{}
+
+void
+Dump::visit (TraitItemConst &item)
+{}
+
+void
+Dump::visit (TraitItemType &item)
+{}
+
+void
+Dump::visit (Trait &trait)
+{}
+
+void
+Dump::visit (InherentImpl &impl)
+{}
+
+void
+Dump::visit (TraitImpl &impl)
+{}
+
+void
+Dump::visit (ExternalStaticItem &item)
+{}
+
+void
+Dump::visit (ExternalFunctionItem &item)
+{}
+
+void
+Dump::visit (ExternBlock &block)
+{}
+
+// rust-macro.h
+void
+Dump::visit (MacroMatchFragment &match)
+{}
+
+void
+Dump::visit (MacroMatchRepetition &match)
+{}
+
+void
+Dump::visit (MacroMatcher &matcher)
+{}
+
+void
+Dump::visit (MacroRulesDefinition &rules_def)
+{}
+
+void
+Dump::visit (MacroInvocation &macro_invoc)
+{}
+
+void
+Dump::visit (MetaItemPath &meta_item)
+{}
+
+void
+Dump::visit (MetaItemSeq &meta_item)
+{}
+
+void
+Dump::visit (MetaWord &meta_item)
+{}
+
+void
+Dump::visit (MetaNameValueStr &meta_item)
+{}
+
+void
+Dump::visit (MetaListPaths &meta_item)
+{}
+
+void
+Dump::visit (MetaListNameValueStr &meta_item)
+{}
+
+// rust-pattern.h
+void
+Dump::visit (LiteralPattern &pattern)
+{}
+
+void
+Dump::visit (IdentifierPattern &pattern)
+{}
+
+void
+Dump::visit (WildcardPattern &pattern)
+{}
+
+// void Dump::visit(RangePatternBound& bound){}
+
+void
+Dump::visit (RangePatternBoundLiteral &bound)
+{}
+
+void
+Dump::visit (RangePatternBoundPath &bound)
+{}
+
+void
+Dump::visit (RangePatternBoundQualPath &bound)
+{}
+
+void
+Dump::visit (RangePattern &pattern)
+{}
+
+void
+Dump::visit (ReferencePattern &pattern)
+{}
+
+// void Dump::visit(StructPatternField& field){}
+
+void
+Dump::visit (StructPatternFieldTuplePat &field)
+{}
+
+void
+Dump::visit (StructPatternFieldIdentPat &field)
+{}
+
+void
+Dump::visit (StructPatternFieldIdent &field)
+{}
+
+void
+Dump::visit (StructPattern &pattern)
+{}
+
+// void Dump::visit(TupleStructItems& tuple_items){}
+
+void
+Dump::visit (TupleStructItemsNoRange &tuple_items)
+{}
+
+void
+Dump::visit (TupleStructItemsRange &tuple_items)
+{}
+
+void
+Dump::visit (TupleStructPattern &pattern)
+{}
+
+// void Dump::visit(TuplePatternItems& tuple_items){}
+
+void
+Dump::visit (TuplePatternItemsMultiple &tuple_items)
+{}
+
+void
+Dump::visit (TuplePatternItemsRanged &tuple_items)
+{}
+
+void
+Dump::visit (TuplePattern &pattern)
+{}
+
+void
+Dump::visit (GroupedPattern &pattern)
+{}
+
+void
+Dump::visit (SlicePattern &pattern)
+{}
+
+// rust-stmt.h
+void
+Dump::visit (EmptyStmt &stmt)
+{}
+
+void
+Dump::visit (LetStmt &stmt)
+{}
+
+void
+Dump::visit (ExprStmtWithoutBlock &stmt)
+{}
+
+void
+Dump::visit (ExprStmtWithBlock &stmt)
+{}
+
+// rust-type.h
+void
+Dump::visit (TraitBound &bound)
+{}
+
+void
+Dump::visit (ImplTraitType &type)
+{}
+
+void
+Dump::visit (TraitObjectType &type)
+{}
+
+void
+Dump::visit (ParenthesisedType &type)
+{}
+
+void
+Dump::visit (ImplTraitTypeOneBound &type)
+{}
+
+void
+Dump::visit (TraitObjectTypeOneBound &type)
+{}
+
+void
+Dump::visit (TupleType &type)
+{}
+
+void
+Dump::visit (NeverType &type)
+{}
+
+void
+Dump::visit (RawPointerType &type)
+{}
+
+void
+Dump::visit (ReferenceType &type)
+{}
+
+void
+Dump::visit (ArrayType &type)
+{}
+
+void
+Dump::visit (SliceType &type)
+{}
+
+void
+Dump::visit (InferredType &type)
+{}
+
+void
+Dump::visit (BareFunctionType &type)
+{}
+
+} // namespace AST
+} // namespace Rust

--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -26,10 +26,7 @@ Indent::Indent () : tabs (0) {}
 std::ostream &
 operator<< (std::ostream &stream, const Indent &indent)
 {
-  for (size_t i = 0; i < indent.tabs; i++)
-    stream << '\t';
-
-  return stream;
+  return stream << std::string (indent.tabs, '\t');
 }
 
 void

--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -21,6 +21,39 @@
 namespace Rust {
 namespace AST {
 
+Indent::Indent () : tabs (0) {}
+
+std::ofstream &
+Indent::operator<< (std::ofstream &stream)
+{
+  for (size_t i = 0; i < tabs; i++)
+    stream << '\t';
+
+  return stream;
+}
+
+void
+Indent::increment ()
+{
+  tabs++;
+}
+
+void
+Indent::decrement ()
+{
+  rust_assert (tabs != 0);
+  tabs--;
+}
+
+Dump::Dump (std::ofstream &stream) : stream (stream), indentation (Indent ()) {}
+
+void
+Dump::go (AST::Crate &crate)
+{
+  for (auto &item : crate.items)
+    item->accept_vis (*this);
+}
+
 void
 Dump::visit (Token &tok)
 {}

--- a/gcc/rust/ast/rust-ast-dump.h
+++ b/gcc/rust/ast/rust-ast-dump.h
@@ -1,0 +1,206 @@
+// Copyright (C) 2020-2022 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-ast-visitor.h"
+#include "rust-ast.h"
+
+#ifndef RUST_AST_DUMP_H
+#define RUST_AST_DUMP_H
+
+namespace Rust {
+namespace AST {
+
+class Dump : public ASTVisitor
+{
+  // rust-ast.h
+  void visit (Token &tok);
+  void visit (DelimTokenTree &delim_tok_tree);
+  void visit (AttrInputMetaItemContainer &input);
+  void visit (IdentifierExpr &ident_expr);
+  void visit (Lifetime &lifetime);
+  void visit (LifetimeParam &lifetime_param);
+
+  // rust-path.h
+  void visit (PathInExpression &path);
+  void visit (TypePathSegment &segment);
+  void visit (TypePathSegmentGeneric &segment);
+  void visit (TypePathSegmentFunction &segment);
+  void visit (TypePath &path);
+  void visit (QualifiedPathInExpression &path);
+  void visit (QualifiedPathInType &path);
+
+  // rust-expr.h
+  void visit (LiteralExpr &expr);
+  void visit (AttrInputLiteral &attr_input);
+  void visit (MetaItemLitExpr &meta_item);
+  void visit (MetaItemPathLit &meta_item);
+  void visit (BorrowExpr &expr);
+  void visit (DereferenceExpr &expr);
+  void visit (ErrorPropagationExpr &expr);
+  void visit (NegationExpr &expr);
+  void visit (ArithmeticOrLogicalExpr &expr);
+  void visit (ComparisonExpr &expr);
+  void visit (LazyBooleanExpr &expr);
+  void visit (TypeCastExpr &expr);
+  void visit (AssignmentExpr &expr);
+  void visit (CompoundAssignmentExpr &expr);
+  void visit (GroupedExpr &expr);
+  void visit (ArrayElemsValues &elems);
+  void visit (ArrayElemsCopied &elems);
+  void visit (ArrayExpr &expr);
+  void visit (ArrayIndexExpr &expr);
+  void visit (TupleExpr &expr);
+  void visit (TupleIndexExpr &expr);
+  void visit (StructExprStruct &expr);
+  void visit (StructExprFieldIdentifier &field);
+  void visit (StructExprFieldIdentifierValue &field);
+  void visit (StructExprFieldIndexValue &field);
+  void visit (StructExprStructFields &expr);
+  void visit (StructExprStructBase &expr);
+  void visit (CallExpr &expr);
+  void visit (MethodCallExpr &expr);
+  void visit (FieldAccessExpr &expr);
+  void visit (ClosureExprInner &expr);
+  void visit (BlockExpr &expr);
+  void visit (ClosureExprInnerTyped &expr);
+  void visit (ContinueExpr &expr);
+  void visit (BreakExpr &expr);
+  void visit (RangeFromToExpr &expr);
+  void visit (RangeFromExpr &expr);
+  void visit (RangeToExpr &expr);
+  void visit (RangeFullExpr &expr);
+  void visit (RangeFromToInclExpr &expr);
+  void visit (RangeToInclExpr &expr);
+  void visit (ReturnExpr &expr);
+  void visit (UnsafeBlockExpr &expr);
+  void visit (LoopExpr &expr);
+  void visit (WhileLoopExpr &expr);
+  void visit (WhileLetLoopExpr &expr);
+  void visit (ForLoopExpr &expr);
+  void visit (IfExpr &expr);
+  void visit (IfExprConseqElse &expr);
+  void visit (IfExprConseqIf &expr);
+  void visit (IfExprConseqIfLet &expr);
+  void visit (IfLetExpr &expr);
+  void visit (IfLetExprConseqElse &expr);
+  void visit (IfLetExprConseqIf &expr);
+  void visit (IfLetExprConseqIfLet &expr);
+  void visit (MatchExpr &expr);
+  void visit (AwaitExpr &expr);
+  void visit (AsyncBlockExpr &expr);
+
+  // rust-item.h
+  void visit (TypeParam &param);
+  void visit (LifetimeWhereClauseItem &item);
+  void visit (TypeBoundWhereClauseItem &item);
+  void visit (Method &method);
+  void visit (Module &module);
+  void visit (ExternCrate &crate);
+  void visit (UseTreeGlob &use_tree);
+  void visit (UseTreeList &use_tree);
+  void visit (UseTreeRebind &use_tree);
+  void visit (UseDeclaration &use_decl);
+  void visit (Function &function);
+  void visit (TypeAlias &type_alias);
+  void visit (StructStruct &struct_item);
+  void visit (TupleStruct &tuple_struct);
+  void visit (EnumItem &item);
+  void visit (EnumItemTuple &item);
+  void visit (EnumItemStruct &item);
+  void visit (EnumItemDiscriminant &item);
+  void visit (Enum &enum_item);
+  void visit (Union &union_item);
+  void visit (ConstantItem &const_item);
+  void visit (StaticItem &static_item);
+  void visit (TraitItemFunc &item);
+  void visit (TraitItemMethod &item);
+  void visit (TraitItemConst &item);
+  void visit (TraitItemType &item);
+  void visit (Trait &trait);
+  void visit (InherentImpl &impl);
+  void visit (TraitImpl &impl);
+  void visit (ExternalStaticItem &item);
+  void visit (ExternalFunctionItem &item);
+  void visit (ExternBlock &block);
+
+  // rust-macro.h
+  void visit (MacroMatchFragment &match);
+  void visit (MacroMatchRepetition &match);
+  void visit (MacroMatcher &matcher);
+  void visit (MacroRulesDefinition &rules_def);
+  void visit (MacroInvocation &macro_invoc);
+  void visit (MetaItemPath &meta_item);
+  void visit (MetaItemSeq &meta_item);
+  void visit (MetaWord &meta_item);
+  void visit (MetaNameValueStr &meta_item);
+  void visit (MetaListPaths &meta_item);
+  void visit (MetaListNameValueStr &meta_item);
+
+  // rust-pattern.h
+  void visit (LiteralPattern &pattern);
+  void visit (IdentifierPattern &pattern);
+  void visit (WildcardPattern &pattern);
+  // void visit(RangePatternBound& bound);
+  void visit (RangePatternBoundLiteral &bound);
+  void visit (RangePatternBoundPath &bound);
+  void visit (RangePatternBoundQualPath &bound);
+  void visit (RangePattern &pattern);
+  void visit (ReferencePattern &pattern);
+  // void visit(StructPatternField& field);
+  void visit (StructPatternFieldTuplePat &field);
+  void visit (StructPatternFieldIdentPat &field);
+  void visit (StructPatternFieldIdent &field);
+  void visit (StructPattern &pattern);
+  // void visit(TupleStructItems& tuple_items);
+  void visit (TupleStructItemsNoRange &tuple_items);
+  void visit (TupleStructItemsRange &tuple_items);
+  void visit (TupleStructPattern &pattern);
+  // void visit(TuplePatternItems& tuple_items);
+  void visit (TuplePatternItemsMultiple &tuple_items);
+  void visit (TuplePatternItemsRanged &tuple_items);
+  void visit (TuplePattern &pattern);
+  void visit (GroupedPattern &pattern);
+  void visit (SlicePattern &pattern);
+
+  // rust-stmt.h
+  void visit (EmptyStmt &stmt);
+  void visit (LetStmt &stmt);
+  void visit (ExprStmtWithoutBlock &stmt);
+  void visit (ExprStmtWithBlock &stmt);
+
+  // rust-type.h
+  void visit (TraitBound &bound);
+  void visit (ImplTraitType &type);
+  void visit (TraitObjectType &type);
+  void visit (ParenthesisedType &type);
+  void visit (ImplTraitTypeOneBound &type);
+  void visit (TraitObjectTypeOneBound &type);
+  void visit (TupleType &type);
+  void visit (NeverType &type);
+  void visit (RawPointerType &type);
+  void visit (ReferenceType &type);
+  void visit (ArrayType &type);
+  void visit (SliceType &type);
+  void visit (InferredType &type);
+  void visit (BareFunctionType &type);
+};
+
+} // namespace AST
+} // namespace Rust
+
+#endif // !RUST_AST_DUMP_H

--- a/gcc/rust/ast/rust-ast-dump.h
+++ b/gcc/rust/ast/rust-ast-dump.h
@@ -25,8 +25,35 @@
 namespace Rust {
 namespace AST {
 
+// TODO: We might want to reuse this class somewhere else
+class Indent
+{
+public:
+  Indent ();
+
+  std::ofstream &operator<< (std::ofstream &stream);
+
+  void increment ();
+  void decrement ();
+
+private:
+  size_t tabs;
+};
+
 class Dump : public ASTVisitor
 {
+public:
+  Dump (std::ofstream &stream);
+
+  /**
+   * Run the visitor on an entire crate and its items
+   */
+  void go (AST::Crate &crate);
+
+private:
+  std::ofstream &stream;
+  Indent indentation;
+
   // rust-ast.h
   void visit (Token &tok);
   void visit (DelimTokenTree &delim_tok_tree);

--- a/gcc/rust/ast/rust-ast-dump.h
+++ b/gcc/rust/ast/rust-ast-dump.h
@@ -18,6 +18,7 @@
 
 #include "rust-ast-visitor.h"
 #include "rust-ast.h"
+#include "rust-ast-full.h"
 
 #ifndef RUST_AST_DUMP_H
 #define RUST_AST_DUMP_H
@@ -31,7 +32,7 @@ class Indent
 public:
   Indent ();
 
-  std::ofstream &operator<< (std::ofstream &stream);
+  friend std::ostream &operator<< (std::ostream &stream, const Indent &indent);
 
   void increment ();
   void decrement ();
@@ -43,7 +44,7 @@ private:
 class Dump : public ASTVisitor
 {
 public:
-  Dump (std::ofstream &stream);
+  Dump (std::ostream &stream);
 
   /**
    * Run the visitor on an entire crate and its items
@@ -51,8 +52,13 @@ public:
   void go (AST::Crate &crate);
 
 private:
-  std::ofstream &stream;
+  std::ostream &stream;
   Indent indentation;
+
+  /**
+   * Format a function's definition parameter
+   */
+  void format_function_param (FunctionParam &param);
 
   // rust-ast.h
   void visit (Token &tok);


### PR DESCRIPTION
This adds a base for pretty printing our AST through a new visitor (Addresses #1261).

This adds enough code to pretty print "functions" without types in the parameters or return type. Looking for feedback on the implementation before we keep going with more code :)

Here's a tiny patch if you want to see the output whenever you're running `-frust-dump-all`:

```diff
diff --git a/gcc/rust/rust-session-manager.cc b/gcc/rust/rust-session-manager.cc
index 0b0e5af915f..3e39c6a6e17 100644
--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -31,6 +31,7 @@
 #include "rust-cfg-parser.h"
 #include "rust-lint-scan-deadcode.h"
 #include "rust-lint-unused-var.h"
+#include "rust-ast-dump.h"
 
 #include "diagnostic.h"
 #include "input.h"
@@ -1023,6 +1024,8 @@ Session::dump_ast (Parser<Lexer> &parser, AST::Crate &crate) const
 
   parser.debug_dump_ast_output (crate, out);
   out.close ();
+
+  AST::Dump (std::cerr).go (crate);
 }
 
 void
```

output:
```rust
arthur@platypus ~/G/r/gccrs (add-ast-dump-visitor) [1]> cat test.rs
fn foo0(a: i32) {
    let a = 15;
    let b: i32 = 15;
}

fn foo1(a: &i32) {}

struct S;

fn foo2(a: S) {}
fn foo3(a: S) -> i32 {}

arthur@platypus ~/G/r/gccrs (add-ast-dump-visitor)> build/gcc/rust1 test.rs -frust-dump-all
fn foo0(a: ) {
	let a = ;
	let b:  = ;

}

fn foo1(a: ) {

}

fn foo2(a: ) {

}

fn foo3(a: ) -> {

}

test.rs:11:1: error: expected [i32] got [()]
   11 | fn foo3(a: S) -> i32 {}
      | ^                ~

Analyzing compilation unit

Time variable                                   usr           sys          wall           GGC
 phase setup                        :   0.00 (  0%)   0.00 (  0%)   0.01 (100%)   129k ( 94%)
 TOTAL                              :   0.00          0.00          0.01          137k
Extra diagnostic checks enabled; compiler may run slowly.
Configure with --enable-checking=release to disable checks.
```