### PR TITLE
Fix bad impl item overlap check

### DIFF
--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -2441,6 +2441,9 @@ ReferenceType::is_equal (const BaseType &other) const
     return false;
 
   auto other2 = static_cast<const ReferenceType &> (other);
+  if (mutability () != other2.mutability ())
+    return false;
+
   return get_base ()->is_equal (*other2.get_base ());
 }
 
@@ -2535,6 +2538,9 @@ PointerType::is_equal (const BaseType &other) const
     return false;
 
   auto other2 = static_cast<const PointerType &> (other);
+  if (mutability () != other2.mutability ())
+    return false;
+
   return get_base ()->is_equal (*other2.get_base ());
 }
 

--- a/gcc/rust/util/rust-lang-item.h
+++ b/gcc/rust/util/rust-lang-item.h
@@ -70,6 +70,7 @@ public:
 
     // https://github.com/rust-lang/rust/blob/master/library/core/src/ptr/const_ptr.rs
     CONST_PTR,
+    MUT_PTR,
     CONST_SLICE_PTR,
 
     UNKNOWN,
@@ -209,6 +210,10 @@ public:
       {
 	return ItemType::CONST_PTR;
       }
+    else if (item.compare ("mut_ptr") == 0)
+      {
+	return ItemType::MUT_PTR;
+      }
     else if (item.compare ("const_slice_ptr") == 0)
       {
 	return ItemType::CONST_SLICE_PTR;
@@ -287,6 +292,8 @@ public:
 	return "RangeToInclusive";
       case CONST_PTR:
 	return "const_ptr";
+      case MUT_PTR:
+	return "mut_ptr";
       case CONST_SLICE_PTR:
 	return "const_slice_ptr";
 

--- a/gcc/testsuite/rust/compile/issue-1289.rs
+++ b/gcc/testsuite/rust/compile/issue-1289.rs
@@ -1,0 +1,42 @@
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+mod intrinsics {
+    extern "rust-intrinsic" {
+        pub fn offset<T>(dst: *const T, offset: isize) -> *const T;
+    }
+}
+
+#[lang = "mut_ptr"]
+impl<T> *mut T {
+    pub const unsafe fn offset(self, count: isize) -> *mut T {
+        unsafe { intrinsics::offset(self, count) as *mut T }
+    }
+
+    pub const unsafe fn add(self, count: usize) -> Self {
+        unsafe { self.offset(count as isize) }
+    }
+}
+
+#[lang = "const_ptr"]
+impl<T> *const T {
+    pub const unsafe fn offset(self, count: isize) -> *mut T {
+        // { dg-warning "associated function is never used" "" { target *-*-* } .-1 }
+        unsafe { intrinsics::offset(self, count) as *mut T }
+    }
+
+    pub const unsafe fn add(self, count: usize) -> Self {
+        // { dg-warning "associated function is never used" "" { target *-*-* } .-1 }
+        unsafe { self.offset(count as isize) }
+    }
+}
+
+fn main() -> i32 {
+    let a: *mut _ = &mut 123;
+    unsafe {
+        let _b = a.add(123);
+    }
+
+    0
+}


### PR DESCRIPTION
This issue here was the equality checks for reference
and pointer types did not check the mutability.
    
Fixes #1289