### PR TITLE
Add name resolution to for loops

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-block.h
+++ b/gcc/rust/hir/rust-ast-lower-block.h
@@ -225,6 +225,8 @@ public:
 
   void visit (AST::WhileLoopExpr &expr) override;
 
+  void visit (AST::ForLoopExpr &expr) override;
+
   void visit (AST::MatchExpr &expr) override;
 
 private:

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -579,6 +579,11 @@ public:
     translated = ASTLoweringExprWithBlock::translate (&expr, &terminated);
   }
 
+  void visit (AST::ForLoopExpr &expr) override
+  {
+    translated = ASTLoweringExprWithBlock::translate (&expr, &terminated);
+  }
+
   void visit (AST::BreakExpr &expr) override
   {
     HIR::Lifetime break_label = lower_lifetime (expr.get_label ());

--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -324,6 +324,32 @@ ASTLoweringExprWithBlock::visit (AST::WhileLoopExpr &expr)
 }
 
 void
+ASTLoweringExprWithBlock::visit (AST::ForLoopExpr &expr)
+{
+  HIR::BlockExpr *loop_block
+    = ASTLoweringBlock::translate (expr.get_loop_block ().get (), &terminated);
+  HIR::LoopLabel loop_label = lower_loop_label (expr.get_loop_label ());
+  HIR::Expr *iterator_expr
+    = ASTLoweringExpr::translate (expr.get_iterator_expr ().get (),
+				  &terminated);
+  HIR::Pattern *loop_pattern
+    = ASTLoweringPattern::translate (expr.get_pattern ().get ());
+
+  auto crate_num = mappings->get_current_crate ();
+  Analysis::NodeMapping mapping (crate_num, expr.get_node_id (),
+				 mappings->get_next_hir_id (crate_num),
+				 UNKNOWN_LOCAL_DEFID);
+
+  translated
+    = new HIR::ForLoopExpr (mapping,
+			    std::unique_ptr<HIR::Pattern> (loop_pattern),
+			    std::unique_ptr<HIR::Expr> (iterator_expr),
+			    std::unique_ptr<HIR::BlockExpr> (loop_block),
+			    expr.get_locus (), std::move (loop_label),
+			    expr.get_outer_attrs ());
+}
+
+void
 ASTLoweringExprWithBlock::visit (AST::MatchExpr &expr)
 {
   HIR::Expr *branch_value

--- a/gcc/rust/resolve/rust-ast-resolve-expr.h
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.h
@@ -99,6 +99,8 @@ public:
 
   void visit (AST::WhileLoopExpr &expr) override;
 
+  void visit (AST::ForLoopExpr &expr) override;
+
   void visit (AST::ContinueExpr &expr) override;
 
   void visit (AST::BorrowExpr &expr) override;


### PR DESCRIPTION
This just adds basic name resolution and hir lowering for
the loop. Eventually we will make all Loops into a single
HIR::LoopExpr but for now its really useful having a separate
visitor to implement this to avoid regressions in the short
term.

Addresses #869 