### PR TITLE
Fixup name canonicalization for impl blocks

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-item.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-item.cc
@@ -613,6 +613,7 @@ ResolveItem::visit (AST::InherentImpl &impl_block)
       resolver->get_name_scope ().pop ();
       return;
     }
+  rust_assert (!self_cpath.is_empty ());
 
   // Setup paths
   bool canonicalize_type_args = !impl_block.has_generics ();
@@ -637,6 +638,7 @@ ResolveItem::visit (AST::InherentImpl &impl_block)
 	= CanonicalPath::new_seg (impl_block.get_node_id (), seg_buf);
       cpath = canonical_prefix.append (seg);
     }
+
   // done setup paths
 
   auto Self

--- a/gcc/rust/resolve/rust-ast-resolve-type.h
+++ b/gcc/rust/resolve/rust-ast-resolve-type.h
@@ -211,15 +211,12 @@ public:
     ResolveType resolver (parent, canonicalize_type_with_generics,
 			  canonical_path);
     type->accept_vis (resolver);
-    if (!resolver.ok)
-      rust_error_at (type->get_locus (), "unresolved type");
 
     return resolver.resolved_node;
   };
 
   void visit (AST::BareFunctionType &fntype) override
   {
-    ok = true;
     for (auto &param : fntype.get_function_params ())
       ResolveType::go (param.get_type ().get (), fntype.get_node_id ());
 
@@ -252,8 +249,6 @@ public:
 		       "Failed to resolve canonical path for TypePath");
 	return;
       }
-
-    ok = !rel_canonical_path.is_empty ();
 
     // lets try and resolve in one go else leave it up to the type resolver to
     // figure outer
@@ -331,7 +326,7 @@ public:
 
   void visit (AST::QualifiedPathInType &path) override
   {
-    ok = ResolveRelativeTypePath::go (path);
+    ResolveRelativeTypePath::go (path);
   }
 
   void visit (AST::ArrayType &type) override;


### PR DESCRIPTION
When we generate the path for impl items we need to base this of the Self
type but this was ignoring cases like pointers, references or slices. This
meant generic slices had the same path has generic pointers etc. The only
reason we didn't end up with a linker symbol clash is due to the symbol
hash.
