### PR TITLE
Add new mappings for items within a module

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-toplevel.h
+++ b/gcc/rust/resolve/rust-ast-resolve-toplevel.h
@@ -41,6 +41,8 @@ public:
 
     ResolveTopLevel resolver (prefix, canonical_prefix, current_module);
     item->accept_vis (resolver);
+    resolver.mappings->insert_child_item_to_parent_module_mapping (
+      item->get_node_id (), current_module);
   };
 
   void visit (AST::Module &module) override
@@ -62,6 +64,7 @@ public:
 				     Definition{module.get_node_id (),
 						module.get_node_id ()});
 
+    mappings->insert_module_child_item (current_module, mod);
     mappings->insert_module_child (current_module, module.get_node_id ());
 
     for (auto &item : module.get_items ())
@@ -86,6 +89,7 @@ public:
 	rust_error_at (r, "redefined multiple times");
       });
 
+    mappings->insert_module_child_item (current_module, talias);
     mappings->insert_canonical_path (mappings->get_current_crate (),
 				     alias.get_node_id (), cpath);
   }
@@ -105,6 +109,7 @@ public:
 	rust_error_at (r, "redefined multiple times");
       });
 
+    mappings->insert_module_child_item (current_module, decl);
     mappings->insert_canonical_path (mappings->get_current_crate (),
 				     struct_decl.get_node_id (), cpath);
   }
@@ -127,6 +132,7 @@ public:
     for (auto &variant : enum_decl.get_variants ())
       ResolveTopLevel::go (variant.get (), path, cpath, current_module);
 
+    mappings->insert_module_child_item (current_module, decl);
     mappings->insert_canonical_path (mappings->get_current_crate (),
 				     enum_decl.get_node_id (), cpath);
   }
@@ -146,6 +152,7 @@ public:
 	rust_error_at (r, "redefined multiple times");
       });
 
+    mappings->insert_module_child_item (current_module, decl);
     mappings->insert_canonical_path (mappings->get_current_crate (),
 				     item.get_node_id (), cpath);
   }
@@ -222,6 +229,7 @@ public:
 	rust_error_at (r, "redefined multiple times");
       });
 
+    mappings->insert_module_child_item (current_module, decl);
     mappings->insert_canonical_path (mappings->get_current_crate (),
 				     struct_decl.get_node_id (), cpath);
   }
@@ -241,6 +249,7 @@ public:
 	rust_error_at (r, "redefined multiple times");
       });
 
+    mappings->insert_module_child_item (current_module, decl);
     mappings->insert_canonical_path (mappings->get_current_crate (),
 				     union_decl.get_node_id (), cpath);
   }
@@ -264,6 +273,7 @@ public:
 						var.get_node_id ()});
     resolver->mark_decl_mutability (var.get_node_id (), var.is_mutable ());
 
+    mappings->insert_module_child_item (current_module, decl);
     mappings->insert_canonical_path (mappings->get_current_crate (),
 				     var.get_node_id (), cpath);
   }
@@ -285,6 +295,7 @@ public:
 				     Definition{constant.get_node_id (),
 						constant.get_node_id ()});
 
+    mappings->insert_module_child_item (current_module, decl);
     mappings->insert_canonical_path (mappings->get_current_crate (),
 				     constant.get_node_id (), cpath);
   }
@@ -314,6 +325,7 @@ public:
 					function.get_node_id ());
       }
 
+    mappings->insert_module_child_item (current_module, decl);
     mappings->insert_canonical_path (mappings->get_current_crate (),
 				     function.get_node_id (), cpath);
   }
@@ -391,6 +403,7 @@ public:
     for (auto &item : trait.get_trait_items ())
       ResolveTopLevelTraitItems::go (item.get (), path, cpath);
 
+    mappings->insert_module_child_item (current_module, decl);
     mappings->insert_canonical_path (mappings->get_current_crate (),
 				     trait.get_node_id (), cpath);
   }

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -884,5 +884,46 @@ Mappings::lookup_module_children (NodeId module)
   return Optional<std::vector<NodeId> &>::some (it->second);
 }
 
+void
+Mappings::insert_module_child_item (NodeId module,
+				    Resolver::CanonicalPath child)
+{
+  rust_assert (!child.is_empty ());
+  rust_assert (child.get_node_id () != UNKNOWN_NODEID);
+
+  auto it = module_child_items.find (module);
+  if (it == module_child_items.end ())
+    module_child_items.insert ({module, {child}});
+  else
+    it->second.emplace_back (child);
+}
+
+Optional<std::vector<Resolver::CanonicalPath> &>
+Mappings::lookup_module_chidren_items (NodeId module)
+{
+  auto it = module_child_items.find (module);
+  if (it == module_child_items.end ())
+    return Optional<std::vector<Resolver::CanonicalPath> &>::none ();
+
+  return Optional<std::vector<Resolver::CanonicalPath> &>::some (it->second);
+}
+
+void
+Mappings::insert_child_item_to_parent_module_mapping (NodeId child_item,
+						      NodeId parent_module)
+{
+  child_to_parent_module_map.insert ({child_item, parent_module});
+}
+
+Optional<NodeId>
+Mappings::lookup_parent_module (NodeId child_item)
+{
+  auto it = child_to_parent_module_map.find (child_item);
+  if (it == child_to_parent_module_map.end ())
+    return Optional<NodeId>::none ();
+
+  return Optional<NodeId>::some (it->second);
+}
+
 } // namespace Analysis
 } // namespace Rust

--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -326,6 +326,14 @@ public:
   void insert_module_child (NodeId module, NodeId child);
   Optional<std::vector<NodeId> &> lookup_module_children (NodeId module);
 
+  void insert_module_child_item (NodeId module, Resolver::CanonicalPath item);
+  Optional<std::vector<Resolver::CanonicalPath> &>
+  lookup_module_chidren_items (NodeId module);
+
+  void insert_child_item_to_parent_module_mapping (NodeId child_item,
+						   NodeId parent_module);
+  Optional<NodeId> lookup_parent_module (NodeId child_item);
+
 private:
   Mappings ();
 
@@ -396,6 +404,8 @@ private:
 
   // Maps each module's node id to a list of its children
   std::map<NodeId, std::vector<NodeId>> module_child_map;
+  std::map<NodeId, std::vector<Resolver::CanonicalPath>> module_child_items;
+  std::map<NodeId, NodeId> child_to_parent_module_map;
 };
 
 } // namespace Analysis


### PR DESCRIPTION
This patch adds two new interfaces to the mappings class.

  - Lookup the child items within a module
  - Lookup the parent module id from the child item id

Each of these API's are going to be required so that we can resolve two new
types of path segment:

  super::foo::bar

Where we need to be able to lookup the super module node id from the
current scope node id. To then lookup the children within that scope. The
other path is simpler such as: crate::foo::bar. Where we lookup the items
within the current Crate NodeId and follow on as normal.

Addresses #1227