### PR TITLE
AST Dump impl traits

### DIFF
--- a/gcc/rust/ast/rust-ast-dump.h
+++ b/gcc/rust/ast/rust-ast-dump.h
@@ -55,6 +55,10 @@ private:
   std::ostream &stream;
   Indent indentation;
 
+  // Format together common items of functions: Parameters, return type, block
+  void format_function_common (std::unique_ptr<Type> &return_type,
+			       std::unique_ptr<BlockExpr> &block);
+
   /**
    * Format a function's definition parameter
    */

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -2872,11 +2872,7 @@ public:
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Type> &get_return_type ()
-  {
-    rust_assert (has_return_type ());
-    return return_type;
-  }
+  std::unique_ptr<Type> &get_return_type () { return return_type; }
 
   // TODO: is this better? Or is a "vis_block" better?
   WhereClause &get_where_clause () { return where_clause; }
@@ -2954,11 +2950,7 @@ public:
   const std::vector<Attribute> &get_outer_attrs () const { return outer_attrs; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<BlockExpr> &get_definition ()
-  {
-    rust_assert (has_definition ());
-    return block_expr;
-  }
+  std::unique_ptr<BlockExpr> &get_definition () { return block_expr; }
 
   // TODO: is this better? Or is a "vis_block" better?
   TraitFunctionDecl &get_trait_function_decl ()
@@ -3097,11 +3089,7 @@ public:
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Type> &get_return_type ()
-  {
-    rust_assert (has_return_type ());
-    return return_type;
-  }
+  std::unique_ptr<Type> &get_return_type () { return return_type; }
 
   // TODO: is this better? Or is a "vis_block" better?
   WhereClause &get_where_clause () { return where_clause; }
@@ -3189,11 +3177,7 @@ public:
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<BlockExpr> &get_definition ()
-  {
-    rust_assert (has_definition ());
-    return block_expr;
-  }
+  std::unique_ptr<BlockExpr> &get_definition () { return block_expr; }
 
 protected:
   // Clone function implementation as (not pure) virtual method


### PR DESCRIPTION
This adds proper AST formatting for inherent impl blocks and traits.

This does not handle trait impls yet (`impl Trait for Type`) but it should be really easy to refactor and add.