### PR TITLE
Ast dump trait impl

### DIFF
--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -624,7 +624,21 @@ Dump::visit (InherentImpl &impl)
 
 void
 Dump::visit (TraitImpl &impl)
-{}
+{
+  stream << "impl ";
+  impl.get_trait_path ().accept_vis (*this);
+  stream << " for ";
+  impl.get_type ()->accept_vis (*this);
+
+  stream << " {\n";
+  indentation.increment ();
+
+  for (auto &item : impl.get_impl_items ())
+    item->accept_vis (*this);
+
+  indentation.decrement ();
+  stream << "\n}\n";
+}
 
 void
 Dump::visit (ExternalStaticItem &item)


### PR DESCRIPTION
Needs #1295

This adds the dumping of trait implementations for types. However, it is incomplete as I don't believe we can yet handle associated types and associated constants properly? Am I looking in the wrong place?

Will dig deeper, but opening for any early review.