### PR TITLE
rust/intrinsic: add a basic size check for `transmute`

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-type.h
+++ b/gcc/rust/hir/tree/rust-hir-type.h
@@ -582,10 +582,7 @@ public:
   ArrayType (ArrayType const &other)
     : TypeNoBounds (other.mappings), elem_type (other.elem_type->clone_type ()),
       size (other.size->clone_expr ()), locus (other.locus)
-  {
-    // Untested.
-    gcc_unreachable ();
-  }
+  {}
 
   // Overload assignment operator to deep copy pointers
   ArrayType &operator= (ArrayType const &other)

--- a/gcc/testsuite/rust/compile/torture/transmute-size-check-1.rs
+++ b/gcc/testsuite/rust/compile/torture/transmute-size-check-1.rs
@@ -1,0 +1,11 @@
+mod mem {
+    extern "rust-intrinsic" {
+        fn size_of<T>() -> usize;
+        fn transmute<U, V>(_: U) -> V; // { dg-error "cannot transmute between types of different sizes, or dependently-sized types" }
+    }
+}
+
+fn main() {
+    let a = 123;
+    let _b: [u32; mem::size_of::<i32>()] = mem::transmute(a);
+}


### PR DESCRIPTION
- rust/intrinsic: add a basic size check for `transmute`

partially addresses #1195