### PR TITLE
rust/lex: skip broken string expression

### DIFF
--- a/gcc/rust/lex/rust-lex.h
+++ b/gcc/rust/lex/rust-lex.h
@@ -114,6 +114,7 @@ private:
   Codepoint peek_codepoint_input ();
   Codepoint test_peek_codepoint_input (int n);
   void skip_codepoint_input ();
+  void skip_broken_string_input (int current_char);
 
   TokenPtr parse_byte_char (Location loc);
   TokenPtr parse_byte_string (Location loc);

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -914,7 +914,8 @@ Parser<ManagedTokenSource>::parse_delim_token_tree ()
 
   // repeat loop until finding the matching delimiter
   t = lexer.peek_token ();
-  while (!token_id_matches_delims (t->get_id (), delim_type))
+  while (!token_id_matches_delims (t->get_id (), delim_type)
+	 && t->get_id () != END_OF_FILE)
     {
       std::unique_ptr<AST::TokenTree> tok_tree = parse_token_tree ();
 

--- a/gcc/testsuite/rust/compile/torture/check-doc-attr-string.rs
+++ b/gcc/testsuite/rust/compile/torture/check-doc-attr-string.rs
@@ -1,0 +1,13 @@
+#![crate_type = "lib"]
+
+#[doc(alias = "foo")] // ok!
+#[doc(alias("bar", "baz"))] // ok!
+pub struct Bar;
+
+#[doc(alias = "
+")] // { dg-error "unended string literal" "" { target *-*-* } .-1 }
+pub struct Foo;
+
+#[doc(alias("
+"))] // { dg-error "unended string literal" "" { target *-*-* } .-1 }
+pub struct Foo2;

--- a/gcc/testsuite/rust/compile/torture/very-broken-attr-string.rs
+++ b/gcc/testsuite/rust/compile/torture/very-broken-attr-string.rs
@@ -1,0 +1,3 @@
+// { dg-excess-errors "...." }
+// { dg-error "unended string literal" "" { target *-*-* } .+1 }
+#[doc(alias = "123


### PR DESCRIPTION
- rust/lex: skip broken string expression and unstuck the parser when it could not advance

should fix #1297
