### PR TITLE
Handle super and crate in path resolution

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -350,8 +350,16 @@ public:
   Location get_locus () const { return locus; }
   NodeId get_node_id () const { return node_id; }
   const std::string &get_segment_name () const { return segment_name; }
-
-  // TODO: visitor pattern?
+  bool is_super_path_seg () const
+  {
+    return as_string ().compare ("super") == 0;
+  }
+  bool is_crate_path_seg () const
+  {
+    return as_string ().compare ("crate") == 0;
+  }
+  bool is_lower_self () const { return as_string ().compare ("self") == 0; }
+  bool is_big_self () const { return as_string ().compare ("Self") == 0; }
 };
 
 // A simple path without generic or type arguments

--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -1432,16 +1432,6 @@ CompileExpr::visit (HIR::IdentifierExpr &expr)
   NodeId ref_node_id = UNKNOWN_NODEID;
   if (ctx->get_resolver ()->lookup_resolved_name (ast_node_id, &ref_node_id))
     {
-      // these ref_node_ids will resolve to a pattern declaration but we are
-      // interested in the definition that this refers to get the parent id
-      Resolver::Definition def;
-      if (!ctx->get_resolver ()->lookup_definition (ref_node_id, &def))
-	{
-	  rust_error_at (expr.get_locus (),
-			 "unknown reference for resolved name");
-	  return;
-	}
-      ref_node_id = def.parent;
       is_value = true;
     }
   else if (!ctx->get_resolver ()->lookup_resolved_type (ast_node_id,

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -512,8 +512,8 @@ public:
 
   void visit (HIR::FieldAccessExpr &expr) override
   {
-    tree receiver_ref
-      = CompileExpr::Compile (expr.get_receiver_expr ().get (), ctx);
+    HIR::Expr *receiver_expr = expr.get_receiver_expr ().get ();
+    tree receiver_ref = CompileExpr::Compile (receiver_expr, ctx);
 
     // resolve the receiver back to ADT type
     TyTy::BaseType *receiver = nullptr;

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -53,22 +53,12 @@ ResolvePathRef::resolve (const HIR::PathIdentSegment &final_segment,
 
   // need to look up the reference for this identifier
   NodeId ref_node_id = UNKNOWN_NODEID;
-  if (ctx->get_resolver ()->lookup_resolved_name (mappings.get_nodeid (),
-						  &ref_node_id))
+  if (!ctx->get_resolver ()->lookup_resolved_name (mappings.get_nodeid (),
+						   &ref_node_id))
     {
-      Resolver::Definition def;
-      if (!ctx->get_resolver ()->lookup_definition (ref_node_id, &def))
-	{
-	  rust_error_at (expr_locus, "unknown reference for resolved name");
-	  return error_mark_node;
-	}
-      ref_node_id = def.parent;
-    }
+      // this can fail because it might be a Constructor for something
+      // in that case the caller should attempt ResolvePathType::Compile
 
-  // this can fail because it might be a Constructor for something
-  // in that case the caller should attempt ResolvePathType::Compile
-  if (ref_node_id == UNKNOWN_NODEID)
-    {
       // it might be an enum data-less enum variant
       if (lookup->get_kind () != TyTy::TypeKind::ADT)
 	return error_mark_node;

--- a/gcc/rust/backend/rust-compile-stmt.h
+++ b/gcc/rust/backend/rust-compile-stmt.h
@@ -51,9 +51,11 @@ public:
     if (!stmt.has_init_expr ())
       return;
 
+    const HIR::Pattern &stmt_pattern = *stmt.get_pattern ();
+    HirId stmt_id = stmt_pattern.get_pattern_mappings ().get_hirid ();
+
     TyTy::BaseType *ty = nullptr;
-    if (!ctx->get_tyctx ()->lookup_type (stmt.get_mappings ().get_hirid (),
-					 &ty))
+    if (!ctx->get_tyctx ()->lookup_type (stmt_id, &ty))
       {
 	// FIXME this should be an assertion instead
 	rust_fatal_error (stmt.get_locus (),
@@ -62,7 +64,7 @@ public:
       }
 
     Bvariable *var = nullptr;
-    if (!ctx->lookup_var_decl (stmt.get_mappings ().get_hirid (), &var))
+    if (!ctx->lookup_var_decl (stmt_id, &var))
       {
 	// FIXME this should be an assertion instead and use error mark node
 	rust_fatal_error (stmt.get_locus (),

--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -79,7 +79,7 @@ ASTLowering::go ()
 
   auto mappings = Analysis::Mappings::get ();
   auto crate_num = mappings->get_current_crate ();
-  Analysis::NodeMapping mapping (crate_num, UNKNOWN_NODEID,
+  Analysis::NodeMapping mapping (crate_num, astCrate.get_node_id (),
 				 mappings->get_next_hir_id (crate_num),
 				 UNKNOWN_LOCAL_DEFID);
 

--- a/gcc/rust/lint/rust-lint-marklive.cc
+++ b/gcc/rust/lint/rust-lint-marklive.cc
@@ -179,16 +179,10 @@ MarkLive::visit_path_segment (HIR::PathExprSegment seg)
   //
   // We should mark them alive all and ignoring other kind of segments.
   // If the segment we dont care then just return false is fine
-  if (resolver->lookup_resolved_name (ast_node_id, &ref_node_id))
+  if (!resolver->lookup_resolved_name (ast_node_id, &ref_node_id))
     {
-      Resolver::Definition def;
-      bool ok = resolver->lookup_definition (ref_node_id, &def);
-      rust_assert (ok);
-      ref_node_id = def.parent;
-    }
-  else if (!resolver->lookup_resolved_type (ast_node_id, &ref_node_id))
-    {
-      return false;
+      if (!resolver->lookup_resolved_type (ast_node_id, &ref_node_id))
+	return false;
     }
   HirId ref;
   bool ok = mappings->lookup_node_to_hir (seg.get_mappings ().get_crate_num (),
@@ -300,16 +294,7 @@ MarkLive::mark_hir_id (HirId id)
 void
 MarkLive::find_ref_node_id (NodeId ast_node_id, NodeId &ref_node_id)
 {
-  if (resolver->lookup_resolved_name (ast_node_id, &ref_node_id))
-    {
-      // these ref_node_ids will resolve to a pattern declaration but we are
-      // interested in the definition that this refers to get the parent id
-      Resolver::Definition def;
-      bool ok = resolver->lookup_definition (ref_node_id, &def);
-      rust_assert (ok);
-      ref_node_id = def.parent;
-    }
-  else
+  if (!resolver->lookup_resolved_name (ast_node_id, &ref_node_id))
     {
       bool ok = resolver->lookup_resolved_type (ast_node_id, &ref_node_id);
       rust_assert (ok);

--- a/gcc/rust/privacy/rust-visibility-resolver.cc
+++ b/gcc/rust/privacy/rust-visibility-resolver.cc
@@ -71,12 +71,6 @@ VisibilityResolver::resolve_module_path (const HIR::SimplePath &restriction,
   // TODO: For the hint, can we point to the original item's definition if
   // present?
 
-  Resolver::Definition def;
-  rust_assert (resolver.lookup_definition (ref_node_id, &def));
-
-  // FIXME: Is that what we want?
-  ref_node_id = def.parent;
-
   HirId ref;
   rust_assert (
     mappings.lookup_node_to_hir (restriction.get_mappings ().get_crate_num (),

--- a/gcc/rust/resolve/rust-ast-resolve-base.h
+++ b/gcc/rust/resolve/rust-ast-resolve-base.h
@@ -199,10 +199,9 @@ public:
   void visit (AST::BareFunctionType &);
 
 protected:
-  ResolverBase (NodeId parent, NodeId current_module = UNKNOWN_NODEID)
+  ResolverBase (NodeId parent)
     : resolver (Resolver::get ()), mappings (Analysis::Mappings::get ()),
-      resolved_node (UNKNOWN_NODEID), parent (parent),
-      current_module (current_module), locus (Location ())
+      resolved_node (UNKNOWN_NODEID), parent (parent), locus (Location ())
   {}
 
   bool resolved () const { return resolved_node != UNKNOWN_NODEID; }
@@ -216,7 +215,6 @@ protected:
   Analysis::Mappings *mappings;
   NodeId resolved_node;
   NodeId parent;
-  NodeId current_module;
   Location locus;
 };
 

--- a/gcc/rust/resolve/rust-ast-resolve-expr.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.cc
@@ -113,16 +113,12 @@ ResolveExpr::visit (AST::IdentifierExpr &expr)
 	&resolved_node))
     {
       resolver->insert_resolved_name (expr.get_node_id (), resolved_node);
-      resolver->insert_new_definition (expr.get_node_id (),
-				       Definition{expr.get_node_id (), parent});
     }
   else if (resolver->get_type_scope ().lookup (
 	     CanonicalPath::new_seg (expr.get_node_id (), expr.as_string ()),
 	     &resolved_node))
     {
       resolver->insert_resolved_type (expr.get_node_id (), resolved_node);
-      resolver->insert_new_definition (expr.get_node_id (),
-				       Definition{expr.get_node_id (), parent});
     }
   else
     {
@@ -352,9 +348,6 @@ ResolveExpr::visit (AST::LoopExpr &expr)
 	  rust_error_at (label.get_locus (), "label redefined multiple times");
 	  rust_error_at (locus, "was defined here");
 	});
-      resolver->insert_new_definition (label_lifetime_node_id,
-				       Definition{label_lifetime_node_id,
-						  label.get_node_id ()});
     }
   resolve_expr (expr.get_loop_block ().get (), expr.get_node_id ());
 }
@@ -412,9 +405,6 @@ ResolveExpr::visit (AST::WhileLoopExpr &expr)
 	  rust_error_at (label.get_locus (), "label redefined multiple times");
 	  rust_error_at (locus, "was defined here");
 	});
-      resolver->insert_new_definition (label_lifetime_node_id,
-				       Definition{label_lifetime_node_id,
-						  label.get_node_id ()});
     }
   resolve_expr (expr.get_predicate_expr ().get (), expr.get_node_id ());
   resolve_expr (expr.get_loop_block ().get (), expr.get_node_id ());
@@ -443,9 +433,6 @@ ResolveExpr::visit (AST::ForLoopExpr &expr)
 	  rust_error_at (label.get_locus (), "label redefined multiple times");
 	  rust_error_at (locus, "was defined here");
 	});
-      resolver->insert_new_definition (label_lifetime_node_id,
-				       Definition{label_lifetime_node_id,
-						  label.get_node_id ()});
     }
 
   // this needs a new rib to contain the pattern

--- a/gcc/rust/resolve/rust-ast-resolve-implitem.h
+++ b/gcc/rust/resolve/rust-ast-resolve-implitem.h
@@ -76,9 +76,6 @@ public:
 	r.add_range (locus);
 	rust_error_at (r, "redefined multiple times");
       });
-    resolver->insert_new_definition (constant.get_node_id (),
-				     Definition{constant.get_node_id (),
-						constant.get_node_id ()});
   }
 
   void visit (AST::Function &function) override
@@ -93,9 +90,6 @@ public:
 	r.add_range (locus);
 	rust_error_at (r, "redefined multiple times");
       });
-    resolver->insert_new_definition (function.get_node_id (),
-				     Definition{function.get_node_id (),
-						function.get_node_id ()});
   }
 
   void visit (AST::Method &method) override
@@ -110,9 +104,6 @@ public:
 	r.add_range (locus);
 	rust_error_at (r, "redefined multiple times");
       });
-    resolver->insert_new_definition (method.get_node_id (),
-				     Definition{method.get_node_id (),
-						method.get_node_id ()});
   }
 
 private:
@@ -150,9 +141,6 @@ public:
 	r.add_range (locus);
 	rust_error_at (r, "redefined multiple times");
       });
-    resolver->insert_new_definition (function.get_node_id (),
-				     Definition{function.get_node_id (),
-						function.get_node_id ()});
 
     mappings->insert_canonical_path (mappings->get_current_crate (),
 				     function.get_node_id (), cpath);
@@ -171,9 +159,6 @@ public:
 	r.add_range (locus);
 	rust_error_at (r, "redefined multiple times");
       });
-    resolver->insert_new_definition (method.get_node_id (),
-				     Definition{method.get_node_id (),
-						method.get_node_id ()});
 
     mappings->insert_canonical_path (mappings->get_current_crate (),
 				     method.get_node_id (), cpath);
@@ -192,9 +177,6 @@ public:
 	r.add_range (locus);
 	rust_error_at (r, "redefined multiple times");
       });
-    resolver->insert_new_definition (constant.get_node_id (),
-				     Definition{constant.get_node_id (),
-						constant.get_node_id ()});
 
     mappings->insert_canonical_path (mappings->get_current_crate (),
 				     constant.get_node_id (), cpath);
@@ -253,9 +235,9 @@ public:
 	r.add_range (locus);
 	rust_error_at (r, "redefined multiple times");
       });
-    resolver->insert_new_definition (function.get_node_id (),
-				     Definition{function.get_node_id (),
-						function.get_node_id ()});
+
+    NodeId current_module = resolver->peek_current_module_scope ();
+    mappings->insert_module_child_item (current_module, decl);
   }
 
   void visit (AST::ExternalStaticItem &item) override
@@ -271,9 +253,9 @@ public:
 	r.add_range (locus);
 	rust_error_at (r, "redefined multiple times");
       });
-    resolver->insert_new_definition (item.get_node_id (),
-				     Definition{item.get_node_id (),
-						item.get_node_id ()});
+
+    NodeId current_module = resolver->peek_current_module_scope ();
+    mappings->insert_module_child_item (current_module, decl);
   }
 
 private:

--- a/gcc/rust/resolve/rust-ast-resolve-item.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-item.cc
@@ -528,6 +528,7 @@ ResolveItem::visit (AST::Function &function)
   auto decl = ResolveFunctionItemToCanonicalPath::resolve (function);
   auto path = prefix.append (decl);
   auto cpath = canonical_prefix.append (decl);
+
   mappings->insert_canonical_path (mappings->get_current_crate (),
 				   function.get_node_id (), cpath);
 
@@ -788,6 +789,7 @@ ResolveItem::visit (AST::TraitImpl &impl_block)
       resolver->get_name_scope ().pop ();
       return;
     }
+  rust_assert (!canonical_impl_type.is_empty ());
 
   // setup paths
   bool canonicalize_type_args = !impl_block.has_generics ();

--- a/gcc/rust/resolve/rust-ast-resolve-item.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-item.cc
@@ -253,11 +253,13 @@ ResolveItem::visit (AST::Module &module)
   // FIXME: Should we reinsert a child here? Any reason we ResolveTopLevel::go
   // in ResolveTopLevel::visit (AST::Module) as well as here?
   for (auto &item : module.get_items ())
-    ResolveTopLevel::go (item.get (), CanonicalPath::create_empty (), cpath,
-			 module.get_node_id ());
+    ResolveTopLevel::go (item.get (), CanonicalPath::create_empty (), cpath);
 
+  resolver->push_new_module_scope (module.get_node_id ());
   for (auto &item : module.get_items ())
     ResolveItem::go (item.get (), path, cpath);
+
+  resolver->pop_module_scope ();
 
   resolver->get_name_scope ().pop ();
   resolver->get_type_scope ().pop ();

--- a/gcc/rust/resolve/rust-ast-resolve-path.h
+++ b/gcc/rust/resolve/rust-ast-resolve-path.h
@@ -40,24 +40,10 @@ private:
   void resolve_path (AST::QualifiedPathInExpression *expr);
   void resolve_path (AST::SimplePath *expr);
 
-  void resolve_segments (CanonicalPath prefix, size_t offs,
-			 std::vector<AST::PathExprSegment> &segs,
-			 NodeId expr_node_id, Location expr_locus);
-
   void
   resolve_simple_path_segments (CanonicalPath prefix, size_t offs,
 				const std::vector<AST::SimplePathSegment> &segs,
 				NodeId expr_node_id, Location expr_locus);
-};
-
-class ResolveSimplePathSegmentToCanonicalPath
-{
-public:
-  static CanonicalPath resolve (const AST::SimplePathSegment &seg)
-  {
-    // FIXME: Since this is so simple, maybe it can simply be a tiny function?
-    return CanonicalPath::new_seg (seg.get_node_id (), seg.get_segment_name ());
-  }
 };
 
 } // namespace Resolver

--- a/gcc/rust/resolve/rust-ast-resolve-pattern.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-pattern.cc
@@ -87,9 +87,7 @@ PatternDeclaration::visit (AST::StructPattern &pattern)
 	      CanonicalPath::new_seg (ident.get_node_id (),
 				      ident.get_identifier ()),
 	      ident.get_node_id (), ident.get_locus ());
-	    resolver->insert_new_definition (ident.get_node_id (),
-					     Definition{ident.get_node_id (),
-							ident.get_node_id ()});
+
 	    resolver->mark_decl_mutability (ident.get_node_id (),
 					    ident.is_mut ());
 	  }

--- a/gcc/rust/resolve/rust-ast-resolve-pattern.h
+++ b/gcc/rust/resolve/rust-ast-resolve-pattern.h
@@ -48,9 +48,6 @@ public:
 	  &resolved_node))
       {
 	resolver->insert_resolved_name (pattern.get_node_id (), resolved_node);
-	resolver->insert_new_definition (pattern.get_node_id (),
-					 Definition{pattern.get_node_id (),
-						    parent});
       }
   }
 
@@ -76,9 +73,7 @@ public:
     resolver->get_name_scope ().insert (
       CanonicalPath::new_seg (pattern.get_node_id (), pattern.get_ident ()),
       pattern.get_node_id (), pattern.get_locus ());
-    resolver->insert_new_definition (pattern.get_node_id (),
-				     Definition{pattern.get_node_id (),
-						parent});
+
     resolver->mark_decl_mutability (pattern.get_node_id (),
 				    pattern.get_is_mut ());
   }
@@ -88,9 +83,7 @@ public:
     resolver->get_name_scope ().insert (
       CanonicalPath::new_seg (pattern.get_node_id (), "_"),
       pattern.get_node_id (), pattern.get_locus ());
-    resolver->insert_new_definition (pattern.get_node_id (),
-				     Definition{pattern.get_node_id (),
-						parent});
+
     resolver->mark_decl_mutability (pattern.get_node_id (), false);
   }
 

--- a/gcc/rust/resolve/rust-ast-resolve-stmt.h
+++ b/gcc/rust/resolve/rust-ast-resolve-stmt.h
@@ -71,9 +71,6 @@ public:
 	r.add_range (locus);
 	rust_error_at (r, "redefined multiple times");
       });
-    resolver->insert_new_definition (constant.get_node_id (),
-				     Definition{constant.get_node_id (),
-						constant.get_node_id ()});
 
     ResolveType::go (constant.get_type ().get (), constant.get_node_id ());
     ResolveExpr::go (constant.get_expr ().get (), constant.get_node_id (),
@@ -361,9 +358,6 @@ public:
 	r.add_range (locus);
 	rust_error_at (r, "redefined multiple times");
       });
-    resolver->insert_new_definition (function.get_node_id (),
-				     Definition{function.get_node_id (),
-						function.get_node_id ()});
 
     NodeId scope_node_id = function.get_node_id ();
     resolver->get_name_scope ().push (scope_node_id);

--- a/gcc/rust/resolve/rust-ast-resolve-toplevel.h
+++ b/gcc/rust/resolve/rust-ast-resolve-toplevel.h
@@ -62,10 +62,6 @@ public:
 	rust_error_at (r, "redefined multiple times");
       });
 
-    resolver->insert_new_definition (module.get_node_id (),
-				     Definition{module.get_node_id (),
-						module.get_node_id ()});
-
     NodeId current_module = resolver->peek_current_module_scope ();
     mappings->insert_module_child_item (current_module, mod);
     mappings->insert_module_child (current_module, module.get_node_id ());
@@ -278,9 +274,7 @@ public:
 	r.add_range (locus);
 	rust_error_at (r, "redefined multiple times");
       });
-    resolver->insert_new_definition (var.get_node_id (),
-				     Definition{var.get_node_id (),
-						var.get_node_id ()});
+
     resolver->mark_decl_mutability (var.get_node_id (), var.is_mutable ());
 
     NodeId current_module = resolver->peek_current_module_scope ();
@@ -302,9 +296,6 @@ public:
 	r.add_range (locus);
 	rust_error_at (r, "redefined multiple times");
       });
-    resolver->insert_new_definition (constant.get_node_id (),
-				     Definition{constant.get_node_id (),
-						constant.get_node_id ()});
 
     NodeId current_module = resolver->peek_current_module_scope ();
     mappings->insert_module_child_item (current_module, decl);
@@ -325,17 +316,6 @@ public:
 	r.add_range (locus);
 	rust_error_at (r, "redefined multiple times");
       });
-    resolver->insert_new_definition (function.get_node_id (),
-				     Definition{function.get_node_id (),
-						function.get_node_id ()});
-
-    // if this does not get a reference it will be determined to be unused
-    // lets give it a fake reference to itself
-    if (function.get_function_name ().compare ("main") == 0)
-      {
-	resolver->insert_resolved_name (function.get_node_id (),
-					function.get_node_id ());
-      }
 
     NodeId current_module = resolver->peek_current_module_scope ();
     mappings->insert_module_child_item (current_module, decl);
@@ -386,11 +366,6 @@ public:
 	r.add_range (locus);
 	rust_error_at (r, "redefined multiple times");
       });
-    resolver->insert_new_definition (impl_block.get_node_id (),
-				     Definition{impl_block.get_node_id (),
-						impl_block.get_node_id ()});
-    resolver->insert_resolved_name (impl_block.get_node_id (),
-				    impl_block.get_node_id ());
 
     for (auto &impl_item : impl_block.get_impl_items ())
       ResolveToplevelImplItem::go (impl_item.get (), impl_prefix);

--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -81,6 +81,11 @@ NameResolution::go (AST::Crate &crate)
     = CanonicalPath::new_seg (scope_node_id, crate_name);
   crate_prefix.set_crate_num (cnum);
 
+  // setup a dummy crate node
+  resolver->get_name_scope ().insert (
+    CanonicalPath::new_seg (crate.get_node_id (), "__$$crate__"),
+    crate.get_node_id (), Location ());
+
   // setup the root scope
   resolver->push_new_module_scope (scope_node_id);
 
@@ -167,19 +172,21 @@ ResolveRelativeTypePath::resolve_qual_seg (AST::QualifiedPathType &seg,
 		     seg.as_string ().c_str ());
       return false;
     }
-  bool include_generic_args_in_path = false;
 
-  NodeId type_resolved_node
-    = ResolveType::go (seg.get_type ().get (), seg.get_node_id ());
+  auto type = seg.get_type ().get ();
+  NodeId type_resolved_node = ResolveType::go (type, seg.get_node_id ());
   if (type_resolved_node == UNKNOWN_NODEID)
     return false;
 
-  CanonicalPath impl_type_seg
-    = ResolveTypeToCanonicalPath::resolve (*seg.get_type ().get (),
-					   include_generic_args_in_path);
+  const CanonicalPath *impl_type_seg = nullptr;
+  bool ok
+    = mappings->lookup_canonical_path (mappings->get_current_crate (),
+				       type_resolved_node, &impl_type_seg);
+  rust_assert (ok);
+
   if (!seg.has_as_clause ())
     {
-      result = result.append (impl_type_seg);
+      result = result.append (*impl_type_seg);
       return true;
     }
 
@@ -188,12 +195,15 @@ ResolveRelativeTypePath::resolve_qual_seg (AST::QualifiedPathType &seg,
   if (trait_resolved_node == UNKNOWN_NODEID)
     return false;
 
-  CanonicalPath trait_type_seg
-    = ResolveTypeToCanonicalPath::resolve (seg.get_as_type_path (),
-					   include_generic_args_in_path);
+  const CanonicalPath *trait_type_seg = nullptr;
+  ok = mappings->lookup_canonical_path (mappings->get_current_crate (),
+					trait_resolved_node, &trait_type_seg);
+  rust_assert (ok);
+
   CanonicalPath projection
-    = TraitImplProjection::resolve (seg.get_node_id (), trait_type_seg,
-				    impl_type_seg);
+    = TraitImplProjection::resolve (seg.get_node_id (), *trait_type_seg,
+				    *impl_type_seg);
+
   result = result.append (projection);
   return true;
 }

--- a/gcc/rust/resolve/rust-name-resolver.h
+++ b/gcc/rust/resolve/rust-name-resolver.h
@@ -166,6 +166,23 @@ public:
   void set_unit_type_node_id (NodeId id) { unit_ty_node_id = id; }
   NodeId get_unit_type_node_id () { return unit_ty_node_id; }
 
+  void push_new_module_scope (NodeId module_id)
+  {
+    current_module_stack.push_back (module_id);
+  }
+
+  void pop_module_scope ()
+  {
+    rust_assert (!current_module_stack.empty ());
+    current_module_stack.pop_back ();
+  }
+
+  NodeId peek_current_module_scope () const
+  {
+    rust_assert (!current_module_stack.empty ());
+    return current_module_stack.back ();
+  }
+
 private:
   Resolver ();
 
@@ -211,6 +228,9 @@ private:
   std::map<NodeId, bool> decl_mutability;
   // map of resolved names and set of assignments to the decl
   std::map<NodeId, std::set<NodeId>> assignment_to_decl;
+
+  // keep track of the current module scope ids
+  std::vector<NodeId> current_module_stack;
 };
 
 } // namespace Resolver

--- a/gcc/rust/resolve/rust-name-resolver.h
+++ b/gcc/rust/resolve/rust-name-resolver.h
@@ -73,11 +73,13 @@ public:
   bool lookup (const CanonicalPath &ident, NodeId *id);
 
   void iterate (std::function<bool (Rib *)> cb);
+  void iterate (std::function<bool (const Rib *)> cb) const;
 
   Rib *peek ();
   void push (NodeId id);
   Rib *pop ();
 
+  bool decl_was_declared_here (NodeId def) const;
   void append_reference_for_def (NodeId refId, NodeId defId);
 
   CrateNum get_crate_num () const { return crate_num; }
@@ -85,32 +87,6 @@ public:
 private:
   CrateNum crate_num;
   std::vector<Rib *> stack;
-};
-
-// This can map simple NodeIds for names to their parent node
-// for example:
-//
-// var x = y + 1;
-//
-// say y has node id=1 and the plus_expression has id=2
-// then the Definition will have
-// Definition { node=1, parent=2 }
-// this will be used later to gather the ribs for the type inferences context
-//
-// if parent is UNKNOWN_NODEID then this is a root declaration
-// say the var_decl hasa node_id=4;
-// the parent could be a BLOCK_Expr node_id but lets make it UNKNOWN_NODE_ID
-// so we know when it terminates
-struct Definition
-{
-  NodeId node;
-  NodeId parent;
-  // add kind ?
-
-  bool is_equal (const Definition &other)
-  {
-    return node == other.node && parent == other.parent;
-  }
 };
 
 class Resolver
@@ -135,9 +111,6 @@ public:
   bool find_type_rib (NodeId id, Rib **rib);
   bool find_label_rib (NodeId id, Rib **rib);
   bool find_macro_rib (NodeId id, Rib **rib);
-
-  void insert_new_definition (NodeId id, Definition def);
-  bool lookup_definition (NodeId id, Definition *def);
 
   void insert_resolved_name (NodeId refId, NodeId defId);
   bool lookup_resolved_name (NodeId refId, NodeId *defId);
@@ -183,6 +156,18 @@ public:
     return current_module_stack.back ();
   }
 
+  NodeId peek_crate_module_scope () const
+  {
+    rust_assert (!current_module_stack.empty ());
+    return current_module_stack.front ();
+  }
+
+  NodeId peek_parent_module_scope () const
+  {
+    rust_assert (current_module_stack.size () > 1);
+    return current_module_stack.at (current_module_stack.size () - 2);
+  }
+
 private:
   Resolver ();
 
@@ -206,10 +191,6 @@ private:
   std::map<NodeId, Rib *> type_ribs;
   std::map<NodeId, Rib *> label_ribs;
   std::map<NodeId, Rib *> macro_ribs;
-
-  // map any Node to its Definition
-  // ie any name or type usage
-  std::map<NodeId, Definition> name_definitions;
 
   // Rust uses DefIds to namespace these under a crate_num
   // but then it uses the def_collector to assign local_defids

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -737,6 +737,9 @@ Session::parse_file (const char *filename)
   if (saw_errors ())
     return;
 
+  // add the mappings to it
+  mappings->insert_hir_crate (&hir);
+
   // type resolve
   Resolver::TypeResolution::Resolve (hir);
   if (options.dump_option_enabled (CompileOptions::TYPE_RESOLUTION_DUMP))

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -423,35 +423,14 @@ public:
 
     // then lookup the reference_node_id
     NodeId ref_node_id = UNKNOWN_NODEID;
-    if (resolver->lookup_resolved_name (ast_node_id, &ref_node_id))
+    if (!resolver->lookup_resolved_name (ast_node_id, &ref_node_id))
       {
-	// these ref_node_ids will resolve to a pattern declaration but we are
-	// interested in the definition that this refers to get the parent id
-	Definition def;
-	if (!resolver->lookup_definition (ref_node_id, &def))
-	  {
-	    // FIXME
-	    // this is an internal error
-	    rust_error_at (expr.get_locus (),
-			   "unknown reference for resolved name");
-	    return;
-	  }
-	ref_node_id = def.parent;
-      }
-    else if (!resolver->lookup_resolved_type (ast_node_id, &ref_node_id))
-      {
-	// FIXME
-	// this is an internal error
-	rust_error_at (expr.get_locus (),
-		       "Failed to lookup type reference for node: %s",
-		       expr.as_string ().c_str ());
-	return;
+	resolver->lookup_resolved_type (ast_node_id, &ref_node_id);
       }
 
     if (ref_node_id == UNKNOWN_NODEID)
       {
-	// FIXME
-	// this is an internal error
+	// FIXME this needs to go away and just return error node
 	rust_error_at (expr.get_locus (), "unresolved node: %s",
 		       expr.as_string ().c_str ());
 	return;

--- a/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
@@ -350,5 +350,11 @@ TypeCheckPattern::visit (HIR::RangePattern &pattern)
   infered = upper->unify (lower);
 }
 
+void
+TypeCheckPattern::visit (HIR::IdentifierPattern &pattern)
+{
+  infered = parent;
+}
+
 } // namespace Resolver
 } // namespace Rust

--- a/gcc/rust/typecheck/rust-hir-type-check-pattern.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-pattern.h
@@ -58,6 +58,8 @@ public:
 
   void visit (HIR::RangePattern &pattern) override;
 
+  void visit (HIR::IdentifierPattern &pattern) override;
+
 private:
   TypeCheckPattern (TyTy::BaseType *parent)
     : TypeCheckBase (), parent (parent), infered (nullptr)

--- a/gcc/rust/typecheck/rust-tycheck-dump.h
+++ b/gcc/rust/typecheck/rust-tycheck-dump.h
@@ -128,7 +128,7 @@ public:
   void visit (HIR::LetStmt &stmt) override
   {
     dump += "let " + stmt.get_pattern ()->as_string () + ":"
-	    + type_string (stmt.get_mappings ());
+	    + type_string (stmt.get_pattern ()->get_pattern_mappings ());
     if (stmt.has_init_expr ())
       {
 	dump += " = ";

--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -122,6 +122,7 @@ public:
   void insert_ast_crate (AST::Crate *crate);
 
   HIR::Crate *get_hir_crate (CrateNum crateNum);
+  bool is_local_hirid_crate (HirId crateNum);
   void insert_hir_crate (HIR::Crate *crate);
 
   void insert_defid_mapping (DefId id, HIR::Item *item);
@@ -329,10 +330,13 @@ public:
   void insert_module_child_item (NodeId module, Resolver::CanonicalPath item);
   Optional<std::vector<Resolver::CanonicalPath> &>
   lookup_module_chidren_items (NodeId module);
+  Optional<Resolver::CanonicalPath &>
+  lookup_module_child (NodeId module, const std::string &item_name);
 
   void insert_child_item_to_parent_module_mapping (NodeId child_item,
 						   NodeId parent_module);
   Optional<NodeId> lookup_parent_module (NodeId child_item);
+  bool node_is_module (NodeId query);
 
 private:
   Mappings ();

--- a/gcc/testsuite/rust/compile/complex-path1.rs
+++ b/gcc/testsuite/rust/compile/complex-path1.rs
@@ -1,0 +1,18 @@
+// { dg-additional-options "-w" }
+mod a {
+    pub fn foo() {}
+}
+
+mod b {
+    pub fn foo() {
+        super::a::foo();
+    }
+}
+
+mod foo {
+    pub struct bar(pub i32);
+}
+
+fn test() -> crate::foo::bar {
+    foo::bar(123)
+}

--- a/gcc/testsuite/rust/compile/issue-1251.rs
+++ b/gcc/testsuite/rust/compile/issue-1251.rs
@@ -1,0 +1,14 @@
+// { dg-additional-options "-w" }
+mod a {
+    pub mod b {
+        pub mod a {
+            pub fn foo() {}
+        }
+    }
+
+    pub fn bidule() {
+        crate::a::b::a::foo()
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
This patch completely reimplements our name resolution process for Paths in
general. This patch gets rid of the old Resolver::Definition structures
which were used so that we can map patterns back to LetStmts and establish
an hierarchy of nodes. This was not nessecary and complicated name/type
resolution.

TypePaths and PathInExpression are similar but have a slightl tweak in the
order they lookup the relevant scopes for types. But overall work the same.
There are several cases of paths you must consider in type resolution:

- i32 (simple type path)
- Self::A (associated type reference)
- mod::foo::impl_item() (reference to impl item)
- super::foo (reference to item)
- crate::foo
- T::bound()

In name resolution we cannot always fully resolve a path but have to rely
on the type-resolution to fully resolve a path as it may require careful
thought. For example a path like:

  mod::foo::item()

might be for a generic foo<T>(), which might have two specialized impl
blocks so the best the name resolution can do is resolve mod::foo then
leave it up to the type resolution to figure out which item this is. We
might have i32 which is just a simple lookup.

Apart from that this patch introduces a module parent child hierachy so
that on paths such as super::foo we resolve super to be our parent module
scope then foo can be resolved with the lookup in the items for that
module.

More over this patch gets rid of some but not all of the awkward name
canonicalization to try and patch paths directly. More cleanup is still
needed here to make the name resolution step easier to read. This was
notable in the Qualified path handling where we can now rely on the type
resolver to setup the associated types properly rather than the name
resolver requiring us to resolve this directly.

Fixes #1251 #1230
Addresses #1227 #1153