### PR TITLE
Fix formatting error on 32-bits targets

### DIFF
--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -707,10 +707,12 @@ MacroExpander::match_repetition (Parser<MacroInvocLexer> &parser,
     rust_error_at (rep.get_match_locus (),
 		   "invalid amount of matches for macro invocation. Expected "
 		   "between %s and %s, got %lu",
-		   lo_str.c_str (), hi_str.c_str (), match_amount);
+		   lo_str.c_str (), hi_str.c_str (),
+		   (unsigned long) match_amount);
 
   rust_debug_loc (rep.get_match_locus (), "%s matched %lu times",
-		  res ? "successfully" : "unsuccessfully", match_amount);
+		  res ? "successfully" : "unsuccessfully",
+		  (unsigned long) match_amount);
 
   // We have to handle zero fragments differently: They will not have been
   // "matched" but they are still valid and should be inserted as a special

--- a/gcc/rust/expand/rust-macro-substitute-ctx.cc
+++ b/gcc/rust/expand/rust-macro-substitute-ctx.cc
@@ -87,8 +87,9 @@ SubstituteCtx::check_repetition_amount (size_t pattern_start,
 		      rust_error_at (
 			frag_token->get_locus (),
 			"different amount of matches used in merged "
-			"repetitions: expected %ld, got %ld",
-			expected_repetition_amount, repeat_amount);
+			"repetitions: expected %lu, got %lu",
+			(unsigned long) expected_repetition_amount,
+			(unsigned long) repeat_amount);
 		      is_valid = false;
 		    }
 		}
@@ -110,7 +111,7 @@ SubstituteCtx::substitute_repetition (
   if (!check_repetition_amount (pattern_start, pattern_end, repeat_amount))
     return {};
 
-  rust_debug ("repetition amount to use: %lu", repeat_amount);
+  rust_debug ("repetition amount to use: %lu", (unsigned long) repeat_amount);
   std::vector<std::unique_ptr<AST::Token>> expanded;
   std::vector<std::unique_ptr<AST::Token>> new_macro;
 

--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -1573,7 +1573,7 @@ Lexer::parse_partial_unicode_escape ()
       rust_error_at (get_current_location (),
 		     "unicode escape should be between 1 and 6 hex "
 		     "characters; it is %lu",
-		     num_str.length ());
+		     (unsigned long) num_str.length ());
       // return false;
       return std::make_pair (Codepoint (0), additional_length_offset);
     }

--- a/gcc/rust/lint/rust-lint-marklive.cc
+++ b/gcc/rust/lint/rust-lint-marklive.cc
@@ -235,8 +235,8 @@ MarkLive::visit (HIR::FieldAccessExpr &expr)
   if (index >= variant->num_fields ())
     {
       rust_error_at (expr.get_receiver_expr ()->get_locus (),
-		     "cannot access struct %s by index: %ld",
-		     adt->get_name ().c_str (), index);
+		     "cannot access struct %s by index: %lu",
+		     adt->get_name ().c_str (), (unsigned long) index);
       return;
     }
 

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -98,8 +98,8 @@ validate_crate_name (const std::string &crate_name, Error &error)
     }
   if (crate_name.length () > kMaxNameLength)
     {
-      error = Error (Location (), "crate name cannot exceed %ld characters",
-		     kMaxNameLength);
+      error = Error (Location (), "crate name cannot exceed %lu characters",
+		     (unsigned long) kMaxNameLength);
       return false;
     }
   for (auto &c : crate_name)

--- a/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
@@ -87,11 +87,12 @@ TypeCheckPattern::visit (HIR::TupleStructPattern &pattern)
 
 	if (items_no_range.get_patterns ().size () != variant->num_fields ())
 	  {
-	    rust_error_at (pattern.get_locus (),
-			   "this pattern has %lu fields but the corresponding "
-			   "tuple variant has %lu field",
-			   items_no_range.get_patterns ().size (),
-			   variant->num_fields ());
+	    rust_error_at (
+	      pattern.get_locus (),
+	      "this pattern has %lu fields but the corresponding "
+	      "tuple variant has %lu field",
+	      (unsigned long) items_no_range.get_patterns ().size (),
+	      (unsigned long) variant->num_fields ());
 	    // we continue on to try and setup the types as best we can for
 	    // type checking
 	  }

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -678,7 +678,8 @@ SubstitutionRef::get_mappings_from_generic_args (HIR::GenericArgs &args)
       rust_error_at (
 	r,
 	"generic item takes at most %lu type arguments but %lu were supplied",
-	substitutions.size (), args.get_type_args ().size ());
+	(unsigned long) substitutions.size (),
+	(unsigned long) args.get_type_args ().size ());
       return SubstitutionArgumentMappings::error ();
     }
 
@@ -690,7 +691,8 @@ SubstitutionRef::get_mappings_from_generic_args (HIR::GenericArgs &args)
       rust_error_at (
 	r,
 	"generic item takes at least %lu type arguments but %lu were supplied",
-	(min_required_substitutions () - offs), args.get_type_args ().size ());
+	(unsigned long) (min_required_substitutions () - offs),
+	(unsigned long) args.get_type_args ().size ());
       return SubstitutionArgumentMappings::error ();
     }
 
@@ -3223,7 +3225,8 @@ TypeCheckCallExpr::visit (ADTType &type)
     {
       rust_error_at (call.get_locus (),
 		     "unexpected number of arguments %lu expected %lu",
-		     call.num_params (), variant.num_fields ());
+		     (unsigned long) call.num_params (),
+		     (unsigned long) variant.num_fields ());
       return;
     }
 
@@ -3254,8 +3257,8 @@ TypeCheckCallExpr::visit (ADTType &type)
   if (i != call.num_params ())
     {
       rust_error_at (call.get_locus (),
-		     "unexpected number of arguments %lu expected %lu", i,
-		     call.num_params ());
+		     "unexpected number of arguments %lu expected %lu",
+		     (unsigned long) i, (unsigned long) call.num_params ());
       return;
     }
 
@@ -3274,7 +3277,8 @@ TypeCheckCallExpr::visit (FnType &type)
 	    {
 	      rust_error_at (call.get_locus (),
 			     "unexpected number of arguments %lu expected %lu",
-			     call.num_params (), type.num_params ());
+			     (unsigned long) call.num_params (),
+			     (unsigned long) type.num_params ());
 	      return;
 	    }
 	}
@@ -3282,7 +3286,8 @@ TypeCheckCallExpr::visit (FnType &type)
 	{
 	  rust_error_at (call.get_locus (),
 			 "unexpected number of arguments %lu expected %lu",
-			 call.num_params (), type.num_params ());
+			 (unsigned long) call.num_params (),
+			 (unsigned long) type.num_params ());
 	  return;
 	}
     }
@@ -3322,8 +3327,8 @@ TypeCheckCallExpr::visit (FnType &type)
   if (i < call.num_params ())
     {
       rust_error_at (call.get_locus (),
-		     "unexpected number of arguments %lu expected %lu", i,
-		     call.num_params ());
+		     "unexpected number of arguments %lu expected %lu",
+		     (unsigned long) i, (unsigned long) call.num_params ());
       return;
     }
 
@@ -3338,7 +3343,8 @@ TypeCheckCallExpr::visit (FnPtr &type)
     {
       rust_error_at (call.get_locus (),
 		     "unexpected number of arguments %lu expected %lu",
-		     call.num_params (), type.num_params ());
+		     (unsigned long) call.num_params (),
+		     (unsigned long) type.num_params ());
       return;
     }
 
@@ -3372,8 +3378,8 @@ TypeCheckCallExpr::visit (FnPtr &type)
   if (i != call.num_params ())
     {
       rust_error_at (call.get_locus (),
-		     "unexpected number of arguments %lu expected %lu", i,
-		     call.num_params ());
+		     "unexpected number of arguments %lu expected %lu",
+		     (unsigned long) i, (unsigned long) call.num_params ());
       return;
     }
 
@@ -3393,7 +3399,8 @@ TypeCheckMethodCallExpr::visit (FnType &type)
     {
       rust_error_at (call.get_locus (),
 		     "unexpected number of arguments %lu expected %lu",
-		     call.num_params (), type.num_params ());
+		     (unsigned long) call.num_params (),
+		     (unsigned long) type.num_params ());
       return;
     }
 
@@ -3427,8 +3434,8 @@ TypeCheckMethodCallExpr::visit (FnType &type)
   if (i != num_args_to_call)
     {
       rust_error_at (call.get_locus (),
-		     "unexpected number of arguments %lu expected %lu", i,
-		     call.num_params ());
+		     "unexpected number of arguments %lu expected %lu",
+		     (unsigned long) i, (unsigned long) call.num_params ());
       return;
     }
 


### PR DESCRIPTION
Printing size_t as [unsigned] long (%ld or %lu) raises warnings on 32-bits
targets. As the GCC pretty printer doesn't have the equivalent of libc's %z/%zu,
fix all formats to use unsigned long and cast values.

refs #1229

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>
Co-authored-by: Rainer Orth <ro@gcc.gnu.org>