### PR TITLE
Fix lexing of empty comments continuing till next line

### DIFF
--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -489,6 +489,7 @@ Lexer::build_token ()
 	      // (but not an inner or outer doc comment)
 	      skip_input ();
 	      current_column += 2;
+	      current_char = peek_input ();
 
 	      // basically ignore until line finishes
 	      while (current_char != '\n' && current_char != EOF)

--- a/gcc/testsuite/rust/compile/empty_comment_before_match.rs
+++ b/gcc/testsuite/rust/compile/empty_comment_before_match.rs
@@ -1,0 +1,7 @@
+fn foo (x: i8) -> i32 { // { dg-warning "function is never used" }
+    //
+    match x {
+        1 => { return 1; }
+        _ => { return 0; }
+    }
+}


### PR DESCRIPTION
Empty comments (comments without any characters including spaces after //) had a bug during lexing. The lexer did not recheck the current character after skipping / characters. When there was no character after //, the lexer skipped the next newline character. This caused lexer to count the next line as a part of the comment to. This commit fixes this bug by rechecking current character after skipping two / characters.

Fixes #1306

Signed-off-by: Nirmal Patel <nirmal@nirmal.dev>