### PR TITLE
Add base for parsing const generic application

### DIFF
--- a/gcc/rust/ast/rust-path.h
+++ b/gcc/rust/ast/rust-path.h
@@ -134,6 +134,8 @@ struct GenericArgs
   std::vector<Lifetime> lifetime_args;
   std::vector<std::unique_ptr<Type> > type_args;
   std::vector<GenericArgsBinding> binding_args;
+  // TODO: Handle const generics here as well.
+  // We can probably keep a vector of `Expr`s for this.
   Location locus;
 
 public:

--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -138,7 +138,7 @@ public:
    */
   std::unique_ptr<AST::Stmt> parse_stmt (ParseRestrictions restrictions
 					 = ParseRestrictions ());
-  std::unique_ptr<AST::Type> parse_type ();
+  std::unique_ptr<AST::Type> parse_type (bool save_errors = true);
   std::unique_ptr<AST::ExternalItem> parse_external_item ();
   std::unique_ptr<AST::TraitItem> parse_trait_item ();
   std::unique_ptr<AST::InherentImplItem> parse_inherent_impl_item ();
@@ -177,6 +177,7 @@ private:
   AST::TypePath parse_type_path ();
   std::unique_ptr<AST::TypePathSegment> parse_type_path_segment ();
   AST::PathIdentSegment parse_path_ident_segment ();
+  std::unique_ptr<AST::Expr> parse_const_generic_expression ();
   AST::GenericArgs parse_path_generic_args ();
   AST::GenericArgsBinding parse_generic_args_binding ();
   AST::TypePathFunction parse_type_path_function (Location locus);

--- a/gcc/testsuite/rust/compile/const_generics_3.rs
+++ b/gcc/testsuite/rust/compile/const_generics_3.rs
@@ -1,0 +1,26 @@
+// { dg-additional-options "-w" }
+
+const M: usize = 4;
+
+struct Foo<T, const N: usize = 1> {
+    // FIXME: This error is bogus. But having it means parsing is valid!
+    value: [i32; N], // { dg-error "failed to find name: N" }
+}
+
+fn main() {
+    let foo = Foo::<i32> { value: [15] };
+    let foo = Foo::<i32, 2> { value: [15, 13] };
+    let foo: Foo<i32, 2> = Foo { value: [15, 13] };
+    let foo: Foo<i32, 2> = Foo::<i32, 2> { value: [15, 13] };
+    let foo: Foo<i32, { 1 + 1 }> = Foo { value: [15, 13] };
+    let foo = Foo::<i32, { 1 + 1 }> { value: [15, 13] };
+    let foo: Foo<i32, { 1 + 1 }> = Foo::<i32, { 1 + 1 }> { value: [15, 13] };
+    let foo: Foo<i32, M> = Foo::<i32, 4> {
+        value: [15, 13, 11, 9],
+    };
+
+    // FIXME: Add proper const typecheck errors here
+    let invalid_foo: Foo<i32, { 1 + 1 }> = Foo::<i32, 3> { value: [15, 13] };
+    let invalid_foo: Foo<i32, { 1 + 1 }> = Foo::<i32, M> { value: [15, 13] };
+    let invalid_foo: Foo<i32> = Foo::<i32, 2> { value: [15, 13] };
+}


### PR DESCRIPTION
1. Refactor const generic declaration

The default value for const generics now benefits from using the same
function as parsing a regular const generic expression

2. `Parser::parse_type` should not always add errors

In the case that we are parsing a const generic and not a type, we
should not emit bogus errors from `parse_type` such as "unexpected token
in type: LITERAL". Thus, we add a flag to the function to not always
add errors to the error table

3. Figure out how to deal with ambiguities

In the following cases, parsing is ambiguous:

```rust
let a: Foo<N>;
```

What is N? Is it a type to be used as a generic argument? Is it a const
value to be used for a const generic argument? We need to keep both
possibilities and differentiate later during typechecking. We need to
figure out if it would be better to keep the ambiguity in our future
`ConstGenericArg` type (something like Kind::ConstVarOrType) or modify
our current `AST::Type` to maybe get differentiated later as a const
variable, which seems more annoying.

Finally, since the const evaluation is not implemented yet, we are
getting some bogus errors in the testcase. This commit simply serves as
a necessary base: parsing const generics before we can apply them.
