### PR TITLE
Add const generic declaration to AST

### DIFF
--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -83,6 +83,10 @@ void
 Dump::visit (LifetimeParam &lifetime_param)
 {}
 
+void
+Dump::visit (ConstGenericParam &lifetime_param)
+{}
+
 // rust-path.h
 void
 Dump::visit (PathInExpression &path)

--- a/gcc/rust/ast/rust-ast-dump.h
+++ b/gcc/rust/ast/rust-ast-dump.h
@@ -71,6 +71,7 @@ private:
   void visit (IdentifierExpr &ident_expr);
   void visit (Lifetime &lifetime);
   void visit (LifetimeParam &lifetime_param);
+  void visit (ConstGenericParam &const_param);
 
   // rust-path.h
   void visit (PathInExpression &path);

--- a/gcc/rust/ast/rust-ast-full-decls.h
+++ b/gcc/rust/ast/rust-ast-full-decls.h
@@ -50,6 +50,7 @@ class TypeParamBound;
 class Lifetime;
 class GenericParam;
 class LifetimeParam;
+class ConstGenericParam;
 class MacroItem;
 class TraitItem;
 class InherentImplItem;

--- a/gcc/rust/ast/rust-ast-full-test.cc
+++ b/gcc/rust/ast/rust-ast-full-test.cc
@@ -18,6 +18,7 @@ along with GCC; see the file COPYING3.  If not see
 <http://www.gnu.org/licenses/>.  */
 
 // FIXME: This does not work on Windows
+#include <string>
 #include <unistd.h>
 
 #include "rust-ast-full.h"
@@ -2352,6 +2353,18 @@ LifetimeParam::as_string () const
       for (const auto &bound : lifetime_bounds)
 	str += "\n  " + bound.as_string ();
     }
+
+  return str;
+}
+
+std::string
+ConstGenericParam::as_string () const
+{
+  std::string str ("ConstGenericParam: ");
+  str += "const " + name + ": " + type->as_string ();
+
+  if (default_value)
+    str += " = " + default_value->as_string ();
 
   return str;
 }
@@ -4874,6 +4887,12 @@ Lifetime::accept_vis (ASTVisitor &vis)
 
 void
 LifetimeParam::accept_vis (ASTVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+void
+ConstGenericParam::accept_vis (ASTVisitor &vis)
 {
   vis.visit (*this);
 }

--- a/gcc/rust/ast/rust-ast-visitor.h
+++ b/gcc/rust/ast/rust-ast-visitor.h
@@ -49,6 +49,7 @@ public:
   virtual void visit (Lifetime &lifetime) = 0;
   // virtual void visit(GenericParam& generic_param) = 0;
   virtual void visit (LifetimeParam &lifetime_param) = 0;
+  virtual void visit (ConstGenericParam &const_param) = 0;
   // virtual void visit(TraitItem& trait_item) = 0;
   // virtual void visit(InherentImplItem& inherent_impl_item) = 0;
   // virtual void visit(TraitImplItem& trait_impl_item) = 0;

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -1342,6 +1342,72 @@ protected:
   }
 };
 
+/**
+ * Representation of const generic parameters
+ */
+class ConstGenericParam : public GenericParam
+{
+  /* Name of the parameter */
+  Identifier name;
+
+  /* Mandatory type of the const parameter - a null pointer is an error */
+  std::unique_ptr<AST::Type> type;
+
+  /**
+   * Default value for the const generic parameter - nullptr indicates a lack
+   * of default value, not an error, as these errors are reported during
+   * parsing.
+   */
+  std::unique_ptr<AST::Expr> default_value;
+
+  Attribute outer_attr;
+  Location locus;
+
+public:
+  ConstGenericParam (Identifier name, std::unique_ptr<AST::Type> type,
+		     std::unique_ptr<AST::Expr> default_value,
+		     Attribute outer_attr, Location locus)
+    : name (name), type (std::move (type)),
+      default_value (std::move (default_value)), outer_attr (outer_attr),
+      locus (locus)
+  {}
+
+  ConstGenericParam (const ConstGenericParam &other)
+    : GenericParam (), name (other.name), type (other.type->clone_type ()),
+      outer_attr (other.outer_attr), locus (other.locus)
+  {
+    if (other.default_value)
+      default_value = other.default_value->clone_expr ();
+  }
+
+  bool has_type () { return type != nullptr; }
+
+  std::unique_ptr<AST::Type> &get_type ()
+  {
+    rust_assert (has_type ());
+
+    return type;
+  }
+
+  std::unique_ptr<AST::Expr> &get_default_value () { return default_value; }
+
+  std::string as_string () const override;
+
+  void accept_vis (ASTVisitor &vis) override;
+
+  Location get_locus () const override final { return locus; }
+
+  Kind get_kind () const override final { return Kind::Const; }
+
+protected:
+  /* Use covariance to implement clone function as returning this object rather
+   * than base */
+  ConstGenericParam *clone_generic_param_impl () const override
+  {
+    return new ConstGenericParam (*this);
+  }
+};
+
 // A macro item AST node - abstract base class
 class MacroItem : public Item
 {

--- a/gcc/rust/expand/rust-attribute-visitor.cc
+++ b/gcc/rust/expand/rust-attribute-visitor.cc
@@ -354,6 +354,11 @@ AttrVisitor::visit (AST::LifetimeParam &)
 {
   // supposedly does not require - cfg does nothing
 }
+void
+AttrVisitor::visit (AST::ConstGenericParam &)
+{
+  // likewise
+}
 
 void
 AttrVisitor::visit (AST::MacroInvocation &macro_invoc)

--- a/gcc/rust/expand/rust-attribute-visitor.h
+++ b/gcc/rust/expand/rust-attribute-visitor.h
@@ -119,6 +119,7 @@ public:
   void visit (AST::IdentifierExpr &ident_expr) override;
   void visit (AST::Lifetime &) override;
   void visit (AST::LifetimeParam &) override;
+  void visit (AST::ConstGenericParam &) override;
 
   void visit (AST::MacroInvocation &macro_invoc) override;
 

--- a/gcc/rust/hir/rust-ast-lower-base.cc
+++ b/gcc/rust/hir/rust-ast-lower-base.cc
@@ -49,6 +49,9 @@ ASTLoweringBase::visit (AST::Lifetime &lifetime)
 void
 ASTLoweringBase::visit (AST::LifetimeParam &lifetime_param)
 {}
+void
+ASTLoweringBase::visit (AST::ConstGenericParam &const_param)
+{}
 //  void ASTLoweringBase::visit(TraitItem& trait_item) {}
 //  void ASTLoweringBase::visit(InherentImplItem& inherent_impl_item) {}
 //  void ASTLoweringBase::visit(TraitImplItem& trait_impl_item) {}

--- a/gcc/rust/hir/rust-ast-lower-base.h
+++ b/gcc/rust/hir/rust-ast-lower-base.h
@@ -53,6 +53,7 @@ public:
   virtual void visit (AST::Lifetime &lifetime);
   //  virtual void visit(GenericParam& generic_param);
   virtual void visit (AST::LifetimeParam &lifetime_param);
+  virtual void visit (AST::ConstGenericParam &const_param);
   //  virtual void visit(TraitItem& trait_item);
   //  virtual void visit(InherentImplItem& inherent_impl_item);
   //  virtual void visit(TraitImplItem& trait_impl_item);

--- a/gcc/rust/hir/rust-ast-lower-type.h
+++ b/gcc/rust/hir/rust-ast-lower-type.h
@@ -368,6 +368,22 @@ public:
 					 std::vector<Lifetime> ());
   }
 
+  void visit (AST::ConstGenericParam &param) override
+  {
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, param.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   mappings->get_next_localdef_id (crate_num));
+
+    // FIXME: This creates a BOGUS HIR::Lifetime instance because we do not have
+    // an `HIR::ConstGenericParam` type yet. This needs to be removed, but for
+    // now it avoids bogus ICEs
+    HIR::Lifetime lt (mapping, AST::Lifetime::LifetimeType::WILDCARD, "fixme",
+		      param.get_locus ());
+    translated = new HIR::LifetimeParam (mapping, lt, param.get_locus (),
+					 std::vector<Lifetime> ());
+  }
+
   void visit (AST::TypeParam &param) override
   {
     AST::Attribute outer_attr = AST::Attribute::create_empty ();

--- a/gcc/rust/resolve/rust-ast-resolve-base.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-base.cc
@@ -67,6 +67,10 @@ ResolverBase::visit (AST::LifetimeParam &)
 {}
 
 void
+ResolverBase::visit (AST::ConstGenericParam &)
+{}
+
+void
 ResolverBase::visit (AST::PathInExpression &)
 {}
 

--- a/gcc/rust/resolve/rust-ast-resolve-base.h
+++ b/gcc/rust/resolve/rust-ast-resolve-base.h
@@ -38,6 +38,7 @@ public:
   void visit (AST::IdentifierExpr &);
   void visit (AST::Lifetime &);
   void visit (AST::LifetimeParam &);
+  void visit (AST::ConstGenericParam &);
   void visit (AST::PathInExpression &);
   void visit (AST::TypePathSegment &);
   void visit (AST::TypePathSegmentGeneric &);

--- a/gcc/rust/resolve/rust-ast-resolve-type.h
+++ b/gcc/rust/resolve/rust-ast-resolve-type.h
@@ -341,6 +341,13 @@ public:
     ok = true;
   }
 
+  void visit (AST::ConstGenericParam &) override
+  {
+    // For now do not do anything and accept everything.
+    // FIXME: This needs to change soon!
+    ok = true;
+  }
+
   void visit (AST::TypeParam &param) override
   {
     ok = true;


### PR DESCRIPTION
This uses a number of hacks and workarounds to avoid implementing the equivalent HIR node in the same PR. I'll raise issues for each of the `FIXME`s in the code. Needs one commit from #1315 to avoid unecessary conflicts.