### PR TITLE
AST for const generic arguments/const application

### DIFF
--- a/gcc/rust/ast/rust-ast-full-test.cc
+++ b/gcc/rust/ast/rust-ast-full-test.cc
@@ -2609,6 +2609,20 @@ GenericArgs::as_string () const
 	}
     }
 
+  // const args
+  if (!const_args.empty ())
+    {
+      auto i = const_args.begin ();
+      auto e = const_args.end ();
+
+      for (; i != e; i++)
+	{
+	  args += i->as_string ();
+	  if (e != i + 1)
+	    args += ", ";
+	}
+    }
+
   // binding args
   if (!binding_args.empty ())
     {

--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -177,7 +177,7 @@ private:
   AST::TypePath parse_type_path ();
   std::unique_ptr<AST::TypePathSegment> parse_type_path_segment ();
   AST::PathIdentSegment parse_path_ident_segment ();
-  std::unique_ptr<AST::Expr> parse_const_generic_expression ();
+  AST::ConstGenericArg parse_const_generic_expression ();
   AST::GenericArgs parse_path_generic_args ();
   AST::GenericArgsBinding parse_generic_args_binding ();
   AST::TypePathFunction parse_type_path_function (Location locus);


### PR DESCRIPTION
This commit adds a new type to the AST which contains const generic
arguments. The `GenericArgs` structure now also keeps a vector of them,
and the parser was modified accordingly. We need to handle these extra
arguments in the various resolvers and type-checking phase.

As pointed out before, const generic arguments are ambiguous at the AST
level. Which is why this "sum type" contains a "Clear" variant when
there is no ambiguity at all (`<5>`, `<{ 5 }>`, `<{ 5 + 15 }>` or
`<{ N }>`) and an "Ambiguous" one if the value in question might be
referring to a type argument (`<N>`) instead of a const generic
argument.