### PR TITLE
Fixes #1263; diagnostics/feature/wrapper

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -239,8 +239,8 @@ CompileExpr::visit (HIR::MatchExpr &expr)
     {
       // FIXME: CASE_LABEL_EXPR does not support floating point types.
       // Find another way to compile these.
-      sorry_at (expr.get_locus ().gcc_location (),
-		"match on floating-point types is not yet supported");
+      rust_sorry_at (expr.get_locus (),
+		     "match on floating-point types is not yet supported");
     }
 
   TyTy::BaseType *expr_tyty = nullptr;

--- a/gcc/rust/backend/rust-compile-pattern.cc
+++ b/gcc/rust/backend/rust-compile-pattern.cc
@@ -96,8 +96,7 @@ CompilePatternCaseLabelExpr::visit (HIR::LiteralPattern &pattern)
   // floating point types.
   if (pattern.get_literal ().get_lit_type () == HIR::Literal::LitType::FLOAT)
     {
-      sorry_at (pattern.get_locus ().gcc_location (),
-		"floating-point literal in pattern");
+      rust_sorry_at (pattern.get_locus (), "floating-point literal in pattern");
     }
 
   tree lit = CompileExpr::Compile (litexpr, ctx);

--- a/gcc/rust/privacy/rust-privacy-reporter.cc
+++ b/gcc/rust/privacy/rust-privacy-reporter.cc
@@ -164,8 +164,7 @@ PrivacyReporter::check_base_type_privacy (Analysis::NodeMapping &node_mappings,
       return recursive_check (
 	static_cast<const TyTy::ProjectionType *> (ty)->get ());
     case TyTy::CLOSURE:
-      sorry_at (locus.gcc_location (),
-		"privacy pass for closures is not handled yet");
+      rust_sorry_at (locus, "privacy pass for closures is not handled yet");
       break;
 
       // If we're dealing with a generic param, there's nothing we should be

--- a/gcc/rust/rust-diagnostics.h
+++ b/gcc/rust/rust-diagnostics.h
@@ -142,6 +142,11 @@ struct Error
 // rust_debug uses normal printf formatting, not GCC diagnostic formatting.
 #define rust_debug(...) rust_debug_loc (Location (), __VA_ARGS__)
 
+// rust_sorry_at wraps GCC diagnostic "sorry_at" to accept "Location" instead of
+// "location_t"
+#define rust_sorry_at(location, ...)                                           \
+  sorry_at (location.gcc_location (), __VA_ARGS__)
+
 void
 rust_debug_loc (const Location location, const char *fmt,
 		...) ATTRIBUTE_PRINTF_2;


### PR DESCRIPTION
* wrapping GCC's diagnostics `sorry_at` with a new rust macro named `rust_sorry_at` which accepts `Location` instead of the default `location_t`.
* refactoring previous usage of `sorry_at` to `rust_sorry_at`

Fixes #1263