### PR TITLE
Lower const generics structures

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -1381,6 +1381,9 @@ public:
   }
 
   bool has_type () { return type != nullptr; }
+  bool has_default_value () { return default_value != nullptr; }
+
+  const Identifier &get_name () const { return name; }
 
   std::unique_ptr<AST::Type> &get_type ()
   {

--- a/gcc/rust/ast/rust-path.h
+++ b/gcc/rust/ast/rust-path.h
@@ -189,6 +189,8 @@ public:
 
   Kind get_kind () const { return kind; }
 
+  std::unique_ptr<AST::Expr> &get_expression () { return expression; }
+
   std::string as_string () const
   {
     switch (get_kind ())

--- a/gcc/rust/hir/rust-ast-lower-type.h
+++ b/gcc/rust/hir/rust-ast-lower-type.h
@@ -375,13 +375,17 @@ public:
 				   mappings->get_next_hir_id (crate_num),
 				   mappings->get_next_localdef_id (crate_num));
 
-    // FIXME: This creates a BOGUS HIR::Lifetime instance because we do not have
-    // an `HIR::ConstGenericParam` type yet. This needs to be removed, but for
-    // now it avoids bogus ICEs
-    HIR::Lifetime lt (mapping, AST::Lifetime::LifetimeType::WILDCARD, "fixme",
-		      param.get_locus ());
-    translated = new HIR::LifetimeParam (mapping, lt, param.get_locus (),
-					 std::vector<Lifetime> ());
+    auto type = ASTLoweringType::translate (param.get_type ().get ());
+    auto default_expr
+      = param.has_default_value ()
+	  ? ASTLoweringExpr::translate (param.get_default_value ().get ())
+	  : nullptr;
+
+    translated
+      = new HIR::ConstGenericParam (param.get_name (),
+				    std::unique_ptr<Type> (type),
+				    std::unique_ptr<Expr> (default_expr),
+				    mapping, param.get_locus ());
   }
 
   void visit (AST::TypeParam &param) override

--- a/gcc/rust/hir/tree/rust-hir-full-test.cc
+++ b/gcc/rust/hir/tree/rust-hir-full-test.cc
@@ -5285,5 +5285,20 @@ StaticItem::accept_vis (HIRVisItemVisitor &vis)
   vis.visit (*this);
 }
 
+std::string
+ConstGenericParam::as_string () const
+{
+  auto result = "ConstGenericParam: " + name + " : " + type->as_string ();
+
+  if (default_expression)
+    result += " = " + default_expression->as_string ();
+
+  return result;
+}
+
+void
+ConstGenericParam::accept_vis (HIRFullVisitor &vis)
+{}
+
 } // namespace HIR
 } // namespace Rust

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -615,13 +615,11 @@ class GenericParam
 public:
   virtual ~GenericParam () {}
 
-  enum GenericKind
+  enum class GenericKind
   {
     TYPE,
     LIFETIME,
-
-    // CONST generic parameter not yet handled
-    // CONST,
+    CONST,
   };
 
   // Unique pointer custom clone function
@@ -648,7 +646,8 @@ protected:
 
   enum GenericKind kind;
 
-  GenericParam (Analysis::NodeMapping mapping, enum GenericKind kind = TYPE)
+  GenericParam (Analysis::NodeMapping mapping,
+		enum GenericKind kind = GenericKind::TYPE)
     : mappings (mapping), kind (kind)
   {}
 };
@@ -730,6 +729,52 @@ protected:
   {
     return new LifetimeParam (*this);
   }
+};
+
+class ConstGenericParam : public GenericParam
+{
+public:
+  ConstGenericParam (std::string name, std::unique_ptr<Type> type,
+		     std::unique_ptr<Expr> default_expression,
+		     Analysis::NodeMapping mapping, Location locus)
+    : GenericParam (mapping, GenericKind::CONST), name (std::move (name)),
+      type (std::move (type)),
+      default_expression (std::move (default_expression)), locus (locus)
+  {}
+
+  ConstGenericParam (const ConstGenericParam &other) : GenericParam (other)
+  {
+    name = other.name;
+    locus = other.locus;
+
+    if (other.type)
+      type = other.type->clone_type ();
+    if (other.default_expression)
+      default_expression = other.default_expression->clone_expr ();
+  }
+
+  std::string as_string () const override final;
+
+  void accept_vis (HIRFullVisitor &vis) override final;
+
+  Location get_locus () const override final { return locus; };
+
+protected:
+  /* Use covariance to implement clone function as returning this object rather
+   * than base */
+  ConstGenericParam *clone_generic_param_impl () const override
+  {
+    return new ConstGenericParam (*this);
+  }
+
+private:
+  std::string name;
+  std::unique_ptr<Type> type;
+
+  /* Optional - can be a null pointer if there is no default expression */
+  std::unique_ptr<Expr> default_expression;
+
+  Location locus;
 };
 
 // Item used in trait declarations - abstract base class

--- a/gcc/rust/privacy/rust-reachability.cc
+++ b/gcc/rust/privacy/rust-reachability.cc
@@ -48,7 +48,7 @@ ReachabilityVisitor::visit_generic_predicates (
 
   for (const auto &generic : generics)
     {
-      if (generic->get_kind () == HIR::GenericParam::TYPE)
+      if (generic->get_kind () == HIR::GenericParam::GenericKind::TYPE)
 	{
 	  TyTy::BaseType *generic_ty = nullptr;
 	  auto ok = ty_ctx.lookup_type (generic->get_mappings ().get_hirid (),

--- a/gcc/rust/typecheck/rust-hir-trait-resolve.cc
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.cc
@@ -141,7 +141,9 @@ TraitResolver::resolve_trait (HIR::Trait *trait_reference)
       switch (generic_param.get ()->get_kind ())
 	{
 	case HIR::GenericParam::GenericKind::LIFETIME:
-	  // Skipping Lifetime completely until better handling.
+	case HIR::GenericParam::GenericKind::CONST:
+	  // FIXME: Skipping Lifetime and Const completely until better
+	  // handling.
 	  break;
 
 	  case HIR::GenericParam::GenericKind::TYPE: {
@@ -383,7 +385,9 @@ AssociatedImplTrait::setup_associated_types (
       switch (generic_param.get ()->get_kind ())
 	{
 	case HIR::GenericParam::GenericKind::LIFETIME:
-	  // Skipping Lifetime completely until better handling.
+	case HIR::GenericParam::GenericKind::CONST:
+	  // FIXME: Skipping Lifetime and Const completely until better
+	  // handling.
 	  break;
 
 	  case HIR::GenericParam::GenericKind::TYPE: {

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -57,7 +57,9 @@ public:
 	    switch (generic_param.get ()->get_kind ())
 	      {
 	      case HIR::GenericParam::GenericKind::LIFETIME:
-		// Skipping Lifetime completely until better handling.
+	      case HIR::GenericParam::GenericKind::CONST:
+		// FIXME: Skipping Lifetime and Const completely until better
+		// handling.
 		break;
 
 		case HIR::GenericParam::GenericKind::TYPE: {
@@ -190,7 +192,9 @@ public:
 	    switch (generic_param.get ()->get_kind ())
 	      {
 	      case HIR::GenericParam::GenericKind::LIFETIME:
-		// Skipping Lifetime completely until better handling.
+	      case HIR::GenericParam::GenericKind::CONST:
+		// FIXME: Skipping Lifetime and Const completely until better
+		// handling.
 		break;
 
 		case HIR::GenericParam::GenericKind::TYPE: {

--- a/gcc/rust/typecheck/rust-hir-type-check-item.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.h
@@ -51,7 +51,9 @@ public:
 	    switch (generic_param.get ()->get_kind ())
 	      {
 	      case HIR::GenericParam::GenericKind::LIFETIME:
-		// Skipping Lifetime completely until better handling.
+	      case HIR::GenericParam::GenericKind::CONST:
+		// FIXME: Skipping Lifetime and Const completely until better
+		// handling.
 		break;
 
 		case HIR::GenericParam::GenericKind::TYPE: {

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.h
@@ -139,7 +139,9 @@ public:
 	    switch (generic_param.get ()->get_kind ())
 	      {
 	      case HIR::GenericParam::GenericKind::LIFETIME:
-		// Skipping Lifetime completely until better handling.
+	      case HIR::GenericParam::GenericKind::CONST:
+		// FIXME: Skipping Lifetime and Const completely until better
+		// handling.
 		break;
 
 		case HIR::GenericParam::GenericKind::TYPE: {
@@ -215,7 +217,9 @@ public:
 	    switch (generic_param.get ()->get_kind ())
 	      {
 	      case HIR::GenericParam::GenericKind::LIFETIME:
-		// Skipping Lifetime completely until better handling.
+	      case HIR::GenericParam::GenericKind::CONST:
+		// FIXME: Skipping Lifetime and Const completely until better
+		// handling.
 		break;
 
 		case HIR::GenericParam::GenericKind::TYPE: {
@@ -273,7 +277,9 @@ public:
 	    switch (generic_param.get ()->get_kind ())
 	      {
 	      case HIR::GenericParam::GenericKind::LIFETIME:
-		// Skipping Lifetime completely until better handling.
+	      case HIR::GenericParam::GenericKind::CONST:
+		// FIXME: Skipping Lifetime and Const completely until better
+		// handling.
 		break;
 
 		case HIR::GenericParam::GenericKind::TYPE: {
@@ -347,7 +353,9 @@ public:
 	    switch (generic_param.get ()->get_kind ())
 	      {
 	      case HIR::GenericParam::GenericKind::LIFETIME:
-		// Skipping Lifetime completely until better handling.
+	      case HIR::GenericParam::GenericKind::CONST:
+		// FIXME: Skipping Lifetime and Const completely until better
+		// handling.
 		break;
 
 		case HIR::GenericParam::GenericKind::TYPE: {
@@ -415,7 +423,9 @@ public:
 	    switch (generic_param.get ()->get_kind ())
 	      {
 	      case HIR::GenericParam::GenericKind::LIFETIME:
-		// Skipping Lifetime completely until better handling.
+	      case HIR::GenericParam::GenericKind::CONST:
+		// FIXME: Skipping Lifetime and Const completely until better
+		// handling.
 		break;
 
 		case HIR::GenericParam::GenericKind::TYPE: {

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.h
@@ -64,7 +64,9 @@ public:
 	    switch (generic_param.get ()->get_kind ())
 	      {
 	      case HIR::GenericParam::GenericKind::LIFETIME:
-		// Skipping Lifetime completely until better handling.
+	      case HIR::GenericParam::GenericKind::CONST:
+		// FIXME: Skipping Lifetime and Const completely until better
+		// handling.
 		break;
 
 		case HIR::GenericParam::GenericKind::TYPE: {
@@ -150,7 +152,9 @@ public:
 	    switch (generic_param.get ()->get_kind ())
 	      {
 	      case HIR::GenericParam::GenericKind::LIFETIME:
-		// Skipping Lifetime completely until better handling.
+	      case HIR::GenericParam::GenericKind::CONST:
+		// FIXME: Skipping Lifetime and Const completely until better
+		// handling.
 		break;
 
 		case HIR::GenericParam::GenericKind::TYPE: {
@@ -228,7 +232,9 @@ public:
 	    switch (generic_param.get ()->get_kind ())
 	      {
 	      case HIR::GenericParam::GenericKind::LIFETIME:
-		// Skipping Lifetime completely until better handling.
+	      case HIR::GenericParam::GenericKind::CONST:
+		// FIXME: Skipping Lifetime and Const completely until better
+		// handling.
 		break;
 
 		case HIR::GenericParam::GenericKind::TYPE: {
@@ -286,7 +292,9 @@ public:
 	    switch (generic_param.get ()->get_kind ())
 	      {
 	      case HIR::GenericParam::GenericKind::LIFETIME:
-		// Skipping Lifetime completely until better handling.
+	      case HIR::GenericParam::GenericKind::CONST:
+		// FIXME: Skipping Lifetime and Const completely until better
+		// handling.
 		break;
 
 		case HIR::GenericParam::GenericKind::TYPE: {
@@ -374,7 +382,9 @@ public:
 	    switch (generic_param.get ()->get_kind ())
 	      {
 	      case HIR::GenericParam::GenericKind::LIFETIME:
-		// Skipping Lifetime completely until better handling.
+	      case HIR::GenericParam::GenericKind::CONST:
+		// FIXME: Skipping Lifetime and Const completely until better
+		// handling.
 		break;
 
 		case HIR::GenericParam::GenericKind::TYPE: {
@@ -457,7 +467,9 @@ public:
 	    switch (generic_param.get ()->get_kind ())
 	      {
 	      case HIR::GenericParam::GenericKind::LIFETIME:
-		// Skipping Lifetime completely until better handling.
+	      case HIR::GenericParam::GenericKind::CONST:
+		// FIXME: Skipping Lifetime and Const completely until better
+		// handling.
 		break;
 
 		case HIR::GenericParam::GenericKind::TYPE: {

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -203,7 +203,9 @@ TraitItemReference::get_type_from_fn (/*const*/ HIR::TraitItemFunc &fn) const
 	  switch (generic_param.get ()->get_kind ())
 	    {
 	    case HIR::GenericParam::GenericKind::LIFETIME:
-	      // Skipping Lifetime completely until better handling.
+	    case HIR::GenericParam::GenericKind::CONST:
+	      // FIXME: Skipping Lifetime and Const completely until better
+	      // handling.
 	      break;
 
 	      case HIR::GenericParam::GenericKind::TYPE: {


### PR DESCRIPTION
This PR adds lowering for both the `ConstGenericParam` type and the `ConstGenericArg` one. Ideally, we should be able to avoid ambiguites (`let a: Foo<N>;` -> what is N? A type? A const?) by going through the name resolver, and resolve either to a different `AST::ConstGenericArg` either to a correct `AST::Type` or equivalent. So I think we can avoid doing the same "Ambiguous/Clear" dance in the `HIR::ConstGenericArg` type.

If that ends up not being possible, we can always add it and disambiguate during typechecking or other.

Closes #1318