### PR TITLE
Add location to HIR::Type base class and improve privacy error reporting

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-path.h
+++ b/gcc/rust/hir/tree/rust-hir-path.h
@@ -623,7 +623,6 @@ class TypePath : public TypeNoBounds
 public:
   bool has_opening_scope_resolution;
   std::vector<std::unique_ptr<TypePathSegment> > segments;
-  Location locus;
 
 protected:
   /* Use covariance to implement clone function as returning this object rather
@@ -660,16 +659,15 @@ public:
   TypePath (Analysis::NodeMapping mappings,
 	    std::vector<std::unique_ptr<TypePathSegment> > segments,
 	    Location locus, bool has_opening_scope_resolution = false)
-    : TypeNoBounds (mappings),
+    : TypeNoBounds (mappings, locus),
       has_opening_scope_resolution (has_opening_scope_resolution),
-      segments (std::move (segments)), locus (locus)
+      segments (std::move (segments))
   {}
 
   // Copy constructor with vector clone
   TypePath (TypePath const &other)
-    : TypeNoBounds (other.mappings),
-      has_opening_scope_resolution (other.has_opening_scope_resolution),
-      locus (other.locus)
+    : TypeNoBounds (other.mappings, other.locus),
+      has_opening_scope_resolution (other.has_opening_scope_resolution)
   {
     segments.reserve (other.segments.size ());
     for (const auto &e : other.segments)
@@ -702,8 +700,6 @@ public:
 
   // Creates a trait bound with a clone of this type path as its only element.
   TraitBound *to_trait_bound (bool in_parens) const override;
-
-  Location get_locus () const { return locus; }
 
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRTypeVisitor &vis) override;
@@ -865,7 +861,6 @@ class QualifiedPathInType : public TypeNoBounds
   QualifiedPathType path_type;
   std::unique_ptr<TypePathSegment> associated_segment;
   std::vector<std::unique_ptr<TypePathSegment> > segments;
-  Location locus;
 
 protected:
   /* Use covariance to implement clone function as returning this object rather
@@ -888,9 +883,9 @@ public:
     std::unique_ptr<TypePathSegment> associated_segment,
     std::vector<std::unique_ptr<TypePathSegment> > path_segments,
     Location locus = Location ())
-    : TypeNoBounds (mappings), path_type (std::move (qual_path_type)),
+    : TypeNoBounds (mappings, locus), path_type (std::move (qual_path_type)),
       associated_segment (std::move (associated_segment)),
-      segments (std::move (path_segments)), locus (locus)
+      segments (std::move (path_segments))
   {}
 
   /* TODO: maybe make a shortcut constructor that has QualifiedPathType elements
@@ -898,8 +893,7 @@ public:
 
   // Copy constructor with vector clone
   QualifiedPathInType (QualifiedPathInType const &other)
-    : TypeNoBounds (other.mappings), path_type (other.path_type),
-      locus (other.locus)
+    : TypeNoBounds (other.mappings, other.locus), path_type (other.path_type)
   {
     segments.reserve (other.segments.size ());
     for (const auto &e : other.segments)
@@ -943,8 +937,6 @@ public:
   {
     return segments;
   }
-
-  Location get_locus () { return locus; }
 };
 
 class SimplePathSegment

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -478,16 +478,18 @@ public:
   virtual void accept_vis (HIRTypeVisitor &vis) = 0;
 
   virtual Analysis::NodeMapping get_mappings () const { return mappings; }
+  virtual Location get_locus () const { return locus; }
 
 protected:
-  Type (Analysis::NodeMapping mappings) : mappings (mappings) {}
+  Type (Analysis::NodeMapping mappings, Location locus)
+    : mappings (mappings), locus (locus)
+  {}
 
   // Clone function implementation as pure virtual method
   virtual Type *clone_type_impl () const = 0;
 
   Analysis::NodeMapping mappings;
-
-  // FIXME: How do we get the location here for each type?
+  Location locus;
 };
 
 // A type without parentheses? - abstract
@@ -501,7 +503,9 @@ public:
   }
 
 protected:
-  TypeNoBounds (Analysis::NodeMapping mappings) : Type (mappings) {}
+  TypeNoBounds (Analysis::NodeMapping mappings, Location locus)
+    : Type (mappings, locus)
+  {}
 
   // Clone function implementation as pure virtual method
   virtual TypeNoBounds *clone_type_no_bounds_impl () const = 0;

--- a/gcc/rust/privacy/rust-privacy-reporter.cc
+++ b/gcc/rust/privacy/rust-privacy-reporter.cc
@@ -188,8 +188,7 @@ PrivacyReporter::check_base_type_privacy (Analysis::NodeMapping &node_mappings,
 }
 
 void
-PrivacyReporter::check_type_privacy (const HIR::Type *type,
-				     const Location &locus)
+PrivacyReporter::check_type_privacy (const HIR::Type *type)
 {
   rust_assert (type);
 
@@ -198,7 +197,7 @@ PrivacyReporter::check_type_privacy (const HIR::Type *type,
     ty_ctx.lookup_type (type->get_mappings ().get_hirid (), &lookup));
 
   auto node_mappings = type->get_mappings ();
-  return check_base_type_privacy (node_mappings, lookup, locus);
+  return check_base_type_privacy (node_mappings, lookup, type->get_locus ());
 }
 
 void
@@ -634,9 +633,7 @@ void
 PrivacyReporter::visit (HIR::Function &function)
 {
   for (auto &param : function.get_function_params ())
-    check_type_privacy (param.get_type (), param.get_locus ());
-
-  // FIXME: It would be better if it was specifically the type's locus (#1256)
+    check_type_privacy (param.get_type ());
 
   function.get_definition ()->accept_vis (*this);
 }
@@ -737,8 +734,7 @@ PrivacyReporter::visit (HIR::LetStmt &stmt)
 {
   auto type = stmt.get_type ();
   if (type)
-    check_type_privacy (type, stmt.get_locus ());
-  // FIXME: #1256
+    check_type_privacy (type);
 
   auto init_expr = stmt.get_init_expr ();
   if (init_expr)

--- a/gcc/rust/privacy/rust-privacy-reporter.h
+++ b/gcc/rust/privacy/rust-privacy-reporter.h
@@ -74,9 +74,8 @@ types
    *
    * @param type Reference to an explicit type used in a statement, expression
    * 		or parameter
-   * @param locus Location of said type
    */
-  void check_type_privacy (const HIR::Type *type, const Location &locus);
+  void check_type_privacy (const HIR::Type *type);
 
   virtual void visit (HIR::StructExprFieldIdentifier &field);
   virtual void visit (HIR::StructExprFieldIdentifierValue &field);

--- a/gcc/testsuite/rust/compile/privacy5.rs
+++ b/gcc/testsuite/rust/compile/privacy5.rs
@@ -12,7 +12,6 @@ mod orange {
 
         let _: green::Foo; // { dg-error "definition is private in this context" }
 
-        fn any(a0: green::Foo, a1: green::Bar) {}
-        // { dg-error "definition is private in this context" "" { target *-*-* } .-1 }
+        fn any(a0: green::Foo, a1: green::Bar) {} // { dg-error "20:definition is private in this context" }
     }
 }


### PR DESCRIPTION
Fix #1256

Adds location to the HIR::Type base class, removes it from all the subclasses and then use it  in the `check_type_privacy` method to improve privacy error reporting.

The privacy error now looks like this (instead of what you can see in the example #1256).

```rust
gcc/testsuite/rust/compile/privacy5.rs:15:20: error: definition is private in this context
   15 |         fn any(a0: green::Foo, a1: green::Bar) {}
      |                    ^
```