### PR TITLE
hir/add: pretty printing visitor skeleton

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -70,6 +70,7 @@ GRS_OBJS = \
     rust/rust-parse.o \
     rust/rust-ast-full-test.o \
     rust/rust-ast-dump.o \
+    rust/rust-hir-dump.o \
     rust/rust-session-manager.o \
     rust/rust-compile.o \
     rust/rust-mangle.o \

--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -1,0 +1,446 @@
+// Copyright (C) 2020-2022 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-hir-dump.h"
+
+namespace Rust {
+namespace HIR {
+
+Dump::Dump (std::ostream &stream) : stream (stream) {}
+
+void
+Dump::go (HIR::Crate &crate)
+{
+  // TODO: print crate inner_attrs
+  // TODO: print crate items
+  // TODO: print crate mappings
+  stream << crate.as_string ();
+}
+
+void
+Dump::visit (IdentifierExpr &)
+{}
+void
+Dump::visit (Lifetime &)
+{}
+void
+Dump::visit (LifetimeParam &)
+{}
+void
+Dump::visit (PathInExpression &)
+{}
+void
+Dump::visit (TypePathSegment &)
+{}
+void
+Dump::visit (TypePathSegmentGeneric &)
+{}
+void
+Dump::visit (TypePathSegmentFunction &)
+{}
+void
+Dump::visit (TypePath &)
+{}
+void
+Dump::visit (QualifiedPathInExpression &)
+{}
+void
+Dump::visit (QualifiedPathInType &)
+{}
+
+void
+Dump::visit (LiteralExpr &)
+{}
+void
+Dump::visit (BorrowExpr &)
+{}
+void
+Dump::visit (DereferenceExpr &)
+{}
+void
+Dump::visit (ErrorPropagationExpr &)
+{}
+void
+Dump::visit (NegationExpr &)
+{}
+void
+Dump::visit (ArithmeticOrLogicalExpr &)
+{}
+void
+Dump::visit (ComparisonExpr &)
+{}
+void
+Dump::visit (LazyBooleanExpr &)
+{}
+void
+Dump::visit (TypeCastExpr &)
+{}
+void
+Dump::visit (AssignmentExpr &)
+{}
+void
+Dump::visit (CompoundAssignmentExpr &)
+{}
+void
+Dump::visit (GroupedExpr &)
+{}
+
+void
+Dump::visit (ArrayElemsValues &)
+{}
+void
+Dump::visit (ArrayElemsCopied &)
+{}
+void
+Dump::visit (ArrayExpr &)
+{}
+void
+Dump::visit (ArrayIndexExpr &)
+{}
+void
+Dump::visit (TupleExpr &)
+{}
+void
+Dump::visit (TupleIndexExpr &)
+{}
+void
+Dump::visit (StructExprStruct &)
+{}
+
+void
+Dump::visit (StructExprFieldIdentifier &)
+{}
+void
+Dump::visit (StructExprFieldIdentifierValue &)
+{}
+
+void
+Dump::visit (StructExprFieldIndexValue &)
+{}
+void
+Dump::visit (StructExprStructFields &)
+{}
+void
+Dump::visit (StructExprStructBase &)
+{}
+
+void
+Dump::visit (CallExpr &)
+{}
+void
+Dump::visit (MethodCallExpr &)
+{}
+void
+Dump::visit (FieldAccessExpr &)
+{}
+void
+Dump::visit (ClosureExprInner &)
+{}
+void
+Dump::visit (BlockExpr &)
+{}
+void
+Dump::visit (ClosureExprInnerTyped &)
+{}
+void
+Dump::visit (ContinueExpr &)
+{}
+void
+Dump::visit (BreakExpr &)
+{}
+void
+Dump::visit (RangeFromToExpr &)
+{}
+void
+Dump::visit (RangeFromExpr &)
+{}
+void
+Dump::visit (RangeToExpr &)
+{}
+void
+Dump::visit (RangeFullExpr &)
+{}
+void
+Dump::visit (RangeFromToInclExpr &)
+{}
+void
+Dump::visit (RangeToInclExpr &)
+{}
+void
+Dump::visit (ReturnExpr &)
+{}
+void
+Dump::visit (UnsafeBlockExpr &)
+{}
+void
+Dump::visit (LoopExpr &)
+{}
+void
+Dump::visit (WhileLoopExpr &)
+{}
+void
+Dump::visit (WhileLetLoopExpr &)
+{}
+void
+Dump::visit (ForLoopExpr &)
+{}
+void
+Dump::visit (IfExpr &)
+{}
+void
+Dump::visit (IfExprConseqElse &)
+{}
+void
+Dump::visit (IfExprConseqIf &)
+{}
+void
+Dump::visit (IfExprConseqIfLet &)
+{}
+void
+Dump::visit (IfLetExpr &)
+{}
+void
+Dump::visit (IfLetExprConseqElse &)
+{}
+void
+Dump::visit (IfLetExprConseqIf &)
+{}
+void
+Dump::visit (IfLetExprConseqIfLet &)
+{}
+
+void
+Dump::visit (MatchExpr &)
+{}
+void
+Dump::visit (AwaitExpr &)
+{}
+void
+Dump::visit (AsyncBlockExpr &)
+{}
+
+void
+Dump::visit (TypeParam &)
+{}
+
+void
+Dump::visit (LifetimeWhereClauseItem &)
+{}
+void
+Dump::visit (TypeBoundWhereClauseItem &)
+{}
+void
+Dump::visit (Module &)
+{}
+void
+Dump::visit (ExternCrate &)
+{}
+
+void
+Dump::visit (UseTreeGlob &)
+{}
+void
+Dump::visit (UseTreeList &)
+{}
+void
+Dump::visit (UseTreeRebind &)
+{}
+void
+Dump::visit (UseDeclaration &)
+{}
+void
+Dump::visit (Function &)
+{}
+void
+Dump::visit (TypeAlias &)
+{}
+void
+Dump::visit (StructStruct &)
+{}
+void
+Dump::visit (TupleStruct &)
+{}
+void
+Dump::visit (EnumItem &)
+{}
+void
+Dump::visit (EnumItemTuple &)
+{}
+void
+Dump::visit (EnumItemStruct &)
+{}
+void
+Dump::visit (EnumItemDiscriminant &)
+{}
+void
+Dump::visit (Enum &)
+{}
+void
+Dump::visit (Union &)
+{}
+void
+Dump::visit (ConstantItem &)
+{}
+void
+Dump::visit (StaticItem &)
+{}
+void
+Dump::visit (TraitItemFunc &)
+{}
+void
+Dump::visit (TraitItemConst &)
+{}
+void
+Dump::visit (TraitItemType &)
+{}
+void
+Dump::visit (Trait &)
+{}
+void
+Dump::visit (ImplBlock &)
+{}
+
+void
+Dump::visit (ExternalStaticItem &)
+{}
+void
+Dump::visit (ExternalFunctionItem &)
+{}
+void
+Dump::visit (ExternBlock &)
+{}
+
+void
+Dump::visit (LiteralPattern &)
+{}
+void
+Dump::visit (IdentifierPattern &)
+{}
+void
+Dump::visit (WildcardPattern &)
+{}
+
+void
+Dump::visit (RangePatternBoundLiteral &)
+{}
+void
+Dump::visit (RangePatternBoundPath &)
+{}
+void
+Dump::visit (RangePatternBoundQualPath &)
+{}
+void
+Dump::visit (RangePattern &)
+{}
+void
+Dump::visit (ReferencePattern &)
+{}
+
+void
+Dump::visit (StructPatternFieldTuplePat &)
+{}
+void
+Dump::visit (StructPatternFieldIdentPat &)
+{}
+void
+Dump::visit (StructPatternFieldIdent &)
+{}
+void
+Dump::visit (StructPattern &)
+{}
+
+void
+Dump::visit (TupleStructItemsNoRange &)
+{}
+void
+Dump::visit (TupleStructItemsRange &)
+{}
+void
+Dump::visit (TupleStructPattern &)
+{}
+
+void
+Dump::visit (TuplePatternItemsMultiple &)
+{}
+void
+Dump::visit (TuplePatternItemsRanged &)
+{}
+void
+Dump::visit (TuplePattern &)
+{}
+void
+Dump::visit (GroupedPattern &)
+{}
+void
+Dump::visit (SlicePattern &)
+{}
+
+void
+Dump::visit (EmptyStmt &)
+{}
+void
+Dump::visit (LetStmt &)
+{}
+void
+Dump::visit (ExprStmtWithoutBlock &)
+{}
+void
+Dump::visit (ExprStmtWithBlock &)
+{}
+
+void
+Dump::visit (TraitBound &)
+{}
+void
+Dump::visit (ImplTraitType &)
+{}
+void
+Dump::visit (TraitObjectType &)
+{}
+void
+Dump::visit (ParenthesisedType &)
+{}
+void
+Dump::visit (ImplTraitTypeOneBound &)
+{}
+void
+Dump::visit (TupleType &)
+{}
+void
+Dump::visit (NeverType &)
+{}
+void
+Dump::visit (RawPointerType &)
+{}
+void
+Dump::visit (ReferenceType &)
+{}
+void
+Dump::visit (ArrayType &)
+{}
+void
+Dump::visit (SliceType &)
+{}
+void
+Dump::visit (InferredType &)
+{}
+void
+Dump::visit (BareFunctionType &)
+{}
+} // namespace HIR
+} // namespace Rust

--- a/gcc/rust/hir/rust-hir-dump.h
+++ b/gcc/rust/hir/rust-hir-dump.h
@@ -1,0 +1,191 @@
+// Copyright (C) 2020-2022 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_HIR_DUMP_H
+#define RUST_HIR_DUMP_H
+
+#include "rust-hir-visitor.h"
+#include "rust-hir.h"
+#include "rust-hir-full.h"
+
+namespace Rust {
+namespace HIR {
+
+class Dump : public HIRFullVisitor
+{
+public:
+  Dump (std::ostream &stream);
+  void go (HIR::Crate &crate);
+
+private:
+  std::ostream &stream;
+
+  virtual void visit (IdentifierExpr &) override;
+  virtual void visit (Lifetime &) override;
+  virtual void visit (LifetimeParam &) override;
+  virtual void visit (PathInExpression &) override;
+  virtual void visit (TypePathSegment &) override;
+  virtual void visit (TypePathSegmentGeneric &) override;
+  virtual void visit (TypePathSegmentFunction &) override;
+  virtual void visit (TypePath &) override;
+  virtual void visit (QualifiedPathInExpression &) override;
+  virtual void visit (QualifiedPathInType &) override;
+
+  virtual void visit (LiteralExpr &) override;
+  virtual void visit (BorrowExpr &) override;
+  virtual void visit (DereferenceExpr &) override;
+  virtual void visit (ErrorPropagationExpr &) override;
+  virtual void visit (NegationExpr &) override;
+  virtual void visit (ArithmeticOrLogicalExpr &) override;
+  virtual void visit (ComparisonExpr &) override;
+  virtual void visit (LazyBooleanExpr &) override;
+  virtual void visit (TypeCastExpr &) override;
+  virtual void visit (AssignmentExpr &) override;
+  virtual void visit (CompoundAssignmentExpr &) override;
+  virtual void visit (GroupedExpr &) override;
+
+  virtual void visit (ArrayElemsValues &) override;
+  virtual void visit (ArrayElemsCopied &) override;
+  virtual void visit (ArrayExpr &) override;
+  virtual void visit (ArrayIndexExpr &) override;
+  virtual void visit (TupleExpr &) override;
+  virtual void visit (TupleIndexExpr &) override;
+  virtual void visit (StructExprStruct &) override;
+
+  virtual void visit (StructExprFieldIdentifier &) override;
+  virtual void visit (StructExprFieldIdentifierValue &) override;
+
+  virtual void visit (StructExprFieldIndexValue &) override;
+  virtual void visit (StructExprStructFields &) override;
+  virtual void visit (StructExprStructBase &) override;
+
+  virtual void visit (CallExpr &) override;
+  virtual void visit (MethodCallExpr &) override;
+  virtual void visit (FieldAccessExpr &) override;
+  virtual void visit (ClosureExprInner &) override;
+  virtual void visit (BlockExpr &) override;
+  virtual void visit (ClosureExprInnerTyped &) override;
+  virtual void visit (ContinueExpr &) override;
+  virtual void visit (BreakExpr &) override;
+  virtual void visit (RangeFromToExpr &) override;
+  virtual void visit (RangeFromExpr &) override;
+  virtual void visit (RangeToExpr &) override;
+  virtual void visit (RangeFullExpr &) override;
+  virtual void visit (RangeFromToInclExpr &) override;
+  virtual void visit (RangeToInclExpr &) override;
+  virtual void visit (ReturnExpr &) override;
+  virtual void visit (UnsafeBlockExpr &) override;
+  virtual void visit (LoopExpr &) override;
+  virtual void visit (WhileLoopExpr &) override;
+  virtual void visit (WhileLetLoopExpr &) override;
+  virtual void visit (ForLoopExpr &) override;
+  virtual void visit (IfExpr &) override;
+  virtual void visit (IfExprConseqElse &) override;
+  virtual void visit (IfExprConseqIf &) override;
+  virtual void visit (IfExprConseqIfLet &) override;
+  virtual void visit (IfLetExpr &) override;
+  virtual void visit (IfLetExprConseqElse &) override;
+  virtual void visit (IfLetExprConseqIf &) override;
+  virtual void visit (IfLetExprConseqIfLet &) override;
+
+  virtual void visit (MatchExpr &) override;
+  virtual void visit (AwaitExpr &) override;
+  virtual void visit (AsyncBlockExpr &) override;
+
+  virtual void visit (TypeParam &) override;
+
+  virtual void visit (LifetimeWhereClauseItem &) override;
+  virtual void visit (TypeBoundWhereClauseItem &) override;
+  virtual void visit (Module &) override;
+  virtual void visit (ExternCrate &) override;
+
+  virtual void visit (UseTreeGlob &) override;
+  virtual void visit (UseTreeList &) override;
+  virtual void visit (UseTreeRebind &) override;
+  virtual void visit (UseDeclaration &) override;
+  virtual void visit (Function &) override;
+  virtual void visit (TypeAlias &) override;
+  virtual void visit (StructStruct &) override;
+  virtual void visit (TupleStruct &) override;
+  virtual void visit (EnumItem &) override;
+  virtual void visit (EnumItemTuple &) override;
+  virtual void visit (EnumItemStruct &) override;
+  virtual void visit (EnumItemDiscriminant &) override;
+  virtual void visit (Enum &) override;
+  virtual void visit (Union &) override;
+  virtual void visit (ConstantItem &) override;
+  virtual void visit (StaticItem &) override;
+  virtual void visit (TraitItemFunc &) override;
+  virtual void visit (TraitItemConst &) override;
+  virtual void visit (TraitItemType &) override;
+  virtual void visit (Trait &) override;
+  virtual void visit (ImplBlock &) override;
+
+  virtual void visit (ExternalStaticItem &) override;
+  virtual void visit (ExternalFunctionItem &) override;
+  virtual void visit (ExternBlock &) override;
+
+  virtual void visit (LiteralPattern &) override;
+  virtual void visit (IdentifierPattern &) override;
+  virtual void visit (WildcardPattern &) override;
+
+  virtual void visit (RangePatternBoundLiteral &) override;
+  virtual void visit (RangePatternBoundPath &) override;
+  virtual void visit (RangePatternBoundQualPath &) override;
+  virtual void visit (RangePattern &) override;
+  virtual void visit (ReferencePattern &) override;
+
+  virtual void visit (StructPatternFieldTuplePat &) override;
+  virtual void visit (StructPatternFieldIdentPat &) override;
+  virtual void visit (StructPatternFieldIdent &) override;
+  virtual void visit (StructPattern &) override;
+
+  virtual void visit (TupleStructItemsNoRange &) override;
+  virtual void visit (TupleStructItemsRange &) override;
+  virtual void visit (TupleStructPattern &) override;
+
+  virtual void visit (TuplePatternItemsMultiple &) override;
+  virtual void visit (TuplePatternItemsRanged &) override;
+  virtual void visit (TuplePattern &) override;
+  virtual void visit (GroupedPattern &) override;
+  virtual void visit (SlicePattern &) override;
+
+  virtual void visit (EmptyStmt &) override;
+  virtual void visit (LetStmt &) override;
+  virtual void visit (ExprStmtWithoutBlock &) override;
+  virtual void visit (ExprStmtWithBlock &) override;
+
+  virtual void visit (TraitBound &) override;
+  virtual void visit (ImplTraitType &) override;
+  virtual void visit (TraitObjectType &) override;
+  virtual void visit (ParenthesisedType &) override;
+  virtual void visit (ImplTraitTypeOneBound &) override;
+  virtual void visit (TupleType &) override;
+  virtual void visit (NeverType &) override;
+  virtual void visit (RawPointerType &) override;
+  virtual void visit (ReferenceType &) override;
+  virtual void visit (ArrayType &) override;
+  virtual void visit (SliceType &) override;
+  virtual void visit (InferredType &) override;
+  virtual void visit (BareFunctionType &) override;
+};
+
+} // namespace HIR
+} // namespace Rust
+
+#endif // !RUST_HIR_DUMP_H

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -31,6 +31,7 @@
 #include "rust-cfg-parser.h"
 #include "rust-lint-scan-deadcode.h"
 #include "rust-lint-unused-var.h"
+#include "rust-hir-dump.h"
 
 #include "diagnostic.h"
 #include "input.h"
@@ -1045,7 +1046,7 @@ Session::dump_ast_expanded (Parser<Lexer> &parser, AST::Crate &crate) const
 }
 
 void
-Session::dump_hir (HIR::Crate &hir) const
+Session::dump_hir (HIR::Crate &crate) const
 {
   std::ofstream out;
   out.open (kHIRDumpFile);
@@ -1056,7 +1057,7 @@ Session::dump_hir (HIR::Crate &hir) const
       return;
     }
 
-  out << hir.as_string ();
+  HIR::Dump (out).go (crate);
   out.close ();
 }
 


### PR DESCRIPTION
This commit adds a visitor skeleton for pretty printing of the HIR. Also,
modifies the session manager to call the new entry point
`Rust::HIR::Dump::crate` which simply prints the crate the way it used to be.