### PR TITLE
Actually set TYPE_PACKED for type_record

### DIFF
--- a/gcc/rust/backend/rust-compile-type.cc
+++ b/gcc/rust/backend/rust-compile-type.cc
@@ -312,7 +312,7 @@ TyTyResolveCompile::visit (const TyTy::ADTType &type)
   TyTy::ADTType::ReprOptions repr = type.get_repr_options ();
   if (repr.pack)
     {
-      TYPE_PACKED (type_record);
+      TYPE_PACKED (type_record) = 1;
       if (repr.pack > 1)
 	{
 	  SET_TYPE_ALIGN (type_record, repr.pack * 8);


### PR DESCRIPTION
When bootstrapping with --enable-checking=no you'll get:

gcc/rust/backend/rust-compile-type.cc: In member function
‘virtual void Rust::Compile::TyTyResolveCompile::visit(const Rust::TyTy::ADTType&)’:
gcc/tree.h:2312:59: error: statement has no effect [-Werror=unused-value]
 2312 | #define TYPE_PACKED(NODE) (TYPE_CHECK (NODE)->base.u.bits.packed_flag)
      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
gcc/rust/backend/rust-compile-type.cc:315:7:
  note: in expansion of macro ‘TYPE_PACKED’
  315 |       TYPE_PACKED (type_record);
      |       ^~~~~~~~~~~

We need to actually set a value for the packed_flag.
