### PR TITLE
gccrs const folding port: continue porting potential_constant_expression_1()

### DIFF
--- a/gcc/rust/backend/rust-constexpr.cc
+++ b/gcc/rust/backend/rust-constexpr.cc
@@ -397,5 +397,45 @@ get_function_named_in_call (tree t)
   return fun;
 }
 
+// forked from gcc/cp/constexpr.cc maybe_constexpr_fn
+
+/* True if a function might be declared constexpr  */
+
+bool
+maybe_constexpr_fn (tree t)
+{
+  return (DECL_DECLARED_CONSTEXPR_P (t));
+}
+
+// forked from gcc/cp/constexpr.cc get_nth_callarg
+
+/* We have an expression tree T that represents a call, either CALL_EXPR.
+  Return the Nth argument.  */
+
+inline tree
+get_nth_callarg (tree t, int n)
+{
+  switch (TREE_CODE (t))
+    {
+    case CALL_EXPR:
+      return CALL_EXPR_ARG (t, n);
+
+    default:
+      gcc_unreachable ();
+      return NULL;
+    }
+}
+
+// forked from gcc/cp/constexpr.cc var_in_maybe_constexpr_fn
+
+/* True if T was declared in a function that might be constexpr: either a
+   function that was declared constexpr.  */
+
+bool
+var_in_maybe_constexpr_fn (tree t)
+{
+  return (DECL_FUNCTION_SCOPE_P (t) && maybe_constexpr_fn (DECL_CONTEXT (t)));
+}
+
 } // namespace Compile
 } // namespace Rust


### PR DESCRIPTION
Card: [Link](https://github.com/Rust-GCC/gccrs/projects/16#card-82300805).

Target function: [Link](https://github.com/Rust-GCC/gccrs/blob/master/gcc/cp/constexpr.cc#L8350)

Following functions are ported in this changeset:
 - [maybe_constexpr_fn](https://github.com/Rust-GCC/gccrs/blob/master/gcc/cp/constexpr.cc#L5495)
 - [get_nth_callarg](https://github.com/Rust-GCC/gccrs/blob/master/gcc/cp/constexpr.cc#L1333)
 - [var_in_maybe_constexpr_fn](https://github.com/Rust-GCC/gccrs/blob/master/gcc/cp/constexpr.cc#L5507)
 - [array_type_nelts_top](https://github.com/Rust-GCC/gccrs/blob/master/gcc/cp/tree.cc#L3055)
 - [builtin_valid_in_constant_expr_p](https://github.com/Rust-GCC/gccrs/blob/master/gcc/cp/tree.cc#L445)
 - [decl_maybe_constant_var_p](https://github.com/Rust-GCC/gccrs/blob/master/gcc/cp/decl2.cc#L4623)
 - [cp_type_quals](https://github.com/Rust-GCC/gccrs/blob/master/gcc/cp/typeck.cc#L10946)