### PR TITLE
Support self paths

### DIFF
--- a/gcc/rust/ast/rust-path.h
+++ b/gcc/rust/ast/rust-path.h
@@ -50,6 +50,8 @@ public:
 
   std::string as_string () const { return segment_name; }
 
+  Location get_locus () const { return locus; }
+
   bool is_super_segment () const { return as_string ().compare ("super") == 0; }
   bool is_crate_segment () const { return as_string ().compare ("crate") == 0; }
   bool is_lower_self () const { return as_string ().compare ("self") == 0; }
@@ -616,6 +618,10 @@ public:
     return get_ident_segment ().is_super_segment ();
   }
   bool is_big_self_seg () const { return get_ident_segment ().is_big_self (); }
+  bool is_lower_self_seg () const
+  {
+    return get_ident_segment ().is_lower_self ();
+  }
 };
 
 // Segment used in type path with generic args

--- a/gcc/rust/resolve/rust-ast-resolve-type.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-type.cc
@@ -155,8 +155,39 @@ ResolveRelativeTypePath::go (AST::TypePath &path, NodeId &resolved_node_id)
 	  break;
 	}
 
-      if (previous_resolved_node_id == module_scope_id
-	  && path.get_segments ().size () > 1)
+      if (is_first_segment)
+	{
+	  // name scope first
+	  NodeId resolved_node = UNKNOWN_NODEID;
+	  const CanonicalPath path
+	    = CanonicalPath::new_seg (segment->get_node_id (),
+				      ident_seg.as_string ());
+	  if (resolver->get_type_scope ().lookup (path, &resolved_node))
+	    {
+	      resolver->insert_resolved_type (segment->get_node_id (),
+					      resolved_node);
+	      resolved_node_id = resolved_node;
+	    }
+	  else if (resolver->get_name_scope ().lookup (path, &resolved_node))
+	    {
+	      resolver->insert_resolved_name (segment->get_node_id (),
+					      resolved_node);
+	      resolved_node_id = resolved_node;
+	    }
+	  else if (segment->is_lower_self_seg ())
+	    {
+	      // what is the current crate scope node id?
+	      module_scope_id = crate_scope_id;
+	      previous_resolved_node_id = module_scope_id;
+	      resolver->insert_resolved_name (segment->get_node_id (),
+					      module_scope_id);
+
+	      continue;
+	    }
+	}
+
+      if (resolved_node_id == UNKNOWN_NODEID
+	  && previous_resolved_node_id == module_scope_id)
 	{
 	  Optional<CanonicalPath &> resolved_child
 	    = mappings->lookup_module_child (module_scope_id,
@@ -188,52 +219,21 @@ ResolveRelativeTypePath::go (AST::TypePath &path, NodeId &resolved_node_id)
 	    }
 	}
 
-      if (resolved_node_id == UNKNOWN_NODEID && is_first_segment)
-	{
-	  // name scope first
-	  NodeId resolved_node = UNKNOWN_NODEID;
-	  const CanonicalPath path
-	    = CanonicalPath::new_seg (segment->get_node_id (),
-				      ident_seg.as_string ());
-	  if (resolver->get_type_scope ().lookup (path, &resolved_node))
-	    {
-	      resolver->insert_resolved_type (segment->get_node_id (),
-					      resolved_node);
-	    }
-	  else if (resolver->get_name_scope ().lookup (path, &resolved_node))
-	    {
-	      resolver->insert_resolved_name (segment->get_node_id (),
-					      resolved_node);
-	    }
-	  else
-	    {
-	      if (segment->is_lower_self_seg ())
-		{
-		  // what is the current crate scope node id?
-		  module_scope_id = crate_scope_id;
-		  previous_resolved_node_id = module_scope_id;
-		  resolver->insert_resolved_name (segment->get_node_id (),
-						  module_scope_id);
-
-		  continue;
-		}
-
-	      rust_error_at (segment->get_locus (),
-			     "failed to resolve TypePath: %s in this scope",
-			     segment->as_string ().c_str ());
-	      return false;
-	    }
-
-	  resolved_node_id = resolved_node;
-	}
-
-      if (resolved_node_id != UNKNOWN_NODEID)
+      bool did_resolve_segment = resolved_node_id != UNKNOWN_NODEID;
+      if (did_resolve_segment)
 	{
 	  if (mappings->node_is_module (resolved_node_id))
 	    {
 	      module_scope_id = resolved_node_id;
 	    }
 	  previous_resolved_node_id = resolved_node_id;
+	}
+      else if (is_first_segment)
+	{
+	  rust_error_at (segment->get_locus (),
+			 "failed to resolve TypePath: %s in this scope",
+			 segment->as_string ().c_str ());
+	  return false;
 	}
     }
 

--- a/gcc/testsuite/rust/compile/self-path1.rs
+++ b/gcc/testsuite/rust/compile/self-path1.rs
@@ -1,0 +1,12 @@
+// { dg-additional-options "-w" }
+struct foo;
+
+fn bar() -> self::foo {
+    crate::foo
+}
+
+fn baz() {
+    let a: foo = self::bar();
+
+    crate::bar();
+}

--- a/gcc/testsuite/rust/compile/self-path2.rs
+++ b/gcc/testsuite/rust/compile/self-path2.rs
@@ -1,0 +1,21 @@
+// { dg-additional-options "-w" }
+struct foo;
+
+fn bar() -> self::foo {
+    crate::foo
+}
+
+fn baz() {
+    let a: foo = self::bar();
+
+    crate::bar();
+
+    crate::self::foo();
+    // { dg-error "failed to resolve: .self. in paths can only be used in start position" "" { target *-*-* } .-1 }
+}
+
+type a = foo;
+type b = crate::foo;
+type c = self::foo;
+type d = crate::self::foo;
+// { dg-error "failed to resolve: .self. in paths can only be used in start position" "" { target *-*-* } .-1 }

--- a/gcc/testsuite/rust/execute/torture/issue-1231.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-1231.rs
@@ -1,0 +1,36 @@
+// { dg-additional-options "-w" }
+// { dg-output "outer\ninner\n" }
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+fn machin() {
+    unsafe {
+        let a = "outer\n\0";
+        let b = a as *const str;
+        let c = b as *const i8;
+
+        printf(c, 123);
+    }
+}
+
+fn bidule() {
+    fn machin() {
+        unsafe {
+            let a = "inner\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c, 123);
+        }
+    }
+
+    self::machin();
+    machin();
+}
+
+fn main() -> i32 {
+    bidule();
+
+    0
+}


### PR DESCRIPTION
This adds support for the self path which is used in two different
contexts. One where it refers to the self parameter within methods
the other is where it can refer to the crate module scope.

Handling self has some limitations where it must be the first
the segment in the path or be a single segment path for example see:

```
  struct foo;

  fn test() {
    crate::self::foo;
  }
```

Errors with (rustc 1.61):

```
  Error[E0433]: failed to resolve: `self` in paths can only be used in start position
```

crate and super keywords can be chained as expected but self seems to be a special case.

The patch here reorders the algorithm to look at the name/type scope first if its the first segment
and handle the lower case self as a special case. If this fails to result in a resolved node we
then try to look at the module_scope_id hierarchy to handle the case that the previous segments
were crate or super and finally error out at the end if we failed to resolve the segment. We can
only error for the first segment as associated paths such as Foo::Bar with Bar being an associated
impl block item requiring type-resolution.

Fixes #1231 #1227