### PR TITLE
Add generic argument disambiguation

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-base.cc
+++ b/gcc/rust/hir/rust-ast-lower-base.cc
@@ -606,21 +606,29 @@ ASTLoweringBase::lower_generic_args (AST::GenericArgs &args)
     }
 
   std::vector<std::unique_ptr<HIR::Type>> type_args;
-  for (auto &type : args.get_type_args ())
-    {
-      HIR::Type *t = ASTLoweringType::translate (type.get ());
-      type_args.push_back (std::unique_ptr<HIR::Type> (t));
-    }
-
   std::vector<HIR::ConstGenericArg> const_args;
-  for (auto &const_arg : args.get_const_args ())
-    const_args.emplace_back (HIR::ConstGenericArg (
-      std::unique_ptr<HIR::Expr> (
-	ASTLoweringExpr::translate (const_arg.get_expression ().get ())),
-      Location ()));
 
-  // FIXME:
-  // const_arg.get_locus ());
+  for (auto &arg : args.get_generic_args ())
+    {
+      switch (arg.get_kind ())
+	{
+	  case AST::GenericArg::Kind::Type: {
+	    auto type = ASTLoweringType::translate (arg.get_type ().get ());
+	    type_args.emplace_back (std::unique_ptr<HIR::Type> (type));
+	    break;
+	  }
+	  case AST::GenericArg::Kind::Const: {
+	    auto expr
+	      = ASTLoweringExpr::translate (arg.get_expression ().get ());
+	    const_args.emplace_back (
+	      HIR::ConstGenericArg (std::unique_ptr<HIR::Expr> (expr),
+				    expr->get_locus ()));
+	    break;
+	  }
+	default:
+	  gcc_unreachable ();
+	}
+    }
 
   return HIR::GenericArgs (std::move (lifetime_args), std::move (type_args),
 			   std::move (binding_args), std::move (const_args),

--- a/gcc/rust/hir/rust-ast-lower-type.h
+++ b/gcc/rust/hir/rust-ast-lower-type.h
@@ -381,7 +381,7 @@ public:
     HIR::Expr *default_expr = nullptr;
     if (param.has_default_value ()
 	&& param.get_default_value ().get_kind ()
-	     == AST::ConstGenericArg::Kind::Clear)
+	     == AST::GenericArg::Kind::Const)
       default_expr = ASTLoweringExpr::translate (
 	param.get_default_value ().get_expression ().get ());
 

--- a/gcc/rust/hir/tree/rust-hir-path.h
+++ b/gcc/rust/hir/tree/rust-hir-path.h
@@ -114,9 +114,6 @@ public:
 
 class ConstGenericArg
 {
-  // FIXME: Do we need to disambiguate or no? We should be able to disambiguate
-  // at name-resolution, hence no need for ambiguities here
-
 public:
   ConstGenericArg (std::unique_ptr<Expr> expression, Location locus)
     : expression (std::move (expression)), locus (locus)

--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -177,7 +177,7 @@ private:
   AST::TypePath parse_type_path ();
   std::unique_ptr<AST::TypePathSegment> parse_type_path_segment ();
   AST::PathIdentSegment parse_path_ident_segment ();
-  AST::ConstGenericArg parse_const_generic_expression ();
+  AST::GenericArg parse_generic_arg ();
   AST::GenericArgs parse_path_generic_args ();
   AST::GenericArgsBinding parse_generic_args_binding ();
   AST::TypePathFunction parse_type_path_function (Location locus);

--- a/gcc/rust/resolve/rust-ast-resolve-expr.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.cc
@@ -87,6 +87,7 @@ ResolveExpr::visit (AST::MethodCallExpr &expr)
   if (expr.get_method_name ().has_generic_args ())
     {
       AST::GenericArgs &args = expr.get_method_name ().get_generic_args ();
+      ResolveGenericArgs::go (args, prefix, canonical_prefix);
       ResolveType::type_resolve_generic_args (args);
     }
 

--- a/gcc/rust/resolve/rust-ast-resolve-path.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-path.cc
@@ -88,6 +88,8 @@ ResolvePath::resolve_path (AST::PathInExpression *expr)
       // resolve any generic args
       if (segment.has_generic_args ())
 	{
+	  auto empty = CanonicalPath::create_empty ();
+	  ResolveGenericArgs::go (segment.get_generic_args (), empty, empty);
 	  ResolveType::type_resolve_generic_args (segment.get_generic_args ());
 	}
 
@@ -226,6 +228,8 @@ ResolvePath::resolve_path (AST::QualifiedPathInExpression *expr)
       // generic arguments used
       if (segment.has_generic_args ())
 	{
+	  auto empty = CanonicalPath::create_empty ();
+	  ResolveGenericArgs::go (segment.get_generic_args (), empty, empty);
 	  ResolveType::type_resolve_generic_args (segment.get_generic_args ());
 	}
     }

--- a/gcc/testsuite/rust/compile/const_generics_2.rs
+++ b/gcc/testsuite/rust/compile/const_generics_2.rs
@@ -1,3 +1,4 @@
 struct Foo<const N>; // { dg-error "expecting .:. but .>. found" }
 struct Bar<const N: >; // { dg-error "unrecognised token .>. in type" }
 struct Baz<const N: usize = >; // { dg-error "invalid token for start of default value for const generic parameter" }
+// { dg-error "unrecognised token .>. in type" "" { target *-*-* } .-1 }

--- a/gcc/testsuite/rust/compile/const_generics_5.rs
+++ b/gcc/testsuite/rust/compile/const_generics_5.rs
@@ -1,0 +1,12 @@
+struct Foo<const N: usize = { 14 }>;
+
+const M: usize = 15;
+type N = Foo<3>;
+
+fn main() {
+    let _: Foo<15> = Foo;
+    let _: Foo<{ M }> = Foo;
+    let _: Foo<M> = Foo;
+    // bogus error, but it means the above const generic gets disambiguated properly
+    let _: Foo<N> = Foo; // { dg-error "TypePath Foo<N> declares generic arguments but the type Foo{Foo {}} does not have any" }
+}


### PR DESCRIPTION
ast: Add disambiguation for generic arguments

This commits adds a new resolver visitor, `ResolveGenericArgs`, which
takes care of differentiating const generics from type generics before
the typechecking phase. This is done solely based on name resolution.

The algorithm is as follows:

is that name referring to a type?
  -> disambiguate to a type
is that name referring to a value?
  -> disambiguate to a const value
else
  -> disambiguate to type

Since types are the default expected behavior, this allows us to report
type errors properly during typechecking.