### PR TITLE
HIR: fixup MatchArm assignment operator

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -3827,6 +3827,7 @@ public:
     if (other.guard_expr != nullptr)
       guard_expr = other.guard_expr->clone_expr ();
 
+    match_arm_patterns.clear ();
     match_arm_patterns.reserve (other.match_arm_patterns.size ());
     for (const auto &e : other.match_arm_patterns)
       match_arm_patterns.push_back (e->clone_pattern ());


### PR DESCRIPTION
We overload the assignment operator to clone the vector of patterns for
the match arm. However the existing patterns were not cleared before
inserting the new ones, so the result was to append the new patterns
onto the assignee arm rather than replace them.
