### PR TITLE
Allow linemap to be optional nullptr

### DIFF
--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -347,7 +347,7 @@ Lexer::build_token ()
 		  current_line++;
 		  current_column = 1;
 		  // tell line_table that new line starts
-		  line_map->start_line (current_line, max_column_hint);
+		  start_line (current_line, max_column_hint);
 		  break;
 		}
 	      else
@@ -368,7 +368,7 @@ Lexer::build_token ()
 	  current_line++;
 	  current_column = 1;
 	  // tell line_table that new line starts
-	  line_map->start_line (current_line, max_column_hint);
+	  start_line (current_line, max_column_hint);
 	  continue;
 	case '\r': // cr
 	  // Ignore, we expect a newline (lf) soon.
@@ -540,7 +540,7 @@ Lexer::build_token ()
 	      current_line++;
 	      current_column = 1;
 	      // tell line_table that new line starts
-	      line_map->start_line (current_line, max_column_hint);
+	      start_line (current_line, max_column_hint);
 
 	      str.shrink_to_fit ();
 	      if (is_inner)
@@ -617,7 +617,7 @@ Lexer::build_token ()
 		      current_line++;
 		      current_column = 1;
 		      // tell line_table that new line starts
-		      line_map->start_line (current_line, max_column_hint);
+		      start_line (current_line, max_column_hint);
 		      continue;
 		    }
 
@@ -686,7 +686,7 @@ Lexer::build_token ()
 		      current_line++;
 		      current_column = 1;
 		      // tell line_table that new line starts
-		      line_map->start_line (current_line, max_column_hint);
+		      start_line (current_line, max_column_hint);
 		      str += '\n';
 		      continue;
 		    }
@@ -1400,7 +1400,7 @@ Lexer::parse_partial_string_continue ()
 	  current_line++;
 	  current_column = 1;
 	  // tell line_table that new line starts
-	  line_map->start_line (current_line, max_column_hint);
+	  start_line (current_line, max_column_hint);
 
 	  // reset "length"
 	  additional_length_offset = 1;
@@ -2688,4 +2688,12 @@ Lexer::split_current_token (TokenId new_left, TokenId new_right)
   token_queue.replace_current_value (std::move (new_left_tok));
   token_queue.insert (1, std::move (new_right_tok));
 }
+
+void
+Lexer::start_line (int current_line, int current_column)
+{
+  if (line_map)
+    line_map->start_line (current_line, current_column);
+}
+
 } // namespace Rust

--- a/gcc/rust/lex/rust-lex.h
+++ b/gcc/rust/lex/rust-lex.h
@@ -205,6 +205,8 @@ public:
   std::string get_filename () { return std::string (input.get_filename ()); }
 
 private:
+  void start_line (int current_line, int current_column);
+
   // File for use as input.
   RAIIFile input;
   // TODO is this actually required? could just have file storage in InputSource


### PR DESCRIPTION
The line map within the lexer is used to notify GCC of location data.
This lexer is used on raw string buffers where the linemap can be
null and thus can hit nullptr's. This patch wraps the linemap usage
behind a function. We might make the linemap mandatory as a reference
but lets figure out how the location info should look for imports first.