### PR TITLE
Support extern-blocks in ast-dumps

### DIFF
--- a/gcc/rust/ast/rust-ast-dump.h
+++ b/gcc/rust/ast/rust-ast-dump.h
@@ -50,6 +50,7 @@ public:
    * Run the visitor on an entire crate and its items
    */
   void go (AST::Crate &crate);
+  void go (AST::Item &item);
 
 private:
   std::ostream &stream;


### PR DESCRIPTION
This allows us to support really basic expressions and extern blocks. These
are used for the hello world version of importing metadata in crates.
