### PR TITLE
Refactor mappings class and HIR lowering to be consistent

### DIFF
--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -1153,6 +1153,9 @@ public:
 
   void accept_vis (ASTVisitor &vis) override;
 
+  const std::string &get_referenced_crate () const { return referenced_crate; }
+  const std::string &get_as_clause () const { return as_clause_name; }
+
   // Override that adds extern crate name in decl to passed list of names.
   void add_crate_name (std::vector<std::string> &names) const override
   {

--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -404,19 +404,16 @@ std::vector<Bvariable *>
 HIRCompileBase::compile_locals_for_block (Context *ctx, Resolver::Rib &rib,
 					  tree fndecl)
 {
-  CrateNum crate = ctx->get_mappings ()->get_current_crate ();
-
   std::vector<Bvariable *> locals;
   for (auto it : rib.get_declarations ())
     {
       NodeId node_id = it.first;
       HirId ref = UNKNOWN_HIRID;
-      if (!ctx->get_mappings ()->lookup_node_to_hir (crate, node_id, &ref))
+      if (!ctx->get_mappings ()->lookup_node_to_hir (node_id, &ref))
 	continue;
 
       // we only care about local patterns
-      HIR::Pattern *pattern
-	= ctx->get_mappings ()->lookup_hir_pattern (crate, ref);
+      HIR::Pattern *pattern = ctx->get_mappings ()->lookup_hir_pattern (ref);
       if (pattern == nullptr)
 	continue;
 

--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -985,8 +985,7 @@ CompileExpr::visit (HIR::MethodCallExpr &expr)
 
   // reverse lookup
   HirId ref;
-  if (!ctx->get_mappings ()->lookup_node_to_hir (
-	expr.get_mappings ().get_crate_num (), resolved_node_id, &ref))
+  if (!ctx->get_mappings ()->lookup_node_to_hir (resolved_node_id, &ref))
     {
       rust_fatal_error (expr.get_locus (), "reverse lookup failure");
       return;
@@ -1188,8 +1187,7 @@ CompileExpr::resolve_method_address (TyTy::FnType *fntype, HirId ref,
   // declared function, generic function which has not be compiled yet or
   // its an not yet trait bound function
   HIR::ImplItem *resolved_item
-    = ctx->get_mappings ()->lookup_hir_implitem (expr_mappings.get_crate_num (),
-						 ref, nullptr);
+    = ctx->get_mappings ()->lookup_hir_implitem (ref, nullptr);
   if (resolved_item != nullptr)
     {
       if (!fntype->has_subsititions_defined ())
@@ -1199,8 +1197,8 @@ CompileExpr::resolve_method_address (TyTy::FnType *fntype, HirId ref,
     }
 
   // it might be resolved to a trait item
-  HIR::TraitItem *trait_item = ctx->get_mappings ()->lookup_hir_trait_item (
-    expr_mappings.get_crate_num (), ref);
+  HIR::TraitItem *trait_item
+    = ctx->get_mappings ()->lookup_hir_trait_item (ref);
   HIR::Trait *trait = ctx->get_mappings ()->lookup_trait_item_mapping (
     trait_item->get_mappings ().get_hirid ());
 
@@ -1284,8 +1282,7 @@ CompileExpr::resolve_operator_overload (
 
   // reverse lookup
   HirId ref;
-  ok = ctx->get_mappings ()->lookup_node_to_hir (
-    expr.get_mappings ().get_crate_num (), resolved_node_id, &ref);
+  ok = ctx->get_mappings ()->lookup_node_to_hir (resolved_node_id, &ref);
   rust_assert (ok);
 
   TyTy::BaseType *receiver = nullptr;
@@ -1874,8 +1871,7 @@ CompileExpr::visit (HIR::IdentifierExpr &expr)
 
   // node back to HIR
   HirId ref;
-  if (!ctx->get_mappings ()->lookup_node_to_hir (
-	expr.get_mappings ().get_crate_num (), ref_node_id, &ref))
+  if (!ctx->get_mappings ()->lookup_node_to_hir (ref_node_id, &ref))
     {
       rust_error_at (expr.get_locus (), "reverse lookup failure");
       return;
@@ -1939,8 +1935,7 @@ CompileExpr::visit (HIR::IdentifierExpr &expr)
   else
     {
       // lets try and query compile it to an item/impl item
-      HIR::Item *resolved_item = ctx->get_mappings ()->lookup_hir_item (
-	expr.get_mappings ().get_crate_num (), ref);
+      HIR::Item *resolved_item = ctx->get_mappings ()->lookup_hir_item (ref);
       bool is_hir_item = resolved_item != nullptr;
       if (!is_hir_item)
 	{

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -715,8 +715,7 @@ public:
 	  }
 
 	HirId ref = UNKNOWN_HIRID;
-	if (!ctx->get_mappings ()->lookup_node_to_hir (
-	      expr.get_mappings ().get_crate_num (), resolved_node_id, &ref))
+	if (!ctx->get_mappings ()->lookup_node_to_hir (resolved_node_id, &ref))
 	  {
 	    rust_fatal_error (expr.get_locus (),
 			      "reverse lookup label failure");
@@ -762,8 +761,7 @@ public:
 	  }
 
 	HirId ref = UNKNOWN_HIRID;
-	if (!ctx->get_mappings ()->lookup_node_to_hir (
-	      expr.get_mappings ().get_crate_num (), resolved_node_id, &ref))
+	if (!ctx->get_mappings ()->lookup_node_to_hir (resolved_node_id, &ref))
 	  {
 	    rust_fatal_error (expr.get_locus (),
 			      "reverse lookup label failure");

--- a/gcc/rust/backend/rust-compile-implitem.cc
+++ b/gcc/rust/backend/rust-compile-implitem.cc
@@ -31,7 +31,6 @@ CompileTraitItem::visit (HIR::TraitItemConst &constant)
 
   const Resolver::CanonicalPath *canonical_path = nullptr;
   bool ok = ctx->get_mappings ()->lookup_canonical_path (
-    constant.get_mappings ().get_crate_num (),
     constant.get_mappings ().get_nodeid (), &canonical_path);
   rust_assert (ok);
 
@@ -84,8 +83,7 @@ CompileTraitItem::visit (HIR::TraitItemFunc &func)
 
   const Resolver::CanonicalPath *canonical_path = nullptr;
   bool ok = ctx->get_mappings ()->lookup_canonical_path (
-    func.get_mappings ().get_crate_num (), func.get_mappings ().get_nodeid (),
-    &canonical_path);
+    func.get_mappings ().get_nodeid (), &canonical_path);
   rust_assert (ok);
 
   // FIXME: How do we get the proper visibility here?

--- a/gcc/rust/backend/rust-compile-item.cc
+++ b/gcc/rust/backend/rust-compile-item.cc
@@ -47,8 +47,7 @@ CompileItem::visit (HIR::StaticItem &var)
 
   const Resolver::CanonicalPath *canonical_path = nullptr;
   ok = ctx->get_mappings ()->lookup_canonical_path (
-    var.get_mappings ().get_crate_num (), var.get_mappings ().get_nodeid (),
-    &canonical_path);
+    var.get_mappings ().get_nodeid (), &canonical_path);
   rust_assert (ok);
 
   std::string name = canonical_path->get ();
@@ -87,7 +86,6 @@ CompileItem::visit (HIR::ConstantItem &constant)
   // canonical path
   const Resolver::CanonicalPath *canonical_path = nullptr;
   ok = ctx->get_mappings ()->lookup_canonical_path (
-    constant.get_mappings ().get_crate_num (),
     constant.get_mappings ().get_nodeid (), &canonical_path);
   rust_assert (ok);
 
@@ -162,7 +160,6 @@ CompileItem::visit (HIR::Function &function)
 
   const Resolver::CanonicalPath *canonical_path = nullptr;
   bool ok = ctx->get_mappings ()->lookup_canonical_path (
-    function.get_mappings ().get_crate_num (),
     function.get_mappings ().get_nodeid (), &canonical_path);
   rust_assert (ok);
 

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -99,8 +99,7 @@ ResolvePathRef::resolve (const HIR::PathIdentSegment &final_segment,
     }
 
   HirId ref;
-  if (!ctx->get_mappings ()->lookup_node_to_hir (mappings.get_crate_num (),
-						 ref_node_id, &ref))
+  if (!ctx->get_mappings ()->lookup_node_to_hir (ref_node_id, &ref))
     {
       rust_error_at (expr_locus, "reverse call path lookup failure");
       return error_mark_node;
@@ -159,11 +158,9 @@ HIRCompileBase::query_compile (HirId ref, TyTy::BaseType *lookup,
 			       const Analysis::NodeMapping &mappings,
 			       Location expr_locus, bool is_qualified_path)
 {
-  HIR::Item *resolved_item
-    = ctx->get_mappings ()->lookup_hir_item (mappings.get_crate_num (), ref);
+  HIR::Item *resolved_item = ctx->get_mappings ()->lookup_hir_item (ref);
   HIR::ExternalItem *resolved_extern_item
-    = ctx->get_mappings ()->lookup_hir_extern_item (mappings.get_crate_num (),
-						    ref);
+    = ctx->get_mappings ()->lookup_hir_extern_item (ref);
   bool is_hir_item = resolved_item != nullptr;
   bool is_hir_extern_item = resolved_extern_item != nullptr;
   if (is_hir_item)
@@ -188,15 +185,13 @@ HIRCompileBase::query_compile (HirId ref, TyTy::BaseType *lookup,
     {
       HirId parent_impl_id = UNKNOWN_HIRID;
       HIR::ImplItem *resolved_item
-	= ctx->get_mappings ()->lookup_hir_implitem (mappings.get_crate_num (),
-						     ref, &parent_impl_id);
+	= ctx->get_mappings ()->lookup_hir_implitem (ref, &parent_impl_id);
       bool is_impl_item = resolved_item != nullptr;
       if (is_impl_item)
 	{
 	  rust_assert (parent_impl_id != UNKNOWN_HIRID);
 	  HIR::Item *impl_ref
-	    = ctx->get_mappings ()->lookup_hir_item (mappings.get_crate_num (),
-						     parent_impl_id);
+	    = ctx->get_mappings ()->lookup_hir_item (parent_impl_id);
 	  rust_assert (impl_ref != nullptr);
 	  HIR::ImplBlock *impl = static_cast<HIR::ImplBlock *> (impl_ref);
 
@@ -216,8 +211,7 @@ HIRCompileBase::query_compile (HirId ref, TyTy::BaseType *lookup,
 	{
 	  // it might be resolved to a trait item
 	  HIR::TraitItem *trait_item
-	    = ctx->get_mappings ()->lookup_hir_trait_item (
-	      mappings.get_crate_num (), ref);
+	    = ctx->get_mappings ()->lookup_hir_trait_item (ref);
 	  HIR::Trait *trait = ctx->get_mappings ()->lookup_trait_item_mapping (
 	    trait_item->get_mappings ().get_hirid ());
 

--- a/gcc/rust/expand/rust-attribute-visitor.cc
+++ b/gcc/rust/expand/rust-attribute-visitor.cc
@@ -2864,6 +2864,8 @@ AttrVisitor::visit (AST::MacroRulesDefinition &rules_def)
   expander.resolver->get_macro_scope ().insert (path, rules_def.get_node_id (),
 						rules_def.get_locus ());
   expander.mappings->insert_macro_def (&rules_def);
+  rust_debug_loc (rules_def.get_locus (), "inserting macro def: [%s]",
+		  path.get ().c_str ());
 }
 
 void

--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -142,7 +142,7 @@ MacroExpander::expand_invoc (AST::MacroInvocation &invoc)
     &resolved_node);
   if (!found)
     {
-      rust_error_at (invoc.get_locus (), "unknown macro");
+      rust_error_at (invoc.get_locus (), "unknown macro 1");
       return;
     }
 
@@ -177,13 +177,14 @@ MacroExpander::expand_invoc_semi (AST::MacroInvocation &invoc)
 
   // lookup the rules for this macro
   NodeId resolved_node = UNKNOWN_NODEID;
-  bool found = resolver->get_macro_scope ().lookup (
-    Resolver::CanonicalPath::new_seg (invoc.get_macro_node_id (),
-				      invoc_data.get_path ().as_string ()),
-    &resolved_node);
+  auto seg
+    = Resolver::CanonicalPath::new_seg (invoc.get_macro_node_id (),
+					invoc_data.get_path ().as_string ());
+  bool found = resolver->get_macro_scope ().lookup (seg, &resolved_node);
   if (!found)
     {
-      rust_error_at (invoc.get_locus (), "unknown macro");
+      rust_error_at (invoc.get_locus (), "unknown macro 2: [%s]",
+		     seg.get ().c_str ());
       return;
     }
 

--- a/gcc/rust/hir/rust-ast-lower-base.cc
+++ b/gcc/rust/hir/rust-ast-lower-base.cc
@@ -527,8 +527,7 @@ ASTLoweringBase::lower_lifetime (AST::Lifetime &lifetime)
   Analysis::NodeMapping mapping (crate_num, lifetime.get_node_id (),
 				 mappings->get_next_hir_id (crate_num),
 				 UNKNOWN_LOCAL_DEFID);
-  mappings->insert_node_to_hir (mapping.get_crate_num (), mapping.get_nodeid (),
-				mapping.get_hirid ());
+  mappings->insert_node_to_hir (mapping.get_nodeid (), mapping.get_hirid ());
 
   return HIR::Lifetime (mapping, lifetime.get_lifetime_type (),
 			lifetime.get_lifetime_name (), lifetime.get_locus ());
@@ -543,8 +542,7 @@ ASTLoweringBase::lower_loop_label (AST::LoopLabel &loop_label)
   Analysis::NodeMapping mapping (crate_num, loop_label.get_node_id (),
 				 mappings->get_next_hir_id (crate_num),
 				 UNKNOWN_LOCAL_DEFID);
-  mappings->insert_node_to_hir (mapping.get_crate_num (), mapping.get_nodeid (),
-				mapping.get_hirid ());
+  mappings->insert_node_to_hir (mapping.get_nodeid (), mapping.get_hirid ());
 
   return HIR::LoopLabel (mapping, std::move (life), loop_label.get_locus ());
 }
@@ -734,13 +732,11 @@ ASTLowerQualifiedPathInType::visit (AST::QualifiedPathInType &path)
 
   Analysis::NodeMapping mapping (crate_num, path.get_node_id (), hirid,
 				 mappings->get_next_localdef_id (crate_num));
-
   translated = new HIR::QualifiedPathInType (std::move (mapping),
 					     std::move (qual_path_type),
 					     std::move (associated_segment),
 					     std::move (translated_segments),
 					     path.get_locus ());
-  mappings->insert_hir_type (crate_num, hirid, translated);
 }
 
 void
@@ -758,9 +754,6 @@ ASTLoweringType::visit (AST::TraitObjectTypeOneBound &type)
 
   translated = new HIR::TraitObjectType (mapping, std::move (bounds),
 					 type.get_locus (), type.is_dyn ());
-
-  mappings->insert_hir_type (mapping.get_crate_num (), mapping.get_hirid (),
-			     translated);
 }
 
 void
@@ -783,9 +776,6 @@ ASTLoweringType::visit (AST::TraitObjectType &type)
 
   translated = new HIR::TraitObjectType (mapping, std::move (bounds),
 					 type.get_locus (), type.is_dyn ());
-
-  mappings->insert_hir_type (mapping.get_crate_num (), mapping.get_hirid (),
-			     translated);
 }
 
 HIR::Type *
@@ -1083,12 +1073,6 @@ ASTLoweringBase::lower_extern_block (AST::ExternBlock &extern_block)
 			    std::move (vis), extern_block.get_inner_attrs (),
 			    extern_block.get_outer_attrs (),
 			    extern_block.get_locus ());
-
-  mappings->insert_defid_mapping (mapping.get_defid (), hir_extern_block);
-  mappings->insert_hir_item (mapping.get_crate_num (), mapping.get_hirid (),
-			     hir_extern_block);
-  mappings->insert_location (crate_num, mapping.get_hirid (),
-			     extern_block.get_locus ());
 
   return hir_extern_block;
 }

--- a/gcc/rust/hir/rust-ast-lower-block.h
+++ b/gcc/rust/hir/rust-ast-lower-block.h
@@ -36,10 +36,7 @@ public:
     expr->accept_vis (resolver);
     if (resolver.translated != nullptr)
       {
-	resolver.mappings->insert_hir_expr (
-	  resolver.translated->get_mappings ().get_crate_num (),
-	  resolver.translated->get_mappings ().get_hirid (),
-	  resolver.translated);
+	resolver.mappings->insert_hir_expr (resolver.translated);
       }
 
     *terminated = resolver.terminated;
@@ -65,9 +62,7 @@ public:
 				  std::unique_ptr<HIR::BlockExpr> (block),
 				  expr->get_outer_attrs (), expr->get_locus ());
 
-    resolver.mappings->insert_hir_expr (
-      translated->get_mappings ().get_crate_num (),
-      translated->get_mappings ().get_hirid (), translated);
+    resolver.mappings->insert_hir_expr (translated);
 
     return translated;
   }
@@ -94,10 +89,7 @@ public:
     expr->accept_vis (resolver);
     if (resolver.translated != nullptr)
       {
-	resolver.mappings->insert_hir_expr (
-	  resolver.translated->get_mappings ().get_crate_num (),
-	  resolver.translated->get_mappings ().get_hirid (),
-	  resolver.translated);
+	resolver.mappings->insert_hir_expr (resolver.translated);
       }
     *terminated = resolver.terminated;
     return resolver.translated;
@@ -131,10 +123,7 @@ public:
     expr->accept_vis (resolver);
     if (resolver.translated != nullptr)
       {
-	resolver.mappings->insert_hir_expr (
-	  resolver.translated->get_mappings ().get_crate_num (),
-	  resolver.translated->get_mappings ().get_hirid (),
-	  resolver.translated);
+	resolver.mappings->insert_hir_expr (resolver.translated);
       }
     return resolver.translated;
   }
@@ -161,10 +150,7 @@ public:
     expr->accept_vis (resolver);
     if (resolver.translated != nullptr)
       {
-	resolver.mappings->insert_hir_expr (
-	  resolver.translated->get_mappings ().get_crate_num (),
-	  resolver.translated->get_mappings ().get_hirid (),
-	  resolver.translated);
+	resolver.mappings->insert_hir_expr (resolver.translated);
       }
 
     *terminated = resolver.terminated;

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -87,11 +87,8 @@ public:
 	return nullptr;
       }
 
-    resolver.mappings->insert_hir_expr (
-      resolver.translated->get_mappings ().get_crate_num (),
-      resolver.translated->get_mappings ().get_hirid (), resolver.translated);
+    resolver.mappings->insert_hir_expr (resolver.translated);
     resolver.mappings->insert_location (
-      resolver.translated->get_mappings ().get_crate_num (),
       resolver.translated->get_mappings ().get_hirid (), expr->get_locus ());
 
     if (terminated != nullptr)

--- a/gcc/rust/hir/rust-ast-lower-extern.h
+++ b/gcc/rust/hir/rust-ast-lower-extern.h
@@ -35,6 +35,13 @@ public:
   {
     ASTLoweringExternItem resolver;
     item->accept_vis (resolver);
+
+    rust_assert (resolver.translated != nullptr);
+    resolver.mappings->insert_hir_extern_item (resolver.translated);
+    resolver.mappings->insert_location (
+      resolver.translated->get_mappings ().get_hirid (),
+      resolver.translated->get_locus ());
+
     return resolver.translated;
   }
 
@@ -49,17 +56,10 @@ public:
 				   mappings->get_next_hir_id (crate_num),
 				   mappings->get_next_localdef_id (crate_num));
 
-    HIR::ExternalStaticItem *static_item = new HIR::ExternalStaticItem (
+    translated = new HIR::ExternalStaticItem (
       mapping, item.get_identifier (), std::unique_ptr<HIR::Type> (static_type),
       item.is_mut () ? Mutability::Mut : Mutability::Imm, std::move (vis),
       item.get_outer_attrs (), item.get_locus ());
-
-    translated = static_item;
-
-    mappings->insert_hir_extern_item (crate_num, mapping.get_hirid (),
-				      translated);
-    mappings->insert_location (crate_num, mapping.get_hirid (),
-			       item.get_locus ());
   }
 
   void visit (AST::ExternalFunctionItem &function) override
@@ -100,18 +100,11 @@ public:
 				   mappings->get_next_hir_id (crate_num),
 				   mappings->get_next_localdef_id (crate_num));
 
-    HIR::ExternalFunctionItem *function_item = new HIR::ExternalFunctionItem (
+    translated = new HIR::ExternalFunctionItem (
       mapping, function.get_identifier (), std::move (generic_params),
       std::unique_ptr<HIR::Type> (return_type), std::move (where_clause),
       std::move (function_params), function.is_variadic (), std::move (vis),
       function.get_outer_attrs (), function.get_locus ());
-
-    translated = function_item;
-
-    mappings->insert_hir_extern_item (crate_num, mapping.get_hirid (),
-				      translated);
-    mappings->insert_location (crate_num, mapping.get_hirid (),
-			       function.get_locus ());
   }
 
 private:

--- a/gcc/rust/hir/rust-ast-lower-pattern.cc
+++ b/gcc/rust/hir/rust-ast-lower-pattern.cc
@@ -133,11 +133,10 @@ ASTLoweringPattern::visit (AST::StructPattern &pattern)
 	}
 
       // insert the reverse mappings and locations
-      auto crate_num = f->get_mappings ().get_crate_num ();
       auto field_id = f->get_mappings ().get_hirid ();
       auto field_node_id = f->get_mappings ().get_nodeid ();
-      mappings->insert_location (crate_num, field_id, f->get_locus ());
-      mappings->insert_node_to_hir (crate_num, field_node_id, field_id);
+      mappings->insert_location (field_id, f->get_locus ());
+      mappings->insert_node_to_hir (field_node_id, field_id);
 
       // add it to the lowered fields list
       fields.push_back (std::unique_ptr<HIR::StructPatternField> (f));

--- a/gcc/rust/hir/rust-ast-lower-pattern.h
+++ b/gcc/rust/hir/rust-ast-lower-pattern.h
@@ -36,12 +36,8 @@ public:
 
     rust_assert (resolver.translated != nullptr);
 
-    resolver.mappings->insert_hir_pattern (
-      resolver.translated->get_pattern_mappings ().get_crate_num (),
-      resolver.translated->get_pattern_mappings ().get_hirid (),
-      resolver.translated);
+    resolver.mappings->insert_hir_pattern (resolver.translated);
     resolver.mappings->insert_location (
-      resolver.translated->get_pattern_mappings ().get_crate_num (),
       resolver.translated->get_pattern_mappings ().get_hirid (),
       pattern->get_locus ());
 

--- a/gcc/rust/hir/rust-ast-lower-struct-field-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-struct-field-expr.h
@@ -36,11 +36,8 @@ public:
     field->accept_vis (compiler);
     rust_assert (compiler.translated != nullptr);
 
-    compiler.mappings->insert_hir_struct_field (
-      compiler.translated->get_mappings ().get_crate_num (),
-      compiler.translated->get_mappings ().get_hirid (), compiler.translated);
+    compiler.mappings->insert_hir_struct_field (compiler.translated);
     compiler.mappings->insert_location (
-      compiler.translated->get_mappings ().get_crate_num (),
       compiler.translated->get_mappings ().get_hirid (), field->get_locus ());
 
     return compiler.translated;

--- a/gcc/rust/hir/rust-ast-lower-type.h
+++ b/gcc/rust/hir/rust-ast-lower-type.h
@@ -84,7 +84,6 @@ public:
       = new HIR::TypePath (std::move (mapping), std::move (translated_segments),
 			   path.get_locus (),
 			   path.has_opening_scope_resolution_op ());
-    mappings->insert_hir_type (crate_num, hirid, translated);
   }
 
 protected:
@@ -124,9 +123,10 @@ public:
     type->accept_vis (resolver);
 
     rust_assert (resolver.translated != nullptr);
+    resolver.mappings->insert_hir_type (resolver.translated);
     resolver.mappings->insert_location (
-      resolver.translated->get_mappings ().get_crate_num (),
-      resolver.translated->get_mappings ().get_hirid (), type->get_locus ());
+      resolver.translated->get_mappings ().get_hirid (),
+      resolver.translated->get_locus ());
 
     return resolver.translated;
   }
@@ -229,8 +229,6 @@ public:
 			    std::unique_ptr<HIR::Type> (translated_type),
 			    std::unique_ptr<HIR::Expr> (array_size),
 			    type.get_locus ());
-    mappings->insert_hir_type (mapping.get_crate_num (), mapping.get_hirid (),
-			       translated);
   }
 
   void visit (AST::ReferenceType &type) override
@@ -250,9 +248,6 @@ public:
 							     : Mutability::Imm,
 					 std::unique_ptr<HIR::Type> (base_type),
 					 type.get_locus (), lifetime);
-
-    mappings->insert_hir_type (mapping.get_crate_num (), mapping.get_hirid (),
-			       translated);
   }
 
   void visit (AST::RawPointerType &type) override
@@ -273,9 +268,6 @@ public:
 				   : Mutability::Imm,
 				 std::unique_ptr<HIR::Type> (base_type),
 				 type.get_locus ());
-
-    mappings->insert_hir_type (mapping.get_crate_num (), mapping.get_hirid (),
-			       translated);
   }
 
   void visit (AST::SliceType &type) override
@@ -291,9 +283,6 @@ public:
     translated
       = new HIR::SliceType (mapping, std::unique_ptr<HIR::Type> (base_type),
 			    type.get_locus ());
-
-    mappings->insert_hir_type (mapping.get_crate_num (), mapping.get_hirid (),
-			       translated);
   }
 
   void visit (AST::InferredType &type) override
@@ -304,9 +293,6 @@ public:
 				   mappings->get_next_localdef_id (crate_num));
 
     translated = new HIR::InferredType (mapping, type.get_locus ());
-
-    mappings->insert_hir_type (mapping.get_crate_num (), mapping.get_hirid (),
-			       translated);
   }
 
   void visit (AST::NeverType &type) override
@@ -317,9 +303,6 @@ public:
 				   mappings->get_next_localdef_id (crate_num));
 
     translated = new HIR::NeverType (mapping, type.get_locus ());
-
-    mappings->insert_hir_type (mapping.get_crate_num (), mapping.get_hirid (),
-			       translated);
   }
 
   void visit (AST::TraitObjectTypeOneBound &type) override;
@@ -344,11 +327,8 @@ public:
 
     rust_assert (resolver.translated != nullptr);
     resolver.mappings->insert_location (
-      resolver.translated->get_mappings ().get_crate_num (),
       resolver.translated->get_mappings ().get_hirid (), param->get_locus ());
-    resolver.mappings->insert_hir_generic_param (
-      resolver.translated->get_mappings ().get_crate_num (),
-      resolver.translated->get_mappings ().get_hirid (), resolver.translated);
+    resolver.mappings->insert_hir_generic_param (resolver.translated);
 
     return resolver.translated;
   }
@@ -440,7 +420,6 @@ public:
 
     rust_assert (resolver.translated != nullptr);
     resolver.mappings->insert_location (
-      resolver.translated->get_mappings ().get_crate_num (),
       resolver.translated->get_mappings ().get_hirid (),
       resolver.translated->get_locus ());
 
@@ -486,7 +465,13 @@ public:
   {
     ASTLowerWhereClauseItem compiler;
     item.accept_vis (compiler);
+
     rust_assert (compiler.translated != nullptr);
+    // FIXME
+    // compiler.mappings->insert_location (
+    //   compiler.translated->get_mappings ().get_hirid (),
+    //   compiler.translated->get_locus ());
+
     return compiler.translated;
   }
 

--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -58,14 +58,14 @@ ASTLowering::ASTLowering (AST::Crate &astCrate) : astCrate (astCrate) {}
 
 ASTLowering::~ASTLowering () {}
 
-HIR::Crate
+std::unique_ptr<HIR::Crate>
 ASTLowering::Resolve (AST::Crate &astCrate)
 {
   ASTLowering resolver (astCrate);
   return resolver.go ();
 }
 
-HIR::Crate
+std::unique_ptr<HIR::Crate>
 ASTLowering::go ()
 {
   std::vector<std::unique_ptr<HIR::Item> > items;
@@ -83,7 +83,8 @@ ASTLowering::go ()
 				 mappings->get_next_hir_id (crate_num),
 				 UNKNOWN_LOCAL_DEFID);
 
-  return HIR::Crate (std::move (items), astCrate.get_inner_attrs (), mapping);
+  return std::unique_ptr<HIR::Crate> (
+    new HIR::Crate (std::move (items), astCrate.get_inner_attrs (), mapping));
 }
 
 // rust-ast-lower-block.h
@@ -413,9 +414,7 @@ ASTLowerPathInExpression::visit (AST::PathInExpression &expr)
 
       // insert the mappings for the segment
       HIR::PathExprSegment *lowered_seg = &path_segments.back ();
-      mappings->insert_hir_path_expr_seg (
-	lowered_seg->get_mappings ().get_crate_num (),
-	lowered_seg->get_mappings ().get_hirid (), lowered_seg);
+      mappings->insert_hir_path_expr_seg (lowered_seg);
     }
   auto crate_num = mappings->get_current_crate ();
   Analysis::NodeMapping mapping (crate_num, expr.get_node_id (),
@@ -461,9 +460,7 @@ ASTLowerQualPathInExpression::visit (AST::QualifiedPathInExpression &expr)
 
       // insert the mappings for the segment
       HIR::PathExprSegment *lowered_seg = &path_segments.back ();
-      mappings->insert_hir_path_expr_seg (
-	lowered_seg->get_mappings ().get_crate_num (),
-	lowered_seg->get_mappings ().get_hirid (), lowered_seg);
+      mappings->insert_hir_path_expr_seg (lowered_seg);
     }
 
   auto crate_num = mappings->get_current_crate ();

--- a/gcc/rust/hir/rust-ast-lower.h
+++ b/gcc/rust/hir/rust-ast-lower.h
@@ -43,12 +43,12 @@ translate_visibility (const AST::Visibility &vis);
 class ASTLowering
 {
 public:
-  static HIR::Crate Resolve (AST::Crate &astCrate);
+  static std::unique_ptr<HIR::Crate> Resolve (AST::Crate &astCrate);
   ~ASTLowering ();
 
 private:
   ASTLowering (AST::Crate &astCrate);
-  HIR::Crate go ();
+  std::unique_ptr<HIR::Crate> go ();
 
   AST::Crate &astCrate;
 };

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -75,9 +75,12 @@ public:
   // Copy constructor uses clone
   TypeParam (TypeParam const &other)
     : GenericParam (other.mappings), outer_attr (other.outer_attr),
-      type_representation (other.type_representation),
-      type (other.type->clone_type ()), locus (other.locus)
+      type_representation (other.type_representation), locus (other.locus)
   {
+    // guard to prevent null pointer dereference
+    if (other.type != nullptr)
+      type = other.type->clone_type ();
+
     type_param_bounds.reserve (other.type_param_bounds.size ());
     for (const auto &e : other.type_param_bounds)
       type_param_bounds.push_back (e->clone_type_param_bound ());
@@ -87,11 +90,15 @@ public:
   TypeParam &operator= (TypeParam const &other)
   {
     type_representation = other.type_representation;
-    // type_param_bounds = other.type_param_bounds;
-    type = other.type->clone_type ();
     outer_attr = other.outer_attr;
     locus = other.locus;
     mappings = other.mappings;
+
+    // guard to prevent null pointer dereference
+    if (other.type != nullptr)
+      type = other.type->clone_type ();
+    else
+      type = nullptr;
 
     type_param_bounds.reserve (other.type_param_bounds.size ());
     for (const auto &e : other.type_param_bounds)
@@ -99,7 +106,6 @@ public:
 
     return *this;
   }
-
   // move constructors
   TypeParam (TypeParam &&other) = default;
   TypeParam &operator= (TypeParam &&other) = default;

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -1111,11 +1111,16 @@ public:
     : VisItem (other), qualifiers (other.qualifiers),
       function_name (other.function_name),
       function_params (other.function_params),
-      return_type (other.return_type->clone_type ()),
       where_clause (other.where_clause),
       function_body (other.function_body->clone_block_expr ()),
       self (other.self), locus (other.locus)
   {
+    // guard to prevent null dereference (always required)
+    if (other.return_type != nullptr)
+      return_type = other.return_type->clone_type ();
+    else
+      return_type = nullptr;
+
     generic_params.reserve (other.generic_params.size ());
     for (const auto &e : other.generic_params)
       generic_params.push_back (e->clone_generic_param ());
@@ -1128,7 +1133,13 @@ public:
     function_name = other.function_name;
     qualifiers = other.qualifiers;
     function_params = other.function_params;
-    return_type = other.return_type->clone_type ();
+
+    // guard to prevent null dereference (always required)
+    if (other.return_type != nullptr)
+      return_type = other.return_type->clone_type ();
+    else
+      return_type = nullptr;
+
     where_clause = other.where_clause;
     function_body = other.function_body->clone_block_expr ();
     locus = other.locus;

--- a/gcc/rust/hir/tree/rust-hir-path.h
+++ b/gcc/rust/hir/tree/rust-hir-path.h
@@ -1001,6 +1001,8 @@ public:
 			    Location ());
   }
 
+  bool is_error () const { return segments.empty (); }
+
   const Analysis::NodeMapping &get_mappings () const { return mappings; }
   const Location &get_locus () const { return locus; }
 };

--- a/gcc/rust/hir/tree/rust-hir-stmt.h
+++ b/gcc/rust/hir/tree/rust-hir-stmt.h
@@ -91,19 +91,40 @@ public:
   // Copy constructor with clone
   LetStmt (LetStmt const &other)
     : Stmt (other.mappings), outer_attrs (other.outer_attrs),
-      variables_pattern (other.variables_pattern->clone_pattern ()),
-      type (other.type->clone_type ()),
-      init_expr (other.init_expr->clone_expr ()), locus (other.locus)
-  {}
+      locus (other.locus)
+  {
+    // guard to prevent null dereference (only required if error state)
+    if (other.variables_pattern != nullptr)
+      variables_pattern = other.variables_pattern->clone_pattern ();
+
+    // guard to prevent null dereference (always required)
+    if (other.init_expr != nullptr)
+      init_expr = other.init_expr->clone_expr ();
+    if (other.type != nullptr)
+      type = other.type->clone_type ();
+  }
 
   // Overloaded assignment operator to clone
   LetStmt &operator= (LetStmt const &other)
   {
-    variables_pattern = other.variables_pattern->clone_pattern ();
-    init_expr = other.init_expr->clone_expr ();
-    type = other.type->clone_type ();
     outer_attrs = other.outer_attrs;
     locus = other.locus;
+
+    // guard to prevent null dereference (only required if error state)
+    if (other.variables_pattern != nullptr)
+      variables_pattern = other.variables_pattern->clone_pattern ();
+    else
+      variables_pattern = nullptr;
+
+    // guard to prevent null dereference (always required)
+    if (other.init_expr != nullptr)
+      init_expr = other.init_expr->clone_expr ();
+    else
+      init_expr = nullptr;
+    if (other.type != nullptr)
+      type = other.type->clone_type ();
+    else
+      type = nullptr;
 
     return *this;
   }

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -424,7 +424,7 @@ Parser<ManagedTokenSource>::parse_items ()
 
 // Parses a crate (compilation unit) - entry point
 template <typename ManagedTokenSource>
-AST::Crate
+std::unique_ptr<AST::Crate>
 Parser<ManagedTokenSource>::parse_crate ()
 {
   // parse inner attributes
@@ -437,7 +437,8 @@ Parser<ManagedTokenSource>::parse_crate ()
   for (const auto &error : error_table)
     error.emit_error ();
 
-  return AST::Crate (std::move (items), std::move (inner_attrs));
+  return std::unique_ptr<AST::Crate> (
+    new AST::Crate (std::move (items), std::move (inner_attrs)));
 }
 
 // Parse a contiguous block of inner attributes.

--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -669,7 +669,7 @@ public:
   std::vector<std::unique_ptr<AST::Item> > parse_items ();
 
   // Main entry point for parser.
-  AST::Crate parse_crate ();
+  std::unique_ptr<AST::Crate> parse_crate ();
 
   // Dumps all lexer output.
   void debug_dump_lex_output (std::ostream &out);

--- a/gcc/rust/privacy/rust-privacy-reporter.cc
+++ b/gcc/rust/privacy/rust-privacy-reporter.cc
@@ -129,8 +129,8 @@ PrivacyReporter::check_base_type_privacy (Analysis::NodeMapping &node_mappings,
 	auto ref_id = ty->get_ref ();
 	NodeId lookup_id;
 
-	mappings.lookup_hir_to_node (node_mappings.get_crate_num (), ref_id,
-				     &lookup_id);
+	bool ok = mappings.lookup_hir_to_node (ref_id, &lookup_id);
+	rust_assert (ok);
 
 	return check_for_privacy_violation (lookup_id, locus);
       }

--- a/gcc/rust/privacy/rust-visibility-resolver.cc
+++ b/gcc/rust/privacy/rust-visibility-resolver.cc
@@ -72,14 +72,9 @@ VisibilityResolver::resolve_module_path (const HIR::SimplePath &restriction,
   // present?
 
   HirId ref;
-  rust_assert (
-    mappings.lookup_node_to_hir (restriction.get_mappings ().get_crate_num (),
-				 ref_node_id, &ref));
+  rust_assert (mappings.lookup_node_to_hir (ref_node_id, &ref));
 
-  auto module
-    = mappings.lookup_module (restriction.get_mappings ().get_crate_num (),
-			      ref);
-
+  auto module = mappings.lookup_module (ref);
   if (!module)
     {
       invalid_path.emit_error ();

--- a/gcc/rust/resolve/rust-ast-resolve-implitem.h
+++ b/gcc/rust/resolve/rust-ast-resolve-implitem.h
@@ -147,8 +147,7 @@ public:
 	rust_error_at (r, "redefined multiple times");
       });
 
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     function.get_node_id (), cpath);
+    mappings->insert_canonical_path (function.get_node_id (), cpath);
   }
 
   void visit (AST::TraitItemMethod &method) override
@@ -166,8 +165,7 @@ public:
 	rust_error_at (r, "redefined multiple times");
       });
 
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     method.get_node_id (), cpath);
+    mappings->insert_canonical_path (method.get_node_id (), cpath);
   }
 
   void visit (AST::TraitItemConst &constant) override
@@ -185,8 +183,7 @@ public:
 	rust_error_at (r, "redefined multiple times");
       });
 
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     constant.get_node_id (), cpath);
+    mappings->insert_canonical_path (constant.get_node_id (), cpath);
   }
 
   void visit (AST::TraitItemType &type) override
@@ -204,8 +201,7 @@ public:
 	rust_error_at (r, "redefined multiple times");
       });
 
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     type.get_node_id (), cpath);
+    mappings->insert_canonical_path (type.get_node_id (), cpath);
   }
 
 private:

--- a/gcc/rust/resolve/rust-ast-resolve-item.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-item.cc
@@ -46,8 +46,7 @@ ResolveTraitItems::visit (AST::TraitItemType &type)
     = CanonicalPath::new_seg (type.get_node_id (), type.get_identifier ());
   auto path = prefix.append (decl);
   auto cpath = canonical_prefix.append (decl);
-  mappings->insert_canonical_path (mappings->get_current_crate (),
-				   type.get_node_id (), cpath);
+  mappings->insert_canonical_path (type.get_node_id (), cpath);
 
   for (auto &bound : type.get_type_param_bounds ())
     ResolveTypeBound::go (bound.get ());
@@ -60,8 +59,7 @@ ResolveTraitItems::visit (AST::TraitItemFunc &func)
     func.get_node_id (), func.get_trait_function_decl ().get_identifier ());
   auto path = prefix.append (decl);
   auto cpath = canonical_prefix.append (decl);
-  mappings->insert_canonical_path (mappings->get_current_crate (),
-				   func.get_node_id (), cpath);
+  mappings->insert_canonical_path (func.get_node_id (), cpath);
 
   NodeId scope_node_id = func.get_node_id ();
   resolver->get_name_scope ().push (scope_node_id);
@@ -107,8 +105,7 @@ ResolveTraitItems::visit (AST::TraitItemMethod &func)
 			      func.get_trait_method_decl ().get_identifier ());
   auto path = prefix.append (decl);
   auto cpath = canonical_prefix.append (decl);
-  mappings->insert_canonical_path (mappings->get_current_crate (),
-				   func.get_node_id (), cpath);
+  mappings->insert_canonical_path (func.get_node_id (), cpath);
 
   NodeId scope_node_id = func.get_node_id ();
   resolver->get_name_scope ().push (scope_node_id);
@@ -170,8 +167,7 @@ ResolveTraitItems::visit (AST::TraitItemConst &constant)
 				      constant.get_identifier ());
   auto path = prefix.append (decl);
   auto cpath = canonical_prefix.append (decl);
-  mappings->insert_canonical_path (mappings->get_current_crate (),
-				   constant.get_node_id (), cpath);
+  mappings->insert_canonical_path (constant.get_node_id (), cpath);
 
   ResolveType::go (constant.get_type ().get ());
 
@@ -199,8 +195,7 @@ ResolveItem::visit (AST::TypeAlias &alias)
     = CanonicalPath::new_seg (alias.get_node_id (), alias.get_new_type_name ());
   auto path = prefix.append (talias);
   auto cpath = canonical_prefix.append (talias);
-  mappings->insert_canonical_path (mappings->get_current_crate (),
-				   alias.get_node_id (), cpath);
+  mappings->insert_canonical_path (alias.get_node_id (), cpath);
 
   NodeId scope_node_id = alias.get_node_id ();
   resolver->get_type_scope ().push (scope_node_id);
@@ -223,8 +218,7 @@ ResolveItem::visit (AST::Module &module)
   auto mod = CanonicalPath::new_seg (module.get_node_id (), module.get_name ());
   auto path = prefix.append (mod);
   auto cpath = canonical_prefix.append (mod);
-  mappings->insert_canonical_path (mappings->get_current_crate (),
-				   module.get_node_id (), cpath);
+  mappings->insert_canonical_path (module.get_node_id (), cpath);
 
   resolve_visibility (module.get_visibility ());
 
@@ -259,8 +253,7 @@ ResolveItem::visit (AST::TupleStruct &struct_decl)
 				      struct_decl.get_identifier ());
   auto path = prefix.append (decl);
   auto cpath = canonical_prefix.append (decl);
-  mappings->insert_canonical_path (mappings->get_current_crate (),
-				   struct_decl.get_node_id (), cpath);
+  mappings->insert_canonical_path (struct_decl.get_node_id (), cpath);
 
   resolve_visibility (struct_decl.get_visibility ());
 
@@ -294,8 +287,7 @@ ResolveItem::visit (AST::Enum &enum_decl)
 				      enum_decl.get_identifier ());
   auto path = prefix.append (decl);
   auto cpath = canonical_prefix.append (decl);
-  mappings->insert_canonical_path (mappings->get_current_crate (),
-				   enum_decl.get_node_id (), cpath);
+  mappings->insert_canonical_path (enum_decl.get_node_id (), cpath);
 
   resolve_visibility (enum_decl.get_visibility ());
 
@@ -327,8 +319,7 @@ ResolveItem::visit (AST::EnumItem &item)
     = CanonicalPath::new_seg (item.get_node_id (), item.get_identifier ());
   auto path = prefix.append (decl);
   auto cpath = canonical_prefix.append (decl);
-  mappings->insert_canonical_path (mappings->get_current_crate (),
-				   item.get_node_id (), cpath);
+  mappings->insert_canonical_path (item.get_node_id (), cpath);
 }
 
 void
@@ -338,8 +329,7 @@ ResolveItem::visit (AST::EnumItemTuple &item)
     = CanonicalPath::new_seg (item.get_node_id (), item.get_identifier ());
   auto path = prefix.append (decl);
   auto cpath = canonical_prefix.append (decl);
-  mappings->insert_canonical_path (mappings->get_current_crate (),
-				   item.get_node_id (), cpath);
+  mappings->insert_canonical_path (item.get_node_id (), cpath);
 
   for (auto &field : item.get_tuple_fields ())
     {
@@ -357,8 +347,7 @@ ResolveItem::visit (AST::EnumItemStruct &item)
     = CanonicalPath::new_seg (item.get_node_id (), item.get_identifier ());
   auto path = prefix.append (decl);
   auto cpath = canonical_prefix.append (decl);
-  mappings->insert_canonical_path (mappings->get_current_crate (),
-				   item.get_node_id (), cpath);
+  mappings->insert_canonical_path (item.get_node_id (), cpath);
 
   for (auto &field : item.get_struct_fields ())
     {
@@ -377,8 +366,7 @@ ResolveItem::visit (AST::EnumItemDiscriminant &item)
   auto path = prefix.append (decl);
   auto cpath = canonical_prefix.append (decl);
 
-  mappings->insert_canonical_path (mappings->get_current_crate (),
-				   item.get_node_id (), cpath);
+  mappings->insert_canonical_path (item.get_node_id (), cpath);
 }
 
 void
@@ -388,8 +376,7 @@ ResolveItem::visit (AST::StructStruct &struct_decl)
 				      struct_decl.get_identifier ());
   auto path = prefix.append (decl);
   auto cpath = canonical_prefix.append (decl);
-  mappings->insert_canonical_path (mappings->get_current_crate (),
-				   struct_decl.get_node_id (), cpath);
+  mappings->insert_canonical_path (struct_decl.get_node_id (), cpath);
 
   resolve_visibility (struct_decl.get_visibility ());
 
@@ -423,8 +410,7 @@ ResolveItem::visit (AST::Union &union_decl)
 				      union_decl.get_identifier ());
   auto path = prefix.append (decl);
   auto cpath = canonical_prefix.append (decl);
-  mappings->insert_canonical_path (mappings->get_current_crate (),
-				   union_decl.get_node_id (), cpath);
+  mappings->insert_canonical_path (union_decl.get_node_id (), cpath);
 
   resolve_visibility (union_decl.get_visibility ());
 
@@ -456,8 +442,7 @@ ResolveItem::visit (AST::StaticItem &var)
     = CanonicalPath::new_seg (var.get_node_id (), var.get_identifier ());
   auto path = prefix.append (decl);
   auto cpath = canonical_prefix.append (decl);
-  mappings->insert_canonical_path (mappings->get_current_crate (),
-				   var.get_node_id (), cpath);
+  mappings->insert_canonical_path (var.get_node_id (), cpath);
 
   ResolveType::go (var.get_type ().get ());
   ResolveExpr::go (var.get_expr ().get (), path, cpath);
@@ -470,8 +455,7 @@ ResolveItem::visit (AST::ConstantItem &constant)
 				      constant.get_identifier ());
   auto path = prefix.append (decl);
   auto cpath = canonical_prefix.append (decl);
-  mappings->insert_canonical_path (mappings->get_current_crate (),
-				   constant.get_node_id (), cpath);
+  mappings->insert_canonical_path (constant.get_node_id (), cpath);
 
   resolve_visibility (constant.get_visibility ());
 
@@ -487,8 +471,7 @@ ResolveItem::visit (AST::Function &function)
   auto path = prefix.append (decl);
   auto cpath = canonical_prefix.append (decl);
 
-  mappings->insert_canonical_path (mappings->get_current_crate (),
-				   function.get_node_id (), cpath);
+  mappings->insert_canonical_path (function.get_node_id (), cpath);
 
   resolve_visibility (function.get_visibility ());
 
@@ -614,8 +597,7 @@ ResolveItem::visit (AST::Method &method)
     = CanonicalPath::new_seg (method.get_node_id (), method.get_method_name ());
   auto path = prefix.append (decl);
   auto cpath = canonical_prefix.append (decl);
-  mappings->insert_canonical_path (mappings->get_current_crate (),
-				   method.get_node_id (), cpath);
+  mappings->insert_canonical_path (method.get_node_id (), cpath);
 
   NodeId scope_node_id = method.get_node_id ();
 

--- a/gcc/rust/resolve/rust-ast-resolve-stmt.h
+++ b/gcc/rust/resolve/rust-ast-resolve-stmt.h
@@ -60,8 +60,7 @@ public:
 					constant.get_identifier ());
     auto path = decl; // this ensures we have the correct relative resolution
     auto cpath = canonical_prefix.append (decl);
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     constant.get_node_id (), cpath);
+    mappings->insert_canonical_path (constant.get_node_id (), cpath);
 
     resolver->get_name_scope ().insert (
       path, constant.get_node_id (), constant.get_locus (), false,
@@ -94,8 +93,7 @@ public:
 					struct_decl.get_identifier ());
     auto path = decl; // this ensures we have the correct relative resolution
     auto cpath = canonical_prefix.append (decl);
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     struct_decl.get_node_id (), cpath);
+    mappings->insert_canonical_path (struct_decl.get_node_id (), cpath);
 
     resolver->get_type_scope ().insert (
       path, struct_decl.get_node_id (), struct_decl.get_locus (), false,
@@ -126,8 +124,7 @@ public:
 					enum_decl.get_identifier ());
     auto path = decl; // this ensures we have the correct relative resolution
     auto cpath = canonical_prefix.append (decl);
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     enum_decl.get_node_id (), cpath);
+    mappings->insert_canonical_path (enum_decl.get_node_id (), cpath);
 
     resolver->get_type_scope ().insert (
       path, enum_decl.get_node_id (), enum_decl.get_locus (), false,
@@ -158,8 +155,7 @@ public:
       CanonicalPath::new_seg (item.get_node_id (), item.get_identifier ()));
     auto path = decl; // this ensures we have the correct relative resolution
     auto cpath = canonical_prefix.append (decl);
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     item.get_node_id (), cpath);
+    mappings->insert_canonical_path (item.get_node_id (), cpath);
 
     resolver->get_type_scope ().insert (
       path, item.get_node_id (), item.get_locus (), false,
@@ -178,8 +174,7 @@ public:
       CanonicalPath::new_seg (item.get_node_id (), item.get_identifier ()));
     auto path = decl; // this ensures we have the correct relative resolution
     auto cpath = canonical_prefix.append (decl);
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     item.get_node_id (), cpath);
+    mappings->insert_canonical_path (item.get_node_id (), cpath);
 
     resolver->get_type_scope ().insert (
       path, item.get_node_id (), item.get_locus (), false,
@@ -204,8 +199,7 @@ public:
       CanonicalPath::new_seg (item.get_node_id (), item.get_identifier ()));
     auto path = decl; // this ensures we have the correct relative resolution
     auto cpath = canonical_prefix.append (decl);
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     item.get_node_id (), cpath);
+    mappings->insert_canonical_path (item.get_node_id (), cpath);
 
     resolver->get_type_scope ().insert (
       path, item.get_node_id (), item.get_locus (), false,
@@ -230,8 +224,7 @@ public:
       CanonicalPath::new_seg (item.get_node_id (), item.get_identifier ()));
     auto path = decl; // this ensures we have the correct relative resolution
     auto cpath = canonical_prefix.append (decl);
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     item.get_node_id (), cpath);
+    mappings->insert_canonical_path (item.get_node_id (), cpath);
 
     resolver->get_type_scope ().insert (
       path, item.get_node_id (), item.get_locus (), false,
@@ -250,8 +243,7 @@ public:
 					struct_decl.get_identifier ());
     auto path = decl; // this ensures we have the correct relative resolution
     auto cpath = canonical_prefix.append (decl);
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     struct_decl.get_node_id (), cpath);
+    mappings->insert_canonical_path (struct_decl.get_node_id (), cpath);
 
     resolver->get_type_scope ().insert (
       path, struct_decl.get_node_id (), struct_decl.get_locus (), false,
@@ -287,8 +279,7 @@ public:
 					union_decl.get_identifier ());
     auto path = decl; // this ensures we have the correct relative resolution
     auto cpath = canonical_prefix.append (decl);
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     union_decl.get_node_id (), cpath);
+    mappings->insert_canonical_path (union_decl.get_node_id (), cpath);
 
     resolver->get_type_scope ().insert (
       path, union_decl.get_node_id (), union_decl.get_locus (), false,
@@ -322,8 +313,7 @@ public:
 					function.get_function_name ());
     auto path = decl; // this ensures we have the correct relative resolution
     auto cpath = canonical_prefix.append (decl);
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     function.get_node_id (), cpath);
+    mappings->insert_canonical_path (function.get_node_id (), cpath);
 
     resolver->get_name_scope ().insert (
       path, function.get_node_id (), function.get_locus (), false,

--- a/gcc/rust/resolve/rust-ast-resolve-toplevel.h
+++ b/gcc/rust/resolve/rust-ast-resolve-toplevel.h
@@ -24,6 +24,7 @@
 #include "rust-ast-resolve-implitem.h"
 #include "rust-ast-full.h"
 #include "rust-name-resolver.h"
+#include "rust-session-manager.h"
 
 namespace Rust {
 namespace Resolver {
@@ -72,8 +73,7 @@ public:
 
     resolver->pop_module_scope ();
 
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     module.get_node_id (), cpath);
+    mappings->insert_canonical_path (module.get_node_id (), cpath);
   }
 
   void visit (AST::TypeAlias &alias) override
@@ -93,8 +93,7 @@ public:
 
     NodeId current_module = resolver->peek_current_module_scope ();
     mappings->insert_module_child_item (current_module, talias);
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     alias.get_node_id (), cpath);
+    mappings->insert_canonical_path (alias.get_node_id (), cpath);
   }
 
   void visit (AST::TupleStruct &struct_decl) override
@@ -114,8 +113,7 @@ public:
 
     NodeId current_module = resolver->peek_current_module_scope ();
     mappings->insert_module_child_item (current_module, decl);
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     struct_decl.get_node_id (), cpath);
+    mappings->insert_canonical_path (struct_decl.get_node_id (), cpath);
   }
 
   void visit (AST::Enum &enum_decl) override
@@ -138,8 +136,7 @@ public:
 
     NodeId current_module = resolver->peek_current_module_scope ();
     mappings->insert_module_child_item (current_module, decl);
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     enum_decl.get_node_id (), cpath);
+    mappings->insert_canonical_path (enum_decl.get_node_id (), cpath);
   }
 
   void visit (AST::EnumItem &item) override
@@ -157,8 +154,7 @@ public:
 	rust_error_at (r, "redefined multiple times");
       });
 
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     item.get_node_id (), cpath);
+    mappings->insert_canonical_path (item.get_node_id (), cpath);
   }
 
   void visit (AST::EnumItemTuple &item) override
@@ -176,8 +172,7 @@ public:
 	rust_error_at (r, "redefined multiple times");
       });
 
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     item.get_node_id (), cpath);
+    mappings->insert_canonical_path (item.get_node_id (), cpath);
   }
 
   void visit (AST::EnumItemStruct &item) override
@@ -195,8 +190,7 @@ public:
 	rust_error_at (r, "redefined multiple times");
       });
 
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     item.get_node_id (), cpath);
+    mappings->insert_canonical_path (item.get_node_id (), cpath);
   }
 
   void visit (AST::EnumItemDiscriminant &item) override
@@ -214,8 +208,7 @@ public:
 	rust_error_at (r, "redefined multiple times");
       });
 
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     item.get_node_id (), cpath);
+    mappings->insert_canonical_path (item.get_node_id (), cpath);
   }
 
   void visit (AST::StructStruct &struct_decl) override
@@ -235,8 +228,7 @@ public:
 
     NodeId current_module = resolver->peek_current_module_scope ();
     mappings->insert_module_child_item (current_module, decl);
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     struct_decl.get_node_id (), cpath);
+    mappings->insert_canonical_path (struct_decl.get_node_id (), cpath);
   }
 
   void visit (AST::Union &union_decl) override
@@ -256,8 +248,7 @@ public:
 
     NodeId current_module = resolver->peek_current_module_scope ();
     mappings->insert_module_child_item (current_module, decl);
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     union_decl.get_node_id (), cpath);
+    mappings->insert_canonical_path (union_decl.get_node_id (), cpath);
   }
 
   void visit (AST::StaticItem &var) override
@@ -277,8 +268,7 @@ public:
 
     NodeId current_module = resolver->peek_current_module_scope ();
     mappings->insert_module_child_item (current_module, decl);
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     var.get_node_id (), cpath);
+    mappings->insert_canonical_path (var.get_node_id (), cpath);
   }
 
   void visit (AST::ConstantItem &constant) override
@@ -298,8 +288,7 @@ public:
 
     NodeId current_module = resolver->peek_current_module_scope ();
     mappings->insert_module_child_item (current_module, decl);
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     constant.get_node_id (), cpath);
+    mappings->insert_canonical_path (constant.get_node_id (), cpath);
   }
 
   void visit (AST::Function &function) override
@@ -319,8 +308,7 @@ public:
 
     NodeId current_module = resolver->peek_current_module_scope ();
     mappings->insert_module_child_item (current_module, decl);
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     function.get_node_id (), cpath);
+    mappings->insert_canonical_path (function.get_node_id (), cpath);
   }
 
   void visit (AST::InherentImpl &impl_block) override
@@ -385,8 +373,7 @@ public:
 
     NodeId current_module = resolver->peek_current_module_scope ();
     mappings->insert_module_child_item (current_module, decl);
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     trait.get_node_id (), cpath);
+    mappings->insert_canonical_path (trait.get_node_id (), cpath);
   }
 
   void visit (AST::ExternBlock &extern_block) override
@@ -394,6 +381,56 @@ public:
     for (auto &item : extern_block.get_extern_items ())
       {
 	ResolveToplevelExternItem::go (item.get (), prefix);
+      }
+  }
+
+  void visit (AST::ExternCrate &extern_crate) override
+  {
+    if (extern_crate.is_marked_for_strip ())
+      return;
+
+    NodeId resolved_crate = UNKNOWN_NODEID;
+    if (extern_crate.references_self ())
+      {
+	// FIXME
+	// then this resolves to current crate_node_id
+	// need to expose on the session object a reference to the current
+	// AST::Crate& to get node_id
+	gcc_unreachable ();
+	return;
+      }
+    else
+      {
+	rust_debug_loc (extern_crate.get_locus (), "load extern crate: [%s]",
+			extern_crate.as_string ().c_str ());
+
+	Session &session = Session::get_instance ();
+	resolved_crate
+	  = session.load_extern_crate (extern_crate.get_referenced_crate ());
+      }
+
+    if (resolved_crate == UNKNOWN_NODEID)
+      {
+	rust_error_at (extern_crate.get_locus (), "failed to resolve crate");
+	return;
+      }
+
+    // mark the node as resolved
+    resolver->insert_resolved_name (extern_crate.get_node_id (),
+				    resolved_crate);
+
+    // does it has an as clause
+    if (extern_crate.has_as_clause ())
+      {
+	auto decl = CanonicalPath::new_seg (extern_crate.get_node_id (),
+					    extern_crate.get_as_clause ());
+	resolver->get_type_scope ().insert (
+	  decl, extern_crate.get_node_id (), extern_crate.get_locus (), false,
+	  [&] (const CanonicalPath &, NodeId, Location locus) -> void {
+	    RichLocation r (extern_crate.get_locus ());
+	    r.add_range (locus);
+	    rust_error_at (r, "redefined multiple times");
+	  });
       }
   }
 

--- a/gcc/rust/resolve/rust-ast-resolve-type.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-type.cc
@@ -371,8 +371,7 @@ ResolveTypeToCanonicalPath::visit (AST::TypePath &path)
     return;
 
   const CanonicalPath *type_path = nullptr;
-  if (mappings->lookup_canonical_path (mappings->get_current_crate (),
-				       resolved_node, &type_path))
+  if (mappings->lookup_canonical_path (resolved_node, &type_path))
     {
       auto &final_seg = path.get_segments ().back ();
       switch (final_seg->get_type ())

--- a/gcc/rust/resolve/rust-ast-resolve-type.h
+++ b/gcc/rust/resolve/rust-ast-resolve-type.h
@@ -184,8 +184,7 @@ public:
 	rust_error_at (locus, "was defined here");
       });
 
-    mappings->insert_canonical_path (mappings->get_current_crate (),
-				     param.get_node_id (), seg);
+    mappings->insert_canonical_path (param.get_node_id (), seg);
   }
 
 private:

--- a/gcc/rust/resolve/rust-name-resolver.cc
+++ b/gcc/rust/resolve/rust-name-resolver.cc
@@ -34,11 +34,10 @@
       _R.push_back (builtin_type);                                             \
       tyctx->insert_builtin (_TY->get_ref (), builtin_type->get_node_id (),    \
 			     _TY);                                             \
-      mappings->insert_node_to_hir (mappings->get_current_crate (),            \
-				    builtin_type->get_node_id (),              \
+      mappings->insert_node_to_hir (builtin_type->get_node_id (),              \
 				    _TY->get_ref ());                          \
       mappings->insert_canonical_path (                                        \
-	mappings->get_current_crate (), builtin_type->get_node_id (),          \
+	builtin_type->get_node_id (),                                          \
 	CanonicalPath::new_seg (builtin_type->get_node_id (), _X));            \
     }                                                                          \
   while (0)
@@ -127,6 +126,24 @@ Rib::decl_was_declared_here (NodeId def) const
 	return true;
     }
   return false;
+}
+
+void
+Rib::debug () const
+{
+  fprintf (stderr, "%s\n", debug_str ().c_str ());
+}
+
+std::string
+Rib::debug_str () const
+{
+  std::string buffer;
+  for (const auto &it : path_mappings)
+    {
+      buffer += it.first.get () + "=" + std::to_string (it.second);
+      buffer += ",";
+    }
+  return "{" + buffer + "}";
 }
 
 Scope::Scope (CrateNum crate_num) : crate_num (crate_num) {}

--- a/gcc/rust/resolve/rust-name-resolver.h
+++ b/gcc/rust/resolve/rust-name-resolver.h
@@ -45,6 +45,8 @@ public:
   void append_reference_for_def (NodeId def, NodeId ref);
   bool have_references_for_node (NodeId def) const;
   bool decl_was_declared_here (NodeId def) const;
+  void debug () const;
+  std::string debug_str () const;
 
   CrateNum get_crate_num () const { return crate_num; }
   NodeId get_node_id () const { return node_id; }

--- a/gcc/rust/typecheck/rust-hir-trait-resolve.cc
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.cc
@@ -107,15 +107,13 @@ TraitResolver::resolve_path (HIR::TypePath &path)
     }
 
   HirId hir_node = UNKNOWN_HIRID;
-  if (!mappings->lookup_node_to_hir (mappings->get_current_crate (), ref,
-				     &hir_node))
+  if (!mappings->lookup_node_to_hir (ref, &hir_node))
     {
       rust_error_at (path.get_locus (), "Failed to resolve path to hir-id");
       return &TraitReference::error_node ();
     }
 
-  HIR::Item *resolved_item
-    = mappings->lookup_hir_item (mappings->get_current_crate (), hir_node);
+  HIR::Item *resolved_item = mappings->lookup_hir_item (hir_node);
 
   rust_assert (resolved_item != nullptr);
   resolved_item->accept_vis (*this);
@@ -248,15 +246,13 @@ TraitResolver::lookup_path (HIR::TypePath &path)
     }
 
   HirId hir_node = UNKNOWN_HIRID;
-  if (!mappings->lookup_node_to_hir (mappings->get_current_crate (), ref,
-				     &hir_node))
+  if (!mappings->lookup_node_to_hir (ref, &hir_node))
     {
       rust_error_at (path.get_locus (), "Failed to resolve path to hir-id");
       return &TraitReference::error_node ();
     }
 
-  HIR::Item *resolved_item
-    = mappings->lookup_hir_item (mappings->get_current_crate (), hir_node);
+  HIR::Item *resolved_item = mappings->lookup_hir_item (hir_node);
 
   rust_assert (resolved_item != nullptr);
   resolved_item->accept_vis (*this);

--- a/gcc/rust/typecheck/rust-hir-type-check-enumitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-enumitem.h
@@ -65,8 +65,7 @@ public:
     context->insert_type (mapping, isize);
 
     const CanonicalPath *canonical_path = nullptr;
-    ok = mappings->lookup_canonical_path (item.get_mappings ().get_crate_num (),
-					  item.get_mappings ().get_nodeid (),
+    ok = mappings->lookup_canonical_path (item.get_mappings ().get_nodeid (),
 					  &canonical_path);
     rust_assert (ok);
 
@@ -95,8 +94,7 @@ public:
 
     const CanonicalPath *canonical_path = nullptr;
     bool ok
-      = mappings->lookup_canonical_path (item.get_mappings ().get_crate_num (),
-					 item.get_mappings ().get_nodeid (),
+      = mappings->lookup_canonical_path (item.get_mappings ().get_nodeid (),
 					 &canonical_path);
     rust_assert (ok);
 
@@ -143,8 +141,7 @@ public:
     context->insert_type (mapping, isize);
 
     const CanonicalPath *canonical_path = nullptr;
-    ok = mappings->lookup_canonical_path (item.get_mappings ().get_crate_num (),
-					  item.get_mappings ().get_nodeid (),
+    ok = mappings->lookup_canonical_path (item.get_mappings ().get_nodeid (),
 					  &canonical_path);
     rust_assert (ok);
 
@@ -190,8 +187,7 @@ public:
     context->insert_type (mapping, isize);
 
     const CanonicalPath *canonical_path = nullptr;
-    ok = mappings->lookup_canonical_path (item.get_mappings ().get_crate_num (),
-					  item.get_mappings ().get_nodeid (),
+    ok = mappings->lookup_canonical_path (item.get_mappings ().get_nodeid (),
 					  &canonical_path);
     rust_assert (ok);
 

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -438,8 +438,7 @@ public:
 
     // node back to HIR
     HirId ref;
-    if (!mappings->lookup_node_to_hir (expr.get_mappings ().get_crate_num (),
-				       ref_node_id, &ref))
+    if (!mappings->lookup_node_to_hir (ref_node_id, &ref))
       {
 	// FIXME
 	// this is an internal error

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -307,9 +307,9 @@ public:
       }
 
     const CanonicalPath *canonical_path = nullptr;
-    bool ok = mappings->lookup_canonical_path (
-      function.get_mappings ().get_crate_num (),
-      function.get_mappings ().get_nodeid (), &canonical_path);
+    bool ok
+      = mappings->lookup_canonical_path (function.get_mappings ().get_nodeid (),
+					 &canonical_path);
     rust_assert (ok);
 
     RustIdent ident{*canonical_path, function.get_locus ()};

--- a/gcc/rust/typecheck/rust-hir-type-check-path.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-path.cc
@@ -205,8 +205,7 @@ TypeCheckExpr::resolve_root_path (HIR::PathInExpression &expr, size_t *offset,
 
       // node back to HIR
       HirId ref;
-      if (!mappings->lookup_node_to_hir (expr.get_mappings ().get_crate_num (),
-					 ref_node_id, &ref))
+      if (!mappings->lookup_node_to_hir (ref_node_id, &ref))
 	{
 	  rust_error_at (seg.get_locus (), "456 reverse lookup failure");
 	  rust_debug_loc (seg.get_locus (),
@@ -218,10 +217,7 @@ TypeCheckExpr::resolve_root_path (HIR::PathInExpression &expr, size_t *offset,
 	  return new TyTy::ErrorType (expr.get_mappings ().get_hirid ());
 	}
 
-      auto seg_is_module
-	= (nullptr
-	   != mappings->lookup_module (expr.get_mappings ().get_crate_num (),
-				       ref));
+      auto seg_is_module = (nullptr != mappings->lookup_module (ref));
       auto seg_is_crate = mappings->is_local_hirid_crate (ref);
       if (seg_is_module || seg_is_crate)
 	{
@@ -354,11 +350,8 @@ TypeCheckExpr::resolve_segments (NodeId root_resolved_node_id,
 	{
 	  const TyTy::VariantDef *variant = candidate.item.enum_field.variant;
 
-	  CrateNum crate_num = mappings->get_current_crate ();
 	  HirId variant_id = variant->get_id ();
-
-	  HIR::Item *enum_item
-	    = mappings->lookup_hir_item (crate_num, variant_id);
+	  HIR::Item *enum_item = mappings->lookup_hir_item (variant_id);
 	  rust_assert (enum_item != nullptr);
 
 	  resolved_node_id = enum_item->get_mappings ().get_nodeid ();

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.h
@@ -177,7 +177,6 @@ public:
     // get the path
     const CanonicalPath *canonical_path = nullptr;
     bool ok = mappings->lookup_canonical_path (
-      struct_decl.get_mappings ().get_crate_num (),
       struct_decl.get_mappings ().get_nodeid (), &canonical_path);
     rust_assert (ok);
     RustIdent ident{*canonical_path, struct_decl.get_locus ()};
@@ -251,7 +250,6 @@ public:
     // get the path
     const CanonicalPath *canonical_path = nullptr;
     bool ok = mappings->lookup_canonical_path (
-      enum_decl.get_mappings ().get_crate_num (),
       enum_decl.get_mappings ().get_nodeid (), &canonical_path);
     rust_assert (ok);
     RustIdent ident{*canonical_path, enum_decl.get_locus ()};
@@ -313,7 +311,6 @@ public:
     // get the path
     const CanonicalPath *canonical_path = nullptr;
     bool ok = mappings->lookup_canonical_path (
-      struct_decl.get_mappings ().get_crate_num (),
       struct_decl.get_mappings ().get_nodeid (), &canonical_path);
     rust_assert (ok);
     RustIdent ident{*canonical_path, struct_decl.get_locus ()};
@@ -389,7 +386,6 @@ public:
     // get the path
     const CanonicalPath *canonical_path = nullptr;
     bool ok = mappings->lookup_canonical_path (
-      union_decl.get_mappings ().get_crate_num (),
       union_decl.get_mappings ().get_nodeid (), &canonical_path);
     rust_assert (ok);
     RustIdent ident{*canonical_path, union_decl.get_locus ()};
@@ -478,9 +474,9 @@ public:
 
     // get the path
     const CanonicalPath *canonical_path = nullptr;
-    bool ok = mappings->lookup_canonical_path (
-      function.get_mappings ().get_crate_num (),
-      function.get_mappings ().get_nodeid (), &canonical_path);
+    bool ok
+      = mappings->lookup_canonical_path (function.get_mappings ().get_nodeid (),
+					 &canonical_path);
     rust_assert (ok);
 
     RustIdent ident{*canonical_path, function.get_locus ()};

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.cc
@@ -99,7 +99,6 @@ TypeCheckTopLevel::visit (HIR::TupleStruct &struct_decl)
   // get the path
   const CanonicalPath *canonical_path = nullptr;
   bool ok = mappings->lookup_canonical_path (
-    struct_decl.get_mappings ().get_crate_num (),
     struct_decl.get_mappings ().get_nodeid (), &canonical_path);
   rust_assert (ok);
   RustIdent ident{*canonical_path, struct_decl.get_locus ()};
@@ -159,7 +158,6 @@ TypeCheckTopLevel::visit (HIR::StructStruct &struct_decl)
   // get the path
   const CanonicalPath *canonical_path = nullptr;
   bool ok = mappings->lookup_canonical_path (
-    struct_decl.get_mappings ().get_crate_num (),
     struct_decl.get_mappings ().get_nodeid (), &canonical_path);
   rust_assert (ok);
   RustIdent ident{*canonical_path, struct_decl.get_locus ()};
@@ -205,9 +203,9 @@ TypeCheckTopLevel::visit (HIR::Enum &enum_decl)
 
   // get the path
   const CanonicalPath *canonical_path = nullptr;
-  bool ok = mappings->lookup_canonical_path (
-    enum_decl.get_mappings ().get_crate_num (),
-    enum_decl.get_mappings ().get_nodeid (), &canonical_path);
+  bool ok
+    = mappings->lookup_canonical_path (enum_decl.get_mappings ().get_nodeid (),
+				       &canonical_path);
   rust_assert (ok);
   RustIdent ident{*canonical_path, enum_decl.get_locus ()};
 
@@ -249,9 +247,9 @@ TypeCheckTopLevel::visit (HIR::Union &union_decl)
 
   // get the path
   const CanonicalPath *canonical_path = nullptr;
-  bool ok = mappings->lookup_canonical_path (
-    union_decl.get_mappings ().get_crate_num (),
-    union_decl.get_mappings ().get_nodeid (), &canonical_path);
+  bool ok
+    = mappings->lookup_canonical_path (union_decl.get_mappings ().get_nodeid (),
+				       &canonical_path);
   rust_assert (ok);
   RustIdent ident{*canonical_path, union_decl.get_locus ()};
 
@@ -335,9 +333,9 @@ TypeCheckTopLevel::visit (HIR::Function &function)
     }
 
   const CanonicalPath *canonical_path = nullptr;
-  bool ok = mappings->lookup_canonical_path (
-    function.get_mappings ().get_crate_num (),
-    function.get_mappings ().get_nodeid (), &canonical_path);
+  bool ok
+    = mappings->lookup_canonical_path (function.get_mappings ().get_nodeid (),
+				       &canonical_path);
   rust_assert (ok);
 
   RustIdent ident{*canonical_path, function.get_locus ()};

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -273,8 +273,7 @@ TypeCheckType::resolve_root_path (HIR::TypePath &path, size_t *offset,
 
       // node back to HIR
       HirId ref = UNKNOWN_HIRID;
-      if (!mappings->lookup_node_to_hir (path.get_mappings ().get_crate_num (),
-					 ref_node_id, &ref))
+      if (!mappings->lookup_node_to_hir (ref_node_id, &ref))
 	{
 	  if (is_root)
 	    {
@@ -291,10 +290,7 @@ TypeCheckType::resolve_root_path (HIR::TypePath &path, size_t *offset,
 	  return root_tyty;
 	}
 
-      auto seg_is_module
-	= (nullptr
-	   != mappings->lookup_module (path.get_mappings ().get_crate_num (),
-				       ref));
+      auto seg_is_module = (nullptr != mappings->lookup_module (ref));
       auto seg_is_crate = mappings->is_local_hirid_crate (ref);
       if (seg_is_module || seg_is_crate)
 	{

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -291,9 +291,7 @@ public:
 
     // node back to HIR
     HirId ref;
-    if (!mappings->lookup_node_to_hir (
-	  binding_type_path->get_mappings ().get_crate_num (), ref_node_id,
-	  &ref))
+    if (!mappings->lookup_node_to_hir (ref_node_id, &ref))
       {
 	// FIXME
 	rust_error_at (Location (), "where-clause reverse lookup failure");

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -313,10 +313,8 @@ TraitItemReference::get_type_from_fn (/*const*/ HIR::TraitItemFunc &fn) const
 
   auto mappings = Analysis::Mappings::get ();
   const CanonicalPath *canonical_path = nullptr;
-  bool ok
-    = mappings->lookup_canonical_path (fn.get_mappings ().get_crate_num (),
-				       fn.get_mappings ().get_nodeid (),
-				       &canonical_path);
+  bool ok = mappings->lookup_canonical_path (fn.get_mappings ().get_nodeid (),
+					     &canonical_path);
   rust_assert (ok);
 
   RustIdent ident{*canonical_path, fn.get_locus ()};

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -329,8 +329,7 @@ TyVar::get_implicit_infer_var (Location locus)
 					       infer->get_ref (),
 					       UNKNOWN_LOCAL_DEFID),
 			infer);
-  mappings->insert_location (mappings->get_current_crate (), infer->get_ref (),
-			     locus);
+  mappings->insert_location (infer->get_ref (), locus);
 
   return TyVar (infer->get_ref ());
 }
@@ -457,7 +456,7 @@ InferType::clone () const
 					       clone->get_ref (),
 					       UNKNOWN_LOCAL_DEFID),
 			clone);
-  mappings->insert_location (mappings->get_current_crate (), clone->get_ref (),
+  mappings->insert_location (clone->get_ref (),
 			     mappings->lookup_location (get_ref ()));
 
   // setup the chain to reference this

--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -35,6 +35,7 @@ static const BuiltinAttrDefinition __definitions[] = {
   {"link_section", CODE_GENERATION},
   {"no_mangle", CODE_GENERATION},
   {"repr", CODE_GENERATION},
+  {"path", EXPANSION},
 };
 
 BuiltinAttributeMappings *

--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -74,10 +74,9 @@ public:
   static Mappings *get ();
   ~Mappings ();
 
-  CrateNum get_next_crate_num ();
+  CrateNum get_next_crate_num (const std::string &name);
   void set_current_crate (CrateNum crateNum);
   CrateNum get_current_crate () const;
-  CrateNum setup_crate_mappings (std::string crate_name);
 
   bool get_crate_name (CrateNum crate_num, std::string &name) const
   {
@@ -90,16 +89,9 @@ public:
   }
 
   // set crate name mid-compilation
-  // don't use this if setting crate name before Session::parse_files
-  bool set_crate_name (CrateNum crate_num, std::string name)
+  void set_crate_name (CrateNum crate_num, const std::string &name)
   {
-    rust_assert (!name.empty ());
-    auto it = crate_names.find (crate_num);
-    if (it == crate_names.end ())
-      return false;
-
-    it->second.assign (name);
-    return true;
+    crate_names[crate_num] = name;
   }
 
   std::string get_current_crate_name () const
@@ -110,20 +102,22 @@ public:
     return name;
   }
 
-  NodeId get_next_node_id () { return get_next_node_id (get_current_crate ()); }
-  NodeId get_next_node_id (CrateNum crateNum);
-
+  NodeId get_next_node_id ();
   HirId get_next_hir_id () { return get_next_hir_id (get_current_crate ()); }
   HirId get_next_hir_id (CrateNum crateNum);
-
+  LocalDefId get_next_localdef_id ()
+  {
+    return get_next_localdef_id (get_current_crate ());
+  }
   LocalDefId get_next_localdef_id (CrateNum crateNum);
 
-  AST::Crate *get_ast_crate (CrateNum crateNum);
-  void insert_ast_crate (AST::Crate *crate);
-
-  HIR::Crate *get_hir_crate (CrateNum crateNum);
+  AST::Crate &get_ast_crate (CrateNum crateNum);
+  AST::Crate &get_ast_crate_by_node_id (NodeId id);
+  AST::Crate &insert_ast_crate (std::unique_ptr<AST::Crate> &&crate,
+				CrateNum crate_num);
+  HIR::Crate &insert_hir_crate (std::unique_ptr<HIR::Crate> &&crate);
+  HIR::Crate &get_hir_crate (CrateNum crateNum);
   bool is_local_hirid_crate (HirId crateNum);
-  void insert_hir_crate (HIR::Crate *crate);
 
   void insert_defid_mapping (DefId id, HIR::Item *item);
   HIR::Item *lookup_defid (DefId id);
@@ -132,88 +126,62 @@ public:
 				   HIR::Item *item);
   HIR::Item *lookup_local_defid (CrateNum crateNum, LocalDefId id);
 
-  void insert_hir_item (CrateNum crateNum, HirId id, HIR::Item *item);
-  HIR::Item *lookup_hir_item (CrateNum crateNum, HirId id);
+  void insert_hir_item (HIR::Item *item);
+  HIR::Item *lookup_hir_item (HirId id);
 
-  void insert_hir_trait_item (CrateNum crateNum, HirId id,
-			      HIR::TraitItem *item);
-  HIR::TraitItem *lookup_hir_trait_item (CrateNum crateNum, HirId id);
+  void insert_hir_trait_item (HIR::TraitItem *item);
+  HIR::TraitItem *lookup_hir_trait_item (HirId id);
 
-  void insert_hir_extern_item (CrateNum crateNum, HirId id,
-			       HIR::ExternalItem *item);
-  HIR::ExternalItem *lookup_hir_extern_item (CrateNum crateNum, HirId id);
+  void insert_hir_extern_item (HIR::ExternalItem *item);
+  HIR::ExternalItem *lookup_hir_extern_item (HirId id);
 
-  void insert_hir_impl_block (CrateNum crateNum, HirId id,
-			      HIR::ImplBlock *item);
-  HIR::ImplBlock *lookup_hir_impl_block (CrateNum crateNum, HirId id);
+  void insert_hir_impl_block (HIR::ImplBlock *item);
+  HIR::ImplBlock *lookup_hir_impl_block (HirId id);
 
-  void insert_module (CrateNum crateNum, HirId id, HIR::Module *module);
-  HIR::Module *lookup_module (CrateNum crateNum, HirId id);
+  void insert_module (HIR::Module *module);
+  HIR::Module *lookup_module (HirId id);
 
-  void insert_hir_implitem (CrateNum crateNum, HirId id, HirId parent_impl_id,
-			    HIR::ImplItem *item);
-  HIR::ImplItem *lookup_hir_implitem (CrateNum crateNum, HirId id,
-				      HirId *parent_impl_id);
+  void insert_hir_implitem (HirId parent_impl_id, HIR::ImplItem *item);
+  HIR::ImplItem *lookup_hir_implitem (HirId id, HirId *parent_impl_id);
 
-  void insert_hir_expr (CrateNum crateNum, HirId id, HIR::Expr *expr);
-  HIR::Expr *lookup_hir_expr (CrateNum crateNum, HirId id);
+  void insert_hir_expr (HIR::Expr *expr);
+  HIR::Expr *lookup_hir_expr (HirId id);
 
-  void insert_hir_path_expr_seg (CrateNum crateNum, HirId id,
-				 HIR::PathExprSegment *expr);
-  HIR::PathExprSegment *lookup_hir_path_expr_seg (CrateNum crateNum, HirId id);
+  void insert_hir_path_expr_seg (HIR::PathExprSegment *expr);
+  HIR::PathExprSegment *lookup_hir_path_expr_seg (HirId id);
 
-  void insert_simple_path_segment (CrateNum crateNum, HirId id,
-				   const AST::SimplePathSegment *path);
-  const AST::SimplePathSegment *lookup_simple_path_segment (CrateNum crateNum,
-							    HirId id);
+  void insert_hir_generic_param (HIR::GenericParam *expr);
+  HIR::GenericParam *lookup_hir_generic_param (HirId id);
 
-  void insert_simple_path (CrateNum crateNum, HirId id,
-			   const AST::SimplePath *path);
-  const AST::SimplePath *lookup_simple_path (CrateNum crateNum, HirId id);
+  void insert_hir_type (HIR::Type *type);
+  HIR::Type *lookup_hir_type (HirId id);
 
-  void insert_hir_generic_param (CrateNum crateNum, HirId id,
-				 HIR::GenericParam *expr);
-  HIR::GenericParam *lookup_hir_generic_param (CrateNum crateNum, HirId id);
+  void insert_hir_stmt (HIR::Stmt *stmt);
+  HIR::Stmt *lookup_hir_stmt (HirId id);
 
-  void insert_hir_type (CrateNum crateNum, HirId id, HIR::Type *type);
-  HIR::Type *lookup_hir_type (CrateNum crateNum, HirId id);
+  void insert_hir_param (HIR::FunctionParam *type);
+  HIR::FunctionParam *lookup_hir_param (HirId id);
 
-  void insert_hir_stmt (CrateNum crateNum, HirId id, HIR::Stmt *stmt);
-  HIR::Stmt *lookup_hir_stmt (CrateNum crateNum, HirId id);
+  void insert_hir_self_param (HIR::SelfParam *type);
+  HIR::SelfParam *lookup_hir_self_param (HirId id);
 
-  void insert_hir_param (CrateNum crateNum, HirId id, HIR::FunctionParam *type);
-  HIR::FunctionParam *lookup_hir_param (CrateNum crateNum, HirId id);
+  void insert_hir_struct_field (HIR::StructExprField *type);
+  HIR::StructExprField *lookup_hir_struct_field (HirId id);
 
-  void insert_hir_self_param (CrateNum crateNum, HirId id,
-			      HIR::SelfParam *type);
-  HIR::SelfParam *lookup_hir_self_param (CrateNum crateNum, HirId id);
-
-  void insert_hir_struct_field (CrateNum crateNum, HirId id,
-				HIR::StructExprField *type);
-  HIR::StructExprField *lookup_hir_struct_field (CrateNum crateNum, HirId id);
-
-  void insert_hir_pattern (CrateNum crateNum, HirId id, HIR::Pattern *pattern);
-  HIR::Pattern *lookup_hir_pattern (CrateNum crateNum, HirId id);
+  void insert_hir_pattern (HIR::Pattern *pattern);
+  HIR::Pattern *lookup_hir_pattern (HirId id);
 
   void walk_local_defids_for_crate (CrateNum crateNum,
 				    std::function<bool (HIR::Item *)> cb);
 
-  void insert_node_to_hir (CrateNum crate, NodeId id, HirId ref);
-  bool lookup_node_to_hir (CrateNum crate, NodeId id, HirId *ref);
-  bool lookup_hir_to_node (CrateNum crate, HirId id, NodeId *ref);
+  void insert_node_to_hir (NodeId id, HirId ref);
+  bool lookup_node_to_hir (NodeId id, HirId *ref);
+  bool lookup_hir_to_node (HirId id, NodeId *ref);
 
-  void insert_location (CrateNum crate, HirId id, Location locus);
-  Location lookup_location (CrateNum crate, HirId id);
-  Location lookup_location (HirId id)
-  {
-    return lookup_location (get_current_crate (), id);
-  }
+  void insert_location (HirId id, Location locus);
+  Location lookup_location (HirId id);
 
-  bool resolve_nodeid_to_stmt (CrateNum crate, NodeId id, HIR::Stmt **stmt);
-  bool resolve_nodeid_to_stmt (NodeId id, HIR::Stmt **stmt)
-  {
-    return resolve_nodeid_to_stmt (get_current_crate (), id, stmt);
-  }
+  bool resolve_nodeid_to_stmt (NodeId id, HIR::Stmt **stmt);
 
   std::set<HirId> &get_hirids_within_crate (CrateNum crate)
   {
@@ -245,8 +213,7 @@ public:
   bool is_impl_item (HirId id)
   {
     HirId parent_impl_block_id = UNKNOWN_HIRID;
-    return lookup_hir_implitem (get_current_crate (), id, &parent_impl_block_id)
-	   != nullptr;
+    return lookup_hir_implitem (id, &parent_impl_block_id) != nullptr;
   }
 
   void insert_trait_item_mapping (HirId trait_item_id, HIR::Trait *trait)
@@ -263,11 +230,10 @@ public:
     return lookup->second;
   }
 
-  void insert_canonical_path (CrateNum crate, NodeId id,
-			      const Resolver::CanonicalPath path)
+  void insert_canonical_path (NodeId id, const Resolver::CanonicalPath path)
   {
     const Resolver::CanonicalPath *p = nullptr;
-    if (lookup_canonical_path (crate, id, &p))
+    if (lookup_canonical_path (id, &p))
       {
 	// if we have already stored a canonical path this is ok so long as
 	// this new path is equal or is smaller that the existing one but in
@@ -281,21 +247,16 @@ public:
 	  }
       }
 
-    paths[crate].emplace (id, std::move (path));
+    paths.emplace (id, std::move (path));
   }
 
-  bool lookup_canonical_path (CrateNum crate, NodeId id,
-			      const Resolver::CanonicalPath **path)
+  bool lookup_canonical_path (NodeId id, const Resolver::CanonicalPath **path)
   {
-    auto it = paths.find (crate);
+    auto it = paths.find (id);
     if (it == paths.end ())
       return false;
 
-    auto iy = it->second.find (id);
-    if (iy == it->second.end ())
-      return false;
-
-    *path = &iy->second;
+    *path = &it->second;
     return true;
   }
 
@@ -338,59 +299,46 @@ public:
   Optional<NodeId> lookup_parent_module (NodeId child_item);
   bool node_is_module (NodeId query);
 
+  void insert_ast_item (AST::Item *item);
+  bool lookup_ast_item (NodeId id, AST::Item **result);
+
 private:
   Mappings ();
 
-  CrateNum crateNumItr = 0;
+  CrateNum crateNumItr;
   CrateNum currentCrateNum;
-
-  std::map<CrateNum, HirId> hirIdIter;
-  std::map<CrateNum, NodeId> nodeIdIter;
+  HirId hirIdIter;
+  NodeId nodeIdIter;
   std::map<CrateNum, LocalDefId> localIdIter;
 
-  std::map<CrateNum, AST::Crate *> astCrateMappings;
-  std::map<CrateNum, HIR::Crate *> hirCrateMappings;
-
+  std::map<NodeId, CrateNum> crate_node_to_crate_num;
+  std::map<CrateNum, AST::Crate *> ast_crate_mappings;
+  std::map<CrateNum, HIR::Crate *> hir_crate_mappings;
   std::map<DefId, HIR::Item *> defIdMappings;
   std::map<CrateNum, std::map<LocalDefId, HIR::Item *>> localDefIdMappings;
-  std::map<CrateNum, std::map<HirId, HIR::Module *>> hirModuleMappings;
-  std::map<CrateNum, std::map<HirId, HIR::Item *>> hirItemMappings;
-  std::map<CrateNum, std::map<HirId, HIR::Type *>> hirTypeMappings;
-  std::map<CrateNum, std::map<HirId, HIR::Expr *>> hirExprMappings;
-  std::map<CrateNum, std::map<HirId, HIR::Stmt *>> hirStmtMappings;
-  std::map<CrateNum, std::map<HirId, HIR::FunctionParam *>> hirParamMappings;
-  std::map<CrateNum, std::map<HirId, HIR::StructExprField *>>
-    hirStructFieldMappings;
-  std::map<CrateNum, std::map<HirId, std::pair<HirId, HIR::ImplItem *>>>
-    hirImplItemMappings;
-  std::map<CrateNum, std::map<HirId, HIR::SelfParam *>> hirSelfParamMappings;
+
+  std::map<HirId, HIR::Module *> hirModuleMappings;
+  std::map<HirId, HIR::Item *> hirItemMappings;
+  std::map<HirId, HIR::Type *> hirTypeMappings;
+  std::map<HirId, HIR::Expr *> hirExprMappings;
+  std::map<HirId, HIR::Stmt *> hirStmtMappings;
+  std::map<HirId, HIR::FunctionParam *> hirParamMappings;
+  std::map<HirId, HIR::StructExprField *> hirStructFieldMappings;
+  std::map<HirId, std::pair<HirId, HIR::ImplItem *>> hirImplItemMappings;
+  std::map<HirId, HIR::SelfParam *> hirSelfParamMappings;
   std::map<HirId, HIR::ImplBlock *> hirImplItemsToImplMappings;
-  std::map<CrateNum, std::map<HirId, HIR::ImplBlock *>> hirImplBlockMappings;
-  std::map<CrateNum, std::map<HirId, HIR::TraitItem *>> hirTraitItemMappings;
-  std::map<CrateNum, std::map<HirId, HIR::ExternalItem *>>
-    hirExternItemMappings;
-  std::map<CrateNum, std::map<HirId, const AST::SimplePath *>>
-    astSimplePathMappings;
-  std::map<CrateNum, std::map<HirId, const AST::SimplePathSegment *>>
-    astSimplePathSegmentMappings;
-  std::map<CrateNum, std::map<HirId, HIR::PathExprSegment *>>
-    hirPathSegMappings;
-  std::map<CrateNum, std::map<HirId, HIR::GenericParam *>>
-    hirGenericParamMappings;
+  std::map<HirId, HIR::ImplBlock *> hirImplBlockMappings;
+  std::map<HirId, HIR::TraitItem *> hirTraitItemMappings;
+  std::map<HirId, HIR::ExternalItem *> hirExternItemMappings;
+  std::map<HirId, HIR::PathExprSegment *> hirPathSegMappings;
+  std::map<HirId, HIR::GenericParam *> hirGenericParamMappings;
   std::map<HirId, HIR::Trait *> hirTraitItemsToTraitMappings;
-  std::map<CrateNum, std::map<HirId, HIR::Pattern *>> hirPatternMappings;
-
-  // this maps the lang=<item_type> to DefId mappings
+  std::map<HirId, HIR::Pattern *> hirPatternMappings;
   std::map<RustLangItem::ItemType, DefId> lang_item_mappings;
-
-  // canonical paths
-  std::map<CrateNum, std::map<NodeId, const Resolver::CanonicalPath>> paths;
-
-  // location info
-  std::map<CrateNum, std::map<NodeId, Location>> locations;
-
-  std::map<CrateNum, std::map<NodeId, HirId>> nodeIdToHirMappings;
-  std::map<CrateNum, std::map<HirId, NodeId>> hirIdToNodeMappings;
+  std::map<NodeId, const Resolver::CanonicalPath> paths;
+  std::map<NodeId, Location> locations;
+  std::map<NodeId, HirId> nodeIdToHirMappings;
+  std::map<HirId, NodeId> hirIdToNodeMappings;
 
   // all hirid nodes
   std::map<CrateNum, std::set<HirId>> hirNodesWithinCrate;
@@ -410,6 +358,9 @@ private:
   std::map<NodeId, std::vector<NodeId>> module_child_map;
   std::map<NodeId, std::vector<Resolver::CanonicalPath>> module_child_items;
   std::map<NodeId, NodeId> child_to_parent_module_map;
+
+  // AST mappings
+  std::map<NodeId, AST::Item *> ast_item_mappings;
 };
 
 } // namespace Analysis


### PR DESCRIPTION
In order to support loading extern crates and use statements we needed to
clarify the usage of NodeId and HirId within gccrs. Each of these id's were
nested behind the CrateNum but the type resolution, linting and code-gen
passes do not support that level of nesting.

In order to get metadata exports and imports working lets focus on gccrs
supporting compilation of a single crate at a time. This means the crate
prefix only matters for imports and limits the complexity here. Down the
line there might be a way to leverage DefId's for all Path resolution
which could solve this problem but significant refactoring would be
required here to do this properly and its not nessecary for a basic working
rust compiler.

The mappings changes here will help us resolve issues like #1361 much more
easily.
