### PR TITLE
Fix bad ABI from string method

### DIFF
--- a/gcc/rust/util/rust-abi.cc
+++ b/gcc/rust/util/rust-abi.cc
@@ -22,7 +22,7 @@ Rust::ABI
 get_abi_from_string (const std::string &abi)
 {
   if (abi.compare ("rust") == 0)
-    return Rust::ABI::C;
+    return Rust::ABI::RUST;
   else if (abi.compare ("rust-intrinsic") == 0)
     return Rust::ABI::INTRINSIC;
   else if (abi.compare ("C") == 0)


### PR DESCRIPTION
We use this method to turn the string ABI into the enum. The
rust abi was wrongly turned into the C ABI always which was
causing issues on the mangling logic for extern crate items.