### PR TITLE
Typecheck const generic params

### DIFF
--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -239,6 +239,10 @@ Dump::visit (TypeParam &)
 {}
 
 void
+Dump::visit (ConstGenericParam &)
+{}
+
+void
 Dump::visit (LifetimeWhereClauseItem &)
 {}
 void

--- a/gcc/rust/hir/rust-hir-dump.h
+++ b/gcc/rust/hir/rust-hir-dump.h
@@ -108,6 +108,7 @@ private:
   virtual void visit (AsyncBlockExpr &) override;
 
   virtual void visit (TypeParam &) override;
+  virtual void visit (ConstGenericParam &) override;
 
   virtual void visit (LifetimeWhereClauseItem &) override;
   virtual void visit (TypeBoundWhereClauseItem &) override;

--- a/gcc/rust/hir/tree/rust-hir-full-decls.h
+++ b/gcc/rust/hir/tree/rust-hir-full-decls.h
@@ -141,6 +141,7 @@ class ExprStmtWithBlock;
 
 // rust-item.h
 class TypeParam;
+class ConstGenericParam;
 class WhereClauseItem;
 class LifetimeWhereClauseItem;
 class TypeBoundWhereClauseItem;

--- a/gcc/rust/hir/tree/rust-hir-visitor.h
+++ b/gcc/rust/hir/tree/rust-hir-visitor.h
@@ -93,6 +93,7 @@ public:
   virtual void visit (AwaitExpr &expr) = 0;
   virtual void visit (AsyncBlockExpr &expr) = 0;
   virtual void visit (TypeParam &param) = 0;
+  virtual void visit (ConstGenericParam &param) = 0;
   virtual void visit (LifetimeWhereClauseItem &item) = 0;
   virtual void visit (TypeBoundWhereClauseItem &item) = 0;
   virtual void visit (Module &module) = 0;
@@ -238,6 +239,7 @@ public:
   virtual void visit (AsyncBlockExpr &) override {}
 
   virtual void visit (TypeParam &) override {}
+  virtual void visit (ConstGenericParam &) override {}
 
   virtual void visit (LifetimeWhereClauseItem &) override {}
   virtual void visit (TypeBoundWhereClauseItem &) override {}

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -769,6 +769,16 @@ public:
 
   Location get_locus () const override final { return locus; };
 
+  bool has_default_expression () { return default_expression != nullptr; }
+
+  std::unique_ptr<Type> &get_type () { return type; }
+  std::unique_ptr<Expr> &get_default_expression ()
+  {
+    rust_assert (has_default_expression ());
+
+    return default_expression;
+  }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.cc
@@ -38,9 +38,25 @@ TypeCheckTopLevel::resolve_generic_params (
       switch (generic_param.get ()->get_kind ())
 	{
 	case HIR::GenericParam::GenericKind::LIFETIME:
-	case HIR::GenericParam::GenericKind::CONST:
-	  // FIXME: Skipping Lifetime and Const completely until better
+	  // FIXME: Skipping Lifetime completely until better
 	  // handling.
+	  break;
+	  case HIR::GenericParam::GenericKind::CONST: {
+	    auto param
+	      = static_cast<HIR::ConstGenericParam *> (generic_param.get ());
+	    auto specified_type
+	      = TypeCheckType::Resolve (param->get_type ().get ());
+
+	    if (param->has_default_expression ())
+	      {
+		auto expr_type = TypeCheckExpr::Resolve (
+		  param->get_default_expression ().get ());
+		specified_type->coerce (expr_type);
+	      }
+
+	    context->insert_type (generic_param->get_mappings (),
+				  specified_type);
+	  }
 	  break;
 
 	  case HIR::GenericParam::GenericKind::TYPE: {

--- a/gcc/testsuite/rust/compile/const_generics_6.rs
+++ b/gcc/testsuite/rust/compile/const_generics_6.rs
@@ -1,0 +1,2 @@
+struct Foo<const N: usize>;
+struct Bar<const N: usize = { 15i32 }>; // { dg-error "expected .usize. got .i32." }


### PR DESCRIPTION
```rust
struct Foo<const N: usize>;
struct Bar<const N: usize = { 15i32 }>; // { dg-error "expected .usize. got .i32." }
```

This PR allows us to typecheck the type of const generics as well as make sure that the optional default expression fits that type