### PR TITLE
backend: explain why cdecl is treated differently when setting up the ABIs

### DIFF
--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -304,6 +304,12 @@ HIRCompileBase::setup_abi_options (tree fndecl, ABI abi)
     case Rust::ABI::INTRINSIC:
     case Rust::ABI::C:
     case Rust::ABI::CDECL:
+      // `decl_attributes` function (not the macro) has the side-effect of
+      // actually switching the codegen backend to use the ABI we annotated.
+      // However, since `cdecl` is the default ABI GCC will be using, explicitly
+      // specifying that ABI will cause GCC to emit a warning saying the
+      // attribute is useless (which is confusing to the user as the attribute
+      // is added by us).
       DECL_ATTRIBUTES (fndecl)
 	= tree_cons (get_identifier ("cdecl"), NULL, DECL_ATTRIBUTES (fndecl));
 


### PR DESCRIPTION
- backend: explain why `cdecl` is treated differently when setting up the ABIs