### PR TITLE
Fix undefined behaviour using .get on unique_ptr

### DIFF
--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -199,7 +199,7 @@ Mappings::insert_ast_crate (std::unique_ptr<AST::Crate> &&crate,
   rust_assert (it == ast_crate_mappings.end ());
 
   // store it
-  ast_crate_mappings.insert ({crate_num, crate.get ()});
+  ast_crate_mappings.insert ({crate_num, crate.release ()});
 
   // return the reference to it
   it = ast_crate_mappings.find (crate_num);
@@ -236,7 +236,7 @@ Mappings::insert_hir_crate (std::unique_ptr<HIR::Crate> &&crate)
 
   insert_node_to_hir (crate->get_mappings ().get_nodeid (),
 		      crate->get_mappings ().get_hirid ());
-  hir_crate_mappings.insert ({crateNum, crate.get ()});
+  hir_crate_mappings.insert ({crateNum, crate.release ()});
 
   it = hir_crate_mappings.find (crateNum);
   rust_assert (it != hir_crate_mappings.end ());


### PR DESCRIPTION
As the move semantics for AST and HIR crates are unsafe on older compilers
we are working around this by storing the pointer into the mappings class
this was using the get method to store the pointer. The issue for loading
extern crates the unique_ptr goes out of scope and this the deletion code
resulting in undefined behaviour. This changes it to call release to take
full ownership of the pointer as we expect.
