### PR TITLE
External Items with Rust ABI need to mangle the full path

### DIFF
--- a/gcc/rust/backend/rust-compile-extern.h
+++ b/gcc/rust/backend/rust-compile-extern.h
@@ -130,6 +130,17 @@ public:
     tree compiled_fn_type = TyTyResolveCompile::compile (ctx, fntype);
     std::string ir_symbol_name = function.get_item_name ();
     std::string asm_name = function.get_item_name ();
+    if (fntype->get_abi () == ABI::RUST)
+      {
+	// then we need to get the canonical path of it and mangle it
+	const Resolver::CanonicalPath *canonical_path = nullptr;
+	bool ok = ctx->get_mappings ()->lookup_canonical_path (
+	  function.get_mappings ().get_nodeid (), &canonical_path);
+	rust_assert (ok);
+
+	ir_symbol_name = canonical_path->get () + fntype->subst_as_string ();
+	asm_name = ctx->mangle_item (fntype, *canonical_path);
+      }
 
     const unsigned int flags = Backend::function_is_declaration;
     tree fndecl

--- a/gcc/rust/resolve/rust-ast-resolve-item.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-item.cc
@@ -1027,6 +1027,12 @@ void
 ResolveExternItem::visit (AST::ExternalFunctionItem &function)
 {
   NodeId scope_node_id = function.get_node_id ();
+  auto decl = CanonicalPath::new_seg (function.get_node_id (),
+				      function.get_identifier ());
+  auto path = prefix.append (decl);
+  auto cpath = canonical_prefix.append (decl);
+
+  mappings->insert_canonical_path (function.get_node_id (), cpath);
 
   resolve_visibility (function.get_visibility ());
 


### PR DESCRIPTION
When compiling external rust abi item requires the fully qualified
canonical path to be mangled in order to link correctly.
