### PR TITLE
Fix ICE on duplicate compilation of ExternBlock items

### DIFF
--- a/gcc/testsuite/rust/compile/issue-1323-1.rs
+++ b/gcc/testsuite/rust/compile/issue-1323-1.rs
@@ -1,0 +1,18 @@
+fn main() {
+    let mut x = [1, 2, 3];
+    let y: i32 = x[0];
+    print_int(y);
+}
+
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+fn print_int(value: i32) {
+    let s = "%d\n\0";
+    let s_p = s as *const str;
+    let c_p = s_p as *const i8;
+    unsafe {
+        printf(c_p, value as isize);
+    }
+}

--- a/gcc/testsuite/rust/compile/issue-1323-2.rs
+++ b/gcc/testsuite/rust/compile/issue-1323-2.rs
@@ -1,0 +1,16 @@
+fn print_int(value: i32) {
+    let s = "%d\n\0";
+    let s_p = s as *const str;
+    let c_p = s_p as *const i8;
+    unsafe {
+        printf(c_p, value as isize);
+    }
+}
+
+fn main() {
+    print_int(5);
+}
+
+extern "C" {
+    fn printf(s: *const i8, ...);
+}


### PR DESCRIPTION
When we declare an extern block after where it is used the query
compilation system in the backend code-gen pass will resolve this and
compile as required. But when the iteration of the crate as part of the
pipeline we end up compiling this function again. The check we used to stop
this was copy paste from the other function items but in this case the
check for function_completed is not valid as this is a prototype for an
extern item so we dont add this to the translation unit as an fndecl which
meant we hit the ICE where we compile and add it again.

Fixes #1323
