### PR TITLE
Ensure we parse any inner item attributes when expanding a module

### DIFF
--- a/gcc/rust/ast/rust-ast-full-test.cc
+++ b/gcc/rust/ast/rust-ast-full-test.cc
@@ -4056,6 +4056,8 @@ Module::load_items ()
   Lexer lex (module_file.c_str (), std::move (file_wrap), linemap);
   Parser<Lexer> parser (lex);
 
+  // we need to parse any possible inner attributes for this module
+  inner_attrs = parser.parse_inner_attributes ();
   auto parsed_items = parser.parse_items ();
   for (const auto &error : parser.get_errors ())
     error.emit_error ();

--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -149,6 +149,7 @@ public:
   std::unique_ptr<AST::IdentifierPattern> parse_identifier_pattern ();
   std::unique_ptr<AST::TokenTree> parse_token_tree ();
   AST::Attribute parse_attribute_body ();
+  AST::AttrVec parse_inner_attributes ();
 
 private:
   void skip_after_semicolon ();
@@ -164,7 +165,6 @@ private:
   void parse_statement_seq (bool (Parser::*done) ());
 
   // AST-related stuff - maybe move or something?
-  AST::AttrVec parse_inner_attributes ();
   AST::Attribute parse_inner_attribute ();
   AST::AttrVec parse_outer_attributes ();
   AST::Attribute parse_outer_attribute ();

--- a/gcc/testsuite/rust/compile/issue-1089.rs
+++ b/gcc/testsuite/rust/compile/issue-1089.rs
@@ -1,0 +1,6 @@
+// { dg-additional-options "-w" }
+pub mod test_mod;
+
+fn main() {
+    let a = test_mod::Test(123);
+}

--- a/gcc/testsuite/rust/compile/test_mod.rs
+++ b/gcc/testsuite/rust/compile/test_mod.rs
@@ -1,0 +1,6 @@
+//! test_mod inner doc comment
+//!
+//! foo bar baz cake pizza carbs
+
+pub struct Test(pub i32);
+// { dg-warning "struct is never constructed" "" { target *-*-* } .-1 }


### PR DESCRIPTION
When compiling code containing module expansions we must first ensure any
possible inner item attributes are parser first and applied to the module,
otherwise we end up in a bad state and ignore attributes.

Fixes #1089

