### PR TITLE
Fix parsing grammer of grouped expressions as the block tail expression

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -7276,12 +7276,6 @@ Parser<ManagedTokenSource>::parse_expr_without_block (
     case LEFT_SQUARE:
       // array expr (creation, not index)
       return parse_array_expr (std::move (outer_attrs));
-    case LEFT_PAREN:
-      /* either grouped expr or tuple expr - depends on whether there is a
-       * comma
-       * inside the parentheses - if so, tuple expr, otherwise, grouped expr.
-       */
-      return parse_grouped_or_tuple_expr (std::move (outer_attrs));
       default: {
 	/* HACK: piggyback on pratt parsed expr and abuse polymorphism to
 	 * essentially downcast */

--- a/gcc/testsuite/rust/compile/issue-1393.rs
+++ b/gcc/testsuite/rust/compile/issue-1393.rs
@@ -1,0 +1,13 @@
+fn tst() {
+    let a = 123;
+    let b = 0;
+    let _c = if b == 0 {
+        (a & 0x7fffff) << 1
+    } else {
+        (a & 0x7fffff) | 0x800000
+    };
+}
+
+fn main() {
+    tst()
+}


### PR DESCRIPTION
When we want to compile a grouped expression we had a check for the
LEFT_PAREN during the parse_expr_without_block but this can't be handled
here since in this paticular example the grouped expressions is simply the
lhs of the bit shift expression. This is already handled as part of
parse_expr so we can simply remove the rule here and rely on parse_expr
handling this.

Fixes #1393
