### PR TITLE
lexer: Allow specifiying tokens as reserved in certain editions

### DIFF
--- a/gcc/rust/rust-session-manager.h
+++ b/gcc/rust/rust-session-manager.h
@@ -191,13 +191,13 @@ struct CompileOptions
   bool proc_macro = false;
   std::string metadata_output_path;
 
-  enum Edition
+  enum class Edition
   {
     E2015 = 0,
     E2018,
     E2021,
   } edition
-    = E2015;
+    = Edition::E2015;
 
   bool dump_option_enabled (DumpOption option) const
   {
@@ -238,6 +238,8 @@ struct CompileOptions
   {
     edition = static_cast<Edition> (raw_edition);
   }
+
+  const Edition &get_edition () { return edition; }
 
   void set_metadata_output (const std::string &path)
   {

--- a/gcc/testsuite/rust/compile/macro-issue1395-2.rs
+++ b/gcc/testsuite/rust/compile/macro-issue1395-2.rs
@@ -1,0 +1,7 @@
+// { dg-additional-options "-frust-edition=2018" }
+
+macro_rules! try {
+    // { dg-error "expecting .identifier. but .try. found" "" { target *-*-* } .-1 }
+    // { dg-error "failed to parse item in crate" "" { target *-*-* } .-2 }
+    () => {};
+}

--- a/gcc/testsuite/rust/compile/macro-issue1395.rs
+++ b/gcc/testsuite/rust/compile/macro-issue1395.rs
@@ -1,0 +1,5 @@
+// Default edition is 2015 - this is valid
+
+macro_rules! try {
+    () => {};
+}


### PR DESCRIPTION
Some tokens such as `try` only became reserved keywords in certain
editions. This behavior might happen again in the future and we should
be able to handle it.

Closes #1395 