### PR TITLE
'gcc/testsuite/rust/link/link.exp': Fix 'runtest_file_p' usage

### DIFF
--- a/gcc/testsuite/rust/link/link.exp
+++ b/gcc/testsuite/rust/link/link.exp
@@ -154,7 +154,16 @@ foreach src [lsort [find $srcdir/$subdir *_0.rs]] {
 	continue
     }
 
+    # To prevent 'runtest_file_p' being tested again (for example, via
+    # 'gcc-dg-runtest'), with undesirable consequences due to its side effects,
+    # interpose a dummy:
+    rename runtest_file_p saved_runtest_file_p
+    proc runtest_file_p { runtests testcase } {
+	return 1
+    }
     rs-link-execute $src
+    rename runtest_file_p {}
+    rename saved_runtest_file_p runtest_file_p
 }
 
 set dg-do-what-default ${saved-dg-do-what-default}


### PR DESCRIPTION
The recent commit 418aef1b006182e84266dcf4f31ee721ed04301a
"Support extern crate" (merged in
commit fd2bd659e44e5b7fea92bc34a4864f057f387490 "Merge #1362"), added
'gcc/testsuite/rust/link/link.exp', which I understand to be a hacked up
variant of the LTO multi-file testing harness (not reviewed in detail).

Since that commit, there are issues in parallel testing, so that, for example
with:

    $ make -j12 check-rust RUNTESTFLAGS='--target_board=unix\{,-m32,-mx32\}'

..., the first variant does test as expected:

    @@ -6490,9 +6490,31 @@ PASS: rust/execute/torture/trait9.rs   -Os   at line 13 (test for warnings, line
     PASS: rust/execute/torture/trait9.rs   -Os  (test for excess errors)
     PASS: rust/execute/torture/trait9.rs   -Os  execution test
     PASS: rust/execute/torture/trait9.rs   -Os  output pattern test
    +Running /home/thomas/tmp/source/gcc/rust/build/trace-slim/source-gcc/gcc/testsuite/rust/link/link.exp ...
    +PASS: rust/link/generic_function_0.rs   -O0  (test for excess errors)
    +[...]
    +PASS: rust/link/trait_import_0.rs   -Os  (test for excess errors)
                    === rust Summary for unix ===

    -# of expected passes           6445
    +# of expected passes           6466
     # of expected failures         31

..., but we then get undesired changes for the second and following variants:

     Running target unix/-m32
     Running /home/thomas/tmp/source/gcc/rust/build/trace-slim/source-gcc/gcc/testsuite/rust/compile/compile.exp ...
     PASS: rust/compile/abi-options1.rs  at line 2 (test for errors, line 1)
     PASS: rust/compile/abi-options1.rs  at line 7 (test for errors, line 6)
     PASS: rust/compile/abi-options1.rs (test for excess errors)
    -PASS: rust/compile/array3.rs  at line 2 (test for warnings, line 1)
    -PASS: rust/compile/array3.rs (test for excess errors)
    -PASS: rust/compile/array_empty_list.rs  at line 3 (test for errors, line 2)
    -PASS: rust/compile/array_empty_list.rs (test for excess errors)
    -PASS: rust/compile/arrays1.rs  (test for errors, line 3)
    -PASS: rust/compile/arrays1.rs (test for excess errors)
     PASS: rust/compile/arrays2.rs  at line 4 (test for errors, line 3)
     PASS: rust/compile/arrays2.rs (test for excess errors)
     PASS: rust/compile/attr-mismatch-crate-name.rs (test for excess errors)
    @@ -8355,110 +8371,215 @@ PASS: rust/compile/torture/generics17.rs   -O3 -g  (test for excess errors)
     PASS: rust/compile/torture/generics17.rs   -Os   at line 18 (test for warnings, line 17)
     PASS: rust/compile/torture/generics17.rs   -Os  (test for excess errors)
     PASS: rust/compile/torture/generics18.rs   -O0   at line 19 (test for warnings, line 18)
    +PASS: rust/compile/torture/generics18.rs   -O0   at line 19 (test for warnings, line 18)
    +PASS: rust/compile/torture/generics18.rs   -O0   at line 5 (test for warnings, line 4)
     PASS: rust/compile/torture/generics18.rs   -O0   at line 5 (test for warnings, line 4)
     PASS: rust/compile/torture/generics18.rs   -O0  (test for excess errors)
    +PASS: rust/compile/torture/generics18.rs   -O0  (test for excess errors)

..., and so on.

This has been determined to be due to repetitive 'runtest_file_p' calls (it's
a mess...), thusly fixed (some would call it a "hack", no doubt), and verified
that, for example:

    $ make -j12 check-rust RUNTESTFLAGS='--target_board=unix\{,-m32,-mx32\} link.exp=simple_function_0.rs'

... only runs the one test as indicated.
