### PR TITLE
Experiment: add optional error codes to diagnostics

### DIFF
--- a/.github/bors_log_expected_warnings
+++ b/.github/bors_log_expected_warnings
@@ -84,7 +84,7 @@
 ../../gcc/config/i386/i386.cc:2565:8: warning: too many arguments for format [-Wformat-extra-args]
 ../../gcc/config/i386/i386.cc:2565:8: warning: unknown conversion type character ‘{’ in format [-Wformat=]
 ../../gcc/config/i386/i386.cc:2565:8: warning: unknown conversion type character ‘}’ in format [-Wformat=]
-../../gcc/diagnostic.cc:2191:52: warning: format not a string literal and no format arguments [-Wformat-security]
+../../gcc/diagnostic.cc:2206:52: warning: format not a string literal and no format arguments [-Wformat-security]
 ../../gcc/doc/sourcebuild.texi:1452: warning: node `Add Options' is next for `Effective-Target Keywords' in menu but not in sectioning
 ../../gcc/doc/sourcebuild.texi:2946: warning: node `Effective-Target Keywords' is prev for `Add Options' in menu but not in sectioning
 ../../gcc/fold-const.cc:314:42: warning: format not a string literal and no format arguments [-Wformat-security]

--- a/gcc/diagnostic-core.h
+++ b/gcc/diagnostic-core.h
@@ -92,6 +92,9 @@ extern void error_n (location_t, unsigned HOST_WIDE_INT, const char *,
 extern void error_at (location_t, const char *, ...) ATTRIBUTE_GCC_DIAG(2,3);
 extern void error_at (rich_location *, const char *, ...)
   ATTRIBUTE_GCC_DIAG(2,3);
+extern void error_meta (rich_location *, const diagnostic_metadata &,
+			const char *, ...)
+  ATTRIBUTE_GCC_DIAG(3,4);
 extern void fatal_error (location_t, const char *, ...) ATTRIBUTE_GCC_DIAG(2,3)
      ATTRIBUTE_NORETURN;
 /* Pass one of the OPT_W* from options.h as the second parameter.  */

--- a/gcc/diagnostic.cc
+++ b/gcc/diagnostic.cc
@@ -2050,6 +2050,21 @@ error_at (rich_location *richloc, const char *gmsgid, ...)
   va_end (ap);
 }
 
+/* Same as above, but with metadata.  */
+
+void
+error_meta (rich_location *richloc, const diagnostic_metadata &metadata,
+	    const char *gmsgid, ...)
+{
+  gcc_assert (richloc);
+
+  auto_diagnostic_group d;
+  va_list ap;
+  va_start (ap, gmsgid);
+  diagnostic_impl (richloc, &metadata, -1, gmsgid, &ap, DK_ERROR);
+  va_end (ap);
+}
+
 /* "Sorry, not implemented."  Use for a language feature which is
    required by the relevant specification but not implemented by GCC.
    An object file will not be produced.  */

--- a/gcc/rust/rust-diagnostics.cc
+++ b/gcc/rust/rust-diagnostics.cc
@@ -167,6 +167,17 @@ rust_error_at (const Location location, const char *fmt, ...)
 }
 
 void
+rust_error_at (const RichLocation &location, const ErrorCode code,
+	       const char *fmt, ...)
+{
+  va_list ap;
+
+  va_start (ap, fmt);
+  rust_be_error_at (location, code, expand_message (fmt, ap));
+  va_end (ap);
+}
+
+void
 rust_warning_at (const Location location, int opt, const char *fmt, ...)
 {
   va_list ap;

--- a/gcc/rust/rust-diagnostics.h
+++ b/gcc/rust/rust-diagnostics.h
@@ -50,6 +50,18 @@
 
 // clang-format off
 // simple location
+
+struct ErrorCode
+{
+  explicit ErrorCode (const char *str) : m_str (str)
+  {
+    gcc_assert (str);
+    gcc_assert (str[0] == 'E');
+  }
+
+  const char *m_str;
+};
+
 extern void
 rust_internal_error_at (const Location, const char *fmt, ...)
   RUST_ATTRIBUTE_GCC_DIAG (2, 3)
@@ -72,6 +84,9 @@ rust_inform (const Location, const char *fmt, ...)
 extern void
 rust_error_at (const RichLocation &, const char *fmt, ...)
   RUST_ATTRIBUTE_GCC_DIAG (2, 3);
+extern void
+rust_error_at (const RichLocation &, const ErrorCode, const char *fmt, ...)
+  RUST_ATTRIBUTE_GCC_DIAG (3, 4);
 // clang-format on
 
 // These interfaces provide a way for the front end to ask for
@@ -96,6 +111,9 @@ extern void
 rust_be_error_at (const Location, const std::string &errmsg);
 extern void
 rust_be_error_at (const RichLocation &, const std::string &errmsg);
+extern void
+rust_be_error_at (const RichLocation &, const ErrorCode,
+		  const std::string &errmsg);
 extern void
 rust_be_warning_at (const Location, int opt, const std::string &warningmsg);
 extern void

--- a/gcc/rust/rust-gcc-diagnostics.cc
+++ b/gcc/rust/rust-gcc-diagnostics.cc
@@ -22,6 +22,7 @@
 #include "rust-diagnostics.h"
 
 #include "options.h"
+#include "diagnostic-metadata.h"
 
 void
 rust_be_internal_error_at (const Location location, const std::string &errmsg)
@@ -68,6 +69,39 @@ rust_be_error_at (const RichLocation &location, const std::string &errmsg)
   /* TODO: 'error_at' would like a non-'const' 'rich_location *'.  */
   rich_location &gcc_loc = const_cast<rich_location &> (location.get ());
   error_at (&gcc_loc, "%s", errmsg.c_str ());
+}
+
+class rust_error_code_rule : public diagnostic_metadata::rule
+{
+public:
+  rust_error_code_rule (const ErrorCode code) : m_code (code) {}
+
+  char *make_description () const final override
+  {
+    return xstrdup (m_code.m_str);
+  }
+
+  char *make_url () const final override
+  {
+    return concat ("https://doc.rust-lang.org/error-index.html#",
+		   m_code.m_str,
+		   NULL);
+  }
+
+private:
+  const ErrorCode m_code;
+};
+
+void
+rust_be_error_at (const RichLocation &location, const ErrorCode code,
+		  const std::string &errmsg)
+{
+  /* TODO: 'error_at' would like a non-'const' 'rich_location *'.  */
+  rich_location &gcc_loc = const_cast<rich_location &> (location.get ());
+  diagnostic_metadata m;
+  rust_error_code_rule rule (code);
+  m.add_rule (rule);
+  error_meta (&gcc_loc, m, "%s", errmsg.c_str ());
 }
 
 void

--- a/gcc/rust/rust-gcc-diagnostics.cc
+++ b/gcc/rust/rust-gcc-diagnostics.cc
@@ -83,8 +83,7 @@ public:
 
   char *make_url () const final override
   {
-    return concat ("https://doc.rust-lang.org/error-index.html#",
-		   m_code.m_str,
+    return concat ("https://doc.rust-lang.org/error-index.html#", m_code.m_str,
 		   NULL);
   }
 

--- a/gcc/rust/typecheck/rust-casts.cc
+++ b/gcc/rust/typecheck/rust-casts.cc
@@ -283,7 +283,7 @@ TypeCastRules::emit_cast_error () const
   RichLocation r (locus);
   r.add_range (from.get_locus ());
   r.add_range (to.get_locus ());
-  rust_error_at (r, "invalid cast %<%s%> to %<%s%>",
+  rust_error_at (r, ErrorCode ("E0054"), "invalid cast %<%s%> to %<%s%>",
 		 from.get_ty ()->get_name ().c_str (),
 		 to.get_ty ()->get_name ().c_str ());
 }

--- a/gcc/testsuite/rust/compile/bad_as_bool_char.rs
+++ b/gcc/testsuite/rust/compile/bad_as_bool_char.rs
@@ -5,13 +5,13 @@ pub fn main ()
   let fone = t as f32;   // { dg-error "invalid cast" }
   let fzero = f as f64;  // { dg-error "invalid cast" }
 
-  let nb = 0u8 as bool;  // { dg-error "invalid cast" }
+  let nb = 0u8 as bool;  // { dg-error "invalid cast .u8. to .bool. \\\[E0054\\\]" }
   let nc = true as char; // { dg-error "invalid cast" }
 
   let a = 'a';
   let b = 'b';
   let fa = a as f32;     // { dg-error "invalid cast" }
-  let bb = b as bool;    // { dg-error "invalid cast" }
+  let bb = b as bool;    // { dg-error "invalid cast .char. to .bool. \\\[E0054\\\]" }
 
   let t32: u32 = 33;
   let ab = t32 as char;  // { dg-error "invalid cast" }


### PR DESCRIPTION
rustc has error codes to identify specific errors, with URLs documenting each error.

In GCC 13 I've extended GCC's diagnostic subsystem so that a diagnostic can be associated with zero or more `diagnostic_metadata::rule` instances, which have a textual description and a URL.  I meant this for rules in coding standards and specifications, but it struck me that potentially gccrs could reuse the same error codes as rustc.

The following pull request implements an experimental form of this; I picked a single error at random: [E0054](https://doc.rust-lang.org/error-index.html#E0054).  

With this patch, gccrs emits e.g.:

```
bad_as_bool_char.rs:8:19: error: invalid cast [u8] to [bool] [E0054]
    8 |   let nb = 0u8 as bool;
      |            ~      ^

```
where the trailing [E0054] is colorized, and, in a suitably capable terminal is a clickable URL to https://doc.rust-lang.org/error-index.html#E0054.

The error code is after the diagnostic message, whereas rustc puts it after the word "error".  I could change that in gcc's diagnostic.cc, perhaps.

I'm not sure if this is a good idea (e.g. is it OK and maintainable to share error codes with rustc?), but thought it was worth sharing.
