### PR TITLE
unsafe: check uses of static variables

### DIFF
--- a/gcc/rust/checks/errors/rust-unsafe-checker.h
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.h
@@ -20,6 +20,7 @@
 #define RUST_UNSAFE_CHECKER_H
 
 #include "rust-hir-visitor.h"
+#include "rust-name-resolver.h"
 #include "rust-hir-type-check.h"
 
 namespace Rust {
@@ -51,7 +52,15 @@ private:
    */
   bool is_unsafe_context ();
 
+  /**
+   * Check if a mutable static or external static item is used outside of an
+   * unsafe context
+   */
+  void check_use_of_static (HirId node_id, Location locus);
+
   Resolver::TypeCheckContext &context;
+  Resolver::Resolver resolver;
+  Analysis::Mappings mappings;
 
   virtual void visit (IdentifierExpr &ident_expr) override;
   virtual void visit (Lifetime &lifetime) override;

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -723,6 +723,8 @@ public:
 
   Location get_locus () const override final { return locus; }
 
+  ItemKind get_item_kind () const override { return ItemKind::Module; }
+
 protected:
   /* Use covariance to implement clone function as returning this object
    * rather than base */
@@ -772,6 +774,8 @@ public:
   {}
 
   Location get_locus () const override final { return locus; }
+
+  ItemKind get_item_kind () const override { return ItemKind::ExternCrate; }
 
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRStmtVisitor &vis) override;
@@ -1039,6 +1043,7 @@ public:
   UseDeclaration &operator= (UseDeclaration &&other) = default;
 
   Location get_locus () const override final { return locus; }
+  ItemKind get_item_kind () const override { return ItemKind::UseDeclaration; }
 
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRStmtVisitor &vis) override;
@@ -1093,6 +1098,8 @@ public:
   {
     return ImplItem::ImplItemType::FUNCTION;
   }
+
+  ItemKind get_item_kind () const override { return ItemKind::Function; }
 
   // Mega-constructor with all possible fields
   Function (Analysis::NodeMapping mappings, Identifier function_name,
@@ -1329,6 +1336,8 @@ public:
 
   Identifier get_new_type_name () const { return new_type_name; }
 
+  ItemKind get_item_kind () const override { return ItemKind::TypeAlias; }
+
   Analysis::NodeMapping get_impl_mappings () const override
   {
     return get_mappings ();
@@ -1373,6 +1382,7 @@ public:
   bool has_where_clause () const { return !where_clause.is_empty (); }
 
   Location get_locus () const override final { return locus; }
+  ItemKind get_item_kind () const override { return ItemKind::Struct; }
 
   std::vector<std::unique_ptr<GenericParam>> &get_generic_params ()
   {
@@ -1709,6 +1719,8 @@ public:
 
   Identifier get_identifier () const { return variant_name; }
 
+  ItemKind get_item_kind () const override { return ItemKind::EnumItem; }
+
 protected:
   EnumItem *clone_item_impl () const override { return new EnumItem (*this); }
 };
@@ -1930,6 +1942,7 @@ public:
   void accept_vis (HIRVisItemVisitor &vis) override;
 
   Identifier get_identifier () const { return enum_name; }
+  ItemKind get_item_kind () const override { return ItemKind::Enum; }
 
   std::vector<std::unique_ptr<GenericParam>> &get_generic_params ()
   {
@@ -2037,6 +2050,8 @@ public:
 
   WhereClause &get_where_clause () { return where_clause; }
 
+  ItemKind get_item_kind () const override { return ItemKind::Union; }
+
 protected:
   /* Use covariance to implement clone function as returning this object
    * rather than base */
@@ -2110,6 +2125,8 @@ public:
   {
     return ImplItem::ImplItemType::CONSTANT;
   }
+
+  ItemKind get_item_kind () const override { return ItemKind::Constant; }
 
 protected:
   /* Use covariance to implement clone function as returning this object
@@ -2187,6 +2204,8 @@ public:
   Expr *get_expr () { return expr.get (); }
 
   Type *get_type () { return type.get (); }
+
+  ItemKind get_item_kind () const override { return ItemKind::Static; }
 
 protected:
   StaticItem *clone_item_impl () const override
@@ -2677,6 +2696,8 @@ public:
     return type_param_bounds;
   }
 
+  ItemKind get_item_kind () const override { return ItemKind::Trait; }
+
 protected:
   /* Use covariance to implement clone function as returning this object
    * rather than base */
@@ -2796,6 +2817,8 @@ public:
   }
 
   WhereClause &get_where_clause () { return where_clause; }
+
+  ItemKind get_item_kind () const override { return ItemKind::Impl; }
 
 protected:
   ImplBlock *clone_item_impl () const override { return new ImplBlock (*this); }
@@ -3148,6 +3171,8 @@ public:
   {
     return extern_items;
   }
+
+  ItemKind get_item_kind () const override { return ItemKind::ExternBlock; }
 
 protected:
   /* Use covariance to implement clone function as returning this object

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -2834,9 +2834,17 @@ class ExternalItem : public Node
   Location locus;
 
 public:
+  enum class ExternKind
+  {
+    Static,
+    Function,
+  };
+
   virtual ~ExternalItem () {}
 
   BaseKind get_hir_kind () override final { return EXTERNAL; }
+
+  virtual ExternKind get_extern_kind () = 0;
 
   // Returns whether item has outer attributes.
   bool has_outer_attrs () const { return !outer_attrs.empty (); }
@@ -2943,6 +2951,8 @@ public:
   Mutability get_mut () { return mut; }
 
   std::unique_ptr<Type> &get_item_type () { return item_type; }
+
+  ExternKind get_extern_kind () override { return ExternKind::Static; }
 
 protected:
   /* Use covariance to implement clone function as returning this object
@@ -3094,6 +3104,8 @@ public:
   }
 
   bool is_variadic () const { return has_variadics; }
+
+  ExternKind get_extern_kind () override { return ExternKind::Function; }
 
 protected:
   /* Use covariance to implement clone function as returning this object

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -175,6 +175,26 @@ class Item : public Stmt
   // TODO: should outer attrs be defined here or in each derived class?
 
 public:
+  enum class ItemKind
+  {
+    Static,
+    Constant,
+    TypeAlias,
+    Function,
+    UseDeclaration,
+    ExternBlock,
+    ExternCrate,
+    Struct,
+    Union,
+    Enum,
+    EnumItem, // FIXME: ARTHUR: Do we need that?
+    Trait,
+    Impl,
+    Module,
+  };
+
+  virtual ItemKind get_item_kind () const = 0;
+
   // Unique pointer custom clone function
   std::unique_ptr<Item> clone_item () const
   {

--- a/gcc/testsuite/rust/compile/unsafe1.rs
+++ b/gcc/testsuite/rust/compile/unsafe1.rs
@@ -1,0 +1,14 @@
+fn foo(_a: &i32) {}
+fn bar(_a: i32) {}
+
+static mut a: i32 = 15;
+
+fn main() {
+    foo(&a); // { dg-error "use of mutable static" }
+    bar(a); // { dg-error "use of mutable static" }
+
+    unsafe {
+        foo(&a);
+        bar(a);
+    }
+}

--- a/gcc/testsuite/rust/compile/unsafe2.rs
+++ b/gcc/testsuite/rust/compile/unsafe2.rs
@@ -1,0 +1,16 @@
+fn foo(_a: &i32) {}
+fn bar(_a: i32) {}
+
+mod inner {
+    pub static mut a: i32 = 15;
+}
+
+fn main() {
+    foo(&inner::a); // { dg-error "use of mutable static" }
+    bar(inner::a); // { dg-error "use of mutable static" }
+
+    unsafe {
+        foo(&inner::a);
+        bar(inner::a);
+    }
+}

--- a/gcc/testsuite/rust/compile/unsafe3.rs
+++ b/gcc/testsuite/rust/compile/unsafe3.rs
@@ -1,0 +1,10 @@
+extern "C" {
+    static VALUE: char;
+}
+
+fn main() {
+    let _ = VALUE; // { dg-error "use of extern static" }
+    unsafe {
+        let _ = VALUE;
+    }
+}


### PR DESCRIPTION
Addresses #1411 

Accessing an extern static or a mut static is unsafe and requires an unsafe function or block