### PR TITLE
Const checker

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -120,6 +120,7 @@ GRS_OBJS = \
     rust/rust-hir-type-check-base.o \
     rust/rust-autoderef.o \
     rust/rust-substitution-mapper.o \
+    rust/rust-const-checker.o \
     rust/rust-lint-marklive.o \
     rust/rust-lint-unused-var.o \
     rust/rust-hir-type-check-path.o \

--- a/gcc/rust/checks/errors/rust-const-checker.h
+++ b/gcc/rust/checks/errors/rust-const-checker.h
@@ -1,0 +1,183 @@
+// Copyright (C) 2020-2022 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_CONST_CHECKER_H
+#define RUST_CONST_CHECKER_H
+
+#include "rust-hir-visitor.h"
+#include "rust-hir-type-check.h"
+#include "rust-stacked-contexts.h"
+#include "rust-name-resolver.h"
+
+namespace Rust {
+namespace HIR {
+class ConstChecker : public HIRFullVisitor
+{
+public:
+  ConstChecker ();
+
+  void go (HIR::Crate &crate);
+
+private:
+  /**
+   * Check that only const functions are called in const contexts
+   */
+  void check_function_call (HirId fn_id, Location locus);
+
+  StackedContexts<HirId> const_context;
+  Resolver::Resolver &resolver;
+  Analysis::Mappings &mappings;
+
+  virtual void visit (IdentifierExpr &ident_expr) override;
+  virtual void visit (Lifetime &lifetime) override;
+  virtual void visit (LifetimeParam &lifetime_param) override;
+  virtual void visit (PathInExpression &path) override;
+  virtual void visit (TypePathSegment &segment) override;
+  virtual void visit (TypePathSegmentGeneric &segment) override;
+  virtual void visit (TypePathSegmentFunction &segment) override;
+  virtual void visit (TypePath &path) override;
+  virtual void visit (QualifiedPathInExpression &path) override;
+  virtual void visit (QualifiedPathInType &path) override;
+  virtual void visit (LiteralExpr &expr) override;
+  virtual void visit (BorrowExpr &expr) override;
+  virtual void visit (DereferenceExpr &expr) override;
+  virtual void visit (ErrorPropagationExpr &expr) override;
+  virtual void visit (NegationExpr &expr) override;
+  virtual void visit (ArithmeticOrLogicalExpr &expr) override;
+  virtual void visit (ComparisonExpr &expr) override;
+  virtual void visit (LazyBooleanExpr &expr) override;
+  virtual void visit (TypeCastExpr &expr) override;
+  virtual void visit (AssignmentExpr &expr) override;
+  virtual void visit (CompoundAssignmentExpr &expr) override;
+  virtual void visit (GroupedExpr &expr) override;
+  virtual void visit (ArrayElemsValues &elems) override;
+  virtual void visit (ArrayElemsCopied &elems) override;
+  virtual void visit (ArrayExpr &expr) override;
+  virtual void visit (ArrayIndexExpr &expr) override;
+  virtual void visit (TupleExpr &expr) override;
+  virtual void visit (TupleIndexExpr &expr) override;
+  virtual void visit (StructExprStruct &expr) override;
+  virtual void visit (StructExprFieldIdentifier &field) override;
+  virtual void visit (StructExprFieldIdentifierValue &field) override;
+  virtual void visit (StructExprFieldIndexValue &field) override;
+  virtual void visit (StructExprStructFields &expr) override;
+  virtual void visit (StructExprStructBase &expr) override;
+  virtual void visit (CallExpr &expr) override;
+  virtual void visit (MethodCallExpr &expr) override;
+  virtual void visit (FieldAccessExpr &expr) override;
+  virtual void visit (ClosureExprInner &expr) override;
+  virtual void visit (BlockExpr &expr) override;
+  virtual void visit (ClosureExprInnerTyped &expr) override;
+  virtual void visit (ContinueExpr &expr) override;
+  virtual void visit (BreakExpr &expr) override;
+  virtual void visit (RangeFromToExpr &expr) override;
+  virtual void visit (RangeFromExpr &expr) override;
+  virtual void visit (RangeToExpr &expr) override;
+  virtual void visit (RangeFullExpr &expr) override;
+  virtual void visit (RangeFromToInclExpr &expr) override;
+  virtual void visit (RangeToInclExpr &expr) override;
+  virtual void visit (ReturnExpr &expr) override;
+  virtual void visit (UnsafeBlockExpr &expr) override;
+  virtual void visit (LoopExpr &expr) override;
+  virtual void visit (WhileLoopExpr &expr) override;
+  virtual void visit (WhileLetLoopExpr &expr) override;
+  virtual void visit (ForLoopExpr &expr) override;
+  virtual void visit (IfExpr &expr) override;
+  virtual void visit (IfExprConseqElse &expr) override;
+  virtual void visit (IfExprConseqIf &expr) override;
+  virtual void visit (IfExprConseqIfLet &expr) override;
+  virtual void visit (IfLetExpr &expr) override;
+  virtual void visit (IfLetExprConseqElse &expr) override;
+  virtual void visit (IfLetExprConseqIf &expr) override;
+  virtual void visit (IfLetExprConseqIfLet &expr) override;
+  virtual void visit (MatchExpr &expr) override;
+  virtual void visit (AwaitExpr &expr) override;
+  virtual void visit (AsyncBlockExpr &expr) override;
+  virtual void visit (TypeParam &param) override;
+  virtual void visit (ConstGenericParam &param) override;
+  virtual void visit (LifetimeWhereClauseItem &item) override;
+  virtual void visit (TypeBoundWhereClauseItem &item) override;
+  virtual void visit (Module &module) override;
+  virtual void visit (ExternCrate &crate) override;
+  virtual void visit (UseTreeGlob &use_tree) override;
+  virtual void visit (UseTreeList &use_tree) override;
+  virtual void visit (UseTreeRebind &use_tree) override;
+  virtual void visit (UseDeclaration &use_decl) override;
+  virtual void visit (Function &function) override;
+  virtual void visit (TypeAlias &type_alias) override;
+  virtual void visit (StructStruct &struct_item) override;
+  virtual void visit (TupleStruct &tuple_struct) override;
+  virtual void visit (EnumItem &item) override;
+  virtual void visit (EnumItemTuple &item) override;
+  virtual void visit (EnumItemStruct &item) override;
+  virtual void visit (EnumItemDiscriminant &item) override;
+  virtual void visit (Enum &enum_item) override;
+  virtual void visit (Union &union_item) override;
+  virtual void visit (ConstantItem &const_item) override;
+  virtual void visit (StaticItem &static_item) override;
+  virtual void visit (TraitItemFunc &item) override;
+  virtual void visit (TraitItemConst &item) override;
+  virtual void visit (TraitItemType &item) override;
+  virtual void visit (Trait &trait) override;
+  virtual void visit (ImplBlock &impl) override;
+  virtual void visit (ExternalStaticItem &item) override;
+  virtual void visit (ExternalFunctionItem &item) override;
+  virtual void visit (ExternBlock &block) override;
+  virtual void visit (LiteralPattern &pattern) override;
+  virtual void visit (IdentifierPattern &pattern) override;
+  virtual void visit (WildcardPattern &pattern) override;
+  virtual void visit (RangePatternBoundLiteral &bound) override;
+  virtual void visit (RangePatternBoundPath &bound) override;
+  virtual void visit (RangePatternBoundQualPath &bound) override;
+  virtual void visit (RangePattern &pattern) override;
+  virtual void visit (ReferencePattern &pattern) override;
+  virtual void visit (StructPatternFieldTuplePat &field) override;
+  virtual void visit (StructPatternFieldIdentPat &field) override;
+  virtual void visit (StructPatternFieldIdent &field) override;
+  virtual void visit (StructPattern &pattern) override;
+  virtual void visit (TupleStructItemsNoRange &tuple_items) override;
+  virtual void visit (TupleStructItemsRange &tuple_items) override;
+  virtual void visit (TupleStructPattern &pattern) override;
+  virtual void visit (TuplePatternItemsMultiple &tuple_items) override;
+  virtual void visit (TuplePatternItemsRanged &tuple_items) override;
+  virtual void visit (TuplePattern &pattern) override;
+  virtual void visit (GroupedPattern &pattern) override;
+  virtual void visit (SlicePattern &pattern) override;
+  virtual void visit (EmptyStmt &stmt) override;
+  virtual void visit (LetStmt &stmt) override;
+  virtual void visit (ExprStmtWithoutBlock &stmt) override;
+  virtual void visit (ExprStmtWithBlock &stmt) override;
+  virtual void visit (TraitBound &bound) override;
+  virtual void visit (ImplTraitType &type) override;
+  virtual void visit (TraitObjectType &type) override;
+  virtual void visit (ParenthesisedType &type) override;
+  virtual void visit (ImplTraitTypeOneBound &type) override;
+  virtual void visit (TupleType &type) override;
+  virtual void visit (NeverType &type) override;
+  virtual void visit (RawPointerType &type) override;
+  virtual void visit (ReferenceType &type) override;
+  virtual void visit (ArrayType &type) override;
+  virtual void visit (SliceType &type) override;
+  virtual void visit (InferredType &type) override;
+  virtual void visit (BareFunctionType &type) override;
+};
+
+} // namespace HIR
+} // namespace Rust
+
+#endif /* !RUST_CONST_CHECKER_H */

--- a/gcc/rust/checks/errors/rust-unsafe-checker.h
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.h
@@ -59,8 +59,8 @@ private:
   void check_use_of_static (HirId node_id, Location locus);
 
   Resolver::TypeCheckContext &context;
-  Resolver::Resolver resolver;
-  Analysis::Mappings mappings;
+  Resolver::Resolver &resolver;
+  Analysis::Mappings &mappings;
 
   virtual void visit (IdentifierExpr &ident_expr) override;
   virtual void visit (Lifetime &lifetime) override;

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -307,7 +307,14 @@ public:
 	elements.push_back (std::unique_ptr<HIR::Expr> (translated_elem));
       }
 
-    translated_array_elems = new HIR::ArrayElemsValues (std::move (elements));
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (mappings->get_current_crate (),
+				   elems.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   UNKNOWN_LOCAL_DEFID);
+
+    translated_array_elems
+      = new HIR::ArrayElemsValues (mapping, std::move (elements));
   }
 
   void visit (AST::ArrayElemsCopied &elems) override
@@ -317,8 +324,15 @@ public:
     HIR::Expr *num_copies
       = ASTLoweringExpr::translate (elems.get_num_copies ().get ());
 
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (mappings->get_current_crate (),
+				   elems.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   UNKNOWN_LOCAL_DEFID);
+
     translated_array_elems
-      = new HIR::ArrayElemsCopied (std::unique_ptr<HIR::Expr> (element),
+      = new HIR::ArrayElemsCopied (mapping,
+				   std::unique_ptr<HIR::Expr> (element),
 				   std::unique_ptr<HIR::Expr> (num_copies));
   }
 

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -17,8 +17,8 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-session-manager.h"
-#include "rust-unsafe-checker.h"
 #include "rust-diagnostics.h"
+#include "rust-unsafe-checker.h"
 #include "rust-lex.h"
 #include "rust-parse.h"
 #include "rust-macro-expand.h"
@@ -26,6 +26,7 @@
 #include "rust-ast-lower.h"
 #include "rust-hir-type-check.h"
 #include "rust-privacy-check.h"
+#include "rust-const-checker.h"
 #include "rust-tycheck-dump.h"
 #include "rust-compile.h"
 #include "rust-cfg-parser.h"
@@ -796,6 +797,8 @@ Session::parse_file (const char *filename)
     return;
 
   HIR::UnsafeChecker ().go (hir);
+  HIR::ConstChecker ().go (hir);
+
   if (saw_errors ())
     return;
 

--- a/gcc/rust/util/rust-stacked-contexts.h
+++ b/gcc/rust/util/rust-stacked-contexts.h
@@ -1,0 +1,86 @@
+// Copyright (C) 2020-2022 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_CONTEXT_STACK_H
+#define RUST_CONTEXT_STACK_H
+
+#include "rust-system.h"
+
+namespace Rust {
+
+/**
+ * Context stack util class. This class is useful for situations where you can
+ * enter the same kind of context multiple times. For example, when dealing with
+ * unsafe contexts, you might be tempted to simply keep a boolean value.
+ *
+ * ```rust
+ * let a = 15;
+ * unsafe { // we set the boolean to true
+ *     // Now unsafe operations are allowed!
+ *     let b = *(&a as *const i32);
+ *     let c = std::mem::transmute<i32, f32>(b); // Urgh!
+ * } // we set it to false
+ * ```
+ *
+ * However, since the language allows nested unsafe blocks, you may run into
+ * this situation:
+ *
+ * ```rust
+ * unsafe { // we set the boolean to true
+ *     unsafe { // we set the boolean to true
+ *     } // we set it to false
+ *
+ *     // Now unsafe operations are forbidden again, the boolean is false
+ *     let f = std::mem::transmute<i32, f32>(15); // Error!
+ * } // we set it to false
+ * ```
+ */
+template <typename T> class StackedContexts
+{
+public:
+  /**
+   * Enter a special context
+   */
+  void enter (T value) { stack.emplace_back (value); }
+
+  /**
+   * Exit a special context
+   */
+  T exit ()
+  {
+    rust_assert (!stack.empty ());
+
+    auto last = stack.back ();
+    stack.pop_back ();
+
+    return last;
+  }
+
+  /**
+   * Are we currently inside of a special context?
+   */
+  bool is_in_context () const { return !stack.empty (); }
+
+private:
+  /* Actual data */
+  std::vector<T> stack;
+};
+
+} // namespace Rust
+
+#endif /* !RUST_CONTEXT_STACK_H */

--- a/gcc/testsuite/rust/compile/const1.rs
+++ b/gcc/testsuite/rust/compile/const1.rs
@@ -1,0 +1,6 @@
+fn bar() {}
+
+const fn foo() {
+    bar(); // { dg-error "only functions marked as .const. are allowed to be called from constant contexts" }
+}
+

--- a/gcc/testsuite/rust/compile/const2.rs
+++ b/gcc/testsuite/rust/compile/const2.rs
@@ -1,0 +1,7 @@
+// { dg-additional-options "-w" }
+
+const fn foo() {
+    const fn bar() {}
+
+    bar();
+}

--- a/gcc/testsuite/rust/compile/const3.rs
+++ b/gcc/testsuite/rust/compile/const3.rs
@@ -1,0 +1,7 @@
+fn size() -> usize {
+    15
+}
+
+fn main() {
+    let a = [15; size()]; // { dg-error "only functions marked as .const. are allowed to be called from constant contexts" }
+}


### PR DESCRIPTION
This commit serves as a base to ensure that only the allowed subset of
the language is called from const contexts. For example, this limits
function calls to calls to const functions only when in a const context

You can skip reviewing b4864c7e5a59a19fea6203c4b581889d4d6c20a1 as it's the exact same commit cherry-picked from #1415 