### PR TITLE
expand: further improves the handling of recursive macros

### DIFF
--- a/gcc/testsuite/rust/compile/torture/macro-issue1403.rs
+++ b/gcc/testsuite/rust/compile/torture/macro-issue1403.rs
@@ -1,0 +1,23 @@
+macro_rules! stmt {
+    ($s:stmt) => {
+        $s
+    };
+    ($s:stmt, $($ss:stmt),*) => {
+        $s;
+        stmt!($($ss),*);
+    };
+}
+
+fn main() {
+    stmt!(
+        struct S;
+    );
+    stmt!(
+        struct A;,
+        struct B;,
+        struct C;,
+        struct D;,
+        struct E;
+    );
+}
+


### PR DESCRIPTION
- expand: further improves the handling of recursive macros.
Now all the attribute visitor that expands the macro fragment will recursively expand the macro using the unified expanding function `expand_macro_fragment_recursive` instead of expanding the fragment only once.

Fixes #1403 