### PR TITLE
Update the type hasher to stop duplication of aggregate types

### DIFF
--- a/gcc/rust/backend/rust-compile-context.cc
+++ b/gcc/rust/backend/rust-compile-context.cc
@@ -62,9 +62,6 @@ Context::type_hasher (tree type)
       hstate.add_object (record_name_hash);
     }
 
-  if (TREE_TYPE (type))
-    hstate.add_object (TYPE_HASH (TREE_TYPE (type)));
-
   for (tree t = TYPE_ATTRIBUTES (type); t; t = TREE_CHAIN (t))
     /* Just the identifier is adequate to distinguish.  */
     hstate.add_object (IDENTIFIER_HASH_VALUE (TREE_PURPOSE (t)));
@@ -125,6 +122,16 @@ Context::type_hasher (tree type)
 	    hstate.add_object (name_hash);
 	    hstate.add_object (type_hash);
 	  }
+      }
+      break;
+
+    case BOOLEAN_TYPE:
+      break;
+
+    case REFERENCE_TYPE:
+      case POINTER_TYPE: {
+	hashval_t type_hash = type_hasher (TREE_TYPE (type));
+	hstate.add_object (type_hash);
       }
       break;
 

--- a/gcc/testsuite/rust/compile/torture/issue-1434.rs
+++ b/gcc/testsuite/rust/compile/torture/issue-1434.rs
@@ -1,0 +1,53 @@
+// { dg-options "-w" }
+const BLOCK_LEN: usize = 64;
+
+const IV: [u32; 8] = [
+    0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A, 0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19,
+];
+
+struct ChunkState {
+    chaining_value: [u32; 8],
+    chunk_counter: u64,
+    block: [u8; BLOCK_LEN],
+    block_len: u8,
+    blocks_compressed: u8,
+    flags: u32,
+}
+
+impl ChunkState {
+    fn new(key_words: [u32; 8], chunk_counter: u64, flags: u32) -> Self {
+        Self {
+            chaining_value: key_words,
+            chunk_counter,
+            block: [0; BLOCK_LEN],
+            block_len: 0,
+            blocks_compressed: 0,
+            flags,
+        }
+    }
+}
+
+pub struct Hasher {
+    chunk_state: ChunkState,
+    key_words: [u32; 8],
+    cv_stack: [[u32; 8]; 54], // Space for 54 subtree chaining values:
+    cv_stack_len: u8,         // 2^54 * CHUNK_LEN = 2^64
+    flags: u32,
+}
+
+impl Hasher {
+    fn new_internal(key_words: [u32; 8], flags: u32) -> Self {
+        Self {
+            chunk_state: ChunkState::new(key_words, 0, flags),
+            key_words,
+            cv_stack: [[0; 8]; 54],
+            cv_stack_len: 0,
+            flags,
+        }
+    }
+
+    /// Construct a new `Hasher` for the regular hash function.
+    pub fn new() -> Self {
+        Self::new_internal(IV, 0)
+    }
+}


### PR DESCRIPTION
The hasher we ported was always calling TYPE_HASH which ends up with
DECL_UID which is geneated causing aggregate types keep having a unique
hash which ends up confusing the middle end as two copy's of the same
aggegate type ends up making GCC think there is some kind of type
conversion required here.

Fixes #1434