### PR TITLE
Enhance #1426 "Invalid recursive :stmt expansion in fragment specifiers" test case

### DIFF
--- a/gcc/testsuite/rust/compile/torture/macro-issue1426.rs
+++ b/gcc/testsuite/rust/compile/torture/macro-issue1426.rs
@@ -1,5 +1,5 @@
-// { dg-do compile }
-// { dg-options "-O1 -gdwarf-5 -dA -w" }
+// { dg-additional-options -fdump-tree-ccp1-raw }
+
 macro_rules! stmt {
     ($s:stmt) => {
         $s
@@ -13,6 +13,7 @@ macro_rules! stmt {
 pub fn test() -> i32 {
     stmt!(
         let a = 1
+	// { dg-warning {unused name 'a'} {} { target *-*-* } .-1 }
     );
     stmt!(
         let b = 2,
@@ -21,8 +22,8 @@ pub fn test() -> i32 {
         let e = 5,
         let f = b + c + d + e
     );
-    // { dg-final { scan-assembler "14" } }
     f
+    // { dg-final { scan-tree-dump-times {gimple_return <14>} 1 ccp1 { target __OPTIMIZE__ } } }
 }
 
 fn main() {


### PR DESCRIPTION
... that was recently added in #1429 commit 9fc6a27b5c6ea2c775646c4474b9084da76b1764 "expand: correctly handles non-macro nodes ...".

  - Rename 'macro-issue1403.rs' -> 'macro-issue1426.rs'.
  - Get rid of '-w'; expect diagnostic instead.
  - Get rid of debugging options not relevant here.
  - Get rid of explicit '-O1'; make it a "torture" test case.
  - Replace always-matching 'scan-assembler "14"' ("14" appears in the crate name) with directed dump scanning.
      - ..., just not for '-O0', where such optimization is not done.
