### PR TITLE
testsuite: test for diagnostics shown when a built-in macro does not exist

### DIFF
--- a/gcc/testsuite/rust/compile/builtin_macro_not_found.rs
+++ b/gcc/testsuite/rust/compile/builtin_macro_not_found.rs
@@ -1,0 +1,4 @@
+#[rustc_builtin_macro]
+macro_rules! crabby_crab_carb { // { dg-error "cannot find a built-in macro with name .crabby_crab_carb." }
+    () => {{}};
+}


### PR DESCRIPTION
- testsuite: test for diagnostics shown when a built-in macro does not exist