### PR TITLE
Handle `rustc_const_{un}stable` properly for intrinsics

### DIFF
--- a/gcc/rust/checks/errors/rust-const-checker.cc
+++ b/gcc/rust/checks/errors/rust-const-checker.cc
@@ -235,11 +235,48 @@ ConstChecker::check_function_call (HirId fn_id, Location locus)
     return;
 
   auto maybe_fn = mappings.lookup_hir_item (fn_id);
-  if (!maybe_fn || maybe_fn->get_item_kind () != Item::ItemKind::Function)
+  if (maybe_fn && maybe_fn->get_item_kind () != Item::ItemKind::Function)
     return;
 
-  auto fn = static_cast<Function *> (maybe_fn);
-  if (!fn->get_qualifiers ().is_const ())
+  // There are const extern functions (intrinsics)
+  // TODO: Should we check the ABI is only "rust intrinsics"? Is that handled
+  // elsewhere?
+  HirId parent_block;
+  auto maybe_extern_item
+    = mappings.lookup_hir_extern_item (fn_id, &parent_block);
+  if (maybe_extern_item
+      && maybe_extern_item->get_extern_kind ()
+	   != ExternalItem::ExternKind::Function)
+    return;
+
+  auto is_error = false;
+  if (maybe_fn)
+    {
+      auto fn = static_cast<Function *> (maybe_fn);
+      if (!fn->get_qualifiers ().is_const ())
+	is_error = true;
+    }
+
+  if (maybe_extern_item)
+    {
+      {
+	auto fn = static_cast<ExternalFunctionItem *> (maybe_extern_item);
+	auto is_const_extern = std::any_of (
+	  fn->get_outer_attrs ().begin (), fn->get_outer_attrs ().end (),
+	  [] (const AST::Attribute &attr) {
+	    // `starts_with` in C++11...
+	    // FIXME: Is it really how we want to handle `rustc_const_stable`
+	    // and `rustc_const_unstable`?
+	    // TODO: Add these attributes to the attribute check and handle
+	    // `stable` and `unstable` as well
+	    return attr.get_path ().as_string ().rfind ("rustc_const_", 0) == 0;
+	  });
+	if (!is_const_extern)
+	  is_error = true;
+      }
+    }
+
+  if (is_error)
     rust_error_at (locus, "only functions marked as %<const%> are allowed to "
 			  "be called from constant contexts");
 }
@@ -521,6 +558,9 @@ ConstChecker::visit (Function &function)
   auto const_fn = function.get_qualifiers ().is_const ();
   if (const_fn)
     const_context.enter (function.get_mappings ().get_hirid ());
+
+  for (auto &param : function.get_function_params ())
+    param.get_type ()->accept_vis (*this);
 
   function.get_definition ()->accept_vis (*this);
 

--- a/gcc/rust/checks/errors/rust-const-checker.h
+++ b/gcc/rust/checks/errors/rust-const-checker.h
@@ -33,6 +33,13 @@ public:
 
   void go (HIR::Crate &crate);
 
+  /**
+   * Check if an item is a const extern item or not
+   * TODO: Move this to a const compilation context class or an attribute
+   * checking class
+   */
+  static bool is_const_extern_fn (HIR::ExternalFunctionItem &fn);
+
 private:
   /**
    * Check that only const functions are called in const contexts

--- a/gcc/testsuite/rust/compile/const-issue1440.rs
+++ b/gcc/testsuite/rust/compile/const-issue1440.rs
@@ -1,13 +1,10 @@
 // { dg-additional-options "-w" }
+
 mod intrinsics {
     extern "rust-intrinsic" {
-        #[rustc_const_stable(feature = "const_int_wrapping", since = "1.40.0")]
         pub fn wrapping_add<T>(a: T, b: T) -> T;
-        #[rustc_const_stable(feature = "const_int_rotate", since = "1.40.0")]
         pub fn rotate_left<T>(a: T, b: T) -> T;
-        #[rustc_const_stable(feature = "const_int_rotate", since = "1.40.0")]
         pub fn rotate_right<T>(a: T, b: T) -> T;
-        #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
         pub fn offset<T>(ptr: *const T, count: isize) -> *const T;
     }
 }
@@ -15,9 +12,8 @@ mod intrinsics {
 mod mem {
     extern "rust-intrinsic" {
         #[rustc_const_stable(feature = "const_transmute", since = "1.46.0")]
-        fn transmute<T, U>(_: T) -> U;
-        #[rustc_const_stable(feature = "const_size_of", since = "1.40.0")]
-        fn size_of<T>() -> usize;
+        pub fn transmute<T, U>(_: T) -> U;
+        pub fn size_of<T>() -> usize;
     }
 }
 
@@ -50,6 +46,7 @@ macro_rules! impl_uint {
                 }
 
                 pub const fn from_le_bytes(bytes: [u8; mem::size_of::<Self>()]) -> Self {
+                    // { dg-error "only functions marked as .const. are allowed to be called from constant contexts" "" { target *-*-* } .-1 }
                     Self::from_le(Self::from_ne_bytes(bytes))
                 }
 
@@ -61,6 +58,7 @@ macro_rules! impl_uint {
                 }
 
                 pub const fn from_ne_bytes(bytes: [u8; mem::size_of::<Self>()]) -> Self {
+                    // { dg-error "only functions marked as .const. are allowed to be called from constant contexts" "" { target *-*-* } .-1 }
                     unsafe { mem::transmute(bytes) }
                 }
             }

--- a/gcc/testsuite/rust/compile/issue-1031.rs
+++ b/gcc/testsuite/rust/compile/issue-1031.rs
@@ -1,4 +1,5 @@
 extern "rust-intrinsic" {
+    #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     pub fn offset<T>(dst: *const T, offset: isize) -> *const T;
 }
 

--- a/gcc/testsuite/rust/compile/issue-1289.rs
+++ b/gcc/testsuite/rust/compile/issue-1289.rs
@@ -4,6 +4,7 @@ extern "C" {
 
 mod intrinsics {
     extern "rust-intrinsic" {
+        #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
         pub fn offset<T>(dst: *const T, offset: isize) -> *const T;
     }
 }

--- a/gcc/testsuite/rust/compile/torture/issue-1075.rs
+++ b/gcc/testsuite/rust/compile/torture/issue-1075.rs
@@ -1,5 +1,6 @@
 // { dg-additional-options "-w" }
 extern "rust-intrinsic" {
+    #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     pub fn offset<T>(dst: *const T, offset: isize) -> *const T;
 }
 

--- a/gcc/testsuite/rust/execute/torture/issue-1120.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-1120.rs
@@ -1,5 +1,6 @@
 // { dg-additional-options "-w" }
 extern "rust-intrinsic" {
+    #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     pub fn offset<T>(dst: *const T, offset: isize) -> *const T;
 }
 

--- a/gcc/testsuite/rust/execute/torture/issue-1133.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-1133.rs
@@ -1,5 +1,6 @@
 // { dg-additional-options "-w" }
 extern "rust-intrinsic" {
+    #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     pub fn offset<T>(dst: *const T, offset: isize) -> *const T;
 }
 

--- a/gcc/testsuite/rust/execute/torture/issue-1232.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-1232.rs
@@ -1,6 +1,7 @@
 // { dg-additional-options "-w" }
 // { dg-output "slice_access=3\n" }
 extern "rust-intrinsic" {
+    #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     fn offset<T>(dst: *const T, offset: isize) -> *const T;
 }
 

--- a/gcc/testsuite/rust/execute/torture/issue-1436.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-1436.rs
@@ -2,6 +2,7 @@
 // { dg-output "" }
 mod intrinsics {
     extern "rust-intrinsic" {
+        #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
         pub fn offset<T>(ptr: *const T, count: isize) -> *const T;
     }
 }

--- a/gcc/testsuite/rust/execute/torture/slice-magic.rs
+++ b/gcc/testsuite/rust/execute/torture/slice-magic.rs
@@ -1,5 +1,6 @@
 // { dg-additional-options "-w" }
 extern "rust-intrinsic" {
+    #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     pub fn offset<T>(dst: *const T, offset: isize) -> *const T;
 }
 

--- a/gcc/testsuite/rust/execute/torture/slice-magic2.rs
+++ b/gcc/testsuite/rust/execute/torture/slice-magic2.rs
@@ -1,5 +1,6 @@
 // { dg-additional-options "-w" }
 extern "rust-intrinsic" {
+    #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     pub fn offset<T>(dst: *const T, offset: isize) -> *const T;
 }
 

--- a/gcc/testsuite/rust/execute/torture/str-layout1.rs
+++ b/gcc/testsuite/rust/execute/torture/str-layout1.rs
@@ -2,6 +2,7 @@
 // { dg-output "t1sz=5 t2sz=10" }
 mod mem {
     extern "rust-intrinsic" {
+        #[rustc_const_stable(feature = "const_transmute", since = "1.46.0")]
         fn transmute<T, U>(_: T) -> U;
     }
 }


### PR DESCRIPTION
Since extern functions cannot be marked as const (they take no
qualifiers) but some intrinsics are const, while still being `extern
"rust-intrinsic", we need to be able to handle the
`#[rustc_const_stable]` and `#[rustc_const_unstable]` attribute.

Technically, this simply indicates that a certain intrinsic is constant
and can be used in const contexts, such as `size_of` or `offset`.

We also need to mark all const intrinsics with `rustc_const_stable` in
the testsuite.

Closes #1440 