### PR TITLE
Fix failiure to type inference on unit-structs

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -310,6 +310,17 @@ public:
       }
 
     infered = lookup->clone ();
+
+    // Generic unit structs look like an identifier but they actually need be
+    // handled as a path-in-expression so this gives us a chance to infer the
+    // generic parameters.
+    // see https://github.com/Rust-GCC/gccrs/issues/1447
+    bool is_unit_struct
+      = infered->get_kind () == TyTy::TypeKind::ADT && infered->is_unit ();
+    if (is_unit_struct && infered->needs_generic_substitutions ())
+      {
+	infered = SubstMapper::InferSubst (infered, expr.get_locus ());
+      }
   }
 
   void visit (HIR::LiteralExpr &expr) override

--- a/gcc/rust/typecheck/rust-tyty-coercion.h
+++ b/gcc/rust/typecheck/rust-tyty-coercion.h
@@ -1133,6 +1133,18 @@ public:
     resolved = type.clone ();
   }
 
+  void visit (InferType &type) override
+  {
+    if (type.get_infer_kind () != InferType::InferTypeKind::GENERAL)
+      {
+	BaseCoercionRules::visit (type);
+	return;
+      }
+
+    resolved = base->clone ();
+    resolved->set_ref (type.get_ref ());
+  }
+
 private:
   BaseType *get_base () override { return base; }
 
@@ -1170,6 +1182,18 @@ public:
 
     resolved = new TyTy::TupleType (type.get_ref (), type.get_ty_ref (),
 				    type.get_ident ().locus, fields);
+  }
+
+  void visit (InferType &type) override
+  {
+    if (type.get_infer_kind () != InferType::InferTypeKind::GENERAL)
+      {
+	BaseCoercionRules::visit (type);
+	return;
+      }
+
+    resolved = base->clone ();
+    resolved->set_ref (type.get_ref ());
   }
 
 private:

--- a/gcc/rust/typecheck/rust-tyty-coercion.h
+++ b/gcc/rust/typecheck/rust-tyty-coercion.h
@@ -1130,6 +1130,28 @@ public:
 	  }
       }
 
+    // generic args for the unit-struct case
+    if (type.is_unit () && base->is_unit ())
+      {
+	rust_assert (type.get_num_substitutions ()
+		     == base->get_num_substitutions ());
+
+	for (size_t i = 0; i < type.get_num_substitutions (); i++)
+	  {
+	    auto &a = base->get_substs ().at (i);
+	    auto &b = type.get_substs ().at (i);
+
+	    auto pa = a.get_param_ty ();
+	    auto pb = b.get_param_ty ();
+
+	    auto res = pa->unify (pb);
+	    if (res->get_kind () == TyTy::TypeKind::ERROR)
+	      {
+		return;
+	      }
+	  }
+      }
+
     resolved = type.clone ();
   }
 

--- a/gcc/rust/typecheck/rust-tyty-rules.h
+++ b/gcc/rust/typecheck/rust-tyty-rules.h
@@ -1128,6 +1128,28 @@ public:
 	  }
       }
 
+    // generic args for the unit-struct case
+    if (type.is_unit () && base->is_unit ())
+      {
+	rust_assert (type.get_num_substitutions ()
+		     == base->get_num_substitutions ());
+
+	for (size_t i = 0; i < type.get_num_substitutions (); i++)
+	  {
+	    auto &a = base->get_substs ().at (i);
+	    auto &b = type.get_substs ().at (i);
+
+	    auto pa = a.get_param_ty ();
+	    auto pb = b.get_param_ty ();
+
+	    auto res = pa->unify (pb);
+	    if (res->get_kind () == TyTy::TypeKind::ERROR)
+	      {
+		return;
+	      }
+	  }
+      }
+
     resolved = type.clone ();
   }
 

--- a/gcc/rust/typecheck/rust-tyty-rules.h
+++ b/gcc/rust/typecheck/rust-tyty-rules.h
@@ -1131,6 +1131,18 @@ public:
     resolved = type.clone ();
   }
 
+  void visit (InferType &type) override
+  {
+    if (type.get_infer_kind () != InferType::InferTypeKind::GENERAL)
+      {
+	BaseRules::visit (type);
+	return;
+      }
+
+    resolved = base->clone ();
+    resolved->set_ref (type.get_ref ());
+  }
+
 private:
   BaseType *get_base () override { return base; }
 

--- a/gcc/testsuite/rust/compile/issue-1447.rs
+++ b/gcc/testsuite/rust/compile/issue-1447.rs
@@ -1,0 +1,28 @@
+// { dg-options "-w" }
+struct PhantomData<T>;
+
+struct Hasher<S> {
+    _marker: PhantomData<S>,
+}
+
+struct Sip24Rounds;
+
+struct SipHasher24 {
+    hasher: Hasher<Sip24Rounds>,
+}
+
+impl SipHasher24 {
+    pub fn new_with_keys(key0: u64, key1: u64) -> SipHasher24 {
+        SipHasher24 {
+            hasher: Hasher::new_with_keys(),
+        }
+    }
+}
+
+impl<S> Hasher<S> {
+    fn new_with_keys() -> Hasher<S> {
+        Hasher {
+            _marker: PhantomData,
+        }
+    }
+}


### PR DESCRIPTION
This patch set adds fixes to ensure we can type inference generic unit-structs.

Fixes #1447 