### PR TITLE
transmute: Fix behavior by always performing the raw copy

### DIFF
--- a/gcc/rust/backend/rust-compile-intrinsic.cc
+++ b/gcc/rust/backend/rust-compile-intrinsic.cc
@@ -390,33 +390,15 @@ transmute_intrinsic_handler (Context *ctx, TyTy::BaseType *fntype_tyty)
   ctx->push_block (code_block);
 
   // BUILTIN transmute FN BODY BEGIN
-  tree result_type_tree = TREE_TYPE (DECL_RESULT (fndecl));
-  tree result_expr = error_mark_node;
-  if (AGGREGATE_TYPE_P (TREE_TYPE (convert_me_expr)))
-    {
-      // Return *(orig_type*)&decl.  */
-      // tree t = build_fold_addr_expr_loc (location.gcc_location (), this->t_);
-      // t = fold_build1_loc (location.gcc_location (), NOP_EXPR,
-      //       	       build_pointer_type (this->orig_type_), t);
-      // return build_fold_indirect_ref_loc (location.gcc_location (), t);
 
-      // result_expr = fold_build1_loc (Location ().gcc_location (),
-      // CONVERT_EXPR,
-      //   			     result_type_tree, convert_me_expr);
+  // Return *((orig_type*)&decl)  */
 
-      tree t = build_fold_addr_expr_loc (Location ().gcc_location (),
-					 convert_me_expr);
-      t = fold_build1_loc (Location ().gcc_location (), NOP_EXPR,
-			   build_pointer_type (target_type_expr), t);
-      result_expr
-	= build_fold_indirect_ref_loc (Location ().gcc_location (), t);
-    }
-  else
-    {
-      result_expr = ctx->get_backend ()->convert_expression (result_type_tree,
-							     convert_me_expr,
-							     Location ());
-    }
+  tree t
+    = build_fold_addr_expr_loc (Location ().gcc_location (), convert_me_expr);
+  t = fold_build1_loc (Location ().gcc_location (), NOP_EXPR,
+		       build_pointer_type (target_type_expr), t);
+  tree result_expr
+    = build_fold_indirect_ref_loc (Location ().gcc_location (), t);
 
   auto return_statement
     = ctx->get_backend ()->return_statement (fndecl, {result_expr},

--- a/gcc/testsuite/rust/execute/torture/transmute1.rs
+++ b/gcc/testsuite/rust/execute/torture/transmute1.rs
@@ -1,0 +1,23 @@
+// { dg-additional-options "-w" }
+
+extern "rust-intrinsic" {
+    fn transmute<T, U>(value: T) -> U;
+}
+
+struct WrapI {
+    inner: i32,
+}
+
+struct WrapF {
+    inner: f32,
+}
+
+fn main() -> i32 {
+    let f = 15.4f32;
+    let f_wrap = WrapF { inner: f };
+
+    let fst = unsafe { transmute::<f32, i32>(f) };
+    let snd = unsafe { transmute::<WrapF, WrapI>(f_wrap) };
+
+    fst - snd.inner
+}


### PR DESCRIPTION
This desugars calls to transmute the following way:

`transmute::<T1, T2>(value)`

->

`*((T2 *) &value)`

This always ends up being optimized into a simple copy for small types
and a memcpy for larger types.