### PR TITLE
intrinsics: Add copy_nonoverlapping<T>

### DIFF
--- a/gcc/rust/backend/rust-builtins.h
+++ b/gcc/rust/backend/rust-builtins.h
@@ -122,6 +122,14 @@ private:
     define_builtin ("breakpoint", BUILT_IN_TRAP, "__builtin_trap", "breakpoint",
 		    build_function_type (void_type_node, void_list_node),
 		    builtin_const | builtin_noreturn);
+
+    define_builtin (
+      "memcpy", BUILT_IN_MEMCPY, "__builtin_memcpy", "memcpy",
+      build_function_type_list (build_pointer_type (void_type_node),
+				build_pointer_type (void_type_node),
+				build_pointer_type (void_type_node),
+				size_type_node, NULL_TREE),
+      0);
   }
 
   // Define a builtin function.  BCODE is the builtin function code

--- a/gcc/testsuite/rust/execute/torture/copy_nonoverlapping1.rs
+++ b/gcc/testsuite/rust/execute/torture/copy_nonoverlapping1.rs
@@ -1,0 +1,17 @@
+extern "rust-intrinsic" {
+    pub fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
+}
+
+fn main() -> i32 {
+    let i = 15;
+    let mut i_copy = 16;
+
+    let i = &i as *const i32;
+    let i_copy = &mut i_copy as *mut i32;
+
+    unsafe {
+        copy_nonoverlapping(i, i_copy, 1);
+
+        *i_copy - *i
+    }
+}


### PR DESCRIPTION
intrinsics: Add copy_nonoverlapping<T>

This intrinsic is similar to C's memcpy (or in our case, GCC's
__builtin_memcpy) with the order of arguments swapped and knowledge
about the type of the operands. So we can desugar the following calls:

`copy_nonoverlapping::<T>(src, dst, count)`

can be converted to

`__builtin_memcpy(dst, src, count * size_of::<T>())`

~~Sadly, calling this intrinsic results in calls being optimized out for some reason. I'll open a separate issue to deal with that as I don't have the skills to resolve it.~~ fixed by not marking the function's declaration as `TREE_READONLY`

Fixes #1450 