### PR TITLE
Ensure we set TREE_SIDE_EFFECTS on call expressions

### DIFF
--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -1848,6 +1848,9 @@ Gcc_backend::call_expression (tree fn, const std::vector<tree> &fn_args,
       ret = build1_loc (location.gcc_location (), NOP_EXPR, rettype, ret);
     }
 
+  if (!TREE_SIDE_EFFECTS (ret))
+    TREE_SIDE_EFFECTS (ret) = TREE_SIDE_EFFECTS (fndecl);
+
   delete[] args;
   return ret;
 }


### PR DESCRIPTION
When we compiling call expressions the GCC helper has quite a simple
implementation to determine if there are SIDE_EFFECTS we have more
information in the front-end to determine this. This adds a check that
the call expression is deemed to have no side effects ensure we check this
against the fndecl used.

Fixes #1460
