### PR TITLE
intrinsics: Add wrapping_{add, sub, mul}

### DIFF
--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -152,8 +152,14 @@ grs_langhook_option_lang_mask (void)
 
 /* Initialize the options structure. */
 static void
-grs_langhook_init_options_struct (struct gcc_options * /* opts */)
+grs_langhook_init_options_struct (struct gcc_options *opts)
 {
+  /* Operations are always wrapping in Rust, even on signed integer. This is
+   * useful for the low level wrapping_{add, sub, mul} intrinsics, not for
+   * regular arithmetic operations which are checked for overflow anyway using
+   * builtins */
+  opts->x_flag_wrapv = 1;
+
   // nothing yet - used by frontends to change specific options for the language
   Rust::Session::get_instance ().init_options ();
 }

--- a/gcc/testsuite/rust/execute/torture/wrapping_op1.rs
+++ b/gcc/testsuite/rust/execute/torture/wrapping_op1.rs
@@ -1,0 +1,14 @@
+extern "rust-intrinsic" {
+    pub fn wrapping_add<T>(l: T, r: T) -> T;
+}
+
+fn five() -> u8 {
+    5
+}
+
+fn main() -> u8 {
+    let l = 255;
+    let r = five();
+
+    unsafe { wrapping_add(l, r) - 4 }
+}

--- a/gcc/testsuite/rust/execute/torture/wrapping_op2.rs
+++ b/gcc/testsuite/rust/execute/torture/wrapping_op2.rs
@@ -1,0 +1,20 @@
+extern "rust-intrinsic" {
+    pub fn wrapping_add<T>(l: T, r: T) -> T;
+    pub fn wrapping_sub<T>(l: T, r: T) -> T;
+    pub fn wrapping_mul<T>(l: T, r: T) -> T;
+}
+
+fn five() -> u8 {
+    5
+}
+
+fn main() -> u8 {
+    let l = 255;
+    let r = five();
+
+    let ret0 = unsafe { wrapping_add(l, r) - 4 }; // 4
+    let ret1 = unsafe { wrapping_sub(r, l) - 6 }; // 6
+    let ret2 = unsafe { wrapping_mul(r, l) - 251 }; // 251
+
+    ret0 + ret1 + ret2
+}


### PR DESCRIPTION
Since wrapping arithmetics are guaranteed in Rust, we turn on the -fwrapv and simply desugar wrapping_{add, sub, mul} to their non-checked inner operations. This is the only difference between a wrapping add and a regular addition: The regular addition will gain some checks for overflows, which are simply not used for the wrapping version.

Fixes #1449 

@bjorn3 if you want to have a look :)