### PR TITLE
Dont return error_mark_node on bad CallExpr arguments

### DIFF
--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -1778,8 +1778,6 @@ Gcc_backend::call_expression (tree fn, const std::vector<tree> &fn_args,
   for (size_t i = 0; i < nargs; ++i)
     {
       args[i] = fn_args.at (i);
-      if (args[i] == error_mark_node)
-	return error_mark_node;
     }
 
   tree fndecl = fn;


### PR DESCRIPTION
If we return error_mark_node on a bad expression argument we loss alot of
useful debug info from the error node within the -fdump-tree-original which
saves alot of debug printf.
