### PR TITLE
Desugar HIR::IdentifierExpr into HIR::PathInExpression

### DIFF
--- a/gcc/rust/backend/rust-compile-block.h
+++ b/gcc/rust/backend/rust-compile-block.h
@@ -46,7 +46,6 @@ public:
   void visit (HIR::StructExprFieldIndexValue &) override {}
   void visit (HIR::StructExprStruct &) override {}
   void visit (HIR::StructExprStructFields &) override {}
-  void visit (HIR::IdentifierExpr &) override {}
   void visit (HIR::LiteralExpr &) override {}
   void visit (HIR::BorrowExpr &) override {}
   void visit (HIR::DereferenceExpr &) override {}
@@ -126,7 +125,6 @@ public:
   void visit (HIR::StructExprFieldIndexValue &) override {}
   void visit (HIR::StructExprStruct &) override {}
   void visit (HIR::StructExprStructFields &) override {}
-  void visit (HIR::IdentifierExpr &) override {}
   void visit (HIR::LiteralExpr &) override {}
   void visit (HIR::BorrowExpr &) override {}
   void visit (HIR::DereferenceExpr &) override {}
@@ -216,7 +214,6 @@ public:
   void visit (HIR::StructExprFieldIndexValue &) override {}
   void visit (HIR::StructExprStruct &) override {}
   void visit (HIR::StructExprStructFields &) override {}
-  void visit (HIR::IdentifierExpr &) override {}
   void visit (HIR::LiteralExpr &) override {}
   void visit (HIR::BorrowExpr &) override {}
   void visit (HIR::DereferenceExpr &) override {}

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -118,8 +118,6 @@ public:
 
   void visit (HIR::MethodCallExpr &expr) override;
 
-  void visit (HIR::IdentifierExpr &expr) override;
-
   void visit (HIR::LiteralExpr &expr) override
   {
     TyTy::BaseType *tyty = nullptr;

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -64,6 +64,13 @@ ResolvePathRef::resolve (const HIR::PathIdentSegment &final_segment,
 	return error_mark_node;
 
       TyTy::ADTType *adt = static_cast<TyTy::ADTType *> (lookup);
+
+      // it might be a unit-struct
+      if (adt->is_unit ())
+	{
+	  return ctx->get_backend ()->unit_expression ();
+	}
+
       if (!adt->is_enum ())
 	return error_mark_node;
 
@@ -119,6 +126,14 @@ ResolvePathRef::resolve (const HIR::PathIdentSegment &final_segment,
     {
       // TREE_USED is setup in the gcc abstraction here
       return ctx->get_backend ()->var_expression (var, expr_locus);
+    }
+
+  // might be a match pattern binding
+  tree binding = error_mark_node;
+  if (ctx->lookup_pattern_binding (ref, &binding))
+    {
+      TREE_USED (binding) = 1;
+      return binding;
     }
 
   // it might be a function call

--- a/gcc/rust/backend/rust-compile-struct-field-expr.h
+++ b/gcc/rust/backend/rust-compile-struct-field-expr.h
@@ -47,7 +47,6 @@ public:
   void visit (HIR::ClosureExprInnerTyped &) override {}
   void visit (HIR::StructExprStruct &) override {}
   void visit (HIR::StructExprStructFields &) override {}
-  void visit (HIR::IdentifierExpr &) override {}
   void visit (HIR::LiteralExpr &) override {}
   void visit (HIR::BorrowExpr &) override {}
   void visit (HIR::DereferenceExpr &) override {}

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -188,10 +188,17 @@ CompileStructExprField::visit (HIR::StructExprFieldIndexValue &field)
 void
 CompileStructExprField::visit (HIR::StructExprFieldIdentifier &field)
 {
-  // we can make the field look like an identifier expr to take advantage of
-  // existing code
-  HIR::IdentifierExpr expr (field.get_mappings (), field.get_field_name (),
-			    field.get_locus ());
+  // we can make the field look like a path expr to take advantage of existing
+  // code
+
+  Analysis::NodeMapping mappings_copy1 = field.get_mappings ();
+  Analysis::NodeMapping mappings_copy2 = field.get_mappings ();
+
+  HIR::PathIdentSegment ident_seg (field.get_field_name ());
+  HIR::PathExprSegment seg (mappings_copy1, ident_seg, field.get_locus (),
+			    HIR::GenericArgs::create_empty ());
+  HIR::PathInExpression expr (mappings_copy2, {seg}, field.get_locus (), false,
+			      {});
   translated = CompileExpr::Compile (&expr, ctx);
 }
 

--- a/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
+++ b/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
@@ -201,10 +201,6 @@ PrivacyReporter::check_type_privacy (const HIR::Type *type)
 }
 
 void
-PrivacyReporter::visit (HIR::IdentifierExpr &ident_expr)
-{}
-
-void
 PrivacyReporter::visit (HIR::PathInExpression &path)
 {
   check_for_privacy_violation (path.get_mappings ().get_nodeid (),

--- a/gcc/rust/checks/errors/privacy/rust-privacy-reporter.h
+++ b/gcc/rust/checks/errors/privacy/rust-privacy-reporter.h
@@ -87,7 +87,6 @@ types
   virtual void visit (HIR::ClosureExprInner &expr);
   virtual void visit (HIR::StructExprStructFields &);
   virtual void visit (HIR::StructExprStruct &);
-  virtual void visit (HIR::IdentifierExpr &ident_expr);
   virtual void visit (HIR::LiteralExpr &expr);
   virtual void visit (HIR::BorrowExpr &expr);
   virtual void visit (HIR::DereferenceExpr &expr);

--- a/gcc/rust/checks/errors/rust-const-checker.cc
+++ b/gcc/rust/checks/errors/rust-const-checker.cc
@@ -53,10 +53,6 @@ ConstChecker::is_const_extern_fn (HIR::ExternalFunctionItem &fn)
 }
 
 void
-ConstChecker::visit (IdentifierExpr &ident_expr)
-{}
-
-void
 ConstChecker::visit (Lifetime &lifetime)
 {}
 

--- a/gcc/rust/checks/errors/rust-const-checker.h
+++ b/gcc/rust/checks/errors/rust-const-checker.h
@@ -50,7 +50,6 @@ private:
   Resolver::Resolver &resolver;
   Analysis::Mappings &mappings;
 
-  virtual void visit (IdentifierExpr &ident_expr) override;
   virtual void visit (Lifetime &lifetime) override;
   virtual void visit (LifetimeParam &lifetime_param) override;
   virtual void visit (PathInExpression &path) override;

--- a/gcc/rust/checks/errors/rust-unsafe-checker.cc
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.cc
@@ -129,21 +129,6 @@ UnsafeChecker::check_function_call (HirId node_id, Location locus)
 }
 
 void
-UnsafeChecker::visit (IdentifierExpr &ident_expr)
-{
-  NodeId ast_node_id = ident_expr.get_mappings ().get_nodeid ();
-  NodeId ref_node_id;
-  HirId definition_id;
-
-  if (!resolver.lookup_resolved_name (ast_node_id, &ref_node_id))
-    return;
-
-  rust_assert (mappings.lookup_node_to_hir (ref_node_id, &definition_id));
-
-  check_use_of_static (definition_id, ident_expr.get_locus ());
-}
-
-void
 UnsafeChecker::visit (Lifetime &lifetime)
 {}
 

--- a/gcc/rust/checks/errors/rust-unsafe-checker.h
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.h
@@ -52,7 +52,6 @@ private:
   Resolver::Resolver &resolver;
   Analysis::Mappings &mappings;
 
-  virtual void visit (IdentifierExpr &ident_expr) override;
   virtual void visit (Lifetime &lifetime) override;
   virtual void visit (LifetimeParam &lifetime_param) override;
   virtual void visit (PathInExpression &path) override;

--- a/gcc/rust/checks/lints/rust-lint-marklive.cc
+++ b/gcc/rust/checks/lints/rust-lint-marklive.cc
@@ -247,20 +247,6 @@ MarkLive::visit (HIR::TupleIndexExpr &expr)
 }
 
 void
-MarkLive::visit (HIR::IdentifierExpr &expr)
-{
-  NodeId ast_node_id = expr.get_mappings ().get_nodeid ();
-  NodeId ref_node_id = UNKNOWN_NODEID;
-  find_ref_node_id (ast_node_id, ref_node_id);
-
-  // node back to HIR
-  HirId ref;
-  bool ok = mappings->lookup_node_to_hir (ref_node_id, &ref);
-  rust_assert (ok);
-  mark_hir_id (ref);
-}
-
-void
 MarkLive::visit (HIR::TypeAlias &alias)
 {
   NodeId ast_node_id;

--- a/gcc/rust/checks/lints/rust-lint-marklive.h
+++ b/gcc/rust/checks/lints/rust-lint-marklive.h
@@ -36,7 +36,6 @@ public:
   void go (HIR::Crate &crate);
 
   void visit (HIR::PathInExpression &expr) override;
-  void visit (HIR::IdentifierExpr &expr) override;
   void visit (HIR::FieldAccessExpr &expr) override;
   void visit (HIR::TupleIndexExpr &expr) override;
   void visit (HIR::MethodCallExpr &expr) override;

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -255,11 +255,16 @@ public:
   void visit (AST::IdentifierExpr &expr) override
   {
     auto crate_num = mappings->get_current_crate ();
-    Analysis::NodeMapping mapping (crate_num, expr.get_node_id (),
-				   mappings->get_next_hir_id (crate_num),
-				   UNKNOWN_LOCAL_DEFID);
-    translated
-      = new HIR::IdentifierExpr (mapping, expr.as_string (), expr.get_locus ());
+    Analysis::NodeMapping mapping1 (crate_num, expr.get_node_id (),
+				    mappings->get_next_hir_id (crate_num),
+				    UNKNOWN_LOCAL_DEFID);
+    Analysis::NodeMapping mapping2 (mapping1);
+
+    HIR::PathIdentSegment ident_seg (expr.get_ident ());
+    HIR::PathExprSegment seg (mapping1, ident_seg, expr.get_locus (),
+			      HIR::GenericArgs::create_empty ());
+    translated = new HIR::PathInExpression (mapping2, {seg}, expr.get_locus (),
+					    false, expr.get_outer_attrs ());
   }
 
   void visit (AST::ArrayExpr &expr) override

--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -78,9 +78,6 @@ Dump::go (HIR::Crate &crate)
 }
 
 void
-Dump::visit (IdentifierExpr &)
-{}
-void
 Dump::visit (Lifetime &)
 {}
 void

--- a/gcc/rust/hir/rust-hir-dump.h
+++ b/gcc/rust/hir/rust-hir-dump.h
@@ -37,7 +37,6 @@ private:
   std::size_t indent; // current indentation level
   char indent_char = '\t';
 
-  virtual void visit (IdentifierExpr &) override;
   virtual void visit (Lifetime &) override;
   virtual void visit (LifetimeParam &) override;
   virtual void visit (PathInExpression &) override;

--- a/gcc/rust/hir/tree/rust-hir-full-decls.h
+++ b/gcc/rust/hir/tree/rust-hir-full-decls.h
@@ -27,7 +27,6 @@ class Stmt;
 class Item;
 class Expr;
 class ExprWithoutBlock;
-class IdentifierExpr;
 class Pattern;
 class Type;
 class TypeNoBounds;

--- a/gcc/rust/hir/tree/rust-hir-full-test.cc
+++ b/gcc/rust/hir/tree/rust-hir-full-test.cc
@@ -3752,18 +3752,6 @@ Module::add_crate_name (std::vector<std::string> &names) const
 /* All accept_vis method below */
 
 void
-IdentifierExpr::accept_vis (HIRFullVisitor &vis)
-{
-  vis.visit (*this);
-}
-
-void
-IdentifierExpr::accept_vis (HIRExpressionVisitor &vis)
-{
-  vis.visit (*this);
-}
-
-void
 Lifetime::accept_vis (HIRFullVisitor &vis)
 {
   vis.visit (*this);

--- a/gcc/rust/hir/tree/rust-hir-visitor.h
+++ b/gcc/rust/hir/tree/rust-hir-visitor.h
@@ -27,7 +27,6 @@ namespace HIR {
 class HIRFullVisitor
 {
 public:
-  virtual void visit (IdentifierExpr &ident_expr) = 0;
   virtual void visit (Lifetime &lifetime) = 0;
   virtual void visit (LifetimeParam &lifetime_param) = 0;
   virtual void visit (PathInExpression &path) = 0;
@@ -166,7 +165,6 @@ class HIRFullVisitorBase : public HIRFullVisitor
 public:
   virtual ~HIRFullVisitorBase () {}
 
-  virtual void visit (IdentifierExpr &) override {}
   virtual void visit (Lifetime &) override {}
   virtual void visit (LifetimeParam &) override {}
   virtual void visit (PathInExpression &) override {}
@@ -425,7 +423,6 @@ public:
   virtual void visit (ClosureExprInner &expr) = 0;
   virtual void visit (StructExprStructFields &) = 0;
   virtual void visit (StructExprStruct &) = 0;
-  virtual void visit (IdentifierExpr &ident_expr) = 0;
   virtual void visit (LiteralExpr &expr) = 0;
   virtual void visit (BorrowExpr &expr) = 0;
   virtual void visit (DereferenceExpr &expr) = 0;

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -274,7 +274,6 @@ public:
     Match,
     Await,
     AsyncBlock,
-    Ident,
     Path,
   };
 
@@ -365,63 +364,6 @@ public:
   {
     return BlockType::WITHOUT_BLOCK;
   };
-};
-
-/* HACK: IdentifierExpr, delete when figure out identifier vs expr problem in
- * Pratt parser */
-/* Alternatively, identifiers could just be represented as single-segment paths
- */
-class IdentifierExpr : public ExprWithoutBlock
-{
-  Identifier ident;
-
-public:
-  Location locus;
-
-  IdentifierExpr (Analysis::NodeMapping mappings, Identifier ident,
-		  Location locus = Location (),
-		  AST::AttrVec outer_attrs = AST::AttrVec ())
-    : ExprWithoutBlock (std::move (mappings), std::move (outer_attrs)),
-      ident (std::move (ident)), locus (locus)
-  {}
-
-  std::string as_string () const override
-  {
-    return "( " + ident + " (" + get_mappings ().as_string () + "))";
-  }
-
-  Location get_locus () const override final { return locus; }
-
-  void accept_vis (HIRFullVisitor &vis) override;
-  void accept_vis (HIRExpressionVisitor &vis) override;
-
-  // Clones this object.
-  std::unique_ptr<IdentifierExpr> clone_identifier_expr () const
-  {
-    return std::unique_ptr<IdentifierExpr> (clone_identifier_expr_impl ());
-  }
-
-  Identifier get_identifier () const { return ident; }
-
-  ExprType get_expression_type () const final override
-  {
-    return ExprType::Ident;
-  }
-
-protected:
-  // Clone method implementation
-  IdentifierExpr *clone_expr_without_block_impl () const override
-  {
-    return clone_identifier_expr_impl ();
-  }
-
-  IdentifierExpr *clone_identifier_expr_impl () const
-  {
-    return new IdentifierExpr (*this);
-  }
-
-  IdentifierExpr (IdentifierExpr const &other) = default;
-  IdentifierExpr &operator= (IdentifierExpr const &other) = default;
 };
 
 // Pattern base HIR node

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -37,7 +37,6 @@ public:
   void visit (HIR::MethodCallExpr &expr) override;
   void visit (HIR::AssignmentExpr &expr) override;
   void visit (HIR::CompoundAssignmentExpr &expr) override;
-  void visit (HIR::IdentifierExpr &expr) override;
   void visit (HIR::LiteralExpr &expr) override;
   void visit (HIR::ArithmeticOrLogicalExpr &expr) override;
   void visit (HIR::ComparisonExpr &expr) override;

--- a/gcc/rust/typecheck/rust-hir-type-check-struct.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-struct.cc
@@ -313,10 +313,16 @@ TypeCheckStructExpr::visit (HIR::StructExprFieldIdentifier &field)
       return;
     }
 
-  // we can make the field look like an identifier expr to take advantage of
-  // existing code to figure out the type
-  HIR::IdentifierExpr expr (field.get_mappings (), field.get_field_name (),
-			    field.get_locus ());
+  // we can make the field look like a path expr to take advantage of existing
+  // code
+  Analysis::NodeMapping mappings_copy1 = field.get_mappings ();
+  Analysis::NodeMapping mappings_copy2 = field.get_mappings ();
+
+  HIR::PathIdentSegment ident_seg (field.get_field_name ());
+  HIR::PathExprSegment seg (mappings_copy1, ident_seg, field.get_locus (),
+			    HIR::GenericArgs::create_empty ());
+  HIR::PathInExpression expr (mappings_copy2, {seg}, field.get_locus (), false,
+			      {});
   TyTy::BaseType *value = TypeCheckExpr::Resolve (&expr);
 
   resolved_field_value_expr

--- a/gcc/rust/typecheck/rust-tycheck-dump.h
+++ b/gcc/rust/typecheck/rust-tycheck-dump.h
@@ -159,11 +159,6 @@ public:
 	    + type_string (expr.get_mappings ());
   }
 
-  void visit (HIR::IdentifierExpr &expr) override
-  {
-    dump += expr.get_identifier () + ":" + type_string (expr.get_mappings ());
-  }
-
   void visit (HIR::ArrayExpr &expr) override
   {
     dump += type_string (expr.get_mappings ()) + ":[";

--- a/gcc/testsuite/rust/compile/torture/issue-1075.rs
+++ b/gcc/testsuite/rust/compile/torture/issue-1075.rs
@@ -19,8 +19,7 @@ impl<T> *const [T] {
     pub const fn len(self) -> usize {
         // SAFETY: this is safe because `*const [T]` and `FatPtr<T>` have the same layout.
         // Only `std` can make this guarantee.
-        let a = unsafe { Repr { rust: self }.raw };
-        a.len
+        unsafe { Repr { rust: self }.raw.len }
     }
 
     pub const fn as_ptr(self) -> *const T {

--- a/gcc/testsuite/rust/compile/traits3.rs
+++ b/gcc/testsuite/rust/compile/traits3.rs
@@ -10,9 +10,9 @@ impl<T> Foo for Bar<T> {
     type A = i32;
 
     fn baz(a: f32) -> f32 {
-        // { dg-error "expected .i32. got .f32." "" { target *-*-* } .-1 }
-        // { dg-error "method .baz. has an incompatible type for trait .Foo." "" { target *-*-* } .-2 }
+        // { dg-error "method .baz. has an incompatible type for trait .Foo." "" { target *-*-* } .-1 }
         a
+        // { dg-error "expected .i32. got .f32." "" { target *-*-* } .-1 }
     }
 }
 

--- a/gcc/testsuite/rust/execute/torture/issue-1120.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-1120.rs
@@ -29,8 +29,7 @@ pub struct Range<Idx> {
 #[lang = "const_slice_ptr"]
 impl<T> *const [T] {
     pub const fn len(self) -> usize {
-        let a = unsafe { Repr { rust: self }.raw };
-        a.len
+        unsafe { Repr { rust: self }.raw.len }
     }
 
     pub const fn as_ptr(self) -> *const T {

--- a/gcc/testsuite/rust/execute/torture/issue-1133.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-1133.rs
@@ -29,8 +29,7 @@ pub struct Range<Idx> {
 #[lang = "const_slice_ptr"]
 impl<T> *const [T] {
     pub const fn len(self) -> usize {
-        let a = unsafe { Repr { rust: self }.raw };
-        a.len
+        unsafe { Repr { rust: self }.raw.len }
     }
 
     pub const fn as_ptr(self) -> *const T {

--- a/gcc/testsuite/rust/execute/torture/issue-1232.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-1232.rs
@@ -34,8 +34,7 @@ pub struct Range<Idx> {
 #[lang = "const_slice_ptr"]
 impl<T> *const [T] {
     pub const fn len(self) -> usize {
-        let a = unsafe { Repr { rust: self }.raw };
-        a.len
+        unsafe { Repr { rust: self }.raw.len }
     }
 
     pub const fn as_ptr(self) -> *const T {

--- a/gcc/testsuite/rust/execute/torture/issue-1436.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-1436.rs
@@ -42,8 +42,7 @@ pub struct Range<Idx> {
 #[lang = "const_slice_ptr"]
 impl<T> *const [T] {
     pub const fn len(self) -> usize {
-        let a = unsafe { Repr { rust: self }.raw };
-        a.len
+        unsafe { Repr { rust: self }.raw.len }
     }
 
     pub const fn as_ptr(self) -> *const T {

--- a/gcc/testsuite/rust/execute/torture/slice-magic.rs
+++ b/gcc/testsuite/rust/execute/torture/slice-magic.rs
@@ -24,8 +24,7 @@ pub struct Range<Idx> {
 #[lang = "const_slice_ptr"]
 impl<A> *const [A] {
     pub const fn len(self) -> usize {
-        let a = unsafe { Repr { rust: self }.raw };
-        a.len
+        unsafe { Repr { rust: self }.raw.len }
     }
 
     pub const fn as_ptr(self) -> *const A {

--- a/gcc/testsuite/rust/execute/torture/slice-magic2.rs
+++ b/gcc/testsuite/rust/execute/torture/slice-magic2.rs
@@ -24,8 +24,7 @@ pub struct Range<Idx> {
 #[lang = "const_slice_ptr"]
 impl<T> *const [T] {
     pub const fn len(self) -> usize {
-        let a = unsafe { Repr { rust: self }.raw };
-        a.len
+        unsafe { Repr { rust: self }.raw.len }
     }
 
     pub const fn as_ptr(self) -> *const T {


### PR DESCRIPTION
This completly removes the HIR::IdentifierExpr and unifies how we handle
generics in general. There was a hack from last year that did not infer
generic arguments on IdentifierExpr's which leads to a type inferencing
behvaiour mismatch which was becoming difficult to debug. This simplifies
everything.

The changes to the test case reflect making our code more compliant to
real rustc apart from compile/traits3.rs which will be fixed as part of the
refactoring effort going on in the type system.

Fixes #1456