### PR TITLE
Revert "Ensure we set TREE_SIDE_EFFECTS on call expressions"

### DIFF
--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -1840,9 +1840,6 @@ Gcc_backend::call_expression (tree fn, const std::vector<tree> &fn_args,
       ret = build1_loc (location.gcc_location (), NOP_EXPR, rettype, ret);
     }
 
-  if (!TREE_SIDE_EFFECTS (ret))
-    TREE_SIDE_EFFECTS (ret) = TREE_SIDE_EFFECTS (fndecl);
-
   delete[] args;
   return ret;
 }


### PR DESCRIPTION
This reverts commit f891a13aa2af912584176d2c595c295b77ff5ff9. This fix
ensures the code is added to the block but still as the artifical function
is marked READONLY it ends up being optimized out anyway.