### PR TITLE
Improve AST dump

### DIFF
--- a/gcc/rust/ast/rust-ast-dump.h
+++ b/gcc/rust/ast/rust-ast-dump.h
@@ -66,6 +66,12 @@ private:
   void format_function_param (FunctionParam &param);
   void emit_attrib (const Attribute &attrib);
 
+  /**
+   * Emit an indented string with an optional extra comment
+   */
+  std::ostream &emit_indented_string (const std::string &value,
+				      const std::string &comment = "");
+
   // rust-ast.h
   void visit (Token &tok);
   void visit (DelimTokenTree &delim_tok_tree);

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -58,6 +58,7 @@ namespace Rust {
 const char *kLexDumpFile = "gccrs.lex.dump";
 const char *kASTDumpFile = "gccrs.ast.dump";
 const char *kASTPrettyDumpFile = "gccrs.ast-pretty.dump";
+const char *kASTPrettyDumpFileExpanded = "gccrs.ast-pretty-expanded.dump";
 const char *kASTExpandedDumpFile = "gccrs.ast-expanded.dump";
 const char *kHIRDumpFile = "gccrs.hir.dump";
 const char *kHIRPrettyDumpFile = "gccrs.hir-pretty.dump";
@@ -509,6 +510,7 @@ Session::compile_crate (const char *filename)
       // dump AST with expanded stuff
       rust_debug ("BEGIN POST-EXPANSION AST DUMP");
       dump_ast_expanded (parser, parsed_crate);
+      dump_ast_pretty (parsed_crate, true);
       rust_debug ("END POST-EXPANSION AST DUMP");
     }
 
@@ -810,10 +812,14 @@ Session::dump_ast (Parser<Lexer> &parser, AST::Crate &crate) const
 }
 
 void
-Session::dump_ast_pretty (AST::Crate &crate) const
+Session::dump_ast_pretty (AST::Crate &crate, bool expanded) const
 {
   std::ofstream out;
-  out.open (kASTPrettyDumpFile);
+  if (expanded)
+    out.open (kASTPrettyDumpFileExpanded);
+  else
+    out.open (kASTPrettyDumpFile);
+
   if (out.fail ())
     {
       rust_error_at (Linemap::unknown_location (), "cannot open %s:%m; ignored",

--- a/gcc/rust/rust-session-manager.h
+++ b/gcc/rust/rust-session-manager.h
@@ -319,7 +319,7 @@ private:
 
   void dump_lex (Parser<Lexer> &parser) const;
   void dump_ast (Parser<Lexer> &parser, AST::Crate &crate) const;
-  void dump_ast_pretty (AST::Crate &crate) const;
+  void dump_ast_pretty (AST::Crate &crate, bool expanded = false) const;
   void dump_ast_expanded (Parser<Lexer> &parser, AST::Crate &crate) const;
   void dump_hir (HIR::Crate &crate) const;
   void dump_hir_pretty (HIR::Crate &crate) const;


### PR DESCRIPTION
Let's abuse C++ a little bit to make dumping and the chaining of dumping operations easier. If anyone has input feel free, this is definitely a roundabout way to go about it.

This also adds pretty printing of the expanded AST, which can be useful to debug macros or `cfg` invocations