### PR TITLE
RFC: arrange tuple matches in trees not HIR

### DIFF
--- a/gcc/testsuite/rust/execute/torture/match_tuple2.rs
+++ b/gcc/testsuite/rust/execute/torture/match_tuple2.rs
@@ -1,0 +1,34 @@
+// { dg-output "x:10\ny:20\n" }
+
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+enum Foo {
+    A,
+    B,
+}
+
+fn inspect(x: (Foo, u8)) -> i32 {
+    match x {
+        (Foo::A, 1) => { return 5; }
+        (Foo::A, 2) => { return 10; }
+        (Foo::B, 2) => { return 15; }
+        _ => { return 20; }
+    }
+    return 25;
+}
+
+fn main () -> i32 {
+    let x = inspect((Foo::A, 2));
+    let y = inspect((Foo::B, 1));
+
+    unsafe {
+        printf("x:%d\n" as *const str as *const i8, x);
+    }
+    unsafe {
+        printf("y:%d\n" as *const str as *const i8, y);
+    }
+
+    y - x - 10
+}


### PR DESCRIPTION
Opening this as draft because I'm not sure whether it is the best path forward,
and I'd like to see if anyone has thoughts one way or another.

This commit changes the way we compile matches on tuple scrutinees to do
as much work as possible on GENERIC trees, rather than first rearranging
the HIR representation of the match.

The pros of this change:
 + Much easier to debug and inspect trees as they are constructed
 + More GCC-y (?)
 + Exactly the same process for tuple and paths-to-tuples as scrutinees
    (see the added test, this is newly-working)
 + Should extend a little more directly to other types of scrutinees,
   such as structs

cons:
 - More boilerplate-ish code repeated, should be fixed with some
   refactoring
 - ??

In any case, there remains a LOT more to do on match expressions, and
probably by the end the whole approach will be entirely different.
