### PR TITLE
typecheck: resolve tuple pattern elt against parent elt

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
@@ -263,9 +263,18 @@ TypeCheckPattern::visit (HIR::TuplePattern &pattern)
 	    pattern.get_items ().get ());
 
 	std::vector<TyTy::TyVar> pattern_elems;
-	for (auto &p : ref.get_patterns ())
+	for (size_t i = 0; i < ref.get_patterns ().size (); i++)
 	  {
-	    TyTy::BaseType *elem = TypeCheckPattern::Resolve (p.get (), parent);
+	    auto &p = ref.get_patterns ()[i];
+	    TyTy::BaseType *par_type = parent;
+	    if (parent->get_kind () == TyTy::TUPLE)
+	      {
+		TyTy::TupleType &par = *static_cast<TyTy::TupleType *> (parent);
+		par_type = par.get_field (i);
+	      }
+
+	    TyTy::BaseType *elem
+	      = TypeCheckPattern::Resolve (p.get (), par_type);
 	    pattern_elems.push_back (TyTy::TyVar (elem->get_ref ()));
 	  }
 	infered

--- a/gcc/testsuite/rust/compile/match7.rs
+++ b/gcc/testsuite/rust/compile/match7.rs
@@ -1,0 +1,12 @@
+fn bar (x: u8, y: u8) -> i32 {
+    match (x, y) {
+        (1, 1) => { return 1; }
+        (1, _) => { return -1; }
+    }
+
+    return 0;
+}
+
+fn main () -> () {
+    bar (1, 2);
+}


### PR DESCRIPTION
When doing type resolution for an element of a tuple pattern, check it
against the corresponding element of the parent, if the parent is also a
tuple.

Fixes: #1476