### PR TITLE
Fix ICE in dyn impl block

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-path.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-path.cc
@@ -242,8 +242,9 @@ void
 ResolvePath::resolve_path (AST::QualifiedPathInExpression *expr)
 {
   AST::QualifiedPathType &root_segment = expr->get_qualified_path_type ();
-  ResolveType::go (&root_segment.get_as_type_path ());
   ResolveType::go (root_segment.get_type ().get ());
+  if (root_segment.has_as_clause ())
+    ResolveType::go (&root_segment.get_as_type_path ());
 
   for (auto &segment : expr->get_segments ())
     {

--- a/gcc/rust/resolve/rust-ast-resolve-type.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-type.cc
@@ -477,6 +477,27 @@ ResolveTypeToCanonicalPath::visit (AST::SliceType &type)
     }
 }
 
+void
+ResolveTypeToCanonicalPath::visit (AST::TraitObjectTypeOneBound &type)
+{
+  CanonicalPath path = CanonicalPath::create_empty ();
+  bool ok
+    = ResolveTypeToCanonicalPath::go (&type.get_trait_bound ().get_type_path (),
+				      path);
+  if (ok)
+    {
+      std::string slice_path = "<dyn " + path.get () + ">";
+      result = CanonicalPath::new_seg (type.get_node_id (), slice_path);
+    }
+}
+
+void
+ResolveTypeToCanonicalPath::visit (AST::TraitObjectType &type)
+{
+  // FIXME is this actually allowed? dyn A+B
+  gcc_unreachable ();
+}
+
 ResolveTypeToCanonicalPath::ResolveTypeToCanonicalPath ()
   : ResolverBase (), result (CanonicalPath::create_empty ())
 {}

--- a/gcc/rust/resolve/rust-ast-resolve-type.h
+++ b/gcc/rust/resolve/rust-ast-resolve-type.h
@@ -242,6 +242,10 @@ public:
 
   void visit (AST::SliceType &type) override;
 
+  void visit (AST::TraitObjectTypeOneBound &type) override;
+
+  void visit (AST::TraitObjectType &type) override;
+
 private:
   ResolveTypeToCanonicalPath ();
 

--- a/gcc/rust/typecheck/rust-hir-type-check-path.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-path.cc
@@ -34,13 +34,7 @@ TypeCheckExpr::visit (HIR::QualifiedPathInExpression &expr)
 
   if (!qual_path_type.has_as_clause ())
     {
-      // then this is just a normal path-in-expression
       NodeId root_resolved_node_id = UNKNOWN_NODEID;
-      bool ok = resolver->lookup_resolved_type (
-	qual_path_type.get_type ()->get_mappings ().get_nodeid (),
-	&root_resolved_node_id);
-      rust_assert (ok);
-
       resolve_segments (root_resolved_node_id, expr.get_segments (), 0, root,
 			expr.get_mappings (), expr.get_locus ());
       return;

--- a/gcc/testsuite/rust/execute/torture/issue-1249.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-1249.rs
@@ -1,0 +1,39 @@
+// { dg-options "-w" }
+// { dg-output "1\n2\n" }
+
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+trait T {
+    fn foo(&self);
+}
+
+impl dyn T {
+    fn bar(&self) {
+        unsafe {
+            let a = "1\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+            printf(c);
+        }
+        self.foo()
+    }
+}
+
+struct S;
+impl T for S {
+    fn foo(&self) {
+        unsafe {
+            let a = "2\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+            printf(c);
+        }
+    }
+}
+
+pub fn main() -> i32 {
+    <dyn T>::bar(&S);
+    0
+}


### PR DESCRIPTION
The issue here was that our name resolution assumed qualified path always
has an as clause. We also had missing visitors to generate the canonical path
for impl blocks using dynamic trait objects.

We should investigate implementing the fine-grained visitors for the AST
similar to the ones we have for HIR. This will solve the issue where we
have missing visitors.

Fixes #1249