### PR TITLE
Add overflow traps

### DIFF
--- a/gcc/rust/backend/rust-compile-item.cc
+++ b/gcc/rust/backend/rust-compile-item.cc
@@ -160,6 +160,9 @@ CompileItem::visit (HIR::Function &function)
     function.get_mappings ().get_nodeid (), &canonical_path);
   rust_assert (ok);
 
+  if (function.get_qualifiers ().is_const ())
+    ctx->push_const_context ();
+
   tree fndecl
     = compile_function (ctx, function.get_function_name (),
 			function.get_self_param (),
@@ -169,6 +172,9 @@ CompileItem::visit (HIR::Function &function)
 			function.get_definition ().get (), canonical_path,
 			fntype, function.has_function_return_type ());
   reference = address_expression (fndecl, ref_locus);
+
+  if (function.get_qualifiers ().is_const ())
+    ctx->pop_const_context ();
 }
 
 void

--- a/gcc/rust/backend/rust-compile-type.cc
+++ b/gcc/rust/backend/rust-compile-type.cc
@@ -370,7 +370,11 @@ TyTyResolveCompile::visit (const TyTy::ArrayType &type)
 {
   tree element_type
     = TyTyResolveCompile::compile (ctx, type.get_element_type ());
+
+  ctx->push_const_context ();
   tree capacity_expr = CompileExpr::Compile (&type.get_capacity_expr (), ctx);
+  ctx->pop_const_context ();
+
   tree folded_capacity_expr = fold_expr (capacity_expr);
 
   translated

--- a/gcc/rust/rust-backend.h
+++ b/gcc/rust/rust-backend.h
@@ -235,13 +235,24 @@ public:
   // Supported values of OP are enumerated in ArithmeticOrLogicalOperator.
   virtual tree arithmetic_or_logical_expression (ArithmeticOrLogicalOperator op,
 						 tree left, tree right,
-						 Location)
+						 Location loc)
+    = 0;
+
+  // Return an expression for the operation LEFT OP RIGHT.
+  // Supported values of OP are enumerated in ArithmeticOrLogicalOperator.
+  // This function adds overflow checking and returns a list of statements to
+  // add to the current function context. The `receiver` variable refers to the
+  // variable which will contain the result of that operation.
+  virtual tree
+  arithmetic_or_logical_expression_checked (ArithmeticOrLogicalOperator op,
+					    tree left, tree right, Location loc,
+					    Bvariable *receiver)
     = 0;
 
   // Return an expression for the operation LEFT OP RIGHT.
   // Supported values of OP are enumerated in ComparisonOperator.
   virtual tree comparison_expression (ComparisonOperator op, tree left,
-				      tree right, Location)
+				      tree right, Location loc)
     = 0;
 
   // Return an expression for the operation LEFT OP RIGHT.
@@ -416,8 +427,8 @@ public:
   // variable, and may not be very useful.  This function should
   // return a variable which can be referenced later and should set
   // *PSTATEMENT to a statement which initializes the variable.
-  virtual Bvariable *temporary_variable (tree, tree, tree, tree init,
-					 bool address_is_taken,
+  virtual Bvariable *temporary_variable (tree fndecl, tree bind_tree, tree type,
+					 tree init, bool address_is_taken,
 					 Location location, tree *pstatement)
     = 0;
 

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -50,37 +50,9 @@
 #include "rust-linemap.h"
 #include "rust-backend.h"
 #include "rust-object-export.h"
+#include "rust-gcc.h"
 
 #include "backend/rust-tree.h"
-
-// TODO: this will have to be significantly modified to work with Rust
-
-// Bvariable is a bit more complicated, because of zero-sized types.
-// The GNU linker does not permit dynamic variables with zero size.
-// When we see such a variable, we generate a version of the type with
-// non-zero size.  However, when referring to the global variable, we
-// want an expression of zero size; otherwise, if, say, the global
-// variable is passed to a function, we will be passing a
-// non-zero-sized value to a zero-sized value, which can lead to a
-// miscompilation.
-
-class Bvariable
-{
-public:
-  Bvariable (tree t) : t_ (t), orig_type_ (NULL) {}
-
-  Bvariable (tree t, tree orig_type) : t_ (t), orig_type_ (orig_type) {}
-
-  // Get the tree for use as an expression.
-  tree get_tree (Location) const;
-
-  // Get the actual decl;
-  tree get_decl () const { return this->t_; }
-
-private:
-  tree t_;
-  tree orig_type_;
-};
 
 // Get the tree of a variable for use as an expression.  If this is a
 // zero-sized global, create an expression that refers to the decl but

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -53,6 +53,7 @@
 #include "rust-gcc.h"
 
 #include "backend/rust-tree.h"
+#include "backend/rust-builtins.h"
 
 // Get the tree of a variable for use as an expression.  If this is a
 // zero-sized global, create an expression that refers to the decl but
@@ -205,6 +206,10 @@ public:
 
   tree arithmetic_or_logical_expression (ArithmeticOrLogicalOperator op,
 					 tree left, tree right, Location);
+
+  tree arithmetic_or_logical_expression_checked (ArithmeticOrLogicalOperator op,
+						 tree left, tree right,
+						 Location, Bvariable *receiver);
 
   tree comparison_expression (ComparisonOperator op, tree left, tree right,
 			      Location);
@@ -1380,25 +1385,26 @@ Gcc_backend::negation_expression (NegationOperator op, tree expr_tree,
   return new_tree;
 }
 
-// Return an expression for the arithmetic or logical operation LEFT OP RIGHT.
 tree
 Gcc_backend::arithmetic_or_logical_expression (ArithmeticOrLogicalOperator op,
-					       tree left_tree, tree right_tree,
+					       tree left, tree right,
 					       Location location)
 {
   /* Check if either expression is an error, in which case we return an error
      expression. */
-  if (left_tree == error_mark_node || right_tree == error_mark_node)
+  if (left == error_mark_node || right == error_mark_node)
     return error_mark_node;
 
   /* We need to determine if we're doing floating point arithmetics of integer
      arithmetics. */
-  bool floating_point = is_floating_point (left_tree);
+  bool floating_point = is_floating_point (left);
+  auto ret = NULL_TREE;
 
   /* For arithmetic or logical operators, the resulting type should be the same
      as the lhs operand. */
-  auto tree_type = TREE_TYPE (left_tree);
+  auto tree_type = TREE_TYPE (left);
   auto original_type = tree_type;
+  auto loc = location.gcc_location ();
   auto tree_code = operator_to_tree_code (op, floating_point);
 
   /* For floating point operations we may need to extend the precision of type.
@@ -1409,21 +1415,127 @@ Gcc_backend::arithmetic_or_logical_expression (ArithmeticOrLogicalOperator op,
       extended_type = excess_precision_type (tree_type);
       if (extended_type != NULL_TREE)
 	{
-	  left_tree = convert (extended_type, left_tree);
-	  right_tree = convert (extended_type, right_tree);
+	  left = convert (extended_type, left);
+	  right = convert (extended_type, right);
 	  tree_type = extended_type;
 	}
     }
 
-  /* Construct a new tree and build an expression from it. */
-  auto new_tree = fold_build2_loc (location.gcc_location (), tree_code,
-				   tree_type, left_tree, right_tree);
-  TREE_CONSTANT (new_tree)
-    = TREE_CONSTANT (left_tree) && TREE_CONSTANT (right_tree);
+  ret = fold_build2_loc (loc, tree_code, tree_type, left, right);
+  TREE_CONSTANT (ret) = TREE_CONSTANT (left) & TREE_CONSTANT (right);
 
+  // TODO: How do we handle floating point?
   if (floating_point && extended_type != NULL_TREE)
-    new_tree = convert (original_type, new_tree);
-  return new_tree;
+    ret = convert (original_type, ret);
+
+  return ret;
+}
+
+static bool
+is_overflowing_expr (ArithmeticOrLogicalOperator op)
+{
+  switch (op)
+    {
+    case ArithmeticOrLogicalOperator::ADD:
+    case ArithmeticOrLogicalOperator::SUBTRACT:
+    case ArithmeticOrLogicalOperator::MULTIPLY:
+      return true;
+    default:
+      return false;
+    }
+}
+
+static std::pair<tree, tree>
+fetch_overflow_builtins (ArithmeticOrLogicalOperator op)
+{
+  auto builtin_ctx = Rust::Compile::BuiltinsContext::get ();
+
+  auto builtin = NULL_TREE;
+  auto abort = NULL_TREE;
+
+  switch (op)
+    {
+    case ArithmeticOrLogicalOperator::ADD:
+      builtin_ctx.lookup_simple_builtin ("add_overflow", &builtin);
+      break;
+    case ArithmeticOrLogicalOperator::SUBTRACT:
+      builtin_ctx.lookup_simple_builtin ("sub_overflow", &builtin);
+      break;
+    case ArithmeticOrLogicalOperator::MULTIPLY:
+      builtin_ctx.lookup_simple_builtin ("mul_overflow", &builtin);
+      break;
+    default:
+      gcc_unreachable ();
+      break;
+    };
+
+  builtin_ctx.lookup_simple_builtin ("abort", &abort);
+
+  rust_assert (abort);
+  rust_assert (builtin);
+
+  // FIXME: ARTHUR: This is really ugly. The builtin context should take care of
+  // that
+  TREE_SIDE_EFFECTS (abort) = 1;
+  TREE_READONLY (abort) = 0;
+
+  // FIXME: ARTHUR: Same here. Remove these!
+  TREE_SIDE_EFFECTS (builtin) = 1;
+  TREE_READONLY (builtin) = 0;
+
+  return {abort, builtin};
+}
+
+// Return an expression for the arithmetic or logical operation LEFT OP RIGHT
+// with overflow checking when possible
+tree
+Gcc_backend::arithmetic_or_logical_expression_checked (
+  ArithmeticOrLogicalOperator op, tree left, tree right, Location location,
+  Bvariable *receiver_var)
+{
+  /* Check if either expression is an error, in which case we return an error
+     expression. */
+  if (left == error_mark_node || right == error_mark_node)
+    return error_mark_node;
+
+  auto loc = location.gcc_location ();
+
+  // FIXME: Add `if (!debug_mode)`
+  // No overflow checks for floating point operations or divisions. In that
+  // case, simply assign the result of the operation to the receiver variable
+  if (is_floating_point (left) || !is_overflowing_expr (op))
+    return assignment_statement (
+      receiver_var->get_tree (location),
+      arithmetic_or_logical_expression (op, left, right, location), location);
+
+  auto receiver = receiver_var->get_tree (location);
+  TREE_ADDRESSABLE (receiver) = 1;
+  auto result_ref = build_fold_addr_expr_loc (loc, receiver);
+
+  auto builtins = fetch_overflow_builtins (op);
+  auto abort = builtins.first;
+  auto builtin = builtins.second;
+
+  auto abort_call = build_call_expr_loc (loc, abort, 0);
+
+  // FIXME: ARTHUR: Is that needed?
+  TREE_SIDE_EFFECTS (abort_call) = 1;
+  TREE_READONLY (abort_call) = 0;
+
+  auto builtin_call
+    = build_call_expr_loc (loc, builtin, 3, left, right, result_ref);
+  auto overflow_check
+    = build2_loc (loc, EQ_EXPR, boolean_type_node, builtin_call,
+		  boolean_constant_expression (true));
+
+  auto if_block = build3_loc (loc, COND_EXPR, void_type_node, overflow_check,
+			      abort_call, NULL_TREE);
+
+  // FIXME: ARTHUR: Needed?
+  TREE_SIDE_EFFECTS (if_block) = 1;
+  TREE_READONLY (if_block) = 0;
+
+  return if_block;
 }
 
 // Return an expression for the comparison operation LEFT OP RIGHT.

--- a/gcc/rust/rust-gcc.h
+++ b/gcc/rust/rust-gcc.h
@@ -1,0 +1,58 @@
+// rust-gcc.cc -- Rust frontend to gcc IR.
+// Copyright (C) 2011-2022 Free Software Foundation, Inc.
+// Contributed by Ian Lance Taylor, Google.
+// forked from gccgo
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-system.h"
+
+// This has to be included outside of extern "C", so we have to
+// include it here before tree.h includes it later.
+#include <gmp.h>
+
+#include "tree.h"
+#include "rust-location.h"
+
+// TODO: this will have to be significantly modified to work with Rust
+
+// Bvariable is a bit more complicated, because of zero-sized types.
+// The GNU linker does not permit dynamic variables with zero size.
+// When we see such a variable, we generate a version of the type with
+// non-zero size.  However, when referring to the global variable, we
+// want an expression of zero size; otherwise, if, say, the global
+// variable is passed to a function, we will be passing a
+// non-zero-sized value to a zero-sized value, which can lead to a
+// miscompilation.
+
+class Bvariable
+{
+public:
+  Bvariable (tree t) : t_ (t), orig_type_ (NULL) {}
+
+  Bvariable (tree t, tree orig_type) : t_ (t), orig_type_ (orig_type) {}
+
+  // Get the tree for use as an expression.
+  tree get_tree (Location) const;
+
+  // Get the actual decl;
+  tree get_decl () const { return this->t_; }
+
+private:
+  tree t_;
+  tree orig_type_;
+};

--- a/gcc/testsuite/rust/debug/win64-abi.rs
+++ b/gcc/testsuite/rust/debug/win64-abi.rs
@@ -1,11 +1,11 @@
 // { dg-do compile { target { x86_64-*-* } } }
 // { dg-options "-gdwarf-5 -dA -w -O1 -m64" }
-pub extern "win64" fn square(num: i32) -> i32 {
-    num * num
+pub extern "win64" fn id(num: i32) -> i32 {
+    num
 }
 
 fn main() {
     // MS ABI dictates that the first argument is ecx instead of edi from the sysv world
-    // { dg-final { scan-assembler "%ecx, %ecx" } }
-    square(1);
+    // { dg-final { scan-assembler "%ecx, %eax" } }
+    id(1);
 }

--- a/gcc/testsuite/rust/execute/torture/macro-issue1426.rs
+++ b/gcc/testsuite/rust/execute/torture/macro-issue1426.rs
@@ -1,5 +1,3 @@
-// { dg-additional-options -fdump-tree-ccp1-raw }
-
 macro_rules! stmt {
     ($s:stmt) => {
         $s
@@ -22,11 +20,10 @@ pub fn test() -> i32 {
         let e = 5,
         let f = b + c + d + e
     );
+
     f
-    // { dg-final { scan-tree-dump-times {gimple_return <14>} 1 ccp1 { target __OPTIMIZE__ } } }
 }
 
-fn main() {
-    let _ = test();
+fn main() -> i32 {
+    test() - 14
 }
-

--- a/gcc/testsuite/rust/execute/torture/overflow1.rs
+++ b/gcc/testsuite/rust/execute/torture/overflow1.rs
@@ -1,0 +1,20 @@
+// { dg-shouldfail "i8 overflow" }
+// { dg-options "-fdump-tree-original" }
+
+fn five() -> i8 {
+    5
+}
+
+extern "C" {
+    fn printf(fmt: *const i8, ...);
+}
+
+fn main() {
+    let a = 127i8;
+    let b = five();
+
+    // { dg-final { scan-tree-dump ADD_OVERFLOW original } }
+    let c = a + b;
+
+    unsafe { printf("%d\n\0" as *const str as *const i8, c) }
+}


### PR DESCRIPTION
Opening as a draft since the code is really ugly and some tests still fail. I am looking for feedback on the implementation and my approximative use of functions like `temporary_variable` which I feel I might be using the wrong way.

I'll open up an issue of what still needs to be done, namely:
- [x] Properly handle sub and mul operations
- [ ] Disable the check in `release` mode (`-frust-disable-overflow-checks`)
- [ ] Handle specific rust overflow attribute (needs checkup on the name)

I'll open up some PRs to clean up some parts of the backend as well.