### PR TITLE
Create canonical process of compiling constant items

### DIFF
--- a/gcc/rust/backend/rust-tree.cc
+++ b/gcc/rust/backend/rust-tree.cc
@@ -2916,27 +2916,7 @@ comptypes (tree t1, tree t2, int strict)
 	   perform a deep check. */
 	return structural_comptypes (t1, t2, strict);
 
-      if (flag_checking && param_use_canonical_types)
-	{
-	  bool result = structural_comptypes (t1, t2, strict);
-
-	  if (result && TYPE_CANONICAL (t1) != TYPE_CANONICAL (t2))
-	    /* The two types are structurally equivalent, but their
-	       canonical types were different. This is a failure of the
-	       canonical type propagation code.*/
-	    internal_error (
-	      "canonical types differ for identical types %qT and %qT", t1, t2);
-	  else if (!result && TYPE_CANONICAL (t1) == TYPE_CANONICAL (t2))
-	    /* Two types are structurally different, but the canonical
-	       types are the same. This means we were over-eager in
-	       assigning canonical types. */
-	    internal_error (
-	      "same canonical type node for different types %qT and %qT", t1,
-	      t2);
-
-	  return result;
-	}
-      if (!flag_checking && param_use_canonical_types)
+      if (!flag_checking)
 	return TYPE_CANONICAL (t1) == TYPE_CANONICAL (t2);
       else
 	return structural_comptypes (t1, t2, strict);


### PR DESCRIPTION
In order to compile a block expression constant, the simplest way for us
was to reuse what code we have and to generate an artifical function which
does not get added to the translation unit. The constant then becomes
a CALL_EXPR to this artifical function which we can pass to the constexpr
evaluator to resolve the result of this artifical 'CALL_EXPR'.

Before this patch we seperated the difference between block expressions
and non block expressions in constants. So for non block expressions we
simply compiled them as if it was a simple constant but this is not
guaranteed to be the case in rust, for example coercion sites can generate
temporaries during autoderef which we let the constant evaluator resolve
for us. This makes all constants handled in the same way to simplify the
logic here.