### PR TITLE
lint: Do not emit unused warnings for public items

### DIFF
--- a/gcc/rust/checks/lints/rust-lint-scan-deadcode.h
+++ b/gcc/rust/checks/lints/rust-lint-scan-deadcode.h
@@ -53,7 +53,7 @@ public:
   void visit (HIR::Function &function) override
   {
     HirId hirId = function.get_mappings ().get_hirid ();
-    if (should_warn (hirId))
+    if (should_warn (hirId) && !function.get_visibility ().is_public ())
       {
 	if (mappings->is_impl_item (hirId))
 	  {
@@ -78,7 +78,7 @@ public:
   void visit (HIR::StructStruct &stct) override
   {
     HirId hirId = stct.get_mappings ().get_hirid ();
-    if (should_warn (hirId))
+    if (should_warn (hirId) && !stct.get_visibility ().is_public ())
       {
 	bool name_starts_underscore = stct.get_identifier ().at (0) == '_';
 	if (!name_starts_underscore)
@@ -92,7 +92,8 @@ public:
 	for (auto &field : stct.get_fields ())
 	  {
 	    HirId field_hir_id = field.get_mappings ().get_hirid ();
-	    if (should_warn (field_hir_id))
+	    if (should_warn (field_hir_id)
+		&& !field.get_visibility ().is_public ())
 	      {
 		rust_warning_at (field.get_locus (), 0,
 				 "field is never read: %<%s%>",
@@ -106,7 +107,7 @@ public:
   {
     // only warn tuple struct unconstructed, and ignoring unused field
     HirId hirId = stct.get_mappings ().get_hirid ();
-    if (should_warn (hirId))
+    if (should_warn (hirId) && !stct.get_visibility ().is_public ())
       {
 	rust_warning_at (stct.get_locus (), 0,
 			 "struct is never constructed: %<%s%>",

--- a/gcc/testsuite/rust/compile/issue-1031.rs
+++ b/gcc/testsuite/rust/compile/issue-1031.rs
@@ -6,12 +6,10 @@ extern "rust-intrinsic" {
 #[lang = "const_ptr"]
 impl<T> *const T {
     pub const unsafe fn offset(self, count: isize) -> *const T {
-        // { dg-warning "associated function is never used" "" { target *-*-* } .-1 }
         unsafe { offset(self, count) }
     }
 
     pub const unsafe fn add(self, count: usize) -> Self {
-        // { dg-warning "associated function is never used" "" { target *-*-* } .-1 }
         unsafe { self.offset(count as isize) }
     }
 }

--- a/gcc/testsuite/rust/compile/issue-1289.rs
+++ b/gcc/testsuite/rust/compile/issue-1289.rs
@@ -23,12 +23,10 @@ impl<T> *mut T {
 #[lang = "const_ptr"]
 impl<T> *const T {
     pub const unsafe fn offset(self, count: isize) -> *mut T {
-        // { dg-warning "associated function is never used" "" { target *-*-* } .-1 }
         unsafe { intrinsics::offset(self, count) as *mut T }
     }
 
     pub const unsafe fn add(self, count: usize) -> Self {
-        // { dg-warning "associated function is never used" "" { target *-*-* } .-1 }
         unsafe { self.offset(count as isize) }
     }
 }

--- a/gcc/testsuite/rust/compile/privacy7.rs
+++ b/gcc/testsuite/rust/compile/privacy7.rs
@@ -1,0 +1,9 @@
+pub struct Foo(i8);
+struct Bar(pub i8); // { dg-warning "struct is never constructed: .Bar." }
+pub struct Baz {
+    a: i32, // { dg-warning "field is never read: .a." }
+    pub b: i32,
+}
+
+pub fn foo() {}
+fn bar() {} // { dg-warning "function is never used: .bar." }

--- a/gcc/testsuite/rust/compile/test_mod.rs
+++ b/gcc/testsuite/rust/compile/test_mod.rs
@@ -3,4 +3,3 @@
 //! foo bar baz cake pizza carbs
 
 pub struct Test(pub i32);
-// { dg-warning "struct is never constructed" "" { target *-*-* } .-1 }

--- a/gcc/testsuite/rust/compile/torture/raw_identifiers.rs
+++ b/gcc/testsuite/rust/compile/torture/raw_identifiers.rs
@@ -1,3 +1,3 @@
-pub fn square(num: i32) -> i32 { /* { dg-warning "used" } */
+pub fn square(num: i32) -> i32 {
     r#num * num
 }

--- a/gcc/testsuite/rust/compile/torture/raw_identifiers_keywords.rs
+++ b/gcc/testsuite/rust/compile/torture/raw_identifiers_keywords.rs
@@ -1,3 +1,3 @@
-pub fn plus(r#break: i32, r#unsafe: i32) -> i32 { /* { dg-warning "used" } */
+pub fn plus(r#break: i32, r#unsafe: i32) -> i32 {
     r#break + r#unsafe
 }


### PR DESCRIPTION
This fixes the overzealous warnings on public items from the unused pass