### PR TITLE
Fix SEGV in transcribe_type when compiling libcore 1.29

### DIFF
--- a/gcc/rust/ast/rust-ast-dump.h
+++ b/gcc/rust/ast/rust-ast-dump.h
@@ -52,6 +52,22 @@ public:
   void go (AST::Crate &crate);
   void go (AST::Item &item);
 
+  /**
+   * Use the AST Dump as a debugging tool
+   */
+  template <typename T> static void debug (T &instance)
+  {
+    auto dump = Dump (std::cerr);
+
+    std::cerr << '\n';
+    instance.accept_vis (dump);
+    std::cerr << '\n';
+  }
+  template <typename T> static void debug (std::unique_ptr<T> &instance)
+  {
+    debug (*instance);
+  }
+
 private:
   std::ostream &stream;
   Indent indentation;

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -24,6 +24,7 @@
 #include "rust-hir-map.h"
 #include "rust-token.h"
 #include "rust-location.h"
+#include "rust-diagnostics.h"
 
 namespace Rust {
 // TODO: remove typedefs and make actual types for these
@@ -1868,6 +1869,10 @@ private:
    */
 
   bool is_single_fragment () const { return nodes.size () == 1; }
+  bool is_single_fragment (SingleASTNode::NodeType expected) const
+  {
+    return is_single_fragment () && nodes[0].get_kind () == expected;
+  }
 
   bool is_single_fragment_kind (SingleASTNode::NodeType kind) const
   {
@@ -1912,6 +1917,16 @@ public:
   bool is_error () const { return fragment_is_error; }
 
   bool should_expand () const { return !is_error (); }
+
+  bool is_expression_fragment () const
+  {
+    return is_single_fragment (SingleASTNode::NodeType::EXPRESSION);
+  }
+
+  bool is_type_fragment () const
+  {
+    return is_single_fragment (SingleASTNode::NodeType::TYPE);
+  }
 
   std::unique_ptr<Expr> take_expression_fragment ()
   {

--- a/gcc/rust/expand/rust-attribute-visitor.cc
+++ b/gcc/rust/expand/rust-attribute-visitor.cc
@@ -2662,7 +2662,7 @@ AttrVisitor::visit (AST::InherentImpl &impl)
   for (auto &param : impl.get_generic_params ())
     param->accept_vis (*this);
 
-  expander.push_context (MacroExpander::ContextType::TYPE);
+  expander.push_context (MacroExpander::ContextType::ITEM);
 
   auto &type = impl.get_type ();
   type->accept_vis (*this);
@@ -2706,7 +2706,7 @@ AttrVisitor::visit (AST::TraitImpl &impl)
   for (auto &param : impl.get_generic_params ())
     param->accept_vis (*this);
 
-  expander.push_context (MacroExpander::ContextType::TYPE);
+  expander.push_context (MacroExpander::ContextType::ITEM);
 
   auto &type = impl.get_type ();
   type->accept_vis (*this);
@@ -3427,11 +3427,13 @@ AttrVisitor::visit (AST::BareFunctionType &type)
 
   // no where clause, apparently
 }
+
 void
 AttrVisitor::maybe_expand_expr (std::unique_ptr<AST::Expr> &expr)
 {
   auto final_fragment = expand_macro_fragment_recursive ();
-  if (final_fragment.should_expand ())
+  if (final_fragment.should_expand ()
+      && final_fragment.is_expression_fragment ())
     expr = final_fragment.take_expression_fragment ();
 }
 
@@ -3439,7 +3441,8 @@ void
 AttrVisitor::maybe_expand_type (std::unique_ptr<AST::Type> &type)
 {
   auto final_fragment = expand_macro_fragment_recursive ();
-  if (final_fragment.should_expand ())
+  if (final_fragment.should_expand () && final_fragment.is_type_fragment ())
     type = final_fragment.take_type_fragment ();
 }
+
 } // namespace Rust

--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -864,7 +864,9 @@ transcribe_expression (Parser<MacroInvocLexer> &parser)
 static AST::ASTFragment
 transcribe_type (Parser<MacroInvocLexer> &parser)
 {
-  auto type = parser.parse_type ();
+  auto type = parser.parse_type (true);
+  for (auto err : parser.get_errors ())
+    err.emit_error ();
 
   return AST::ASTFragment ({std::move (type)});
 }


### PR DESCRIPTION
Needs #1513, Skip reviewing the first commit