### PR TITLE
parser: Parse RangeFullExpr without erroring out

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -14102,9 +14102,13 @@ std::unique_ptr<AST::RangeExpr>
 Parser<ManagedTokenSource>::parse_nud_range_exclusive_expr (
   const_TokenPtr tok, AST::AttrVec outer_attrs ATTRIBUTE_UNUSED)
 {
+  auto restrictions = ParseRestrictions ();
+  restrictions.expr_can_be_null = true;
+
   // FIXME: this probably parses expressions accidently or whatever
   // try parsing RHS (as tok has already been consumed in parse_expression)
-  std::unique_ptr<AST::Expr> right = parse_expr (LBP_DOT_DOT, AST::AttrVec ());
+  std::unique_ptr<AST::Expr> right
+    = parse_expr (LBP_DOT_DOT, AST::AttrVec (), restrictions);
 
   Location locus = tok->get_locus ();
 

--- a/gcc/testsuite/rust/compile/parse_range.rs
+++ b/gcc/testsuite/rust/compile/parse_range.rs
@@ -1,0 +1,9 @@
+// { dg-additional-options "-fsyntax-only" }
+
+fn main() {
+    let a = [1, 2, 3, 4];
+    let _ = a[0..];
+    let _ = a[..3];
+    let _ = a[0..3];
+    let _ = a[..];
+}


### PR DESCRIPTION
Previously the parser would emit the errors despite later allowing the parsed expression to be null.