### PR TITLE
Refactor error handling on unify

### DIFF
--- a/gcc/rust/typecheck/rust-autoderef.cc
+++ b/gcc/rust/typecheck/rust-autoderef.cc
@@ -255,7 +255,12 @@ resolve_operator_overload_fn (
 	  lookup = fn->infer_substitions (Location ());
 	  rust_assert (lookup->get_kind () == TyTy::TypeKind::FNDEF);
 	  fn = static_cast<TyTy::FnType *> (lookup);
-	  fn->get_self_type ()->unify (adjusted_self);
+
+	  Location unify_locus = mappings->lookup_location (ty->get_ref ());
+	  TypeCheckBase::unify_site (
+	    ty->get_ref (), TyTy::TyWithLocation (fn->get_self_type ()),
+	    TyTy::TyWithLocation (adjusted_self), unify_locus);
+
 	  lookup = fn;
 	}
     }
@@ -284,6 +289,7 @@ AutoderefCycle::cycle (const TyTy::BaseType *receiver)
   const TyTy::BaseType *r = receiver;
   while (true)
     {
+      rust_debug ("autoderef try 1: {%s}", r->debug_str ().c_str ());
       if (try_autoderefed (r))
 	return true;
 
@@ -292,12 +298,15 @@ AutoderefCycle::cycle (const TyTy::BaseType *receiver)
 	return false;
 
       // try unsize
+
       Adjustment unsize = Adjuster::try_unsize_type (r);
       if (!unsize.is_error ())
 	{
 	  adjustments.push_back (unsize);
 	  auto unsize_r = unsize.get_expected ();
 
+	  rust_debug ("autoderef try unsize: {%s}",
+		      unsize_r->debug_str ().c_str ());
 	  if (try_autoderefed (unsize_r))
 	    return true;
 
@@ -311,6 +320,8 @@ AutoderefCycle::cycle (const TyTy::BaseType *receiver)
 	  auto deref_r = deref.get_expected ();
 	  adjustments.push_back (deref);
 
+	  rust_debug ("autoderef try lang-item DEREF: {%s}",
+		      deref_r->debug_str ().c_str ());
 	  if (try_autoderefed (deref_r))
 	    return true;
 
@@ -324,6 +335,8 @@ AutoderefCycle::cycle (const TyTy::BaseType *receiver)
 	  auto deref_r = deref_mut.get_expected ();
 	  adjustments.push_back (deref_mut);
 
+	  rust_debug ("autoderef try lang-item DEREF_MUT: {%s}",
+		      deref_r->debug_str ().c_str ());
 	  if (try_autoderefed (deref_r))
 	    return true;
 

--- a/gcc/rust/typecheck/rust-hir-dot-operator.cc
+++ b/gcc/rust/typecheck/rust-hir-dot-operator.cc
@@ -171,12 +171,21 @@ MethodResolver::select (const TyTy::BaseType &receiver)
     TyTy::FnType *fntype;
   };
 
+  rust_debug ("inherent_impl_fns found {%lu}, trait_fns found {%lu}, "
+	      "predicate_items found {%lu}",
+	      (unsigned long) inherent_impl_fns.size (),
+	      (unsigned long) trait_fns.size (),
+	      (unsigned long) predicate_items.size ());
+
   for (auto impl_item : inherent_impl_fns)
     {
       TyTy::FnType *fn = impl_item.ty;
       rust_assert (fn->is_method ());
 
       TyTy::BaseType *fn_self = fn->get_self_type ();
+      rust_debug ("dot-operator impl_item fn_self={%s} can_eq receiver={%s}",
+		  fn_self->debug_str ().c_str (),
+		  receiver.debug_str ().c_str ());
       if (fn_self->can_eq (&receiver, false))
 	{
 	  PathProbeCandidate::ImplItemCandidate c{impl_item.item,
@@ -195,6 +204,9 @@ MethodResolver::select (const TyTy::BaseType &receiver)
       rust_assert (fn->is_method ());
 
       TyTy::BaseType *fn_self = fn->get_self_type ();
+      rust_debug ("dot-operator trait_item fn_self={%s} can_eq receiver={%s}",
+		  fn_self->debug_str ().c_str (),
+		  receiver.debug_str ().c_str ());
       if (fn_self->can_eq (&receiver, false))
 	{
 	  PathProbeCandidate::TraitItemCandidate c{trait_item.reference,
@@ -214,6 +226,9 @@ MethodResolver::select (const TyTy::BaseType &receiver)
       rust_assert (fn->is_method ());
 
       TyTy::BaseType *fn_self = fn->get_self_type ();
+      rust_debug ("dot-operator predicate fn_self={%s} can_eq receiver={%s}",
+		  fn_self->debug_str ().c_str (),
+		  receiver.debug_str ().c_str ());
       if (fn_self->can_eq (&receiver, false))
 	{
 	  const TraitReference *trait_ref

--- a/gcc/rust/typecheck/rust-hir-type-check-base.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.cc
@@ -25,6 +25,11 @@
 namespace Rust {
 namespace Resolver {
 
+TypeCheckBase::TypeCheckBase ()
+  : mappings (Analysis::Mappings::get ()), resolver (Resolver::get ()),
+    context (TypeCheckContext::get ())
+{}
+
 bool
 TypeCheckBase::check_for_unconstrained (
   const std::vector<TyTy::SubstitutionParamMapping> &params_to_constrain,
@@ -332,9 +337,12 @@ TypeCheckBase::parse_repr_options (const AST::AttrVec &attrs, Location locus)
 }
 
 TyTy::BaseType *
-TypeCheckBase::coercion_site (HirId id, TyTy::BaseType *expected,
-			      TyTy::BaseType *expr, Location locus)
+TypeCheckBase::coercion_site (HirId id, TyTy::TyWithLocation lhs,
+			      TyTy::TyWithLocation rhs, Location locus)
 {
+  TyTy::BaseType *expected = lhs.get_ty ();
+  TyTy::BaseType *expr = rhs.get_ty ();
+
   rust_debug ("coercion_site id={%u} expected={%s} expr={%s}", id,
 	      expected->debug_str ().c_str (), expr->debug_str ().c_str ());
 

--- a/gcc/rust/typecheck/rust-hir-type-check-base.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.h
@@ -34,6 +34,10 @@ class TypeCheckBase
 public:
   virtual ~TypeCheckBase () {}
 
+  static TyTy::BaseType *unify_site (HirId id, TyTy::TyWithLocation lhs,
+				     TyTy::TyWithLocation rhs,
+				     Location unify_locus);
+
   static TyTy::BaseType *coercion_site (HirId id, TyTy::TyWithLocation lhs,
 					TyTy::TyWithLocation rhs,
 					Location coercion_locus);

--- a/gcc/rust/typecheck/rust-hir-type-check-base.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.h
@@ -24,7 +24,6 @@
 #include "rust-name-resolver.h"
 #include "rust-hir-visitor.h"
 #include "rust-hir-map.h"
-#include "rust-backend.h"
 
 namespace Rust {
 namespace Resolver {
@@ -35,8 +34,8 @@ class TypeCheckBase
 public:
   virtual ~TypeCheckBase () {}
 
-  static TyTy::BaseType *coercion_site (HirId id, TyTy::BaseType *lhs,
-					TyTy::BaseType *rhs,
+  static TyTy::BaseType *coercion_site (HirId id, TyTy::TyWithLocation lhs,
+					TyTy::TyWithLocation rhs,
 					Location coercion_locus);
 
   static TyTy::BaseType *cast_site (HirId id, TyTy::TyWithLocation from,
@@ -44,10 +43,7 @@ public:
 				    Location cast_locus);
 
 protected:
-  TypeCheckBase ()
-    : mappings (Analysis::Mappings::get ()), resolver (Resolver::get ()),
-      context (TypeCheckContext::get ())
-  {}
+  TypeCheckBase ();
 
   TraitReference *resolve_trait_path (HIR::TypePath &);
 

--- a/gcc/rust/typecheck/rust-hir-type-check-enumitem.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-enumitem.cc
@@ -129,7 +129,8 @@ TypeCheckEnumItem::visit (HIR::EnumItemTuple &item)
 	= TypeCheckType::Resolve (field.get_field_type ().get ());
       TyTy::StructFieldType *ty_field
 	= new TyTy::StructFieldType (field.get_mappings ().get_hirid (),
-				     std::to_string (idx), field_type);
+				     std::to_string (idx), field_type,
+				     field.get_locus ());
       fields.push_back (ty_field);
       context->insert_type (field.get_mappings (), ty_field->get_field_type ());
       idx++;
@@ -176,7 +177,8 @@ TypeCheckEnumItem::visit (HIR::EnumItemStruct &item)
 	= TypeCheckType::Resolve (field.get_field_type ().get ());
       TyTy::StructFieldType *ty_field
 	= new TyTy::StructFieldType (field.get_mappings ().get_hirid (),
-				     field.get_field_name (), field_type);
+				     field.get_field_name (), field_type,
+				     field.get_locus ());
       fields.push_back (ty_field);
       context->insert_type (field.get_mappings (), ty_field->get_field_type ());
     }

--- a/gcc/rust/typecheck/rust-hir-type-check-enumitem.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-enumitem.cc
@@ -100,9 +100,9 @@ TypeCheckEnumItem::visit (HIR::EnumItemDiscriminant &item)
     = new TyTy::ISizeType (discriminant->get_mappings ().get_hirid ());
   context->insert_type (discriminant->get_mappings (), expected_ty);
 
-  auto unified = expected_ty->unify (capacity_type);
-  if (unified->get_kind () == TyTy::TypeKind::ERROR)
-    return;
+  unify_site (item.get_mappings ().get_hirid (),
+	      TyTy::TyWithLocation (expected_ty),
+	      TyTy::TyWithLocation (capacity_type), item.get_locus ());
 
   const CanonicalPath *canonical_path = nullptr;
   bool ok = mappings->lookup_canonical_path (item.get_mappings ().get_nodeid (),

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -224,7 +224,9 @@ TypeCheckExpr::visit (HIR::AssignmentExpr &expr)
   auto lhs = TypeCheckExpr::Resolve (expr.get_lhs ());
   auto rhs = TypeCheckExpr::Resolve (expr.get_rhs ());
 
-  coercion_site (expr.get_mappings ().get_hirid (), lhs, rhs,
+  coercion_site (expr.get_mappings ().get_hirid (),
+		 TyTy::TyWithLocation (lhs, expr.get_lhs ()->get_locus ()),
+		 TyTy::TyWithLocation (rhs, expr.get_rhs ()->get_locus ()),
 		 expr.get_locus ());
 }
 

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -25,7 +25,7 @@
 namespace Rust {
 namespace Resolver {
 
-class TypeCheckExpr : public TypeCheckBase, private HIR::HIRExpressionVisitor
+class TypeCheckExpr : private TypeCheckBase, private HIR::HIRExpressionVisitor
 {
 public:
   static TyTy::BaseType *Resolve (HIR::Expr *expr);

--- a/gcc/rust/typecheck/rust-hir-type-check-item.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.cc
@@ -214,10 +214,15 @@ TypeCheckItem::visit (HIR::Function &function)
   auto block_expr_ty
     = TypeCheckExpr::Resolve (function.get_definition ().get ());
 
-  context->pop_return_type ();
+  Location fn_return_locus = function.has_function_return_type ()
+			       ? function.get_return_type ()->get_locus ()
+			       : function.get_locus ();
+  coercion_site (function.get_definition ()->get_mappings ().get_hirid (),
+		 TyTy::TyWithLocation (expected_ret_tyty, fn_return_locus),
+		 TyTy::TyWithLocation (block_expr_ty),
+		 function.get_definition ()->get_locus ());
 
-  if (block_expr_ty->get_kind () != TyTy::NEVER)
-    expected_ret_tyty->unify (block_expr_ty);
+  context->pop_return_type ();
 }
 
 void

--- a/gcc/rust/typecheck/rust-hir-type-check-path.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-path.cc
@@ -390,7 +390,10 @@ TypeCheckExpr::resolve_segments (NodeId root_resolved_node_id,
 	    impl_block_ty
 	      = SubstMapper::InferSubst (impl_block_ty, seg.get_locus ());
 
-	  prev_segment = prev_segment->unify (impl_block_ty);
+	  prev_segment = unify_site (seg.get_mappings ().get_hirid (),
+				     TyTy::TyWithLocation (prev_segment),
+				     TyTy::TyWithLocation (impl_block_ty),
+				     seg.get_locus ());
 	}
 
       if (tyseg->needs_generic_substitutions ())

--- a/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
@@ -375,7 +375,9 @@ TypeCheckPattern::visit (HIR::RangePattern &pattern)
       break;
     }
 
-  infered = upper->unify (lower);
+  infered = unify_site (pattern.get_pattern_mappings ().get_hirid (),
+			TyTy::TyWithLocation (upper),
+			TyTy::TyWithLocation (lower), pattern.get_locus ());
 }
 
 void

--- a/gcc/rust/typecheck/rust-hir-type-check-struct.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-struct.cc
@@ -252,9 +252,15 @@ TypeCheckStructExpr::visit (HIR::StructExprFieldIdentifierValue &field)
     }
 
   TyTy::BaseType *value = TypeCheckExpr::Resolve (field.get_value ());
+  Location value_locus = field.get_value ()->get_locus ();
+
+  HirId coercion_site_id = field.get_mappings ().get_hirid ();
   resolved_field_value_expr
-    = coercion_site (field.get_mappings ().get_hirid (),
-		     field_type->get_field_type (), value, field.get_locus ());
+    = coercion_site (coercion_site_id,
+		     TyTy::TyWithLocation (field_type->get_field_type (),
+					   field_type->get_locus ()),
+		     TyTy::TyWithLocation (value, value_locus),
+		     field.get_locus ());
   if (resolved_field_value_expr != nullptr)
     {
       fields_assigned.insert (field.field_name);
@@ -283,9 +289,15 @@ TypeCheckStructExpr::visit (HIR::StructExprFieldIndexValue &field)
     }
 
   TyTy::BaseType *value = TypeCheckExpr::Resolve (field.get_value ());
+  Location value_locus = field.get_value ()->get_locus ();
+
+  HirId coercion_site_id = field.get_mappings ().get_hirid ();
   resolved_field_value_expr
-    = coercion_site (field.get_mappings ().get_hirid (),
-		     field_type->get_field_type (), value, field.get_locus ());
+    = coercion_site (coercion_site_id,
+		     TyTy::TyWithLocation (field_type->get_field_type (),
+					   field_type->get_locus ()),
+		     TyTy::TyWithLocation (value, value_locus),
+		     field.get_locus ());
   if (resolved_field_value_expr != nullptr)
     {
       fields_assigned.insert (field_name);
@@ -324,10 +336,15 @@ TypeCheckStructExpr::visit (HIR::StructExprFieldIdentifier &field)
   HIR::PathInExpression expr (mappings_copy2, {seg}, field.get_locus (), false,
 			      {});
   TyTy::BaseType *value = TypeCheckExpr::Resolve (&expr);
+  Location value_locus = expr.get_locus ();
 
+  HirId coercion_site_id = field.get_mappings ().get_hirid ();
   resolved_field_value_expr
-    = coercion_site (field.get_mappings ().get_hirid (),
-		     field_type->get_field_type (), value, field.get_locus ());
+    = coercion_site (coercion_site_id,
+		     TyTy::TyWithLocation (field_type->get_field_type (),
+					   field_type->get_locus ()),
+		     TyTy::TyWithLocation (value, value_locus),
+		     field.get_locus ());
   if (resolved_field_value_expr != nullptr)
 
     {

--- a/gcc/rust/typecheck/rust-hir-type-check-struct.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-struct.cc
@@ -57,14 +57,20 @@ TypeCheckStructExpr::resolve (HIR::StructExprStructFields &struct_expr)
     {
       TyTy::BaseType *base_resolved
 	= TypeCheckExpr::Resolve (struct_expr.struct_base->base_struct.get ());
-      struct_def = static_cast<TyTy::ADTType *> (
-	struct_path_resolved->unify (base_resolved));
-      if (struct_def == nullptr)
+      TyTy::BaseType *base_unify = unify_site (
+	struct_expr.struct_base->base_struct->get_mappings ().get_hirid (),
+	TyTy::TyWithLocation (struct_path_resolved),
+	TyTy::TyWithLocation (base_resolved),
+	struct_expr.struct_base->base_struct->get_locus ());
+
+      if (base_unify->get_kind () != struct_path_ty->get_kind ())
 	{
 	  rust_fatal_error (struct_expr.struct_base->base_struct->get_locus (),
 			    "incompatible types for base struct reference");
 	  return;
 	}
+
+      struct_def = static_cast<TyTy::ADTType *> (base_unify);
     }
 
   // figure out the variant

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.cc
@@ -260,7 +260,13 @@ TypeCheckTopLevel::visit (HIR::StaticItem &var)
   TyTy::BaseType *type = TypeCheckType::Resolve (var.get_type ());
   TyTy::BaseType *expr_type = TypeCheckExpr::Resolve (var.get_expr ());
 
-  context->insert_type (var.get_mappings (), type->unify (expr_type));
+  TyTy::BaseType *unified
+    = unify_site (var.get_mappings ().get_hirid (),
+		  TyTy::TyWithLocation (type, var.get_type ()->get_locus ()),
+		  TyTy::TyWithLocation (expr_type,
+					var.get_expr ()->get_locus ()),
+		  var.get_locus ());
+  context->insert_type (var.get_mappings (), unified);
 }
 
 void
@@ -269,7 +275,12 @@ TypeCheckTopLevel::visit (HIR::ConstantItem &constant)
   TyTy::BaseType *type = TypeCheckType::Resolve (constant.get_type ());
   TyTy::BaseType *expr_type = TypeCheckExpr::Resolve (constant.get_expr ());
 
-  context->insert_type (constant.get_mappings (), type->unify (expr_type));
+  TyTy::BaseType *unified = unify_site (
+    constant.get_mappings ().get_hirid (),
+    TyTy::TyWithLocation (type, constant.get_type ()->get_locus ()),
+    TyTy::TyWithLocation (expr_type, constant.get_expr ()->get_locus ()),
+    constant.get_locus ());
+  context->insert_type (constant.get_mappings (), unified);
 }
 
 void

--- a/gcc/rust/typecheck/rust-hir-type-check-toplevel.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-toplevel.cc
@@ -72,7 +72,8 @@ TypeCheckTopLevel::visit (HIR::TupleStruct &struct_decl)
 	= TypeCheckType::Resolve (field.get_field_type ().get ());
       TyTy::StructFieldType *ty_field
 	= new TyTy::StructFieldType (field.get_mappings ().get_hirid (),
-				     std::to_string (idx), field_type);
+				     std::to_string (idx), field_type,
+				     field.get_locus ());
       fields.push_back (ty_field);
       context->insert_type (field.get_mappings (), ty_field->get_field_type ());
       idx++;
@@ -132,7 +133,8 @@ TypeCheckTopLevel::visit (HIR::StructStruct &struct_decl)
 	= TypeCheckType::Resolve (field.get_field_type ().get ());
       TyTy::StructFieldType *ty_field
 	= new TyTy::StructFieldType (field.get_mappings ().get_hirid (),
-				     field.get_field_name (), field_type);
+				     field.get_field_name (), field_type,
+				     field.get_locus ());
       fields.push_back (ty_field);
       context->insert_type (field.get_mappings (), ty_field->get_field_type ());
     }
@@ -221,7 +223,8 @@ TypeCheckTopLevel::visit (HIR::Union &union_decl)
 	= TypeCheckType::Resolve (variant.get_field_type ().get ());
       TyTy::StructFieldType *ty_variant
 	= new TyTy::StructFieldType (variant.get_mappings ().get_hirid (),
-				     variant.get_field_name (), variant_type);
+				     variant.get_field_name (), variant_type,
+				     variant.get_locus ());
       fields.push_back (ty_variant);
       context->insert_type (variant.get_mappings (),
 			    ty_variant->get_field_type ());

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -623,9 +623,11 @@ TypeCheckType::visit (HIR::ArrayType &type)
   rust_assert (ok);
   context->insert_type (type.get_size_expr ()->get_mappings (), expected_ty);
 
-  auto unified = expected_ty->unify (capacity_type);
-  if (unified->get_kind () == TyTy::TypeKind::ERROR)
-    return;
+  unify_site (type.get_size_expr ()->get_mappings ().get_hirid (),
+	      TyTy::TyWithLocation (expected_ty),
+	      TyTy::TyWithLocation (capacity_type,
+				    type.get_size_expr ()->get_locus ()),
+	      type.get_size_expr ()->get_locus ());
 
   TyTy::BaseType *base = TypeCheckType::Resolve (type.get_element_type ());
   translated = new TyTy::ArrayType (type.get_mappings ().get_hirid (),

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -70,7 +70,12 @@ TypeResolution::Resolve (HIR::Crate &crate)
       }
     else
       {
-	auto result = ty->unify (default_type);
+	auto result
+	  = TypeCheckBase::unify_site (id, TyTy::TyWithLocation (ty),
+				       TyTy::TyWithLocation (default_type),
+				       Location ());
+	rust_assert (result);
+	rust_assert (result->get_kind () != TyTy::TypeKind::ERROR);
 	result->set_ref (id);
 	context->insert_type (
 	  Analysis::NodeMapping (mappings->get_current_crate (), 0, id,
@@ -144,7 +149,10 @@ TraitItemReference::get_type_from_constant (
       TyTy::BaseType *expr
 	= TypeCheckExpr::Resolve (constant.get_expr ().get ());
 
-      return type->unify (expr);
+      return TypeCheckBase::unify_site (constant.get_mappings ().get_hirid (),
+					TyTy::TyWithLocation (type),
+					TyTy::TyWithLocation (expr),
+					constant.get_locus ());
     }
   return type;
 }

--- a/gcc/rust/typecheck/rust-tyctx.cc
+++ b/gcc/rust/typecheck/rust-tyctx.cc
@@ -129,6 +129,7 @@ TypeCheckContext::lookup_type_by_node_id (NodeId ref, HirId *id)
 TyTy::BaseType *
 TypeCheckContext::peek_return_type ()
 {
+  rust_assert (!return_type_stack.empty ());
   return return_type_stack.back ().second;
 }
 

--- a/gcc/rust/typecheck/rust-tyctx.cc
+++ b/gcc/rust/typecheck/rust-tyctx.cc
@@ -142,12 +142,14 @@ TypeCheckContext::push_return_type (TypeCheckContextItem item,
 void
 TypeCheckContext::pop_return_type ()
 {
+  rust_assert (!return_type_stack.empty ());
   return_type_stack.pop_back ();
 }
 
 TypeCheckContextItem &
 TypeCheckContext::peek_context ()
 {
+  rust_assert (!return_type_stack.empty ());
   return return_type_stack.back ().first;
 }
 

--- a/gcc/rust/typecheck/rust-tyty-call.cc
+++ b/gcc/rust/typecheck/rust-tyty-call.cc
@@ -219,7 +219,10 @@ TypeCheckCallExpr::visit (FnPtr &type)
 void
 TypeCheckMethodCallExpr::visit (FnType &type)
 {
-  type.get_self_type ()->unify (adjusted_self);
+  Resolver::TypeCheckBase::unify_site (
+    call.get_mappings ().get_hirid (), TyWithLocation (type.get_self_type ()),
+    TyWithLocation (adjusted_self, call.get_receiver ()->get_locus ()),
+    call.get_locus ());
 
   // +1 for the receiver self
   size_t num_args_to_call = call.num_params () + 1;

--- a/gcc/rust/typecheck/rust-tyty-cmp.h
+++ b/gcc/rust/typecheck/rust-tyty-cmp.h
@@ -1243,8 +1243,8 @@ public:
     auto base_type = base->get_base ();
     auto other_base_type = type.get_base ();
 
-    bool mutability_match = base->is_mutable () == type.is_mutable ();
-    if (!mutability_match)
+    bool mutability_ok = base->is_mutable () ? type.is_mutable () : true;
+    if (!mutability_ok)
       {
 	BaseCmp::visit (type);
 	return;

--- a/gcc/rust/typecheck/rust-tyty-rules.h
+++ b/gcc/rust/typecheck/rust-tyty-rules.h
@@ -123,269 +123,53 @@ public:
     return resolved;
   }
 
-  virtual void visit (TupleType &type) override
-  {
-    Location ref_locus = mappings->lookup_location (type.get_ref ());
-    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
-    RichLocation r (ref_locus);
-    r.add_range (base_locus);
-    rust_error_at (r, "expected [%s] got [%s]",
-		   get_base ()->as_string ().c_str (),
-		   type.as_string ().c_str ());
-  }
+  virtual void visit (TupleType &type) override {}
 
-  virtual void visit (ADTType &type) override
-  {
-    Location ref_locus = mappings->lookup_location (type.get_ref ());
-    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
-    RichLocation r (ref_locus);
-    r.add_range (base_locus);
-    rust_error_at (r, "expected [%s] got [%s]",
-		   get_base ()->as_string ().c_str (),
-		   type.as_string ().c_str ());
-  }
+  virtual void visit (ADTType &type) override {}
 
-  virtual void visit (InferType &type) override
-  {
-    Location ref_locus = mappings->lookup_location (type.get_ref ());
-    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
-    RichLocation r (ref_locus);
-    r.add_range (base_locus);
-    rust_error_at (r, "expected [%s] got [%s]",
-		   get_base ()->as_string ().c_str (),
-		   type.as_string ().c_str ());
-  }
+  virtual void visit (InferType &type) override {}
 
-  virtual void visit (FnType &type) override
-  {
-    Location ref_locus = mappings->lookup_location (type.get_ref ());
-    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
-    RichLocation r (ref_locus);
-    r.add_range (base_locus);
-    rust_error_at (r, "expected [%s] got [%s]",
-		   get_base ()->as_string ().c_str (),
-		   type.as_string ().c_str ());
-  }
+  virtual void visit (FnType &type) override {}
 
-  virtual void visit (FnPtr &type) override
-  {
-    Location ref_locus = mappings->lookup_location (type.get_ref ());
-    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
-    RichLocation r (ref_locus);
-    r.add_range (base_locus);
-    rust_error_at (r, "expected [%s] got [%s]",
-		   get_base ()->as_string ().c_str (),
-		   type.as_string ().c_str ());
-  }
+  virtual void visit (FnPtr &type) override {}
 
-  virtual void visit (ArrayType &type) override
-  {
-    Location ref_locus = mappings->lookup_location (type.get_ref ());
-    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
-    RichLocation r (ref_locus);
-    r.add_range (base_locus);
-    rust_error_at (r, "expected [%s] got [%s]",
-		   get_base ()->as_string ().c_str (),
-		   type.as_string ().c_str ());
-  }
+  virtual void visit (ArrayType &type) override {}
 
-  virtual void visit (SliceType &type) override
-  {
-    Location ref_locus = mappings->lookup_location (type.get_ref ());
-    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
-    RichLocation r (ref_locus);
-    r.add_range (base_locus);
-    rust_error_at (r, "expected [%s] got [%s]",
-		   get_base ()->as_string ().c_str (),
-		   type.as_string ().c_str ());
-  }
+  virtual void visit (SliceType &type) override {}
 
-  virtual void visit (BoolType &type) override
-  {
-    Location ref_locus = mappings->lookup_location (type.get_ref ());
-    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
-    RichLocation r (ref_locus);
-    r.add_range (base_locus);
-    rust_error_at (r, "expected [%s] got [%s]",
-		   get_base ()->as_string ().c_str (),
-		   type.as_string ().c_str ());
-  }
+  virtual void visit (BoolType &type) override {}
 
-  virtual void visit (IntType &type) override
-  {
-    Location ref_locus = mappings->lookup_location (type.get_ref ());
-    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
-    RichLocation r (ref_locus);
-    r.add_range (base_locus);
-    rust_error_at (r, "expected [%s] got [%s]",
-		   get_base ()->as_string ().c_str (),
-		   type.as_string ().c_str ());
-  }
+  virtual void visit (IntType &type) override {}
 
-  virtual void visit (UintType &type) override
-  {
-    Location ref_locus = mappings->lookup_location (type.get_ref ());
-    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
-    RichLocation r (ref_locus);
-    r.add_range (base_locus);
-    rust_error_at (r, "expected [%s] got [%s]",
-		   get_base ()->as_string ().c_str (),
-		   type.as_string ().c_str ());
-  }
+  virtual void visit (UintType &type) override {}
 
-  virtual void visit (USizeType &type) override
-  {
-    Location ref_locus = mappings->lookup_location (type.get_ref ());
-    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
-    RichLocation r (ref_locus);
-    r.add_range (base_locus);
-    rust_error_at (r, "expected [%s] got [%s]",
-		   get_base ()->as_string ().c_str (),
-		   type.as_string ().c_str ());
-  }
+  virtual void visit (USizeType &type) override {}
 
-  virtual void visit (ISizeType &type) override
-  {
-    Location ref_locus = mappings->lookup_location (type.get_ref ());
-    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
-    RichLocation r (ref_locus);
-    r.add_range (base_locus);
-    rust_error_at (r, "expected [%s] got [%s]",
-		   get_base ()->as_string ().c_str (),
-		   type.as_string ().c_str ());
-  }
+  virtual void visit (ISizeType &type) override {}
 
-  virtual void visit (FloatType &type) override
-  {
-    Location ref_locus = mappings->lookup_location (type.get_ref ());
-    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
-    RichLocation r (ref_locus);
-    r.add_range (base_locus);
-    rust_error_at (r, "expected [%s] got [%s]",
-		   get_base ()->as_string ().c_str (),
-		   type.as_string ().c_str ());
-  }
+  virtual void visit (FloatType &type) override {}
 
-  virtual void visit (ErrorType &type) override
-  {
-    Location ref_locus = mappings->lookup_location (type.get_ref ());
-    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
-    RichLocation r (ref_locus);
-    r.add_range (base_locus);
-    rust_error_at (r, "expected [%s] got [%s]",
-		   get_base ()->as_string ().c_str (),
-		   type.as_string ().c_str ());
-  }
+  virtual void visit (ErrorType &type) override {}
 
-  virtual void visit (CharType &type) override
-  {
-    Location ref_locus = mappings->lookup_location (type.get_ref ());
-    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
-    RichLocation r (ref_locus);
-    r.add_range (base_locus);
-    rust_error_at (r, "expected [%s] got [%s]",
-		   get_base ()->as_string ().c_str (),
-		   type.as_string ().c_str ());
-  }
+  virtual void visit (CharType &type) override {}
 
-  virtual void visit (ReferenceType &type) override
-  {
-    Location ref_locus = mappings->lookup_location (type.get_ref ());
-    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
-    RichLocation r (ref_locus);
-    r.add_range (base_locus);
-    rust_error_at (r, "expected [%s] got [%s]",
-		   get_base ()->as_string ().c_str (),
-		   type.as_string ().c_str ());
-  }
+  virtual void visit (ReferenceType &type) override {}
 
-  virtual void visit (PointerType &type) override
-  {
-    Location ref_locus = mappings->lookup_location (type.get_ref ());
-    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
-    RichLocation r (ref_locus);
-    r.add_range (base_locus);
-    rust_error_at (r, "expected [%s] got [%s]",
-		   get_base ()->as_string ().c_str (),
-		   type.as_string ().c_str ());
-  }
+  virtual void visit (PointerType &type) override {}
 
-  virtual void visit (ParamType &type) override
-  {
-    Location ref_locus = mappings->lookup_location (type.get_ref ());
-    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
-    RichLocation r (ref_locus);
-    r.add_range (base_locus);
-    rust_error_at (r, "expected [%s] got [%s]",
-		   get_base ()->as_string ().c_str (),
-		   type.as_string ().c_str ());
-  }
+  virtual void visit (ParamType &type) override {}
 
-  virtual void visit (StrType &type) override
-  {
-    Location ref_locus = mappings->lookup_location (type.get_ref ());
-    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
-    RichLocation r (ref_locus);
-    r.add_range (base_locus);
-    rust_error_at (r, "expected [%s] got [%s]",
-		   get_base ()->as_string ().c_str (),
-		   type.as_string ().c_str ());
-  }
+  virtual void visit (StrType &type) override {}
 
-  virtual void visit (NeverType &type) override
-  {
-    Location ref_locus = mappings->lookup_location (type.get_ref ());
-    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
-    RichLocation r (ref_locus);
-    r.add_range (base_locus);
-    rust_error_at (r, "expected [%s] got [%s]",
-		   get_base ()->as_string ().c_str (),
-		   type.as_string ().c_str ());
-  }
+  virtual void visit (NeverType &type) override {}
 
-  virtual void visit (PlaceholderType &type) override
-  {
-    Location ref_locus = mappings->lookup_location (type.get_ref ());
-    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
-    RichLocation r (ref_locus);
-    r.add_range (base_locus);
-    rust_error_at (r, "expected [%s] got [%s]",
-		   get_base ()->as_string ().c_str (),
-		   type.as_string ().c_str ());
-  }
+  virtual void visit (PlaceholderType &type) override {}
 
-  virtual void visit (ProjectionType &type) override
-  {
-    Location ref_locus = mappings->lookup_location (type.get_ref ());
-    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
-    RichLocation r (ref_locus);
-    r.add_range (base_locus);
-    rust_error_at (r, "expected [%s] got [%s]",
-		   get_base ()->as_string ().c_str (),
-		   type.as_string ().c_str ());
-  }
+  virtual void visit (ProjectionType &type) override {}
 
-  virtual void visit (DynamicObjectType &type) override
-  {
-    Location ref_locus = mappings->lookup_location (type.get_ref ());
-    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
-    RichLocation r (ref_locus);
-    r.add_range (base_locus);
-    rust_error_at (r, "expected [%s] got [%s]",
-		   get_base ()->as_string ().c_str (),
-		   type.as_string ().c_str ());
-  }
+  virtual void visit (DynamicObjectType &type) override {}
 
-  virtual void visit (ClosureType &type) override
-  {
-    Location ref_locus = mappings->lookup_location (type.get_ref ());
-    Location base_locus = mappings->lookup_location (get_base ()->get_ref ());
-    RichLocation r (ref_locus);
-    r.add_range (base_locus);
-    rust_error_at (r, "expected [%s] got [%s]",
-		   get_base ()->as_string ().c_str (),
-		   type.as_string ().c_str ());
-  }
+  virtual void visit (ClosureType &type) override {}
 
 protected:
   BaseRules (BaseType *base)

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -296,6 +296,33 @@ BaseType::destructure () const
   return x;
 }
 
+std::string
+BaseType::mappings_str () const
+{
+  std::string buffer = "Ref: " + std::to_string (get_ref ())
+		       + " TyRef: " + std::to_string (get_ty_ref ());
+  buffer += "[";
+  for (auto &ref : combined)
+    buffer += std::to_string (ref) + ",";
+  buffer += "]";
+  return "(" + buffer + ")";
+}
+
+std::string
+BaseType::debug_str () const
+{
+  // return TypeKindFormat::to_string (get_kind ()) + ":" + as_string () + ":"
+  //        + mappings_str () + ":" + bounds_as_string ();
+  return get_name ();
+}
+
+void
+BaseType::debug () const
+{
+  rust_debug ("[%p] %s", static_cast<const void *> (this),
+	      debug_str ().c_str ());
+}
+
 TyVar::TyVar (HirId ref) : ref (ref)
 {
   // ensure this reference is defined within the context
@@ -1159,11 +1186,29 @@ TupleType::accept_vis (TyConstVisitor &vis) const
 std::string
 TupleType::as_string () const
 {
+  size_t i = 0;
   std::string fields_buffer;
   for (const TyVar &field : get_fields ())
     {
       fields_buffer += field.get_tyty ()->as_string ();
-      fields_buffer += ", ";
+      bool has_next = (i + 1) < get_fields ().size ();
+      fields_buffer += has_next ? ", " : "";
+      i++;
+    }
+  return "(" + fields_buffer + ")";
+}
+
+std::string
+TupleType::get_name () const
+{
+  size_t i = 0;
+  std::string fields_buffer;
+  for (const TyVar &field : get_fields ())
+    {
+      fields_buffer += field.get_tyty ()->as_string ();
+      bool has_next = (i + 1) < get_fields ().size ();
+      fields_buffer += has_next ? ", " : "";
+      i++;
     }
   return "(" + fields_buffer + ")";
 }
@@ -2194,6 +2239,13 @@ ReferenceType::as_string () const
 	 + get_base ()->as_string ();
 }
 
+std::string
+ReferenceType::get_name () const
+{
+  return std::string ("&") + (is_mutable () ? "mut" : "") + " "
+	 + get_base ()->get_name ();
+}
+
 BaseType *
 ReferenceType::unify (BaseType *other)
 {
@@ -2275,6 +2327,13 @@ PointerType::as_string () const
 {
   return std::string ("* ") + (is_mutable () ? "mut" : "const") + " "
 	 + get_base ()->as_string ();
+}
+
+std::string
+PointerType::get_name () const
+{
+  return std::string ("* ") + (is_mutable () ? "mut" : "const") + " "
+	 + get_base ()->get_name ();
 }
 
 BaseType *

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -27,6 +27,7 @@
 #include "rust-substitution-mapper.h"
 #include "rust-hir-trait-ref.h"
 #include "rust-hir-type-bounds.h"
+#include "options.h"
 
 namespace Rust {
 namespace TyTy {
@@ -559,14 +560,14 @@ StructFieldType *
 StructFieldType::clone () const
 {
   return new StructFieldType (get_ref (), get_name (),
-			      get_field_type ()->clone ());
+			      get_field_type ()->clone (), locus);
 }
 
 StructFieldType *
 StructFieldType::monomorphized_clone () const
 {
   return new StructFieldType (get_ref (), get_name (),
-			      get_field_type ()->monomorphized_clone ());
+			      get_field_type ()->monomorphized_clone (), locus);
 }
 
 bool

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -230,28 +230,11 @@ public:
 
   bool contains_type_parameters () const { return !is_concrete (); }
 
-  std::string mappings_str () const
-  {
-    std::string buffer = "Ref: " + std::to_string (get_ref ())
-			 + " TyRef: " + std::to_string (get_ty_ref ());
-    buffer += "[";
-    for (auto &ref : combined)
-      buffer += std::to_string (ref) + ",";
-    buffer += "]";
-    return "(" + buffer + ")";
-  }
+  std::string mappings_str () const;
 
-  std::string debug_str () const
-  {
-    return TypeKindFormat::to_string (get_kind ()) + ":" + as_string () + ":"
-	   + mappings_str () + ":" + bounds_as_string ();
-  }
+  std::string debug_str () const;
 
-  void debug () const
-  {
-    rust_debug ("[%p] %s", static_cast<const void *> (this),
-		debug_str ().c_str ());
-  }
+  void debug () const;
 
   // FIXME this will eventually go away
   const BaseType *get_root () const;
@@ -560,7 +543,7 @@ public:
 
   const std::vector<TyVar> &get_fields () const { return fields; }
 
-  std::string get_name () const override final { return as_string (); }
+  std::string get_name () const override final;
 
   TupleType *handle_substitions (SubstitutionArgumentMappings mappings);
 
@@ -2164,10 +2147,7 @@ public:
 
   std::string as_string () const override;
 
-  std::string get_name () const override final
-  {
-    return "&" + get_base ()->get_name ();
-  }
+  std::string get_name () const override final;
 
   BaseType *unify (BaseType *other) override;
   bool can_eq (const BaseType *other, bool emit_errors) const override final;
@@ -2249,11 +2229,7 @@ public:
   void accept_vis (TyConstVisitor &vis) const override;
 
   std::string as_string () const override;
-
-  std::string get_name () const override final
-  {
-    return "*" + get_base ()->get_name ();
-  }
+  std::string get_name () const override final;
 
   BaseType *unify (BaseType *other) override;
   bool can_eq (const BaseType *other, bool emit_errors) const override final;

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -314,8 +314,8 @@ private:
 class TyWithLocation
 {
 public:
-  TyWithLocation (BaseType *ty, Location locus);
-  TyWithLocation (BaseType *ty);
+  explicit TyWithLocation (BaseType *ty, Location locus);
+  explicit TyWithLocation (BaseType *ty);
 
   BaseType *get_ty () const { return ty; }
   Location get_locus () const { return locus; }
@@ -472,8 +472,8 @@ private:
 class StructFieldType
 {
 public:
-  StructFieldType (HirId ref, std::string name, BaseType *ty)
-    : ref (ref), name (name), ty (ty)
+  StructFieldType (HirId ref, std::string name, BaseType *ty, Location locus)
+    : ref (ref), name (name), ty (ty), locus (locus)
   {}
 
   HirId get_ref () const { return ref; }
@@ -496,10 +496,13 @@ public:
 
   void debug () const { rust_debug ("%s", as_string ().c_str ()); }
 
+  Location get_locus () const { return locus; }
+
 private:
   HirId ref;
   std::string name;
   BaseType *ty;
+  Location locus;
 };
 
 class TupleType : public BaseType

--- a/gcc/testsuite/rust/compile/issue-1152.rs
+++ b/gcc/testsuite/rust/compile/issue-1152.rs
@@ -1,8 +1,6 @@
 fn test() {
     let f = [0; -4_isize];
     // { dg-error "expected .usize. got .isize." "" { target *-*-* } .-1 }
-    // { dg-error "failed to type resolve expression" "" { target *-*-* } .-2 }
     let f = [0_usize; -1_isize];
     // { dg-error "expected .usize. got .isize." "" { target *-*-* } .-1 }
-    // { dg-error "failed to type resolve expression" "" { target *-*-* } .-2 }
 }

--- a/gcc/testsuite/rust/compile/tuple1.rs
+++ b/gcc/testsuite/rust/compile/tuple1.rs
@@ -1,5 +1,5 @@
 fn main() {
-    let a: (i32, bool) = (123, 123); // { dg-error "expected .bool. got .<integer>." }
+    let a: (i32, bool) = (123, 123); // { dg-error "expected" }
     let b;
     b = (456, 5f32);
 }

--- a/gcc/testsuite/rust/compile/type-alias1.rs
+++ b/gcc/testsuite/rust/compile/type-alias1.rs
@@ -2,5 +2,5 @@ type TypeAlias = (i32, u32);
 
 fn main() {
     let a: TypeAlias;
-    a = (123, 456f32); // { dg-error "expected .u32. got .f32." }
+    a = (123, 456f32); // { dg-error "expected" }
 }

--- a/gcc/testsuite/rust/execute/torture/operator_overload_9.rs
+++ b/gcc/testsuite/rust/execute/torture/operator_overload_9.rs
@@ -1,4 +1,4 @@
-/* { dg-output "mut_deref\n123\n" } */
+/* { dg-output "imm_deref\n123\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/slice1.rs
+++ b/gcc/testsuite/rust/execute/torture/slice1.rs
@@ -12,9 +12,10 @@ union Repr<T> {
 
 const fn slice_from_raw_parts<T>(data: *const T, len: usize) -> *const [T] {
     unsafe {
-        let a = FatPtr { data, len };
-        let b = Repr { raw: a };
-        b.rust
+        Repr {
+            raw: FatPtr { data, len },
+        }
+        .rust
     }
 }
 


### PR DESCRIPTION
This is the first pass on a refactor for error handling on unify sites. Eventually we
will be able to get rid of our can_eq interface but this is the first pass to abstract
unify's to use this interface.

Eventually, we will have unify and unify_and_commit. Unify will become our can_eq
interface but will require more helpers around inference variables.