### PR TITLE
backend: correctly formulate the exit condition

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -727,8 +727,11 @@ CompileExpr::visit (HIR::WhileLoopExpr &expr)
 
   tree condition
     = CompileExpr::Compile (expr.get_predicate_expr ().get (), ctx);
+  tree exit_condition
+    = fold_build1_loc (expr.get_locus ().gcc_location (), TRUTH_NOT_EXPR,
+		       boolean_type_node, condition);
   tree exit_expr
-    = ctx->get_backend ()->exit_expression (condition, expr.get_locus ());
+    = ctx->get_backend ()->exit_expression (exit_condition, expr.get_locus ());
   ctx->add_statement (exit_expr);
 
   tree code_block_stmt

--- a/gcc/testsuite/rust/execute/torture/loop-condition-eval.rs
+++ b/gcc/testsuite/rust/execute/torture/loop-condition-eval.rs
@@ -1,0 +1,21 @@
+// { dg-output "1\n" }
+pub fn test() -> u64 {
+    let mut n = 113383; // #20 in https://oeis.org/A006884
+    while n != 1 {
+        n = if n % 2 == 0 { n / 2 } else { 3 * n + 1 };
+    }
+    n
+}
+
+pub fn test_1() -> u64 {
+    test()
+}
+
+extern "C" {
+    fn printf(fmt: *const i8, ...);
+}
+
+fn main() -> i32 {
+    unsafe { printf("%lu\n" as *const str as *const i8, test_1()) }
+    0
+}


### PR DESCRIPTION
- backend: correctly formulate the exit condition. Previously the exit condition was treated the same as the loop condition (which is the inverse condition of the exit condition). Now, this is corrected.

Should fix #1523 