### PR TITLE
rust: Add -frust-compile-until option

### DIFF
--- a/gcc/rust/lang.opt
+++ b/gcc/rust/lang.opt
@@ -113,6 +113,48 @@ Rust Joined RejectNegative
 
 o
 Rust Joined Separate
+
+frust-compile-until=
+Rust Joined RejectNegative Enum(frust_compile_until) Var(flag_rust_compile_until)
+-frust-compile-until=[ast|attributecheck|expansion|nameresolution|lowering|typecheck|privacy|unsafety|const|copimlation|end]             When to stop in the pipeline when compiling Rust code
+
+Enum
+Name(frust_compile_until) Type(int) UnknownError(unknown rust compile-until %qs)
+
+EnumValue
+Enum(frust_compile_until) String(ast) Value(0)
+
+EnumValue
+Enum(frust_compile_until) String(attributecheck) Value(1)
+
+EnumValue
+Enum(frust_compile_until) String(expansion) Value(2)
+
+EnumValue
+Enum(frust_compile_until) String(nameresolution) Value(3)
+
+EnumValue
+Enum(frust_compile_until) String(lowering) Value(4)
+
+EnumValue
+Enum(frust_compile_until) String(typecheck) Value(5)
+
+EnumValue
+Enum(frust_compile_until) String(privacy) Value(6)
+
+EnumValue
+Enum(frust_compile_until) String(unsafety) Value(7)
+
+EnumValue
+Enum(frust_compile_until) String(const) Value(8)
+
+EnumValue
+Enum(frust_compile_until) String(compilation) Value(9)
+
+EnumValue
+Enum(frust_compile_until) String(end) Value(10)
+
+
 ; Documented in common.opt
 
 ; This comment is to ensure we retain the blank line above.

--- a/gcc/rust/rust-session-manager.h
+++ b/gcc/rust/rust-session-manager.h
@@ -199,6 +199,22 @@ struct CompileOptions
   } edition
     = Edition::E2015;
 
+  enum class CompileStep
+  {
+    Ast,
+    AttributeCheck,
+    Expansion,
+    NameResolution,
+    Lowering,
+    TypeCheck,
+    Privacy,
+    Unsafety,
+    Const,
+    Compilation,
+    End,
+  } compile_until
+    = CompileStep::End;
+
   bool dump_option_enabled (DumpOption option) const
   {
     return dump_options.find (option) != dump_options.end ();
@@ -239,7 +255,14 @@ struct CompileOptions
     edition = static_cast<Edition> (raw_edition);
   }
 
-  const Edition &get_edition () { return edition; }
+  const Edition &get_edition () const { return edition; }
+
+  void set_compile_step (int raw_step)
+  {
+    compile_until = static_cast<CompileStep> (raw_step);
+  }
+
+  const CompileStep &get_compile_until () const { return compile_until; }
 
   void set_metadata_output (const std::string &path)
   {

--- a/gcc/testsuite/rust/compile/frust-compile-until.rs
+++ b/gcc/testsuite/rust/compile/frust-compile-until.rs
@@ -1,0 +1,7 @@
+// { dg-additional-options "-frust-compile-until=unsafety" }
+
+unsafe fn foo() {}
+
+fn main() {
+    foo()
+}


### PR DESCRIPTION
This option helps ensure that we do not introduce regressions on various
parts of the compilation pipeline. For example, a testcase (or testsuite
from the `testing` project) might pass attribute checking, expansion and
lowering, but fail during typechecking. Should a change suddenly make
that testcase fail expansion, we would not be able to notice it. By
generating tests that run up until expansion, typechecking, compilation
and so forth we ensure that no regressions are added accidentally to
already failing tests/testsuites.
