### PR TITLE
attributes: Add #[macro_use] as builtin

### DIFF
--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -40,6 +40,7 @@ static const BuiltinAttrDefinition __definitions[]
      {"no_mangle", CODE_GENERATION},
      {"repr", CODE_GENERATION},
      {"path", EXPANSION},
+     {"macro_use", NAME_RESOLUTION},
      // From now on, these are reserved by the compiler and gated through
      // #![feature(rustc_attrs)]
      {"rustc_inherit_overflow_checks", CODE_GENERATION}};

--- a/gcc/testsuite/rust/compile/macro_export_1.rs
+++ b/gcc/testsuite/rust/compile/macro_export_1.rs
@@ -1,0 +1,2 @@
+#[macro_use]
+mod foo {}


### PR DESCRIPTION
Fixes #1531 

I think the checking for builtin attributes should definitely be moved to the `AttributeChecker` visitor. It's also a bit messy at the moment considering it isn't in effect on *everything*, simply some nodes such as `Module`s. Thoughts?