### PR TITLE
module lowering: Do not append null pointers as items

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-item.cc
+++ b/gcc/rust/hir/rust-ast-lower-item.cc
@@ -59,7 +59,10 @@ ASTLoweringItem::visit (AST::Module &module)
   for (auto &item : module.get_items ())
     {
       auto transitem = translate (item.get ());
-      items.push_back (std::unique_ptr<Item> (transitem));
+      // The item may be null if it doesn't need to live in the HIR - for
+      // example, macro rules definitions
+      if (transitem)
+	items.push_back (std::unique_ptr<Item> (transitem));
     }
 
   // should be lowered/copied from module.get_in/outer_attrs()

--- a/gcc/testsuite/rust/compile/macro44.rs
+++ b/gcc/testsuite/rust/compile/macro44.rs
@@ -1,0 +1,34 @@
+mod foo {
+    mod bar {
+        mod baz {
+            macro_rules! baz {
+                () => {{}};
+            }
+        }
+    }
+
+    macro_rules! foo {
+        () => {{}};
+    }
+
+    fn foo_f() { // { dg-warning "function is never used" }
+        foo!();
+    }
+
+    fn bar_f() { // { dg-warning "function is never used" }
+        baz!();
+    }
+}
+
+mod foo2 {
+    #[macro_export]
+    macro_rules! bar1 {
+        () => {};
+    }
+
+    macro_rules! bar2 {
+        () => {};
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Some module items do not need to get lowered to HIR such as `macro_rules!` definitions. Hence, module lowering should act the same as crate lowering: Only emplace back the lowered item if it is a valid pointer

Fixes #1533 