### PR TITLE
Add catch for recusive type queries

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check.h
+++ b/gcc/rust/typecheck/rust-hir-type-check.h
@@ -372,6 +372,15 @@ public:
     return true;
   }
 
+  void insert_query (HirId id) { querys_in_progress.insert (id); }
+
+  void query_completed (HirId id) { querys_in_progress.erase (id); }
+
+  bool query_in_progress (HirId id) const
+  {
+    return querys_in_progress.find (id) != querys_in_progress.end ();
+  }
+
 private:
   TypeCheckContext ();
 
@@ -406,6 +415,9 @@ private:
 
   // predicates
   std::map<HirId, TyTy::TypeBoundPredicate> predicates;
+
+  // query context lookups
+  std::set<HirId> querys_in_progress;
 };
 
 class TypeResolution

--- a/gcc/rust/typecheck/rust-tyty-bounds.cc
+++ b/gcc/rust/typecheck/rust-tyty-bounds.cc
@@ -34,8 +34,9 @@ TypeBoundsProbe::scan ()
       if (!impl->has_trait_ref ())
 	return true;
 
-      TyTy::BaseType *impl_type = TypeCheckItem::ResolveImplBlockSelf (*impl);
-      if (impl_type->get_kind () == TyTy::TypeKind::ERROR)
+      HirId impl_ty_id = impl->get_type ()->get_mappings ().get_hirid ();
+      TyTy::BaseType *impl_type = nullptr;
+      if (!query_type (impl_ty_id, &impl_type))
 	return true;
 
       if (!receiver->can_eq (impl_type, false))


### PR DESCRIPTION
When we have a type query where by generic substitution occurs we can hit the case where we need to Probe the bounds of the substited item to determine whether the the bounds are compatible this can cause us to end up querying the same type recursively.

Fixes #1550
