### PR TITLE
make: Inherit CXXFLAGS, guard against non g++ compilers for warnings

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -326,8 +326,7 @@ CFLAGS-rust/rust-lex.o += $(RUST_INCLUDES)
 CFLAGS-rust/rust-parse.o += $(RUST_INCLUDES)
 CFLAGS-rust/rust-session-manager.o += $(RUST_INCLUDES)
 
-# TODO: possibly find a way to ensure C++11 compilation level here?
-RUST_CXXFLAGS = -std=c++11 -Wno-unused-parameter -Werror=overloaded-virtual
+RUST_CXXFLAGS = $(CXXFLAGS)
 
 # build all rust/lex files in rust folder, add cross-folder includes
 rust/%.o: rust/lex/%.cc


### PR DESCRIPTION
Fixes #1538 

I don't know if there is a better way to do this or if this is what was expected. I also didn't have the heart to look for the proper warning flag equivalents on the MSVC++ side or for other compilers. I think it's safe to assume that if people are boostrapping `gccrs` with something else than `g++`, they're not hacking on the compiler and thus don't need these warnings?