### PR TITLE
Fix -Wunused using `rust-lang.cc` hack

### DIFF
--- a/gcc/rust/lang.opt
+++ b/gcc/rust/lang.opt
@@ -39,7 +39,7 @@ Rust
 ; Documented in c.opt
 
 Wunused-variable
-Rust Var(warn_unused_variable) Init(1) Warning
+Rust Var(warn_unused_variable) Warning
 ; documented in common.opt
 
 Wunused-const-variable
@@ -47,11 +47,11 @@ Rust Warning Alias(Wunused-const-variable=, 2, 0)
 Warn when a const variable is unused.
 
 Wunused-const-variable=
-Rust Joined RejectNegative UInteger Var(warn_unused_const_variable) Init(1) Warning LangEnabledBy(Rust,Wunused-variable, 1, 0) IntegerRange(0, 2)
+Rust Joined RejectNegative UInteger Var(warn_unused_const_variable) Warning LangEnabledBy(Rust,Wunused-variable, 1, 0) IntegerRange(0, 2)
 Warn when a const variable is unused.
 
 Wunused-result
-Rust Var(warn_unused_result) Init(1) Warning
+Rust Var(warn_unused_result) Warning
 Warn if a caller of a function, marked with attribute warn_unused_result, does not use its return value.
 
 frust-crate=

--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -162,6 +162,13 @@ grs_langhook_init_options_struct (struct gcc_options *opts)
    * builtins */
   opts->x_flag_wrapv = 1;
 
+  /* We need to warn on unused variables by default */
+  opts->x_warn_unused_variable = 1;
+  /* For const variables too */
+  opts->x_warn_unused_const_variable = 1;
+  /* And finally unused result for #[must_use] */
+  opts->x_warn_unused_result = 1;
+
   // nothing yet - used by frontends to change specific options for the language
   Rust::Session::get_instance ().init_options ();
 }


### PR DESCRIPTION
@tschwinge if your patch lands first I'll happily revert that and use `LangInit`