### PR TITLE
fix ICE on missing closing paren

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -11728,10 +11728,17 @@ Parser<ManagedTokenSource>::parse_stmt_or_expr_without_block ()
 	    // must be expression statement
 	    lexer.skip_token ();
 
-	    std::unique_ptr<AST::ExprStmtWithoutBlock> stmt (
-	      new AST::ExprStmtWithoutBlock (std::move (expr),
-					     t->get_locus ()));
-	    return ExprOrStmt (std::move (stmt));
+	    if (expr)
+	      {
+		std::unique_ptr<AST::ExprStmtWithoutBlock> stmt (
+		  new AST::ExprStmtWithoutBlock (std::move (expr),
+						 t->get_locus ()));
+		return ExprOrStmt (std::move (stmt));
+	      }
+	    else
+	      {
+		return ExprOrStmt::create_error ();
+	      }
 	  }
 
 	// return expression

--- a/gcc/testsuite/rust/compile/missing_closing_paren.rs
+++ b/gcc/testsuite/rust/compile/missing_closing_paren.rs
@@ -1,0 +1,3 @@
+fn foo() {
+    (""; // { dg-error "unexpected token .*" }
+}


### PR DESCRIPTION
Fix crash (segfault) on a missing closing parenthesis when parsing the expressions in a block. The returned `expr` was missing a check before being used.

Add corresponding test.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>