### PR TITLE
Support type resolution on super traits on dyn objects

### DIFF
--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -247,6 +247,8 @@ HIRCompileBase::compute_address_for_trait_item (
   // Algo:
   // check if there is an impl-item for this trait-item-ref first
   // else assert that the trait-item-ref has an implementation
+  //
+  // FIXME this does not support super traits
 
   TyTy::TypeBoundPredicateItem predicate_item
     = predicate->lookup_associated_item (ref->get_identifier ());

--- a/gcc/rust/typecheck/rust-hir-trait-ref.h
+++ b/gcc/rust/typecheck/rust-hir-trait-ref.h
@@ -380,6 +380,16 @@ public:
     return item_refs;
   }
 
+  void get_trait_items_and_supers (
+    std::vector<const TraitItemReference *> &result) const
+  {
+    for (const auto &item : item_refs)
+      result.push_back (&item);
+
+    for (const auto &super_trait : super_traits)
+      super_trait->get_trait_items_and_supers (result);
+  }
+
   void on_resolved ()
   {
     for (auto &item : item_refs)
@@ -449,6 +459,20 @@ public:
   std::vector<TyTy::SubstitutionParamMapping> get_trait_substs () const
   {
     return trait_substs;
+  }
+
+  bool satisfies_bound (const TraitReference &reference) const
+  {
+    if (is_equal (reference))
+      return true;
+
+    for (const auto &super_trait : super_traits)
+      {
+	if (super_trait->satisfies_bound (reference))
+	  return true;
+      }
+
+    return false;
   }
 
 private:


### PR DESCRIPTION
When checking if specified bounds satisfy other bounds we must lookup the super traits. To finish the support for super traits we need to redo the computation of method addresses to support super traits.

Addresses #914
