### PR TITLE
Add missing lang item mappings

### DIFF
--- a/gcc/rust/util/rust-abi.cc
+++ b/gcc/rust/util/rust-abi.cc
@@ -23,6 +23,8 @@ get_abi_from_string (const std::string &abi)
 {
   if (abi.compare ("rust") == 0)
     return Rust::ABI::RUST;
+  else if (abi.compare ("rust-call") == 0)
+    return Rust::ABI::RUST;
   else if (abi.compare ("rust-intrinsic") == 0)
     return Rust::ABI::INTRINSIC;
   else if (abi.compare ("C") == 0)

--- a/gcc/rust/util/rust-lang-item.h
+++ b/gcc/rust/util/rust-lang-item.h
@@ -73,6 +73,9 @@ public:
     MUT_PTR,
     CONST_SLICE_PTR,
 
+    // functions
+    FN_ONCE,
+
     UNKNOWN,
   };
 
@@ -218,6 +221,10 @@ public:
       {
 	return ItemType::CONST_SLICE_PTR;
       }
+    else if (item.compare ("fn_once") == 0)
+      {
+	return ItemType::FN_ONCE;
+      }
 
     return ItemType::UNKNOWN;
   }
@@ -296,6 +303,8 @@ public:
 	return "mut_ptr";
       case CONST_SLICE_PTR:
 	return "const_slice_ptr";
+      case FN_ONCE:
+	return "fn_once";
 
       case UNKNOWN:
 	return "<UNKNOWN>";


### PR DESCRIPTION
Adds the missing fn_once lang item and the missing rust-call abi option.