### PR TITLE
Support outer attribute handling on trait items just like normal items

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-base.cc
+++ b/gcc/rust/hir/rust-ast-lower-base.cc
@@ -824,7 +824,7 @@ ASTLoweringBase::lower_qualifiers (const AST::FunctionQualifiers &qualifiers)
 }
 
 void
-ASTLoweringBase::handle_outer_attributes (const HIR::Item &item)
+ASTLoweringBase::handle_outer_attributes (const ItemWrapper &item)
 {
   for (const auto &attr : item.get_outer_attrs ())
     {
@@ -855,7 +855,7 @@ ASTLoweringBase::handle_outer_attributes (const HIR::Item &item)
 }
 
 void
-ASTLoweringBase::handle_doc_item_attribute (const HIR::Item &item,
+ASTLoweringBase::handle_doc_item_attribute (const ItemWrapper &item,
 					    const AST::Attribute &attr)
 {
   auto simple_doc_comment = attr.has_attr_input ()
@@ -878,7 +878,7 @@ ASTLoweringBase::handle_doc_item_attribute (const HIR::Item &item,
 }
 
 void
-ASTLoweringBase::handle_lang_item_attribute (const HIR::Item &item,
+ASTLoweringBase::handle_lang_item_attribute (const ItemWrapper &item,
 					     const AST::Attribute &attr)
 {
   auto &literal = static_cast<AST::AttrInputLiteral &> (attr.get_attr_input ());

--- a/gcc/rust/hir/rust-ast-lower-base.h
+++ b/gcc/rust/hir/rust-ast-lower-base.h
@@ -29,6 +29,30 @@
 namespace Rust {
 namespace HIR {
 
+// proxy class so we can do attribute checking on items and trait items
+class ItemWrapper
+{
+public:
+  ItemWrapper (const HIR::Item &item)
+    : mappings (item.get_mappings ()), locus (item.get_locus ()),
+      outer_attrs (item.get_outer_attrs ())
+  {}
+
+  ItemWrapper (const HIR::TraitItem &item)
+    : mappings (item.get_mappings ()), locus (item.get_trait_locus ()),
+      outer_attrs (item.get_outer_attrs ())
+  {}
+
+  const Analysis::NodeMapping &get_mappings () const { return mappings; }
+  Location get_locus () const { return locus; }
+  const AST::AttrVec &get_outer_attrs () const { return outer_attrs; }
+
+private:
+  const Analysis::NodeMapping &mappings;
+  Location locus;
+  const AST::AttrVec &outer_attrs;
+};
+
 // base class to allow derivatives to overload as needed
 class ASTLoweringBase : public AST::ASTVisitor
 {
@@ -264,12 +288,12 @@ protected:
   HIR::FunctionQualifiers
   lower_qualifiers (const AST::FunctionQualifiers &qualifiers);
 
-  void handle_outer_attributes (const HIR::Item &item);
+  void handle_outer_attributes (const ItemWrapper &item);
 
-  void handle_lang_item_attribute (const HIR::Item &item,
+  void handle_lang_item_attribute (const ItemWrapper &item,
 				   const AST::Attribute &attr);
 
-  void handle_doc_item_attribute (const HIR::Item &item,
+  void handle_doc_item_attribute (const ItemWrapper &item,
 				  const AST::Attribute &attr);
 
   bool is_known_attribute (const std::string &attribute_path) const;

--- a/gcc/rust/hir/rust-ast-lower-implitem.h
+++ b/gcc/rust/hir/rust-ast-lower-implitem.h
@@ -305,16 +305,14 @@ public:
 
     if (resolver.translated != nullptr)
       {
-	// FIXME
+	auto id = resolver.translated->get_mappings ().get_hirid ();
+	auto defid = resolver.translated->get_mappings ().get_defid ();
+	auto locus = resolver.translated->get_trait_locus ();
 
-	// auto id = resolver.translated->get_mappings ().get_hirid ();
-	// auto defid = resolver.translated->get_mappings ().get_defid ();
-	// auto locus = resolver.translated->get_locus ();
-
-	// resolver.handle_outer_attributes (*resolver.translated);
+	resolver.handle_outer_attributes (*resolver.translated);
 	resolver.mappings->insert_hir_trait_item (resolver.translated);
-	// resolver.mappings->insert_location (id, locus);
-	// resolver.mappings->insert_defid_mapping (defid, resolver.item_cast);
+	resolver.mappings->insert_location (id, locus);
+	resolver.mappings->insert_defid_mapping (defid, resolver.translated);
       }
 
     return resolver.translated;

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -2394,6 +2394,8 @@ public:
     return outer_attrs;
   }
 
+  Location get_trait_locus () const override { return get_locus (); }
+
 protected:
   // Clone function implementation as (not pure) virtual method
   TraitItemFunc *clone_trait_item_impl () const override
@@ -2479,6 +2481,8 @@ public:
   {
     return outer_attrs;
   }
+
+  Location get_trait_locus () const override { return get_locus (); }
 
 protected:
   // Clone function implementation as (not pure) virtual method
@@ -2566,6 +2570,8 @@ public:
   {
     return outer_attrs;
   }
+
+  Location get_trait_locus () const override { return get_locus (); }
 
 protected:
   // Clone function implementation as (not pure) virtual method

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -796,7 +796,9 @@ public:
 
   virtual const std::string trait_identifier () const = 0;
 
-  const Analysis::NodeMapping get_mappings () const { return mappings; }
+  const Analysis::NodeMapping &get_mappings () const { return mappings; }
+
+  virtual Location get_trait_locus () const = 0;
 
   virtual TraitItemKind get_item_kind () const = 0;
 

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -316,6 +316,7 @@ Mappings::insert_defid_mapping (DefId id, HIR::Item *item)
 
   rust_assert (lookup_defid (id) == nullptr);
   rust_assert (lookup_local_defid (crate_num, local_def_id) == nullptr);
+  rust_assert (lookup_trait_item_defid (id) == nullptr);
 
   defIdMappings[id] = item;
   insert_local_defid_mapping (crate_num, local_def_id, item);
@@ -326,6 +327,29 @@ Mappings::lookup_defid (DefId id)
 {
   auto it = defIdMappings.find (id);
   if (it == defIdMappings.end ())
+    return nullptr;
+
+  return it->second;
+}
+
+void
+Mappings::insert_defid_mapping (DefId id, HIR::TraitItem *item)
+{
+  CrateNum crate_num = id.crateNum;
+  LocalDefId local_def_id = id.localDefId;
+
+  rust_assert (lookup_defid (id) == nullptr);
+  rust_assert (lookup_local_defid (crate_num, local_def_id) == nullptr);
+  rust_assert (lookup_trait_item_defid (id) == nullptr);
+
+  defIdTraitItemMappings[id] = item;
+}
+
+HIR::TraitItem *
+Mappings::lookup_trait_item_defid (DefId id)
+{
+  auto it = defIdTraitItemMappings.find (id);
+  if (it == defIdTraitItemMappings.end ())
     return nullptr;
 
   return it->second;

--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -104,6 +104,8 @@ public:
 
   void insert_defid_mapping (DefId id, HIR::Item *item);
   HIR::Item *lookup_defid (DefId id);
+  void insert_defid_mapping (DefId id, HIR::TraitItem *item);
+  HIR::TraitItem *lookup_trait_item_defid (DefId id);
 
   void insert_local_defid_mapping (CrateNum crateNum, LocalDefId id,
 				   HIR::Item *item);
@@ -302,6 +304,7 @@ private:
   std::map<CrateNum, AST::Crate *> ast_crate_mappings;
   std::map<CrateNum, HIR::Crate *> hir_crate_mappings;
   std::map<DefId, HIR::Item *> defIdMappings;
+  std::map<DefId, HIR::TraitItem *> defIdTraitItemMappings;
   std::map<CrateNum, std::map<LocalDefId, HIR::Item *>> localDefIdMappings;
 
   std::map<HirId, HIR::Module *> hirModuleMappings;


### PR DESCRIPTION
This patch adds a proxy class ItemWrapper to be a proxy allowing us to use the same code paths for attribute handling as we have with normal items. We need this so we can grab the fn trait associated type lang item's. Which are being missed currently.

Addresses #195

