### PR TITLE
Add more implementations for TARGET_RUST_OS_INFO

### DIFF
--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -848,6 +848,9 @@ case ${target} in
   ;;
 *-*-fuchsia*)
   native_system_header_dir=/include
+  tmake_file="t-fuchsia"
+  rust_target_objs="${rust_target_objs} fuchsia-rust.o"
+  target_has_targetrustm=yes
   ;;
 *-*-linux* | frv-*-*linux* | *-*-kfreebsd*-gnu | *-*-gnu* | *-*-kopensolaris*-gnu | *-*-uclinuxfdpiceabi)
   extra_options="$extra_options gnu-user.opt"

--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -919,6 +919,12 @@ case ${target} in
       gcc_cv_initfini_array=yes
       ;;
   esac
+  case $target in
+    *linux*)
+      rust_target_objs="${rust_target_objs} linux-rust.o"
+      target_has_targetrustm=yes
+      ;;
+  esac
   ;;
 *-*-netbsd*)
   tm_p_file="${tm_p_file} netbsd-protos.h"

--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -934,6 +934,8 @@ case ${target} in
       default_gnu_indirect_function=yes
       ;;
   esac
+  rust_target_objs="${rust_target_objs} netbsd-rust.o"
+  target_has_targetrustm=yes
   ;;
 *-*-openbsd*)
   tmake_file="t-openbsd"

--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -790,6 +790,8 @@ case ${target} in
   d_target_objs="${d_target_objs} dragonfly-d.o"
   tmake_file="${tmake_file} t-dragonfly"
   target_has_targetdm=yes
+  rust_target_objs="${rust_target_objs} dragonfly-rust.o"
+  target_has_targetrustm=yes
   ;;
 *-*-freebsd*)
   # This is the generic ELF configuration of FreeBSD.  Later

--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -2116,6 +2116,8 @@ i[34567]86-*-mingw* | x86_64-*-mingw*)
 	d_target_objs="${d_target_objs} winnt-d.o"
 	target_has_targetcm="yes"
 	target_has_targetdm="yes"
+	rust_target_objs="${rust_target_objs} winnt-rust.o"
+	target_has_targetrustm="yes"
 	case ${target} in
 		x86_64-*-* | *-w64-*)
 			need_64bit_isa=yes

--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -1053,6 +1053,9 @@ case ${target} in
   extra_headers="${extra_headers} ../vxworks/vxworks-predef.h"
   target_has_targetcm="yes"
 
+  rust_target_objs="${rust_target_objs} vxworks-rust.o"
+  target_has_targetrustm=yes
+
   # This private header exposes a consistent interface for checks on
   # the VxWorks version our runtime header files need to perform, based on
   # what the system headers adverstise:

--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -841,6 +841,8 @@ case ${target} in
   d_target_objs="${d_target_objs} freebsd-d.o"
   tmake_file="${tmake_file} t-freebsd"
   target_has_targetdm=yes
+  rust_target_objs="${rust_target_objs} freebsd-rust.o"
+  target_has_targetrustm=yes
   ;;
 *-*-fuchsia*)
   native_system_header_dir=/include

--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -951,6 +951,8 @@ case ${target} in
   esac
   d_target_objs="${d_target_objs} openbsd-d.o"
   target_has_targetdm=yes
+  rust_target_objs="${rust_target_objs} openbsd-rust.o"
+  target_has_targetrustm=yes
   ;;
 *-*-phoenix*)
   gas=yes

--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -1017,6 +1017,8 @@ case ${target} in
       ;;
   esac
   target_has_targetdm=yes
+  rust_target_objs="${rust_target_objs} sol2-rust.o"
+  target_has_targetrustm=yes
   ;;
 *-*-*vms*)
   extra_options="${extra_options} vms/vms.opt"

--- a/gcc/config/dragonfly-rust.cc
+++ b/gcc/config/dragonfly-rust.cc
@@ -1,0 +1,40 @@
+/* DragonFly support needed only by Rust front-end.
+   Copyright (C) 2022 Free Software Foundation, Inc.
+
+GCC is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free
+Software Foundation; either version 3, or (at your option) any later
+version.
+
+GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with GCC; see the file COPYING3.  If not see
+<http://www.gnu.org/licenses/>.  */
+
+#include "config.h"
+#include "system.h"
+#include "coretypes.h"
+#include "tm.h"
+#include "tm_rust.h"
+#include "rust/rust-target.h"
+#include "rust/rust-target-def.h"
+
+/* Implement TARGET_RUST_OS_INFO for DragonFly targets.  */
+
+static void
+dragonfly_rust_target_os_info (void)
+{
+  rust_add_target_info ("target_family", "unix");
+  rust_add_target_info ("target_os", "dragonfly");
+  rust_add_target_info ("target_vendor", "unknown");
+  rust_add_target_info ("target_env", "");
+}
+
+#undef TARGET_RUST_OS_INFO
+#define TARGET_RUST_OS_INFO dragonfly_rust_target_os_info
+
+struct gcc_targetrustm targetrustm = TARGETRUSTM_INITIALIZER;

--- a/gcc/config/freebsd-rust.cc
+++ b/gcc/config/freebsd-rust.cc
@@ -1,0 +1,40 @@
+/* FreeBSD support needed only by Rust front-end.
+   Copyright (C) 2022 Free Software Foundation, Inc.
+
+GCC is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free
+Software Foundation; either version 3, or (at your option) any later
+version.
+
+GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with GCC; see the file COPYING3.  If not see
+<http://www.gnu.org/licenses/>.  */
+
+#include "config.h"
+#include "system.h"
+#include "coretypes.h"
+#include "tm.h"
+#include "tm_rust.h"
+#include "rust/rust-target.h"
+#include "rust/rust-target-def.h"
+
+/* Implement TARGET_RUST_OS_INFO for FreeBSD targets.  */
+
+static void
+freebsd_rust_target_os_info (void)
+{
+  rust_add_target_info ("target_family", "unix");
+  rust_add_target_info ("target_os", "freebsd");
+  rust_add_target_info ("target_vendor", "unknown");
+  rust_add_target_info ("target_env", "");
+}
+
+#undef TARGET_RUST_OS_INFO
+#define TARGET_RUST_OS_INFO freebsd_rust_target_os_info
+
+struct gcc_targetrustm targetrustm = TARGETRUSTM_INITIALIZER;

--- a/gcc/config/fuchsia-rust.cc
+++ b/gcc/config/fuchsia-rust.cc
@@ -1,0 +1,40 @@
+/* Fuchsia support needed only by Rust front-end.
+   Copyright (C) 2022 Free Software Foundation, Inc.
+
+GCC is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free
+Software Foundation; either version 3, or (at your option) any later
+version.
+
+GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with GCC; see the file COPYING3.  If not see
+<http://www.gnu.org/licenses/>.  */
+
+#include "config.h"
+#include "system.h"
+#include "coretypes.h"
+#include "tm.h"
+#include "tm_rust.h"
+#include "rust/rust-target.h"
+#include "rust/rust-target-def.h"
+
+/* Implement TARGET_RUST_OS_INFO for Fuchsia targets.  */
+
+static void
+fushsia_rust_target_os_info (void)
+{
+  rust_add_target_info ("target_family", "unix");
+  rust_add_target_info ("target_os", "fushsia");
+  rust_add_target_info ("target_vendor", "unknown");
+  rust_add_target_info ("target_env", "");
+}
+
+#undef TARGET_RUST_OS_INFO
+#define TARGET_RUST_OS_INFO fushsia_rust_target_os_info
+
+struct gcc_targetrustm targetrustm = TARGETRUSTM_INITIALIZER;

--- a/gcc/config/linux-rust.cc
+++ b/gcc/config/linux-rust.cc
@@ -1,0 +1,57 @@
+/* Linux support needed only by Rust front-end.
+   Copyright (C) 2022 Free Software Foundation, Inc.
+
+GCC is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free
+Software Foundation; either version 3, or (at your option) any later
+version.
+
+GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with GCC; see the file COPYING3.  If not see
+<http://www.gnu.org/licenses/>.  */
+
+#include "config.h"
+#include "system.h"
+#include "coretypes.h"
+#include "tm.h"
+#include "tm_rust.h"
+#include "rust/rust-target.h"
+#include "rust/rust-target-def.h"
+
+/* `-mandroid' is not available as an command-line option.  */
+#ifndef TARGET_ANDROID
+#define TARGET_ANDROID 0
+#endif
+
+/* Implement TARGET_RUST_OS_INFO for Linux targets.  */
+
+static void
+linux_rust_target_os_info (void)
+{
+  rust_add_target_info ("target_family", "unix");
+  rust_add_target_info ("target_vendor", "unknown");
+
+  if (TARGET_ANDROID)
+    rust_add_target_info ("target_os", "android");
+  else
+    rust_add_target_info ("target_os", "linux");
+
+  if (OPTION_GLIBC)
+    rust_add_target_info ("target_env", "gnu");
+  else if (OPTION_MUSL)
+    rust_add_target_info ("target_env", "musl");
+  else if (OPTION_UCLIBC)
+    rust_add_target_info ("target_env", "uclibc");
+  else
+    rust_add_target_info ("target_env", "");
+}
+
+#undef TARGET_RUST_OS_INFO
+#define TARGET_RUST_OS_INFO linux_rust_target_os_info
+
+struct gcc_targetrustm targetrustm = TARGETRUSTM_INITIALIZER;

--- a/gcc/config/netbsd-rust.cc
+++ b/gcc/config/netbsd-rust.cc
@@ -1,0 +1,40 @@
+/* NetBSD support needed only by Rust front-end.
+   Copyright (C) 2022 Free Software Foundation, Inc.
+
+GCC is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free
+Software Foundation; either version 3, or (at your option) any later
+version.
+
+GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with GCC; see the file COPYING3.  If not see
+<http://www.gnu.org/licenses/>.  */
+
+#include "config.h"
+#include "system.h"
+#include "coretypes.h"
+#include "tm.h"
+#include "tm_rust.h"
+#include "rust/rust-target.h"
+#include "rust/rust-target-def.h"
+
+/* Implement TARGET_RUST_OS_INFO for NetBSD targets.  */
+
+static void
+netbsd_rust_target_os_info (void)
+{
+  rust_add_target_info ("target_family", "unix");
+  rust_add_target_info ("target_os", "netbsd");
+  rust_add_target_info ("target_vendor", "unknown");
+  rust_add_target_info ("target_env", "");
+}
+
+#undef TARGET_RUST_OS_INFO
+#define TARGET_RUST_OS_INFO netbsd_rust_target_os_info
+
+struct gcc_targetrustm targetrustm = TARGETRUSTM_INITIALIZER;

--- a/gcc/config/openbsd-rust.cc
+++ b/gcc/config/openbsd-rust.cc
@@ -1,0 +1,40 @@
+/* OpenBSD support needed only by Rust front-end.
+   Copyright (C) 2022 Free Software Foundation, Inc.
+
+GCC is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free
+Software Foundation; either version 3, or (at your option) any later
+version.
+
+GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with GCC; see the file COPYING3.  If not see
+<http://www.gnu.org/licenses/>.  */
+
+#include "config.h"
+#include "system.h"
+#include "coretypes.h"
+#include "tm.h"
+#include "tm_rust.h"
+#include "rust/rust-target.h"
+#include "rust/rust-target-def.h"
+
+/* Implement TARGET_RUST_OS_INFO for OpenBSD targets.  */
+
+static void
+openbsd_rust_target_os_info (void)
+{
+  rust_add_target_info ("target_family", "unix");
+  rust_add_target_info ("target_os", "openbsd");
+  rust_add_target_info ("target_vendor", "unknown");
+  rust_add_target_info ("target_env", "");
+}
+
+#undef TARGET_RUST_OS_INFO
+#define TARGET_RUST_OS_INFO openbsd_rust_target_os_info
+
+struct gcc_targetrustm targetrustm = TARGETRUSTM_INITIALIZER;

--- a/gcc/config/sol2-rust.cc
+++ b/gcc/config/sol2-rust.cc
@@ -1,0 +1,40 @@
+/* Solaris support needed only by Rust front-end.
+   Copyright (C) 2022 Free Software Foundation, Inc.
+
+GCC is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free
+Software Foundation; either version 3, or (at your option) any later
+version.
+
+GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with GCC; see the file COPYING3.  If not see
+<http://www.gnu.org/licenses/>.  */
+
+#include "config.h"
+#include "system.h"
+#include "coretypes.h"
+#include "tm.h"
+#include "tm_rust.h"
+#include "rust/rust-target.h"
+#include "rust/rust-target-def.h"
+
+/* Implement TARGET_RUST_OS_INFO for Solaris targets.  */
+
+static void
+solaris_rust_target_os_info (void)
+{
+  rust_add_target_info ("target_family", "unix");
+  rust_add_target_info ("target_os", "solaris");
+  rust_add_target_info ("target_vendor", "sun");
+  rust_add_target_info ("target_env", "");
+}
+
+#undef TARGET_RUST_OS_INFO
+#define TARGET_RUST_OS_INFO solaris_rust_target_os_info
+
+struct gcc_targetrustm targetrustm = TARGETRUSTM_INITIALIZER;

--- a/gcc/config/t-dragonfly
+++ b/gcc/config/t-dragonfly
@@ -19,3 +19,7 @@
 dragonfly-d.o: $(srcdir)/config/dragonfly-d.cc
 	$(COMPILE) $<
 	$(POSTCOMPILE)
+
+dragonfly-rust.o: $(srcdir)/config/dragonfly-rust.cc
+	$(COMPILE) $<
+	$(POSTCOMPILE)

--- a/gcc/config/t-freebsd
+++ b/gcc/config/t-freebsd
@@ -19,3 +19,7 @@
 freebsd-d.o: $(srcdir)/config/freebsd-d.cc
 	$(COMPILE) $<
 	$(POSTCOMPILE)
+
+freebsd-rust.o: $(srcdir)/config/freebsd-rust.cc
+	$(COMPILE) $<
+	$(POSTCOMPILE)

--- a/gcc/config/t-fuchsia
+++ b/gcc/config/t-fuchsia
@@ -1,0 +1,21 @@
+# Copyright (C) 2022 Free Software Foundation, Inc.
+#
+# This file is part of GCC.
+#
+# GCC is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# GCC is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GCC; see the file COPYING3.  If not see
+# <http://www.gnu.org/licenses/>.
+
+fuchsia-rust.o: $(srcdir)/config/fuchsia-rust.cc
+	$(COMPILE) $<
+	$(POSTCOMPILE)

--- a/gcc/config/t-linux
+++ b/gcc/config/t-linux
@@ -19,3 +19,7 @@
 linux.o: $(srcdir)/config/linux.cc
 	  $(COMPILE) $<
 	  $(POSTCOMPILE)
+
+linux-rust.o: $(srcdir)/config/linux-rust.cc
+	  $(COMPILE) $<
+	  $(POSTCOMPILE)

--- a/gcc/config/t-netbsd
+++ b/gcc/config/t-netbsd
@@ -23,3 +23,7 @@ netbsd.o: $(srcdir)/config/netbsd.cc
 netbsd-d.o: $(srcdir)/config/netbsd-d.cc
 	$(COMPILE) $<
 	$(POSTCOMPILE)
+
+netbsd-rust.o: $(srcdir)/config/netbsd-rust.cc
+	$(COMPILE) $<
+	$(POSTCOMPILE)

--- a/gcc/config/t-openbsd
+++ b/gcc/config/t-openbsd
@@ -5,3 +5,8 @@ USER_H = $(EXTRA_HEADERS)
 openbsd-d.o: $(srcdir)/config/openbsd-d.cc
 	$(COMPILE) $<
 	$(POSTCOMPILE)
+
+# OpenBSD-specific Rust support.
+openbsd-rust.o: $(srcdir)/config/openbsd-rust.cc
+	$(COMPILE) $<
+	$(POSTCOMPILE)

--- a/gcc/config/t-sol2
+++ b/gcc/config/t-sol2
@@ -31,6 +31,11 @@ sol2-d.o: $(srcdir)/config/sol2-d.cc
 	$(COMPILE) $<
 	$(POSTCOMPILE)
 
+# Solaris-specific Rust support.
+sol2-rust.o: $(srcdir)/config/sol2-rust.cc
+	$(COMPILE) $<
+	$(POSTCOMPILE)
+
 # Corresponding stub routines.
 sol2-stubs.o: $(srcdir)/config/sol2-stubs.cc
 	$(COMPILE) $<

--- a/gcc/config/t-vxworks
+++ b/gcc/config/t-vxworks
@@ -24,6 +24,10 @@ vxworks-c.o: $(srcdir)/config/vxworks-c.cc
 	$(COMPILE) $<
 	$(POSTCOMPILE)
 
+vxworks-rust.o: $(srcdir)/config/vxworks-rust.cc
+	$(COMPILE) $<
+	$(POSTCOMPILE)
+
 # We leverage $sysroot to find target system headers only, distributed
 # in a VxWorks (a)typical fashion with a different set of headers for
 # rtp vs kernel mode.  We setup SYSROOT_HEADERS_SUFFIX_SPEC to handle

--- a/gcc/config/t-winnt
+++ b/gcc/config/t-winnt
@@ -20,3 +20,7 @@ winnt-c.o: config/winnt-c.cc $(CONFIG_H) $(SYSTEM_H) coretypes.h \
   $(C_TARGET_H) $(C_TARGET_DEF_H)
 	$(COMPILER) -c $(ALL_COMPILERFLAGS) $(ALL_CPPFLAGS) \
 	  $< $(OUTPUT_OPTION)
+
+winnt-rust.o: $(srcdir)/config/winnt-rust.cc
+	$(COMPILE) $<
+	$(POSTCOMPILE)

--- a/gcc/config/vxworks-rust.cc
+++ b/gcc/config/vxworks-rust.cc
@@ -1,0 +1,40 @@
+/* VxWorks support needed only by Rust front-end.
+   Copyright (C) 2022 Free Software Foundation, Inc.
+
+GCC is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free
+Software Foundation; either version 3, or (at your option) any later
+version.
+
+GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with GCC; see the file COPYING3.  If not see
+<http://www.gnu.org/licenses/>.  */
+
+#include "config.h"
+#include "system.h"
+#include "coretypes.h"
+#include "tm.h"
+#include "tm_rust.h"
+#include "rust/rust-target.h"
+#include "rust/rust-target-def.h"
+
+/* Implement TARGET_RUST_OS_INFO for VxWorks targets.  */
+
+static void
+vxworks_rust_target_os_info (void)
+{
+  rust_add_target_info ("target_family", "unix");
+  rust_add_target_info ("target_os", "vxworks");
+  rust_add_target_info ("target_vendor", "wrs");
+  rust_add_target_info ("target_env", "gnu");
+}
+
+#undef TARGET_RUST_OS_INFO
+#define TARGET_RUST_OS_INFO vxworks_rust_target_os_info
+
+struct gcc_targetrustm targetrustm = TARGETRUSTM_INITIALIZER;

--- a/gcc/config/winnt-rust.cc
+++ b/gcc/config/winnt-rust.cc
@@ -1,0 +1,40 @@
+/* Windows support needed only by Rust front-end.
+   Copyright (C) 2022 Free Software Foundation, Inc.
+
+GCC is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free
+Software Foundation; either version 3, or (at your option) any later
+version.
+
+GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with GCC; see the file COPYING3.  If not see
+<http://www.gnu.org/licenses/>.  */
+
+#include "config.h"
+#include "system.h"
+#include "coretypes.h"
+#include "tm.h"
+#include "tm_rust.h"
+#include "rust/rust-target.h"
+#include "rust/rust-target-def.h"
+
+/* Implement TARGET_RUST_OS_INFO for Windows targets.  */
+
+static void
+winnt_rust_target_os_info (void)
+{
+  rust_add_target_info ("target_family", "windows");
+  rust_add_target_info ("target_os", "windows");
+  rust_add_target_info ("target_vendor", "pc");
+  rust_add_target_info ("target_env", "gnu");
+}
+
+#undef TARGET_RUST_OS_INFO
+#define TARGET_RUST_OS_INFO winnt_rust_target_os_info
+
+struct gcc_targetrustm targetrustm = TARGETRUSTM_INITIALIZER;


### PR DESCRIPTION
Pretty much all follow the same template as how darwin was added in the first commit, so mostly uninteresting.

The only slight deviation is with `*-*-linux*`, where rather than putting it in a common `glibc-rust.cc` file, I've instead opted to force each platform have their own source file. So Linux gets a `linux-rust.cc` file, and anyone who wants to add Hurd, kFreeBSD, or kOpenSolaris later can do so by adding a case to this switch with the appropriately named file (i.e: `gnu-rust.cc` for Hurd).

The same can also be said for MinGW targets - `winnt-rust.cc` is explicitly _not_ set for Cygwin, and I'd prefer that whoever does add Cygwin support will create a separate file for it - otherwise you've either got to modify the target headers to add whatever defines you need in order to abstract the two away, or start adding some defines to `tm_rust.h` to expose hints about the target known at configure time.

Linux is also the only implementation that has an `#ifndef` condition, as not all Linux targets include `linux-android.{h,opt}`.

Checked dumps of target_options on a plethora of target configurations, though this list is by no means exhaustive.

---

<details>
  <summary>i686-dragonflybsd</summary>

```
target_pointer_width: "32"
target_env: ""
target_vendor: "unknown"
target_endian: "little"
target_os: "dragonfly"
target_family: "unix"
target_arch: "x86"
```
</details>
<details>
  <summary>x86_64-dragonflybsd</summary>

```
target_pointer_width: "64"
target_env: ""
target_vendor: "unknown"
target_endian: "little"
target_os: "dragonfly"
target_family: "unix"
target_feature: "fxsr"
target_feature: "sse"
target_feature: "sse2"
target_feature: "mmx"
target_arch: "x86_64"
```
</details>
<details>
  <summary>aarch64-freebsd12, ia64-freebsd6, riscv64-freebsd12</summary>

```
target_pointer_width: "64"
target_env: ""
target_vendor: "unknown"
target_endian: "little"
target_os: "freebsd"
target_family: "unix"
```
</details>
<details>
  <summary>arm-freebsd12</summary>

```
target_pointer_width: "32"
target_env: ""
target_vendor: "unknown"
target_endian: "little"
target_os: "freebsd"
target_family: "unix"
```
</details>
<details>
  <summary>i486-freebsd4, i686-freebsd6</summary>

```
target_pointer_width: "32"
target_env: ""
target_vendor: "unknown"
target_endian: "little"
target_os: "freebsd"
target_family: "unix"
target_arch: "x86"
```
</details>
<details>
  <summary>powerpc-freebsd6</summary>

```
target_pointer_width: "32"
target_env: ""
target_vendor: "unknown"
target_endian: "big"
target_os: "freebsd"
target_family: "unix"
```
</details>
<details>
  <summary>sparc64-freebsd6</summary>

```
target_pointer_width: "64"
target_env: ""
target_vendor: "unknown"
target_endian: "big"
target_os: "freebsd"
target_family: "unix"
```
</details>
<details>
  <summary>x86_64-freebsd6</summary>

```
target_pointer_width: "64"
target_env: ""
target_vendor: "unknown"
target_endian: "little"
target_os: "freebsd"
target_family: "unix"
target_feature: "fxsr"
target_feature: "sse"
target_feature: "sse2"
target_feature: "mmx"
target_arch: "x86_64"
```
</details>
<details>
  <summary>aarch64-fuchsia</summary>

```
target_pointer_width: "64"
target_env: ""
target_vendor: "unknown"
target_endian: "little"
target_os: "fushsia"
target_family: "unix"
```
</details>
<details>
  <summary>x86_64-fuchsia</summary>

```
target_pointer_width: "64"
target_env: ""
target_vendor: "unknown"
target_endian: "little"
target_os: "fushsia"
target_family: "unix"
target_feature: "fxsr"
target_feature: "sse"
target_feature: "sse2"
target_feature: "mmx"
target_arch: "x86_64"
```
</details>
<details>
  <summary>i686-kfreebsd-gnu</summary>

```
target_endian: "little"
target_pointer_width: "32"
target_arch: "x86"
```
</details> 
<details>
  <summary>arm-linux-androideabi</summary>

```
target_pointer_width: "32"
target_env: ""
target_endian: "little"
target_os: "android"
target_vendor: "unknown"
target_family: "unix"
```
</details>
<details>
  <summary>aarch64-linux-gnu, alpha-linux-gnu, ia64-linux, riscv64-unknown-linux-gnu</summary>

```
target_pointer_width: "64"
target_env: "gnu"
target_endian: "little"
target_os: "linux"
target_vendor: "unknown"
target_family: "unix"
```
</details>
<details>
  <summary>am33_2.0-linux-gnu, csky-linux-gnu, mips64el-st-linux-gnu, nios2-linux-gnu, powerpcle-linux, riscv32-unknown-linux-gnu, rx-linux, shle-linux, vax-linux-gnu</summary>

```
target_pointer_width: "32"
target_env: "gnu"
target_endian: "little"
target_os: "linux"
target_vendor: "unknown"
target_family: "unix"
```
</details>
<details>
  <summary>arc-linux-uclibc, bfin-linux-uclibc</summary>

```
target_pointer_width: "32"
target_env: "uclibc"
target_endian: "little"
target_os: "linux"
target_vendor: "unknown"
target_family: "unix"
```
</details>
<details>
  <summary>arceb-linux-uclibc, or1k-linux-uclibc</summary>

```
target_pointer_width: "32"
target_env: "uclibc"
target_endian: "big"
target_os: "linux"
target_vendor: "unknown"
target_family: "unix"
```
</details>
<details>
  <summary>frv-linux, h8300-linux, hppa-linux-gnu, m68k-linux, microblaze-linux, mips64octeon-linux, mipsisa32r2-linux-gnu, mipsisa64r2-linux, mips-linux, mips-mti-linux, powerpc64-linux_altivec, powerpc-linux, s390-linux-gnu, sparc-leon3-linux-gnu, sparc-linux-gnu, xtensa-linux</summary>

```
target_pointer_width: "32"
target_env: "gnu"
target_endian: "big"
target_os: "linux"
target_vendor: "unknown"
target_family: "unix"
```
</details>
<details>
  <summary>hppa64-linux-gnu, s390x-linux-gnu, sparc64-linux</summary>

```
target_pointer_width: "64"
target_env: "gnu"
target_endian: "big"
target_os: "linux"
target_vendor: "unknown"
target_family: "unix"
```
</details>
<details>
  <summary>i686-pc-linux-gnu, i686-pc-linux</summary>

```
target_pointer_width: "32"
target_env: "gnu"
target_endian: "little"
target_os: "linux"
target_vendor: "unknown"
target_family: "unix"
target_arch: "x86"
```
</details>
<details>
  <summary>or1k-linux-musl</summary>

```
target_pointer_width: "32"
target_env: "musl"
target_endian: "big"
target_os: "linux"
target_vendor: "unknown"
target_family: "unix"
```
</details>
<details>
  <summary>i686-mingw32crt</summary>

```
target_pointer_width: "32"
target_env: "gnu"
target_vendor: "pc"
target_endian: "little"
target_os: "windows"
target_family: "windows"
target_arch: "x86"
```
</details>
<details>
  <summary>x86_64-mingw32, x86_64-w64-mingw32</summary>

```
target_pointer_width: "64"
target_env: "gnu"
target_vendor: "pc"
target_endian: "little"
target_os: "windows"
target_family: "windows"
target_feature: "fxsr"
target_feature: "sse"
target_feature: "sse2"
target_feature: "mmx"
target_arch: "x86_64"
```
</details>
<details>
  <summary>aarch64-netbsd, alpha-netbsd</summary>

```
target_pointer_width: "64"
target_env: ""
target_vendor: "unknown"
target_endian: "little"
target_os: "netbsd"
target_family: "unix"
```
</details>
<details>
  <summary>arm-netbsdelf, vax-netbsdelf</summary>

```
target_pointer_width: "32"
target_env: ""
target_vendor: "unknown"
target_endian: "little"
target_os: "netbsd"
target_family: "unix"
```
</details>
<details>
  <summary>hppa-netbsd, m68k-netbsdelf, mips-netbsd, powerpc-netbsd, sh-netbsdelf, sparc-netbsdelf</summary>

```
target_pointer_width: "32"
target_env: ""
target_vendor: "unknown"
target_endian: "big"
target_os: "netbsd"
target_family: "unix"
```
</details>
<details>
  <summary>i686-netbsdelf9</summary>

```
target_pointer_width: "32"
target_env: ""
target_vendor: "unknown"
target_endian: "little"
target_os: "netbsd"
target_family: "unix"
target_arch: "x86"
```
</details>
<details>
  <summary>sparc64-netbsd</summary>

```
target_pointer_width: "64"
target_env: ""
target_vendor: "unknown"
target_endian: "big"
target_os: "netbsd"
target_family: "unix"
```
</details> 
<details>
  <summary>x86_64-netbsd</summary>

```
target_pointer_width: "64"
target_env: ""
target_vendor: "unknown"
target_endian: "little"
target_os: "netbsd"
target_family: "unix"
target_feature: "fxsr"
target_feature: "sse"
target_feature: "sse2"
target_feature: "mmx"
target_arch: "x86_64"
```
</details>
<details>
  <summary>alpha-openbsd</summary>

```
target_pointer_width: "64"
target_env: ""
target_vendor: "unknown"
target_endian: "little"
target_os: "openbsd"
target_family: "unix"
```
</details>
<details>
  <summary>bfin-openbsd</summary>

```
target_pointer_width: "32"
target_env: ""
target_vendor: "unknown"
target_endian: "little"
target_os: "openbsd"
target_family: "unix"
```
</details>
<details>
  <summary>i686-openbsd</summary>

```
target_pointer_width: "32"
target_env: ""
target_vendor: "unknown"
target_endian: "little"
target_os: "openbsd"
target_family: "unix"
target_arch: "x86"
```
</details>
<details>
  <summary>sparc64-openbsd</summary>

```
target_pointer_width: "64"
target_env: ""
target_vendor: "unknown"
target_endian: "big"
target_os: "openbsd"
target_family: "unix"
```
</details>
<details>
  <summary>x86_64-openbsd</summary>

```
target_pointer_width: "64"
target_env: ""
target_vendor: "unknown"
target_endian: "little"
target_os: "openbsd"
target_family: "unix"
target_feature: "fxsr"
target_feature: "sse"
target_feature: "sse2"
target_feature: "mmx"
target_arch: "x86_64"
```
</details>
<details>
  <summary>aarch64-wrs-vxworks</summary>

```
target_pointer_width: "64"
target_env: "gnu"
target_vendor: "wrs"
target_endian: "little"
target_os: "vxworks"
target_family: "unix"
```
</details>
<details>
  <summary>arm-wrs-vxworks7</summary>

```
target_pointer_width: "32"
target_env: "gnu"
target_vendor: "wrs"
target_endian: "little"
target_os: "vxworks"
target_family: "unix"
```
</details>
<details>
  <summary>i686-wrs-vxworks, i686-wrs-vxworksae</summary>

```
target_pointer_width: "32"
target_env: "gnu"
target_vendor: "wrs"
target_endian: "little"
target_os: "vxworks"
target_family: "unix"
target_arch: "x86"
```
</details>
<details>
  <summary>mips-wrs-vxworks, powerpc-wrs-vxworksae, powerpc-wrs-vxworks, powerpc-wrs-vxworksmils, sh-wrs-vxworks, sparc-wrs-vxworks</summary>

```
target_pointer_width: "32"
target_env: "gnu"
target_vendor: "wrs"
target_endian: "big"
target_os: "vxworks"
target_family: "unix"
```
</details>
<details>
  <summary>arm-uclinux_eabi, bfin-uclinux, c6x-uclinux</summary>

```
target_endian: "little"
target_pointer_width: "32"
```
</details>
<details>
  <summary>lm32-uclinux, m68k-uclinux, moxie-uclinux, xtensa-uclinux</summary>

```
target_endian: "big"
target_pointer_width: "32"
```
</details>