### PR TITLE
Add check for recursive trait cycles

### DIFF
--- a/gcc/testsuite/rust/compile/issue-1589.rs
+++ b/gcc/testsuite/rust/compile/issue-1589.rs
@@ -1,0 +1,5 @@
+pub trait A: B {}
+// { dg-error "trait cycle detected" "" { target *-*-* } .-1 }
+
+pub trait B: A {}
+// { dg-error "trait cycle detected" "" { target *-*-* } .-1 }


### PR DESCRIPTION
This adds a new RAII style TraitQueryGuard so that we can manage the query lifetime when resolving a trait. This adds in a DefId into a set when we begin to resolve and then finally removes it when completed. This allows us to add in a check at the start if this DefId is already within the set which means this is a trait cycle.

Fixes #1589
