### PR TITLE
Perform expansion pass in a fixed point fashion

### DIFF
--- a/gcc/rust/expand/rust-attribute-visitor.cc
+++ b/gcc/rust/expand/rust-attribute-visitor.cc
@@ -389,6 +389,8 @@ AttrVisitor::visit (AST::ConstGenericParam &)
 void
 AttrVisitor::visit (AST::MacroInvocation &macro_invoc)
 {
+  // FIXME: Probably need to check macro_invoc.kind
+
   // initial strip test based on outer attrs
   expander.expand_cfg_attrs (macro_invoc.get_outer_attrs ());
   if (expander.fails_cfg_with_expand (macro_invoc.get_outer_attrs ()))

--- a/gcc/rust/expand/rust-attribute-visitor.cc
+++ b/gcc/rust/expand/rust-attribute-visitor.cc
@@ -1122,7 +1122,7 @@ AttrVisitor::visit (AST::CallExpr &expr)
 
       stmt->accept_vis (*this);
 
-      auto final_fragment = expander.take_expanded_fragment (*this);
+      auto final_fragment = expander.take_expanded_fragment ();
       if (final_fragment.should_expand ())
 	{
 	  // Remove the current expanded invocation
@@ -3421,7 +3421,7 @@ AttrVisitor::visit (AST::BareFunctionType &type)
 void
 AttrVisitor::maybe_expand_expr (std::unique_ptr<AST::Expr> &expr)
 {
-  auto final_fragment = expander.take_expanded_fragment (*this);
+  auto final_fragment = expander.take_expanded_fragment ();
   if (final_fragment.should_expand ()
       && final_fragment.is_expression_fragment ())
     expr = final_fragment.take_expression_fragment ();
@@ -3430,7 +3430,7 @@ AttrVisitor::maybe_expand_expr (std::unique_ptr<AST::Expr> &expr)
 void
 AttrVisitor::maybe_expand_type (std::unique_ptr<AST::Type> &type)
 {
-  auto final_fragment = expander.take_expanded_fragment (*this);
+  auto final_fragment = expander.take_expanded_fragment ();
   if (final_fragment.should_expand () && final_fragment.is_type_fragment ())
     type = final_fragment.take_type_fragment ();
 }

--- a/gcc/rust/expand/rust-attribute-visitor.cc
+++ b/gcc/rust/expand/rust-attribute-visitor.cc
@@ -1122,7 +1122,7 @@ AttrVisitor::visit (AST::CallExpr &expr)
 
       stmt->accept_vis (*this);
 
-      auto final_fragment = expand_macro_fragment_recursive ();
+      auto final_fragment = expander.take_expanded_fragment (*this);
       if (final_fragment.should_expand ())
 	{
 	  // Remove the current expanded invocation
@@ -3421,7 +3421,7 @@ AttrVisitor::visit (AST::BareFunctionType &type)
 void
 AttrVisitor::maybe_expand_expr (std::unique_ptr<AST::Expr> &expr)
 {
-  auto final_fragment = expand_macro_fragment_recursive ();
+  auto final_fragment = expander.take_expanded_fragment (*this);
   if (final_fragment.should_expand ()
       && final_fragment.is_expression_fragment ())
     expr = final_fragment.take_expression_fragment ();
@@ -3430,7 +3430,7 @@ AttrVisitor::maybe_expand_expr (std::unique_ptr<AST::Expr> &expr)
 void
 AttrVisitor::maybe_expand_type (std::unique_ptr<AST::Type> &type)
 {
-  auto final_fragment = expand_macro_fragment_recursive ();
+  auto final_fragment = expander.take_expanded_fragment (*this);
   if (final_fragment.should_expand () && final_fragment.is_type_fragment ())
     type = final_fragment.take_type_fragment ();
 }

--- a/gcc/rust/expand/rust-attribute-visitor.h
+++ b/gcc/rust/expand/rust-attribute-visitor.h
@@ -56,25 +56,25 @@ public:
    * @return Either the expanded fragment or an empty errored-out fragment
    * indicating an expansion failure.
    */
-  AST::Fragment expand_macro_fragment_recursive ()
-  {
-    auto fragment = expander.take_expanded_fragment (*this);
-    unsigned int original_depth = expander.expansion_depth;
-    auto final_fragment = AST::Fragment::create_error ();
+  // AST::ASTFragment expand_macro_fragment_recursive ()
+  // {
+  //   auto fragment = expander.take_expanded_fragment (*this);
+  //   unsigned int original_depth = expander.expansion_depth;
+  //   auto final_fragment = AST::ASTFragment ({}, true);
 
-    while (fragment.should_expand ())
-      {
-	final_fragment = std::move (fragment);
-	expander.expansion_depth++;
-	// further expand the previously expanded macro fragment
-	auto new_fragment = expander.take_expanded_fragment (*this);
-	if (new_fragment.is_error ())
-	  break;
-	fragment = std::move (new_fragment);
-      }
-    expander.expansion_depth = original_depth;
-    return final_fragment;
-  }
+  //   while (fragment.should_expand ())
+  //     {
+  //     final_fragment = std::move (fragment);
+  //     expander.expansion_depth++;
+  //     // further expand the previously expanded macro fragment
+  //     auto new_fragment = expander.take_expanded_fragment (*this);
+  //     if (new_fragment.is_error ())
+  //       break;
+  //     fragment = std::move (new_fragment);
+  //     }
+  //   expander.expansion_depth = original_depth;
+  //   return final_fragment;
+  // }
 
   /**
    * Expand a set of values, erasing them if they are marked for strip, and
@@ -101,8 +101,7 @@ public:
 	// mark for stripping if required
 	value->accept_vis (*this);
 
-	// recursively expand the children
-	auto final_fragment = expand_macro_fragment_recursive ();
+	auto final_fragment = expander.take_expanded_fragment (*this);
 
 	if (final_fragment.should_expand ())
 	  {

--- a/gcc/rust/expand/rust-attribute-visitor.h
+++ b/gcc/rust/expand/rust-attribute-visitor.h
@@ -101,7 +101,7 @@ public:
 	// mark for stripping if required
 	value->accept_vis (*this);
 
-	auto final_fragment = expander.take_expanded_fragment (*this);
+	auto final_fragment = expander.take_expanded_fragment ();
 
 	if (final_fragment.should_expand ())
 	  {

--- a/gcc/rust/expand/rust-macro-builtins.cc
+++ b/gcc/rust/expand/rust-macro-builtins.cc
@@ -72,7 +72,7 @@ try_expand_macro_expression (AST::Expr *expr, MacroExpander *expander)
   rust_assert (expander);
 
   auto attr_visitor = Rust::AttrVisitor (*expander);
-  auto early_name_resolver = Resolver::EarlyNameResolver ();
+  auto early_name_resolver = Resolver::EarlyNameResolver::get ();
   expr->accept_vis (early_name_resolver);
   expr->accept_vis (attr_visitor);
   return expander->take_expanded_fragment (attr_visitor);

--- a/gcc/rust/expand/rust-macro-builtins.cc
+++ b/gcc/rust/expand/rust-macro-builtins.cc
@@ -71,6 +71,9 @@ try_expand_macro_expression (AST::Expr *expr, MacroExpander *expander)
 {
   rust_assert (expander);
 
+  /* This is probably the one case where we want to eagerly expand and
+   * name-resolve macros */
+
   auto attr_visitor = Rust::AttrVisitor (*expander);
   auto early_name_resolver = Resolver::EarlyNameResolver::get ();
   expr->accept_vis (early_name_resolver);

--- a/gcc/rust/expand/rust-macro-builtins.cc
+++ b/gcc/rust/expand/rust-macro-builtins.cc
@@ -334,6 +334,7 @@ MacroBuiltin::include_bytes_handler (Location invoc_locus,
     new AST::BorrowExpr (std::move (array), false, false, {}, invoc_locus));
 
   auto node = AST::SingleASTNode (std::move (borrow));
+
   return AST::Fragment::complete ({node});
 }
 
@@ -385,7 +386,6 @@ MacroBuiltin::compile_error_handler (Location invoc_locus,
 
 /* Expand builtin macro concat!(), which joins all the literal parameters
    into a string with no delimiter. */
-
 AST::Fragment
 MacroBuiltin::concat_handler (Location invoc_locus, AST::MacroInvocData &invoc)
 {
@@ -492,6 +492,7 @@ MacroBuiltin::env_handler (Location invoc_locus, AST::MacroInvocData &invoc)
     }
 
   auto node = AST::SingleASTNode (make_string (invoc_locus, env_value));
+
   return AST::Fragment::complete ({node});
 }
 

--- a/gcc/rust/expand/rust-macro-builtins.cc
+++ b/gcc/rust/expand/rust-macro-builtins.cc
@@ -440,6 +440,10 @@ MacroBuiltin::compile_error_handler (Location invoc_locus,
 // invocation?
 // Do we split the two passes of parsing the token tree and then expanding it?
 // Can we do that easily?
+//
+// We still need to show the fact that a call to concat!() might be unexpanded.
+// So if we do see a macro invocation still when parsing the new token tree,
+// return an `Unexpanded` fragment.
 
 AST::Fragment
 MacroBuiltin::concat_handler (Location invoc_locus, AST::MacroInvocData &invoc)

--- a/gcc/rust/expand/rust-macro-builtins.cc
+++ b/gcc/rust/expand/rust-macro-builtins.cc
@@ -74,11 +74,14 @@ try_expand_macro_expression (AST::Expr *expr, MacroExpander *expander)
   /* This is probably the one case where we want to eagerly expand and
    * name-resolve macros */
 
+  /* FIXME: But how do we do that? It's going to be super hard
+   * right? How do we get it right? How does rustc do it? */
+
   auto attr_visitor = Rust::AttrVisitor (*expander);
-  auto early_name_resolver = Resolver::EarlyNameResolver::get ();
+  auto early_name_resolver = Resolver::EarlyNameResolver ();
   expr->accept_vis (early_name_resolver);
   expr->accept_vis (attr_visitor);
-  return expander->take_expanded_fragment (attr_visitor);
+  return expander->take_expanded_fragment ();
 }
 
 /* Expand and then extract a string literal from the macro */

--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -113,6 +113,8 @@ MacroExpander::expand_decl_macro (Location invoc_locus,
 void
 MacroExpander::expand_invoc (AST::MacroInvocation &invoc, bool has_semicolon)
 {
+  // FIXME: ARTHUR: Can we remove this check? Since we already perform it in the
+  // fixed point
   if (depth_exceeds_recursion_limit ())
     {
       rust_error_at (invoc.get_locus (), "reached recursion limit");

--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -151,6 +151,11 @@ MacroExpander::expand_invoc (AST::MacroInvocation &invoc, bool has_semicolon)
   if (!ok)
     return;
 
+  // We store the last expanded invocation and macro definition for error
+  // reporting in case the recursion limit is reached
+  last_invoc = &invoc;
+  last_def = rules_def;
+
   if (rules_def->is_builtin ())
     fragment
       = rules_def->get_builtin_transcriber () (invoc.get_locus (), invoc_data);

--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -292,7 +292,7 @@ MacroExpander::expand_crate ()
       // mark for stripping if required
       item->accept_vis (attr_visitor);
 
-      auto fragment = take_expanded_fragment (attr_visitor);
+      auto fragment = take_expanded_fragment ();
       if (fragment.should_expand ())
 	{
 	  // Remove the current expanded invocation

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -320,36 +320,41 @@ struct MacroExpander
 
   AST::Fragment take_expanded_fragment (AST::ASTVisitor &vis)
   {
-    AST::Fragment old_fragment = std::move (expanded_fragment);
-    auto accumulator = std::vector<AST::SingleASTNode> ();
+    auto fragment = std::move (expanded_fragment);
     expanded_fragment = AST::Fragment::create_error ();
-    auto early_name_resolver = Resolver::EarlyNameResolver::get ();
 
-    for (auto &node : old_fragment.get_nodes ())
-      {
-	expansion_depth++;
+    return fragment;
 
-	node.accept_vis (early_name_resolver);
-	node.accept_vis (vis);
-	// we'll decide the next move according to the outcome of the macro
-	// expansion
-	if (expanded_fragment.is_error ())
-	  accumulator.push_back (node); // if expansion fails, there might be a
-					// non-macro expression we need to keep
-	else
-	  {
-	    // if expansion succeeded, then we need to merge the fragment with
-	    // the contents in the accumulator, so that our final expansion
-	    // result will contain non-macro nodes as it should
-	    auto new_nodes = expanded_fragment.get_nodes ();
-	    std::move (new_nodes.begin (), new_nodes.end (),
-		       std::back_inserter (accumulator));
-	    expanded_fragment = AST::Fragment::complete (accumulator);
-	  }
-	expansion_depth--;
-      }
+    // AST::ASTFragment old_fragment = std::move (expanded_fragment);
+    // auto accumulator = std::vector<AST::SingleASTNode> ();
+    // expanded_fragment = AST::ASTFragment::create_error ();
+    // auto early_name_resolver = Resolver::EarlyNameResolver::get ();
 
-    return old_fragment;
+    // for (auto &node : old_fragment.get_nodes ())
+    //   {
+    //   expansion_depth++;
+
+    //   node.accept_vis (early_name_resolver);
+    //   node.accept_vis (vis);
+    //   // we'll decide the next move according to the outcome of the macro
+    //   // expansion
+    //   if (expanded_fragment.is_error ())
+    //     accumulator.push_back (node); // if expansion fails, there might be a
+    //   				// non-macro expression we need to keep
+    //   else
+    //     {
+    //       // if expansion succeeded, then we need to merge the fragment with
+    //       // the contents in the accumulator, so that our final expansion
+    //       // result will contain non-macro nodes as it should
+    //       auto new_nodes = expanded_fragment.get_nodes ();
+    //       std::move (new_nodes.begin (), new_nodes.end (),
+    //   	       std::back_inserter (accumulator));
+    //       expanded_fragment = AST::ASTFragment (accumulator);
+    //     }
+    //   expansion_depth--;
+    //   }
+
+    // return old_fragment;
   }
 
 private:

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -323,7 +323,7 @@ struct MacroExpander
     AST::Fragment old_fragment = std::move (expanded_fragment);
     auto accumulator = std::vector<AST::SingleASTNode> ();
     expanded_fragment = AST::Fragment::create_error ();
-    auto early_name_resolver = Resolver::EarlyNameResolver ();
+    auto early_name_resolver = Resolver::EarlyNameResolver::get ();
 
     for (auto &node : old_fragment.get_nodes ())
       {

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -230,13 +230,8 @@ struct MacroExpander
   MacroExpander (AST::Crate &crate, ExpansionCfg cfg, Session &session)
     : cfg (cfg), crate (crate), session (session),
       sub_stack (SubstitutionScope ()),
-<<<<<<< HEAD
       expanded_fragment (AST::Fragment::create_error ()),
-      resolver (Resolver::Resolver::get ()),
-=======
-      expanded_fragment (AST::ASTFragment::create_error ()),
       has_changed_flag (false), resolver (Resolver::Resolver::get ()),
->>>>>>> e81121759cd (session-manager: Run EarlyNameResolution and Expansion in a fixed point)
       mappings (Analysis::Mappings::get ())
   {}
 

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -340,11 +340,7 @@ struct MacroExpander
    * Reset the expander's "changed" state. This function should be executed at
    * each iteration in a fixed point loop
    */
-  void reset_changed_state ()
-  {
-    has_changed_flag = false;
-    enr.clear_pending_invocations ();
-  }
+  void reset_changed_state () { has_changed_flag = false; }
 
   AST::MacroRulesDefinition *get_last_definition () { return last_def; }
   AST::MacroInvocation *get_last_invocation () { return last_invoc; }

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -345,6 +345,9 @@ struct MacroExpander
    */
   void reset_changed_state () { has_changed_flag = false; }
 
+  AST::MacroRulesDefinition *get_last_definition () { return last_def; }
+  AST::MacroInvocation *get_last_invocation () { return last_invoc; }
+
 private:
   AST::Crate &crate;
   Session &session;
@@ -352,6 +355,9 @@ private:
   std::vector<ContextType> context;
   AST::Fragment expanded_fragment;
   bool has_changed_flag;
+
+  AST::MacroRulesDefinition *last_def;
+  AST::MacroInvocation *last_invoc;
 
 public:
   Resolver::Resolver *resolver;

--- a/gcc/rust/resolve/rust-early-name-resolver.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver.cc
@@ -23,21 +23,37 @@
 namespace Rust {
 namespace Resolver {
 
+// We need to turn the EarlyNameResolver into a singleton if we want it to keep
+// state and to be able to call it from nested scopes/modules For that:
+// 	+ Implement `.get()` method
+// 	+ Make constructor private
+// 	+ Add `NodeId current_scope` field
+// 	+ Add `Scoped` class
+//
+// Now... coffee
+
 EarlyNameResolver::EarlyNameResolver ()
-  : resolver (*Resolver::get ()), mappings (*Analysis::Mappings::get ())
+  : current_scope (UNKNOWN_NODEID), resolver (*Resolver::get ()),
+    mappings (*Analysis::Mappings::get ())
 {}
+
+EarlyNameResolver &
+EarlyNameResolver::get ()
+{
+  static EarlyNameResolver instance;
+
+  rust_debug ("[ARTHUR]: Current lexical scope: %d", instance.current_scope);
+
+  return instance;
+}
 
 void
 EarlyNameResolver::go (AST::Crate &crate)
 {
-  // FIXME: Is that valid? Why is the regular name resolution doing
-  // mappings->get_next_node_id()?
-  resolver.get_macro_scope ().push (crate.get_node_id ());
-
-  for (auto &item : crate.items)
-    item->accept_vis (*this);
-
-  // FIXME: Should we pop the macro scope?
+  scoped (crate.get_node_id (), [&crate, this] () {
+    for (auto &item : crate.items)
+      item->accept_vis (*this);
+  });
 }
 
 void
@@ -335,11 +351,13 @@ EarlyNameResolver::visit (AST::ClosureExprInner &expr)
 void
 EarlyNameResolver::visit (AST::BlockExpr &expr)
 {
-  for (auto &stmt : expr.get_statements ())
-    stmt->accept_vis (*this);
+  scoped (expr.get_node_id (), [&expr, this] () {
+    for (auto &stmt : expr.get_statements ())
+      stmt->accept_vis (*this);
 
-  if (expr.has_tail_expr ())
-    expr.get_tail_expr ()->accept_vis (*this);
+    if (expr.has_tail_expr ())
+      expr.get_tail_expr ()->accept_vis (*this);
+  });
 }
 
 void
@@ -434,8 +452,11 @@ EarlyNameResolver::visit (AST::WhileLetLoopExpr &expr)
 void
 EarlyNameResolver::visit (AST::ForLoopExpr &expr)
 {
-  expr.get_iterator_expr ()->accept_vis (*this);
-  expr.get_loop_block ()->accept_vis (*this);
+  scoped (expr.get_node_id (), [&expr, this] () {
+    expr.get_pattern ()->accept_vis (*this);
+    expr.get_iterator_expr ()->accept_vis (*this);
+    expr.get_loop_block ()->accept_vis (*this);
+  });
 }
 
 void
@@ -473,7 +494,9 @@ void
 EarlyNameResolver::visit (AST::IfLetExpr &expr)
 {
   expr.get_value_expr ()->accept_vis (*this);
-  expr.get_if_block ()->accept_vis (*this);
+
+  scoped (expr.get_node_id (),
+	  [&expr, this] () { expr.get_if_block ()->accept_vis (*this); });
 }
 
 void
@@ -504,16 +527,21 @@ void
 EarlyNameResolver::visit (AST::MatchExpr &expr)
 {
   expr.get_scrutinee_expr ()->accept_vis (*this);
-  for (auto &match_arm : expr.get_match_cases ())
-    {
-      if (match_arm.get_arm ().has_match_arm_guard ())
-	match_arm.get_arm ().get_guard_expr ()->accept_vis (*this);
 
-      for (auto &pattern : match_arm.get_arm ().get_patterns ())
-	pattern->accept_vis (*this);
+  scoped (expr.get_node_id (), [&expr, this] () {
+    for (auto &arm : expr.get_match_cases ())
+      {
+	scoped (arm.get_node_id (), [&arm, this] () {
+	  if (arm.get_arm ().has_match_arm_guard ())
+	    arm.get_arm ().get_guard_expr ()->accept_vis (*this);
 
-      match_arm.get_expr ()->accept_vis (*this);
-    }
+	  for (auto &pattern : arm.get_arm ().get_patterns ())
+	    pattern->accept_vis (*this);
+
+	  arm.get_expr ()->accept_vis (*this);
+	});
+      }
+  });
 }
 
 void
@@ -571,8 +599,10 @@ EarlyNameResolver::visit (AST::Method &method)
 void
 EarlyNameResolver::visit (AST::Module &module)
 {
-  for (auto &item : module.get_items ())
-    item->accept_vis (*this);
+  scoped (module.get_node_id (), [&module, this] () {
+    for (auto &item : module.get_items ())
+      item->accept_vis (*this);
+  });
 }
 
 void
@@ -722,8 +752,13 @@ EarlyNameResolver::visit (AST::TraitItemType &)
 void
 EarlyNameResolver::visit (AST::Trait &trait)
 {
-  for (auto &item : trait.get_trait_items ())
-    item->accept_vis (*this);
+  for (auto &generic : trait.get_generic_params ())
+    generic->accept_vis (*this);
+
+  scoped (trait.get_node_id (), [&trait, this] () {
+    for (auto &item : trait.get_trait_items ())
+      item->accept_vis (*this);
+  });
 }
 
 void
@@ -734,8 +769,10 @@ EarlyNameResolver::visit (AST::InherentImpl &impl)
   for (auto &generic : impl.get_generic_params ())
     generic->accept_vis (*this);
 
-  for (auto &item : impl.get_impl_items ())
-    item->accept_vis (*this);
+  scoped (impl.get_node_id (), [&impl, this] () {
+    for (auto &item : impl.get_impl_items ())
+      item->accept_vis (*this);
+  });
 }
 
 void
@@ -746,8 +783,10 @@ EarlyNameResolver::visit (AST::TraitImpl &impl)
   for (auto &generic : impl.get_generic_params ())
     generic->accept_vis (*this);
 
-  for (auto &item : impl.get_impl_items ())
-    item->accept_vis (*this);
+  scoped (impl.get_node_id (), [&impl, this] () {
+    for (auto &item : impl.get_impl_items ())
+      item->accept_vis (*this);
+  });
 }
 
 void
@@ -772,8 +811,10 @@ EarlyNameResolver::visit (AST::ExternalFunctionItem &item)
 void
 EarlyNameResolver::visit (AST::ExternBlock &block)
 {
-  for (auto &item : block.get_extern_items ())
-    item->accept_vis (*this);
+  scoped (block.get_node_id (), [&block, this] () {
+    for (auto &item : block.get_extern_items ())
+      item->accept_vis (*this);
+  });
 }
 
 void
@@ -795,6 +836,15 @@ EarlyNameResolver::visit (AST::MacroRulesDefinition &rules_def)
 				      rules_def.get_rule_name ());
   resolver.get_macro_scope ().insert (path, rules_def.get_node_id (),
 				      rules_def.get_locus ());
+
+  /* Since the EarlyNameResolver runs multiple time (fixed point algorithm)
+   * we could be inserting the same macro def over and over again until we
+   * implement some optimizations */
+  // FIXME: ARTHUR: Remove that lookup and add proper optimizations instead
+  AST::MacroRulesDefinition *tmp = nullptr;
+  if (mappings.lookup_macro_def (rules_def.get_node_id (), &tmp))
+    return;
+
   mappings.insert_macro_def (&rules_def);
   rust_debug_loc (rules_def.get_locus (), "inserting macro def: [%s]",
 		  path.get ().c_str ());
@@ -846,6 +896,14 @@ EarlyNameResolver::visit (AST::MacroInvocation &invoc)
   AST::MacroRulesDefinition *rules_def = nullptr;
   bool ok = mappings.lookup_macro_def (resolved_node, &rules_def);
   rust_assert (ok);
+
+  /* Since the EarlyNameResolver runs multiple time (fixed point algorithm)
+   * we could be inserting the same macro def over and over again until we
+   * implement some optimizations */
+  // FIXME: ARTHUR: Remove that lookup and add proper optimizations instead
+  AST::MacroRulesDefinition *tmp_def = nullptr;
+  if (mappings.lookup_macro_invocation (invoc, &tmp_def))
+    return;
 
   mappings.insert_macro_invocation (invoc, rules_def);
 }

--- a/gcc/rust/resolve/rust-early-name-resolver.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver.cc
@@ -37,16 +37,6 @@ EarlyNameResolver::EarlyNameResolver ()
     mappings (*Analysis::Mappings::get ())
 {}
 
-EarlyNameResolver &
-EarlyNameResolver::get ()
-{
-  static EarlyNameResolver instance;
-
-  rust_debug ("[ARTHUR]: Current lexical scope: %d", instance.current_scope);
-
-  return instance;
-}
-
 void
 EarlyNameResolver::go (AST::Crate &crate)
 {

--- a/gcc/rust/resolve/rust-early-name-resolver.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver.cc
@@ -47,39 +47,6 @@ EarlyNameResolver::go (AST::Crate &crate)
 }
 
 void
-EarlyNameResolver::insert_pending_invocation (
-  NodeId parent_id, AST::MacroInvocation new_invocation)
-{
-  // We assert that we are not in any scope: if the `current_scope` is none,
-  // this means that the ENR will have run through the whole crate and reset
-  // its current scope.
-  rust_assert (current_scope == UNKNOWN_NODEID);
-
-  auto it = pending_invocations.find (parent_id);
-  if (it != pending_invocations.end ())
-    it->second.emplace_back (new_invocation);
-  else
-    pending_invocations.insert ({parent_id, {new_invocation}});
-}
-
-void
-EarlyNameResolver::clear_pending_invocations ()
-{
-  pending_invocations.clear ();
-}
-
-void
-EarlyNameResolver::resolve_pending_invocations (NodeId parent_id)
-{
-  auto it = pending_invocations.find (parent_id);
-  if (it == pending_invocations.end ())
-    return;
-
-  for (auto &invocation : it->second)
-    invocation.accept_vis (*this);
-}
-
-void
 EarlyNameResolver::scoped (NodeId scope_id, std::function<void ()> fn)
 {
   auto old_scope = current_scope;
@@ -945,10 +912,6 @@ EarlyNameResolver::visit (AST::MacroInvocation &invoc)
   AST::MacroRulesDefinition *rules_def = nullptr;
   bool ok = mappings.lookup_macro_def (resolved_node, &rules_def);
   rust_assert (ok);
-
-  /* If the macro is a builtin, it might have pending invocations */
-  if (rules_def->is_builtin ())
-    resolve_pending_invocations (invoc.get_macro_node_id ());
 
   /* Since the EarlyNameResolver runs multiple time (fixed point algorithm)
    * we could be inserting the same macro def over and over again until we

--- a/gcc/rust/resolve/rust-early-name-resolver.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver.cc
@@ -846,6 +846,18 @@ EarlyNameResolver::visit (AST::MacroInvocation &invoc)
   auto &invoc_data = invoc.get_invoc_data ();
   auto has_semicolon = invoc.has_semicolon ();
 
+  // We need to do one extra thing for macro invocations:
+  // If the macro invoked is a builtin which expects to be expanded eagerly (all
+  // of them? Only some like `concat!`?), we must go through all its "arguments"
+  // and check if some are other macro invocations. In that case, resolve those
+  // macro invocations.
+  // This is going to be enough to make the builtin macros work, but maybe not
+  // enough for them to be eagerly expanded?
+  //
+  // Or...
+  // We simply insert these macro invocations calls and then leave it to the
+  // next fixed-point pass to expand them?
+
   // ??
   // switch on type of macro:
   //  - '!' syntax macro (inner switch)

--- a/gcc/rust/resolve/rust-early-name-resolver.h
+++ b/gcc/rust/resolve/rust-early-name-resolver.h
@@ -30,11 +30,78 @@ namespace Resolver {
 class EarlyNameResolver : public AST::ASTVisitor
 {
 public:
-  EarlyNameResolver ();
+  static EarlyNameResolver &get ();
 
   void go (AST::Crate &crate);
 
 private:
+  EarlyNameResolver ();
+
+  /**
+   * Execute a lambda within a scope. This is equivalent to calling
+   * `enter_scope` before your code and `exit_scope` after. This ensures
+   * no errors can be committed
+   */
+  void scoped (NodeId scope_id, std::function<void ()> fn)
+  {
+    auto old_scope = current_scope;
+    current_scope = scope_id;
+    resolver.get_macro_scope ().push (scope_id);
+    resolver.push_new_macro_rib (resolver.get_macro_scope ().peek ());
+
+    fn ();
+
+    resolver.get_macro_scope ().pop ();
+    current_scope = old_scope;
+  }
+
+  /**
+   * The "scope" we are currently in.
+   *
+   * This involves lexical scopes:
+   *
+   * ```rust
+   * // current_scope = crate_id;
+   * macro_rules! foo { () => {} )
+   *
+   * {
+   *     // current_scope = current_block_id;
+   *     macro_rules! foo { () => { something!(); } }
+   * }
+   * // current_scope = crate_id;
+   * ```
+   *
+   * as well as any sort of scope-like structure that might impact import name
+   * resolution or macro name resolution:
+   *
+   * ```rust
+   * macro_rules! foo {
+   *     () => { fn empty() {} }
+   * }
+   *
+   *
+   * trait Foo {
+   *     fn foo() {
+   *         fn inner_foo() {
+   *             macro_rules! foo { () => {} )
+   *
+   *             foo!();
+   *         }
+   *
+   *         foo!();
+   *     }
+   *
+   *     foo!();
+   * }
+   *
+   * foo!();
+   * ```
+   */
+  NodeId current_scope;
+
+  /* The crate's scope */
+  NodeId crate_scope;
+
   Resolver &resolver;
   Analysis::Mappings &mappings;
 

--- a/gcc/rust/resolve/rust-early-name-resolver.h
+++ b/gcc/rust/resolve/rust-early-name-resolver.h
@@ -124,14 +124,6 @@ private:
   /* The crate's scope */
   NodeId crate_scope;
 
-  /**
-   * Pending invocations resolved when expanding builtin macros. These
-   * invocations need to be expanded eagerly, before the parent macro itself
-   * gets expanded.
-   */
-  std::unordered_map<NodeId, std::vector<AST::MacroInvocation>>
-    pending_invocations;
-
   Resolver &resolver;
   Analysis::Mappings &mappings;
 
@@ -145,12 +137,6 @@ private:
    * invocations
    */
   void resolve_qualified_path_type (AST::QualifiedPathType &path);
-
-  /**
-   * Parse the arguments given to a builtin macro. If one of these arguments
-   * is a macro invocation, then we need to resolve it.
-   */
-  void resolve_builtin_macro_arguments (AST::MacroInvocData &invoc_data);
 
   virtual void visit (AST::Token &tok);
   virtual void visit (AST::DelimTokenTree &delim_tok_tree);

--- a/gcc/rust/resolve/rust-early-name-resolver.h
+++ b/gcc/rust/resolve/rust-early-name-resolver.h
@@ -30,13 +30,11 @@ namespace Resolver {
 class EarlyNameResolver : public AST::ASTVisitor
 {
 public:
-  static EarlyNameResolver &get ();
+  EarlyNameResolver ();
 
   void go (AST::Crate &crate);
 
 private:
-  EarlyNameResolver ();
-
   /**
    * Execute a lambda within a scope. This is equivalent to calling
    * `enter_scope` before your code and `exit_scope` after. This ensures

--- a/gcc/rust/resolve/rust-early-name-resolver.h
+++ b/gcc/rust/resolve/rust-early-name-resolver.h
@@ -40,18 +40,7 @@ private:
    * `enter_scope` before your code and `exit_scope` after. This ensures
    * no errors can be committed
    */
-  void scoped (NodeId scope_id, std::function<void ()> fn)
-  {
-    auto old_scope = current_scope;
-    current_scope = scope_id;
-    resolver.get_macro_scope ().push (scope_id);
-    resolver.push_new_macro_rib (resolver.get_macro_scope ().peek ());
-
-    fn ();
-
-    resolver.get_macro_scope ().pop ();
-    current_scope = old_scope;
-  }
+  void scoped (NodeId scope_id, std::function<void ()> fn);
 
   /**
    * The "scope" we are currently in.
@@ -113,6 +102,12 @@ private:
    * invocations
    */
   void resolve_qualified_path_type (AST::QualifiedPathType &path);
+
+  /**
+   * Parse the arguments given to a builtin macro. If one of these arguments
+   * is a macro invocation, then we need to resolve it.
+   */
+  void resolve_builtin_macro_arguments (AST::MacroInvocData &invoc_data);
 
   virtual void visit (AST::Token &tok);
   virtual void visit (AST::DelimTokenTree &delim_tok_tree);

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -835,6 +835,11 @@ Session::expansion (AST::Crate &crate)
   auto fixed_point_reached = false;
   unsigned iterations = 0;
 
+  // create extctxt? from parse session, cfg, and resolver?
+  /* expand by calling cxtctxt object's monotonic_expander's expand_crate
+   * method. */
+  MacroExpander expander (crate, cfg, *this);
+
   // FIXME: Missing expansion_depth check
   // FIXME: How do we handle builtins for that?
   while (!fixed_point_reached && iterations < cfg.recursion_limit)
@@ -842,10 +847,6 @@ Session::expansion (AST::Crate &crate)
       /* We need to name resolve macros and imports here */
       Resolver::EarlyNameResolver ().go (crate);
 
-      // create extctxt? from parse session, cfg, and resolver?
-      /* expand by calling cxtctxt object's monotonic_expander's expand_crate
-       * method. */
-      MacroExpander expander (crate, cfg, *this);
       expander.expand_crate ();
 
       fixed_point_reached = !expander.has_changed ();
@@ -859,7 +860,17 @@ Session::expansion (AST::Crate &crate)
   // TODO: Keep a reference to last MacroRulesDef and last MacroInvocation in
   // MacroExpander
   if (iterations == cfg.recursion_limit)
-    rust_error_at (Location (), "reached recursion limit");
+    {
+      auto last_invoc = expander.get_last_invocation ();
+      auto last_def = expander.get_last_definition ();
+
+      rust_assert (last_def && last_invoc);
+
+      RichLocation range (last_invoc->get_locus ());
+      range.add_range (last_def->get_locus ());
+
+      rust_error_at (range, "reached recursion limit");
+    }
 
   // error reporting - check unused macros, get missing fragment specifiers
 

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -835,17 +835,18 @@ Session::expansion (AST::Crate &crate)
   auto fixed_point_reached = false;
   unsigned iterations = 0;
 
+  /* We need to name resolve macros and imports here */
+  auto enr = Resolver::EarlyNameResolver ();
   // create extctxt? from parse session, cfg, and resolver?
   /* expand by calling cxtctxt object's monotonic_expander's expand_crate
    * method. */
-  MacroExpander expander (crate, cfg, *this);
+  auto expander = MacroExpander (crate, cfg, *this, enr);
 
   // FIXME: Missing expansion_depth check
   // FIXME: How do we handle builtins for that?
   while (!fixed_point_reached && iterations < cfg.recursion_limit)
     {
-      /* We need to name resolve macros and imports here */
-      Resolver::EarlyNameResolver ().go (crate);
+      enr.go (crate);
 
       expander.expand_crate ();
 

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -824,7 +824,7 @@ void
 Session::expansion (AST::Crate &crate)
 {
   /* We need to name resolve macros and imports here */
-  Resolver::EarlyNameResolver ().go (crate);
+  Resolver::EarlyNameResolver::get ().go (crate);
 
   rust_debug ("started expansion");
 

--- a/gcc/testsuite/rust/compile/macro17.rs
+++ b/gcc/testsuite/rust/compile/macro17.rs
@@ -1,9 +1,7 @@
-// { dg-error "reached recursion limit" }
-
 macro_rules! rep {
     ($a:literal) => { $a };
     ($a:literal $(, $e:literal)*) => {
-        $a + rep!(0 $(, $e)*)
+        $a + rep!(0 $(, $e)*) // { dg-error "reached recursion limit" }
     }
 }
 

--- a/gcc/testsuite/rust/compile/macro17.rs
+++ b/gcc/testsuite/rust/compile/macro17.rs
@@ -1,7 +1,9 @@
+// { dg-error "reached recursion limit" }
+
 macro_rules! rep {
-    ($a:literal) => { $a }; // { dg-error "reached recursion limit" }
-    ($a:literal $(, $e:literal)*) => { // { dg-error "reached recursion limit" }
-        $a + rep!(0 $(, $e)*) // { dg-error "Failed to match" }
+    ($a:literal) => { $a };
+    ($a:literal $(, $e:literal)*) => {
+        $a + rep!(0 $(, $e)*)
     }
 }
 

--- a/gcc/testsuite/rust/compile/macro44.rs
+++ b/gcc/testsuite/rust/compile/macro44.rs
@@ -11,12 +11,12 @@ mod foo {
         () => {{}};
     }
 
-    fn foo_f() { // { dg-warning "function is never used" }
+    fn foo_f() {
         foo!();
     }
 
-    fn bar_f() { // { dg-warning "function is never used" }
-        baz!();
+    fn bar_f() {
+        baz!(); // { dg-error "unknown macro" }
     }
 }
 

--- a/gcc/testsuite/rust/compile/macro45.rs
+++ b/gcc/testsuite/rust/compile/macro45.rs
@@ -1,0 +1,19 @@
+fn foo() {}
+
+fn main() {
+    macro_rules! a {
+        () => {
+            foo();
+        };
+    }
+
+    {
+        macro_rules! a {
+            () => {
+                bar();
+            };
+        }
+    }
+
+    a!();
+}


### PR DESCRIPTION
This also adds proper scoping to the Early Name Resolver. The PR is still a draft as some regressions are still present:

~~1. `compile/macro17.rs`~~

~~The test message about reaching recursion limit does not contain location info, hence the error. This should be easy enough to fix~~

2. `compile/builtin_macro_recurse.rs`

This is going to be much harder. Because the EarlyNameResolver is now wired to work in a fixed point fashion, it's much harder to eagerly expand builtin macros compared to before. We'll need to figure that one out. @liushuyu if you have any ideas I'm all ears :)