### PR TITLE
Initial state capture for closures

### DIFF
--- a/gcc/rust/backend/rust-compile-context.cc
+++ b/gcc/rust/backend/rust-compile-context.cc
@@ -142,5 +142,52 @@ Context::type_hasher (tree type)
   return hstate.end ();
 }
 
+void
+Context::push_closure_context (HirId id)
+{
+  auto it = closure_bindings.find (id);
+  rust_assert (it == closure_bindings.end ());
+
+  closure_bindings.insert ({id, {}});
+  closure_scope_bindings.push_back (id);
+}
+
+void
+Context::pop_closure_context ()
+{
+  rust_assert (!closure_scope_bindings.empty ());
+
+  HirId ref = closure_scope_bindings.back ();
+  closure_scope_bindings.pop_back ();
+  closure_bindings.erase (ref);
+}
+
+void
+Context::insert_closure_binding (HirId id, tree expr)
+{
+  rust_assert (!closure_scope_bindings.empty ());
+
+  HirId ref = closure_scope_bindings.back ();
+  closure_bindings[ref].insert ({id, expr});
+}
+
+bool
+Context::lookup_closure_binding (HirId id, tree *expr)
+{
+  if (closure_scope_bindings.empty ())
+    return false;
+
+  HirId ref = closure_scope_bindings.back ();
+  auto it = closure_bindings.find (ref);
+  rust_assert (it != closure_bindings.end ());
+
+  auto iy = it->second.find (id);
+  if (iy == it->second.end ())
+    return false;
+
+  *expr = iy->second;
+  return true;
+}
+
 } // namespace Compile
 } // namespace Rust

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -345,6 +345,11 @@ public:
     return mangler.mangle_item (ty, path);
   }
 
+  void push_closure_context (HirId id);
+  void pop_closure_context ();
+  void insert_closure_binding (HirId id, tree expr);
+  bool lookup_closure_binding (HirId id, tree *expr);
+
   std::vector<tree> &get_type_decls () { return type_decls; }
   std::vector<::Bvariable *> &get_var_decls () { return var_decls; }
   std::vector<tree> &get_const_decls () { return const_decls; }
@@ -376,6 +381,10 @@ private:
     mono_closure_fns;
   std::map<HirId, tree> implicit_pattern_bindings;
   std::map<hashval_t, tree> main_variants;
+
+  // closure bindings
+  std::vector<HirId> closure_scope_bindings;
+  std::map<HirId, std::map<HirId, tree>> closure_bindings;
 
   // To GCC middle-end
   std::vector<tree> type_decls;

--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -2824,10 +2824,25 @@ CompileExpr::visit (HIR::ClosureExpr &expr)
 
   // lets ignore state capture for now we need to instantiate the struct anyway
   // then generate the function
-
   std::vector<tree> vals;
-  // TODO
-  // setup argument captures based on the mode?
+  for (const auto &capture : closure_tyty->get_captures ())
+    {
+      // lookup the HirId
+      HirId ref = UNKNOWN_HIRID;
+      bool ok = ctx->get_mappings ()->lookup_node_to_hir (capture, &ref);
+      rust_assert (ok);
+
+      // lookup the var decl
+      Bvariable *var = nullptr;
+      bool found = ctx->lookup_var_decl (ref, &var);
+      rust_assert (found);
+
+      // FIXME
+      // this should bes based on the closure move-ability
+      tree var_expr = var->get_tree (expr.get_locus ());
+      tree val = address_expression (var_expr, expr.get_locus ());
+      vals.push_back (val);
+    }
 
   translated
     = ctx->get_backend ()->constructor_expression (compiled_closure_tyty, false,
@@ -2874,8 +2889,29 @@ CompileExpr::generate_closure_function (HIR::ClosureExpr &expr,
   DECL_ARTIFICIAL (self_param->get_decl ()) = 1;
   param_vars.push_back (self_param);
 
+  // push a new context
+  ctx->push_closure_context (expr.get_mappings ().get_hirid ());
+
   // setup the implicit argument captures
-  // TODO
+  size_t idx = 0;
+  for (const auto &capture : closure_tyty.get_captures ())
+    {
+      // lookup the HirId
+      HirId ref = UNKNOWN_HIRID;
+      bool ok = ctx->get_mappings ()->lookup_node_to_hir (capture, &ref);
+      rust_assert (ok);
+
+      // get the assessor
+      tree binding = ctx->get_backend ()->struct_field_expression (
+	self_param->get_tree (expr.get_locus ()), idx, expr.get_locus ());
+      tree indirection = indirect_expression (binding, expr.get_locus ());
+
+      // insert bindings
+      ctx->insert_closure_binding (ref, indirection);
+
+      // continue
+      idx++;
+    }
 
   // args tuple
   tree args_type
@@ -2905,7 +2941,10 @@ CompileExpr::generate_closure_function (HIR::ClosureExpr &expr,
     }
 
   if (!ctx->get_backend ()->function_set_parameters (fndecl, param_vars))
-    return error_mark_node;
+    {
+      ctx->pop_closure_context ();
+      return error_mark_node;
+    }
 
   // lookup locals
   HIR::Expr *function_body = expr.get_expr ().get ();
@@ -2972,6 +3011,7 @@ CompileExpr::generate_closure_function (HIR::ClosureExpr &expr,
   gcc_assert (TREE_CODE (bind_tree) == BIND_EXPR);
   DECL_SAVED_TREE (fndecl) = bind_tree;
 
+  ctx->pop_closure_context ();
   ctx->pop_fn ();
   ctx->push_function (fndecl);
 

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -121,6 +121,14 @@ ResolvePathRef::resolve (const HIR::PathIdentSegment &final_segment,
       return constant_expr;
     }
 
+  // maybe closure binding
+  tree closure_binding = error_mark_node;
+  if (ctx->lookup_closure_binding (ref, &closure_binding))
+    {
+      TREE_USED (closure_binding) = 1;
+      return closure_binding;
+    }
+
   // this might be a variable reference or a function reference
   Bvariable *var = nullptr;
   if (ctx->lookup_var_decl (ref, &var))

--- a/gcc/rust/resolve/rust-ast-resolve-expr.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.cc
@@ -209,7 +209,7 @@ ResolveExpr::visit (AST::IfLetExpr &expr)
 
   for (auto &pattern : expr.get_patterns ())
     {
-      PatternDeclaration::go (pattern.get ());
+      PatternDeclaration::go (pattern.get (), Rib::ItemType::Var);
     }
 
   ResolveExpr::go (expr.get_if_block ().get (), prefix, canonical_prefix);
@@ -343,7 +343,7 @@ ResolveExpr::visit (AST::LoopExpr &expr)
       auto label_lifetime_node_id = label.get_lifetime ().get_node_id ();
       resolver->get_label_scope ().insert (
 	CanonicalPath::new_seg (expr.get_node_id (), label_name),
-	label_lifetime_node_id, label.get_locus (), false,
+	label_lifetime_node_id, label.get_locus (), false, Rib::ItemType::Label,
 	[&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	  rust_error_at (label.get_locus (), "label redefined multiple times");
 	  rust_error_at (locus, "was defined here");
@@ -400,7 +400,7 @@ ResolveExpr::visit (AST::WhileLoopExpr &expr)
       auto label_lifetime_node_id = label.get_lifetime ().get_node_id ();
       resolver->get_label_scope ().insert (
 	CanonicalPath::new_seg (label.get_node_id (), label_name),
-	label_lifetime_node_id, label.get_locus (), false,
+	label_lifetime_node_id, label.get_locus (), false, Rib::ItemType::Label,
 	[&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	  rust_error_at (label.get_locus (), "label redefined multiple times");
 	  rust_error_at (locus, "was defined here");
@@ -429,7 +429,7 @@ ResolveExpr::visit (AST::ForLoopExpr &expr)
       auto label_lifetime_node_id = label.get_lifetime ().get_node_id ();
       resolver->get_label_scope ().insert (
 	CanonicalPath::new_seg (label.get_node_id (), label_name),
-	label_lifetime_node_id, label.get_locus (), false,
+	label_lifetime_node_id, label.get_locus (), false, Rib::ItemType::Label,
 	[&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	  rust_error_at (label.get_locus (), "label redefined multiple times");
 	  rust_error_at (locus, "was defined here");
@@ -446,7 +446,7 @@ ResolveExpr::visit (AST::ForLoopExpr &expr)
   resolver->push_new_label_rib (resolver->get_type_scope ().peek ());
 
   // resolve the expression
-  PatternDeclaration::go (expr.get_pattern ().get ());
+  PatternDeclaration::go (expr.get_pattern ().get (), Rib::ItemType::Var);
   ResolveExpr::go (expr.get_iterator_expr ().get (), prefix, canonical_prefix);
   ResolveExpr::go (expr.get_loop_block ().get (), prefix, canonical_prefix);
 
@@ -520,7 +520,7 @@ ResolveExpr::visit (AST::MatchExpr &expr)
       // insert any possible new patterns
       for (auto &pattern : arm.get_patterns ())
 	{
-	  PatternDeclaration::go (pattern.get ());
+	  PatternDeclaration::go (pattern.get (), Rib::ItemType::Var);
 	}
 
       // resolve the body
@@ -617,7 +617,7 @@ ResolveExpr::visit (AST::ClosureExprInnerTyped &expr)
 void
 ResolveExpr::resolve_closure_param (AST::ClosureParam &param)
 {
-  PatternDeclaration::go (param.get_pattern ().get ());
+  PatternDeclaration::go (param.get_pattern ().get (), Rib::ItemType::Param);
 
   if (param.has_type_given ())
     ResolveType::go (param.get_type ().get ());

--- a/gcc/rust/resolve/rust-ast-resolve-expr.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.cc
@@ -581,8 +581,12 @@ ResolveExpr::visit (AST::ClosureExprInner &expr)
       resolve_closure_param (p);
     }
 
+  resolver->push_closure_context (expr.get_node_id ());
+
   ResolveExpr::go (expr.get_definition_expr ().get (), prefix,
 		   canonical_prefix);
+
+  resolver->pop_closure_context ();
 
   resolver->get_name_scope ().pop ();
   resolver->get_type_scope ().pop ();
@@ -606,8 +610,13 @@ ResolveExpr::visit (AST::ClosureExprInnerTyped &expr)
     }
 
   ResolveType::go (expr.get_return_type ().get ());
+
+  resolver->push_closure_context (expr.get_node_id ());
+
   ResolveExpr::go (expr.get_definition_block ().get (), prefix,
 		   canonical_prefix);
+
+  resolver->pop_closure_context ();
 
   resolver->get_name_scope ().pop ();
   resolver->get_type_scope ().pop ();

--- a/gcc/rust/resolve/rust-ast-resolve-implitem.h
+++ b/gcc/rust/resolve/rust-ast-resolve-implitem.h
@@ -56,7 +56,7 @@ public:
     auto path = prefix.append (decl);
 
     resolver->get_type_scope ().insert (
-      path, type.get_node_id (), type.get_locus (), false,
+      path, type.get_node_id (), type.get_locus (), false, Rib::ItemType::Type,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (type.get_locus ());
 	r.add_range (locus);
@@ -72,6 +72,7 @@ public:
 
     resolver->get_name_scope ().insert (
       path, constant.get_node_id (), constant.get_locus (), false,
+      Rib::ItemType::Const,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (constant.get_locus ());
 	r.add_range (locus);
@@ -87,6 +88,7 @@ public:
 
     resolver->get_name_scope ().insert (
       path, function.get_node_id (), function.get_locus (), false,
+      Rib::ItemType::Function,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (function.get_locus ());
 	r.add_range (locus);
@@ -102,6 +104,7 @@ public:
 
     resolver->get_name_scope ().insert (
       path, method.get_node_id (), method.get_locus (), false,
+      Rib::ItemType::Function,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (method.get_locus ());
 	r.add_range (locus);
@@ -141,6 +144,7 @@ public:
 
     resolver->get_name_scope ().insert (
       path, function.get_node_id (), function.get_locus (), false,
+      Rib::ItemType::Function,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (function.get_locus ());
 	r.add_range (locus);
@@ -159,6 +163,7 @@ public:
 
     resolver->get_name_scope ().insert (
       path, method.get_node_id (), method.get_locus (), false,
+      Rib::ItemType::Function,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (method.get_locus ());
 	r.add_range (locus);
@@ -177,6 +182,7 @@ public:
 
     resolver->get_name_scope ().insert (
       path, constant.get_node_id (), constant.get_locus (), false,
+      Rib::ItemType::Const,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (constant.get_locus ());
 	r.add_range (locus);
@@ -194,7 +200,7 @@ public:
     auto cpath = canonical_prefix.append (decl);
 
     resolver->get_type_scope ().insert (
-      path, type.get_node_id (), type.get_locus (), false,
+      path, type.get_node_id (), type.get_locus (), false, Rib::ItemType::Type,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (type.get_locus ());
 	r.add_range (locus);
@@ -233,6 +239,7 @@ public:
 
     resolver->get_name_scope ().insert (
       path, function.get_node_id (), function.get_locus (), false,
+      Rib::ItemType::Function,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (function.get_locus ());
 	r.add_range (locus);
@@ -251,6 +258,7 @@ public:
 
     resolver->get_name_scope ().insert (
       path, item.get_node_id (), item.get_locus (), false,
+      Rib::ItemType::Static,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (item.get_locus ());
 	r.add_range (locus);

--- a/gcc/rust/resolve/rust-ast-resolve-item.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-item.cc
@@ -82,7 +82,8 @@ ResolveTraitItems::visit (AST::TraitItemFunc &func)
   for (auto &param : function.get_function_params ())
     {
       ResolveType::go (param.get_type ().get ());
-      PatternDeclaration::go (param.get_pattern ().get ());
+      PatternDeclaration::go (param.get_pattern ().get (),
+			      Rib::ItemType::Param);
     }
 
   if (function.has_where_clause ())
@@ -138,14 +139,15 @@ ResolveTraitItems::visit (AST::TraitItemMethod &func)
   AST::TypePath self_type_path (std::move (segments), self_param.get_locus ());
 
   ResolveType::go (&self_type_path);
-  PatternDeclaration::go (&self_pattern);
+  PatternDeclaration::go (&self_pattern, Rib::ItemType::Param);
 
   // we make a new scope so the names of parameters are resolved and shadowed
   // correctly
   for (auto &param : function.get_function_params ())
     {
       ResolveType::go (param.get_type ().get ());
-      PatternDeclaration::go (param.get_pattern ().get ());
+      PatternDeclaration::go (param.get_pattern ().get (),
+			      Rib::ItemType::Param);
     }
 
   if (function.has_where_clause ())
@@ -499,10 +501,8 @@ ResolveItem::visit (AST::Function &function)
   for (auto &param : function.get_function_params ())
     {
       ResolveType::go (param.get_type ().get ());
-      PatternDeclaration::go (param.get_pattern ().get ());
-
-      // the mutability checker needs to verify for immutable decls the number
-      // of assignments are <1. This marks an implicit assignment
+      PatternDeclaration::go (param.get_pattern ().get (),
+			      Rib::ItemType::Param);
     }
 
   // resolve the function body
@@ -631,14 +631,15 @@ ResolveItem::visit (AST::Method &method)
   AST::TypePath self_type_path (std::move (segments), self_param.get_locus ());
 
   ResolveType::go (&self_type_path);
-  PatternDeclaration::go (&self_pattern);
+  PatternDeclaration::go (&self_pattern, Rib::ItemType::Param);
 
   // we make a new scope so the names of parameters are resolved and shadowed
   // correctly
   for (auto &param : method.get_function_params ())
     {
       ResolveType::go (param.get_type ().get ());
-      PatternDeclaration::go (param.get_pattern ().get ());
+      PatternDeclaration::go (param.get_pattern ().get (),
+			      Rib::ItemType::Param);
     }
 
   // resolve any where clause items

--- a/gcc/rust/resolve/rust-ast-resolve-pattern.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-pattern.cc
@@ -49,7 +49,7 @@ PatternDeclaration::visit (AST::TupleStructPattern &pattern)
 
 	for (auto &inner_pattern : items_no_range.get_patterns ())
 	  {
-	    PatternDeclaration::go (inner_pattern.get ());
+	    PatternDeclaration::go (inner_pattern.get (), type);
 	  }
       }
       break;

--- a/gcc/rust/resolve/rust-ast-resolve-pattern.h
+++ b/gcc/rust/resolve/rust-ast-resolve-pattern.h
@@ -55,9 +55,9 @@ class PatternDeclaration : public ResolverBase
   using Rust::Resolver::ResolverBase::visit;
 
 public:
-  static void go (AST::Pattern *pattern)
+  static void go (AST::Pattern *pattern, Rib::ItemType type)
   {
-    PatternDeclaration resolver;
+    PatternDeclaration resolver (type);
     pattern->accept_vis (resolver);
   };
 
@@ -67,14 +67,14 @@ public:
     // as new refs to this decl will match back here so it is ok to overwrite
     resolver->get_name_scope ().insert (
       CanonicalPath::new_seg (pattern.get_node_id (), pattern.get_ident ()),
-      pattern.get_node_id (), pattern.get_locus ());
+      pattern.get_node_id (), pattern.get_locus (), type);
   }
 
   void visit (AST::WildcardPattern &pattern) override
   {
     resolver->get_name_scope ().insert (
       CanonicalPath::new_seg (pattern.get_node_id (), "_"),
-      pattern.get_node_id (), pattern.get_locus ());
+      pattern.get_node_id (), pattern.get_locus (), type);
   }
 
   // cases in a match expression
@@ -89,7 +89,9 @@ public:
   void visit (AST::RangePattern &pattern) override;
 
 private:
-  PatternDeclaration () : ResolverBase () {}
+  PatternDeclaration (Rib::ItemType type) : ResolverBase (), type (type) {}
+
+  Rib::ItemType type;
 };
 
 } // namespace Resolver

--- a/gcc/rust/resolve/rust-ast-resolve-stmt.h
+++ b/gcc/rust/resolve/rust-ast-resolve-stmt.h
@@ -64,6 +64,7 @@ public:
 
     resolver->get_name_scope ().insert (
       path, constant.get_node_id (), constant.get_locus (), false,
+      Rib::ItemType::Const,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (constant.get_locus ());
 	r.add_range (locus);
@@ -82,7 +83,7 @@ public:
 			 canonical_prefix);
       }
 
-    PatternDeclaration::go (stmt.get_pattern ().get ());
+    PatternDeclaration::go (stmt.get_pattern ().get (), Rib::ItemType::Var);
     if (stmt.has_type ())
       ResolveType::go (stmt.get_type ().get ());
   }
@@ -97,6 +98,7 @@ public:
 
     resolver->get_type_scope ().insert (
       path, struct_decl.get_node_id (), struct_decl.get_locus (), false,
+      Rib::ItemType::Type,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (struct_decl.get_locus ());
 	r.add_range (locus);
@@ -128,6 +130,7 @@ public:
 
     resolver->get_type_scope ().insert (
       path, enum_decl.get_node_id (), enum_decl.get_locus (), false,
+      Rib::ItemType::Type,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (enum_decl.get_locus ());
 	r.add_range (locus);
@@ -158,7 +161,7 @@ public:
     mappings->insert_canonical_path (item.get_node_id (), cpath);
 
     resolver->get_type_scope ().insert (
-      path, item.get_node_id (), item.get_locus (), false,
+      path, item.get_node_id (), item.get_locus (), false, Rib::ItemType::Type,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (item.get_locus ());
 	r.add_range (locus);
@@ -177,7 +180,7 @@ public:
     mappings->insert_canonical_path (item.get_node_id (), cpath);
 
     resolver->get_type_scope ().insert (
-      path, item.get_node_id (), item.get_locus (), false,
+      path, item.get_node_id (), item.get_locus (), false, Rib::ItemType::Type,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (item.get_locus ());
 	r.add_range (locus);
@@ -202,7 +205,7 @@ public:
     mappings->insert_canonical_path (item.get_node_id (), cpath);
 
     resolver->get_type_scope ().insert (
-      path, item.get_node_id (), item.get_locus (), false,
+      path, item.get_node_id (), item.get_locus (), false, Rib::ItemType::Type,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (item.get_locus ());
 	r.add_range (locus);
@@ -227,7 +230,7 @@ public:
     mappings->insert_canonical_path (item.get_node_id (), cpath);
 
     resolver->get_type_scope ().insert (
-      path, item.get_node_id (), item.get_locus (), false,
+      path, item.get_node_id (), item.get_locus (), false, Rib::ItemType::Type,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (item.get_locus ());
 	r.add_range (locus);
@@ -247,6 +250,7 @@ public:
 
     resolver->get_type_scope ().insert (
       path, struct_decl.get_node_id (), struct_decl.get_locus (), false,
+      Rib::ItemType::Type,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (struct_decl.get_locus ());
 	r.add_range (locus);
@@ -283,6 +287,7 @@ public:
 
     resolver->get_type_scope ().insert (
       path, union_decl.get_node_id (), union_decl.get_locus (), false,
+      Rib::ItemType::Type,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (union_decl.get_locus ());
 	r.add_range (locus);
@@ -317,6 +322,7 @@ public:
 
     resolver->get_name_scope ().insert (
       path, function.get_node_id (), function.get_locus (), false,
+      Rib::ItemType::Function,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (function.get_locus ());
 	r.add_range (locus);
@@ -343,7 +349,8 @@ public:
     for (auto &param : function.get_function_params ())
       {
 	ResolveType::go (param.get_type ().get ());
-	PatternDeclaration::go (param.get_pattern ().get ());
+	PatternDeclaration::go (param.get_pattern ().get (),
+				Rib::ItemType::Param);
       }
 
     // resolve the function body

--- a/gcc/rust/resolve/rust-ast-resolve-toplevel.h
+++ b/gcc/rust/resolve/rust-ast-resolve-toplevel.h
@@ -57,6 +57,7 @@ public:
 
     resolver->get_name_scope ().insert (
       path, module.get_node_id (), module.get_locus (), false,
+      Rib::ItemType::Module,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (module.get_locus ());
 	r.add_range (locus);
@@ -85,6 +86,7 @@ public:
 
     resolver->get_type_scope ().insert (
       path, alias.get_node_id (), alias.get_locus (), false,
+      Rib::ItemType::Type,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (alias.get_locus ());
 	r.add_range (locus);
@@ -105,6 +107,7 @@ public:
 
     resolver->get_type_scope ().insert (
       path, struct_decl.get_node_id (), struct_decl.get_locus (), false,
+      Rib::ItemType::Type,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (struct_decl.get_locus ());
 	r.add_range (locus);
@@ -125,6 +128,7 @@ public:
 
     resolver->get_type_scope ().insert (
       path, enum_decl.get_node_id (), enum_decl.get_locus (), false,
+      Rib::ItemType::Type,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (enum_decl.get_locus ());
 	r.add_range (locus);
@@ -147,7 +151,7 @@ public:
     auto cpath = canonical_prefix.append (decl);
 
     resolver->get_type_scope ().insert (
-      path, item.get_node_id (), item.get_locus (), false,
+      path, item.get_node_id (), item.get_locus (), false, Rib::ItemType::Type,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (item.get_locus ());
 	r.add_range (locus);
@@ -165,7 +169,7 @@ public:
     auto cpath = canonical_prefix.append (decl);
 
     resolver->get_type_scope ().insert (
-      path, item.get_node_id (), item.get_locus (), false,
+      path, item.get_node_id (), item.get_locus (), false, Rib::ItemType::Type,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (item.get_locus ());
 	r.add_range (locus);
@@ -183,7 +187,7 @@ public:
     auto cpath = canonical_prefix.append (decl);
 
     resolver->get_type_scope ().insert (
-      path, item.get_node_id (), item.get_locus (), false,
+      path, item.get_node_id (), item.get_locus (), false, Rib::ItemType::Type,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (item.get_locus ());
 	r.add_range (locus);
@@ -201,7 +205,7 @@ public:
     auto cpath = canonical_prefix.append (decl);
 
     resolver->get_type_scope ().insert (
-      path, item.get_node_id (), item.get_locus (), false,
+      path, item.get_node_id (), item.get_locus (), false, Rib::ItemType::Type,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (item.get_locus ());
 	r.add_range (locus);
@@ -220,6 +224,7 @@ public:
 
     resolver->get_type_scope ().insert (
       path, struct_decl.get_node_id (), struct_decl.get_locus (), false,
+      Rib::ItemType::Type,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (struct_decl.get_locus ());
 	r.add_range (locus);
@@ -240,6 +245,7 @@ public:
 
     resolver->get_type_scope ().insert (
       path, union_decl.get_node_id (), union_decl.get_locus (), false,
+      Rib::ItemType::Type,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (union_decl.get_locus ());
 	r.add_range (locus);
@@ -259,7 +265,7 @@ public:
     auto cpath = canonical_prefix.append (decl);
 
     resolver->get_name_scope ().insert (
-      path, var.get_node_id (), var.get_locus (), false,
+      path, var.get_node_id (), var.get_locus (), false, Rib::ItemType::Static,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (var.get_locus ());
 	r.add_range (locus);
@@ -280,6 +286,7 @@ public:
 
     resolver->get_name_scope ().insert (
       path, constant.get_node_id (), constant.get_locus (), false,
+      Rib::ItemType::Const,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (constant.get_locus ());
 	r.add_range (locus);
@@ -300,6 +307,7 @@ public:
 
     resolver->get_name_scope ().insert (
       path, function.get_node_id (), function.get_locus (), false,
+      Rib::ItemType::Function,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (function.get_locus ());
 	r.add_range (locus);
@@ -343,6 +351,7 @@ public:
 
     resolver->get_name_scope ().insert (
       impl_prefix, impl_block.get_node_id (), impl_block.get_locus (), false,
+      Rib::ItemType::TraitImpl,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (impl_block.get_locus ());
 	r.add_range (locus);
@@ -362,6 +371,7 @@ public:
 
     resolver->get_type_scope ().insert (
       path, trait.get_node_id (), trait.get_locus (), false,
+      Rib::ItemType::Trait,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (trait.get_locus ());
 	r.add_range (locus);
@@ -437,6 +447,7 @@ public:
 
     resolver->get_type_scope ().insert (
       decl, resolved_crate, extern_crate.get_locus (), false,
+      Rib::ItemType::ExternCrate,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	RichLocation r (extern_crate.get_locus ());
 	r.add_range (locus);

--- a/gcc/rust/resolve/rust-ast-resolve-type.h
+++ b/gcc/rust/resolve/rust-ast-resolve-type.h
@@ -177,7 +177,7 @@ public:
     auto seg = CanonicalPath::new_seg (param.get_node_id (),
 				       param.get_type_representation ());
     resolver->get_type_scope ().insert (
-      seg, param.get_node_id (), param.get_locus (), false,
+      seg, param.get_node_id (), param.get_locus (), false, Rib::ItemType::Type,
       [&] (const CanonicalPath &, NodeId, Location locus) -> void {
 	rust_error_at (param.get_locus (),
 		       "generic param redefined multiple times");

--- a/gcc/rust/resolve/rust-name-resolver.h
+++ b/gcc/rust/resolve/rust-name-resolver.h
@@ -96,6 +96,8 @@ public:
   void insert (const CanonicalPath &ident, NodeId id, Location locus,
 	       Rib::ItemType type = Rib::ItemType::Unknown);
   bool lookup (const CanonicalPath &ident, NodeId *id);
+  bool lookup_decl_type (NodeId id, Rib::ItemType *type);
+  bool lookup_rib_for_decl (NodeId id, const Rib **rib);
 
   void iterate (std::function<bool (Rib *)> cb);
   void iterate (std::function<bool (const Rib *)> cb) const;
@@ -108,6 +110,8 @@ public:
   void append_reference_for_def (NodeId refId, NodeId defId);
 
   CrateNum get_crate_num () const { return crate_num; }
+
+  const std::vector<Rib *> &get_context () const { return stack; };
 
 private:
   CrateNum crate_num;
@@ -191,6 +195,15 @@ public:
     return current_module_stack.at (current_module_stack.size () - 2);
   }
 
+  void push_closure_context (NodeId closure_expr_id);
+  void pop_closure_context ();
+  void insert_captured_item (NodeId id);
+  const std::set<NodeId> &get_captures (NodeId id) const;
+
+protected:
+  bool decl_needs_capture (NodeId decl_rib_node_id, NodeId closure_rib_node_id,
+			   const Scope &scope);
+
 private:
   Resolver ();
 
@@ -234,6 +247,10 @@ private:
 
   // keep track of the current module scope ids
   std::vector<NodeId> current_module_stack;
+
+  // captured variables mappings
+  std::vector<NodeId> closure_context;
+  std::map<NodeId, std::set<NodeId>> closures_capture_mappings;
 };
 
 } // namespace Resolver

--- a/gcc/rust/resolve/rust-name-resolver.h
+++ b/gcc/rust/resolve/rust-name-resolver.h
@@ -30,6 +30,24 @@ namespace Resolver {
 class Rib
 {
 public:
+  enum ItemType
+  {
+    Var,
+    Param,
+    Function,
+    Type,
+    Module,
+    Static,
+    Const,
+    Trait,
+    Impl,
+    TraitImpl,
+    ExternCrate,
+    MacroDecl,
+    Label,
+    Unknown
+  };
+
   // FIXME
   // Rust uses local_def_ids assigned by def_collector on the AST. Consider
   // moving to a local-def-id
@@ -38,6 +56,7 @@ public:
   // this takes the relative paths of items within a compilation unit for lookup
   void insert_name (
     const CanonicalPath &path, NodeId id, Location locus, bool shadow,
+    ItemType type,
     std::function<void (const CanonicalPath &, NodeId, Location)> dup_cb);
 
   bool lookup_canonical_path (const NodeId &id, CanonicalPath *ident);
@@ -46,6 +65,7 @@ public:
   void append_reference_for_def (NodeId def, NodeId ref);
   bool have_references_for_node (NodeId def) const;
   bool decl_was_declared_here (NodeId def) const;
+  bool lookup_decl_type (NodeId def, ItemType *type) const;
   void debug () const;
   std::string debug_str () const;
 
@@ -60,6 +80,7 @@ private:
   std::map<NodeId, CanonicalPath> reverse_path_mappings;
   std::map<NodeId, Location> decls_within_rib;
   std::map<NodeId, std::set<NodeId>> references;
+  std::map<NodeId, ItemType> decl_type_mappings;
 };
 
 class Scope
@@ -69,9 +90,11 @@ public:
 
   void
   insert (const CanonicalPath &ident, NodeId id, Location locus, bool shadow,
+	  Rib::ItemType type,
 	  std::function<void (const CanonicalPath &, NodeId, Location)> dup_cb);
 
-  void insert (const CanonicalPath &ident, NodeId id, Location locus);
+  void insert (const CanonicalPath &ident, NodeId id, Location locus,
+	       Rib::ItemType type = Rib::ItemType::Unknown);
   bool lookup (const CanonicalPath &ident, NodeId *id);
 
   void iterate (std::function<bool (Rib *)> cb);

--- a/gcc/rust/resolve/rust-name-resolver.h
+++ b/gcc/rust/resolve/rust-name-resolver.h
@@ -30,8 +30,9 @@ namespace Resolver {
 class Rib
 {
 public:
-  // Rust uses local_def_ids assigned by def_collector on the AST
-  // lets use NodeId instead
+  // FIXME
+  // Rust uses local_def_ids assigned by def_collector on the AST. Consider
+  // moving to a local-def-id
   Rib (CrateNum crateNum, NodeId node_id);
 
   // this takes the relative paths of items within a compilation unit for lookup
@@ -59,7 +60,6 @@ private:
   std::map<NodeId, CanonicalPath> reverse_path_mappings;
   std::map<NodeId, Location> decls_within_rib;
   std::map<NodeId, std::set<NodeId>> references;
-  Analysis::Mappings *mappings;
 };
 
 class Scope
@@ -172,6 +172,7 @@ private:
   Resolver ();
 
   void generate_builtins ();
+  void setup_builtin (const std::string &name, TyTy::BaseType *tyty);
 
   Analysis::Mappings *mappings;
   TypeCheckContext *tyctx;

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -1492,8 +1492,10 @@ TypeCheckExpr::visit (HIR::ClosureExpr &expr)
 		 expr.get_locus ());
 
   // generate the closure type
+  NodeId closure_node_id = expr.get_mappings ().get_nodeid ();
+  const std::set<NodeId> &captures = resolver->get_captures (closure_node_id);
   infered = new TyTy::ClosureType (ref, id, ident, closure_args, result_type,
-				   subst_refs);
+				   subst_refs, captures);
 
   // FIXME
   // all closures automatically inherit the appropriate fn trait. Lets just

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -1675,8 +1675,7 @@ std::string
 ClosureType::as_string () const
 {
   std::string params_buf = parameters->as_string ();
-  return "|" + params_buf + "| {" + result_type.get_tyty ()->as_string ()
-	 + "} {" + raw_bounds_as_string () + "}";
+  return "|" + params_buf + "| {" + result_type.get_tyty ()->as_string () + "}";
 }
 
 BaseType *
@@ -1714,7 +1713,7 @@ ClosureType::clone () const
 {
   return new ClosureType (get_ref (), get_ty_ref (), ident, id,
 			  (TyTy::TupleType *) parameters->clone (), result_type,
-			  clone_substs (), get_combined_refs (),
+			  clone_substs (), captures, get_combined_refs (),
 			  specified_bounds);
 }
 

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -1628,13 +1628,15 @@ public:
   ClosureType (HirId ref, DefId id, RustIdent ident,
 	       TyTy::TupleType *parameters, TyVar result_type,
 	       std::vector<SubstitutionParamMapping> subst_refs,
+	       std::set<NodeId> captures,
 	       std::set<HirId> refs = std::set<HirId> (),
 	       std::vector<TypeBoundPredicate> specified_bounds
 	       = std::vector<TypeBoundPredicate> ())
     : BaseType (ref, ref, TypeKind::CLOSURE, ident, refs),
       SubstitutionRef (std::move (subst_refs),
 		       SubstitutionArgumentMappings::error ()),
-      parameters (parameters), result_type (std::move (result_type)), id (id)
+      parameters (parameters), result_type (std::move (result_type)), id (id),
+      captures (captures)
   {
     LocalDefId local_def_id = id.localDefId;
     rust_assert (local_def_id != UNKNOWN_LOCAL_DEFID);
@@ -1644,13 +1646,15 @@ public:
   ClosureType (HirId ref, HirId ty_ref, RustIdent ident, DefId id,
 	       TyTy::TupleType *parameters, TyVar result_type,
 	       std::vector<SubstitutionParamMapping> subst_refs,
+	       std::set<NodeId> captures,
 	       std::set<HirId> refs = std::set<HirId> (),
 	       std::vector<TypeBoundPredicate> specified_bounds
 	       = std::vector<TypeBoundPredicate> ())
     : BaseType (ref, ty_ref, TypeKind::CLOSURE, ident, refs),
       SubstitutionRef (std::move (subst_refs),
 		       SubstitutionArgumentMappings::error ()),
-      parameters (parameters), result_type (std::move (result_type)), id (id)
+      parameters (parameters), result_type (std::move (result_type)), id (id),
+      captures (captures)
   {
     LocalDefId local_def_id = id.localDefId;
     rust_assert (local_def_id != UNKNOWN_LOCAL_DEFID);
@@ -1699,10 +1703,13 @@ public:
 
   void setup_fn_once_output () const;
 
+  const std::set<NodeId> &get_captures () const { return captures; }
+
 private:
   TyTy::TupleType *parameters;
   TyVar result_type;
   DefId id;
+  std::set<NodeId> captures;
 };
 
 class ArrayType : public BaseType

--- a/gcc/testsuite/rust/execute/torture/closure3.rs
+++ b/gcc/testsuite/rust/execute/torture/closure3.rs
@@ -1,0 +1,33 @@
+// { dg-output "3\n" }
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+#[lang = "fn_once"]
+pub trait FnOnce<Args> {
+    #[lang = "fn_once_output"]
+    type Output;
+
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+}
+
+fn f<F: FnOnce(i32) -> i32>(g: F) {
+    let call = g(1);
+    unsafe {
+        let a = "%i\n\0";
+        let b = a as *const str;
+        let c = b as *const i8;
+
+        printf(c, call);
+    }
+}
+
+pub fn main() -> i32 {
+    let capture = 2;
+    let a = |i: i32| {
+        let b = i + capture;
+        b
+    };
+    f(a);
+    0
+}


### PR DESCRIPTION
This patch set adds the initial support closure captures, move semantics are not
handled here. We track what variables are being captured by a closure during
name resolution so that when a VAR_DECL is resolved, we check if we are inside
a closure context node_id which is the same id as its associated rib id. So when
we resolve a name that resides in an outermost rib we can add this to set of 
node-id's that are captured by this closure.

There is a gap here for the case where we need to check if it is inside a nested
function and that function contains closures which could wrongly capture variables
in the enclosing function. This will also be a problem for nested functions in general.

Fixes #195