### PR TITLE
intrinsics: Add rust_sorry wrapper for unimplemented intrinsics

### DIFF
--- a/gcc/rust/backend/rust-compile-intrinsic.cc
+++ b/gcc/rust/backend/rust-compile-intrinsic.cc
@@ -93,6 +93,15 @@ prefetch_write_data (Context *ctx, TyTy::FnType *fntype)
   return prefetch_data_handler (ctx, fntype, Prefetch::Write);
 }
 
+static inline tree
+sorry_handler (Context *ctx, TyTy::FnType *fntype)
+{
+  rust_sorry_at (fntype->get_locus (), "intrinsic %qs is not yet implemented",
+		 fntype->get_identifier ().c_str ());
+
+  return error_mark_node;
+}
+
 static const std::map<std::string,
 		      std::function<tree (Context *, TyTy::FnType *)>>
   generic_intrinsics = {
@@ -107,6 +116,7 @@ static const std::map<std::string,
     {"copy_nonoverlapping", &copy_nonoverlapping_handler},
     {"prefetch_read_data", &prefetch_read_data},
     {"prefetch_write_data", &prefetch_write_data},
+    {"atomic_load", &sorry_handler},
 };
 
 Intrinsics::Intrinsics (Context *ctx) : ctx (ctx) {}

--- a/gcc/testsuite/rust/compile/torture/intrinsics-3.rs
+++ b/gcc/testsuite/rust/compile/torture/intrinsics-3.rs
@@ -1,0 +1,9 @@
+extern "rust-intrinsic" {
+    fn not_an_intrinsic();
+    fn atomic_load(); // { dg-message "sorry, unimplemented: intrinsic .atomic_load. is not yet implemented" }
+}
+
+fn main() {
+    unsafe { not_an_intrinsic() }; // { dg-error "unknown builtin intrinsic: not_an_intrinsic" }
+    unsafe { atomic_load() };
+}


### PR DESCRIPTION
This allows us to define intrinsics without implementing their body. This will be useful for atomic intrinsics for example, as there are a lot of them and we should work on implementing them one by one properly and slowly

