### PR TITLE
intrinsics: Add early implementation for atomic_store_{seqcst, relaxed, release}

### DIFF
--- a/gcc/rust/backend/rust-builtins.cc
+++ b/gcc/rust/backend/rust-builtins.cc
@@ -69,10 +69,46 @@ BuiltinsContext::setup_math_fns ()
 }
 
 void
+BuiltinsContext::setup_atomic_fns ()
+{
+  define_builtin ("atomic_store", BUILT_IN_ATOMIC_STORE, "__atomic_store", NULL,
+		  build_function_type_list (void_type_node, size_type_node,
+					    build_pointer_type (void_type_node),
+					    const_ptr_type_node,
+					    integer_type_node, NULL_TREE),
+		  0);
+  define_builtin ("atomic_store_n", BUILT_IN_ATOMIC_STORE_N, "__atomic_store_n",
+		  NULL,
+		  build_varargs_function_type_list (void_type_node, NULL_TREE),
+		  0);
+  define_builtin ("atomic_store_1", BUILT_IN_ATOMIC_STORE_1, "__atomic_store_1",
+		  NULL,
+		  build_varargs_function_type_list (void_type_node, NULL_TREE),
+		  0);
+  define_builtin ("atomic_store_2", BUILT_IN_ATOMIC_STORE_2, "__atomic_store_2",
+		  NULL,
+		  build_varargs_function_type_list (void_type_node, NULL_TREE),
+		  0);
+  define_builtin ("atomic_store_4", BUILT_IN_ATOMIC_STORE_4, "__atomic_store_4",
+		  NULL,
+		  build_varargs_function_type_list (void_type_node, NULL_TREE),
+		  0);
+  define_builtin ("atomic_store_8", BUILT_IN_ATOMIC_STORE_8, "__atomic_store_8",
+		  NULL,
+		  build_varargs_function_type_list (void_type_node, NULL_TREE),
+		  0);
+  define_builtin ("atomic_store_16", BUILT_IN_ATOMIC_STORE_16,
+		  "__atomic_store_16", NULL,
+		  build_varargs_function_type_list (void_type_node, NULL_TREE),
+		  0);
+}
+
+void
 BuiltinsContext::setup ()
 {
   setup_math_fns ();
   setup_overflow_fns ();
+  setup_atomic_fns ();
 
   define_builtin ("unreachable", BUILT_IN_UNREACHABLE, "__builtin_unreachable",
 		  NULL, build_function_type (void_type_node, void_list_node),

--- a/gcc/rust/backend/rust-builtins.h
+++ b/gcc/rust/backend/rust-builtins.h
@@ -86,8 +86,8 @@ private:
   BuiltinsContext ();
 
   void setup_overflow_fns ();
-
   void setup_math_fns ();
+  void setup_atomic_fns ();
 
   void setup ();
 

--- a/gcc/testsuite/rust/compile/torture/intrinsics-4.rs
+++ b/gcc/testsuite/rust/compile/torture/intrinsics-4.rs
@@ -1,0 +1,20 @@
+trait Copy {}
+
+extern "rust-intrinsic" {
+    pub fn atomic_store_seqcst<T: Copy>(dst: *mut T, val: T);
+    pub fn atomic_store_release<T: Copy>(dst: *mut T, val: T);
+    pub fn atomic_store_relaxed<T: Copy>(dst: *mut T, val: T);
+    // pub fn atomic_store_unordered<T: Copy>(dst: *mut T, val: T);
+}
+
+fn main() {
+    let mut dst = 15;
+    let new_value = 14;
+
+    unsafe {
+        atomic_store_seqcst(&mut dst, new_value);
+        atomic_store_release(&mut dst, new_value);
+        atomic_store_relaxed(&mut dst, new_value);
+        // atomic_store_unordered(&mut dst, new_value);
+    }
+}

--- a/gcc/testsuite/rust/compile/torture/intrinsics-5.rs
+++ b/gcc/testsuite/rust/compile/torture/intrinsics-5.rs
@@ -1,0 +1,35 @@
+trait Copy {}
+
+extern "rust-intrinsic" {
+    pub fn atomic_store_seqcst<T: Copy>(dst: *mut T, value: T);
+    // { dg-error "atomic intrinsics are only available for basic integer types: got type .intrinsics_5::VeryLargeType." "" { target *-*-* } .-1 }
+    // { dg-error "atomic intrinsics are only available for basic integer types: got type .bool." "" { target *-*-* } .-2 }
+}
+
+struct VeryLargeType {
+    a0: i128,
+    a1: i128,
+    a2: i128,
+    a3: i128,
+}
+
+impl VeryLargeType {
+    pub fn new(value: i128) -> VeryLargeType {
+        VeryLargeType {
+            a0: value,
+            a1: 0,
+            a2: 0,
+            a3: 0,
+        }
+    }
+}
+
+fn main() {
+    let mut dst = VeryLargeType::new(0);
+    let mut b = false;
+
+    unsafe {
+        atomic_store_seqcst(&mut dst, VeryLargeType::new(1));
+        atomic_store_seqcst(&mut b, true);
+    }
+}

--- a/gcc/testsuite/rust/execute/torture/atomic_store.rs
+++ b/gcc/testsuite/rust/execute/torture/atomic_store.rs
@@ -1,0 +1,32 @@
+trait Copy {}
+
+extern "rust-intrinsic" {
+    pub fn atomic_store_seqcst<T: Copy>(dst: *mut T, val: T);
+    pub fn atomic_store_release<T: Copy>(dst: *mut T, val: T);
+    pub fn atomic_store_relaxed<T: Copy>(dst: *mut T, val: T);
+    pub fn atomic_store_unordered<T: Copy>(dst: *mut T, val: T);
+}
+
+fn main() -> i32 {
+    let mut dst = 15;
+    let one;
+    let two;
+    let three;
+    let four;
+
+    unsafe {
+        atomic_store_seqcst(&mut dst, 1);
+        one = dst;
+
+        atomic_store_release(&mut dst, 2);
+        two = dst;
+
+        atomic_store_relaxed(&mut dst, 3);
+        three = dst;
+
+        atomic_store_unordered(&mut dst, 4);
+        four = dst;
+    }
+
+    (four + three + two + one) - 10
+}


### PR DESCRIPTION
Needs #1614 so ignore the first commit

This commit adds support for three `atomic_store_*` intrinsics declared
in the core library. The mapping is as follows:

- atomic_store_seqcst(dst, val) -> __atomic_store_n(dst, val,
  __ATOMIC_SEQ_CST)
- atomic_store_relaxed(dst, val) -> __atomic_store_n(dst, val,
  __ATOMIC_RELAXED)
- atomic_store_release(dst, val) -> __atomic_store_n(dst, val,
  __ATOMIC_RELEASE)

The one remaining question is whether `atomic_store_unordered` can be
abstracted as an atomic store with the __ATOMIC_RELAXED ordering.

This commit also performs the overloading "by hand": Replacing
`atomic_store_release<i32>` with `__atomic_store_4` as I cannot get the
generic version to work. This will be done in future improvements.