### PR TITLE
parser: Fix ICE in closure parsing

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -8903,8 +8903,9 @@ Parser<ManagedTokenSource>::parse_closure_param ()
 	}
     }
 
-  return AST::ClosureParam (std::move (pattern), pattern->get_locus (),
-			    std::move (type), std::move (outer_attrs));
+  auto locus = pattern->get_locus ();
+  return AST::ClosureParam (std::move (pattern), locus, std::move (type),
+			    std::move (outer_attrs));
 }
 
 // Parses a grouped or tuple expression (disambiguates).


### PR DESCRIPTION
`pattern` is a `unique_ptr`, which should be set to NULL once `std::move`d, hence causing the ICE as we were dereferencing a NULL pointer to get its location.

Addresses #1612 

This should also help bring the MacOS build back to green