### PR TITLE
typecheck: Fix overzealous `delete` call

### DIFF
--- a/gcc/rust/typecheck/rust-tyty-call.cc
+++ b/gcc/rust/typecheck/rust-tyty-call.cc
@@ -68,7 +68,6 @@ TypeCheckCallExpr::visit (ADTType &type)
 	  return;
 	}
 
-      delete res;
       i++;
     }
 


### PR DESCRIPTION
I'm hoping this fixes the MacOS problem