### PR TITLE
Intrinsics atomic cxchg

### DIFF
--- a/gcc/rust/backend/rust-builtins.cc
+++ b/gcc/rust/backend/rust-builtins.cc
@@ -17,6 +17,7 @@
 #include "rust-diagnostics.h"
 #include "rust-system.h"
 #include "rust-builtins.h"
+#include "tree.h"
 
 #include "target.h"
 #include "stringpool.h"

--- a/gcc/testsuite/rust/execute/torture/atomic_cmp_xchg.rs
+++ b/gcc/testsuite/rust/execute/torture/atomic_cmp_xchg.rs
@@ -1,0 +1,29 @@
+trait Copy {}
+
+extern "rust-intrinsic" {
+    pub fn atomic_cxchg_seqcst_seqcst<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
+}
+
+fn perform_call(old: u32) -> (u32, bool) {
+    let mut dst = 15u32;
+    let new = 14u32;
+
+    // FIXME: This is a little weird. We get a verification error during gimple checking about
+    // non-trivial conversion between `struct (T=i32, bool)` and `struct (i32, bool)`
+    // Destructuring and re-tupling fixes it for now. This probably happens because we create
+    // the tuple type by hand instead of creating the proper `HIR::TupleType()` and compiling it
+    let res = unsafe { atomic_cxchg_seqcst_seqcst(&mut dst, old, new) };
+
+    (res.0, res.1)
+}
+
+fn main() -> u32 {
+    let res0 = perform_call(15); // valid - should return {15, true}
+    let res1 = perform_call(189); // invalid - should return {15, false}
+
+    if res0.1 && !res1.1 {
+        (res0.0 - 15) + (res1.0 - 15)
+    } else {
+        1 // return an error
+    }
+}


### PR DESCRIPTION
This PR implements all intrinsics centered around `atomic_cxchg` (which stands for "compare exchange").

I am encountering an extremely weird issue which is causing the tests to fail: depending on the optimization level, the provided test file (`atomic_cmp_xchg.rs`) will execute properly. There is some undefined behavior at bay, and I've tried running the file under `valgrind`, which shows some initialization errors. The issue is that I believe these initialization errors to stem from the trees I generate for the intrinsic's function declaration. I cannot figure out what I am doing wrong, and would love an external eye on this.

The abundance of `TREE_READONLY(...)` and `TREE_SIDE_EFFECTS(...)` is a poor attempt at trying to avoid any errors, as that has been an issue before. This will be removed before merging as soon as the root cause of the issue is figured out.

GCC adventurers are welcome to participate :) @ibuclaw @davidmalcolm 