### PR TITLE
Ast dump where clause

### DIFF
--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -66,6 +66,13 @@ Dump::visit (std::unique_ptr<T> &node)
 
 template <typename T>
 void
+Dump::visit (T &node)
+{
+  node.accept_vis (*this);
+}
+
+template <typename T>
+void
 Dump::visit_items_joined_by_separator (T &collection,
 				       const std::string &separator,
 				       size_t start_offset, size_t end_offset)
@@ -129,7 +136,7 @@ Dump::visit (FunctionParam &param)
 }
 
 void
-Dump::visit (const Attribute &attrib)
+Dump::visit (Attribute &attrib)
 {
   stream << "#[";
   visit_items_joined_by_separator (attrib.get_path ().get_segments (), "::");
@@ -158,13 +165,13 @@ Dump::visit (const Attribute &attrib)
 }
 
 void
-Dump::visit (const SimplePathSegment &segment)
+Dump::visit (SimplePathSegment &segment)
 {
   stream << segment.get_segment_name ();
 }
 
 void
-Dump::visit (const Visibility &vis)
+Dump::visit (Visibility &vis)
 {
   switch (vis.get_vis_type ())
     {
@@ -1099,7 +1106,7 @@ Dump::visit (TraitItemType &item)
 void
 Dump::visit (Trait &trait)
 {
-  for (const auto &attr : trait.get_outer_attrs ())
+  for (auto &attr : trait.get_outer_attrs ())
     {
       visit (attr);
       stream << "\n" << indentation;

--- a/gcc/rust/ast/rust-ast-dump.h
+++ b/gcc/rust/ast/rust-ast-dump.h
@@ -81,6 +81,11 @@ private:
   template <typename T> void visit (std::unique_ptr<T> &node);
 
   /**
+   * @see visit<std::unique_ptr<T>>
+   */
+  template <typename T> void visit (T &node);
+
+  /**
    * Visit all items in given @collection, placing the separator in between but
    * not at the end.
    * Start and end offset allow to visit only a "slice" from the collection.
@@ -122,12 +127,12 @@ private:
 			      std::unique_ptr<BlockExpr> &block);
 
   void visit (FunctionParam &param);
-  void visit (const Attribute &attrib);
-  void visit (const Visibility &vis);
+  void visit (Attribute &attrib);
+  void visit (Visibility &vis);
   void visit (std::vector<std::unique_ptr<GenericParam>> &params);
   void visit (TupleField &field);
   void visit (StructField &field);
-  void visit (const SimplePathSegment &segment);
+  void visit (SimplePathSegment &segment);
   void visit (NamedFunctionParam &param);
   void visit (MacroRule &rule);
 

--- a/gcc/rust/ast/rust-ast-dump.h
+++ b/gcc/rust/ast/rust-ast-dump.h
@@ -135,6 +135,8 @@ private:
   void visit (SimplePathSegment &segment);
   void visit (NamedFunctionParam &param);
   void visit (MacroRule &rule);
+  void visit (WhereClause &rule);
+  void visit (std::vector<LifetimeParam> &for_lifetimes);
 
   // rust-ast.h
   void visit (Token &tok);

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -1310,6 +1310,8 @@ public:
   // Returns whether the lifetime param has any lifetime bounds.
   bool has_lifetime_bounds () const { return !lifetime_bounds.empty (); }
 
+  std::vector<Lifetime> &get_lifetime_bounds () { return lifetime_bounds; }
+
   // Returns whether the lifetime param has an outer attribute.
   bool has_outer_attribute () const { return !outer_attr.is_empty (); }
 

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -901,6 +901,7 @@ public:
 
   FunctionQualifiers get_qualifiers () { return qualifiers; }
 
+  Visibility &get_visibility () { return vis; }
   const Visibility &get_visibility () const { return vis; }
 
 protected:
@@ -1975,6 +1976,7 @@ public:
     return field_type;
   }
 
+  Visibility &get_visibility () { return visibility; }
   const Visibility &get_visibility () const { return visibility; }
 
   NodeId get_node_id () const { return node_id; }
@@ -2109,6 +2111,7 @@ public:
 
   NodeId get_node_id () const { return node_id; }
 
+  Visibility &get_visibility () { return visibility; }
   const Visibility &get_visibility () const { return visibility; }
 
   Location get_locus () const { return locus; }
@@ -4150,6 +4153,7 @@ public:
 
   Location get_locus () const { return locus; }
 
+  Visibility &get_visibility () { return visibility; }
   const Visibility &get_visibility () const { return visibility; }
 
   ExternalFunctionItem (

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -236,6 +236,8 @@ public:
   // Returns whether the item has ForLifetimes
   bool has_for_lifetimes () const { return !for_lifetimes.empty (); }
 
+  std::vector<LifetimeParam> &get_for_lifetimes () { return for_lifetimes; }
+
   // Returns whether the item has type param bounds
   bool has_type_param_bounds () const { return !type_param_bounds.empty (); }
 

--- a/gcc/rust/ast/rust-type.h
+++ b/gcc/rust/ast/rust-type.h
@@ -46,6 +46,8 @@ public:
   // Returns whether trait bound has "for" lifetimes
   bool has_for_lifetimes () const { return !for_lifetimes.empty (); }
 
+  std::vector<LifetimeParam> &get_for_lifetimes () { return for_lifetimes; }
+
   TraitBound (TypePath type_path, Location locus, bool in_parens = false,
 	      bool opening_question_mark = false,
 	      std::vector<LifetimeParam> for_lifetimes


### PR DESCRIPTION
Adds dump of the where clause and recursively needed nodes.
Adds visitor compatibility layer for general references except for unique pointers - needed for lifetimes. The enable is necessary to coexist with the unique_ptr overload.

Depends on #1624 and will be rebased when it is merged. 