### PR TITLE
Fix mac-os regression in apply generic arguments to method calls

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -1872,7 +1872,8 @@ public:
 
   std::unique_ptr<Expr> &get_receiver () { return receiver; }
 
-  PathExprSegment get_method_name () const { return method_name; };
+  PathExprSegment &get_method_name () { return method_name; };
+  const PathExprSegment &get_method_name () const { return method_name; };
 
   size_t num_params () const { return params.size (); }
 

--- a/gcc/rust/hir/tree/rust-hir-full-decls.h
+++ b/gcc/rust/hir/tree/rust-hir-full-decls.h
@@ -43,7 +43,7 @@ class PathExpr;
 // rust-path.h
 class PathIdentSegment;
 struct GenericArgsBinding;
-struct GenericArgs;
+class GenericArgs;
 class PathExprSegment;
 class PathPattern;
 class PathInExpression;

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -1149,10 +1149,11 @@ TypeCheckExpr::visit (HIR::MethodCallExpr &expr)
   // apply any remaining generic arguments
   if (expr.get_method_name ().has_generic_args ())
     {
-      rust_debug_loc (expr.get_method_name ().get_generic_args ().get_locus (),
+      HIR::GenericArgs &args = expr.get_method_name ().get_generic_args ();
+      rust_debug_loc (args.get_locus (),
 		      "applying generic arguments to method_call: {%s}",
 		      lookup->debug_str ().c_str ());
-      HIR::GenericArgs &args = expr.get_method_name ().get_generic_args ();
+
       lookup
 	= SubstMapper::Resolve (lookup, expr.get_method_name ().get_locus (),
 				&args);

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -699,6 +699,10 @@ public:
     return *this;
   }
 
+  SubstitutionArgumentMappings (SubstitutionArgumentMappings &&other) = default;
+  SubstitutionArgumentMappings &operator= (SubstitutionArgumentMappings &&other)
+    = default;
+
   static SubstitutionArgumentMappings error ()
   {
     return SubstitutionArgumentMappings ({}, Location (), nullptr, false);

--- a/gcc/testsuite/rust/debug/chartype.rs
+++ b/gcc/testsuite/rust/debug/chartype.rs
@@ -1,10 +1,11 @@
-// 'char' should use DW_ATE_UTF
-fn main () {
-    let c = 'x';
 // { dg-do compile }
-// Use -w to avoid warnings about the unused variables
-// DW_ATE_UTF entered in DWARF 4.
+// { dg-skip-if "see https://github.com/Rust-GCC/gccrs/pull/1632" { *-*-darwin* } }
 // { dg-options "-w -gdwarf-4 -dA" }
-// DW_ATE_UTF = 0x10
-// { dg-final { scan-assembler "0x10\[ \t]\[^\n\r]* DW_AT_encoding" } } */
+// 'char' should use DW_ATE_UTF
+fn main() {
+    let c = 'x';
+    // Use -w to avoid warnings about the unused variables
+    // DW_ATE_UTF entered in DWARF 4.
+    // DW_ATE_UTF = 0x10
+    // { dg-final { scan-assembler "0x10\[ \t]\[^\n\r]* DW_AT_encoding" } } */
 }


### PR DESCRIPTION
When applying generic arguments to method calls such as:

```receiver.method_name<i32, bool>()```

This ended up wrongly using the default constructor with an empty generic arguments which seems
like a possible bug in the new version of clang. This explicitly sets up all relevant copy constructors
for HIR::PathExprSegment and removes the defaults.