### PR TITLE
rust: Remove unused variables and fix dangling references

### DIFF
--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -269,7 +269,7 @@ Dump::visit (DelimTokenTree &delim_tok_tree)
 }
 
 void
-Dump::visit (AttrInputMetaItemContainer &input)
+Dump::visit (AttrInputMetaItemContainer &)
 {}
 
 void
@@ -311,7 +311,7 @@ Dump::visit (LifetimeParam &lifetime_param)
 }
 
 void
-Dump::visit (ConstGenericParam &lifetime_param)
+Dump::visit (ConstGenericParam &)
 {}
 
 // rust-path.h
@@ -322,15 +322,15 @@ Dump::visit (PathInExpression &path)
 }
 
 void
-Dump::visit (TypePathSegment &segment)
+Dump::visit (TypePathSegment &)
 {}
 
 void
-Dump::visit (TypePathSegmentGeneric &segment)
+Dump::visit (TypePathSegmentGeneric &)
 {}
 
 void
-Dump::visit (TypePathSegmentFunction &segment)
+Dump::visit (TypePathSegmentFunction &)
 {}
 
 void
@@ -346,7 +346,7 @@ Dump::visit (QualifiedPathInExpression &path)
 }
 
 void
-Dump::visit (QualifiedPathInType &path)
+Dump::visit (QualifiedPathInType &)
 {}
 
 // rust-expr.h
@@ -357,15 +357,15 @@ Dump::visit (LiteralExpr &expr)
 }
 
 void
-Dump::visit (AttrInputLiteral &attr_input)
+Dump::visit (AttrInputLiteral &)
 {}
 
 void
-Dump::visit (MetaItemLitExpr &meta_item)
+Dump::visit (MetaItemLitExpr &)
 {}
 
 void
-Dump::visit (MetaItemPathLit &meta_item)
+Dump::visit (MetaItemPathLit &)
 {}
 
 void
@@ -623,35 +623,35 @@ Dump::visit (ArrayIndexExpr &expr)
 }
 
 void
-Dump::visit (TupleExpr &expr)
+Dump::visit (TupleExpr &)
 {}
 
 void
-Dump::visit (TupleIndexExpr &expr)
+Dump::visit (TupleIndexExpr &)
 {}
 
 void
-Dump::visit (StructExprStruct &expr)
+Dump::visit (StructExprStruct &)
 {}
 
 void
-Dump::visit (StructExprFieldIdentifier &field)
+Dump::visit (StructExprFieldIdentifier &)
 {}
 
 void
-Dump::visit (StructExprFieldIdentifierValue &field)
+Dump::visit (StructExprFieldIdentifierValue &)
 {}
 
 void
-Dump::visit (StructExprFieldIndexValue &field)
+Dump::visit (StructExprFieldIndexValue &)
 {}
 
 void
-Dump::visit (StructExprStructFields &expr)
+Dump::visit (StructExprStructFields &)
 {}
 
 void
-Dump::visit (StructExprStructBase &expr)
+Dump::visit (StructExprStructBase &)
 {}
 
 void
@@ -669,15 +669,15 @@ Dump::visit (CallExpr &expr)
 }
 
 void
-Dump::visit (MethodCallExpr &expr)
+Dump::visit (MethodCallExpr &)
 {}
 
 void
-Dump::visit (FieldAccessExpr &expr)
+Dump::visit (FieldAccessExpr &)
 {}
 
 void
-Dump::visit (ClosureExprInner &expr)
+Dump::visit (ClosureExprInner &)
 {}
 
 void
@@ -696,15 +696,15 @@ Dump::visit (BlockExpr &expr)
 }
 
 void
-Dump::visit (ClosureExprInnerTyped &expr)
+Dump::visit (ClosureExprInnerTyped &)
 {}
 
 void
-Dump::visit (ContinueExpr &expr)
+Dump::visit (ContinueExpr &)
 {}
 
 void
-Dump::visit (BreakExpr &expr)
+Dump::visit (BreakExpr &)
 {}
 
 void
@@ -730,7 +730,7 @@ Dump::visit (RangeToExpr &expr)
 }
 
 void
-Dump::visit (RangeFullExpr &expr)
+Dump::visit (RangeFullExpr &)
 {
   stream << "..";
 }
@@ -751,27 +751,27 @@ Dump::visit (RangeToInclExpr &expr)
 }
 
 void
-Dump::visit (ReturnExpr &expr)
+Dump::visit (ReturnExpr &)
 {}
 
 void
-Dump::visit (UnsafeBlockExpr &expr)
+Dump::visit (UnsafeBlockExpr &)
 {}
 
 void
-Dump::visit (LoopExpr &expr)
+Dump::visit (LoopExpr &)
 {}
 
 void
-Dump::visit (WhileLoopExpr &expr)
+Dump::visit (WhileLoopExpr &)
 {}
 
 void
-Dump::visit (WhileLetLoopExpr &expr)
+Dump::visit (WhileLetLoopExpr &)
 {}
 
 void
-Dump::visit (ForLoopExpr &expr)
+Dump::visit (ForLoopExpr &)
 {}
 
 void
@@ -807,35 +807,35 @@ Dump::visit (IfExprConseqIf &expr)
 }
 
 void
-Dump::visit (IfExprConseqIfLet &expr)
+Dump::visit (IfExprConseqIfLet &)
 {}
 
 void
-Dump::visit (IfLetExpr &expr)
+Dump::visit (IfLetExpr &)
 {}
 
 void
-Dump::visit (IfLetExprConseqElse &expr)
+Dump::visit (IfLetExprConseqElse &)
 {}
 
 void
-Dump::visit (IfLetExprConseqIf &expr)
+Dump::visit (IfLetExprConseqIf &)
 {}
 
 void
-Dump::visit (IfLetExprConseqIfLet &expr)
+Dump::visit (IfLetExprConseqIfLet &)
 {}
 
 void
-Dump::visit (MatchExpr &expr)
+Dump::visit (MatchExpr &)
 {}
 
 void
-Dump::visit (AwaitExpr &expr)
+Dump::visit (AwaitExpr &)
 {}
 
 void
-Dump::visit (AsyncBlockExpr &expr)
+Dump::visit (AsyncBlockExpr &)
 {}
 
 // rust-item.h
@@ -959,23 +959,23 @@ Dump::visit (Module &module)
 }
 
 void
-Dump::visit (ExternCrate &crate)
+Dump::visit (ExternCrate &)
 {}
 
 void
-Dump::visit (UseTreeGlob &use_tree)
+Dump::visit (UseTreeGlob &)
 {}
 
 void
-Dump::visit (UseTreeList &use_tree)
+Dump::visit (UseTreeList &)
 {}
 
 void
-Dump::visit (UseTreeRebind &use_tree)
+Dump::visit (UseTreeRebind &)
 {}
 
 void
-Dump::visit (UseDeclaration &use_decl)
+Dump::visit (UseDeclaration &)
 {}
 
 void
@@ -1117,11 +1117,11 @@ Dump::visit (Union &union_item)
 }
 
 void
-Dump::visit (ConstantItem &const_item)
+Dump::visit (ConstantItem &)
 {}
 
 void
-Dump::visit (StaticItem &static_item)
+Dump::visit (StaticItem &)
 {}
 
 void
@@ -1259,7 +1259,7 @@ Dump::visit (TraitImpl &impl)
 }
 
 void
-Dump::visit (ExternalStaticItem &item)
+Dump::visit (ExternalStaticItem &)
 {}
 
 void
@@ -1386,36 +1386,36 @@ Dump::visit (MacroRulesDefinition &rules_def)
 }
 
 void
-Dump::visit (MacroInvocation &macro_invoc)
+Dump::visit (MacroInvocation &)
 {}
 
 void
-Dump::visit (MetaItemPath &meta_item)
+Dump::visit (MetaItemPath &)
 {}
 
 void
-Dump::visit (MetaItemSeq &meta_item)
+Dump::visit (MetaItemSeq &)
 {}
 
 void
-Dump::visit (MetaWord &meta_item)
+Dump::visit (MetaWord &)
 {}
 
 void
-Dump::visit (MetaNameValueStr &meta_item)
+Dump::visit (MetaNameValueStr &)
 {}
 
 void
-Dump::visit (MetaListPaths &meta_item)
+Dump::visit (MetaListPaths &)
 {}
 
 void
-Dump::visit (MetaListNameValueStr &meta_item)
+Dump::visit (MetaListNameValueStr &)
 {}
 
 // rust-pattern.h
 void
-Dump::visit (LiteralPattern &pattern)
+Dump::visit (LiteralPattern &)
 {}
 
 void
@@ -1425,88 +1425,88 @@ Dump::visit (IdentifierPattern &pattern)
 }
 
 void
-Dump::visit (WildcardPattern &pattern)
+Dump::visit (WildcardPattern &)
 {}
 
-// void Dump::visit(RangePatternBound& bound){}
+// void Dump::visit(RangePatternBound& ){}
 
 void
-Dump::visit (RangePatternBoundLiteral &bound)
-{}
-
-void
-Dump::visit (RangePatternBoundPath &bound)
+Dump::visit (RangePatternBoundLiteral &)
 {}
 
 void
-Dump::visit (RangePatternBoundQualPath &bound)
+Dump::visit (RangePatternBoundPath &)
 {}
 
 void
-Dump::visit (RangePattern &pattern)
+Dump::visit (RangePatternBoundQualPath &)
 {}
 
 void
-Dump::visit (ReferencePattern &pattern)
-{}
-
-// void Dump::visit(StructPatternField& field){}
-
-void
-Dump::visit (StructPatternFieldTuplePat &field)
+Dump::visit (RangePattern &)
 {}
 
 void
-Dump::visit (StructPatternFieldIdentPat &field)
+Dump::visit (ReferencePattern &)
+{}
+
+// void Dump::visit(StructPatternField& ){}
+
+void
+Dump::visit (StructPatternFieldTuplePat &)
 {}
 
 void
-Dump::visit (StructPatternFieldIdent &field)
+Dump::visit (StructPatternFieldIdentPat &)
 {}
 
 void
-Dump::visit (StructPattern &pattern)
-{}
-
-// void Dump::visit(TupleStructItems& tuple_items){}
-
-void
-Dump::visit (TupleStructItemsNoRange &tuple_items)
+Dump::visit (StructPatternFieldIdent &)
 {}
 
 void
-Dump::visit (TupleStructItemsRange &tuple_items)
+Dump::visit (StructPattern &)
+{}
+
+// void Dump::visit(TupleStructItems& ){}
+
+void
+Dump::visit (TupleStructItemsNoRange &)
 {}
 
 void
-Dump::visit (TupleStructPattern &pattern)
-{}
-
-// void Dump::visit(TuplePatternItems& tuple_items){}
-
-void
-Dump::visit (TuplePatternItemsMultiple &tuple_items)
+Dump::visit (TupleStructItemsRange &)
 {}
 
 void
-Dump::visit (TuplePatternItemsRanged &tuple_items)
+Dump::visit (TupleStructPattern &)
+{}
+
+// void Dump::visit(TuplePatternItems& ){}
+
+void
+Dump::visit (TuplePatternItemsMultiple &)
 {}
 
 void
-Dump::visit (TuplePattern &pattern)
+Dump::visit (TuplePatternItemsRanged &)
 {}
 
 void
-Dump::visit (GroupedPattern &pattern)
+Dump::visit (TuplePattern &)
 {}
 
 void
-Dump::visit (SlicePattern &pattern)
+Dump::visit (GroupedPattern &)
+{}
+
+void
+Dump::visit (SlicePattern &)
 {}
 
 // rust-stmt.h
 void
-Dump::visit (EmptyStmt &stmt)
+Dump::visit (EmptyStmt &)
 {}
 
 void
@@ -1560,35 +1560,35 @@ Dump::visit (TraitBound &bound)
 }
 
 void
-Dump::visit (ImplTraitType &type)
+Dump::visit (ImplTraitType &)
 {}
 
 void
-Dump::visit (TraitObjectType &type)
+Dump::visit (TraitObjectType &)
 {}
 
 void
-Dump::visit (ParenthesisedType &type)
+Dump::visit (ParenthesisedType &)
 {}
 
 void
-Dump::visit (ImplTraitTypeOneBound &type)
+Dump::visit (ImplTraitTypeOneBound &)
 {}
 
 void
-Dump::visit (TraitObjectTypeOneBound &type)
+Dump::visit (TraitObjectTypeOneBound &)
 {}
 
 void
-Dump::visit (TupleType &type)
+Dump::visit (TupleType &)
 {}
 
 void
-Dump::visit (NeverType &type)
+Dump::visit (NeverType &)
 {}
 
 void
-Dump::visit (RawPointerType &type)
+Dump::visit (RawPointerType &)
 {}
 
 void
@@ -1610,13 +1610,13 @@ Dump::visit (SliceType &type)
 }
 
 void
-Dump::visit (InferredType &type)
+Dump::visit (InferredType &)
 {
   stream << "_";
 }
 
 void
-Dump::visit (BareFunctionType &type)
+Dump::visit (BareFunctionType &)
 {}
 
 } // namespace AST

--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -354,7 +354,7 @@ HIRCompileBase::setup_abi_options (tree fndecl, ABI abi)
 // it is fine to use ARRAY_REFs for vector subscripts on vector
 // register variables.
 bool
-HIRCompileBase::mark_addressable (tree exp, Location locus)
+HIRCompileBase::mark_addressable (tree exp)
 {
   tree x = exp;
 
@@ -418,7 +418,7 @@ HIRCompileBase::address_expression (tree expr, Location location)
   if (expr == error_mark_node)
     return error_mark_node;
 
-  if (!mark_addressable (expr, location))
+  if (!mark_addressable (expr))
     return error_mark_node;
 
   return build_fold_addr_expr_loc (location.gcc_location (), expr);

--- a/gcc/rust/backend/rust-compile-base.h
+++ b/gcc/rust/backend/rust-compile-base.h
@@ -55,7 +55,7 @@ protected:
     const TyTy::TypeBoundPredicate *predicate,
     std::vector<std::pair<Resolver::TraitReference *, HIR::ImplBlock *>>
       &receiver_bounds,
-    const TyTy::BaseType *receiver, const TyTy::BaseType *root, Location locus);
+    const TyTy::BaseType *root, Location locus);
 
   bool verify_array_capacities (tree ltype, tree rtype, Location ltype_locus,
 				Location rtype_locus);
@@ -63,7 +63,7 @@ protected:
   tree query_compile (HirId ref, TyTy::BaseType *lookup,
 		      const HIR::PathIdentSegment &final_segment,
 		      const Analysis::NodeMapping &mappings,
-		      Location expr_locus, bool is_qualified_path);
+		      Location expr_locus);
 
   tree resolve_adjustements (std::vector<Resolver::Adjustment> &adjustments,
 			     tree expression, Location locus);
@@ -113,7 +113,7 @@ protected:
 
   static tree indirect_expression (tree expr, Location locus);
 
-  static bool mark_addressable (tree, Location);
+  static bool mark_addressable (tree);
 
   static std::vector<Bvariable *>
   compile_locals_for_block (Context *ctx, Resolver::Rib &rib, tree fndecl);

--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -1814,17 +1814,15 @@ CompileExpr::visit (HIR::MethodCallExpr &expr)
 
       fn_expr
 	= get_fn_addr_from_dyn (dyn, receiver, fntype, self, expr.get_locus ());
-      self = get_receiver_from_dyn (dyn, receiver, fntype, self,
-				    expr.get_locus ());
+      self = get_receiver_from_dyn (receiver, self, expr.get_locus ());
     }
   else
     {
       // lookup compiled functions since it may have already been compiled
       HIR::PathExprSegment method_name = expr.get_method_name ();
       HIR::PathIdentSegment segment_name = method_name.get_segment ();
-      fn_expr
-	= resolve_method_address (fntype, ref, receiver, segment_name,
-				  expr.get_mappings (), expr.get_locus ());
+      fn_expr = resolve_method_address (fntype, ref, receiver, segment_name,
+					expr.get_locus ());
     }
 
   // lookup the autoderef mappings
@@ -1925,9 +1923,7 @@ CompileExpr::get_fn_addr_from_dyn (const TyTy::DynamicObjectType *dyn,
 }
 
 tree
-CompileExpr::get_receiver_from_dyn (const TyTy::DynamicObjectType *dyn,
-				    TyTy::BaseType *receiver,
-				    TyTy::FnType *fntype, tree receiver_ref,
+CompileExpr::get_receiver_from_dyn (TyTy::BaseType *receiver, tree receiver_ref,
 				    Location expr_locus)
 {
   // get any indirection sorted out
@@ -1946,7 +1942,6 @@ tree
 CompileExpr::resolve_method_address (TyTy::FnType *fntype, HirId ref,
 				     TyTy::BaseType *receiver,
 				     HIR::PathIdentSegment &segment,
-				     Analysis::NodeMapping expr_mappings,
 				     Location expr_locus)
 {
   // lookup compiled functions since it may have already been compiled
@@ -2016,7 +2011,7 @@ CompileExpr::resolve_method_address (TyTy::FnType *fntype, HirId ref,
       // implementation and we should just return error_mark_node
 
       rust_assert (candidates.size () == 1);
-      auto &candidate = *candidates.begin ();
+      auto candidate = *candidates.begin ();
       rust_assert (candidate.is_impl_candidate ());
       rust_assert (candidate.ty->get_kind () == TyTy::TypeKind::FNDEF);
       TyTy::FnType *candidate_call = static_cast<TyTy::FnType *> (candidate.ty);
@@ -2040,7 +2035,8 @@ CompileExpr::resolve_method_address (TyTy::FnType *fntype, HirId ref,
 tree
 CompileExpr::resolve_operator_overload (
   Analysis::RustLangItem::ItemType lang_item_type, HIR::OperatorExprMeta expr,
-  tree lhs, tree rhs, HIR::Expr *lhs_expr, HIR::Expr *rhs_expr)
+  tree lhs, tree rhs, HIR::Expr *lhs_expr,
+  HIR::Expr * /* rhs_expr // FIXME: Reuse when needed */)
 {
   TyTy::FnType *fntype;
   bool is_op_overload = ctx->get_tyctx ()->lookup_operator_overload (
@@ -2073,9 +2069,8 @@ CompileExpr::resolve_operator_overload (
   // lookup compiled functions since it may have already been compiled
   HIR::PathIdentSegment segment_name (
     Analysis::RustLangItem::ToString (lang_item_type));
-  tree fn_expr
-    = resolve_method_address (fntype, ref, receiver, segment_name,
-			      expr.get_mappings (), expr.get_locus ());
+  tree fn_expr = resolve_method_address (fntype, ref, receiver, segment_name,
+					 expr.get_locus ());
 
   // lookup the autoderef mappings
   std::vector<Resolver::Adjustment> *adjustments = nullptr;
@@ -2096,8 +2091,9 @@ CompileExpr::resolve_operator_overload (
 }
 
 tree
-CompileExpr::compile_bool_literal (const HIR::LiteralExpr &expr,
-				   const TyTy::BaseType *tyty)
+CompileExpr::compile_bool_literal (
+  const HIR::LiteralExpr &expr,
+  const TyTy::BaseType * /* tyty FIXME: Reuse when needed */)
 {
   rust_assert (expr.get_lit_type () == HIR::Literal::BOOL);
 
@@ -2179,8 +2175,9 @@ CompileExpr::compile_float_literal (const HIR::LiteralExpr &expr,
 }
 
 tree
-CompileExpr::compile_char_literal (const HIR::LiteralExpr &expr,
-				   const TyTy::BaseType *tyty)
+CompileExpr::compile_char_literal (
+  const HIR::LiteralExpr &expr,
+  const TyTy::BaseType * /* tyty FIXME: Reuse when needed */)
 {
   rust_assert (expr.get_lit_type () == HIR::Literal::CHAR);
   const auto literal_value = expr.get_literal ();
@@ -2359,8 +2356,6 @@ CompileExpr::visit (HIR::ArrayExpr &expr)
     }
 
   rust_assert (tyty->get_kind () == TyTy::TypeKind::ARRAY);
-  const TyTy::ArrayType &array_tyty
-    = static_cast<const TyTy::ArrayType &> (*tyty);
 
   HIR::ArrayElems &elements = *expr.get_internal_elements ();
   switch (elements.get_array_expr_type ())
@@ -2368,23 +2363,20 @@ CompileExpr::visit (HIR::ArrayExpr &expr)
       case HIR::ArrayElems::ArrayExprType::VALUES: {
 	HIR::ArrayElemsValues &elems
 	  = static_cast<HIR::ArrayElemsValues &> (elements);
-	translated
-	  = array_value_expr (expr.get_locus (), array_tyty, array_type, elems);
+	translated = array_value_expr (expr.get_locus (), array_type, elems);
       }
       return;
 
     case HIR::ArrayElems::ArrayExprType::COPIED:
       HIR::ArrayElemsCopied &elems
 	= static_cast<HIR::ArrayElemsCopied &> (elements);
-      translated
-	= array_copied_expr (expr.get_locus (), array_tyty, array_type, elems);
+      translated = array_copied_expr (expr.get_locus (), array_type, elems);
     }
 }
 
 tree
-CompileExpr::array_value_expr (Location expr_locus,
-			       const TyTy::ArrayType &array_tyty,
-			       tree array_type, HIR::ArrayElemsValues &elems)
+CompileExpr::array_value_expr (Location expr_locus, tree array_type,
+			       HIR::ArrayElemsValues &elems)
 {
   std::vector<unsigned long> indexes;
   std::vector<tree> constructor;
@@ -2402,9 +2394,8 @@ CompileExpr::array_value_expr (Location expr_locus,
 }
 
 tree
-CompileExpr::array_copied_expr (Location expr_locus,
-				const TyTy::ArrayType &array_tyty,
-				tree array_type, HIR::ArrayElemsCopied &elems)
+CompileExpr::array_copied_expr (Location expr_locus, tree array_type,
+				HIR::ArrayElemsCopied &elems)
 {
   //  see gcc/cp/typeck2.cc:1369-1401
   gcc_assert (TREE_CODE (array_type) == ARRAY_TYPE);
@@ -2566,7 +2557,8 @@ HIRCompileBase::resolve_deref_adjustment (Resolver::Adjustment &adjustment,
 
 tree
 HIRCompileBase::resolve_indirection_adjustment (
-  Resolver::Adjustment &adjustment, tree expression, Location locus)
+  Resolver::Adjustment & /* adjustment FIXME: Reuse when needed */,
+  tree expression, Location locus)
 {
   return indirect_expression (expression, locus);
 }
@@ -2979,14 +2971,13 @@ CompileExpr::generate_closure_function (HIR::ClosureExpr &expr,
 }
 
 tree
-CompileExpr::generate_closure_fntype (HIR::ClosureExpr &expr,
+CompileExpr::generate_closure_fntype (HIR::ClosureExpr &,
 				      const TyTy::ClosureType &closure_tyty,
-				      tree compiled_closure_tyty,
-				      TyTy::FnType **fn_tyty)
+				      tree, TyTy::FnType **fn_tyty)
 {
   // grab the specified_bound
   rust_assert (closure_tyty.num_specified_bounds () == 1);
-  const TyTy::TypeBoundPredicate &predicate
+  const TyTy::TypeBoundPredicate predicate
     = *closure_tyty.get_specified_bounds ().begin ();
 
   // ensure the fn_once_output associated type is set

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -97,14 +97,12 @@ protected:
 			     TyTy::BaseType *receiver, TyTy::FnType *fntype,
 			     tree receiver_ref, Location expr_locus);
 
-  tree get_receiver_from_dyn (const TyTy::DynamicObjectType *dyn,
-			      TyTy::BaseType *receiver, TyTy::FnType *fntype,
-			      tree receiver_ref, Location expr_locus);
+  tree get_receiver_from_dyn (TyTy::BaseType *receiver, tree receiver_ref,
+			      Location expr_locus);
 
   tree resolve_method_address (TyTy::FnType *fntype, HirId ref,
 			       TyTy::BaseType *receiver,
 			       HIR::PathIdentSegment &segment,
-			       Analysis::NodeMapping expr_mappings,
 			       Location expr_locus);
 
   tree
@@ -135,11 +133,10 @@ protected:
 
   tree type_cast_expression (tree type_to_cast_to, tree expr, Location locus);
 
-  tree array_value_expr (Location expr_locus, const TyTy::ArrayType &array_tyty,
-			 tree array_type, HIR::ArrayElemsValues &elems);
+  tree array_value_expr (Location expr_locus, tree array_type,
+			 HIR::ArrayElemsValues &elems);
 
-  tree array_copied_expr (Location expr_locus,
-			  const TyTy::ArrayType &array_tyty, tree array_type,
+  tree array_copied_expr (Location expr_locus, tree array_type,
 			  HIR::ArrayElemsCopied &elems);
 
 protected:

--- a/gcc/rust/backend/rust-compile-fnparam.cc
+++ b/gcc/rust/backend/rust-compile-fnparam.cc
@@ -61,7 +61,7 @@ CompileFnParam::visit (HIR::IdentifierPattern &pattern)
 }
 
 void
-CompileFnParam::visit (HIR::WildcardPattern &pattern)
+CompileFnParam::visit (HIR::WildcardPattern &)
 {
   decl_type = ctx->get_backend ()->immutable_type (decl_type);
 

--- a/gcc/rust/backend/rust-compile-implitem.h
+++ b/gcc/rust/backend/rust-compile-implitem.h
@@ -72,7 +72,7 @@ public:
   void visit (HIR::TraitItemConst &constant) override;
   void visit (HIR::TraitItemFunc &func) override;
 
-  void visit (HIR::TraitItemType &typ) override {}
+  void visit (HIR::TraitItemType &) override {}
 
 private:
   CompileTraitItem (Context *ctx, TyTy::BaseType *concrete, Location ref_locus)

--- a/gcc/rust/backend/rust-compile-intrinsic.cc
+++ b/gcc/rust/backend/rust-compile-intrinsic.cc
@@ -151,7 +151,7 @@ unchecked_op_handler (tree_code op)
 }
 
 inline tree
-sorry_handler (Context *ctx, TyTy::FnType *fntype)
+sorry_handler (Context *, TyTy::FnType *fntype)
 {
   rust_sorry_at (fntype->get_locus (), "intrinsic %qs is not yet implemented",
 		 fntype->get_identifier ().c_str ());

--- a/gcc/rust/backend/rust-compile-pattern.cc
+++ b/gcc/rust/backend/rust-compile-pattern.cc
@@ -71,7 +71,7 @@ CompilePatternCaseLabelExpr::visit (HIR::TupleStructPattern &pattern)
 }
 
 void
-CompilePatternCaseLabelExpr::visit (HIR::WildcardPattern &pattern)
+CompilePatternCaseLabelExpr::visit (HIR::WildcardPattern &)
 {
   // operand 0 being NULL_TREE signifies this is the default case label see:
   // tree.def for documentation for CASE_LABEL_EXPR

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -33,20 +33,20 @@ void
 ResolvePathRef::visit (HIR::QualifiedPathInExpression &expr)
 {
   resolved = resolve (expr.get_final_segment ().get_segment (),
-		      expr.get_mappings (), expr.get_locus (), true);
+		      expr.get_mappings (), expr.get_locus ());
 }
 
 void
 ResolvePathRef::visit (HIR::PathInExpression &expr)
 {
   resolved = resolve (expr.get_final_segment ().get_segment (),
-		      expr.get_mappings (), expr.get_locus (), false);
+		      expr.get_mappings (), expr.get_locus ());
 }
 
 tree
 ResolvePathRef::resolve (const HIR::PathIdentSegment &final_segment,
 			 const Analysis::NodeMapping &mappings,
-			 Location expr_locus, bool is_qualified_path)
+			 Location expr_locus)
 {
   TyTy::BaseType *lookup = nullptr;
   bool ok = ctx->get_tyctx ()->lookup_type (mappings.get_hirid (), &lookup);
@@ -157,8 +157,8 @@ ResolvePathRef::resolve (const HIR::PathIdentSegment &final_segment,
     }
 
   // let the query system figure it out
-  tree resolved_item = query_compile (ref, lookup, final_segment, mappings,
-				      expr_locus, is_qualified_path);
+  tree resolved_item
+    = query_compile (ref, lookup, final_segment, mappings, expr_locus);
   if (resolved_item != error_mark_node)
     {
       TREE_USED (resolved_item) = 1;
@@ -170,7 +170,7 @@ tree
 HIRCompileBase::query_compile (HirId ref, TyTy::BaseType *lookup,
 			       const HIR::PathIdentSegment &final_segment,
 			       const Analysis::NodeMapping &mappings,
-			       Location expr_locus, bool is_qualified_path)
+			       Location expr_locus)
 {
   HIR::Item *resolved_item = ctx->get_mappings ()->lookup_hir_item (ref);
   HirId parent_block;

--- a/gcc/rust/backend/rust-compile-resolve-path.h
+++ b/gcc/rust/backend/rust-compile-resolve-path.h
@@ -61,8 +61,7 @@ public:
   {}
 
   tree resolve (const HIR::PathIdentSegment &final_segment,
-		const Analysis::NodeMapping &mappings, Location locus,
-		bool is_qualified_path);
+		const Analysis::NodeMapping &mappings, Location locus);
 
   tree resolved;
 };

--- a/gcc/rust/backend/rust-compile-type.cc
+++ b/gcc/rust/backend/rust-compile-type.cc
@@ -399,7 +399,7 @@ TyTyResolveCompile::visit (const TyTy::SliceType &type)
 }
 
 void
-TyTyResolveCompile::visit (const TyTy::BoolType &type)
+TyTyResolveCompile::visit (const TyTy::BoolType &)
 {
   translated
     = ctx->get_backend ()->named_type ("bool",
@@ -503,7 +503,7 @@ TyTyResolveCompile::visit (const TyTy::FloatType &type)
 }
 
 void
-TyTyResolveCompile::visit (const TyTy::USizeType &type)
+TyTyResolveCompile::visit (const TyTy::USizeType &)
 {
   translated = ctx->get_backend ()->named_type (
     "usize",
@@ -513,7 +513,7 @@ TyTyResolveCompile::visit (const TyTy::USizeType &type)
 }
 
 void
-TyTyResolveCompile::visit (const TyTy::ISizeType &type)
+TyTyResolveCompile::visit (const TyTy::ISizeType &)
 {
   translated = ctx->get_backend ()->named_type (
     "isize",
@@ -523,7 +523,7 @@ TyTyResolveCompile::visit (const TyTy::ISizeType &type)
 }
 
 void
-TyTyResolveCompile::visit (const TyTy::CharType &type)
+TyTyResolveCompile::visit (const TyTy::CharType &)
 {
   translated
     = ctx->get_backend ()->named_type ("char",

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -214,7 +214,7 @@ HIRCompileBase::coerce_to_dyn_object (tree compiled_ref,
 
       auto address = compute_address_for_trait_item (item, predicate,
 						     probed_bounds_for_receiver,
-						     actual, actual, locus);
+						     actual, locus);
       vtable_ctor_elems.push_back (address);
       vtable_ctor_idx.push_back (i++);
     }
@@ -233,7 +233,7 @@ HIRCompileBase::compute_address_for_trait_item (
   const TyTy::TypeBoundPredicate *predicate,
   std::vector<std::pair<Resolver::TraitReference *, HIR::ImplBlock *>>
     &receiver_bounds,
-  const TyTy::BaseType *receiver, const TyTy::BaseType *root, Location locus)
+  const TyTy::BaseType *root, Location locus)
 {
   // There are two cases here one where its an item which has an implementation
   // within a trait-impl-block. Then there is the case where there is a default
@@ -360,9 +360,11 @@ HIRCompileBase::compute_address_for_trait_item (
 }
 
 bool
-HIRCompileBase::verify_array_capacities (tree ltype, tree rtype,
-					 Location lvalue_locus,
-					 Location rvalue_locus)
+HIRCompileBase::verify_array_capacities (
+  tree ltype, tree rtype,
+  // TODO: Reuse `lvalue_locus` when we want to switch to a RichLocation and
+  // point to the
+  Location /* lvalue_locus */, Location rvalue_locus)
 {
   rust_assert (ltype != NULL_TREE);
   rust_assert (rtype != NULL_TREE);

--- a/gcc/rust/backend/rust-constexpr.cc
+++ b/gcc/rust/backend/rust-constexpr.cc
@@ -3996,8 +3996,7 @@ constexpr_fn_retval (const constexpr_ctx *ctx, tree body)
 // return an aggregate constant.  If UNSHARE_P, return an unshared
 // copy of the initializer.
 static tree
-constant_value_1 (tree decl, bool strict_p, bool return_aggregate_cst_ok_p,
-		  bool unshare_p)
+constant_value_1 (tree decl, bool, bool, bool unshare_p)
 {
   while (TREE_CODE (decl) == CONST_DECL)
     {
@@ -6486,8 +6485,7 @@ potential_constant_expression_1 (tree t, bool want_rval, bool strict, bool now,
 /* Like maybe_constant_init but first fully instantiate the argument.  */
 
 tree
-fold_non_dependent_init (tree t,
-			 tsubst_flags_t complain /*=tf_warning_or_error*/,
+fold_non_dependent_init (tree t, tsubst_flags_t /*=tf_warning_or_error*/,
 			 bool manifestly_const_eval /*=false*/,
 			 tree object /* = NULL_TREE */)
 {

--- a/gcc/rust/backend/rust-tree.cc
+++ b/gcc/rust/backend/rust-tree.cc
@@ -2059,11 +2059,7 @@ rs_tree_equal (tree t1, tree t2)
 
 /* TRUE iff TYPE is publicly & uniquely derived from PARENT.  */
 
-bool
-publicly_uniquely_derived_p (tree parent, tree type)
-{
-  return false;
-}
+bool publicly_uniquely_derived_p (tree, tree) { return false; }
 
 // forked from gcc/cp/typeck.cc comp_except_types
 
@@ -3343,11 +3339,7 @@ release_tree_vector (vec<tree, va_gc> *vec)
 
 /* As above, but also check value-dependence of the expression as a whole.  */
 
-bool
-instantiation_dependent_expression_p (tree expression)
-{
-  return false;
-}
+bool instantiation_dependent_expression_p (tree) { return false; }
 
 // forked from gcc/cp/cvt.cc cp_get_callee
 
@@ -3397,11 +3389,7 @@ scalarish_type_p (const_tree t)
    constructors are deleted.  This function implements the ABI notion of
    non-trivial copy, which has diverged from the one in the standard.  */
 
-bool
-type_has_nontrivial_copy_init (const_tree type)
-{
-  return false;
-}
+bool type_has_nontrivial_copy_init (const_tree) { return false; }
 
 // forked from gcc/cp/tree.cc build_local_temp
 
@@ -3424,11 +3412,7 @@ build_local_temp (tree type)
 /* Returns true iff DECL is a capture proxy for a normal capture
    (i.e. without explicit initializer).  */
 
-bool
-is_normal_capture_proxy (tree decl)
-{
-  return false;
-}
+bool is_normal_capture_proxy (tree) { return false; }
 
 // forked from gcc/cp/c-common.cc reject_gcc_builtin
 
@@ -3693,7 +3677,7 @@ char_type_p (tree type)
    lvalue for the function template specialization.  */
 
 tree
-resolve_nondeduced_context (tree orig_expr, tsubst_flags_t complain)
+resolve_nondeduced_context (tree orig_expr, tsubst_flags_t)
 {
   return orig_expr;
 }
@@ -3972,21 +3956,13 @@ decl_constant_var_p (tree decl)
 /* Returns true iff DECL is a variable or function declared with an auto type
    that has not yet been deduced to a real type.  */
 
-bool
-undeduced_auto_decl (tree decl)
-{
-  return false;
-}
+bool undeduced_auto_decl (tree) { return false; }
 
 // forked from gcc/cp/decl.cc require_deduced_type
 
 /* Complain if DECL has an undeduced return type.  */
 
-bool
-require_deduced_type (tree decl, tsubst_flags_t complain)
-{
-  return true;
-}
+bool require_deduced_type (tree, tsubst_flags_t) { return true; }
 
 /* Return the location of a tree passed to %+ formats.  */
 

--- a/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
+++ b/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
@@ -226,7 +226,7 @@ PrivacyReporter::visit (HIR::PathInExpression &path)
 }
 
 void
-PrivacyReporter::visit (HIR::TypePathSegmentFunction &segment)
+PrivacyReporter::visit (HIR::TypePathSegmentFunction &)
 {
   // FIXME: Do we need to do anything for this?
 }
@@ -253,7 +253,7 @@ PrivacyReporter::visit (HIR::QualifiedPathInType &path)
 }
 
 void
-PrivacyReporter::visit (HIR::LiteralExpr &expr)
+PrivacyReporter::visit (HIR::LiteralExpr &)
 {
   // Literals cannot contain any sort of privacy violation
 }
@@ -371,13 +371,13 @@ PrivacyReporter::visit (HIR::TupleIndexExpr &expr)
 }
 
 void
-PrivacyReporter::visit (HIR::StructExprStruct &expr)
+PrivacyReporter::visit (HIR::StructExprStruct &)
 {
   // FIXME: We need to check the visibility of the type it refers to here
 }
 
 void
-PrivacyReporter::visit (HIR::StructExprFieldIdentifier &field)
+PrivacyReporter::visit (HIR::StructExprFieldIdentifier &)
 {}
 
 void
@@ -426,7 +426,7 @@ PrivacyReporter::visit (HIR::FieldAccessExpr &expr)
 }
 
 void
-PrivacyReporter::visit (HIR::ClosureExpr &expr)
+PrivacyReporter::visit (HIR::ClosureExpr &)
 {
   // Not handled yet
 }
@@ -443,7 +443,7 @@ PrivacyReporter::visit (HIR::BlockExpr &expr)
 }
 
 void
-PrivacyReporter::visit (HIR::ContinueExpr &expr)
+PrivacyReporter::visit (HIR::ContinueExpr &)
 {}
 
 void
@@ -474,7 +474,7 @@ PrivacyReporter::visit (HIR::RangeToExpr &expr)
 }
 
 void
-PrivacyReporter::visit (HIR::RangeFullExpr &expr)
+PrivacyReporter::visit (HIR::RangeFullExpr &)
 {}
 
 void
@@ -485,7 +485,7 @@ PrivacyReporter::visit (HIR::RangeFromToInclExpr &expr)
 }
 
 void
-PrivacyReporter::visit (HIR::RangeToInclExpr &expr)
+PrivacyReporter::visit (HIR::RangeToInclExpr &)
 {
   // Not handled yet
 }
@@ -564,14 +564,14 @@ PrivacyReporter::visit (HIR::IfExprConseqIfLet &expr)
 }
 
 void
-PrivacyReporter::visit (HIR::IfLetExpr &expr)
+PrivacyReporter::visit (HIR::IfLetExpr &)
 {
   // TODO: We need to visit the if_let_expr
   // TODO: We need to visit the block as well
 }
 
 void
-PrivacyReporter::visit (HIR::IfLetExprConseqElse &expr)
+PrivacyReporter::visit (HIR::IfLetExprConseqElse &)
 {
   // TODO: We need to visit the if_let_expr
   // TODO: We need to visit the if_block as well
@@ -579,7 +579,7 @@ PrivacyReporter::visit (HIR::IfLetExprConseqElse &expr)
 }
 
 void
-PrivacyReporter::visit (HIR::IfLetExprConseqIf &expr)
+PrivacyReporter::visit (HIR::IfLetExprConseqIf &)
 {
   // TODO: We need to visit the if_let_expr
   // TODO: We need to visit the if_block as well
@@ -587,7 +587,7 @@ PrivacyReporter::visit (HIR::IfLetExprConseqIf &expr)
 }
 
 void
-PrivacyReporter::visit (HIR::IfLetExprConseqIfLet &expr)
+PrivacyReporter::visit (HIR::IfLetExprConseqIfLet &)
 {
   // TODO: We need to visit the if_let_expr
   // TODO: We need to visit the if_block as well
@@ -601,13 +601,13 @@ PrivacyReporter::visit (HIR::MatchExpr &expr)
 }
 
 void
-PrivacyReporter::visit (HIR::AwaitExpr &expr)
+PrivacyReporter::visit (HIR::AwaitExpr &)
 {
   // Not handled yet
 }
 
 void
-PrivacyReporter::visit (HIR::AsyncBlockExpr &expr)
+PrivacyReporter::visit (HIR::AsyncBlockExpr &)
 {
   // Not handled yet
 }
@@ -628,11 +628,11 @@ PrivacyReporter::visit (HIR::Module &module)
 }
 
 void
-PrivacyReporter::visit (HIR::ExternCrate &crate)
+PrivacyReporter::visit (HIR::ExternCrate &)
 {}
 
 void
-PrivacyReporter::visit (HIR::UseDeclaration &use_decl)
+PrivacyReporter::visit (HIR::UseDeclaration &)
 {
   // FIXME: Is there anything we need to do here?
 }
@@ -647,51 +647,51 @@ PrivacyReporter::visit (HIR::Function &function)
 }
 
 void
-PrivacyReporter::visit (HIR::TypeAlias &type_alias)
+PrivacyReporter::visit (HIR::TypeAlias &)
 {
   // TODO: Check the type here
 }
 
 void
-PrivacyReporter::visit (HIR::StructStruct &struct_item)
+PrivacyReporter::visit (HIR::StructStruct &)
 {
   // TODO: Check the type of all fields
 }
 
 void
-PrivacyReporter::visit (HIR::TupleStruct &tuple_struct)
+PrivacyReporter::visit (HIR::TupleStruct &)
 {
   // TODO: Check the type of all fields
 }
 
 void
-PrivacyReporter::visit (HIR::EnumItem &item)
+PrivacyReporter::visit (HIR::EnumItem &)
 {
   // TODO: Check the type of all variants
 }
 
 void
-PrivacyReporter::visit (HIR::EnumItemTuple &item)
+PrivacyReporter::visit (HIR::EnumItemTuple &)
 {
   // TODO: Check the type
 }
 
 void
-PrivacyReporter::visit (HIR::EnumItemStruct &item)
+PrivacyReporter::visit (HIR::EnumItemStruct &)
 {
   // TODO: Check the type
 }
 
 void
-PrivacyReporter::visit (HIR::EnumItemDiscriminant &item)
+PrivacyReporter::visit (HIR::EnumItemDiscriminant &)
 {}
 
 void
-PrivacyReporter::visit (HIR::Enum &enum_item)
+PrivacyReporter::visit (HIR::Enum &)
 {}
 
 void
-PrivacyReporter::visit (HIR::Union &union_item)
+PrivacyReporter::visit (HIR::Union &)
 {
   // TODO: Check the type
 }
@@ -711,7 +711,7 @@ PrivacyReporter::visit (HIR::StaticItem &static_item)
 }
 
 void
-PrivacyReporter::visit (HIR::Trait &trait)
+PrivacyReporter::visit (HIR::Trait &)
 {
   // FIXME: We need to be an ItemVisitor as well
   // for (auto &item : trait.get_trait_items ())
@@ -726,15 +726,15 @@ PrivacyReporter::visit (HIR::ImplBlock &impl)
 }
 
 void
-PrivacyReporter::visit (HIR::ExternBlock &block)
+PrivacyReporter::visit (HIR::ExternBlock &)
 {
   // FIXME: We need to be an ItemVisitor as well
-  // for (auto &item : block.get_extern_items ())
+  // for (auto &block: block.get_extern_items ())
   //   item->accept_vis (*this);
 }
 
 void
-PrivacyReporter::visit (HIR::EmptyStmt &stmt)
+PrivacyReporter::visit (HIR::EmptyStmt &)
 {}
 
 void

--- a/gcc/rust/checks/errors/privacy/rust-reachability.cc
+++ b/gcc/rust/checks/errors/privacy/rust-reachability.cc
@@ -140,7 +140,7 @@ ReachabilityVisitor::visit (HIR::StructStruct &struct_item)
 }
 
 void
-ReachabilityVisitor::visit (HIR::TupleStruct &tuple_struct)
+ReachabilityVisitor::visit (HIR::TupleStruct &)
 {}
 
 void
@@ -227,7 +227,7 @@ ReachabilityVisitor::visit (HIR::ImplBlock &impl)
 }
 
 void
-ReachabilityVisitor::visit (HIR::ExternBlock &block)
+ReachabilityVisitor::visit (HIR::ExternBlock &)
 {}
 
 // FIXME: How can we visit Blocks in the current configuration? Have a full

--- a/gcc/rust/checks/errors/privacy/rust-visibility-resolver.cc
+++ b/gcc/rust/checks/errors/privacy/rust-visibility-resolver.cc
@@ -141,11 +141,11 @@ VisibilityResolver::visit (HIR::Module &mod)
 }
 
 void
-VisibilityResolver::visit (HIR::ExternCrate &crate)
+VisibilityResolver::visit (HIR::ExternCrate &)
 {}
 
 void
-VisibilityResolver::visit (HIR::UseDeclaration &use_decl)
+VisibilityResolver::visit (HIR::UseDeclaration &)
 {}
 
 void
@@ -185,7 +185,7 @@ VisibilityResolver::visit (HIR::Enum &enum_item)
 }
 
 void
-VisibilityResolver::visit (HIR::Union &union_item)
+VisibilityResolver::visit (HIR::Union &)
 {}
 
 void
@@ -238,7 +238,7 @@ VisibilityResolver::visit (HIR::ImplBlock &impl)
 }
 
 void
-VisibilityResolver::visit (HIR::ExternBlock &block)
+VisibilityResolver::visit (HIR::ExternBlock &)
 {}
 
 } // namespace Privacy

--- a/gcc/rust/checks/errors/rust-const-checker.cc
+++ b/gcc/rust/checks/errors/rust-const-checker.cc
@@ -114,43 +114,43 @@ ConstChecker::check_default_const_generics (
 }
 
 void
-ConstChecker::visit (Lifetime &lifetime)
+ConstChecker::visit (Lifetime &)
 {}
 
 void
-ConstChecker::visit (LifetimeParam &lifetime_param)
+ConstChecker::visit (LifetimeParam &)
 {}
 
 void
-ConstChecker::visit (PathInExpression &path)
+ConstChecker::visit (PathInExpression &)
 {}
 
 void
-ConstChecker::visit (TypePathSegment &segment)
+ConstChecker::visit (TypePathSegment &)
 {}
 
 void
-ConstChecker::visit (TypePathSegmentGeneric &segment)
+ConstChecker::visit (TypePathSegmentGeneric &)
 {}
 
 void
-ConstChecker::visit (TypePathSegmentFunction &segment)
+ConstChecker::visit (TypePathSegmentFunction &)
 {}
 
 void
-ConstChecker::visit (TypePath &path)
+ConstChecker::visit (TypePath &)
 {}
 
 void
-ConstChecker::visit (QualifiedPathInExpression &path)
+ConstChecker::visit (QualifiedPathInExpression &)
 {}
 
 void
-ConstChecker::visit (QualifiedPathInType &path)
+ConstChecker::visit (QualifiedPathInType &)
 {}
 
 void
-ConstChecker::visit (LiteralExpr &expr)
+ConstChecker::visit (LiteralExpr &)
 {}
 
 void
@@ -270,11 +270,11 @@ ConstChecker::visit (TupleIndexExpr &expr)
 }
 
 void
-ConstChecker::visit (StructExprStruct &expr)
+ConstChecker::visit (StructExprStruct &)
 {}
 
 void
-ConstChecker::visit (StructExprFieldIdentifier &field)
+ConstChecker::visit (StructExprFieldIdentifier &)
 {}
 
 void
@@ -297,7 +297,7 @@ ConstChecker::visit (StructExprStructFields &expr)
 }
 
 void
-ConstChecker::visit (StructExprStructBase &expr)
+ConstChecker::visit (StructExprStructBase &)
 {}
 
 void
@@ -398,7 +398,7 @@ ConstChecker::visit (BlockExpr &expr)
 }
 
 void
-ConstChecker::visit (ContinueExpr &expr)
+ConstChecker::visit (ContinueExpr &)
 {}
 
 void
@@ -428,7 +428,7 @@ ConstChecker::visit (RangeToExpr &expr)
 }
 
 void
-ConstChecker::visit (RangeFullExpr &expr)
+ConstChecker::visit (RangeFullExpr &)
 {}
 
 void
@@ -439,7 +439,7 @@ ConstChecker::visit (RangeFromToInclExpr &expr)
 }
 
 void
-ConstChecker::visit (RangeToInclExpr &expr)
+ConstChecker::visit (RangeToInclExpr &)
 {
   // FIXME: Visit to_expr
 }
@@ -558,31 +558,31 @@ ConstChecker::visit (MatchExpr &expr)
 }
 
 void
-ConstChecker::visit (AwaitExpr &expr)
+ConstChecker::visit (AwaitExpr &)
 {
   // TODO: Visit expression
 }
 
 void
-ConstChecker::visit (AsyncBlockExpr &expr)
+ConstChecker::visit (AsyncBlockExpr &)
 {
   // TODO: Visit block expression
 }
 
 void
-ConstChecker::visit (TypeParam &param)
+ConstChecker::visit (TypeParam &)
 {}
 
 void
-ConstChecker::visit (ConstGenericParam &param)
+ConstChecker::visit (ConstGenericParam &)
 {}
 
 void
-ConstChecker::visit (LifetimeWhereClauseItem &item)
+ConstChecker::visit (LifetimeWhereClauseItem &)
 {}
 
 void
-ConstChecker::visit (TypeBoundWhereClauseItem &item)
+ConstChecker::visit (TypeBoundWhereClauseItem &)
 {}
 
 void
@@ -593,23 +593,23 @@ ConstChecker::visit (Module &module)
 }
 
 void
-ConstChecker::visit (ExternCrate &crate)
+ConstChecker::visit (ExternCrate &)
 {}
 
 void
-ConstChecker::visit (UseTreeGlob &use_tree)
+ConstChecker::visit (UseTreeGlob &)
 {}
 
 void
-ConstChecker::visit (UseTreeList &use_tree)
+ConstChecker::visit (UseTreeList &)
 {}
 
 void
-ConstChecker::visit (UseTreeRebind &use_tree)
+ConstChecker::visit (UseTreeRebind &)
 {}
 
 void
-ConstChecker::visit (UseDeclaration &use_decl)
+ConstChecker::visit (UseDeclaration &)
 {}
 
 void
@@ -653,15 +653,15 @@ ConstChecker::visit (TupleStruct &tuple_struct)
 }
 
 void
-ConstChecker::visit (EnumItem &enum_item)
+ConstChecker::visit (EnumItem &)
 {}
 
 void
-ConstChecker::visit (EnumItemTuple &item)
+ConstChecker::visit (EnumItemTuple &)
 {}
 
 void
-ConstChecker::visit (EnumItemStruct &item)
+ConstChecker::visit (EnumItemStruct &)
 {}
 
 void
@@ -723,7 +723,7 @@ ConstChecker::visit (TraitItemConst &item)
 }
 
 void
-ConstChecker::visit (TraitItemType &item)
+ConstChecker::visit (TraitItemType &)
 {}
 
 void
@@ -747,11 +747,11 @@ ConstChecker::visit (ImplBlock &impl)
 }
 
 void
-ConstChecker::visit (ExternalStaticItem &item)
+ConstChecker::visit (ExternalStaticItem &)
 {}
 
 void
-ConstChecker::visit (ExternalFunctionItem &item)
+ConstChecker::visit (ExternalFunctionItem &)
 {}
 
 void
@@ -763,87 +763,87 @@ ConstChecker::visit (ExternBlock &block)
 }
 
 void
-ConstChecker::visit (LiteralPattern &pattern)
+ConstChecker::visit (LiteralPattern &)
 {}
 
 void
-ConstChecker::visit (IdentifierPattern &pattern)
+ConstChecker::visit (IdentifierPattern &)
 {}
 
 void
-ConstChecker::visit (WildcardPattern &pattern)
+ConstChecker::visit (WildcardPattern &)
 {}
 
 void
-ConstChecker::visit (RangePatternBoundLiteral &bound)
+ConstChecker::visit (RangePatternBoundLiteral &)
 {}
 
 void
-ConstChecker::visit (RangePatternBoundPath &bound)
+ConstChecker::visit (RangePatternBoundPath &)
 {}
 
 void
-ConstChecker::visit (RangePatternBoundQualPath &bound)
+ConstChecker::visit (RangePatternBoundQualPath &)
 {}
 
 void
-ConstChecker::visit (RangePattern &pattern)
+ConstChecker::visit (RangePattern &)
 {}
 
 void
-ConstChecker::visit (ReferencePattern &pattern)
+ConstChecker::visit (ReferencePattern &)
 {}
 
 void
-ConstChecker::visit (StructPatternFieldTuplePat &field)
+ConstChecker::visit (StructPatternFieldTuplePat &)
 {}
 
 void
-ConstChecker::visit (StructPatternFieldIdentPat &field)
+ConstChecker::visit (StructPatternFieldIdentPat &)
 {}
 
 void
-ConstChecker::visit (StructPatternFieldIdent &field)
+ConstChecker::visit (StructPatternFieldIdent &)
 {}
 
 void
-ConstChecker::visit (StructPattern &pattern)
+ConstChecker::visit (StructPattern &)
 {}
 
 void
-ConstChecker::visit (TupleStructItemsNoRange &tuple_items)
+ConstChecker::visit (TupleStructItemsNoRange &)
 {}
 
 void
-ConstChecker::visit (TupleStructItemsRange &tuple_items)
+ConstChecker::visit (TupleStructItemsRange &)
 {}
 
 void
-ConstChecker::visit (TupleStructPattern &pattern)
+ConstChecker::visit (TupleStructPattern &)
 {}
 
 void
-ConstChecker::visit (TuplePatternItemsMultiple &tuple_items)
+ConstChecker::visit (TuplePatternItemsMultiple &)
 {}
 
 void
-ConstChecker::visit (TuplePatternItemsRanged &tuple_items)
+ConstChecker::visit (TuplePatternItemsRanged &)
 {}
 
 void
-ConstChecker::visit (TuplePattern &pattern)
+ConstChecker::visit (TuplePattern &)
 {}
 
 void
-ConstChecker::visit (GroupedPattern &pattern)
+ConstChecker::visit (GroupedPattern &)
 {}
 
 void
-ConstChecker::visit (SlicePattern &pattern)
+ConstChecker::visit (SlicePattern &)
 {}
 
 void
-ConstChecker::visit (EmptyStmt &stmt)
+ConstChecker::visit (EmptyStmt &)
 {}
 
 void
@@ -866,39 +866,39 @@ ConstChecker::visit (ExprStmtWithBlock &stmt)
 }
 
 void
-ConstChecker::visit (TraitBound &bound)
+ConstChecker::visit (TraitBound &)
 {}
 
 void
-ConstChecker::visit (ImplTraitType &type)
+ConstChecker::visit (ImplTraitType &)
 {}
 
 void
-ConstChecker::visit (TraitObjectType &type)
+ConstChecker::visit (TraitObjectType &)
 {}
 
 void
-ConstChecker::visit (ParenthesisedType &type)
+ConstChecker::visit (ParenthesisedType &)
 {}
 
 void
-ConstChecker::visit (ImplTraitTypeOneBound &type)
+ConstChecker::visit (ImplTraitTypeOneBound &)
 {}
 
 void
-ConstChecker::visit (TupleType &type)
+ConstChecker::visit (TupleType &)
 {}
 
 void
-ConstChecker::visit (NeverType &type)
+ConstChecker::visit (NeverType &)
 {}
 
 void
-ConstChecker::visit (RawPointerType &type)
+ConstChecker::visit (RawPointerType &)
 {}
 
 void
-ConstChecker::visit (ReferenceType &type)
+ConstChecker::visit (ReferenceType &)
 {}
 
 void
@@ -912,15 +912,15 @@ ConstChecker::visit (ArrayType &type)
 }
 
 void
-ConstChecker::visit (SliceType &type)
+ConstChecker::visit (SliceType &)
 {}
 
 void
-ConstChecker::visit (InferredType &type)
+ConstChecker::visit (InferredType &)
 {}
 
 void
-ConstChecker::visit (BareFunctionType &type)
+ConstChecker::visit (BareFunctionType &)
 {}
 
 } // namespace HIR

--- a/gcc/rust/checks/errors/rust-unsafe-checker.cc
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.cc
@@ -180,11 +180,11 @@ UnsafeChecker::check_function_call (HirId node_id, Location locus)
 }
 
 void
-UnsafeChecker::visit (Lifetime &lifetime)
+UnsafeChecker::visit (Lifetime &)
 {}
 
 void
-UnsafeChecker::visit (LifetimeParam &lifetime_param)
+UnsafeChecker::visit (LifetimeParam &)
 {}
 
 void
@@ -203,31 +203,31 @@ UnsafeChecker::visit (PathInExpression &path)
 }
 
 void
-UnsafeChecker::visit (TypePathSegment &segment)
+UnsafeChecker::visit (TypePathSegment &)
 {}
 
 void
-UnsafeChecker::visit (TypePathSegmentGeneric &segment)
+UnsafeChecker::visit (TypePathSegmentGeneric &)
 {}
 
 void
-UnsafeChecker::visit (TypePathSegmentFunction &segment)
+UnsafeChecker::visit (TypePathSegmentFunction &)
 {}
 
 void
-UnsafeChecker::visit (TypePath &path)
+UnsafeChecker::visit (TypePath &)
 {}
 
 void
-UnsafeChecker::visit (QualifiedPathInExpression &path)
+UnsafeChecker::visit (QualifiedPathInExpression &)
 {}
 
 void
-UnsafeChecker::visit (QualifiedPathInType &path)
+UnsafeChecker::visit (QualifiedPathInType &)
 {}
 
 void
-UnsafeChecker::visit (LiteralExpr &expr)
+UnsafeChecker::visit (LiteralExpr &)
 {}
 
 void
@@ -349,11 +349,11 @@ UnsafeChecker::visit (TupleIndexExpr &expr)
 }
 
 void
-UnsafeChecker::visit (StructExprStruct &expr)
+UnsafeChecker::visit (StructExprStruct &)
 {}
 
 void
-UnsafeChecker::visit (StructExprFieldIdentifier &field)
+UnsafeChecker::visit (StructExprFieldIdentifier &)
 {}
 
 void
@@ -376,7 +376,7 @@ UnsafeChecker::visit (StructExprStructFields &expr)
 }
 
 void
-UnsafeChecker::visit (StructExprStructBase &expr)
+UnsafeChecker::visit (StructExprStructBase &)
 {}
 
 void
@@ -469,7 +469,7 @@ UnsafeChecker::visit (BlockExpr &expr)
 }
 
 void
-UnsafeChecker::visit (ContinueExpr &expr)
+UnsafeChecker::visit (ContinueExpr &)
 {}
 
 void
@@ -499,7 +499,7 @@ UnsafeChecker::visit (RangeToExpr &expr)
 }
 
 void
-UnsafeChecker::visit (RangeFullExpr &expr)
+UnsafeChecker::visit (RangeFullExpr &)
 {}
 
 void
@@ -633,31 +633,31 @@ UnsafeChecker::visit (MatchExpr &expr)
 }
 
 void
-UnsafeChecker::visit (AwaitExpr &expr)
+UnsafeChecker::visit (AwaitExpr &)
 {
   // TODO: Visit expression
 }
 
 void
-UnsafeChecker::visit (AsyncBlockExpr &expr)
+UnsafeChecker::visit (AsyncBlockExpr &)
 {
   // TODO: Visit block expression
 }
 
 void
-UnsafeChecker::visit (TypeParam &param)
+UnsafeChecker::visit (TypeParam &)
 {}
 
 void
-UnsafeChecker::visit (ConstGenericParam &param)
+UnsafeChecker::visit (ConstGenericParam &)
 {}
 
 void
-UnsafeChecker::visit (LifetimeWhereClauseItem &item)
+UnsafeChecker::visit (LifetimeWhereClauseItem &)
 {}
 
 void
-UnsafeChecker::visit (TypeBoundWhereClauseItem &item)
+UnsafeChecker::visit (TypeBoundWhereClauseItem &)
 {}
 
 void
@@ -668,23 +668,23 @@ UnsafeChecker::visit (Module &module)
 }
 
 void
-UnsafeChecker::visit (ExternCrate &crate)
+UnsafeChecker::visit (ExternCrate &)
 {}
 
 void
-UnsafeChecker::visit (UseTreeGlob &use_tree)
+UnsafeChecker::visit (UseTreeGlob &)
 {}
 
 void
-UnsafeChecker::visit (UseTreeList &use_tree)
+UnsafeChecker::visit (UseTreeList &)
 {}
 
 void
-UnsafeChecker::visit (UseTreeRebind &use_tree)
+UnsafeChecker::visit (UseTreeRebind &)
 {}
 
 void
-UnsafeChecker::visit (UseDeclaration &use_decl)
+UnsafeChecker::visit (UseDeclaration &)
 {}
 
 void
@@ -702,42 +702,42 @@ UnsafeChecker::visit (Function &function)
 }
 
 void
-UnsafeChecker::visit (TypeAlias &type_alias)
+UnsafeChecker::visit (TypeAlias &)
 {
   // FIXME: What do we need to do to handle type aliasing? Is it possible to
   // have unsafe types? Type aliases on unsafe functions?
 }
 
 void
-UnsafeChecker::visit (StructStruct &struct_item)
+UnsafeChecker::visit (StructStruct &)
 {}
 
 void
-UnsafeChecker::visit (TupleStruct &tuple_struct)
+UnsafeChecker::visit (TupleStruct &)
 {}
 
 void
-UnsafeChecker::visit (EnumItem &item)
+UnsafeChecker::visit (EnumItem &)
 {}
 
 void
-UnsafeChecker::visit (EnumItemTuple &item)
+UnsafeChecker::visit (EnumItemTuple &)
 {}
 
 void
-UnsafeChecker::visit (EnumItemStruct &item)
+UnsafeChecker::visit (EnumItemStruct &)
 {}
 
 void
-UnsafeChecker::visit (EnumItemDiscriminant &item)
+UnsafeChecker::visit (EnumItemDiscriminant &)
 {}
 
 void
-UnsafeChecker::visit (Enum &enum_item)
+UnsafeChecker::visit (Enum &)
 {}
 
 void
-UnsafeChecker::visit (Union &union_item)
+UnsafeChecker::visit (Union &)
 {}
 
 void
@@ -767,7 +767,7 @@ UnsafeChecker::visit (TraitItemConst &item)
 }
 
 void
-UnsafeChecker::visit (TraitItemType &item)
+UnsafeChecker::visit (TraitItemType &)
 {}
 
 void
@@ -787,11 +787,11 @@ UnsafeChecker::visit (ImplBlock &impl)
 }
 
 void
-UnsafeChecker::visit (ExternalStaticItem &item)
+UnsafeChecker::visit (ExternalStaticItem &)
 {}
 
 void
-UnsafeChecker::visit (ExternalFunctionItem &item)
+UnsafeChecker::visit (ExternalFunctionItem &)
 {}
 
 void
@@ -803,87 +803,87 @@ UnsafeChecker::visit (ExternBlock &block)
 }
 
 void
-UnsafeChecker::visit (LiteralPattern &pattern)
+UnsafeChecker::visit (LiteralPattern &)
 {}
 
 void
-UnsafeChecker::visit (IdentifierPattern &pattern)
+UnsafeChecker::visit (IdentifierPattern &)
 {}
 
 void
-UnsafeChecker::visit (WildcardPattern &pattern)
+UnsafeChecker::visit (WildcardPattern &)
 {}
 
 void
-UnsafeChecker::visit (RangePatternBoundLiteral &bound)
+UnsafeChecker::visit (RangePatternBoundLiteral &)
 {}
 
 void
-UnsafeChecker::visit (RangePatternBoundPath &bound)
+UnsafeChecker::visit (RangePatternBoundPath &)
 {}
 
 void
-UnsafeChecker::visit (RangePatternBoundQualPath &bound)
+UnsafeChecker::visit (RangePatternBoundQualPath &)
 {}
 
 void
-UnsafeChecker::visit (RangePattern &pattern)
+UnsafeChecker::visit (RangePattern &)
 {}
 
 void
-UnsafeChecker::visit (ReferencePattern &pattern)
+UnsafeChecker::visit (ReferencePattern &)
 {}
 
 void
-UnsafeChecker::visit (StructPatternFieldTuplePat &field)
+UnsafeChecker::visit (StructPatternFieldTuplePat &)
 {}
 
 void
-UnsafeChecker::visit (StructPatternFieldIdentPat &field)
+UnsafeChecker::visit (StructPatternFieldIdentPat &)
 {}
 
 void
-UnsafeChecker::visit (StructPatternFieldIdent &field)
+UnsafeChecker::visit (StructPatternFieldIdent &)
 {}
 
 void
-UnsafeChecker::visit (StructPattern &pattern)
+UnsafeChecker::visit (StructPattern &)
 {}
 
 void
-UnsafeChecker::visit (TupleStructItemsNoRange &tuple_items)
+UnsafeChecker::visit (TupleStructItemsNoRange &)
 {}
 
 void
-UnsafeChecker::visit (TupleStructItemsRange &tuple_items)
+UnsafeChecker::visit (TupleStructItemsRange &)
 {}
 
 void
-UnsafeChecker::visit (TupleStructPattern &pattern)
+UnsafeChecker::visit (TupleStructPattern &)
 {}
 
 void
-UnsafeChecker::visit (TuplePatternItemsMultiple &tuple_items)
+UnsafeChecker::visit (TuplePatternItemsMultiple &)
 {}
 
 void
-UnsafeChecker::visit (TuplePatternItemsRanged &tuple_items)
+UnsafeChecker::visit (TuplePatternItemsRanged &)
 {}
 
 void
-UnsafeChecker::visit (TuplePattern &pattern)
+UnsafeChecker::visit (TuplePattern &)
 {}
 
 void
-UnsafeChecker::visit (GroupedPattern &pattern)
+UnsafeChecker::visit (GroupedPattern &)
 {}
 
 void
-UnsafeChecker::visit (SlicePattern &pattern)
+UnsafeChecker::visit (SlicePattern &)
 {}
 
 void
-UnsafeChecker::visit (EmptyStmt &stmt)
+UnsafeChecker::visit (EmptyStmt &)
 {}
 
 void
@@ -906,55 +906,55 @@ UnsafeChecker::visit (ExprStmtWithBlock &stmt)
 }
 
 void
-UnsafeChecker::visit (TraitBound &bound)
+UnsafeChecker::visit (TraitBound &)
 {}
 
 void
-UnsafeChecker::visit (ImplTraitType &type)
+UnsafeChecker::visit (ImplTraitType &)
 {}
 
 void
-UnsafeChecker::visit (TraitObjectType &type)
+UnsafeChecker::visit (TraitObjectType &)
 {}
 
 void
-UnsafeChecker::visit (ParenthesisedType &type)
+UnsafeChecker::visit (ParenthesisedType &)
 {}
 
 void
-UnsafeChecker::visit (ImplTraitTypeOneBound &type)
+UnsafeChecker::visit (ImplTraitTypeOneBound &)
 {}
 
 void
-UnsafeChecker::visit (TupleType &type)
+UnsafeChecker::visit (TupleType &)
 {}
 
 void
-UnsafeChecker::visit (NeverType &type)
+UnsafeChecker::visit (NeverType &)
 {}
 
 void
-UnsafeChecker::visit (RawPointerType &type)
+UnsafeChecker::visit (RawPointerType &)
 {}
 
 void
-UnsafeChecker::visit (ReferenceType &type)
+UnsafeChecker::visit (ReferenceType &)
 {}
 
 void
-UnsafeChecker::visit (ArrayType &type)
+UnsafeChecker::visit (ArrayType &)
 {}
 
 void
-UnsafeChecker::visit (SliceType &type)
+UnsafeChecker::visit (SliceType &)
 {}
 
 void
-UnsafeChecker::visit (InferredType &type)
+UnsafeChecker::visit (InferredType &)
 {}
 
 void
-UnsafeChecker::visit (BareFunctionType &type)
+UnsafeChecker::visit (BareFunctionType &)
 {}
 
 } // namespace HIR

--- a/gcc/rust/checks/lints/rust-lint-marklive.cc
+++ b/gcc/rust/checks/lints/rust-lint-marklive.cc
@@ -78,7 +78,7 @@ MarkLive::Analysis (HIR::Crate &crate)
 //    visited first time
 // 2. save all the live symbols in liveSymbols
 void
-MarkLive::go (HIR::Crate &crate)
+MarkLive::go (HIR::Crate &)
 {
   while (!worklist.empty ())
     {

--- a/gcc/rust/checks/lints/rust-lint-unused-var.cc
+++ b/gcc/rust/checks/lints/rust-lint-unused-var.cc
@@ -53,7 +53,7 @@ check_decl (tree *t)
 }
 
 static tree
-unused_var_walk_fn (tree *t, int *walk_subtrees, void *closure)
+unused_var_walk_fn (tree *t, int *, void *)
 {
   switch (TREE_CODE (*t))
     {

--- a/gcc/rust/hir/rust-ast-lower-base.cc
+++ b/gcc/rust/hir/rust-ast-lower-base.cc
@@ -25,499 +25,499 @@ namespace Rust {
 namespace HIR {
 
 void
-ASTLoweringBase::visit (AST::Token &tok)
+ASTLoweringBase::visit (AST::Token &)
 {}
 void
-ASTLoweringBase::visit (AST::DelimTokenTree &delim_tok_tree)
+ASTLoweringBase::visit (AST::DelimTokenTree &)
 {}
 void
-ASTLoweringBase::visit (AST::AttrInputMetaItemContainer &input)
+ASTLoweringBase::visit (AST::AttrInputMetaItemContainer &)
 {}
-//  void ASTLoweringBase::visit(MetaItem& meta_item) {}
-//  void vsit(Stmt& stmt) {}
-//  void ASTLoweringBase::visit(Expr& expr) {}
+//  void ASTLoweringBase::visit(MetaItemmeta_item) {}
+//  void vsit(Stmtstmt) {}
+//  void ASTLoweringBase::visit(Exprexpr) {}
 void
-ASTLoweringBase::visit (AST::IdentifierExpr &ident_expr)
+ASTLoweringBase::visit (AST::IdentifierExpr &)
 {}
-//  void ASTLoweringBase::visit(Pattern& pattern) {}
-//  void ASTLoweringBase::visit(Type& type) {}
-//  void ASTLoweringBase::visit(TypeParamBound& type_param_bound) {}
+//  void ASTLoweringBase::visit(Patternpattern) {}
+//  void ASTLoweringBase::visit(Typetype) {}
+//  void ASTLoweringBase::visit(TypeParamBoundtype_param_bound) {}
 void
-ASTLoweringBase::visit (AST::Lifetime &lifetime)
+ASTLoweringBase::visit (AST::Lifetime &)
 {}
-//  void ASTLoweringBase::visit(GenericParam& generic_param) {}
+//  void ASTLoweringBase::visit(GenericParamgeneric_param) {}
 void
-ASTLoweringBase::visit (AST::LifetimeParam &lifetime_param)
+ASTLoweringBase::visit (AST::LifetimeParam &)
 {}
 void
-ASTLoweringBase::visit (AST::ConstGenericParam &const_param)
+ASTLoweringBase::visit (AST::ConstGenericParam &)
 {}
-//  void ASTLoweringBase::visit(TraitItem& trait_item) {}
-//  void ASTLoweringBase::visit(InherentImplItem& inherent_impl_item) {}
-//  void ASTLoweringBase::visit(TraitImplItem& trait_impl_item) {}
+//  void ASTLoweringBase::visit(TraitItemtrait_item) {}
+//  void ASTLoweringBase::visit(InherentImplIteminherent_impl_item) {}
+//  void ASTLoweringBase::visit(TraitImplItemtrait_impl_item) {}
 
 // rust-path.h
 void
-ASTLoweringBase::visit (AST::PathInExpression &path)
+ASTLoweringBase::visit (AST::PathInExpression &)
 {}
 void
-ASTLoweringBase::visit (AST::TypePathSegment &segment)
+ASTLoweringBase::visit (AST::TypePathSegment &)
 {}
 void
-ASTLoweringBase::visit (AST::TypePathSegmentGeneric &segment)
+ASTLoweringBase::visit (AST::TypePathSegmentGeneric &)
 {}
 void
-ASTLoweringBase::visit (AST::TypePathSegmentFunction &segment)
+ASTLoweringBase::visit (AST::TypePathSegmentFunction &)
 {}
 void
-ASTLoweringBase::visit (AST::TypePath &path)
+ASTLoweringBase::visit (AST::TypePath &)
 {}
 void
-ASTLoweringBase::visit (AST::QualifiedPathInExpression &path)
+ASTLoweringBase::visit (AST::QualifiedPathInExpression &)
 {}
 void
-ASTLoweringBase::visit (AST::QualifiedPathInType &path)
+ASTLoweringBase::visit (AST::QualifiedPathInType &)
 {}
 
 // rust-expr.h
 void
-ASTLoweringBase::visit (AST::LiteralExpr &expr)
+ASTLoweringBase::visit (AST::LiteralExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::AttrInputLiteral &attr_input)
+ASTLoweringBase::visit (AST::AttrInputLiteral &)
 {}
 void
-ASTLoweringBase::visit (AST::MetaItemLitExpr &meta_item)
+ASTLoweringBase::visit (AST::MetaItemLitExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::MetaItemPathLit &meta_item)
+ASTLoweringBase::visit (AST::MetaItemPathLit &)
 {}
 void
-ASTLoweringBase::visit (AST::BorrowExpr &expr)
+ASTLoweringBase::visit (AST::BorrowExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::DereferenceExpr &expr)
+ASTLoweringBase::visit (AST::DereferenceExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::ErrorPropagationExpr &expr)
+ASTLoweringBase::visit (AST::ErrorPropagationExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::NegationExpr &expr)
+ASTLoweringBase::visit (AST::NegationExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::ArithmeticOrLogicalExpr &expr)
+ASTLoweringBase::visit (AST::ArithmeticOrLogicalExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::ComparisonExpr &expr)
+ASTLoweringBase::visit (AST::ComparisonExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::LazyBooleanExpr &expr)
+ASTLoweringBase::visit (AST::LazyBooleanExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::TypeCastExpr &expr)
+ASTLoweringBase::visit (AST::TypeCastExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::AssignmentExpr &expr)
+ASTLoweringBase::visit (AST::AssignmentExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::CompoundAssignmentExpr &expr)
+ASTLoweringBase::visit (AST::CompoundAssignmentExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::GroupedExpr &expr)
+ASTLoweringBase::visit (AST::GroupedExpr &)
 {}
-//  void ASTLoweringBase::visit(ArrayElems& elems) {}
+//  void ASTLoweringBase::visit(ArrayElemselems) {}
 void
-ASTLoweringBase::visit (AST::ArrayElemsValues &elems)
-{}
-void
-ASTLoweringBase::visit (AST::ArrayElemsCopied &elems)
+ASTLoweringBase::visit (AST::ArrayElemsValues &)
 {}
 void
-ASTLoweringBase::visit (AST::ArrayExpr &expr)
+ASTLoweringBase::visit (AST::ArrayElemsCopied &)
 {}
 void
-ASTLoweringBase::visit (AST::ArrayIndexExpr &expr)
+ASTLoweringBase::visit (AST::ArrayExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::TupleExpr &expr)
+ASTLoweringBase::visit (AST::ArrayIndexExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::TupleIndexExpr &expr)
+ASTLoweringBase::visit (AST::TupleExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::StructExprStruct &expr)
-{}
-//  void ASTLoweringBase::visit(StructExprField& field) {}
-void
-ASTLoweringBase::visit (AST::StructExprFieldIdentifier &field)
+ASTLoweringBase::visit (AST::TupleIndexExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::StructExprFieldIdentifierValue &field)
+ASTLoweringBase::visit (AST::StructExprStruct &)
+{}
+//  void ASTLoweringBase::visit(StructExprFieldfield) {}
+void
+ASTLoweringBase::visit (AST::StructExprFieldIdentifier &)
 {}
 void
-ASTLoweringBase::visit (AST::StructExprFieldIndexValue &field)
+ASTLoweringBase::visit (AST::StructExprFieldIdentifierValue &)
 {}
 void
-ASTLoweringBase::visit (AST::StructExprStructFields &expr)
+ASTLoweringBase::visit (AST::StructExprFieldIndexValue &)
 {}
 void
-ASTLoweringBase::visit (AST::StructExprStructBase &expr)
+ASTLoweringBase::visit (AST::StructExprStructFields &)
 {}
 void
-ASTLoweringBase::visit (AST::CallExpr &expr)
+ASTLoweringBase::visit (AST::StructExprStructBase &)
 {}
 void
-ASTLoweringBase::visit (AST::MethodCallExpr &expr)
+ASTLoweringBase::visit (AST::CallExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::FieldAccessExpr &expr)
+ASTLoweringBase::visit (AST::MethodCallExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::ClosureExprInner &expr)
+ASTLoweringBase::visit (AST::FieldAccessExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::BlockExpr &expr)
+ASTLoweringBase::visit (AST::ClosureExprInner &)
 {}
 void
-ASTLoweringBase::visit (AST::ClosureExprInnerTyped &expr)
+ASTLoweringBase::visit (AST::BlockExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::ContinueExpr &expr)
+ASTLoweringBase::visit (AST::ClosureExprInnerTyped &)
 {}
 void
-ASTLoweringBase::visit (AST::BreakExpr &expr)
+ASTLoweringBase::visit (AST::ContinueExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::RangeFromToExpr &expr)
+ASTLoweringBase::visit (AST::BreakExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::RangeFromExpr &expr)
+ASTLoweringBase::visit (AST::RangeFromToExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::RangeToExpr &expr)
+ASTLoweringBase::visit (AST::RangeFromExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::RangeFullExpr &expr)
+ASTLoweringBase::visit (AST::RangeToExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::RangeFromToInclExpr &expr)
+ASTLoweringBase::visit (AST::RangeFullExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::RangeToInclExpr &expr)
+ASTLoweringBase::visit (AST::RangeFromToInclExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::ReturnExpr &expr)
+ASTLoweringBase::visit (AST::RangeToInclExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::UnsafeBlockExpr &expr)
+ASTLoweringBase::visit (AST::ReturnExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::LoopExpr &expr)
+ASTLoweringBase::visit (AST::UnsafeBlockExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::WhileLoopExpr &expr)
+ASTLoweringBase::visit (AST::LoopExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::WhileLetLoopExpr &expr)
+ASTLoweringBase::visit (AST::WhileLoopExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::ForLoopExpr &expr)
+ASTLoweringBase::visit (AST::WhileLetLoopExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::IfExpr &expr)
+ASTLoweringBase::visit (AST::ForLoopExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::IfExprConseqElse &expr)
+ASTLoweringBase::visit (AST::IfExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::IfExprConseqIf &expr)
+ASTLoweringBase::visit (AST::IfExprConseqElse &)
 {}
 void
-ASTLoweringBase::visit (AST::IfExprConseqIfLet &expr)
+ASTLoweringBase::visit (AST::IfExprConseqIf &)
 {}
 void
-ASTLoweringBase::visit (AST::IfLetExpr &expr)
+ASTLoweringBase::visit (AST::IfExprConseqIfLet &)
 {}
 void
-ASTLoweringBase::visit (AST::IfLetExprConseqElse &expr)
+ASTLoweringBase::visit (AST::IfLetExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::IfLetExprConseqIf &expr)
+ASTLoweringBase::visit (AST::IfLetExprConseqElse &)
 {}
 void
-ASTLoweringBase::visit (AST::IfLetExprConseqIfLet &expr)
-{}
-//  void ASTLoweringBase::visit(MatchCase& match_case) {}
-// void ASTLoweringBase:: (AST::MatchCaseBlockExpr &match_case) {}
-// void ASTLoweringBase:: (AST::MatchCaseExpr &match_case) {}
-void
-ASTLoweringBase::visit (AST::MatchExpr &expr)
+ASTLoweringBase::visit (AST::IfLetExprConseqIf &)
 {}
 void
-ASTLoweringBase::visit (AST::AwaitExpr &expr)
+ASTLoweringBase::visit (AST::IfLetExprConseqIfLet &)
+{}
+//  void ASTLoweringBase::visit(MatchCasematch_case) {}
+// void ASTLoweringBase:: (AST::MatchCaseBlockExpr &) {}
+// void ASTLoweringBase:: (AST::MatchCaseExpr &) {}
+void
+ASTLoweringBase::visit (AST::MatchExpr &)
 {}
 void
-ASTLoweringBase::visit (AST::AsyncBlockExpr &expr)
+ASTLoweringBase::visit (AST::AwaitExpr &)
+{}
+void
+ASTLoweringBase::visit (AST::AsyncBlockExpr &)
 {}
 
 // rust-item.h
 void
-ASTLoweringBase::visit (AST::TypeParam &param)
+ASTLoweringBase::visit (AST::TypeParam &)
 {}
-//  void ASTLoweringBase::visit(WhereClauseItem& item) {}
+//  void ASTLoweringBase::visit(WhereClauseItemitem) {}
 void
-ASTLoweringBase::visit (AST::LifetimeWhereClauseItem &item)
-{}
-void
-ASTLoweringBase::visit (AST::TypeBoundWhereClauseItem &item)
+ASTLoweringBase::visit (AST::LifetimeWhereClauseItem &)
 {}
 void
-ASTLoweringBase::visit (AST::Method &method)
+ASTLoweringBase::visit (AST::TypeBoundWhereClauseItem &)
 {}
 void
-ASTLoweringBase::visit (AST::Module &module)
+ASTLoweringBase::visit (AST::Method &)
 {}
 void
-ASTLoweringBase::visit (AST::ExternCrate &crate)
-{}
-//  void ASTLoweringBase::visit(UseTree& use_tree) {}
-void
-ASTLoweringBase::visit (AST::UseTreeGlob &use_tree)
+ASTLoweringBase::visit (AST::Module &)
 {}
 void
-ASTLoweringBase::visit (AST::UseTreeList &use_tree)
+ASTLoweringBase::visit (AST::ExternCrate &)
+{}
+//  void ASTLoweringBase::visit(UseTreeuse_tree) {}
+void
+ASTLoweringBase::visit (AST::UseTreeGlob &)
 {}
 void
-ASTLoweringBase::visit (AST::UseTreeRebind &use_tree)
+ASTLoweringBase::visit (AST::UseTreeList &)
 {}
 void
-ASTLoweringBase::visit (AST::UseDeclaration &use_decl)
+ASTLoweringBase::visit (AST::UseTreeRebind &)
 {}
 void
-ASTLoweringBase::visit (AST::Function &function)
+ASTLoweringBase::visit (AST::UseDeclaration &)
 {}
 void
-ASTLoweringBase::visit (AST::TypeAlias &type_alias)
+ASTLoweringBase::visit (AST::Function &)
 {}
 void
-ASTLoweringBase::visit (AST::StructStruct &struct_item)
+ASTLoweringBase::visit (AST::TypeAlias &)
 {}
 void
-ASTLoweringBase::visit (AST::TupleStruct &tuple_struct)
+ASTLoweringBase::visit (AST::StructStruct &)
 {}
 void
-ASTLoweringBase::visit (AST::EnumItem &item)
+ASTLoweringBase::visit (AST::TupleStruct &)
 {}
 void
-ASTLoweringBase::visit (AST::EnumItemTuple &item)
+ASTLoweringBase::visit (AST::EnumItem &)
 {}
 void
-ASTLoweringBase::visit (AST::EnumItemStruct &item)
+ASTLoweringBase::visit (AST::EnumItemTuple &)
 {}
 void
-ASTLoweringBase::visit (AST::EnumItemDiscriminant &item)
+ASTLoweringBase::visit (AST::EnumItemStruct &)
 {}
 void
-ASTLoweringBase::visit (AST::Enum &enum_item)
+ASTLoweringBase::visit (AST::EnumItemDiscriminant &)
 {}
 void
-ASTLoweringBase::visit (AST::Union &union_item)
+ASTLoweringBase::visit (AST::Enum &)
 {}
 void
-ASTLoweringBase::visit (AST::ConstantItem &const_item)
+ASTLoweringBase::visit (AST::Union &)
 {}
 void
-ASTLoweringBase::visit (AST::StaticItem &static_item)
+ASTLoweringBase::visit (AST::ConstantItem &)
 {}
 void
-ASTLoweringBase::visit (AST::TraitItemFunc &item)
+ASTLoweringBase::visit (AST::StaticItem &)
 {}
 void
-ASTLoweringBase::visit (AST::TraitItemMethod &item)
+ASTLoweringBase::visit (AST::TraitItemFunc &)
 {}
 void
-ASTLoweringBase::visit (AST::TraitItemConst &item)
+ASTLoweringBase::visit (AST::TraitItemMethod &)
 {}
 void
-ASTLoweringBase::visit (AST::TraitItemType &item)
+ASTLoweringBase::visit (AST::TraitItemConst &)
 {}
 void
-ASTLoweringBase::visit (AST::Trait &trait)
+ASTLoweringBase::visit (AST::TraitItemType &)
 {}
 void
-ASTLoweringBase::visit (AST::InherentImpl &impl)
+ASTLoweringBase::visit (AST::Trait &)
 {}
 void
-ASTLoweringBase::visit (AST::TraitImpl &impl)
-{}
-//  void ASTLoweringBase::visit(ExternalItem& item) {}
-void
-ASTLoweringBase::visit (AST::ExternalStaticItem &item)
+ASTLoweringBase::visit (AST::InherentImpl &)
 {}
 void
-ASTLoweringBase::visit (AST::ExternalFunctionItem &item)
+ASTLoweringBase::visit (AST::TraitImpl &)
+{}
+//  void ASTLoweringBase::visit(ExternalItemitem) {}
+void
+ASTLoweringBase::visit (AST::ExternalStaticItem &)
 {}
 void
-ASTLoweringBase::visit (AST::ExternBlock &block)
+ASTLoweringBase::visit (AST::ExternalFunctionItem &)
+{}
+void
+ASTLoweringBase::visit (AST::ExternBlock &)
 {}
 
 // rust-macro.h
 void
-ASTLoweringBase::visit (AST::MacroMatchFragment &match)
+ASTLoweringBase::visit (AST::MacroMatchFragment &)
 {}
 void
-ASTLoweringBase::visit (AST::MacroMatchRepetition &match)
+ASTLoweringBase::visit (AST::MacroMatchRepetition &)
 {}
 void
-ASTLoweringBase::visit (AST::MacroMatcher &matcher)
+ASTLoweringBase::visit (AST::MacroMatcher &)
 {}
 void
-ASTLoweringBase::visit (AST::MacroRulesDefinition &rules_def)
+ASTLoweringBase::visit (AST::MacroRulesDefinition &)
 {}
 void
-ASTLoweringBase::visit (AST::MacroInvocation &macro_invoc)
+ASTLoweringBase::visit (AST::MacroInvocation &)
 {}
 void
-ASTLoweringBase::visit (AST::MetaItemPath &meta_item)
+ASTLoweringBase::visit (AST::MetaItemPath &)
 {}
 void
-ASTLoweringBase::visit (AST::MetaItemSeq &meta_item)
+ASTLoweringBase::visit (AST::MetaItemSeq &)
 {}
 void
-ASTLoweringBase::visit (AST::MetaWord &meta_item)
+ASTLoweringBase::visit (AST::MetaWord &)
 {}
 void
-ASTLoweringBase::visit (AST::MetaNameValueStr &meta_item)
+ASTLoweringBase::visit (AST::MetaNameValueStr &)
 {}
 void
-ASTLoweringBase::visit (AST::MetaListPaths &meta_item)
+ASTLoweringBase::visit (AST::MetaListPaths &)
 {}
 void
-ASTLoweringBase::visit (AST::MetaListNameValueStr &meta_item)
+ASTLoweringBase::visit (AST::MetaListNameValueStr &)
 {}
 
 // rust-pattern.h
 void
-ASTLoweringBase::visit (AST::LiteralPattern &pattern)
+ASTLoweringBase::visit (AST::LiteralPattern &)
 {}
 void
-ASTLoweringBase::visit (AST::IdentifierPattern &pattern)
+ASTLoweringBase::visit (AST::IdentifierPattern &)
 {}
 void
-ASTLoweringBase::visit (AST::WildcardPattern &pattern)
+ASTLoweringBase::visit (AST::WildcardPattern &)
 {}
-//  void ASTLoweringBase::visit(RangePatternBound& bound) {}
+//  void ASTLoweringBase::visit(RangePatternBoundbound) {}
 void
-ASTLoweringBase::visit (AST::RangePatternBoundLiteral &bound)
-{}
-void
-ASTLoweringBase::visit (AST::RangePatternBoundPath &bound)
+ASTLoweringBase::visit (AST::RangePatternBoundLiteral &)
 {}
 void
-ASTLoweringBase::visit (AST::RangePatternBoundQualPath &bound)
+ASTLoweringBase::visit (AST::RangePatternBoundPath &)
 {}
 void
-ASTLoweringBase::visit (AST::RangePattern &pattern)
+ASTLoweringBase::visit (AST::RangePatternBoundQualPath &)
 {}
 void
-ASTLoweringBase::visit (AST::ReferencePattern &pattern)
-{}
-//  void ASTLoweringBase::visit(StructPatternField& field) {}
-void
-ASTLoweringBase::visit (AST::StructPatternFieldTuplePat &field)
+ASTLoweringBase::visit (AST::RangePattern &)
 {}
 void
-ASTLoweringBase::visit (AST::StructPatternFieldIdentPat &field)
+ASTLoweringBase::visit (AST::ReferencePattern &)
+{}
+//  void ASTLoweringBase::visit(StructPatternFieldfield) {}
+void
+ASTLoweringBase::visit (AST::StructPatternFieldTuplePat &)
 {}
 void
-ASTLoweringBase::visit (AST::StructPatternFieldIdent &field)
+ASTLoweringBase::visit (AST::StructPatternFieldIdentPat &)
 {}
 void
-ASTLoweringBase::visit (AST::StructPattern &pattern)
-{}
-//  void ASTLoweringBase::visit(TupleStructItems& tuple_items) {}
-void
-ASTLoweringBase::visit (AST::TupleStructItemsNoRange &tuple_items)
+ASTLoweringBase::visit (AST::StructPatternFieldIdent &)
 {}
 void
-ASTLoweringBase::visit (AST::TupleStructItemsRange &tuple_items)
+ASTLoweringBase::visit (AST::StructPattern &)
+{}
+//  void ASTLoweringBase::visit(TupleStructItemstuple_items) {}
+void
+ASTLoweringBase::visit (AST::TupleStructItemsNoRange &)
 {}
 void
-ASTLoweringBase::visit (AST::TupleStructPattern &pattern)
-{}
-//  void ASTLoweringBase::visit(TuplePatternItems& tuple_items) {}
-void
-ASTLoweringBase::visit (AST::TuplePatternItemsMultiple &tuple_items)
+ASTLoweringBase::visit (AST::TupleStructItemsRange &)
 {}
 void
-ASTLoweringBase::visit (AST::TuplePatternItemsRanged &tuple_items)
+ASTLoweringBase::visit (AST::TupleStructPattern &)
+{}
+//  void ASTLoweringBase::visit(TuplePatternItemstuple_items) {}
+void
+ASTLoweringBase::visit (AST::TuplePatternItemsMultiple &)
 {}
 void
-ASTLoweringBase::visit (AST::TuplePattern &pattern)
+ASTLoweringBase::visit (AST::TuplePatternItemsRanged &)
 {}
 void
-ASTLoweringBase::visit (AST::GroupedPattern &pattern)
+ASTLoweringBase::visit (AST::TuplePattern &)
 {}
 void
-ASTLoweringBase::visit (AST::SlicePattern &pattern)
+ASTLoweringBase::visit (AST::GroupedPattern &)
+{}
+void
+ASTLoweringBase::visit (AST::SlicePattern &)
 {}
 
 // rust-stmt.h
 void
-ASTLoweringBase::visit (AST::EmptyStmt &stmt)
+ASTLoweringBase::visit (AST::EmptyStmt &)
 {}
 void
-ASTLoweringBase::visit (AST::LetStmt &stmt)
+ASTLoweringBase::visit (AST::LetStmt &)
 {}
 void
-ASTLoweringBase::visit (AST::ExprStmtWithoutBlock &stmt)
+ASTLoweringBase::visit (AST::ExprStmtWithoutBlock &)
 {}
 void
-ASTLoweringBase::visit (AST::ExprStmtWithBlock &stmt)
+ASTLoweringBase::visit (AST::ExprStmtWithBlock &)
 {}
 
 // rust-type.h
 void
-ASTLoweringBase::visit (AST::TraitBound &bound)
+ASTLoweringBase::visit (AST::TraitBound &)
 {}
 void
-ASTLoweringBase::visit (AST::ImplTraitType &type)
+ASTLoweringBase::visit (AST::ImplTraitType &)
 {}
 void
-ASTLoweringBase::visit (AST::TraitObjectType &type)
+ASTLoweringBase::visit (AST::TraitObjectType &)
 {}
 void
-ASTLoweringBase::visit (AST::ParenthesisedType &type)
+ASTLoweringBase::visit (AST::ParenthesisedType &)
 {}
 void
-ASTLoweringBase::visit (AST::ImplTraitTypeOneBound &type)
+ASTLoweringBase::visit (AST::ImplTraitTypeOneBound &)
 {}
 void
-ASTLoweringBase::visit (AST::TraitObjectTypeOneBound &type)
+ASTLoweringBase::visit (AST::TraitObjectTypeOneBound &)
 {}
 void
-ASTLoweringBase::visit (AST::TupleType &type)
+ASTLoweringBase::visit (AST::TupleType &)
 {}
 void
-ASTLoweringBase::visit (AST::NeverType &type)
+ASTLoweringBase::visit (AST::NeverType &)
 {}
 void
-ASTLoweringBase::visit (AST::RawPointerType &type)
+ASTLoweringBase::visit (AST::RawPointerType &)
 {}
 void
-ASTLoweringBase::visit (AST::ReferenceType &type)
+ASTLoweringBase::visit (AST::ReferenceType &)
 {}
 void
-ASTLoweringBase::visit (AST::ArrayType &type)
+ASTLoweringBase::visit (AST::ArrayType &)
 {}
 void
-ASTLoweringBase::visit (AST::SliceType &type)
+ASTLoweringBase::visit (AST::SliceType &)
 {}
 void
-ASTLoweringBase::visit (AST::InferredType &type)
+ASTLoweringBase::visit (AST::InferredType &)
 {}
 void
-ASTLoweringBase::visit (AST::BareFunctionType &type)
+ASTLoweringBase::visit (AST::BareFunctionType &)
 {}
 
 HIR::Lifetime
@@ -742,7 +742,7 @@ ASTLoweringBase::handle_outer_attributes (const ItemWrapper &item)
 }
 
 void
-ASTLoweringBase::handle_doc_item_attribute (const ItemWrapper &item,
+ASTLoweringBase::handle_doc_item_attribute (const ItemWrapper &,
 					    const AST::Attribute &attr)
 {
   auto simple_doc_comment = attr.has_attr_input ()

--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -200,7 +200,7 @@ void
 Dump::visit (ClosureExpr &)
 {}
 void
-Dump::visit (BlockExpr &block_expr)
+Dump::visit (BlockExpr &)
 {
   stream << "BlockExpr"
 	 << ":"
@@ -324,7 +324,7 @@ void
 Dump::visit (UseDeclaration &)
 {}
 void
-Dump::visit (Function &function)
+Dump::visit (Function &)
 {
   indent++;
   stream << std::string (indent, indent_char);

--- a/gcc/rust/hir/tree/rust-hir-full-test.cc
+++ b/gcc/rust/hir/tree/rust-hir-full-test.cc
@@ -5256,7 +5256,7 @@ ConstGenericParam::as_string () const
 }
 
 void
-ConstGenericParam::accept_vis (HIRFullVisitor &vis)
+ConstGenericParam::accept_vis (HIRFullVisitor &)
 {}
 
 } // namespace HIR

--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -1323,7 +1323,7 @@ Lexer::parse_escape (char opening_char)
 /* Parses an escape (or string continue) in a string or character. Supports
  * unicode escapes. */
 std::tuple<Codepoint, int, bool>
-Lexer::parse_utf8_escape (char opening_char)
+Lexer::parse_utf8_escape ()
 {
   Codepoint output_char;
   int additional_length_offset = 0;
@@ -1923,7 +1923,7 @@ Lexer::parse_string (Location loc)
       if (current_char32.value == '\\')
 	{
 	  // parse escape
-	  auto utf8_escape_pair = parse_utf8_escape ('\'');
+	  auto utf8_escape_pair = parse_utf8_escape ();
 	  current_char32 = std::get<0> (utf8_escape_pair);
 
 	  if (current_char32 == Codepoint (0) && std::get<2> (utf8_escape_pair))
@@ -2324,7 +2324,7 @@ Lexer::parse_char_or_lifetime (Location loc)
   if (current_char32.value == '\\')
     {
       // parse escape
-      auto utf8_escape_pair = parse_utf8_escape ('\'');
+      auto utf8_escape_pair = parse_utf8_escape ();
       current_char32 = std::get<0> (utf8_escape_pair);
       length += std::get<1> (utf8_escape_pair);
 

--- a/gcc/rust/lex/rust-lex.h
+++ b/gcc/rust/lex/rust-lex.h
@@ -108,7 +108,7 @@ private:
   std::pair<std::string, int> parse_in_exponent_part ();
   std::pair<PrimitiveCoreType, int> parse_in_type_suffix ();
   std::tuple<char, int, bool> parse_escape (char opening_char);
-  std::tuple<Codepoint, int, bool> parse_utf8_escape (char opening_char);
+  std::tuple<Codepoint, int, bool> parse_utf8_escape ();
   int parse_partial_string_continue ();
   std::pair<long, int> parse_partial_hex_escape ();
   std::pair<Codepoint, int> parse_partial_unicode_escape ();

--- a/gcc/rust/metadata/rust-export-metadata.cc
+++ b/gcc/rust/metadata/rust-export-metadata.cc
@@ -157,18 +157,18 @@ class ExportVisItems : public HIR::HIRVisItemVisitor
 public:
   ExportVisItems (ExportContext &context) : ctx (context) {}
 
-  void visit (HIR::Module &module) override {}
-  void visit (HIR::ExternCrate &crate) override {}
-  void visit (HIR::UseDeclaration &use_decl) override {}
-  void visit (HIR::TypeAlias &type_alias) override {}
-  void visit (HIR::StructStruct &struct_item) override {}
-  void visit (HIR::TupleStruct &tuple_struct) override {}
-  void visit (HIR::Enum &enum_item) override {}
-  void visit (HIR::Union &union_item) override {}
-  void visit (HIR::ConstantItem &const_item) override {}
-  void visit (HIR::StaticItem &static_item) override {}
-  void visit (HIR::ImplBlock &impl) override {}
-  void visit (HIR::ExternBlock &block) override {}
+  void visit (HIR::Module &) override {}
+  void visit (HIR::ExternCrate &) override {}
+  void visit (HIR::UseDeclaration &) override {}
+  void visit (HIR::TypeAlias &) override {}
+  void visit (HIR::StructStruct &) override {}
+  void visit (HIR::TupleStruct &) override {}
+  void visit (HIR::Enum &) override {}
+  void visit (HIR::Union &) override {}
+  void visit (HIR::ConstantItem &) override {}
+  void visit (HIR::StaticItem &) override {}
+  void visit (HIR::ImplBlock &) override {}
+  void visit (HIR::ExternBlock &) override {}
 
   void visit (HIR::Trait &trait) override { ctx.emit_trait (trait); }
 

--- a/gcc/rust/resolve/rust-ast-resolve-expr.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.cc
@@ -102,7 +102,7 @@ ResolveExpr::visit (AST::AssignmentExpr &expr)
   ResolveExpr::go (expr.get_right_expr ().get (), prefix, canonical_prefix);
 
   // need to verify the assignee
-  VerifyAsignee::go (expr.get_left_expr ().get (), expr.get_node_id ());
+  VerifyAsignee::go (expr.get_left_expr ().get ());
 }
 
 void
@@ -141,7 +141,7 @@ ResolveExpr::visit (AST::CompoundAssignmentExpr &expr)
   ResolveExpr::go (expr.get_right_expr ().get (), prefix, canonical_prefix);
 
   // need to verify the assignee
-  VerifyAsignee::go (expr.get_left_expr ().get (), expr.get_node_id ());
+  VerifyAsignee::go (expr.get_left_expr ().get ());
 }
 
 void
@@ -553,7 +553,7 @@ ResolveExpr::visit (AST::RangeToExpr &expr)
 }
 
 void
-ResolveExpr::visit (AST::RangeFullExpr &expr)
+ResolveExpr::visit (AST::RangeFullExpr &)
 {
   // nothing to do
 }

--- a/gcc/rust/resolve/rust-ast-resolve-type.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-type.cc
@@ -61,13 +61,13 @@ ResolveType::visit (AST::RawPointerType &type)
 }
 
 void
-ResolveType::visit (AST::InferredType &type)
+ResolveType::visit (AST::InferredType &)
 {
   // FIXME
 }
 
 void
-ResolveType::visit (AST::NeverType &type)
+ResolveType::visit (AST::NeverType &)
 {
   // FIXME
 }
@@ -505,7 +505,7 @@ ResolveTypeToCanonicalPath::visit (AST::TraitObjectTypeOneBound &type)
 }
 
 void
-ResolveTypeToCanonicalPath::visit (AST::TraitObjectType &type)
+ResolveTypeToCanonicalPath::visit (AST::TraitObjectType &)
 {
   // FIXME is this actually allowed? dyn A+B
   gcc_unreachable ();

--- a/gcc/rust/resolve/rust-ast-verify-assignee.h
+++ b/gcc/rust/resolve/rust-ast-verify-assignee.h
@@ -30,9 +30,9 @@ class VerifyAsignee : public ResolverBase
   using Rust::Resolver::ResolverBase::visit;
 
 public:
-  static bool go (AST::Expr *assignee, NodeId parent)
+  static bool go (AST::Expr *assignee)
   {
-    VerifyAsignee checker (parent);
+    VerifyAsignee checker;
     assignee->accept_vis (checker);
     if (!checker.ok)
       rust_error_at (assignee->get_locus (),
@@ -70,10 +70,10 @@ public:
     expr.get_dereferenced_expr ()->accept_vis (*this);
   }
 
-  void visit (AST::PathInExpression &expr) override { ok = true; }
+  void visit (AST::PathInExpression &) override { ok = true; }
 
 private:
-  VerifyAsignee (NodeId parent) : ResolverBase (), ok (false) {}
+  VerifyAsignee () : ResolverBase (), ok (false) {}
 
   bool ok;
 };

--- a/gcc/rust/resolve/rust-early-name-resolver.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver.cc
@@ -60,31 +60,31 @@ EarlyNameResolver::resolve_qualified_path_type (AST::QualifiedPathType &path)
 }
 
 void
-EarlyNameResolver::visit (AST::Token &tok)
+EarlyNameResolver::visit (AST::Token &)
 {}
 
 void
-EarlyNameResolver::visit (AST::DelimTokenTree &delim_tok_tree)
+EarlyNameResolver::visit (AST::DelimTokenTree &)
 {}
 
 void
-EarlyNameResolver::visit (AST::AttrInputMetaItemContainer &input)
+EarlyNameResolver::visit (AST::AttrInputMetaItemContainer &)
 {}
 
 void
-EarlyNameResolver::visit (AST::IdentifierExpr &ident_expr)
+EarlyNameResolver::visit (AST::IdentifierExpr &)
 {}
 
 void
-EarlyNameResolver::visit (AST::Lifetime &lifetime)
+EarlyNameResolver::visit (AST::Lifetime &)
 {}
 
 void
-EarlyNameResolver::visit (AST::LifetimeParam &lifetime_param)
+EarlyNameResolver::visit (AST::LifetimeParam &)
 {}
 
 void
-EarlyNameResolver::visit (AST::ConstGenericParam &const_param)
+EarlyNameResolver::visit (AST::ConstGenericParam &)
 {}
 
 // FIXME: ARTHUR: Do we need to perform macro resolution for paths as well?
@@ -98,7 +98,7 @@ EarlyNameResolver::visit (AST::PathInExpression &path)
 }
 
 void
-EarlyNameResolver::visit (AST::TypePathSegment &segment)
+EarlyNameResolver::visit (AST::TypePathSegment &)
 {}
 
 void
@@ -144,19 +144,19 @@ EarlyNameResolver::visit (AST::QualifiedPathInType &path)
 }
 
 void
-EarlyNameResolver::visit (AST::LiteralExpr &expr)
+EarlyNameResolver::visit (AST::LiteralExpr &)
 {}
 
 void
-EarlyNameResolver::visit (AST::AttrInputLiteral &attr_input)
+EarlyNameResolver::visit (AST::AttrInputLiteral &)
 {}
 
 void
-EarlyNameResolver::visit (AST::MetaItemLitExpr &meta_item)
+EarlyNameResolver::visit (AST::MetaItemLitExpr &)
 {}
 
 void
-EarlyNameResolver::visit (AST::MetaItemPathLit &meta_item)
+EarlyNameResolver::visit (AST::MetaItemPathLit &)
 {}
 
 void
@@ -271,11 +271,11 @@ EarlyNameResolver::visit (AST::TupleIndexExpr &expr)
 }
 
 void
-EarlyNameResolver::visit (AST::StructExprStruct &expr)
+EarlyNameResolver::visit (AST::StructExprStruct &)
 {}
 
 void
-EarlyNameResolver::visit (AST::StructExprFieldIdentifier &field)
+EarlyNameResolver::visit (AST::StructExprFieldIdentifier &)
 {}
 
 void
@@ -298,7 +298,7 @@ EarlyNameResolver::visit (AST::StructExprStructFields &expr)
 }
 
 void
-EarlyNameResolver::visit (AST::StructExprStructBase &expr)
+EarlyNameResolver::visit (AST::StructExprStructBase &)
 {}
 
 void
@@ -352,7 +352,7 @@ EarlyNameResolver::visit (AST::ClosureExprInnerTyped &expr)
 }
 
 void
-EarlyNameResolver::visit (AST::ContinueExpr &expr)
+EarlyNameResolver::visit (AST::ContinueExpr &)
 {}
 
 void
@@ -382,7 +382,7 @@ EarlyNameResolver::visit (AST::RangeToExpr &expr)
 }
 
 void
-EarlyNameResolver::visit (AST::RangeFullExpr &expr)
+EarlyNameResolver::visit (AST::RangeFullExpr &)
 {}
 
 void
@@ -539,7 +539,7 @@ EarlyNameResolver::visit (AST::TypeParam &param)
 }
 
 void
-EarlyNameResolver::visit (AST::LifetimeWhereClauseItem &item)
+EarlyNameResolver::visit (AST::LifetimeWhereClauseItem &)
 {}
 
 void
@@ -576,23 +576,23 @@ EarlyNameResolver::visit (AST::Module &module)
 }
 
 void
-EarlyNameResolver::visit (AST::ExternCrate &crate)
+EarlyNameResolver::visit (AST::ExternCrate &)
 {}
 
 void
-EarlyNameResolver::visit (AST::UseTreeGlob &use_tree)
+EarlyNameResolver::visit (AST::UseTreeGlob &)
 {}
 
 void
-EarlyNameResolver::visit (AST::UseTreeList &use_tree)
+EarlyNameResolver::visit (AST::UseTreeList &)
 {}
 
 void
-EarlyNameResolver::visit (AST::UseTreeRebind &use_tree)
+EarlyNameResolver::visit (AST::UseTreeRebind &)
 {}
 
 void
-EarlyNameResolver::visit (AST::UseDeclaration &use_decl)
+EarlyNameResolver::visit (AST::UseDeclaration &)
 {}
 
 void
@@ -632,27 +632,27 @@ EarlyNameResolver::visit (AST::TupleStruct &tuple_struct)
 }
 
 void
-EarlyNameResolver::visit (AST::EnumItem &item)
+EarlyNameResolver::visit (AST::EnumItem &)
 {}
 
 void
-EarlyNameResolver::visit (AST::EnumItemTuple &item)
+EarlyNameResolver::visit (AST::EnumItemTuple &)
 {}
 
 void
-EarlyNameResolver::visit (AST::EnumItemStruct &item)
+EarlyNameResolver::visit (AST::EnumItemStruct &)
 {}
 
 void
-EarlyNameResolver::visit (AST::EnumItemDiscriminant &item)
+EarlyNameResolver::visit (AST::EnumItemDiscriminant &)
 {}
 
 void
-EarlyNameResolver::visit (AST::Enum &enum_item)
+EarlyNameResolver::visit (AST::Enum &)
 {}
 
 void
-EarlyNameResolver::visit (AST::Union &union_item)
+EarlyNameResolver::visit (AST::Union &)
 {}
 
 void
@@ -716,7 +716,7 @@ EarlyNameResolver::visit (AST::TraitItemConst &item)
 }
 
 void
-EarlyNameResolver::visit (AST::TraitItemType &item)
+EarlyNameResolver::visit (AST::TraitItemType &)
 {}
 
 void
@@ -777,15 +777,15 @@ EarlyNameResolver::visit (AST::ExternBlock &block)
 }
 
 void
-EarlyNameResolver::visit (AST::MacroMatchFragment &match)
+EarlyNameResolver::visit (AST::MacroMatchFragment &)
 {}
 
 void
-EarlyNameResolver::visit (AST::MacroMatchRepetition &match)
+EarlyNameResolver::visit (AST::MacroMatchRepetition &)
 {}
 
 void
-EarlyNameResolver::visit (AST::MacroMatcher &matcher)
+EarlyNameResolver::visit (AST::MacroMatcher &)
 {}
 
 void
@@ -853,31 +853,31 @@ EarlyNameResolver::visit (AST::MacroInvocation &invoc)
 // FIXME: ARTHUR: Do we need to resolve these as well here?
 
 void
-EarlyNameResolver::visit (AST::MetaItemPath &meta_item)
+EarlyNameResolver::visit (AST::MetaItemPath &)
 {}
 
 void
-EarlyNameResolver::visit (AST::MetaItemSeq &meta_item)
+EarlyNameResolver::visit (AST::MetaItemSeq &)
 {}
 
 void
-EarlyNameResolver::visit (AST::MetaWord &meta_item)
+EarlyNameResolver::visit (AST::MetaWord &)
 {}
 
 void
-EarlyNameResolver::visit (AST::MetaNameValueStr &meta_item)
+EarlyNameResolver::visit (AST::MetaNameValueStr &)
 {}
 
 void
-EarlyNameResolver::visit (AST::MetaListPaths &meta_item)
+EarlyNameResolver::visit (AST::MetaListPaths &)
 {}
 
 void
-EarlyNameResolver::visit (AST::MetaListNameValueStr &meta_item)
+EarlyNameResolver::visit (AST::MetaListNameValueStr &)
 {}
 
 void
-EarlyNameResolver::visit (AST::LiteralPattern &pattern)
+EarlyNameResolver::visit (AST::LiteralPattern &)
 {}
 
 void
@@ -888,19 +888,19 @@ EarlyNameResolver::visit (AST::IdentifierPattern &pattern)
 }
 
 void
-EarlyNameResolver::visit (AST::WildcardPattern &pattern)
+EarlyNameResolver::visit (AST::WildcardPattern &)
 {}
 
 void
-EarlyNameResolver::visit (AST::RangePatternBoundLiteral &bound)
+EarlyNameResolver::visit (AST::RangePatternBoundLiteral &)
 {}
 
 void
-EarlyNameResolver::visit (AST::RangePatternBoundPath &bound)
+EarlyNameResolver::visit (AST::RangePatternBoundPath &)
 {}
 
 void
-EarlyNameResolver::visit (AST::RangePatternBoundQualPath &bound)
+EarlyNameResolver::visit (AST::RangePatternBoundQualPath &)
 {}
 
 void
@@ -929,11 +929,11 @@ EarlyNameResolver::visit (AST::StructPatternFieldIdentPat &field)
 }
 
 void
-EarlyNameResolver::visit (AST::StructPatternFieldIdent &field)
+EarlyNameResolver::visit (AST::StructPatternFieldIdent &)
 {}
 
 void
-EarlyNameResolver::visit (AST::StructPattern &pattern)
+EarlyNameResolver::visit (AST::StructPattern &)
 {}
 
 void
@@ -994,7 +994,7 @@ EarlyNameResolver::visit (AST::SlicePattern &pattern)
 }
 
 void
-EarlyNameResolver::visit (AST::EmptyStmt &stmt)
+EarlyNameResolver::visit (AST::EmptyStmt &)
 {}
 
 void
@@ -1022,55 +1022,55 @@ EarlyNameResolver::visit (AST::ExprStmtWithBlock &stmt)
 }
 
 void
-EarlyNameResolver::visit (AST::TraitBound &bound)
+EarlyNameResolver::visit (AST::TraitBound &)
 {}
 
 void
-EarlyNameResolver::visit (AST::ImplTraitType &type)
+EarlyNameResolver::visit (AST::ImplTraitType &)
 {}
 
 void
-EarlyNameResolver::visit (AST::TraitObjectType &type)
+EarlyNameResolver::visit (AST::TraitObjectType &)
 {}
 
 void
-EarlyNameResolver::visit (AST::ParenthesisedType &type)
+EarlyNameResolver::visit (AST::ParenthesisedType &)
 {}
 
 void
-EarlyNameResolver::visit (AST::ImplTraitTypeOneBound &type)
+EarlyNameResolver::visit (AST::ImplTraitTypeOneBound &)
 {}
 
 void
-EarlyNameResolver::visit (AST::TraitObjectTypeOneBound &type)
+EarlyNameResolver::visit (AST::TraitObjectTypeOneBound &)
 {}
 
 void
-EarlyNameResolver::visit (AST::TupleType &type)
+EarlyNameResolver::visit (AST::TupleType &)
 {}
 
 void
-EarlyNameResolver::visit (AST::NeverType &type)
+EarlyNameResolver::visit (AST::NeverType &)
 {}
 
 void
-EarlyNameResolver::visit (AST::RawPointerType &type)
+EarlyNameResolver::visit (AST::RawPointerType &)
 {}
 
 void
-EarlyNameResolver::visit (AST::ReferenceType &type)
+EarlyNameResolver::visit (AST::ReferenceType &)
 {}
 
 void
-EarlyNameResolver::visit (AST::ArrayType &type)
+EarlyNameResolver::visit (AST::ArrayType &)
 {}
 
 void
-EarlyNameResolver::visit (AST::SliceType &type)
+EarlyNameResolver::visit (AST::SliceType &)
 {}
 
 void
-EarlyNameResolver::visit (AST::InferredType &type)
+EarlyNameResolver::visit (AST::InferredType &)
 {}
 
 void

--- a/gcc/rust/typecheck/rust-hir-dot-operator.cc
+++ b/gcc/rust/typecheck/rust-hir-dot-operator.cc
@@ -58,7 +58,7 @@ MethodResolver::select (const TyTy::BaseType &receiver)
   // assemble inherent impl items
   std::vector<impl_item_candidate> inherent_impl_fns;
   mappings->iterate_impl_items (
-    [&] (HirId id, HIR::ImplItem *item, HIR::ImplBlock *impl) mutable -> bool {
+    [&] (HirId, HIR::ImplItem *item, HIR::ImplBlock *impl) mutable -> bool {
       bool is_trait_impl = impl->has_trait_ref ();
       if (is_trait_impl)
 	return true;
@@ -102,7 +102,7 @@ MethodResolver::select (const TyTy::BaseType &receiver)
   };
 
   std::vector<trait_item_candidate> trait_fns;
-  mappings->iterate_impl_blocks ([&] (HirId id,
+  mappings->iterate_impl_blocks ([&] (HirId,
 				      HIR::ImplBlock *impl) mutable -> bool {
     bool is_trait_impl = impl->has_trait_ref ();
     if (!is_trait_impl)

--- a/gcc/rust/typecheck/rust-hir-inherent-impl-overlap.h
+++ b/gcc/rust/typecheck/rust-hir-inherent-impl-overlap.h
@@ -71,20 +71,19 @@ public:
 
     // generate mappings
     pass.mappings->iterate_impl_items (
-      [&] (HirId id, HIR::ImplItem *impl_item, HIR::ImplBlock *impl) -> bool {
+      [&] (HirId, HIR::ImplItem *impl_item, HIR::ImplBlock *impl) -> bool {
 	// ignoring trait-impls might need thought later on
 	if (impl->has_trait_ref ())
 	  return true;
 
-	pass.process_impl_item (id, impl_item, impl);
+	pass.process_impl_item (impl_item, impl);
 	return true;
       });
 
     pass.scan ();
   }
 
-  void process_impl_item (HirId id, HIR::ImplItem *impl_item,
-			  HIR::ImplBlock *impl)
+  void process_impl_item (HIR::ImplItem *impl_item, HIR::ImplBlock *impl)
   {
     // lets make a mapping of impl-item Self type to (impl-item,name):
     // {

--- a/gcc/rust/typecheck/rust-hir-path-probe.cc
+++ b/gcc/rust/typecheck/rust-hir-path-probe.cc
@@ -23,7 +23,7 @@ namespace Rust {
 namespace Resolver {
 
 void
-PathProbeType::process_impl_item_candidate (HirId id, HIR::ImplItem *item,
+PathProbeType::process_impl_item_candidate (HirId, HIR::ImplItem *item,
 					    HIR::ImplBlock *impl)
 {
   current_impl = impl;

--- a/gcc/rust/typecheck/rust-hir-trait-ref.h
+++ b/gcc/rust/typecheck/rust-hir-trait-ref.h
@@ -112,8 +112,7 @@ public:
 	break;
 
       case TYPE:
-	return get_type_from_typealias (
-	  static_cast</*const*/ HIR::TraitItemType &> (*hir_trait_item));
+	return get_type_from_typealias ();
 
       case FN:
 	return get_type_from_fn (
@@ -149,8 +148,7 @@ private:
     return new TyTy::ErrorType (get_mappings ().get_hirid ());
   }
 
-  TyTy::BaseType *get_type_from_typealias (/*const*/
-					   HIR::TraitItemType &type) const;
+  TyTy::BaseType *get_type_from_typealias () const;
 
   TyTy::BaseType *
   get_type_from_constant (/*const*/ HIR::TraitItemConst &constant) const;

--- a/gcc/rust/typecheck/rust-hir-trait-resolve.cc
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.cc
@@ -302,7 +302,7 @@ TraitItemReference::resolve_item (HIR::TraitItemType &type)
 }
 
 void
-TraitItemReference::resolve_item (HIR::TraitItemConst &constant)
+TraitItemReference::resolve_item (HIR::TraitItemConst &)
 {
   // TODO
 }

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -1152,7 +1152,7 @@ TypeCheckExpr::visit (HIR::MethodCallExpr &expr)
       rust_debug_loc (expr.get_method_name ().get_generic_args ().get_locus (),
 		      "applying generic arguments to method_call: {%s}",
 		      lookup->debug_str ().c_str ());
-      HIR::GenericArgs &args = expr.get_method_name ().get_generic_args ();
+      HIR::GenericArgs args = expr.get_method_name ().get_generic_args ();
       lookup
 	= SubstMapper::Resolve (lookup, expr.get_method_name ().get_locus (),
 				&args);

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -72,27 +72,21 @@ public:
   void visit (HIR::ClosureExpr &expr) override;
 
   // TODO
-  void visit (HIR::ErrorPropagationExpr &expr) override {}
-  void visit (HIR::RangeToInclExpr &expr) override {}
-  void visit (HIR::WhileLetLoopExpr &expr) override {}
-  void visit (HIR::ForLoopExpr &expr) override {}
-  void visit (HIR::IfExprConseqIfLet &expr) override {}
-  void visit (HIR::IfLetExprConseqElse &expr) override {}
-  void visit (HIR::IfLetExprConseqIf &expr) override {}
-  void visit (HIR::IfLetExprConseqIfLet &expr) override {}
-  void visit (HIR::AwaitExpr &expr) override {}
-  void visit (HIR::AsyncBlockExpr &expr) override {}
+  void visit (HIR::ErrorPropagationExpr &) override {}
+  void visit (HIR::RangeToInclExpr &) override {}
+  void visit (HIR::WhileLetLoopExpr &) override {}
+  void visit (HIR::ForLoopExpr &) override {}
+  void visit (HIR::IfExprConseqIfLet &) override {}
+  void visit (HIR::IfLetExprConseqElse &) override {}
+  void visit (HIR::IfLetExprConseqIf &) override {}
+  void visit (HIR::IfLetExprConseqIfLet &) override {}
+  void visit (HIR::AwaitExpr &) override {}
+  void visit (HIR::AsyncBlockExpr &) override {}
 
   // don't need to implement these see rust-hir-type-check-struct-field.h
-  void visit (HIR::StructExprFieldIdentifier &field) override
-  {
-    gcc_unreachable ();
-  }
-  void visit (HIR::StructExprFieldIdentifierValue &field) override
-  {
-    gcc_unreachable ();
-  }
-  void visit (HIR::StructExprFieldIndexValue &field) override
+  void visit (HIR::StructExprFieldIdentifier &) override { gcc_unreachable (); }
+  void visit (HIR::StructExprFieldIndexValue &) override { gcc_unreachable (); }
+  void visit (HIR::StructExprFieldIdentifierValue &) override
   {
     gcc_unreachable ();
   }

--- a/gcc/rust/typecheck/rust-hir-type-check-item.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.h
@@ -48,8 +48,8 @@ public:
   void visit (HIR::Trait &trait_block) override;
 
   // nothing to do
-  void visit (HIR::ExternCrate &crate) override {}
-  void visit (HIR::UseDeclaration &use_decl) override {}
+  void visit (HIR::ExternCrate &) override {}
+  void visit (HIR::UseDeclaration &) override {}
 
 protected:
   std::vector<TyTy::SubstitutionParamMapping>

--- a/gcc/rust/typecheck/rust-hir-type-check-path.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-path.cc
@@ -337,7 +337,7 @@ TypeCheckExpr::resolve_segments (NodeId root_resolved_node_id,
 	  return;
 	}
 
-      auto &candidate = *candidates.begin ();
+      auto candidate = *candidates.begin ();
       prev_segment = tyseg;
       tyseg = candidate.ty;
 

--- a/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
@@ -381,34 +381,34 @@ TypeCheckPattern::visit (HIR::RangePattern &pattern)
 }
 
 void
-TypeCheckPattern::visit (HIR::IdentifierPattern &pattern)
+TypeCheckPattern::visit (HIR::IdentifierPattern &)
 {
   infered = parent;
 }
 
 void
-TypeCheckPattern::visit (HIR::GroupedPattern &pattern)
+TypeCheckPattern::visit (HIR::GroupedPattern &)
 {
   // TODO
   gcc_unreachable ();
 }
 
 void
-TypeCheckPattern::visit (HIR::QualifiedPathInExpression &pattern)
+TypeCheckPattern::visit (HIR::QualifiedPathInExpression &)
 {
   // TODO
   gcc_unreachable ();
 }
 
 void
-TypeCheckPattern::visit (HIR::ReferencePattern &pattern)
+TypeCheckPattern::visit (HIR::ReferencePattern &)
 {
   // TODO
   gcc_unreachable ();
 }
 
 void
-TypeCheckPattern::visit (HIR::SlicePattern &pattern)
+TypeCheckPattern::visit (HIR::SlicePattern &)
 {
   // TODO
   gcc_unreachable ();

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.h
@@ -50,14 +50,11 @@ public:
 
   // FIXME
   // this seems like it should not be part of this visitor
-  void visit (HIR::TypePathSegmentFunction &segment) override
-  {
-    gcc_unreachable ();
-  }
+  void visit (HIR::TypePathSegmentFunction &) override { gcc_unreachable (); }
 
   // nothing to do for these
-  void visit (HIR::ExternCrate &crate) override {}
-  void visit (HIR::UseDeclaration &use_decl) override {}
+  void visit (HIR::ExternCrate &) override {}
+  void visit (HIR::UseDeclaration &) override {}
 
   // nothing to do for these as they are taken care of by the
   // hir-type-check-enumitem.h

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -462,7 +462,7 @@ TypeCheckType::resolve_segments (
 	  return new TyTy::ErrorType (expr_id);
 	}
 
-      auto &candidate = *candidates.begin ();
+      auto candidate = *candidates.begin ();
       prev_segment = tyseg;
       tyseg = candidate.ty;
 
@@ -635,7 +635,7 @@ TypeCheckType::visit (HIR::InferredType &type)
 }
 
 void
-TypeCheckType::visit (HIR::NeverType &type)
+TypeCheckType::visit (HIR::NeverType &)
 {
   TyTy::BaseType *lookup = nullptr;
   bool ok = context->lookup_builtin ("!", &lookup);
@@ -666,13 +666,13 @@ TypeResolveGenericParam::Resolve (HIR::GenericParam *param)
 }
 
 void
-TypeResolveGenericParam::visit (HIR::LifetimeParam &param)
+TypeResolveGenericParam::visit (HIR::LifetimeParam &)
 {
   // nothing to do
 }
 
 void
-TypeResolveGenericParam::visit (HIR::ConstGenericParam &param)
+TypeResolveGenericParam::visit (HIR::ConstGenericParam &)
 {
   // TODO
 }
@@ -730,7 +730,7 @@ ResolveWhereClauseItem::Resolve (HIR::WhereClauseItem &item)
 }
 
 void
-ResolveWhereClauseItem::visit (HIR::LifetimeWhereClauseItem &item)
+ResolveWhereClauseItem::visit (HIR::LifetimeWhereClauseItem &)
 {}
 
 void

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -62,19 +62,19 @@ public:
   void visit (HIR::NeverType &type) override;
   void visit (HIR::TraitObjectType &type) override;
 
-  void visit (HIR::TypePathSegmentFunction &segment) override
+  void visit (HIR::TypePathSegmentFunction &) override
   { /* TODO */
   }
-  void visit (HIR::TraitBound &bound) override
+  void visit (HIR::TraitBound &) override
   { /* TODO */
   }
-  void visit (HIR::ImplTraitType &type) override
+  void visit (HIR::ImplTraitType &) override
   { /* TODO */
   }
-  void visit (HIR::ParenthesisedType &type) override
+  void visit (HIR::ParenthesisedType &) override
   { /* TODO */
   }
-  void visit (HIR::ImplTraitTypeOneBound &type) override
+  void visit (HIR::ImplTraitTypeOneBound &) override
   { /* TODO */
   }
 

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -125,8 +125,7 @@ TraitItemReference::operator= (TraitItemReference const &other)
 }
 
 TyTy::BaseType *
-TraitItemReference::get_type_from_typealias (/*const*/
-					     HIR::TraitItemType &type) const
+TraitItemReference::get_type_from_typealias () const
 {
   TyTy::TyVar var (get_mappings ().get_hirid ());
   return var.get_tyty ();

--- a/gcc/rust/typecheck/rust-tyty-bounds.cc
+++ b/gcc/rust/typecheck/rust-tyty-bounds.cc
@@ -29,7 +29,7 @@ TypeBoundsProbe::scan ()
   std::vector<std::pair<HIR::TypePath *, HIR::ImplBlock *>>
     possible_trait_paths;
   mappings->iterate_impl_blocks (
-    [&] (HirId id, HIR::ImplBlock *impl) mutable -> bool {
+    [&] (HirId, HIR::ImplBlock *impl) mutable -> bool {
       // we are filtering for trait-impl-blocks
       if (!impl->has_trait_ref ())
 	return true;

--- a/gcc/rust/typecheck/rust-tyty-call.h
+++ b/gcc/rust/typecheck/rust-tyty-call.h
@@ -60,7 +60,7 @@ public:
   void visit (PlaceholderType &) override { gcc_unreachable (); }
   void visit (ProjectionType &) override { gcc_unreachable (); }
   void visit (DynamicObjectType &) override { gcc_unreachable (); }
-  void visit (ClosureType &type) override { gcc_unreachable (); }
+  void visit (ClosureType &) override { gcc_unreachable (); }
 
   // tuple-structs
   void visit (ADTType &type) override;

--- a/gcc/rust/typecheck/rust-tyty-cmp.h
+++ b/gcc/rust/typecheck/rust-tyty-cmp.h
@@ -381,7 +381,7 @@ public:
       }
   }
 
-  virtual void visit (const PlaceholderType &type) override
+  virtual void visit (const PlaceholderType &) override
   {
     // it is ok for types to can eq to a placeholder
     ok = true;
@@ -436,7 +436,7 @@ public:
   }
 
 protected:
-  BaseCmp (const BaseType *base, bool emit_errors)
+  BaseCmp (const BaseType *, bool emit_errors)
     : mappings (Analysis::Mappings::get ()),
       context (Resolver::TypeCheckContext::get ()), ok (false),
       emit_error_flag (emit_errors)
@@ -986,7 +986,7 @@ public:
     : BaseCmp (base, emit_errors), base (base)
   {}
 
-  void visit (const BoolType &type) override { ok = true; }
+  void visit (const BoolType &) override { ok = true; }
 
   void visit (const InferType &type) override
   {
@@ -1207,7 +1207,7 @@ public:
     ok = type.get_infer_kind () != InferType::InferTypeKind::FLOAT;
   }
 
-  void visit (const USizeType &type) override { ok = true; }
+  void visit (const USizeType &) override { ok = true; }
 
 private:
   const BaseType *get_base () const override { return base; }
@@ -1228,7 +1228,7 @@ public:
     ok = type.get_infer_kind () != InferType::InferTypeKind::FLOAT;
   }
 
-  void visit (const ISizeType &type) override { ok = true; }
+  void visit (const ISizeType &) override { ok = true; }
 
 private:
   const BaseType *get_base () const override { return base; }
@@ -1249,7 +1249,7 @@ public:
     ok = type.get_infer_kind () == InferType::InferTypeKind::GENERAL;
   }
 
-  void visit (const CharType &type) override { ok = true; }
+  void visit (const CharType &) override { ok = true; }
 
 private:
   const BaseType *get_base () const override { return base; }
@@ -1447,7 +1447,7 @@ public:
     : BaseCmp (base, emit_errors), base (base)
   {}
 
-  void visit (const StrType &type) override { ok = true; }
+  void visit (const StrType &) override { ok = true; }
 
   void visit (const InferType &type) override
   {
@@ -1474,7 +1474,7 @@ public:
     : BaseCmp (base, emit_errors), base (base)
   {}
 
-  void visit (const NeverType &type) override { ok = true; }
+  void visit (const NeverType &) override { ok = true; }
 
   void visit (const InferType &type) override
   {

--- a/gcc/rust/typecheck/rust-tyty-rules.h
+++ b/gcc/rust/typecheck/rust-tyty-rules.h
@@ -123,53 +123,53 @@ public:
     return resolved;
   }
 
-  virtual void visit (TupleType &type) override {}
+  virtual void visit (TupleType &) override {}
 
-  virtual void visit (ADTType &type) override {}
+  virtual void visit (ADTType &) override {}
 
-  virtual void visit (InferType &type) override {}
+  virtual void visit (InferType &) override {}
 
-  virtual void visit (FnType &type) override {}
+  virtual void visit (FnType &) override {}
 
-  virtual void visit (FnPtr &type) override {}
+  virtual void visit (FnPtr &) override {}
 
-  virtual void visit (ArrayType &type) override {}
+  virtual void visit (ArrayType &) override {}
 
-  virtual void visit (SliceType &type) override {}
+  virtual void visit (SliceType &) override {}
 
-  virtual void visit (BoolType &type) override {}
+  virtual void visit (BoolType &) override {}
 
-  virtual void visit (IntType &type) override {}
+  virtual void visit (IntType &) override {}
 
-  virtual void visit (UintType &type) override {}
+  virtual void visit (UintType &) override {}
 
-  virtual void visit (USizeType &type) override {}
+  virtual void visit (USizeType &) override {}
 
-  virtual void visit (ISizeType &type) override {}
+  virtual void visit (ISizeType &) override {}
 
-  virtual void visit (FloatType &type) override {}
+  virtual void visit (FloatType &) override {}
 
-  virtual void visit (ErrorType &type) override {}
+  virtual void visit (ErrorType &) override {}
 
-  virtual void visit (CharType &type) override {}
+  virtual void visit (CharType &) override {}
 
-  virtual void visit (ReferenceType &type) override {}
+  virtual void visit (ReferenceType &) override {}
 
-  virtual void visit (PointerType &type) override {}
+  virtual void visit (PointerType &) override {}
 
-  virtual void visit (ParamType &type) override {}
+  virtual void visit (ParamType &) override {}
 
-  virtual void visit (StrType &type) override {}
+  virtual void visit (StrType &) override {}
 
-  virtual void visit (NeverType &type) override {}
+  virtual void visit (NeverType &) override {}
 
-  virtual void visit (PlaceholderType &type) override {}
+  virtual void visit (PlaceholderType &) override {}
 
-  virtual void visit (ProjectionType &type) override {}
+  virtual void visit (ProjectionType &) override {}
 
-  virtual void visit (DynamicObjectType &type) override {}
+  virtual void visit (DynamicObjectType &) override {}
 
-  virtual void visit (ClosureType &type) override {}
+  virtual void visit (ClosureType &) override {}
 
 protected:
   BaseRules (BaseType *base)

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -544,13 +544,13 @@ ErrorType::as_string () const
 }
 
 BaseType *
-ErrorType::unify (BaseType *other)
+ErrorType::unify (BaseType *)
 {
   return this;
 }
 
 bool
-ErrorType::can_eq (const BaseType *other, bool emit_errors) const
+ErrorType::can_eq (const BaseType *other, bool) const
 {
   return get_kind () == other->get_kind ();
 }
@@ -1724,8 +1724,7 @@ ClosureType::monomorphized_clone () const
   return clone ();
 }
 
-ClosureType *
-ClosureType::handle_substitions (SubstitutionArgumentMappings mappings)
+ClosureType *ClosureType::handle_substitions (SubstitutionArgumentMappings)
 {
   gcc_unreachable ();
   return nullptr;

--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -210,342 +210,342 @@ AttributeChecker::check_attributes (const AST::AttrVec &attributes)
 }
 
 void
-AttributeChecker::visit (AST::Token &tok)
+AttributeChecker::visit (AST::Token &)
 {}
 
 void
-AttributeChecker::visit (AST::DelimTokenTree &delim_tok_tree)
+AttributeChecker::visit (AST::DelimTokenTree &)
 {}
 
 void
-AttributeChecker::visit (AST::AttrInputMetaItemContainer &input)
+AttributeChecker::visit (AST::AttrInputMetaItemContainer &)
 {}
 
 void
-AttributeChecker::visit (AST::IdentifierExpr &ident_expr)
+AttributeChecker::visit (AST::IdentifierExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::Lifetime &lifetime)
+AttributeChecker::visit (AST::Lifetime &)
 {}
 
 void
-AttributeChecker::visit (AST::LifetimeParam &lifetime_param)
+AttributeChecker::visit (AST::LifetimeParam &)
 {}
 
 void
-AttributeChecker::visit (AST::ConstGenericParam &const_param)
+AttributeChecker::visit (AST::ConstGenericParam &)
 {}
 
 // rust-path.h
 void
-AttributeChecker::visit (AST::PathInExpression &path)
+AttributeChecker::visit (AST::PathInExpression &)
 {}
 
 void
-AttributeChecker::visit (AST::TypePathSegment &segment)
+AttributeChecker::visit (AST::TypePathSegment &)
 {}
 
 void
-AttributeChecker::visit (AST::TypePathSegmentGeneric &segment)
+AttributeChecker::visit (AST::TypePathSegmentGeneric &)
 {}
 
 void
-AttributeChecker::visit (AST::TypePathSegmentFunction &segment)
+AttributeChecker::visit (AST::TypePathSegmentFunction &)
 {}
 
 void
-AttributeChecker::visit (AST::TypePath &path)
+AttributeChecker::visit (AST::TypePath &)
 {}
 
 void
-AttributeChecker::visit (AST::QualifiedPathInExpression &path)
+AttributeChecker::visit (AST::QualifiedPathInExpression &)
 {}
 
 void
-AttributeChecker::visit (AST::QualifiedPathInType &path)
+AttributeChecker::visit (AST::QualifiedPathInType &)
 {}
 
 // rust-expr.h
 void
-AttributeChecker::visit (AST::LiteralExpr &expr)
+AttributeChecker::visit (AST::LiteralExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::AttrInputLiteral &attr_input)
+AttributeChecker::visit (AST::AttrInputLiteral &)
 {}
 
 void
-AttributeChecker::visit (AST::MetaItemLitExpr &meta_item)
+AttributeChecker::visit (AST::MetaItemLitExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::MetaItemPathLit &meta_item)
+AttributeChecker::visit (AST::MetaItemPathLit &)
 {}
 
 void
-AttributeChecker::visit (AST::BorrowExpr &expr)
+AttributeChecker::visit (AST::BorrowExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::DereferenceExpr &expr)
+AttributeChecker::visit (AST::DereferenceExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::ErrorPropagationExpr &expr)
+AttributeChecker::visit (AST::ErrorPropagationExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::NegationExpr &expr)
+AttributeChecker::visit (AST::NegationExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::ArithmeticOrLogicalExpr &expr)
+AttributeChecker::visit (AST::ArithmeticOrLogicalExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::ComparisonExpr &expr)
+AttributeChecker::visit (AST::ComparisonExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::LazyBooleanExpr &expr)
+AttributeChecker::visit (AST::LazyBooleanExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::TypeCastExpr &expr)
+AttributeChecker::visit (AST::TypeCastExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::AssignmentExpr &expr)
+AttributeChecker::visit (AST::AssignmentExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::CompoundAssignmentExpr &expr)
+AttributeChecker::visit (AST::CompoundAssignmentExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::GroupedExpr &expr)
+AttributeChecker::visit (AST::GroupedExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::ArrayElemsValues &elems)
+AttributeChecker::visit (AST::ArrayElemsValues &)
 {}
 
 void
-AttributeChecker::visit (AST::ArrayElemsCopied &elems)
+AttributeChecker::visit (AST::ArrayElemsCopied &)
 {}
 
 void
-AttributeChecker::visit (AST::ArrayExpr &expr)
+AttributeChecker::visit (AST::ArrayExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::ArrayIndexExpr &expr)
+AttributeChecker::visit (AST::ArrayIndexExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::TupleExpr &expr)
+AttributeChecker::visit (AST::TupleExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::TupleIndexExpr &expr)
+AttributeChecker::visit (AST::TupleIndexExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::StructExprStruct &expr)
+AttributeChecker::visit (AST::StructExprStruct &)
 {}
 
 void
-AttributeChecker::visit (AST::StructExprFieldIdentifier &field)
+AttributeChecker::visit (AST::StructExprFieldIdentifier &)
 {}
 
 void
-AttributeChecker::visit (AST::StructExprFieldIdentifierValue &field)
+AttributeChecker::visit (AST::StructExprFieldIdentifierValue &)
 {}
 
 void
-AttributeChecker::visit (AST::StructExprFieldIndexValue &field)
+AttributeChecker::visit (AST::StructExprFieldIndexValue &)
 {}
 
 void
-AttributeChecker::visit (AST::StructExprStructFields &expr)
+AttributeChecker::visit (AST::StructExprStructFields &)
 {}
 
 void
-AttributeChecker::visit (AST::StructExprStructBase &expr)
+AttributeChecker::visit (AST::StructExprStructBase &)
 {}
 
 void
-AttributeChecker::visit (AST::CallExpr &expr)
+AttributeChecker::visit (AST::CallExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::MethodCallExpr &expr)
+AttributeChecker::visit (AST::MethodCallExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::FieldAccessExpr &expr)
+AttributeChecker::visit (AST::FieldAccessExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::ClosureExprInner &expr)
+AttributeChecker::visit (AST::ClosureExprInner &)
 {}
 
 void
-AttributeChecker::visit (AST::BlockExpr &expr)
+AttributeChecker::visit (AST::BlockExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::ClosureExprInnerTyped &expr)
+AttributeChecker::visit (AST::ClosureExprInnerTyped &)
 {}
 
 void
-AttributeChecker::visit (AST::ContinueExpr &expr)
+AttributeChecker::visit (AST::ContinueExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::BreakExpr &expr)
+AttributeChecker::visit (AST::BreakExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::RangeFromToExpr &expr)
+AttributeChecker::visit (AST::RangeFromToExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::RangeFromExpr &expr)
+AttributeChecker::visit (AST::RangeFromExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::RangeToExpr &expr)
+AttributeChecker::visit (AST::RangeToExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::RangeFullExpr &expr)
+AttributeChecker::visit (AST::RangeFullExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::RangeFromToInclExpr &expr)
+AttributeChecker::visit (AST::RangeFromToInclExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::RangeToInclExpr &expr)
+AttributeChecker::visit (AST::RangeToInclExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::ReturnExpr &expr)
+AttributeChecker::visit (AST::ReturnExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::UnsafeBlockExpr &expr)
+AttributeChecker::visit (AST::UnsafeBlockExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::LoopExpr &expr)
+AttributeChecker::visit (AST::LoopExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::WhileLoopExpr &expr)
+AttributeChecker::visit (AST::WhileLoopExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::WhileLetLoopExpr &expr)
+AttributeChecker::visit (AST::WhileLetLoopExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::ForLoopExpr &expr)
+AttributeChecker::visit (AST::ForLoopExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::IfExpr &expr)
+AttributeChecker::visit (AST::IfExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::IfExprConseqElse &expr)
+AttributeChecker::visit (AST::IfExprConseqElse &)
 {}
 
 void
-AttributeChecker::visit (AST::IfExprConseqIf &expr)
+AttributeChecker::visit (AST::IfExprConseqIf &)
 {}
 
 void
-AttributeChecker::visit (AST::IfExprConseqIfLet &expr)
+AttributeChecker::visit (AST::IfExprConseqIfLet &)
 {}
 
 void
-AttributeChecker::visit (AST::IfLetExpr &expr)
+AttributeChecker::visit (AST::IfLetExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::IfLetExprConseqElse &expr)
+AttributeChecker::visit (AST::IfLetExprConseqElse &)
 {}
 
 void
-AttributeChecker::visit (AST::IfLetExprConseqIf &expr)
+AttributeChecker::visit (AST::IfLetExprConseqIf &)
 {}
 
 void
-AttributeChecker::visit (AST::IfLetExprConseqIfLet &expr)
+AttributeChecker::visit (AST::IfLetExprConseqIfLet &)
 {}
 
 void
-AttributeChecker::visit (AST::MatchExpr &expr)
+AttributeChecker::visit (AST::MatchExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::AwaitExpr &expr)
+AttributeChecker::visit (AST::AwaitExpr &)
 {}
 
 void
-AttributeChecker::visit (AST::AsyncBlockExpr &expr)
+AttributeChecker::visit (AST::AsyncBlockExpr &)
 {}
 
 // rust-item.h
 void
-AttributeChecker::visit (AST::TypeParam &param)
+AttributeChecker::visit (AST::TypeParam &)
 {}
 
 void
-AttributeChecker::visit (AST::LifetimeWhereClauseItem &item)
+AttributeChecker::visit (AST::LifetimeWhereClauseItem &)
 {}
 
 void
-AttributeChecker::visit (AST::TypeBoundWhereClauseItem &item)
+AttributeChecker::visit (AST::TypeBoundWhereClauseItem &)
 {}
 
 void
-AttributeChecker::visit (AST::Method &method)
+AttributeChecker::visit (AST::Method &)
 {}
 
 void
-AttributeChecker::visit (AST::Module &module)
+AttributeChecker::visit (AST::Module &)
 {}
 
 void
-AttributeChecker::visit (AST::ExternCrate &crate)
+AttributeChecker::visit (AST::ExternCrate &)
 {}
 
 void
-AttributeChecker::visit (AST::UseTreeGlob &use_tree)
+AttributeChecker::visit (AST::UseTreeGlob &)
 {}
 
 void
-AttributeChecker::visit (AST::UseTreeList &use_tree)
+AttributeChecker::visit (AST::UseTreeList &)
 {}
 
 void
-AttributeChecker::visit (AST::UseTreeRebind &use_tree)
+AttributeChecker::visit (AST::UseTreeRebind &)
 {}
 
 void
-AttributeChecker::visit (AST::UseDeclaration &use_decl)
+AttributeChecker::visit (AST::UseDeclaration &)
 {}
 
 void
-AttributeChecker::visit (AST::Function &function)
+AttributeChecker::visit (AST::Function &)
 {}
 
 void
-AttributeChecker::visit (AST::TypeAlias &type_alias)
+AttributeChecker::visit (AST::TypeAlias &)
 {}
 
 void
@@ -555,287 +555,287 @@ AttributeChecker::visit (AST::StructStruct &struct_item)
 }
 
 void
-AttributeChecker::visit (AST::TupleStruct &tuple_struct)
+AttributeChecker::visit (AST::TupleStruct &)
 {}
 
 void
-AttributeChecker::visit (AST::EnumItem &item)
+AttributeChecker::visit (AST::EnumItem &)
 {}
 
 void
-AttributeChecker::visit (AST::EnumItemTuple &item)
+AttributeChecker::visit (AST::EnumItemTuple &)
 {}
 
 void
-AttributeChecker::visit (AST::EnumItemStruct &item)
+AttributeChecker::visit (AST::EnumItemStruct &)
 {}
 
 void
-AttributeChecker::visit (AST::EnumItemDiscriminant &item)
+AttributeChecker::visit (AST::EnumItemDiscriminant &)
 {}
 
 void
-AttributeChecker::visit (AST::Enum &enum_item)
+AttributeChecker::visit (AST::Enum &)
 {}
 
 void
-AttributeChecker::visit (AST::Union &union_item)
+AttributeChecker::visit (AST::Union &)
 {}
 
 void
-AttributeChecker::visit (AST::ConstantItem &const_item)
+AttributeChecker::visit (AST::ConstantItem &)
 {}
 
 void
-AttributeChecker::visit (AST::StaticItem &static_item)
+AttributeChecker::visit (AST::StaticItem &)
 {}
 
 void
-AttributeChecker::visit (AST::TraitItemFunc &item)
+AttributeChecker::visit (AST::TraitItemFunc &)
 {}
 
 void
-AttributeChecker::visit (AST::TraitItemMethod &item)
+AttributeChecker::visit (AST::TraitItemMethod &)
 {}
 
 void
-AttributeChecker::visit (AST::TraitItemConst &item)
+AttributeChecker::visit (AST::TraitItemConst &)
 {}
 
 void
-AttributeChecker::visit (AST::TraitItemType &item)
+AttributeChecker::visit (AST::TraitItemType &)
 {}
 
 void
-AttributeChecker::visit (AST::Trait &trait)
+AttributeChecker::visit (AST::Trait &)
 {}
 
 void
-AttributeChecker::visit (AST::InherentImpl &impl)
+AttributeChecker::visit (AST::InherentImpl &)
 {}
 
 void
-AttributeChecker::visit (AST::TraitImpl &impl)
+AttributeChecker::visit (AST::TraitImpl &)
 {}
 
 void
-AttributeChecker::visit (AST::ExternalStaticItem &item)
+AttributeChecker::visit (AST::ExternalStaticItem &)
 {}
 
 void
-AttributeChecker::visit (AST::ExternalFunctionItem &item)
+AttributeChecker::visit (AST::ExternalFunctionItem &)
 {}
 
 void
-AttributeChecker::visit (AST::ExternBlock &block)
+AttributeChecker::visit (AST::ExternBlock &)
 {}
 
 // rust-macro.h
 void
-AttributeChecker::visit (AST::MacroMatchFragment &match)
+AttributeChecker::visit (AST::MacroMatchFragment &)
 {}
 
 void
-AttributeChecker::visit (AST::MacroMatchRepetition &match)
+AttributeChecker::visit (AST::MacroMatchRepetition &)
 {}
 
 void
-AttributeChecker::visit (AST::MacroMatcher &matcher)
+AttributeChecker::visit (AST::MacroMatcher &)
 {}
 
 void
-AttributeChecker::visit (AST::MacroRulesDefinition &rules_def)
+AttributeChecker::visit (AST::MacroRulesDefinition &)
 {}
 
 void
-AttributeChecker::visit (AST::MacroInvocation &macro_invoc)
+AttributeChecker::visit (AST::MacroInvocation &)
 {}
 
 void
-AttributeChecker::visit (AST::MetaItemPath &meta_item)
+AttributeChecker::visit (AST::MetaItemPath &)
 {}
 
 void
-AttributeChecker::visit (AST::MetaItemSeq &meta_item)
+AttributeChecker::visit (AST::MetaItemSeq &)
 {}
 
 void
-AttributeChecker::visit (AST::MetaWord &meta_item)
+AttributeChecker::visit (AST::MetaWord &)
 {}
 
 void
-AttributeChecker::visit (AST::MetaNameValueStr &meta_item)
+AttributeChecker::visit (AST::MetaNameValueStr &)
 {}
 
 void
-AttributeChecker::visit (AST::MetaListPaths &meta_item)
+AttributeChecker::visit (AST::MetaListPaths &)
 {}
 
 void
-AttributeChecker::visit (AST::MetaListNameValueStr &meta_item)
+AttributeChecker::visit (AST::MetaListNameValueStr &)
 {}
 
 // rust-pattern.h
 void
-AttributeChecker::visit (AST::LiteralPattern &pattern)
+AttributeChecker::visit (AST::LiteralPattern &)
 {}
 
 void
-AttributeChecker::visit (AST::IdentifierPattern &pattern)
+AttributeChecker::visit (AST::IdentifierPattern &)
 {}
 
 void
-AttributeChecker::visit (AST::WildcardPattern &pattern)
+AttributeChecker::visit (AST::WildcardPattern &)
 {}
 
-// void AttributeChecker::visit(RangePatternBound& bound){}
+// void AttributeChecker::visit(RangePatternBound& ){}
 
 void
-AttributeChecker::visit (AST::RangePatternBoundLiteral &bound)
-{}
-
-void
-AttributeChecker::visit (AST::RangePatternBoundPath &bound)
+AttributeChecker::visit (AST::RangePatternBoundLiteral &)
 {}
 
 void
-AttributeChecker::visit (AST::RangePatternBoundQualPath &bound)
+AttributeChecker::visit (AST::RangePatternBoundPath &)
 {}
 
 void
-AttributeChecker::visit (AST::RangePattern &pattern)
+AttributeChecker::visit (AST::RangePatternBoundQualPath &)
 {}
 
 void
-AttributeChecker::visit (AST::ReferencePattern &pattern)
-{}
-
-// void AttributeChecker::visit(StructPatternField& field){}
-
-void
-AttributeChecker::visit (AST::StructPatternFieldTuplePat &field)
+AttributeChecker::visit (AST::RangePattern &)
 {}
 
 void
-AttributeChecker::visit (AST::StructPatternFieldIdentPat &field)
+AttributeChecker::visit (AST::ReferencePattern &)
+{}
+
+// void AttributeChecker::visit(StructPatternField& ){}
+
+void
+AttributeChecker::visit (AST::StructPatternFieldTuplePat &)
 {}
 
 void
-AttributeChecker::visit (AST::StructPatternFieldIdent &field)
+AttributeChecker::visit (AST::StructPatternFieldIdentPat &)
 {}
 
 void
-AttributeChecker::visit (AST::StructPattern &pattern)
-{}
-
-// void AttributeChecker::visit(TupleStructItems& tuple_items){}
-
-void
-AttributeChecker::visit (AST::TupleStructItemsNoRange &tuple_items)
+AttributeChecker::visit (AST::StructPatternFieldIdent &)
 {}
 
 void
-AttributeChecker::visit (AST::TupleStructItemsRange &tuple_items)
+AttributeChecker::visit (AST::StructPattern &)
+{}
+
+// void AttributeChecker::visit(TupleStructItems& ){}
+
+void
+AttributeChecker::visit (AST::TupleStructItemsNoRange &)
 {}
 
 void
-AttributeChecker::visit (AST::TupleStructPattern &pattern)
-{}
-
-// void AttributeChecker::visit(TuplePatternItems& tuple_items){}
-
-void
-AttributeChecker::visit (AST::TuplePatternItemsMultiple &tuple_items)
+AttributeChecker::visit (AST::TupleStructItemsRange &)
 {}
 
 void
-AttributeChecker::visit (AST::TuplePatternItemsRanged &tuple_items)
+AttributeChecker::visit (AST::TupleStructPattern &)
+{}
+
+// void AttributeChecker::visit(TuplePatternItems& ){}
+
+void
+AttributeChecker::visit (AST::TuplePatternItemsMultiple &)
 {}
 
 void
-AttributeChecker::visit (AST::TuplePattern &pattern)
+AttributeChecker::visit (AST::TuplePatternItemsRanged &)
 {}
 
 void
-AttributeChecker::visit (AST::GroupedPattern &pattern)
+AttributeChecker::visit (AST::TuplePattern &)
 {}
 
 void
-AttributeChecker::visit (AST::SlicePattern &pattern)
+AttributeChecker::visit (AST::GroupedPattern &)
+{}
+
+void
+AttributeChecker::visit (AST::SlicePattern &)
 {}
 
 // rust-stmt.h
 void
-AttributeChecker::visit (AST::EmptyStmt &stmt)
+AttributeChecker::visit (AST::EmptyStmt &)
 {}
 
 void
-AttributeChecker::visit (AST::LetStmt &stmt)
+AttributeChecker::visit (AST::LetStmt &)
 {}
 
 void
-AttributeChecker::visit (AST::ExprStmtWithoutBlock &stmt)
+AttributeChecker::visit (AST::ExprStmtWithoutBlock &)
 {}
 
 void
-AttributeChecker::visit (AST::ExprStmtWithBlock &stmt)
+AttributeChecker::visit (AST::ExprStmtWithBlock &)
 {}
 
 // rust-type.h
 void
-AttributeChecker::visit (AST::TraitBound &bound)
+AttributeChecker::visit (AST::TraitBound &)
 {}
 
 void
-AttributeChecker::visit (AST::ImplTraitType &type)
+AttributeChecker::visit (AST::ImplTraitType &)
 {}
 
 void
-AttributeChecker::visit (AST::TraitObjectType &type)
+AttributeChecker::visit (AST::TraitObjectType &)
 {}
 
 void
-AttributeChecker::visit (AST::ParenthesisedType &type)
+AttributeChecker::visit (AST::ParenthesisedType &)
 {}
 
 void
-AttributeChecker::visit (AST::ImplTraitTypeOneBound &type)
+AttributeChecker::visit (AST::ImplTraitTypeOneBound &)
 {}
 
 void
-AttributeChecker::visit (AST::TraitObjectTypeOneBound &type)
+AttributeChecker::visit (AST::TraitObjectTypeOneBound &)
 {}
 
 void
-AttributeChecker::visit (AST::TupleType &type)
+AttributeChecker::visit (AST::TupleType &)
 {}
 
 void
-AttributeChecker::visit (AST::NeverType &type)
+AttributeChecker::visit (AST::NeverType &)
 {}
 
 void
-AttributeChecker::visit (AST::RawPointerType &type)
+AttributeChecker::visit (AST::RawPointerType &)
 {}
 
 void
-AttributeChecker::visit (AST::ReferenceType &type)
+AttributeChecker::visit (AST::ReferenceType &)
 {}
 
 void
-AttributeChecker::visit (AST::ArrayType &type)
+AttributeChecker::visit (AST::ArrayType &)
 {}
 
 void
-AttributeChecker::visit (AST::SliceType &type)
+AttributeChecker::visit (AST::SliceType &)
 {}
 
 void
-AttributeChecker::visit (AST::InferredType &type)
+AttributeChecker::visit (AST::InferredType &)
 {}
 
 void
-AttributeChecker::visit (AST::BareFunctionType &type)
+AttributeChecker::visit (AST::BareFunctionType &)
 {}
 
 } // namespace Analysis


### PR DESCRIPTION
This should make the bootstrap build green again.

This commit contains some aggressive refactoring which either removes unused arguments altogether or removes the argument name in some cases where it might get used later on or cannot change due to implementing a virtual method or something like that.