### PR TITLE
dwarf2out.c: Don't emit DW_LANG_Rust_old

### DIFF
--- a/gcc/dwarf2out.cc
+++ b/gcc/dwarf2out.cc
@@ -5600,14 +5600,15 @@ is_fortran (const_tree decl)
   return is_fortran ();
 }
 
-/* Return TRUE if the language is Rust.  */
+/* Return TRUE if the language is Rust.
+   Note, returns FALSE for dwarf_version < 5 && dwarf_strict. */
 
 static inline bool
 is_rust ()
 {
   unsigned int lang = get_AT_unsigned (comp_unit_die (), DW_AT_language);
 
-  return lang == DW_LANG_Rust || lang == DW_LANG_Rust_old;
+  return lang == DW_LANG_Rust;
 }
 
 /* Return TRUE if the language is Ada.  */
@@ -25216,13 +25217,6 @@ gen_compile_unit_die (const char *filename)
     }
   else if (strcmp (language_string, "GNU F77") == 0)
     language = DW_LANG_Fortran77;
-  else if (strcmp (language_string, "GNU Rust") == 0)
-    {
-      if (dwarf_version >= 5 || !dwarf_strict)
-	language = DW_LANG_Rust;
-      else
-	language = DW_LANG_Rust_old;
-    }
   else if (dwarf_version >= 3 || !dwarf_strict)
     {
       if (strcmp (language_string, "GNU Ada") == 0)
@@ -25248,6 +25242,8 @@ gen_compile_unit_die (const char *filename)
 	{
 	  if (strcmp (language_string, "GNU Go") == 0)
 	    language = DW_LANG_Go;
+	  else if (strcmp (language_string, "GNU Rust") == 0)
+	    language = DW_LANG_Rust;
 	}
     }
   /* Use a degraded Fortran setting in strict DWARF2 so is_fortran works.  */

--- a/gcc/testsuite/rust/debug/oldlang.rs
+++ b/gcc/testsuite/rust/debug/oldlang.rs
@@ -1,6 +1,6 @@
 fn main () {
 // { dg-do compile }
 // { dg-options "-gstrict-dwarf -gdwarf-3 -dA" }
-// DW_LANG_Rust_old is 0x9000
-// { dg-final { scan-assembler "0x9000\[ \t]\[^\n\r]* DW_AT_language" } } */
+// Strict DWARF < 5 uses DW_LANG_C = 0x0002
+// { dg-final { scan-assembler "0x2\[ \t]\[^\n\r]* DW_AT_language" } } */
 }


### PR DESCRIPTION
DW_LANG_Rust_old is a non-standard DWARF language code used by old rustc compilers before DWARF5 (released in 2017). Just always emit DW_LANG_Rust unless producing strict DWARF for versions before 5. And in that old strict DWARF case just emit DW_LANG_C instead of a non-standard language code.