### PR TITLE
AST dump types

### DIFF
--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -892,7 +892,19 @@ Dump::visit (AsyncBlockExpr &)
 void
 Dump::visit (TypeParam &param)
 {
+  // Syntax:
+  //    IDENTIFIER( : TypeParamBounds? )? ( = Type )?
+  // TypeParamBounds :
+  //    TypeParamBound ( + TypeParamBound )* +?
+
+  // FIXME this outputs things like "Ambiguous: String" - this comes from
+  // Token::str
   stream << param.get_type_representation ();
+  if (param.has_type_param_bounds ())
+    {
+      stream << ": ";
+      visit_items_joined_by_separator (param.get_type_param_bounds (), " + ");
+    }
   if (param.has_type ())
     {
       stream << " = ";
@@ -1663,7 +1675,7 @@ Dump::visit (TraitObjectTypeOneBound &type)
 
   if (type.is_dyn ())
     stream << "dyn ";
-  visit(type.get_trait_bound());
+  visit (type.get_trait_bound ());
 }
 
 void

--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -1656,8 +1656,15 @@ Dump::visit (ImplTraitTypeOneBound &type)
 }
 
 void
-Dump::visit (TraitObjectTypeOneBound &)
-{}
+Dump::visit (TraitObjectTypeOneBound &type)
+{
+  // Syntax:
+  //    dyn? TraitBound
+
+  if (type.is_dyn ())
+    stream << "dyn ";
+  visit(type.get_trait_bound());
+}
 
 void
 Dump::visit (TupleType &type)

--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -1600,7 +1600,14 @@ Dump::visit (ReferenceType &type)
 void
 Dump::visit (ArrayType &type)
 {
+  // Syntax:
+  //    [ Type ; Expression ]
+
+  stream << '[';
   visit (type.get_elem_type ());
+  stream << "; ";
+  visit(type.get_size_expr());
+  stream << ']';
 }
 
 void

--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -1077,8 +1077,12 @@ Dump::visit (Method &method)
   visit (method.get_visibility ());
   stream << "fn " << method.get_method_name () << '(';
 
-  stream << method.get_self_param ().as_string () << ", ";
-  visit_items_joined_by_separator (method.get_function_params (), ", ");
+  stream << method.get_self_param ().as_string ();
+  if (!method.get_function_params ().empty ())
+    {
+      stream << ", ";
+      visit_items_joined_by_separator (method.get_function_params (), ", ");
+    }
 
   stream << ") ";
 
@@ -1343,9 +1347,13 @@ Dump::visit (TraitItemMethod &item)
   // emit_visibility (method.get_visibility ());
   stream << "fn " << method.get_identifier () << '(';
 
-  stream << method.get_self_param ().as_string () << ", ";
+  stream << method.get_self_param ().as_string ();
 
-  visit_items_joined_by_separator (method.get_function_params (), ", ");
+  if (!method.get_function_params ().empty ())
+    {
+      stream << ", ";
+      visit_items_joined_by_separator (method.get_function_params (), ", ");
+    }
 
   stream << ") ";
 

--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -1622,8 +1622,14 @@ Dump::visit (ParenthesisedType &)
 {}
 
 void
-Dump::visit (ImplTraitTypeOneBound &)
-{}
+Dump::visit (ImplTraitTypeOneBound &type)
+{
+  // Syntax:
+  //    impl TraitBound
+
+  stream << "impl ";
+  visit (type.get_trait_bound());
+}
 
 void
 Dump::visit (TraitObjectTypeOneBound &)

--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -1635,8 +1635,15 @@ Dump::visit (TraitObjectType &type)
 }
 
 void
-Dump::visit (ParenthesisedType &)
-{}
+Dump::visit (ParenthesisedType &type)
+{
+  // Syntax:
+  //    ( Type )
+
+  stream << "(";
+  visit (type.get_type_in_parens ());
+  stream << ")";
+}
 
 void
 Dump::visit (ImplTraitTypeOneBound &type)

--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -848,7 +848,7 @@ Dump::visit (BlockExpr &expr)
   stream << "{\n";
   indentation.increment ();
 
-  visit_items_as_lines (expr.get_statements (), "; /* stmt */");
+  visit_items_as_lines (expr.get_statements (), ";");
 
   if (expr.has_tail_expr ())
     visit_as_line (expr.get_tail_expr (), " /* tail expr */\n");
@@ -1205,7 +1205,6 @@ Dump::visit (TypeAlias &type_alias)
     visit (type_alias.get_where_clause ());
   stream << " = ";
   visit (type_alias.get_type_aliased ());
-  stream << ";\n";
 }
 
 void

--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -1580,16 +1580,24 @@ Dump::visit (TraitObjectTypeOneBound &)
 {}
 
 void
-Dump::visit (TupleType &)
-{}
+Dump::visit (TupleType &type)
+{
+  // Syntax:
+  //   ( )
+  //   | ( ( Type , )+ Type? )
+
+  stream << '(';
+  visit_items_joined_by_separator (type.get_elems (), ", ");
+  stream << ')';
+}
 
 void
 Dump::visit (NeverType &)
 {
-    // Syntax:
-    //  !
+  // Syntax:
+  //  !
 
-    stream << '!';
+  stream << '!';
 }
 
 void

--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -1606,7 +1606,12 @@ Dump::visit (ArrayType &type)
 void
 Dump::visit (SliceType &type)
 {
+  // Syntax:
+  //    [ Type ]
+
+  stream << '[';
   visit (type.get_elem_type ());
+  stream << ']';
 }
 
 void

--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -1588,12 +1588,36 @@ Dump::visit (NeverType &)
 {}
 
 void
-Dump::visit (RawPointerType &)
-{}
+Dump::visit (RawPointerType &type)
+{
+  // Syntax:
+  //    * ( mut | const ) TypeNoBounds
+
+  if (type.get_pointer_type () == RawPointerType::MUT)
+    stream << "*mut ";
+  else /* RawPointerType::CONST */
+    stream << "*const ";
+
+  visit (type.get_type_pointed_to ());
+}
 
 void
 Dump::visit (ReferenceType &type)
 {
+  // Syntax:
+  //    & Lifetime? mut? TypeNoBounds
+
+  stream << '&';
+
+  if (type.has_lifetime ())
+    {
+      visit (type.get_lifetime ());
+      stream << ' ';
+    }
+
+  if (type.get_has_mut ())
+    stream << "mut ";
+
   visit (type.get_type_referenced ());
 }
 
@@ -1606,7 +1630,7 @@ Dump::visit (ArrayType &type)
   stream << '[';
   visit (type.get_elem_type ());
   stream << "; ";
-  visit(type.get_size_expr());
+  visit (type.get_size_expr ());
   stream << ']';
 }
 

--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -1661,6 +1661,9 @@ Dump::visit (SliceType &type)
 void
 Dump::visit (InferredType &)
 {
+  // Syntax:
+  //    _
+
   stream << "_";
 }
 

--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -1610,8 +1610,16 @@ Dump::visit (TraitBound &bound)
 }
 
 void
-Dump::visit (ImplTraitType &)
-{}
+Dump::visit (ImplTraitType &type)
+{
+  // Syntax:
+  //    impl TypeParamBounds
+  // TypeParamBounds :
+  //    TypeParamBound ( + TypeParamBound )* +?
+
+  stream << "impl ";
+  visit_items_joined_by_separator(type.get_type_param_bounds (), " + ");
+}
 
 void
 Dump::visit (TraitObjectType &)

--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -17,7 +17,6 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-ast-dump.h"
-#include "rust-diagnostics.h"
 
 namespace Rust {
 namespace AST {

--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -1618,12 +1618,21 @@ Dump::visit (ImplTraitType &type)
   //    TypeParamBound ( + TypeParamBound )* +?
 
   stream << "impl ";
-  visit_items_joined_by_separator(type.get_type_param_bounds (), " + ");
+  visit_items_joined_by_separator (type.get_type_param_bounds (), " + ");
 }
 
 void
-Dump::visit (TraitObjectType &)
-{}
+Dump::visit (TraitObjectType &type)
+{
+  // Syntax:
+  //   dyn? TypeParamBounds
+  // TypeParamBounds :
+  //   TypeParamBound ( + TypeParamBound )* +?
+
+  if (type.is_dyn ())
+    stream << "dyn ";
+  visit_items_joined_by_separator (type.get_type_param_bounds (), " + ");
+}
 
 void
 Dump::visit (ParenthesisedType &)
@@ -1636,7 +1645,7 @@ Dump::visit (ImplTraitTypeOneBound &type)
   //    impl TraitBound
 
   stream << "impl ";
-  visit (type.get_trait_bound());
+  visit (type.get_trait_bound ());
 }
 
 void

--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -1585,7 +1585,12 @@ Dump::visit (TupleType &)
 
 void
 Dump::visit (NeverType &)
-{}
+{
+    // Syntax:
+    //  !
+
+    stream << '!';
+}
 
 void
 Dump::visit (RawPointerType &type)

--- a/gcc/rust/ast/rust-ast-dump.h
+++ b/gcc/rust/ast/rust-ast-dump.h
@@ -139,6 +139,9 @@ private:
   void visit (std::vector<LifetimeParam> &for_lifetimes);
   void visit (FunctionQualifiers &qualifiers);
   void visit (MaybeNamedParam &param);
+  void visit (TypePathFunction &type_path_fn);
+  void visit (GenericArgsBinding &binding);
+  void visit (GenericArg &arg);
 
   // rust-ast.h
   void visit (Token &tok);

--- a/gcc/rust/ast/rust-ast-dump.h
+++ b/gcc/rust/ast/rust-ast-dump.h
@@ -137,6 +137,8 @@ private:
   void visit (MacroRule &rule);
   void visit (WhereClause &rule);
   void visit (std::vector<LifetimeParam> &for_lifetimes);
+  void visit (FunctionQualifiers &qualifiers);
+  void visit (MaybeNamedParam &param);
 
   // rust-ast.h
   void visit (Token &tok);

--- a/gcc/rust/ast/rust-ast-full-test.cc
+++ b/gcc/rust/ast/rust-ast-full-test.cc
@@ -3071,7 +3071,7 @@ BareFunctionType::as_string () const
     }
 
   str += "\n Is variadic: ";
-  if (is_variadic)
+  if (_is_variadic)
     str += "true";
   else
     str += "false";

--- a/gcc/rust/ast/rust-type.h
+++ b/gcc/rust/ast/rust-type.h
@@ -835,7 +835,7 @@ public:
 };
 
 /* A function pointer type - can be created via coercion from function items and
- * non- capturing closures. */
+ * non-capturing closures. */
 class BareFunctionType : public TypeNoBounds
 {
   // bool has_for_lifetimes;
@@ -844,7 +844,7 @@ class BareFunctionType : public TypeNoBounds
 
   FunctionQualifiers function_qualifiers;
   std::vector<MaybeNamedParam> params;
-  bool is_variadic;
+  bool _is_variadic;
   std::vector<Attribute> variadic_attrs;
 
   // bool has_return_type;
@@ -860,6 +860,16 @@ public:
   // Whether the function has ForLifetimes.
   bool has_for_lifetimes () const { return !for_lifetimes.empty (); }
 
+  std::vector<LifetimeParam> &get_for_lifetimes () { return for_lifetimes; }
+
+  bool is_variadic () const { return _is_variadic; }
+
+  std::vector<Attribute> &get_variadic_attr () { return variadic_attrs; };
+  const std::vector<Attribute> &get_variadic_attr () const
+  {
+    return variadic_attrs;
+  };
+
   BareFunctionType (std::vector<LifetimeParam> lifetime_params,
 		    FunctionQualifiers qualifiers,
 		    std::vector<MaybeNamedParam> named_params, bool is_variadic,
@@ -867,7 +877,7 @@ public:
 		    std::unique_ptr<TypeNoBounds> type, Location locus)
     : for_lifetimes (std::move (lifetime_params)),
       function_qualifiers (std::move (qualifiers)),
-      params (std::move (named_params)), is_variadic (is_variadic),
+      params (std::move (named_params)), _is_variadic (is_variadic),
       variadic_attrs (std::move (variadic_attrs)),
       return_type (std::move (type)), locus (locus)
   {
@@ -879,7 +889,7 @@ public:
   BareFunctionType (BareFunctionType const &other)
     : for_lifetimes (other.for_lifetimes),
       function_qualifiers (other.function_qualifiers), params (other.params),
-      is_variadic (other.is_variadic), variadic_attrs (other.variadic_attrs),
+      _is_variadic (other._is_variadic), variadic_attrs (other.variadic_attrs),
       locus (other.locus)
   {
     // guard to prevent null dereference
@@ -893,7 +903,7 @@ public:
     for_lifetimes = other.for_lifetimes;
     function_qualifiers = other.function_qualifiers;
     params = other.params;
-    is_variadic = other.is_variadic;
+    _is_variadic = other._is_variadic;
     variadic_attrs = other.variadic_attrs;
     locus = other.locus;
 
@@ -930,7 +940,7 @@ public:
     return return_type;
   }
 
-  FunctionQualifiers get_function_qualifiers () { return function_qualifiers; }
+  FunctionQualifiers &get_function_qualifiers () { return function_qualifiers; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather


### PR DESCRIPTION

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`
- N\A - Added any relevant test cases to `gcc/testsuite/rust/`

---

Add/fix AST dump of types incl. generic parameters.
