### PR TITLE
ci: Remove warning checks on gcc-patch-dev

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -2,7 +2,7 @@ name: GCC Bootstrap Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ gcc-patch-dev ]
 
 env:
   CXXFLAGS: "-Wno-unused-parameter -Werror=overloaded-virtual"

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -122,17 +122,6 @@ jobs:
            cd gccrs-build; \
            make -Otarget -j $(nproc) 2>&1 | tee log
 
-    - name: Check for new warnings
-      run: |
-           cd gccrs-build
-           < log grep 'warning: ' | sort > log_warnings
-           if diff -U0 ../.github/bors_log_expected_warnings log_warnings; then
-               :
-           else
-               echo 'See <https://github.com/Rust-GCC/gccrs/pull/1026>.'
-               exit 1
-           fi >&2
-
     - name: Run Tests
       run: |
            cd gccrs-build; \

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -6,7 +6,7 @@ on:
       - trying
       - staging
   pull_request:
-    branches: [ master, gcc-patch-dev ]
+    branches: [ gcc-patch-dev ]
 
 env:
   CXXFLAGS: "-Wno-unused-parameter -Werror=overloaded-virtual"
@@ -55,17 +55,6 @@ jobs:
       run: |
            cd gccrs-build; \
            make -Otarget -j $(nproc) 2>&1 | tee log
-
-    - name: Check for new warnings
-      run: |
-           cd gccrs-build
-           < log grep 'warning: ' | sort > log_warnings
-           if diff -U0 ../.github/bors_log_expected_warnings log_warnings; then
-               :
-           else
-               echo 'See <https://github.com/Rust-GCC/gccrs/pull/1026>.'
-               exit 1
-           fi >&2
 
     - name: Run Tests
       run: |


### PR DESCRIPTION
This is a temporary solution since the gcc-patch-dev branch will eventually disappear in favor of another upstreaming strategy
