### PR TITLE
Use `wide_int_to_tree` instead of `double_int_to_tree`

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -2095,8 +2095,8 @@ CompileExpr::compile_integer_literal (const HIR::LiteralExpr &expr,
 		     tyty->get_name ().c_str ());
       return error_mark_node;
     }
-  tree result
-    = double_int_to_tree (type, mpz_get_double_int (type, ival, true));
+
+  tree result = wide_int_to_tree (type, wi::from_mpz (type, ival, true));
 
   mpz_clear (type_min);
   mpz_clear (type_max);

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -1052,7 +1052,7 @@ Gcc_backend::integer_constant_expression (tree t, mpz_t val)
   if (t == error_mark_node)
     return error_mark_node;
 
-  tree ret = double_int_to_tree (t, mpz_get_double_int (t, val, true));
+  tree ret = wide_int_to_tree (t, wi::from_mpz (t, val, true));
   return ret;
 }
 


### PR DESCRIPTION
Fixes #1642 