### PR TITLE
58e75f65e56d: Remove HOST_WIDE_INT struct member

### DIFF
--- a/gcc/rust/backend/rust-constexpr.cc
+++ b/gcc/rust/backend/rust-constexpr.cc
@@ -31,7 +31,7 @@ namespace Compile {
 
 struct constexpr_global_ctx
 {
-  HOST_WIDE_INT constexpr_ops_count;
+  unsigned long constexpr_ops_count;
 
   constexpr_global_ctx () : constexpr_ops_count (0) {}
 };


### PR DESCRIPTION
Fixes #1647 