### PR TITLE
Repair 'gcc/rust/lang.opt' comment

### DIFF
--- a/gcc/rust/lang.opt
+++ b/gcc/rust/lang.opt
@@ -113,6 +113,7 @@ Rust Joined RejectNegative
 
 o
 Rust Joined Separate
+; Documented in common.opt
 
 frust-compile-until=
 Rust Joined RejectNegative Enum(frust_compile_until) Var(flag_rust_compile_until)
@@ -153,8 +154,5 @@ Enum(frust_compile_until) String(compilation) Value(9)
 
 EnumValue
 Enum(frust_compile_until) String(end) Value(10)
-
-
-; Documented in common.opt
 
 ; This comment is to ensure we retain the blank line above.


### PR DESCRIPTION
... lost in #1527 commit 138a6260124740208b8f3aff2e38617f43b05fe8
"rust: Add -frust-compile-until option".
