### PR TITLE
ci: Lock Ubuntu version to 20.04

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -168,7 +168,7 @@ jobs:
 
   build-and-check-gcc-48:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -18,7 +18,7 @@ jobs:
       # Force locale, in particular for reproducible results re '.github/bors_log_expected_warnings' (see below).
       LC_ALL: C.UTF-8
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
@@ -95,7 +95,7 @@ jobs:
       # Force locale, in particular for reproducible results re '.github/bors_log_expected_warnings' (see below).
       LC_ALL: C.UTF-8
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
@@ -168,7 +168,7 @@ jobs:
 
   build-and-check-gcc-48:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
This locks all of our CI images to Ubuntu-20.04.

This should be upgraded eventually to 22.04, in time. I'll open up an issue to accompany it.

All of yesterday's PRs will need to be rebased on master once this is merged