### PR TITLE
testsuite: Add xfail clauses for big-endian-related type errors

### DIFF
--- a/gcc/testsuite/rust/compile/const-issue1440.rs
+++ b/gcc/testsuite/rust/compile/const-issue1440.rs
@@ -1,3 +1,5 @@
+// { dg-xfail-if "expected failure on big endian systems" { be } }
+
 // { dg-additional-options "-w" }
 
 mod intrinsics {
@@ -39,6 +41,7 @@ macro_rules! impl_uint {
                 }
 
                 pub fn to_le(self) -> Self {
+                    // { dg-error "" "" { xfail { le } } .-1 }
                     #[cfg(target_endian = "little")]
                     {
                         self
@@ -46,11 +49,12 @@ macro_rules! impl_uint {
                 }
 
                 pub const fn from_le_bytes(bytes: [u8; mem::size_of::<Self>()]) -> Self {
-                    // { dg-error "only functions marked as .const. are allowed to be called from constant contexts" "" { target *-*-* } .-1 }
+                    // { dg-error "only functions marked as .const. are allowed to be called from constant contexts" "" { target { le } } .-1 }
                     Self::from_le(Self::from_ne_bytes(bytes))
                 }
 
                 pub const fn from_le(x: Self) -> Self {
+                    // { dg-error "" "" { xfail { le } } .-1 }
                     #[cfg(target_endian = "little")]
                     {
                         x
@@ -58,7 +62,7 @@ macro_rules! impl_uint {
                 }
 
                 pub const fn from_ne_bytes(bytes: [u8; mem::size_of::<Self>()]) -> Self {
-                    // { dg-error "only functions marked as .const. are allowed to be called from constant contexts" "" { target *-*-* } .-1 }
+                    // { dg-error "only functions marked as .const. are allowed to be called from constant contexts" "" { target { le } } .-1 }
                     unsafe { mem::transmute(bytes) }
                 }
             }

--- a/gcc/testsuite/rust/compile/torture/issue-1432.rs
+++ b/gcc/testsuite/rust/compile/torture/issue-1432.rs
@@ -1,3 +1,5 @@
+// { dg-xfail-if "expected failure on big endian" { be } }
+
 // { dg-additional-options "-w" }
 mod intrinsics {
     extern "rust-intrinsic" {
@@ -43,6 +45,7 @@ macro_rules! impl_uint {
                 }
 
                 pub fn to_le(self) -> Self {
+                    // { dg-error "" "" { xfail { le } } .-1 }
                     #[cfg(target_endian = "little")]
                     {
                         self
@@ -54,6 +57,7 @@ macro_rules! impl_uint {
                 }
 
                 pub const fn from_le(x: Self) -> Self {
+                    // { dg-error "" "" { xfail { le } } .-1 }
                     #[cfg(target_endian = "little")]
                     {
                         x


### PR DESCRIPTION
This runs properly on one of the BE Sparc machines of the GCC compile farm. Now, it needs to pass the little-endian testsuite :) these dejagnu directives are a bit annoying to weld.

This also needs issue/bugzilla numbers around the `dg-xfail-if`