### PR TITLE
Backport "c++: Quash -Wdangling-reference for member operator* [PR107488]"

### DIFF
--- a/gcc/testsuite/g++.dg/warn/Wdangling-reference5.C
+++ b/gcc/testsuite/g++.dg/warn/Wdangling-reference5.C
@@ -1,0 +1,22 @@
+// PR c++/107488
+// { dg-do compile }
+// { dg-options "-Wdangling-reference" }
+
+#include <vector>
+
+int
+do_sum (std::vector<int>& v)
+{
+  int sum = 0;
+
+  std::vector<int>::const_iterator it = v.begin();
+  while (it != v.end())
+    {
+      // R refers to one of the int elements of V, not to a temporary
+      // object, so no dangling reference here.
+      const int &r = *it++; // { dg-bogus "dangling reference" }
+      sum += r;
+    }
+
+  return sum;
+}


### PR DESCRIPTION
As had also been reported in <https://gcc.gnu.org/PR107633> "Bootstrap failure due to -Werror=unused-parameter and -Werror=dangling-reference", GCC `--enable-bootstrap` build is currently broken:

    [...]/gcc/rust/backend/rust-compile-expr.cc: In member function ‘tree_node* Rust::Compile::CompileExpr::resolve_method_address(Rust::TyTy::FnType*, Rust::HirId, Rust::TyTy::BaseType*, Rust::HIR::PathIdentSegment&, Rust::Analysis::NodeMapping, Location)’:
    [...]/gcc/rust/backend/rust-compile-expr.cc:2019:13: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
     2019 |       auto &candidate = *candidates.begin ();
          |             ^~~~~~~~~
    [...]/gcc/rust/backend/rust-compile-expr.cc:2019:44: note: the temporary was destroyed at the end of the full expression ‘candidates.std::set<Rust::Resolver::PathProbeCandidate>::begin().std::_Rb_tree_const_iterator<Rust::Resolver::PathProbeCandidate>::operator*()’
     2019 |       auto &candidate = *candidates.begin ();
          |                                            ^
    [...]/gcc/rust/backend/rust-compile-expr.cc: In member function ‘tree_node* Rust::Compile::CompileExpr::generate_closure_fntype(Rust::HIR::ClosureExpr&, const Rust::TyTy::ClosureType&, tree, Rust::TyTy::FnType**)’:
    [...]/gcc/rust/backend/rust-compile-expr.cc:3034:35: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
     3034 |   const TyTy::TypeBoundPredicate &predicate
          |                                   ^~~~~~~~~
    [...]/gcc/rust/backend/rust-compile-expr.cc:3035:52: note: the temporary was destroyed at the end of the full expression ‘(&(& closure_tyty)->Rust::TyTy::ClosureType::<anonymous>.Rust::TyTy::BaseType::<anonymous>.Rust::TyTy::TypeBoundsMappings::get_specified_bounds())->std::vector<Rust::TyTy::TypeBoundPredicate>::begin().__gnu_cxx::__normal_iterator<const Rust::TyTy::TypeBoundPredicate*, std::vector<Rust::TyTy::TypeBoundPredicate> >::operator*()’
     3035 |     = *closure_tyty.get_specified_bounds ().begin ();
          |                                                    ^
    
    [...]/gcc/rust/typecheck/rust-hir-type-check-path.cc: In member function ‘void Rust::Resolver::TypeCheckExpr::resolve_segments(Rust::NodeId, std::vector<Rust::HIR::PathExprSegment>&, size_t, Rust::TyTy::BaseType*, const Rust::Analysis::NodeMapping&, Location)’:
    [...]/gcc/rust/typecheck/rust-hir-type-check-path.cc:340:13: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
      340 |       auto &candidate = *candidates.begin ();
          |             ^~~~~~~~~
    [...]/gcc/rust/typecheck/rust-hir-type-check-path.cc:340:44: note: the temporary was destroyed at the end of the full expression ‘candidates.std::set<Rust::Resolver::PathProbeCandidate>::begin().std::_Rb_tree_const_iterator<Rust::Resolver::PathProbeCandidate>::operator*()’
      340 |       auto &candidate = *candidates.begin ();
          |                                            ^
    
    [...]/gcc/rust/typecheck/rust-hir-type-check-type.cc: In member function ‘Rust::TyTy::BaseType* Rust::Resolver::TypeCheckType::resolve_segments(Rust::NodeId, Rust::HirId, std::vector<std::unique_ptr<Rust::HIR::TypePathSegment> >&, size_t, Rust::TyTy::BaseType*, const Rust::Analysis::NodeMapping&, Location)’:
    [...]/gcc/rust/typecheck/rust-hir-type-check-type.cc:465:13: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
      465 |       auto &candidate = *candidates.begin ();
          |             ^~~~~~~~~
    [...]/gcc/rust/typecheck/rust-hir-type-check-type.cc:465:44: note: the temporary was destroyed at the end of the full expression ‘candidates.std::set<Rust::Resolver::PathProbeCandidate>::begin().std::_Rb_tree_const_iterator<Rust::Resolver::PathProbeCandidate>::operator*()’
      465 |       auto &candidate = *candidates.begin ();
          |                                            ^

I understand this code has been changed in the GCC/Rust upstream submission; but in order to make progress with #1700, I'd like to first individually backport "c++: Quash -Wdangling-reference for member operator* [PR107488]", to resolve this issue here.
