### PR TITLE
rust: fix link serialization [PR108113]

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -35,6 +35,8 @@ GCCRS_TARGET_INSTALL_NAME := $(target_noncanonical)-$(shell echo gccrs|sed '$(pr
 # Define the names for selecting rust in LANGUAGES.
 rust: rust1$(exeext)
 
+rust.serial = rust1$(exeext)
+
 # Tell GNU make to ignore files by these names if they exist.
 .PHONY: rust
 
@@ -168,9 +170,11 @@ RUST_ALL_OBJS = $(GRS_OBJS) $(RUST_TARGET_OBJS)
 rust_OBJS = $(RUST_ALL_OBJS) rust/rustspec.o
 
 # The compiler itself is called rust1 (formerly grs1)
-rust1$(exeext): $(RUST_ALL_OBJS) attribs.o $(BACKEND) $(LIBDEPS)
+rust1$(exeext): $(RUST_ALL_OBJS) attribs.o $(BACKEND) $(LIBDEPS) $(rust.prev)
+	@$(call LINK_PROGRESS,$(INDEX.rust),start)
 	+$(LLINKER) $(ALL_LINKERFLAGS) $(LDFLAGS) -o $@ \
 	      $(RUST_ALL_OBJS) attribs.o $(BACKEND) $(LIBS) $(BACKENDLIBS)
+	@$(call LINK_PROGRESS,$(INDEX.rust),end)
 
 # Build hooks.
 


### PR DESCRIPTION
The Make-lang.in was missing the link serialization support.

    PR rust/108113

gcc/rust
	* Make-lang.in (rust.serial): New variable. 
	(rust1$(exeext)): Depend on $(rust.prev). Call LINK_PROGRESS.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>