### PR TITLE
unsafe: check use of `target_feature` attribute

### DIFF
--- a/gcc/rust/checks/errors/rust-unsafe-checker.h
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.h
@@ -46,6 +46,11 @@ private:
    */
   void check_function_call (HirId node_id, Location locus);
 
+  /**
+   * Check if any unsafe attributes are present on a function
+   */
+  void check_function_attr (HirId node_id, Location locus);
+
   StackedContexts<HirId> unsafe_context;
 
   Resolver::TypeCheckContext &context;

--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -41,6 +41,9 @@ static const BuiltinAttrDefinition __definitions[]
      {"repr", CODE_GENERATION},
      {"path", EXPANSION},
      {"macro_use", NAME_RESOLUTION},
+     // FIXME: This is not implemented yet, see
+     // https://github.com/Rust-GCC/gccrs/issues/1475
+     {"target_feature", CODE_GENERATION},
      // From now on, these are reserved by the compiler and gated through
      // #![feature(rustc_attrs)]
      {"rustc_inherit_overflow_checks", CODE_GENERATION}};

--- a/gcc/testsuite/rust/compile/unsafe11.rs
+++ b/gcc/testsuite/rust/compile/unsafe11.rs
@@ -1,0 +1,8 @@
+#[target_feature(sse)]
+fn foo() {
+    let a: usize = 0;
+}
+
+fn main() {
+    foo() // { dg-error "requires unsafe function or block" }
+}


### PR DESCRIPTION
The `target_feature` attribute is for conditional compilation and may or may not compile on all platforms. Using it requires an unsafe function or block.

Addresses #1411 