### PR TITLE
rust: add bound parsing in parse_generic_arg.

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -6189,6 +6189,23 @@ Parser<ManagedTokenSource>::parse_generic_arg ()
 	    else
 	      return AST::GenericArg::create_error ();
 	  }
+	else if (next_tok->get_id () == COLON)
+	  {
+	    lexer.skip_token (); // skip ident
+	    lexer.skip_token (); // skip colon
+
+	    auto tok = lexer.peek_token ();
+	    std::vector<std::unique_ptr<AST::TypeParamBound>> bounds
+	      = parse_type_param_bounds ();
+
+	    auto type = std::unique_ptr<AST::TraitObjectType> (
+	      new AST::TraitObjectType (std::move (bounds), tok->get_locus (),
+					false));
+	    if (type)
+	      return AST::GenericArg::create_type (std::move (type));
+	    else
+	      return AST::GenericArg::create_error ();
+	  }
 	lexer.skip_token ();
 	return AST::GenericArg::create_ambiguous (tok->get_str (),
 						  tok->get_locus ());

--- a/gcc/testsuite/rust/compile/bounds.rs
+++ b/gcc/testsuite/rust/compile/bounds.rs
@@ -1,0 +1,10 @@
+trait Foo {
+    type Bar;
+}
+
+trait Copy {}
+
+
+fn c<F: Foo<Bar: Foo>>() where F::Bar: Copy { // { dg-warning "function is never used: 'c'" }
+}
+


### PR DESCRIPTION
This patch adds parsing for generic parameters like: <F: Foo<Bar: Foo>>. In current version, this pattern  leads to endless loop.
