### PR TITLE
format: Fix git whitespace errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@
 
 * **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/Rust-GCC/gccrs/issues).
 
-* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/Rust-GCC/gccrs/issues/new). 
-  Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample** 
+* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/Rust-GCC/gccrs/issues/new).
+  Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample**
   or an **executable test case** demonstrating the expected behavior that is not occurring.
 
 #### **Do you want to submit a patch?**
@@ -18,14 +18,14 @@
    Please see the [Contributing to GCC](https://gcc.gnu.org/contribute.html) guide or [Developer's Certificate of Origin (DCO) Sign-off](https://gcc.gnu.org/dco.html) guide.
 
 * Patches sent to the [`gcc-rust` mailing list](https://gcc.gnu.org/mailman/listinfo/gcc-rust) are likewise welcome.
-These will be imported into a GitHub PR to follow the normal review process, 
+These will be imported into a GitHub PR to follow the normal review process,
 and the link to the GitHub PR sent to the submitter.
 
 #### **Do you intend to add a new feature or change an existing one?**
 
 * Suggest your change in the [Zulip](https://gcc-rust.zulipchat.com/) and start writing code.
 
-* Do not open an issue on GitHub until you have collected positive feedback about the change. 
+* Do not open an issue on GitHub until you have collected positive feedback about the change.
   GitHub issues are primarily intended for bug reports and fixes.
 
 #### **Do you have questions about the source code?**
@@ -43,20 +43,20 @@ and the link to the GitHub PR sent to the submitter.
 
 * Avoid PR's with merge commit unless there's a good reason
 
-* Where possible please add test cases to `gcc/testsuite/rust/` for all PRs. 
+* Where possible please add test cases to `gcc/testsuite/rust/` for all PRs.
   Some issues may not be testable via dejagnu/automation such as debug dump changes.
 
 * Follow the [GCC coding style](https://gcc.gnu.org/codingconventions.html) (see `clang-format` below).
 
 * PRs won't be merged until the build and tests pass.
 
-* Please take the time to create good git commit messages. 
+* Please take the time to create good git commit messages.
   See the existing format of them in the git log or refer to something like: https://chris.beams.io/posts/git-commit/
 
 #### Running `clang-format` locally
 
 * on all files using python scripts
-... corresponding to what the _Clang Format Lint_ (`.github/workflows/clang-format.yml`) 
+... corresponding to what the _Clang Format Lint_ (`.github/workflows/clang-format.yml`)
 is doing, with `clang-format-10` being available locally, and avoiding the Docker overhead.
 
 ```shell
@@ -95,12 +95,12 @@ index bd3043295ce..9559374ce60 100644
    STDCALL,
    FASTCALL,
  };
- 
+
 gccrs/gcc/rust on  dkm/clang_format [$!+?]
 ❯ git clang-format
 changed files:
     gcc/rust/rust-abi.h
- 
+
 gccrs/gcc/rust on  dkm/clang_format [$!+?]
 $ git diff rust-abi.h
 diff --git a/gcc/rust/rust-abi.h b/gcc/rust/rust-abi.h
@@ -122,7 +122,7 @@ index 9559374ce60..bd3043295ce 100644
  };
 ```
 
-Also note that you can use a given version of `clang-format` by using `git clang-format-10` if you have 
+Also note that you can use a given version of `clang-format` by using `git clang-format-10` if you have
 installed that particular version.
 
 Thanks! :heart: :heart: :heart:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The path of header dir and sysroot should be specified when you configure the pr
 ```bash
 $ mkdir mac-build
 $ cd mac-build
-$ ../gccrs/configure --prefix=$HOME/gccrs-install --disable-bootstrap --enable-multilib --enable-languages=rust --with-native-system-header-dir=/usr/include --with-sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk 
+$ ../gccrs/configure --prefix=$HOME/gccrs-install --disable-bootstrap --enable-multilib --enable-languages=rust --with-native-system-header-dir=/usr/include --with-sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
 $ make
 
 ```
@@ -96,7 +96,7 @@ $ $HOME/gccrs-install/gccrs -g -O2 -c test.rs -o test.o
 $ $HOME/gccrs-install/gccrs -o test test.o
 ```
 
-You can also setup your shell to automatically find the installed compiler. For example for `bash`, 
+You can also setup your shell to automatically find the installed compiler. For example for `bash`,
 add the following in your `$HOME/.bashrc`:
 
 ```bash
@@ -140,7 +140,7 @@ test cases referencing any issues on Github.
 
 ### Enabling internal checks
 
-GCC has several internal checks that can be enabled during configuration. In the case of `gccrs`, 
+GCC has several internal checks that can be enabled during configuration. In the case of `gccrs`,
 you can enable the following:
 ```bash
 $ ../gccrs/configure --prefix=$HOME/gccrs-install --disable-bootstrap --enable-multilib --enable-languages=rust --enable-checking=gimple,tree,types
@@ -159,7 +159,7 @@ $ gdb --args  /some/path/../../rust1 test.rs -quiet -dumpbase arithmetic_express
  -mtune=generic -march=x86-64 -O0 -w -version -fdiagnostics-color=never -fno-diagnostics-show-caret -fno-diagnostics-show-line-numbers -fdiagnostics-urls=never -fdiagnostics-path-format=separate-events -o test.s -L/lib/x86_64-linux-gnu -L/lib/../lib64 -L/usr/lib/x86_64-linux-gnu
 ```
 
-Or simply add the `-wrapper gdb,--args` option. 
+Or simply add the `-wrapper gdb,--args` option.
 This will call each subcommand in `gdb` and you simply have to break/debug in `rust1`:
 ```bash
 $ gccrs test.rs -O0 -S -o arithmetic_expressions1.s -wrapper gdb,--args
@@ -167,7 +167,7 @@ $ gccrs test.rs -O0 -S -o arithmetic_expressions1.s -wrapper gdb,--args
 
 ## Docker image
 
-There is a docker image hosted over on: 
+There is a docker image hosted over on:
 
 https://hub.docker.com/repository/docker/philberty/gccrs
 
@@ -180,7 +180,7 @@ Or you can build your own image:
 ```bash
 $ docker build . -t gccrs-dev
 ```
-If you want to build an object file: 
+If you want to build an object file:
 
 ```bash
 $ docker run --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp \
@@ -199,7 +199,7 @@ To emit assembly :
 ```bash
 $ docker run --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp \
     gccrs-dev:latest gccrs -g -O2 \
-    gcc/testsuite/rust/compile/torture/type_infer1.rs -S -o type_infer1.s 
+    gcc/testsuite/rust/compile/torture/type_infer1.rs -S -o type_infer1.s
 ```
 
 To emit Rust front end debug output, you may add options like `-frust-debug`, `-frust-dump-all`.
@@ -209,11 +209,11 @@ To emit Rust front end debug output, you may add options like `-frust-debug`, `-
 
 If you want to contribute to GCC Rust, you can find more information in [CONTRIBUTING.md](https://github.com/Rust-GCC/gccrs/blob/master/CONTRIBUTING.md).
 
-Please be aware this project is designed to be pushed upstream to GCC when we reach some milestones, 
-and this means we require copyright assignment or the Developer's Certificate of Origin sign-off. 
+Please be aware this project is designed to be pushed upstream to GCC when we reach some milestones,
+and this means we require copyright assignment or the Developer's Certificate of Origin sign-off.
 Please see the [Contributing to GCC](https://gcc.gnu.org/contribute.html) guide or [Developer's Certificate of Origin (DCO) Sign-off](https://gcc.gnu.org/dco.html) guide.
 
-Not all contributions must be code; we would love to see new test cases or bugs and issues to be reported. 
+Not all contributions must be code; we would love to see new test cases or bugs and issues to be reported.
 Feel free to add any comments on open PRs
 
 

--- a/gcc/rust/lang.opt
+++ b/gcc/rust/lang.opt
@@ -7,12 +7,12 @@
 ; the terms of the GNU General Public License as published by the Free
 ; Software Foundation; either version 3, or (at your option) any later
 ; version.
-; 
+;
 ; GCC is distributed in the hope that it will be useful, but WITHOUT ANY
 ; WARRANTY; without even the implied warranty of MERCHANTABILITY or
 ; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 ; for more details.
-; 
+;
 ; You should have received a copy of the GNU General Public License
 ; along with GCC; see the file COPYING3.  If not see
 ; <http://www.gnu.org/licenses/>.

--- a/gcc/rust/lex/rust-token.h
+++ b/gcc/rust/lex/rust-token.h
@@ -147,7 +147,6 @@ enum PrimitiveCoreType
   RS_TOKEN (INNER_DOC_COMMENT, "#![doc]")                                      \
   RS_TOKEN (OUTER_DOC_COMMENT, "#[doc]")                                       \
   /* have "weak" union and 'static keywords? */                                \
-                                                                               \
   RS_TOKEN_KEYWORD (ABSTRACT, "abstract") /* unused */                         \
   RS_TOKEN_KEYWORD (AS, "as")                                                  \
   RS_TOKEN_KEYWORD (ASYNC, "async")   /* unused */                             \
@@ -200,7 +199,6 @@ enum PrimitiveCoreType
   RS_TOKEN_KEYWORD (WHERE, "where")                                            \
   RS_TOKEN_KEYWORD (WHILE, "while")                                            \
   RS_TOKEN_KEYWORD (YIELD, "yield") /* unused */                               \
-                                                                               \
   RS_TOKEN (LAST_TOKEN, "<last-token-marker>")
 
 // Contains all token types. Crappy implementation via x-macros.

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -102,16 +102,25 @@ enum binding_powers
   LBP_CLOSURE = LBP_RETURN, // unary prefix operators
 
 #if 0
-        // rust precedences
-        PREC_CLOSURE = -40,     // used for closures
-        PREC_JUMP = -30,        // used for break, continue, return, and yield
-        PREC_RANGE = -10,       // used for range (although weird comment in rustc about this)
-        PREC_BINOP = FROM_ASSOC_OP,
-        // used for binary operators mentioned below - also cast, colon (type), assign, assign_op
-        PREC_PREFIX = 50,       // used for box, address_of, let, unary (again, weird comment on let)
-        PREC_POSTFIX = 60,      // used for await, call, method call, field, index, try, inline asm, macro invocation
-        PREC_PAREN = 99,        // used for array, repeat, tuple, literal, path, paren, if, while, for, 'loop', match, block, try block, async, struct
-        PREC_FORCE_PAREN = 100,
+  // rust precedences
+  // used for closures
+  PREC_CLOSURE = -40,
+  // used for break, continue, return, and yield
+  PREC_JUMP = -30,
+  // used for range (although weird comment in rustc about this)
+  PREC_RANGE = -10,
+  // used for binary operators mentioned below - also cast, colon (type),
+  // assign, assign_op
+  PREC_BINOP = FROM_ASSOC_OP,
+  // used for box, address_of, let, unary (again, weird comment on let)
+  PREC_PREFIX = 50,
+  // used for await, call, method call, field, index, try,
+  // inline asm, macro invocation
+  PREC_POSTFIX = 60,
+  // used for array, repeat, tuple, literal, path, paren, if,
+  // while, for, 'loop', match, block, try block, async, struct
+  PREC_PAREN = 99,
+  PREC_FORCE_PAREN = 100,
 #endif
 
   // lowest priority


### PR DESCRIPTION
Addresses #1680 
Fixes #1680 

Probably does not need a changelog since I assume this commit will just be dropped when we merge