### PR TITLE
[CL] First update Changelog tryout: Updating AST dump

### DIFF
--- a/gcc/rust/ast/rust-ast-dump.h
+++ b/gcc/rust/ast/rust-ast-dump.h
@@ -66,6 +66,12 @@ private:
   void format_function_param (FunctionParam &param);
   void emit_attrib (const Attribute &attrib);
 
+  /**
+   * Emit an indented string with an optional extra comment
+   */
+  std::ostream &emit_indented_string (const std::string &value,
+				      const std::string &comment = "");
+
   // rust-ast.h
   void visit (Token &tok);
   void visit (DelimTokenTree &delim_tok_tree);

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -58,6 +58,7 @@ namespace Rust {
 const char *kLexDumpFile = "gccrs.lex.dump";
 const char *kASTDumpFile = "gccrs.ast.dump";
 const char *kASTPrettyDumpFile = "gccrs.ast-pretty.dump";
+const char *kASTPrettyDumpFileExpanded = "gccrs.ast-pretty-expanded.dump";
 const char *kASTExpandedDumpFile = "gccrs.ast-expanded.dump";
 const char *kHIRDumpFile = "gccrs.hir.dump";
 const char *kHIRPrettyDumpFile = "gccrs.hir-pretty.dump";
@@ -531,6 +532,7 @@ Session::compile_crate (const char *filename)
       // dump AST with expanded stuff
       rust_debug ("BEGIN POST-EXPANSION AST DUMP");
       dump_ast_expanded (parser, parsed_crate);
+      dump_ast_pretty (parsed_crate, true);
       rust_debug ("END POST-EXPANSION AST DUMP");
     }
 
@@ -832,10 +834,14 @@ Session::dump_ast (Parser<Lexer> &parser, AST::Crate &crate) const
 }
 
 void
-Session::dump_ast_pretty (AST::Crate &crate) const
+Session::dump_ast_pretty (AST::Crate &crate, bool expanded) const
 {
   std::ofstream out;
-  out.open (kASTPrettyDumpFile);
+  if (expanded)
+    out.open (kASTPrettyDumpFileExpanded);
+  else
+    out.open (kASTPrettyDumpFile);
+
   if (out.fail ())
     {
       rust_error_at (Linemap::unknown_location (), "cannot open %s:%m; ignored",

--- a/gcc/rust/rust-session-manager.h
+++ b/gcc/rust/rust-session-manager.h
@@ -319,7 +319,7 @@ private:
 
   void dump_lex (Parser<Lexer> &parser) const;
   void dump_ast (Parser<Lexer> &parser, AST::Crate &crate) const;
-  void dump_ast_pretty (AST::Crate &crate) const;
+  void dump_ast_pretty (AST::Crate &crate, bool expanded = false) const;
   void dump_ast_expanded (Parser<Lexer> &parser, AST::Crate &crate) const;
   void dump_hir (HIR::Crate &crate) const;
   void dump_hir_pretty (HIR::Crate &crate) const;


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* ast/rust-ast-dump.cc (Dump::go): Switch single character string to character
	(Dump::emit_attrib): Merge two pretty-print characters in one string
	(Dump::emit_indented_string): New
	(Dump::visit): Add missing visitors, refactor dumping of operators
	(Dump::format_function_common): Refactor
	* ast/rust-ast-dump.h: Add documentation for `emit_indented_string`
	
and

gcc/rust/ChangeLog:

	* rust-session-manager.cc (Session::compile_crate): Allow the dump of prettified AST
	(Session::dump_ast_pretty): New
	* rust-session-manager.h: Add new output file for pretty AST dump

This PR should serve as a tryout for updating Changelog entries in previous, non-upstreamed commits.

I assume the best course of action will be to update `gcc-patch-dev` to the current state of the GCC master branch and merge PRs by PRs. I'll add the authors of commits in order for them to validate the Changelog entries I'll be writing. In that case @CohenArthur please review the changelog :)

It might be worth it to add a CI step which executes `./contrib/gcc-changelog/git-check-commit.py`. For that PR, the script outputs okay. But I'm aware there might be style issues regarding long sentences or capital letters, so @dkm @tschwinge feel free to rip into the messages