### PR TITLE
gccrs: fix bootstrap

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -24,9 +24,11 @@
 
 # Use strict warnings for this front end.
 rust-warn = $(STRICT_WARN)
-# ..., with the exception of '-Wunused-parameter'; waiting for
-# <https://github.com/Rust-GCC/gccrs/issues/1626> "bootstrap build failure".
+# ..., with the exception of '-Wunused-parameter' and '-Wunused-function';
+# waiting for <https://github.com/Rust-GCC/gccrs/issues/1626> "bootstrap build
+# failure".
 rust-warn += -Wno-unused-parameter
+rust-warn += -Wno-unused-function
 
 # Installation name. Useful for cross compilers and used during install.
 GCCRS_INSTALL_NAME := $(shell echo gccrs|sed '$(program_transform_name)')


### PR DESCRIPTION
Temporary disabling of warning on unused function to keep bootstrap build. See https://github.com/Rust-GCC/gccrs/issues/1626.

```
gcc/rust
	* Make-lang.in (rust-warn): Add -Wno-unused-function.
```
Signed-off-by: Marc Poulhiès <dkm@kataplop.net>