### PR TITLE
testsuite: Handle Windows carriage returns properly

### DIFF
--- a/gcc/testsuite/rust/execute/torture/builtin_macro_cfg.rs
+++ b/gcc/testsuite/rust/execute/torture/builtin_macro_cfg.rs
@@ -1,5 +1,5 @@
 // { dg-additional-options "-w -frust-cfg=A" }
-// { dg-output "A\n" }
+// { dg-output "A\r*\n" }
 #[rustc_builtin_macro]
 macro_rules! cfg {
     () => {{}};
@@ -12,7 +12,7 @@ extern "C" {
 fn print(s: &str) {
     unsafe {
         printf(
-            "%s\n" as *const str as *const i8,
+            "%s\n\0" as *const str as *const i8,
             s as *const str as *const i8,
         );
     }
@@ -21,11 +21,11 @@ fn print(s: &str) {
 fn main() -> i32 {
     let cfg = cfg!(A);
     if cfg {
-        print("A");
+        print("A\0");
     }
     let cfg = cfg!(B);
     if cfg {
-        print("B");
+        print("B\0");
     }
 
     0

--- a/gcc/testsuite/rust/execute/torture/builtin_macro_concat.rs
+++ b/gcc/testsuite/rust/execute/torture/builtin_macro_concat.rs
@@ -1,4 +1,4 @@
-// { dg-output "\ntest10btrue2.15\ntest10bfalse2.151\n" }
+// { dg-output "\r*\ntest10btrue2.15\r*\ntest10bfalse2.151\r*\n" }
 #[rustc_builtin_macro]
 macro_rules! concat {
     () => {{}};

--- a/gcc/testsuite/rust/execute/torture/builtin_macro_env.rs
+++ b/gcc/testsuite/rust/execute/torture/builtin_macro_env.rs
@@ -1,4 +1,4 @@
-// { dg-output "VALUE\nVALUE\n" }
+// { dg-output "VALUE\r*\nVALUE\r*\n" }
 // { dg-set-compiler-env-var ENV_MACRO_TEST "VALUE" }
 #[rustc_builtin_macro]
 macro_rules! env {

--- a/gcc/testsuite/rust/execute/torture/builtin_macro_include_bytes.rs
+++ b/gcc/testsuite/rust/execute/torture/builtin_macro_include_bytes.rs
@@ -1,4 +1,4 @@
-// { dg-output "104\n33\n1\n" }
+// { dg-output "104\r*\n33\r*\n1\r*\n" }
 #[rustc_builtin_macro]
 macro_rules! include_bytes {
     () => {{}};

--- a/gcc/testsuite/rust/execute/torture/builtin_macro_include_str.rs
+++ b/gcc/testsuite/rust/execute/torture/builtin_macro_include_str.rs
@@ -1,4 +1,4 @@
-// { dg-output "hello, include!\n" }
+// { dg-output "hello, include!\r*\n" }
 #[rustc_builtin_macro]
 macro_rules! include_str {
     () => {{}};

--- a/gcc/testsuite/rust/execute/torture/builtin_macro_line.rs
+++ b/gcc/testsuite/rust/execute/torture/builtin_macro_line.rs
@@ -1,4 +1,4 @@
-// { dg-output "18\n21\n" }
+// { dg-output "18\r*\n21\r*\n" }
 extern "C" {
     fn printf(fmt: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/builtin_macros1.rs
+++ b/gcc/testsuite/rust/execute/torture/builtin_macros1.rs
@@ -1,4 +1,4 @@
-// { dg-output "rust/execute/torture/builtin_macros1.rs" }
+// { dg-output "rust/execute/torture/builtin_macros1.rs\r*" }
 #[rustc_builtin_macro]
 macro_rules! file {
     () => {{}};

--- a/gcc/testsuite/rust/execute/torture/builtin_macros3.rs
+++ b/gcc/testsuite/rust/execute/torture/builtin_macros3.rs
@@ -1,4 +1,4 @@
-// { dg-output "14\n42\n" }
+// { dg-output "14\r*\n42\r*\n" }
 #[rustc_builtin_macro]
 macro_rules! column {
     () => {{}};
@@ -19,10 +19,9 @@ fn main() -> i32 {
 
     print(c0);
 
-    let c1 =                             column!();
+    let c1 = /* --------------------- */ column!();
 
     print(c1);
 
     0
 }
-

--- a/gcc/testsuite/rust/execute/torture/cfg1.rs
+++ b/gcc/testsuite/rust/execute/torture/cfg1.rs
@@ -1,5 +1,5 @@
 // { dg-additional-options "-w -frust-cfg=A" }
-// { dg-output "test1\n" }
+// { dg-output "test1\r*\n" }
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/cfg2.rs
+++ b/gcc/testsuite/rust/execute/torture/cfg2.rs
@@ -1,5 +1,5 @@
 // { dg-additional-options "-w -frust-cfg=A" }
-// { dg-output "test1\n" }
+// { dg-output "test1\r*\n" }
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/cfg3.rs
+++ b/gcc/testsuite/rust/execute/torture/cfg3.rs
@@ -1,5 +1,5 @@
 // { dg-additional-options "-w -frust-cfg=A" }
-// { dg-output "test1\n" }
+// { dg-output "test1\r*\n" }
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/cfg4.rs
+++ b/gcc/testsuite/rust/execute/torture/cfg4.rs
@@ -1,5 +1,5 @@
 // { dg-additional-options "-w -frust-cfg=A" }
-// { dg-output "test1\ntest2\n" }
+// { dg-output "test1\r*\ntest2\r*\n" }
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/closure2.rs
+++ b/gcc/testsuite/rust/execute/torture/closure2.rs
@@ -1,4 +1,4 @@
-// { dg-output "3\n" }
+// { dg-output "3\r*\n" }
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/closure3.rs
+++ b/gcc/testsuite/rust/execute/torture/closure3.rs
@@ -1,4 +1,4 @@
-// { dg-output "3\n" }
+// { dg-output "3\r*\n" }
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/coercion1.rs
+++ b/gcc/testsuite/rust/execute/torture/coercion1.rs
@@ -1,4 +1,4 @@
-/* { dg-output "123\n123\n" } */
+/* { dg-output "123\r*\n123\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/coercion2.rs
+++ b/gcc/testsuite/rust/execute/torture/coercion2.rs
@@ -1,4 +1,4 @@
-/* { dg-output "123\n123\n" } */
+/* { dg-output "123\r*\n123\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/extern_mod4.rs
+++ b/gcc/testsuite/rust/execute/torture/extern_mod4.rs
@@ -1,5 +1,5 @@
 // { dg-additional-options "-w" }
-// { dg-output "12" }
+// { dg-output "12\r*" }
 mod modules;
 
 extern "C" {

--- a/gcc/testsuite/rust/execute/torture/helloworld1.rs
+++ b/gcc/testsuite/rust/execute/torture/helloworld1.rs
@@ -1,4 +1,4 @@
-/* { dg-output "Hello World" }*/
+/* { dg-output "Hello World\r*" }*/
 extern "C" {
     fn puts(s: *const i8);
 }

--- a/gcc/testsuite/rust/execute/torture/helloworld2.rs
+++ b/gcc/testsuite/rust/execute/torture/helloworld2.rs
@@ -1,4 +1,4 @@
-/* { dg-output "Hello World 123\n" }*/
+/* { dg-output "Hello World 123\r*\n" }*/
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/issue-1198.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-1198.rs
@@ -1,4 +1,4 @@
-/* { dg-output "foo_deref\nimm_deref\n123\n" } */
+/* { dg-output "foo_deref\r*\nimm_deref\r*\n123\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/issue-1231.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-1231.rs
@@ -1,5 +1,5 @@
 // { dg-additional-options "-w" }
-// { dg-output "outer\ninner\n" }
+// { dg-output "outer\r*\ninner\r*\n" }
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/issue-1232.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-1232.rs
@@ -1,5 +1,5 @@
 // { dg-additional-options "-w" }
-// { dg-output "slice_access=3\n" }
+// { dg-output "slice_access=3\r*\n" }
 extern "rust-intrinsic" {
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     fn offset<T>(dst: *const T, offset: isize) -> *const T;

--- a/gcc/testsuite/rust/execute/torture/issue-1249.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-1249.rs
@@ -1,5 +1,5 @@
 // { dg-options "-w" }
-// { dg-output "1\n2\n" }
+// { dg-output "1\r*\n2\r*\n" }
 
 extern "C" {
     fn printf(s: *const i8, ...);

--- a/gcc/testsuite/rust/execute/torture/issue-1436.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-1436.rs
@@ -1,5 +1,4 @@
 // { dg-options "-w" }
-// { dg-output "" }
 mod intrinsics {
     extern "rust-intrinsic" {
         #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]

--- a/gcc/testsuite/rust/execute/torture/issue-1496.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-1496.rs
@@ -1,4 +1,4 @@
-/* { dg-output "foo_deref\nimm_deref\n123\n" } */
+/* { dg-output "foo_deref\r*\nimm_deref\r*\n123\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/issue-647.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-647.rs
@@ -1,4 +1,4 @@
-/* { dg-output "Hello World 123\n" }*/
+/* { dg-output "Hello World 123\r*\n" }*/
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/issue-845.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-845.rs
@@ -1,4 +1,4 @@
-// { dg-output "Foo::bar\n" }
+// { dg-output "Foo::bar\r*\n" }
 // { dg-additional-options "-w" }
 extern "C" {
     fn printf(s: *const i8, ...);

--- a/gcc/testsuite/rust/execute/torture/issue-851.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-851.rs
@@ -1,4 +1,4 @@
-/* { dg-output "Result: 123\n" } */
+/* { dg-output "Result: 123\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/issue-858.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-858.rs
@@ -1,4 +1,4 @@
-/* { dg-output "Result: 123\n" } */
+/* { dg-output "Result: 123\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/issue-976.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-976.rs
@@ -1,4 +1,4 @@
-/* { dg-output "hi" } */
+/* { dg-output "hi\r*" } */
 fn main() -> i32 {
     {
         extern "C" {

--- a/gcc/testsuite/rust/execute/torture/loop-condition-eval.rs
+++ b/gcc/testsuite/rust/execute/torture/loop-condition-eval.rs
@@ -1,4 +1,4 @@
-// { dg-output "1\n" }
+// { dg-output "1\r*\n" }
 pub fn test() -> u64 {
     let mut n = 113383; // #20 in https://oeis.org/A006884
     while n != 1 {

--- a/gcc/testsuite/rust/execute/torture/macros10.rs
+++ b/gcc/testsuite/rust/execute/torture/macros10.rs
@@ -1,4 +1,4 @@
-// { dg-output "18\n" }
+// { dg-output "18\r*\n" }
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/macros11.rs
+++ b/gcc/testsuite/rust/execute/torture/macros11.rs
@@ -1,4 +1,4 @@
-// { dg-output "2" }
+// { dg-output "2\r*" }
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/macros12.rs
+++ b/gcc/testsuite/rust/execute/torture/macros12.rs
@@ -1,4 +1,4 @@
-// { dg-output "0\n" }
+// { dg-output "0\r*\n" }
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/macros13.rs
+++ b/gcc/testsuite/rust/execute/torture/macros13.rs
@@ -1,4 +1,4 @@
-// { dg-output "18\n" }
+// { dg-output "18\r*\n" }
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/macros14.rs
+++ b/gcc/testsuite/rust/execute/torture/macros14.rs
@@ -1,4 +1,4 @@
-// { dg-output "15\n" }
+// { dg-output "15\r*\n" }
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/macros2.rs
+++ b/gcc/testsuite/rust/execute/torture/macros2.rs
@@ -1,4 +1,4 @@
-// { dg-output "arg\narg\narg\n" }
+// { dg-output "arg\r*\narg\r*\narg\r*\n" }
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/macros22.rs
+++ b/gcc/testsuite/rust/execute/torture/macros22.rs
@@ -1,4 +1,4 @@
-// { dg-output "1\n2\nNaN\n3\n" }
+// { dg-output "1\r*\n2\r*\nNaN\r*\n3\r*\n" }
 
 macro_rules! print_num {
     ($l:literal) => {{

--- a/gcc/testsuite/rust/execute/torture/macros29.rs
+++ b/gcc/testsuite/rust/execute/torture/macros29.rs
@@ -1,4 +1,4 @@
-// { dg-output "1\n" }
+// { dg-output "1\r*\n" }
 #[rustc_builtin_macro]
 macro_rules! concat {
     () => {{}};

--- a/gcc/testsuite/rust/execute/torture/macros3.rs
+++ b/gcc/testsuite/rust/execute/torture/macros3.rs
@@ -1,4 +1,4 @@
-// { dg-output "invok\ninvok\ninvok\ninvok\ninvok\n" }
+// { dg-output "invok\r*\ninvok\r*\ninvok\r*\ninvok\r*\ninvok\r*\n" }
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/macros30.rs
+++ b/gcc/testsuite/rust/execute/torture/macros30.rs
@@ -1,4 +1,4 @@
-// { dg-output "1\n" }
+// { dg-output "1\r*\n" }
 #[rustc_builtin_macro]
 macro_rules! concat {
     () => {{}};

--- a/gcc/testsuite/rust/execute/torture/macros31.rs
+++ b/gcc/testsuite/rust/execute/torture/macros31.rs
@@ -1,5 +1,5 @@
 // { dg-additional-options "-w -frust-cfg=A" }
-// { dg-output "A\nB\n" }
+// { dg-output "A\r*\nB\r*\n" }
 #[rustc_builtin_macro]
 macro_rules! cfg {
     () => {{}};

--- a/gcc/testsuite/rust/execute/torture/macros7.rs
+++ b/gcc/testsuite/rust/execute/torture/macros7.rs
@@ -1,4 +1,4 @@
-// { dg-output "any\nany\nany\n" }
+// { dg-output "any\r*\nany\r*\nany\r*\n" }
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/macros8.rs
+++ b/gcc/testsuite/rust/execute/torture/macros8.rs
@@ -1,4 +1,4 @@
-// { dg-output "zo1\nzo1\n" }
+// { dg-output "zo1\r*\nzo1\r*\n" }
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/macros9.rs
+++ b/gcc/testsuite/rust/execute/torture/macros9.rs
@@ -1,4 +1,4 @@
-// { dg-output "oom\noom\noom\n" }
+// { dg-output "oom\r*\noom\r*\noom\r*\n" }
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/match1.rs
+++ b/gcc/testsuite/rust/execute/torture/match1.rs
@@ -1,4 +1,4 @@
-// { dg-output "Foo::A\nFoo::B\nFoo::C x\nFoo::D 20 80\n" }
+// { dg-output "Foo::A\r*\nFoo::B\r*\nFoo::C x\r*\nFoo::D 20 80\r*\n" }
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/match2.rs
+++ b/gcc/testsuite/rust/execute/torture/match2.rs
@@ -1,4 +1,4 @@
-// { dg-output "123\n80\n" }
+// { dg-output "123\r*\n80\r*\n" }
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/match3.rs
+++ b/gcc/testsuite/rust/execute/torture/match3.rs
@@ -1,4 +1,4 @@
-// { dg-output "Foo::A\nwildcard\nwildcard\nFoo::D 20 80\n" }
+// { dg-output "Foo::A\r*\nwildcard\r*\nwildcard\r*\nFoo::D 20 80\r*\n" }
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/match_bool1.rs
+++ b/gcc/testsuite/rust/execute/torture/match_bool1.rs
@@ -1,4 +1,4 @@
-// { dg-output "182 is more than 100\n55 is less than 100\n" }
+// { dg-output "182 is more than 100\r*\n55 is less than 100\r*\n" }
 
 extern "C" {
     fn printf(s: *const i8, ...);

--- a/gcc/testsuite/rust/execute/torture/match_byte1.rs
+++ b/gcc/testsuite/rust/execute/torture/match_byte1.rs
@@ -1,4 +1,4 @@
-// { dg-output "a\nseven\nquote\nelse" }
+// { dg-output "a\r*\nseven\r*\nquote\r*\nelse" }
 
 extern "C" {
     fn printf(s: *const i8, ...);

--- a/gcc/testsuite/rust/execute/torture/match_char1.rs
+++ b/gcc/testsuite/rust/execute/torture/match_char1.rs
@@ -1,4 +1,4 @@
-// { dg-output "amazing\nwildcard\ncompiler\nproductivity\n" }
+// { dg-output "amazing\r*\nwildcard\r*\ncompiler\r*\nproductivity\r*\n" }
 
 extern "C" {
     fn printf(s: *const i8, ...);

--- a/gcc/testsuite/rust/execute/torture/match_int1.rs
+++ b/gcc/testsuite/rust/execute/torture/match_int1.rs
@@ -1,4 +1,4 @@
-// { dg-output "other!\nother!\nother!\nfifteen!\nfifteen!\nother!\nother!\nfifteen!\n" }
+// { dg-output "other!\r*\nother!\r*\nother!\r*\nfifteen!\r*\nfifteen!\r*\nother!\r*\nother!\r*\nfifteen!\r*\n" }
 
 extern "C" {
     fn printf(s: *const i8, ...);

--- a/gcc/testsuite/rust/execute/torture/match_loop1.rs
+++ b/gcc/testsuite/rust/execute/torture/match_loop1.rs
@@ -1,4 +1,4 @@
-// { dg-output "E::One\nE::Two\nbreak!\n" }
+// { dg-output "E::One\r*\nE::Two\r*\nbreak!\r*\n" }
 
 extern "C" {
     fn printf(s: *const i8, ...);

--- a/gcc/testsuite/rust/execute/torture/match_range1.rs
+++ b/gcc/testsuite/rust/execute/torture/match_range1.rs
@@ -1,4 +1,4 @@
-// { dg-output "zero to END_RANGE\nzero to END_RANGE\nelse\n" }
+// { dg-output "zero to END_RANGE\r*\nzero to END_RANGE\r*\nelse\r*\n" }
 
 extern "C" {
     fn printf(s: *const i8, ...);

--- a/gcc/testsuite/rust/execute/torture/match_range2.rs
+++ b/gcc/testsuite/rust/execute/torture/match_range2.rs
@@ -1,4 +1,4 @@
-// { dg-output "lowercase\nuppercase\nother\n" }
+// { dg-output "lowercase\r*\nuppercase\r*\nother\r*\n" }
 
 extern "C" {
     fn printf(s: *const i8, ...);

--- a/gcc/testsuite/rust/execute/torture/match_tuple1.rs
+++ b/gcc/testsuite/rust/execute/torture/match_tuple1.rs
@@ -1,4 +1,4 @@
-// { dg-output "x:15\ny:20\n" }
+// { dg-output "x:15\r*\ny:20\r*\n" }
 
 extern "C" {
     fn printf(s: *const i8, ...);

--- a/gcc/testsuite/rust/execute/torture/method1.rs
+++ b/gcc/testsuite/rust/execute/torture/method1.rs
@@ -1,4 +1,4 @@
-/* { dg-output "124\n458" } */
+/* { dg-output "124\r*\n458" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/method2.rs
+++ b/gcc/testsuite/rust/execute/torture/method2.rs
@@ -1,5 +1,5 @@
 // { dg-additional-options "-w" }
-// { dg-output "foo_deref\nimm_deref\n" }
+// { dg-output "foo_deref\r*\nimm_deref\r*\n" }
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/method3.rs
+++ b/gcc/testsuite/rust/execute/torture/method3.rs
@@ -1,5 +1,5 @@
 // { dg-additional-options "-w" }
-// { dg-output "mut_deref\nfoobar: 123\n" }
+// { dg-output "mut_deref\r*\nfoobar: 123\r*\n" }
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/method4.rs
+++ b/gcc/testsuite/rust/execute/torture/method4.rs
@@ -1,5 +1,5 @@
 // { dg-additional-options "-w" }
-// { dg-output "mut_deref\nfoobar: 123\n" }
+// { dg-output "mut_deref\r*\nfoobar: 123\r*\n" }
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/operator_overload_1.rs
+++ b/gcc/testsuite/rust/execute/torture/operator_overload_1.rs
@@ -1,4 +1,4 @@
-/* { dg-output "3\n" } */
+/* { dg-output "3\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/operator_overload_10.rs
+++ b/gcc/testsuite/rust/execute/torture/operator_overload_10.rs
@@ -1,4 +1,4 @@
-/* { dg-output "foo_deref\n123\n" } */
+/* { dg-output "foo_deref\r*\n123\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/operator_overload_11.rs
+++ b/gcc/testsuite/rust/execute/torture/operator_overload_11.rs
@@ -1,4 +1,4 @@
-// { dg-output "1\n" }
+// { dg-output "1\r*\n" }
 // { dg-additional-options "-w" }
 extern "C" {
     fn printf(s: *const i8, ...);

--- a/gcc/testsuite/rust/execute/torture/operator_overload_12.rs
+++ b/gcc/testsuite/rust/execute/torture/operator_overload_12.rs
@@ -1,4 +1,4 @@
-// { dg-output "1\n" }
+// { dg-output "1\r*\n" }
 // { dg-additional-options "-w" }
 extern "C" {
     fn printf(s: *const i8, ...);

--- a/gcc/testsuite/rust/execute/torture/operator_overload_2.rs
+++ b/gcc/testsuite/rust/execute/torture/operator_overload_2.rs
@@ -1,4 +1,4 @@
-/* { dg-output "3\n" } */
+/* { dg-output "3\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/operator_overload_3.rs
+++ b/gcc/testsuite/rust/execute/torture/operator_overload_3.rs
@@ -1,4 +1,4 @@
-/* { dg-output "3\n3\n" } */
+/* { dg-output "3\r*\n3\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/operator_overload_4.rs
+++ b/gcc/testsuite/rust/execute/torture/operator_overload_4.rs
@@ -1,4 +1,4 @@
-/* { dg-output "neg\n" } */
+/* { dg-output "neg\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/operator_overload_5.rs
+++ b/gcc/testsuite/rust/execute/torture/operator_overload_5.rs
@@ -1,4 +1,4 @@
-/* { dg-output "not\n" } */
+/* { dg-output "not\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/operator_overload_6.rs
+++ b/gcc/testsuite/rust/execute/torture/operator_overload_6.rs
@@ -1,4 +1,4 @@
-/* { dg-output "add_assign\n3\n" } */
+/* { dg-output "add_assign\r*\n3\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/operator_overload_7.rs
+++ b/gcc/testsuite/rust/execute/torture/operator_overload_7.rs
@@ -1,4 +1,4 @@
-/* { dg-output "imm_deref\n123\n" } */
+/* { dg-output "imm_deref\r*\n123\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/operator_overload_8.rs
+++ b/gcc/testsuite/rust/execute/torture/operator_overload_8.rs
@@ -1,4 +1,4 @@
-/* { dg-output "imm_deref\n123\n" } */
+/* { dg-output "imm_deref\r*\n123\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/operator_overload_9.rs
+++ b/gcc/testsuite/rust/execute/torture/operator_overload_9.rs
@@ -1,4 +1,4 @@
-/* { dg-output "mut_deref\n123\n" } */
+/* { dg-output "mut_deref\r*\n123\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/str-layout1.rs
+++ b/gcc/testsuite/rust/execute/torture/str-layout1.rs
@@ -1,5 +1,5 @@
 // { dg-additional-options "-w" }
-// { dg-output "t1sz=5 t2sz=10" }
+// { dg-output "t1sz=5 t2sz=10\r*" }
 mod mem {
     extern "rust-intrinsic" {
         #[rustc_const_stable(feature = "const_transmute", since = "1.46.0")]

--- a/gcc/testsuite/rust/execute/torture/str-zero.rs
+++ b/gcc/testsuite/rust/execute/torture/str-zero.rs
@@ -1,26 +1,23 @@
-/* { dg-output "bar foo baz foobar\n" } */
-extern "C"
-{
-  fn printf(s: *const i8, ...);
-  fn memchr(s: *const i8, c: u8, n: usize) -> *const i8;
+/* { dg-output "bar foo baz foobar\r*\n" } */
+extern "C" {
+    fn printf(s: *const i8, ...);
+    fn memchr(s: *const i8, c: u8, n: usize) -> *const i8;
 }
 
-pub fn main () -> i32
-{
-  let f = "%s %s %s %s\n\0";
-  let s = "bar\0\
+pub fn main() -> i32 {
+    let f = "%s %s %s %s\n\0";
+    let s = "bar\0\
            foo\
            \x00\
            baz\u{0000}\
            foobar\0";
-  let cf = f as *const str as *const i8;
-  let cs = s as *const str as *const i8;
-  unsafe
-    {
-      let cs2 = memchr (cs, b'f', 5);
-      let cs3 = memchr (cs2, b'b', 5);
-      let cs4 = memchr (cs3, b'f', 5);
-      printf (cf, cs, cs2, cs3, cs4);
+    let cf = f as *const str as *const i8;
+    let cs = s as *const str as *const i8;
+    unsafe {
+        let cs2 = memchr(cs, b'f', 5);
+        let cs3 = memchr(cs2, b'b', 5);
+        let cs4 = memchr(cs3, b'f', 5);
+        printf(cf, cs, cs2, cs3, cs4);
     }
-  0
+    0
 }

--- a/gcc/testsuite/rust/execute/torture/trait1.rs
+++ b/gcc/testsuite/rust/execute/torture/trait1.rs
@@ -1,4 +1,4 @@
-/* { dg-output "S::f\nT1::f\nT2::f\n" } */
+/* { dg-output "S::f\r*\nT1::f\r*\nT2::f\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/trait10.rs
+++ b/gcc/testsuite/rust/execute/torture/trait10.rs
@@ -1,4 +1,4 @@
-/* { dg-output "123\n" } */
+/* { dg-output "123\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/trait11.rs
+++ b/gcc/testsuite/rust/execute/torture/trait11.rs
@@ -1,4 +1,4 @@
-/* { dg-output "3\n" } */
+/* { dg-output "3\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/trait12.rs
+++ b/gcc/testsuite/rust/execute/torture/trait12.rs
@@ -1,4 +1,4 @@
-/* { dg-output "3\n" } */
+/* { dg-output "3\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/trait13.rs
+++ b/gcc/testsuite/rust/execute/torture/trait13.rs
@@ -1,4 +1,4 @@
-/* { dg-output "123\n456\n" } */
+/* { dg-output "123\r*\n456\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/trait2.rs
+++ b/gcc/testsuite/rust/execute/torture/trait2.rs
@@ -1,4 +1,4 @@
-/* { dg-output "Bar::A = 456\n<Foo as Bar>::A = 456\n" } */
+/* { dg-output "Bar::A = 456\r*\n<Foo as Bar>::A = 456\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/trait3.rs
+++ b/gcc/testsuite/rust/execute/torture/trait3.rs
@@ -1,4 +1,4 @@
-/* { dg-output "123, 777" } */
+/* { dg-output "123, 777\r*" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/trait4.rs
+++ b/gcc/testsuite/rust/execute/torture/trait4.rs
@@ -1,4 +1,4 @@
-/* { dg-output "123\n" }*/
+/* { dg-output "123\r*\n" }*/
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/trait5.rs
+++ b/gcc/testsuite/rust/execute/torture/trait5.rs
@@ -1,4 +1,4 @@
-/* { dg-output "123\n123\n" } */
+/* { dg-output "123\r*\n123\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/trait6.rs
+++ b/gcc/testsuite/rust/execute/torture/trait6.rs
@@ -1,4 +1,4 @@
-/* { dg-output "123\n" } */
+/* { dg-output "123\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/trait7.rs
+++ b/gcc/testsuite/rust/execute/torture/trait7.rs
@@ -1,4 +1,4 @@
-/* { dg-output "123\n" } */
+/* { dg-output "123\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/trait8.rs
+++ b/gcc/testsuite/rust/execute/torture/trait8.rs
@@ -1,4 +1,4 @@
-/* { dg-output "123\n" } */
+/* { dg-output "123\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/trait9.rs
+++ b/gcc/testsuite/rust/execute/torture/trait9.rs
@@ -1,4 +1,4 @@
-/* { dg-output "3\n" } */
+/* { dg-output "3\r*\n" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }


### PR DESCRIPTION
In dg-output, check for \r* carriage returns to make sure execution tests pass on windows platforms

gcc/testsuite/ChangeLog:

	* rust/execute/torture/builtin_macro_cfg.rs: Handle carriage returns properly
	* rust/execute/torture/builtin_macro_concat.rs: Handle carriage returns properly
	* rust/execute/torture/builtin_macro_env.rs: Handle carriage returns properly
	* rust/execute/torture/builtin_macro_include_bytes.rs: Handle carriage returns properly
	* rust/execute/torture/builtin_macro_include_str.rs: Handle carriage returns properly
	* rust/execute/torture/builtin_macro_line.rs: Handle carriage returns properly
	* rust/execute/torture/builtin_macros1.rs: Handle carriage returns properly
	* rust/execute/torture/builtin_macros3.rs: Handle carriage returns properly
	* rust/execute/torture/cfg1.rs: Handle carriage returns properly
	* rust/execute/torture/cfg2.rs: Handle carriage returns properly
	* rust/execute/torture/cfg3.rs: Handle carriage returns properly
	* rust/execute/torture/cfg4.rs: Handle carriage returns properly
	* rust/execute/torture/coercion1.rs: Handle carriage returns properly
	* rust/execute/torture/coercion2.rs: Handle carriage returns properly
	* rust/execute/torture/extern_mod4.rs: Handle carriage returns properly
	* rust/execute/torture/helloworld1.rs: Handle carriage returns properly
	* rust/execute/torture/helloworld2.rs: Handle carriage returns properly
	* rust/execute/torture/issue-1198.rs: Handle carriage returns properly
	* rust/execute/torture/issue-1231.rs: Handle carriage returns properly
	* rust/execute/torture/issue-1232.rs: Handle carriage returns properly
	* rust/execute/torture/issue-1249.rs: Handle carriage returns properly
	* rust/execute/torture/issue-1436.rs: Handle carriage returns properly
	* rust/execute/torture/issue-1496.rs: Handle carriage returns properly
	* rust/execute/torture/issue-647.rs: Handle carriage returns properly
	* rust/execute/torture/issue-845.rs: Handle carriage returns properly
	* rust/execute/torture/issue-851.rs: Handle carriage returns properly
	* rust/execute/torture/issue-858.rs: Handle carriage returns properly
	* rust/execute/torture/issue-976.rs: Handle carriage returns properly
	* rust/execute/torture/macros10.rs: Handle carriage returns properly
	* rust/execute/torture/macros11.rs: Handle carriage returns properly
	* rust/execute/torture/macros12.rs: Handle carriage returns properly
	* rust/execute/torture/macros13.rs: Handle carriage returns properly
	* rust/execute/torture/macros14.rs: Handle carriage returns properly
	* rust/execute/torture/macros2.rs: Handle carriage returns properly
	* rust/execute/torture/macros22.rs: Handle carriage returns properly
	* rust/execute/torture/macros29.rs: Handle carriage returns properly
	* rust/execute/torture/macros3.rs: Handle carriage returns properly
	* rust/execute/torture/macros30.rs: Handle carriage returns properly
	* rust/execute/torture/macros31.rs: Handle carriage returns properly
	* rust/execute/torture/macros7.rs: Handle carriage returns properly
	* rust/execute/torture/macros8.rs: Handle carriage returns properly
	* rust/execute/torture/macros9.rs: Handle carriage returns properly
	* rust/execute/torture/match1.rs: Handle carriage returns properly
	* rust/execute/torture/match2.rs: Handle carriage returns properly
	* rust/execute/torture/match3.rs: Handle carriage returns properly
	* rust/execute/torture/match_bool1.rs: Handle carriage returns properly
	* rust/execute/torture/match_byte1.rs: Handle carriage returns properly
	* rust/execute/torture/match_char1.rs: Handle carriage returns properly
	* rust/execute/torture/match_int1.rs: Handle carriage returns properly
	* rust/execute/torture/match_loop1.rs: Handle carriage returns properly
	* rust/execute/torture/match_range1.rs: Handle carriage returns properly
	* rust/execute/torture/match_range2.rs: Handle carriage returns properly
	* rust/execute/torture/match_tuple1.rs: Handle carriage returns properly
	* rust/execute/torture/method1.rs: Handle carriage returns properly
	* rust/execute/torture/method2.rs: Handle carriage returns properly
	* rust/execute/torture/method3.rs: Handle carriage returns properly
	* rust/execute/torture/method4.rs: Handle carriage returns properly
	* rust/execute/torture/operator_overload_1.rs: Handle carriage returns properly
	* rust/execute/torture/operator_overload_10.rs: Handle carriage returns properly
	* rust/execute/torture/operator_overload_11.rs: Handle carriage returns properly
	* rust/execute/torture/operator_overload_12.rs: Handle carriage returns properly
	* rust/execute/torture/operator_overload_2.rs: Handle carriage returns properly
	* rust/execute/torture/operator_overload_4.rs: Handle carriage returns properly
	* rust/execute/torture/operator_overload_5.rs: Handle carriage returns properly
	* rust/execute/torture/operator_overload_6.rs: Handle carriage returns properly
	* rust/execute/torture/operator_overload_7.rs: Handle carriage returns properly
	* rust/execute/torture/operator_overload_8.rs: Handle carriage returns properly
	* rust/execute/torture/operator_overload_9.rs: Handle carriage returns properly
	* rust/execute/torture/str-layout1.rs: Handle carriage returns properly
	* rust/execute/torture/str-zero.rs: Handle carriage returns properly
	* rust/execute/torture/trait1.rs: Handle carriage returns properly
	* rust/execute/torture/trait10.rs: Handle carriage returns properly
	* rust/execute/torture/trait11.rs: Handle carriage returns properly
	* rust/execute/torture/trait12.rs: Handle carriage returns properly
	* rust/execute/torture/trait13.rs: Handle carriage returns properly
	* rust/execute/torture/trait2.rs: Handle carriage returns properly
	* rust/execute/torture/trait3.rs: Handle carriage returns properly
	* rust/execute/torture/trait4.rs: Handle carriage returns properly
	* rust/execute/torture/trait5.rs: Handle carriage returns properly
	* rust/execute/torture/trait6.rs: Handle carriage returns properly
	* rust/execute/torture/trait7.rs: Handle carriage returns properly
	* rust/execute/torture/trait8.rs: Handle carriage returns properly
	* rust/execute/torture/trait9.rs: Handle carriage returns properly