### PR TITLE
Add get_locus function for abstract class MetaItemInner.

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -630,6 +630,8 @@ public:
 
   virtual ~MetaItemInner ();
 
+  virtual Location get_locus () const = 0;
+
   virtual std::string as_string () const = 0;
 
   virtual void accept_vis (ASTVisitor &vis) = 0;

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -150,6 +150,8 @@ public:
 
   std::string as_string () const override { return lit_expr.as_string (); }
 
+  Location get_locus () const override { return lit_expr.get_locus (); }
+
   void accept_vis (ASTVisitor &vis) override;
 
   bool check_cfg_predicate (const Session &session) const override;
@@ -177,6 +179,12 @@ public:
   {
     return path.as_string () + " = " + lit.as_string ();
   }
+
+  // There are two Locations in MetaItemPathLit (path and lit_expr),
+  //  we have no idea use which of them, just simply return UNKNOWN_LOCATION
+  //  now.
+  // Maybe we will figure out when we really need the location in the future.
+  Location get_locus () const override { return Location (UNKNOWN_LOCATION); }
 
   void accept_vis (ASTVisitor &vis) override;
 

--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -725,6 +725,8 @@ public:
     return path;
   }
 
+  Location get_locus () const override { return path.get_locus (); }
+
   bool check_cfg_predicate (const Session &session) const override;
 
   Attribute to_attribute () const override;
@@ -778,6 +780,8 @@ public:
 
   void accept_vis (ASTVisitor &vis) override;
 
+  Location get_locus () const override { return path.get_locus (); }
+
   bool check_cfg_predicate (const Session &session) const override;
 
   Attribute to_attribute () const override;
@@ -804,6 +808,8 @@ public:
   std::string as_string () const override { return ident; }
 
   void accept_vis (ASTVisitor &vis) override;
+
+  Location get_locus () const override { return ident_locus; }
 
   bool check_cfg_predicate (const Session &session) const override;
 
@@ -847,6 +853,8 @@ public:
     return std::unique_ptr<MetaNameValueStr> (clone_meta_item_inner_impl ());
   }
 
+  Location get_locus () const override { return ident_locus; }
+
   bool check_cfg_predicate (const Session &session) const override;
 
   Attribute to_attribute () const override;
@@ -885,6 +893,8 @@ public:
 
   void accept_vis (ASTVisitor &vis) override;
 
+  Location get_locus () const override { return ident_locus; }
+
   bool check_cfg_predicate (const Session &session) const override;
 
   Attribute to_attribute () const override;
@@ -918,6 +928,8 @@ public:
   std::string as_string () const override;
 
   void accept_vis (ASTVisitor &vis) override;
+
+  Location get_locus () const override { return ident_locus; }
 
   bool check_cfg_predicate (const Session &session) const override;
 


### PR DESCRIPTION
This commit adds virtual function get_locus to base class MetaItemInner, which is helpful when we need to print  diagnostics on some sub-classes of MetaItemInner.

This commit is split from pr https://github.com/Rust-GCC/gccrs/pull/1718.

Signed-off-by: Xiao Ma <mxlol233@outlook.com>


