### PR TITLE
Change how CompileVarDecl outputs Bvariable's

### DIFF
--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -457,9 +457,7 @@ HIRCompileBase::compile_locals_for_block (Context *ctx, Resolver::Rib &rib,
 
       // compile the local
       tree type = TyTyResolveCompile::compile (ctx, tyty);
-      Bvariable *compiled
-	= CompileVarDecl::compile (fndecl, type, pattern, ctx);
-      locals.push_back (compiled);
+      CompileVarDecl::compile (fndecl, type, pattern, locals, ctx);
     }
   return locals;
 }

--- a/gcc/rust/backend/rust-compile-var-decl.h
+++ b/gcc/rust/backend/rust-compile-var-decl.h
@@ -30,12 +30,11 @@ class CompileVarDecl : public HIRCompileBase, public HIR::HIRPatternVisitor
   using HIR::HIRPatternVisitor::visit;
 
 public:
-  static ::Bvariable *compile (tree fndecl, tree translated_type,
-			       HIR::Pattern *pattern, Context *ctx)
+  static void compile (tree fndecl, tree translated_type, HIR::Pattern *pattern,
+		       std::vector<Bvariable *> &locals, Context *ctx)
   {
-    CompileVarDecl compiler (ctx, fndecl, translated_type);
+    CompileVarDecl compiler (ctx, fndecl, translated_type, locals);
     pattern->accept_vis (compiler);
-    return compiler.compiled_variable;
   }
 
   void visit (HIR::IdentifierPattern &pattern) override
@@ -43,26 +42,30 @@ public:
     if (!pattern.is_mut ())
       translated_type = ctx->get_backend ()->immutable_type (translated_type);
 
-    compiled_variable
+    Bvariable *var
       = ctx->get_backend ()->local_variable (fndecl, pattern.get_identifier (),
 					     translated_type, NULL /*decl_var*/,
 					     pattern.get_locus ());
 
     HirId stmt_id = pattern.get_pattern_mappings ().get_hirid ();
-    ctx->insert_var_decl (stmt_id, compiled_variable);
+    ctx->insert_var_decl (stmt_id, var);
+
+    locals.push_back (var);
   }
 
   void visit (HIR::WildcardPattern &pattern) override
   {
     translated_type = ctx->get_backend ()->immutable_type (translated_type);
 
-    compiled_variable
+    Bvariable *var
       = ctx->get_backend ()->local_variable (fndecl, "_", translated_type,
 					     NULL /*decl_var*/,
 					     pattern.get_locus ());
 
     HirId stmt_id = pattern.get_pattern_mappings ().get_hirid ();
-    ctx->insert_var_decl (stmt_id, compiled_variable);
+    ctx->insert_var_decl (stmt_id, var);
+
+    locals.push_back (var);
   }
 
   // Empty visit for unused Pattern HIR nodes.
@@ -78,15 +81,16 @@ public:
   void visit (HIR::TupleStructPattern &) override {}
 
 private:
-  CompileVarDecl (Context *ctx, tree fndecl, tree translated_type)
+  CompileVarDecl (Context *ctx, tree fndecl, tree translated_type,
+		  std::vector<Bvariable *> &locals)
     : HIRCompileBase (ctx), fndecl (fndecl), translated_type (translated_type),
-      compiled_variable (ctx->get_backend ()->error_variable ())
+      locals (locals)
   {}
 
   tree fndecl;
   tree translated_type;
 
-  Bvariable *compiled_variable;
+  std::vector<Bvariable *> &locals;
 };
 
 } // namespace Compile


### PR DESCRIPTION
This allows patterns to declare multiple/no variables

Signed-off-by: Owen Avery <powerboat9.gamer@gmail.com>
---