### PR TITLE
Add CL checking automation to gcc-patch-dev

### DIFF
--- a/.github/workflows/commit-format.yml
+++ b/.github/workflows/commit-format.yml
@@ -1,0 +1,43 @@
+name: GNU Commit Format Checker
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  check_commit_formats:
+    runs-on: ubuntu-latest
+    name: Commits Check
+    
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Install Deps
+        run: |
+          sudo apt-get update;
+          sudo apt-get install -y \
+            python3 \
+            python3-git
+      
+      - name: Get PR Commits
+        run: |
+          git rev-list \
+              origin/master..${{ github.event.pull_request.head.sha }} \
+              > commits.txt
+
+      - name: Check commits
+        run: |
+          for i in `cat commits.txt`; do \
+              echo "Checking commit $i" \
+              python3 contrib/gcc-changelog/git_check_commit.py \
+                  | tee results.log ; \
+          done; \
+          if grep -e "ERR:" -e "FAILED" results.log; \
+          then \
+              echo "::error commit's are not formatted correctly"; \
+              exit 1; \
+          fi

--- a/.github/workflows/commit-format.yml
+++ b/.github/workflows/commit-format.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - gcc-patch-dev
 
 jobs:
   check_commit_formats:
@@ -23,21 +24,21 @@ jobs:
             python3 \
             python3-git
       
-      - name: Get PR Commits
+      - name: GCC check PR Commits
         run: |
-          git rev-list \
-              origin/master..${{ github.event.pull_request.head.sha }} \
-              > commits.txt
-
-      - name: Check commits
-        run: |
-          for i in `cat commits.txt`; do \
-              echo "Checking commit $i" \
-              python3 contrib/gcc-changelog/git_check_commit.py \
-                  | tee results.log ; \
-          done; \
-          if grep -e "ERR:" -e "FAILED" results.log; \
-          then \
-              echo "::error commit's are not formatted correctly"; \
-              exit 1; \
+          retval=0
+          if ! python3 contrib/gcc-changelog/git_check_commit.py origin/${{ github.event.pull_request.base.ref }}..${{ github.event.pull_request.head.sha }}; then
+            retval=1
           fi
+          for commit in $(git rev-list origin/${{ github.event.pull_request.base.ref }}..${{ github.event.pull_request.head.sha }});
+          do
+            echo -n "Checking gccrs prefix for $commit: "
+            if [[ $(git log -1 --format="%s" $commit) = gccrs:* ]]; then
+              echo "OK"
+            else
+              retval=1
+              echo "KO"
+            fi
+          done
+          exit $retval
+     


### PR DESCRIPTION
@philberty what do you think of this? The commits are intentionally "wrong" so that the CI fails and shows the output. Let me know if you think it's good.

I looked into having the action post a comment on the PR but it's more annoying than I thought to do it directly in the github action and still have nice formatting or posting files and a message at once, etc... and I think having an actual bot could be nicer for this.