### PR TITLE
Support GroupedPattern during name resolution

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-pattern.h
+++ b/gcc/rust/resolve/rust-ast-resolve-pattern.h
@@ -77,6 +77,11 @@ public:
       pattern.get_node_id (), pattern.get_locus (), type);
   }
 
+  void visit (AST::GroupedPattern &pattern) override
+  {
+    pattern.get_pattern_in_parens ()->accept_vis (*this);
+  }
+
   // cases in a match expression
   void visit (AST::PathInExpression &pattern) override;
 


### PR DESCRIPTION
Signed-off-by: Owen Avery <powerboat9.gamer@gmail.com>

Adds support for GroupedPattern during name resolution.

Addresses #1136 