### PR TITLE
[CL] first-half-update Changelogs for 24e9bd93f7..b3fcf322af96b766fed010256ea4302fa4168f7c

### DIFF
--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -109,6 +109,22 @@ Dump::emit_attrib (const Attribute &attrib)
 }
 
 void
+Dump::emit_generic_params (std::vector<std::unique_ptr<GenericParam>> &params)
+{
+  stream << "<";
+  for (size_t i = 0; i < params.size (); i++)
+    {
+      auto &param = params.at (i);
+      param->accept_vis (*this);
+
+      bool has_next = (i + 1) < params.size ();
+      if (has_next)
+	stream << ", ";
+    }
+  stream << ">";
+}
+
+void
 Dump::visit (Token &tok)
 {}
 
@@ -555,19 +571,7 @@ Dump::visit (Function &function)
   stream << "fn " << function.get_function_name ();
 
   if (function.has_generics ())
-    {
-      stream << "<";
-      for (size_t i = 0; i < function.get_generic_params ().size (); i++)
-	{
-	  auto &param = function.get_generic_params ().at (i);
-	  param->accept_vis (*this);
-
-	  bool has_next = (i + 1) < function.get_generic_params ().size ();
-	  if (has_next)
-	    stream << ", ";
-	}
-      stream << ">";
-    }
+    emit_generic_params (function.get_generic_params ());
 
   stream << '(';
   auto &params = function.get_function_params ();

--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -626,35 +626,154 @@ Dump::visit (TypeAlias &type_alias)
 
 void
 Dump::visit (StructStruct &struct_item)
-{}
+{
+  stream << "struct " << struct_item.get_identifier ();
+  if (struct_item.has_generics ())
+    emit_generic_params (struct_item.get_generic_params ());
+
+  // FIXME: where-clause
+
+  stream << " {";
+
+  auto &fields = struct_item.get_fields ();
+
+  indentation.increment ();
+  for (auto &field : fields)
+    {
+      stream << '\n' << indentation;
+      format_struct_field (field);
+      stream << ',';
+    }
+  indentation.decrement ();
+
+  if (fields.size () > 0)
+    stream << '\n' << indentation;
+  stream << "}\n";
+}
 
 void
 Dump::visit (TupleStruct &tuple_struct)
-{}
+{
+  stream << "struct " << tuple_struct.get_identifier ();
+  if (tuple_struct.has_generics ())
+    emit_generic_params (tuple_struct.get_generic_params ());
+
+  // FIXME: where-clause
+
+  stream << '(';
+
+  auto &fields = tuple_struct.get_fields ();
+  if (fields.size () >= 1)
+    {
+      format_tuple_field (fields[0]);
+      for (size_t i = 1; i < fields.size (); i++)
+	{
+	  stream << ", ";
+	  format_tuple_field (fields[i]);
+	}
+    }
+  stream << ");\n";
+}
 
 void
 Dump::visit (EnumItem &item)
-{}
+{
+  stream << item.get_identifier ();
+}
 
 void
 Dump::visit (EnumItemTuple &item)
-{}
+{
+  stream << item.get_identifier () << '(';
+  auto &fields = item.get_tuple_fields ();
+  if (fields.size () >= 1)
+    {
+      format_tuple_field (fields[0]);
+      for (size_t i = 1; i < fields.size (); i++)
+	{
+	  stream << ", ";
+	  format_tuple_field (fields[i]);
+	}
+    }
+  stream << ')';
+}
 
 void
 Dump::visit (EnumItemStruct &item)
-{}
+{
+  stream << item.get_identifier () << " {";
+
+  auto &fields = item.get_struct_fields ();
+
+  indentation.increment ();
+  for (auto &field : fields)
+    {
+      stream << '\n' << indentation;
+      format_struct_field (field);
+      stream << ',';
+    }
+  indentation.decrement ();
+
+  if (fields.size () > 0)
+    stream << '\n' << indentation;
+  stream << '}';
+}
 
 void
 Dump::visit (EnumItemDiscriminant &item)
-{}
+{
+  stream << item.get_identifier () << " = ";
+  item.get_expr ()->accept_vis (*this);
+}
 
 void
 Dump::visit (Enum &enum_item)
-{}
+{
+  stream << "enum " << enum_item.get_identifier ();
+  if (enum_item.has_generics ())
+    emit_generic_params (enum_item.get_generic_params ());
+
+  // FIXME: where-clause
+
+  stream << " {";
+  auto &variants = enum_item.get_variants ();
+  if (variants.size () >= 1)
+    {
+      stream << '\n';
+      indentation.increment ();
+      for (auto &var : variants)
+	{
+	  stream << indentation;
+	  var->accept_vis (*this);
+	  stream << ",\n";
+	}
+      indentation.decrement ();
+    }
+
+  stream << "}\n";
+}
 
 void
 Dump::visit (Union &union_item)
-{}
+{
+  stream << "union " << union_item.get_identifier ();
+  if (union_item.has_generics ())
+    emit_generic_params (union_item.get_generic_params ());
+
+  // FIXME: where-clause
+
+  stream << " {";
+  indentation.increment ();
+  for (auto &field : union_item.get_variants ())
+    {
+      stream << '\n' << indentation;
+      format_struct_field (field);
+      stream << ',';
+    }
+  indentation.decrement ();
+
+  stream << '\n' << indentation << "}\n";
+}
 
 void
 Dump::visit (ConstantItem &const_item)

--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -125,6 +125,23 @@ Dump::emit_generic_params (std::vector<std::unique_ptr<GenericParam>> &params)
 }
 
 void
+Dump::format_tuple_field (TupleField &field)
+{
+  // TODO: do we need to emit outer attrs here?
+  emit_visibility (field.get_visibility ());
+  field.get_field_type ()->accept_vis (*this);
+}
+
+void
+Dump::format_struct_field (StructField &field)
+{
+  // TODO: do we need to emit outer attrs here?
+  emit_visibility (field.get_visibility ());
+  stream << field.get_field_name () << ": ";
+  field.get_field_type ()->accept_vis (*this);
+}
+
+void
 Dump::visit (Token &tok)
 {}
 

--- a/gcc/rust/ast/rust-ast-dump.h
+++ b/gcc/rust/ast/rust-ast-dump.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2023 Free Software Foundation, Inc.
+// Copyright (C) 2020-2022 Free Software Foundation, Inc.
 
 // This file is part of GCC.
 
@@ -81,6 +81,15 @@ private:
    */
   void format_function_param (FunctionParam &param);
   void emit_attrib (const Attribute &attrib);
+
+  /**
+   * Emit an indented string with an optional extra comment
+   */
+  std::ostream &emit_indented_string (const std::string &value,
+				      const std::string &comment = "");
+
+  // Emit formatted string for generic parameters.
+  void emit_generic_params (std::vector<std::unique_ptr<GenericParam>> &params);
 
   // rust-ast.h
   void visit (Token &tok);

--- a/gcc/rust/ast/rust-ast-dump.h
+++ b/gcc/rust/ast/rust-ast-dump.h
@@ -91,6 +91,12 @@ private:
   // Emit formatted string for generic parameters.
   void emit_generic_params (std::vector<std::unique_ptr<GenericParam>> &params);
 
+  // Format a single field of a tuple.
+  void format_tuple_field (TupleField &field);
+
+  // Format a single field of a struct.
+  void format_struct_field (StructField &field);
+
   // rust-ast.h
   void visit (Token &tok);
   void visit (DelimTokenTree &delim_tok_tree);

--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -1982,7 +1982,7 @@ CompileExpr::resolve_method_address (TyTy::FnType *fntype, HirId ref,
   // trait-impl-item's definition
 
   auto root = receiver->get_root ();
-  std::vector<Resolver::PathProbeCandidate> candidates
+  auto candidates
     = Resolver::PathProbeType::Probe (root, segment, true /* probe_impls */,
 				      false /* probe_bounds */,
 				      true /* ignore_mandatory_trait_items */);
@@ -2011,7 +2011,7 @@ CompileExpr::resolve_method_address (TyTy::FnType *fntype, HirId ref,
       // implementation and we should just return error_mark_node
 
       rust_assert (candidates.size () == 1);
-      auto &candidate = candidates.at (0);
+      auto &candidate = *candidates.begin ();
       rust_assert (candidate.is_impl_candidate ());
       rust_assert (candidate.ty->get_kind () == TyTy::TypeKind::FNDEF);
       TyTy::FnType *candidate_call = static_cast<TyTy::FnType *> (candidate.ty);

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -251,7 +251,7 @@ HIRCompileBase::query_compile (HirId ref, TyTy::BaseType *lookup,
 	  // item so its up to us to figure out if this path should resolve
 	  // to an trait-impl-block-item or if it can be defaulted to the
 	  // trait-impl-item's definition
-	  std::vector<Resolver::PathProbeCandidate> candidates
+	  auto candidates
 	    = Resolver::PathProbeImplTrait::Probe (receiver, final_segment,
 						   trait_ref);
 	  if (candidates.size () == 0)
@@ -270,7 +270,9 @@ HIRCompileBase::query_compile (HirId ref, TyTy::BaseType *lookup,
 	    }
 	  else
 	    {
-	      Resolver::PathProbeCandidate &candidate = candidates.at (0);
+	      rust_assert (candidates.size () == 1);
+
+	      auto candidate = *candidates.begin ();
 	      rust_assert (candidate.is_impl_candidate ());
 
 	      HIR::ImplBlock *impl = candidate.item.impl.parent;
@@ -288,8 +290,6 @@ HIRCompileBase::query_compile (HirId ref, TyTy::BaseType *lookup,
 	      else
 		return CompileInherentImplItem::Compile (impl_item, ctx, lookup,
 							 true, expr_locus);
-
-	      lookup->set_ty_ref (impl_item->get_impl_mappings ().get_hirid ());
 	    }
 	}
     }

--- a/gcc/rust/typecheck/rust-hir-path-probe.h
+++ b/gcc/rust/typecheck/rust-hir-path-probe.h
@@ -80,17 +80,17 @@ struct PathProbeCandidate
 
   PathProbeCandidate (CandidateType type, TyTy::BaseType *ty, Location locus,
 		      EnumItemCandidate enum_field)
-    : type (type), ty (ty), item (enum_field)
+    : type (type), ty (ty), locus (locus), item (enum_field)
   {}
 
   PathProbeCandidate (CandidateType type, TyTy::BaseType *ty, Location locus,
 		      ImplItemCandidate impl)
-    : type (type), ty (ty), item (impl)
+    : type (type), ty (ty), locus (locus), item (impl)
   {}
 
   PathProbeCandidate (CandidateType type, TyTy::BaseType *ty, Location locus,
 		      TraitItemCandidate trait)
-    : type (type), ty (ty), item (trait)
+    : type (type), ty (ty), locus (locus), item (trait)
   {}
 
   std::string as_string () const
@@ -123,12 +123,45 @@ struct PathProbeCandidate
   }
 
   bool is_error () const { return type == ERROR; }
+
+  DefId get_defid () const
+  {
+    switch (type)
+      {
+      case ENUM_VARIANT:
+	return item.enum_field.variant->get_defid ();
+	break;
+
+      case IMPL_CONST:
+      case IMPL_TYPE_ALIAS:
+      case IMPL_FUNC:
+	return item.impl.impl_item->get_impl_mappings ().get_defid ();
+	break;
+
+      case TRAIT_ITEM_CONST:
+      case TRAIT_TYPE_ALIAS:
+      case TRAIT_FUNC:
+	return item.trait.item_ref->get_mappings ().get_defid ();
+	break;
+
+      case ERROR:
+      default:
+	return UNKNOWN_DEFID;
+      }
+
+    return UNKNOWN_DEFID;
+  }
+
+  bool operator< (const PathProbeCandidate &c) const
+  {
+    return get_defid () < c.get_defid ();
+  }
 };
 
 class PathProbeType : public TypeCheckBase, public HIR::HIRImplVisitor
 {
 public:
-  static std::vector<PathProbeCandidate>
+  static std::set<PathProbeCandidate>
   Probe (const TyTy::BaseType *receiver,
 	 const HIR::PathIdentSegment &segment_name, bool probe_impls,
 	 bool probe_bounds, bool ignore_mandatory_trait_items,
@@ -203,7 +236,7 @@ public:
 	PathProbeCandidate candidate{
 	  PathProbeCandidate::CandidateType::IMPL_TYPE_ALIAS, ty,
 	  alias.get_locus (), impl_item_candidate};
-	candidates.push_back (std::move (candidate));
+	candidates.insert (std::move (candidate));
       }
   }
 
@@ -222,7 +255,7 @@ public:
 	PathProbeCandidate candidate{
 	  PathProbeCandidate::CandidateType::IMPL_CONST, ty,
 	  constant.get_locus (), impl_item_candidate};
-	candidates.push_back (std::move (candidate));
+	candidates.insert (std::move (candidate));
       }
   }
 
@@ -241,7 +274,7 @@ public:
 	PathProbeCandidate candidate{
 	  PathProbeCandidate::CandidateType::IMPL_FUNC, ty,
 	  function.get_locus (), impl_item_candidate};
-	candidates.push_back (std::move (candidate));
+	candidates.insert (std::move (candidate));
       }
   }
 
@@ -259,7 +292,7 @@ protected:
     PathProbeCandidate candidate{
       PathProbeCandidate::CandidateType::ENUM_VARIANT, receiver->clone (),
       mappings->lookup_location (adt->get_ty_ref ()), enum_item_candidate};
-    candidates.push_back (std::move (candidate));
+    candidates.insert (std::move (candidate));
   }
 
   void process_impl_items_for_candidates ()
@@ -338,8 +371,9 @@ protected:
 								impl};
 
     PathProbeCandidate candidate{candidate_type, trait_item_tyty,
-				 trait_ref->get_locus (), trait_item_candidate};
-    candidates.push_back (std::move (candidate));
+				 trait_item_ref->get_locus (),
+				 trait_item_candidate};
+    candidates.insert (std::move (candidate));
   }
 
   void
@@ -383,7 +417,7 @@ protected:
     PathProbeCandidate candidate{candidate_type, trait_item_tyty,
 				 trait_item_ref->get_locus (),
 				 trait_item_candidate};
-    candidates.push_back (std::move (candidate));
+    candidates.insert (std::move (candidate));
   }
 
 protected:
@@ -428,72 +462,30 @@ protected:
 
   const TyTy::BaseType *receiver;
   const HIR::PathIdentSegment &search;
-  std::vector<PathProbeCandidate> candidates;
+  std::set<PathProbeCandidate> candidates;
   HIR::ImplBlock *current_impl;
   DefId specific_trait_id;
 };
 
-class ReportMultipleCandidateError : private TypeCheckBase,
-				     private HIR::HIRImplVisitor
+class ReportMultipleCandidateError : private TypeCheckBase
 {
 public:
-  static void Report (std::vector<PathProbeCandidate> &candidates,
+  static void Report (std::set<PathProbeCandidate> &candidates,
 		      const HIR::PathIdentSegment &query, Location query_locus)
   {
     RichLocation r (query_locus);
-    ReportMultipleCandidateError visitor (r);
     for (auto &c : candidates)
-      {
-	switch (c.type)
-	  {
-	  case PathProbeCandidate::CandidateType::ERROR:
-	  case PathProbeCandidate::CandidateType::ENUM_VARIANT:
-	    gcc_unreachable ();
-	    break;
-
-	  case PathProbeCandidate::CandidateType::IMPL_CONST:
-	  case PathProbeCandidate::CandidateType::IMPL_TYPE_ALIAS:
-	  case PathProbeCandidate::CandidateType::IMPL_FUNC:
-	    c.item.impl.impl_item->accept_vis (visitor);
-	    break;
-
-	  case PathProbeCandidate::CandidateType::TRAIT_ITEM_CONST:
-	  case PathProbeCandidate::CandidateType::TRAIT_TYPE_ALIAS:
-	  case PathProbeCandidate::CandidateType::TRAIT_FUNC:
-	    r.add_range (c.item.trait.item_ref->get_locus ());
-	    break;
-	  }
-      }
+      r.add_range (c.locus);
 
     rust_error_at (r, "multiple applicable items in scope for: %s",
 		   query.as_string ().c_str ());
   }
-
-  void visit (HIR::TypeAlias &alias) override
-  {
-    r.add_range (alias.get_locus ());
-  }
-
-  void visit (HIR::ConstantItem &constant) override
-  {
-    r.add_range (constant.get_locus ());
-  }
-
-  void visit (HIR::Function &function) override
-  {
-    r.add_range (function.get_locus ());
-  }
-
-private:
-  ReportMultipleCandidateError (RichLocation &r) : TypeCheckBase (), r (r) {}
-
-  RichLocation &r;
 };
 
 class PathProbeImplTrait : public PathProbeType
 {
 public:
-  static std::vector<PathProbeCandidate>
+  static std::set<PathProbeCandidate>
   Probe (const TyTy::BaseType *receiver,
 	 const HIR::PathIdentSegment &segment_name,
 	 const TraitReference *trait_reference)

--- a/gcc/rust/typecheck/rust-hir-trait-ref.h
+++ b/gcc/rust/typecheck/rust-hir-trait-ref.h
@@ -336,6 +336,15 @@ public:
 	    return true;
 	  }
       }
+
+    // lookup super traits
+    for (const auto &super_trait : super_traits)
+      {
+	bool found = super_trait->lookup_trait_item (ident, ref);
+	if (found)
+	  return true;
+      }
+
     return false;
   }
 
@@ -351,6 +360,16 @@ public:
 	if (ident.compare (item.get_identifier ()) == 0)
 	  return &item;
       }
+
+    // lookup super traits
+    for (const auto &super_trait : super_traits)
+      {
+	const TraitItemReference *res
+	  = super_trait->lookup_trait_item (ident, type);
+	if (!res->is_error ())
+	  return res;
+      }
+
     return &TraitItemReference::error_node ();
   }
 

--- a/gcc/rust/typecheck/rust-hir-type-check-enumitem.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-enumitem.cc
@@ -82,6 +82,7 @@ TypeCheckEnumItem::visit (HIR::EnumItem &item)
 
   RustIdent ident{*canonical_path, item.get_locus ()};
   variant = new TyTy::VariantDef (item.get_mappings ().get_hirid (),
+				  item.get_mappings ().get_defid (),
 				  item.get_identifier (), ident, discim_expr);
 }
 
@@ -111,6 +112,7 @@ TypeCheckEnumItem::visit (HIR::EnumItemDiscriminant &item)
 
   RustIdent ident{*canonical_path, item.get_locus ()};
   variant = new TyTy::VariantDef (item.get_mappings ().get_hirid (),
+				  item.get_mappings ().get_defid (),
 				  item.get_identifier (), ident,
 				  item.get_discriminant_expression ().get ());
 }
@@ -159,6 +161,7 @@ TypeCheckEnumItem::visit (HIR::EnumItemTuple &item)
 
   RustIdent ident{*canonical_path, item.get_locus ()};
   variant = new TyTy::VariantDef (item.get_mappings ().get_hirid (),
+				  item.get_mappings ().get_defid (),
 				  item.get_identifier (), ident,
 				  TyTy::VariantDef::VariantType::TUPLE,
 				  discim_expr, fields);
@@ -206,6 +209,7 @@ TypeCheckEnumItem::visit (HIR::EnumItemStruct &item)
 
   RustIdent ident{*canonical_path, item.get_locus ()};
   variant = new TyTy::VariantDef (item.get_mappings ().get_hirid (),
+				  item.get_mappings ().get_defid (),
 				  item.get_identifier (), ident,
 				  TyTy::VariantDef::VariantType::STRUCT,
 				  discrim_expr, fields);

--- a/gcc/rust/typecheck/rust-hir-type-check-item.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.cc
@@ -125,7 +125,8 @@ TypeCheckItem::visit (HIR::TupleStruct &struct_decl)
   // its a single variant ADT
   std::vector<TyTy::VariantDef *> variants;
   variants.push_back (new TyTy::VariantDef (
-    struct_decl.get_mappings ().get_hirid (), struct_decl.get_identifier (),
+    struct_decl.get_mappings ().get_hirid (),
+    struct_decl.get_mappings ().get_defid (), struct_decl.get_identifier (),
     ident, TyTy::VariantDef::VariantType::TUPLE, nullptr, std::move (fields)));
 
   // Process #[repr(X)] attribute, if any
@@ -179,7 +180,8 @@ TypeCheckItem::visit (HIR::StructStruct &struct_decl)
   // its a single variant ADT
   std::vector<TyTy::VariantDef *> variants;
   variants.push_back (new TyTy::VariantDef (
-    struct_decl.get_mappings ().get_hirid (), struct_decl.get_identifier (),
+    struct_decl.get_mappings ().get_hirid (),
+    struct_decl.get_mappings ().get_defid (), struct_decl.get_identifier (),
     ident, TyTy::VariantDef::VariantType::STRUCT, nullptr, std::move (fields)));
 
   // Process #[repr(X)] attribute, if any
@@ -273,7 +275,8 @@ TypeCheckItem::visit (HIR::Union &union_decl)
   // there is only a single variant
   std::vector<TyTy::VariantDef *> variants;
   variants.push_back (new TyTy::VariantDef (
-    union_decl.get_mappings ().get_hirid (), union_decl.get_identifier (),
+    union_decl.get_mappings ().get_hirid (),
+    union_decl.get_mappings ().get_defid (), union_decl.get_identifier (),
     ident, TyTy::VariantDef::VariantType::STRUCT, nullptr, std::move (fields)));
 
   TyTy::BaseType *type

--- a/gcc/rust/typecheck/rust-hir-type-check-path.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-path.cc
@@ -337,7 +337,7 @@ TypeCheckExpr::resolve_segments (NodeId root_resolved_node_id,
 	  return;
 	}
 
-      auto &candidate = candidates.at (0);
+      auto &candidate = *candidates.begin ();
       prev_segment = tyseg;
       tyseg = candidate.ty;
 

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -462,7 +462,7 @@ TypeCheckType::resolve_segments (
 	  return new TyTy::ErrorType (expr_id);
 	}
 
-      auto &candidate = candidates.at (0);
+      auto &candidate = *candidates.begin ();
       prev_segment = tyseg;
       tyseg = candidate.ty;
 

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -1063,9 +1063,9 @@ public:
     return "";
   }
 
-  VariantDef (HirId id, std::string identifier, RustIdent ident,
+  VariantDef (HirId id, DefId defid, std::string identifier, RustIdent ident,
 	      HIR::Expr *discriminant)
-    : id (id), identifier (identifier), ident (ident),
+    : id (id), defid (defid), identifier (identifier), ident (ident),
       discriminant (discriminant)
 
   {
@@ -1073,11 +1073,11 @@ public:
     fields = {};
   }
 
-  VariantDef (HirId id, std::string identifier, RustIdent ident,
+  VariantDef (HirId id, DefId defid, std::string identifier, RustIdent ident,
 	      VariantType type, HIR::Expr *discriminant,
 	      std::vector<StructFieldType *> fields)
-    : id (id), identifier (identifier), ident (ident), type (type),
-      discriminant (discriminant), fields (fields)
+    : id (id), defid (defid), identifier (identifier), ident (ident),
+      type (type), discriminant (discriminant), fields (fields)
   {
     rust_assert (
       (type == VariantType::NUM && fields.empty ())
@@ -1085,8 +1085,8 @@ public:
   }
 
   VariantDef (const VariantDef &other)
-    : id (other.id), identifier (other.identifier), ident (other.ident),
-      type (other.type), discriminant (other.discriminant),
+    : id (other.id), defid (other.defid), identifier (other.identifier),
+      ident (other.ident), type (other.type), discriminant (other.discriminant),
       fields (other.fields)
   {}
 
@@ -1105,7 +1105,7 @@ public:
   static VariantDef &get_error_node ()
   {
     static VariantDef node
-      = VariantDef (UNKNOWN_HIRID, "",
+      = VariantDef (UNKNOWN_HIRID, UNKNOWN_DEFID, "",
 		    {Resolver::CanonicalPath::create_empty (),
 		     Linemap::unknown_location ()},
 		    nullptr);
@@ -1116,6 +1116,7 @@ public:
   bool is_error () const { return get_id () == UNKNOWN_HIRID; }
 
   HirId get_id () const { return id; }
+  DefId get_defid () const { return defid; }
 
   VariantType get_variant_type () const { return type; }
   bool is_data_variant () const { return type != VariantType::NUM; }
@@ -1211,7 +1212,7 @@ public:
     for (auto &f : fields)
       cloned_fields.push_back ((StructFieldType *) f->clone ());
 
-    return new VariantDef (id, identifier, ident, type, discriminant,
+    return new VariantDef (id, defid, identifier, ident, type, discriminant,
 			   cloned_fields);
   }
 
@@ -1221,7 +1222,7 @@ public:
     for (auto &f : fields)
       cloned_fields.push_back ((StructFieldType *) f->monomorphized_clone ());
 
-    return new VariantDef (id, identifier, ident, type, discriminant,
+    return new VariantDef (id, defid, identifier, ident, type, discriminant,
 			   cloned_fields);
   }
 
@@ -1229,6 +1230,7 @@ public:
 
 private:
   HirId id;
+  DefId defid;
   std::string identifier;
   RustIdent ident;
   VariantType type;

--- a/gcc/testsuite/rust/compile/torture/issue-1555.rs
+++ b/gcc/testsuite/rust/compile/torture/issue-1555.rs
@@ -1,0 +1,48 @@
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+struct Foo(i32);
+trait Bar {
+    fn baz(&self);
+}
+
+trait Baz: Bar {
+    fn qux(&self);
+}
+
+impl Bar for Foo {
+    fn baz(&self) {
+        unsafe {
+            let a = "baz %i\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c, self.0);
+        }
+    }
+}
+
+impl Baz for Foo {
+    fn qux(&self) {
+        unsafe {
+            let a = "qux %i\n\0";
+            let b = a as *const str;
+            let c = b as *const i8;
+
+            printf(c, self.0);
+        }
+    }
+}
+
+fn static_dispatch<T: Baz>(t: &T) {
+    t.baz();
+    t.qux();
+}
+
+pub fn main() {
+    let a;
+    a = &Foo(123);
+
+    static_dispatch(a);
+}


### PR DESCRIPTION
https://github.com/Rust-GCC/gccrs/compare/82b64a2845707f2...b3fcf322af96b766fed010256ea4302fa4168f7c

So basically 6 commits from https://github.com/Rust-GCC/gccrs/tree/first-half-update, right after the ones in https://github.com/Rust-GCC/gccrs/pull/1757:

24e9bd93f7dcb96b31baace55a67cd905bc49998
777944e49c6ee90d63d479caa37204eee13d8160
6505e5a10d7ea3bd4f63ae33033f98a73191e2bb
d11e801180ac5ea48ec7e5b0e4581a2b5ebdb289
885fbd93f7a8a3f2b22c2c37c2cbcbb82da225b8
b3fcf322af96b766fed010256ea4302fa4168f7c