### PR TITLE
Do not crash on empty macros expand. Fixes #1712

### DIFF
--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -839,6 +839,8 @@ static AST::Fragment
 transcribe_expression (Parser<MacroInvocLexer> &parser)
 {
   auto expr = parser.parse_expr ();
+  if (expr == nullptr)
+    return AST::Fragment::create_error ();
 
   return AST::Fragment::complete ({std::move (expr)});
 }

--- a/gcc/testsuite/rust/compile/macro45.rs
+++ b/gcc/testsuite/rust/compile/macro45.rs
@@ -1,0 +1,7 @@
+macro_rules! empty {
+    () => {}; // { dg-error "found unexpected token '\}' in null denotation" }
+}
+
+fn main() {
+    let a = empty!();
+}


### PR DESCRIPTION
This PR fixes a compiler crash when expanding an empty macro into an existing AST.
(I ran clang-format but it marked a few other files as dirty, and I therefore did not touch them)

Signed-off-by: Lyra Karenai <teromene@teromene.fr>

Fixes #1712