### PR TITLE
fixed compiler error message on wildcard pattern within expression

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -13021,6 +13021,12 @@ Parser<ManagedTokenSource>::null_denotation (const_TokenPtr tok,
     case UNSAFE:
       return parse_unsafe_block_expr (std::move (outer_attrs),
 				      tok->get_locus ());
+    case UNDERSCORE:
+      add_error (
+	Error (tok->get_locus (),
+	       "use of %qs is not allowed on the right-side of an assignment",
+	       tok->get_token_description ()));
+      return nullptr;
     default:
       if (!restrictions.expr_can_be_null)
 	add_error (Error (tok->get_locus (),

--- a/gcc/testsuite/rust/compile/issue-867.rs
+++ b/gcc/testsuite/rust/compile/issue-867.rs
@@ -1,0 +1,8 @@
+fn main() {
+    let _ = 42;
+    let a = _ + 123; // { dg-error "use of '_' is not allowed on the right-side of an assignment" }
+                     // { dg-error {failed to parse expression in let statement} "" { target *-*-* } .-1  }
+                     // { dg-error {failed to parse statement or expression without block in block expression} "" { target *-*-* } .-2 }
+                     // { dg-error {unrecognised token '\}' for start of item} "" { target *-*-* } .+2 }
+                     // { dg-error {failed to parse item in crate} "" { target *-*-* } .+1 }
+}


### PR DESCRIPTION
Signed-off-by: Abdul Rafey <abdulrafeyq@gmail.com>

fixed compiler error message on wildcard pattern '_'  within expression.
Added a new testcase for the same.
#867 