### PR TITLE
ci: Require commits check to pass for bors to merge and fix CI names

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,7 +1,10 @@
 status = [
   "build-and-check-ubuntu-64bit",
   "build-and-check-ubuntu-32bit",
-  "build-and-check-gcc-48"
+  "build-and-check-gcc-48",
+  "check-commit-changelogs",
+  "check-commit-prefixes",
+  "check-commit-signoffs",
 ]
 # Uncomment this to use a two hour timeout.
 # The default is one hour.

--- a/.github/workflows/commit-format.yml
+++ b/.github/workflows/commit-format.yml
@@ -7,7 +7,7 @@ on:
       - gcc-patch-dev
 
 jobs:
-  check_commit_changelogs:
+  check-commit-changelogs:
     runs-on: ubuntu-latest
     name: check-changelogs
     
@@ -28,7 +28,7 @@ jobs:
         run: |
           python3 contrib/gcc-changelog/git_check_commit.py origin/${{ github.event.pull_request.base.ref }}..${{ github.event.pull_request.head.sha }}
 
-  check_commit_prefixes:
+  check-commit-prefixes:
     runs-on: ubuntu-latest
     name: check-gccrs-prefix
     
@@ -54,7 +54,7 @@ jobs:
           done
           exit $retval
 
-  check_commit_signoff:
+  check-commit-signoff:
     runs-on: ubuntu-latest
     name: check-commit-signoff
     


### PR DESCRIPTION
ChangeLog:

	* .github/bors.toml: Add commit checkers.
	* .github/workflows/commit-format.yml: Rename commit checker jobs.

Fixes #1790