### PR TITLE
Implement lowering ReferencePattern from AST to HIR

### DIFF
--- a/gcc/rust/ast/rust-pattern.h
+++ b/gcc/rust/ast/rust-pattern.h
@@ -469,6 +469,10 @@ public:
     return pattern;
   }
 
+  bool is_double_reference () const { return has_two_amps; }
+
+  bool get_is_mut () const { return is_mut; }
+
   NodeId get_node_id () const { return node_id; }
 
   NodeId get_pattern_node_id () const override final { return node_id; }

--- a/gcc/rust/hir/rust-ast-lower-pattern.cc
+++ b/gcc/rust/hir/rust-ast-lower-pattern.cc
@@ -259,5 +259,34 @@ ASTLoweringPattern::visit (AST::GroupedPattern &pattern)
 			       pattern.get_locus ());
 }
 
+void
+ASTLoweringPattern::visit (AST::ReferencePattern &pattern)
+{
+  auto crate_num = mappings->get_current_crate ();
+  Analysis::NodeMapping mapping (crate_num, pattern.get_node_id (),
+				 mappings->get_next_hir_id (crate_num),
+				 UNKNOWN_LOCAL_DEFID);
+
+  HIR::Pattern *inner
+    = ASTLoweringPattern::translate (pattern.get_referenced_pattern ().get ());
+
+  translated
+    = new HIR::ReferencePattern (mapping, std::unique_ptr<HIR::Pattern> (inner),
+				 pattern.get_is_mut () ? Mutability::Mut
+						       : Mutability::Imm,
+				 pattern.get_locus ());
+
+  if (pattern.is_double_reference ())
+    {
+      Analysis::NodeMapping mapping2 (crate_num, pattern.get_node_id (),
+				      mappings->get_next_hir_id (crate_num),
+				      UNKNOWN_LOCAL_DEFID);
+      translated
+	= new HIR::ReferencePattern (mapping2,
+				     std::unique_ptr<HIR::Pattern> (translated),
+				     Mutability::Imm, pattern.get_locus ());
+    }
+}
+
 } // namespace HIR
 } // namespace Rust

--- a/gcc/rust/hir/rust-ast-lower-pattern.h
+++ b/gcc/rust/hir/rust-ast-lower-pattern.h
@@ -40,6 +40,7 @@ public:
   void visit (AST::LiteralPattern &pattern) override;
   void visit (AST::RangePattern &pattern) override;
   void visit (AST::GroupedPattern &pattern) override;
+  void visit (AST::ReferencePattern &pattern) override;
 
 private:
   ASTLoweringPattern ();

--- a/gcc/rust/hir/tree/rust-hir-full-test.cc
+++ b/gcc/rust/hir/tree/rust-hir-full-test.cc
@@ -2583,11 +2583,6 @@ ReferencePattern::as_string () const
 {
   std::string str ("&");
 
-  if (has_two_amps)
-    {
-      str += "&";
-    }
-
   if (is_mut ())
     {
       str += "mut ";

--- a/gcc/rust/hir/tree/rust-hir-pattern.h
+++ b/gcc/rust/hir/tree/rust-hir-pattern.h
@@ -424,7 +424,6 @@ protected:
 // HIR node for pattern based on dereferencing the pointers given
 class ReferencePattern : public Pattern
 {
-  bool has_two_amps;
   Mutability mut;
   std::unique_ptr<Pattern> pattern;
   Location locus;
@@ -435,16 +434,15 @@ public:
 
   ReferencePattern (Analysis::NodeMapping mappings,
 		    std::unique_ptr<Pattern> pattern, Mutability reference_mut,
-		    bool ref_has_two_amps, Location locus)
-    : has_two_amps (ref_has_two_amps), mut (reference_mut),
-      pattern (std::move (pattern)), locus (locus), mappings (mappings)
+		    Location locus)
+    : mut (reference_mut), pattern (std::move (pattern)), locus (locus),
+      mappings (mappings)
   {}
 
   // Copy constructor requires clone
   ReferencePattern (ReferencePattern const &other)
-    : has_two_amps (other.has_two_amps), mut (other.mut),
-      pattern (other.pattern->clone_pattern ()), locus (other.locus),
-      mappings (other.mappings)
+    : mut (other.mut), pattern (other.pattern->clone_pattern ()),
+      locus (other.locus), mappings (other.mappings)
   {}
 
   // Overload assignment operator to clone
@@ -452,7 +450,6 @@ public:
   {
     pattern = other.pattern->clone_pattern ();
     mut = other.mut;
-    has_two_amps = other.has_two_amps;
     locus = other.locus;
     mappings = other.mappings;
 


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* ast/rust-pattern.h (ReferencePattern::get_has_two_amps): Add method. (ReferencePattern::get_is_mut): Add method.
	* hir/rust-ast-lower-pattern.cc (ASTLoweringPattern::visit): Add ReferencePattern visitor.
	* hir/rust-ast-lower-pattern.h (ASTLoweringPattern::visit): Add ReferencePattern visitor.

Signed-off-by: Owen Avery <powerboat9.gamer@gmail.com>

Partially addresses #1813