### PR TITLE
Dummy PR to check mklog

### DIFF
--- a/.github/workflows/commit-format.yml
+++ b/.github/workflows/commit-format.yml
@@ -17,7 +17,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      # mess it up
       - name: Install Deps
         run: |
           sudo apt-get update;

--- a/.github/workflows/commit-format.yml
+++ b/.github/workflows/commit-format.yml
@@ -17,6 +17,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
+      # mess it up
       - name: Install Deps
         run: |
           sudo apt-get update;


### PR DESCRIPTION
It seems in my testing on https://github.com/cohenarthur/gccrs/pull/8 that the unidiff module in the mklog/check_commit script was broken. Testing it out here to see if it might have been caused by changes from the merge. 