### PR TITLE
parser: Improve parsing of complex generic arguments

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -6309,7 +6309,9 @@ Parser<ManagedTokenSource>::parse_generic_arg ()
 	// could either have a valid type or a macro (FIXME: anything else?). So
 	// we need one bit of lookahead to differentiate if this is really
 	auto next_tok = lexer.peek_token (1);
-	if (next_tok->get_id () == EXCLAM)
+	if (next_tok->get_id () == LEFT_ANGLE
+	    || next_tok->get_id () == SCOPE_RESOLUTION
+	    || next_tok->get_id () == EXCLAM)
 	  {
 	    auto type = parse_type ();
 	    if (type)

--- a/gcc/testsuite/rust/compile/parse_complex_generic_application.rs
+++ b/gcc/testsuite/rust/compile/parse_complex_generic_application.rs
@@ -1,0 +1,17 @@
+pub enum Either<T, E> {
+    Left(T),
+    Right(E),
+}
+
+pub mod err {
+    pub struct Error;
+    pub struct ErrorWrap<T>(T);
+}
+
+pub fn foo_err() -> Either<(), err::Error> {
+    Either::Left(())
+}
+
+pub fn foo_err_wrap() -> Either<(), err::ErrorWrap<u8>> {
+    Either::Left(())
+}

--- a/gcc/testsuite/rust/compile/parse_complex_generic_application2.rs
+++ b/gcc/testsuite/rust/compile/parse_complex_generic_application2.rs
@@ -1,0 +1,10 @@
+pub enum Either<L, R> {
+    Left(L),
+    Right(R),
+}
+
+pub struct Wrap<T>(T);
+
+pub fn foo_wrap() -> Either<(), Wrap<u8>> {
+    Either::Left(())
+}


### PR DESCRIPTION
The parser was missing code for handling complex type arguments such as type paths or nested generics.

gcc/rust/ChangeLog:

	* parse/rust-parse-impl.h (Parser::parse_generic_arg): Handle type paths and nested generics properly.

gcc/testsuite/ChangeLog:

	* rust/compile/parse_complex_generic_application.rs: New test.
	* rust/compile/parse_complex_generic_application2.rs: New test.