### PR TITLE
parser: Fix parsing of closure param list

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -7590,6 +7590,7 @@ Parser<ManagedTokenSource>::parse_closure_expr (AST::AttrVec outer_attrs)
     case PIPE:
       // actually may have parameters
       lexer.skip_token ();
+      t = lexer.peek_token ();
 
       while (t->get_id () != PIPE)
 	{
@@ -7606,6 +7607,7 @@ Parser<ManagedTokenSource>::parse_closure_expr (AST::AttrVec outer_attrs)
 
 	  if (lexer.peek_token ()->get_id () != COMMA)
 	    {
+	      lexer.skip_token ();
 	      // not an error but means param list is done
 	      break;
 	    }

--- a/gcc/testsuite/rust/compile/closure_move_expr.rs
+++ b/gcc/testsuite/rust/compile/closure_move_expr.rs
@@ -1,0 +1,9 @@
+// { dg-additional-options "-fsyntax-only" }
+
+fn foo() {
+    move |l: u32, r: u32| l + r
+}
+
+fn foo2() {
+    |l: u32, r: u32| l + r
+}


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* parse/rust-parse-impl.h (Parser::parse_closure_expr): Advance tokens properly when parsing closure param list.

gcc/testsuite/ChangeLog:

	* rust/compile/closure_move_expr.rs: New test.

