### PR TITLE
Add feature gate for "rust-intrinsic".

### DIFF
--- a/gcc/rust/checks/errors/rust-feature-gate.h
+++ b/gcc/rust/checks/errors/rust-feature-gate.h
@@ -21,6 +21,7 @@
 
 #include "rust-ast-visitor.h"
 #include "rust-ast-full.h"
+#include "rust-feature.h"
 
 namespace Rust {
 
@@ -136,7 +137,7 @@ public:
   void visit (AST::TraitImpl &impl) override {}
   void visit (AST::ExternalStaticItem &item) override {}
   void visit (AST::ExternalFunctionItem &item) override {}
-  void visit (AST::ExternBlock &block) override {}
+  void visit (AST::ExternBlock &block) override;
   void visit (AST::MacroMatchFragment &match) override {}
   void visit (AST::MacroMatchRepetition &match) override {}
   void visit (AST::MacroMatcher &matcher) override {}
@@ -186,6 +187,10 @@ public:
   void visit (AST::SliceType &type) override {}
   void visit (AST::InferredType &type) override {}
   void visit (AST::BareFunctionType &type) override {}
+
+private:
+  void gate (Feature::Name name, Location loc, const std::string &error_msg);
+  std::set<Feature::Name> valid_features;
 };
 } // namespace Rust
 #endif

--- a/gcc/rust/checks/errors/rust-feature.h
+++ b/gcc/rust/checks/errors/rust-feature.h
@@ -47,6 +47,7 @@ public:
   Name name () { return m_name; }
   const std::string &description () { return m_description; }
   State state () { return m_state; }
+  uint64_t issue () { return m_issue; }
 
   static Optional<Name> as_name (const std::string &name);
   static Feature create (Name name);
@@ -57,7 +58,7 @@ private:
 	   const Optional<CompileOptions::Edition> &edition,
 	   const char *description)
     : m_state (state), m_name (name), m_name_str (name_str),
-      m_rustc_since (rustc_since), issue (issue_number), edition (edition),
+      m_rustc_since (rustc_since), m_issue (issue_number), edition (edition),
       m_description (description)
   {}
 
@@ -65,7 +66,7 @@ private:
   Name m_name;
   std::string m_name_str;
   std::string m_rustc_since;
-  uint64_t issue;
+  uint64_t m_issue;
   Optional<CompileOptions::Edition> edition;
   std::string m_description;
 

--- a/gcc/testsuite/rust/compile/const-issue1440.rs
+++ b/gcc/testsuite/rust/compile/const-issue1440.rs
@@ -1,4 +1,5 @@
 // { dg-additional-options "-w" }
+#![feature(intrinsics)]
 
 mod intrinsics {
     extern "rust-intrinsic" {

--- a/gcc/testsuite/rust/compile/feature_intrinsics.rs
+++ b/gcc/testsuite/rust/compile/feature_intrinsics.rs
@@ -1,0 +1,7 @@
+
+extern "rust-intrinsic" { //{ dg-error "intrinsics are subject to change." "" { target *-*-* }  }
+    pub fn sqrtf32(x: f32) -> f32;
+}
+
+fn main() {
+}

--- a/gcc/testsuite/rust/compile/issue-1031.rs
+++ b/gcc/testsuite/rust/compile/issue-1031.rs
@@ -1,3 +1,5 @@
+#![feature(intrinsics)]
+
 extern "rust-intrinsic" {
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     pub fn offset<T>(dst: *const T, offset: isize) -> *const T;

--- a/gcc/testsuite/rust/compile/issue-1130.rs
+++ b/gcc/testsuite/rust/compile/issue-1130.rs
@@ -1,4 +1,6 @@
 // { dg-additional-options "-w" }
+#![feature(intrinsics)]
+
 mod mem {
     extern "rust-intrinsic" {
         fn size_of<T>() -> usize;

--- a/gcc/testsuite/rust/compile/issue-1131.rs
+++ b/gcc/testsuite/rust/compile/issue-1131.rs
@@ -1,3 +1,5 @@
+#![feature(intrinsics)]
+
 extern "rust-intrinsic" {
     fn size_of<T>() -> usize;
     fn offset<T>(dst: *const T, offset: isize) -> *const T;

--- a/gcc/testsuite/rust/compile/issue-1237.rs
+++ b/gcc/testsuite/rust/compile/issue-1237.rs
@@ -1,4 +1,6 @@
 // { dg-additional-options "-w" }
+#![feature(intrinsics)]
+
 mod intrinsics {
     extern "rust-intrinsic" {
         pub fn offset<T>(ptr: *const T, count: isize) -> *const T;

--- a/gcc/testsuite/rust/compile/issue-1289.rs
+++ b/gcc/testsuite/rust/compile/issue-1289.rs
@@ -1,3 +1,5 @@
+#![feature(intrinsics)]
+
 extern "C" {
     fn printf(s: *const i8, ...);
 }

--- a/gcc/testsuite/rust/compile/rust-const-blog-issue.rs
+++ b/gcc/testsuite/rust/compile/rust-const-blog-issue.rs
@@ -1,4 +1,6 @@
 // { dg-excess-errors "accessing value of"  }
+#![feature(intrinsics)]
+
 mod mem {
     extern "rust-intrinsic" {
         #[rustc_const_stable(feature = "const_transmute", since = "1.46.0")]

--- a/gcc/testsuite/rust/compile/torture/intrinsics-3.rs
+++ b/gcc/testsuite/rust/compile/torture/intrinsics-3.rs
@@ -1,3 +1,5 @@
+#![feature(intrinsics)]
+
 extern "rust-intrinsic" {
     fn not_an_intrinsic();
 }

--- a/gcc/testsuite/rust/compile/torture/intrinsics-4.rs
+++ b/gcc/testsuite/rust/compile/torture/intrinsics-4.rs
@@ -1,3 +1,5 @@
+#![feature(intrinsics)]
+
 #[lang = "sized"]
 pub trait Sized {}
 

--- a/gcc/testsuite/rust/compile/torture/intrinsics-5.rs
+++ b/gcc/testsuite/rust/compile/torture/intrinsics-5.rs
@@ -1,3 +1,5 @@
+#![feature(intrinsics)]
+
 #[lang = "sized"]
 pub trait Sized {}
 

--- a/gcc/testsuite/rust/compile/torture/intrinsics-6.rs
+++ b/gcc/testsuite/rust/compile/torture/intrinsics-6.rs
@@ -1,3 +1,5 @@
+#![feature(intrinsics)]
+
 extern "rust-intrinsic" {
     pub fn unchecked_add<T>(x: T, y: T) -> T;
     pub fn unchecked_sub<T>(x: T, y: T) -> T;

--- a/gcc/testsuite/rust/compile/torture/intrinsics-7.rs
+++ b/gcc/testsuite/rust/compile/torture/intrinsics-7.rs
@@ -1,3 +1,5 @@
+#![feature(intrinsics)]
+
 extern "rust-intrinsic" {
     pub fn unchecked_add<T>(x: T, y: T) -> T;
     // { dg-error "unchecked operation intrinsics can only be used with basic integer types .got .NotAdd.." "" { target *-*-* } .-1 }

--- a/gcc/testsuite/rust/compile/torture/issue-1024.rs
+++ b/gcc/testsuite/rust/compile/torture/issue-1024.rs
@@ -1,3 +1,5 @@
+#![feature(intrinsics)]
+
 extern "rust-intrinsic" {
     pub fn size_of<T>() -> usize;
 }

--- a/gcc/testsuite/rust/compile/torture/issue-1075.rs
+++ b/gcc/testsuite/rust/compile/torture/issue-1075.rs
@@ -1,4 +1,6 @@
 // { dg-additional-options "-w" }
+#![feature(intrinsics)]
+
 extern "rust-intrinsic" {
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     pub fn offset<T>(dst: *const T, offset: isize) -> *const T;

--- a/gcc/testsuite/rust/compile/torture/issue-1432.rs
+++ b/gcc/testsuite/rust/compile/torture/issue-1432.rs
@@ -1,4 +1,5 @@
 // { dg-additional-options "-w" }
+#![feature(intrinsics)]
 mod intrinsics {
     extern "rust-intrinsic" {
         #[rustc_const_stable(feature = "const_int_wrapping", since = "1.40.0")]

--- a/gcc/testsuite/rust/compile/unsafe10.rs
+++ b/gcc/testsuite/rust/compile/unsafe10.rs
@@ -1,3 +1,5 @@
+#![feature(intrinsics)]
+
 extern "rust-intrinsic" {
     pub fn rotate_left<T>(l: T, r: T) -> T;
 }

--- a/gcc/testsuite/rust/execute/torture/atomic_load.rs
+++ b/gcc/testsuite/rust/execute/torture/atomic_load.rs
@@ -1,3 +1,5 @@
+#![feature(intrinsics)]
+
 #[lang = "sized"]
 pub trait Sized {}
 

--- a/gcc/testsuite/rust/execute/torture/atomic_store.rs
+++ b/gcc/testsuite/rust/execute/torture/atomic_store.rs
@@ -1,3 +1,5 @@
+#![feature(intrinsics)]
+
 #[lang = "sized"]
 pub trait Sized {}
 

--- a/gcc/testsuite/rust/execute/torture/copy_nonoverlapping1.rs
+++ b/gcc/testsuite/rust/execute/torture/copy_nonoverlapping1.rs
@@ -1,3 +1,5 @@
+#![feature(intrinsics)]
+
 extern "rust-intrinsic" {
     pub fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
 }

--- a/gcc/testsuite/rust/execute/torture/issue-1120.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-1120.rs
@@ -1,4 +1,6 @@
 // { dg-additional-options "-w" }
+#![feature(intrinsics)]
+
 extern "rust-intrinsic" {
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     pub fn offset<T>(dst: *const T, offset: isize) -> *const T;

--- a/gcc/testsuite/rust/execute/torture/issue-1133.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-1133.rs
@@ -1,4 +1,6 @@
 // { dg-additional-options "-w" }
+#![feature(intrinsics)]
+
 extern "rust-intrinsic" {
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     pub fn offset<T>(dst: *const T, offset: isize) -> *const T;

--- a/gcc/testsuite/rust/execute/torture/issue-1232.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-1232.rs
@@ -1,5 +1,7 @@
 // { dg-additional-options "-w" }
 // { dg-output "slice_access=3\r*\n" }
+#![feature(intrinsics)]
+
 extern "rust-intrinsic" {
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     fn offset<T>(dst: *const T, offset: isize) -> *const T;

--- a/gcc/testsuite/rust/execute/torture/slice-magic.rs
+++ b/gcc/testsuite/rust/execute/torture/slice-magic.rs
@@ -1,4 +1,6 @@
 // { dg-additional-options "-w" }
+#![feature(intrinsics)]
+
 extern "rust-intrinsic" {
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     pub fn offset<T>(dst: *const T, offset: isize) -> *const T;

--- a/gcc/testsuite/rust/execute/torture/slice-magic2.rs
+++ b/gcc/testsuite/rust/execute/torture/slice-magic2.rs
@@ -1,4 +1,6 @@
 // { dg-additional-options "-w" }
+#![feature(intrinsics)]
+
 extern "rust-intrinsic" {
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     pub fn offset<T>(dst: *const T, offset: isize) -> *const T;

--- a/gcc/testsuite/rust/execute/torture/str-layout1.rs
+++ b/gcc/testsuite/rust/execute/torture/str-layout1.rs
@@ -1,5 +1,7 @@
 // { dg-additional-options "-w" }
 // { dg-output "t1sz=5 t2sz=10\r*" }
+#![feature(intrinsics)]
+
 mod mem {
     extern "rust-intrinsic" {
         #[rustc_const_stable(feature = "const_transmute", since = "1.46.0")]

--- a/gcc/testsuite/rust/execute/torture/transmute1.rs
+++ b/gcc/testsuite/rust/execute/torture/transmute1.rs
@@ -1,4 +1,5 @@
 // { dg-additional-options "-w" }
+#![feature(intrinsics)]
 
 extern "rust-intrinsic" {
     fn transmute<T, U>(value: T) -> U;

--- a/gcc/testsuite/rust/execute/torture/wrapping_op1.rs
+++ b/gcc/testsuite/rust/execute/torture/wrapping_op1.rs
@@ -1,3 +1,5 @@
+#![feature(intrinsics)]
+
 extern "rust-intrinsic" {
     pub fn wrapping_add<T>(l: T, r: T) -> T;
 }

--- a/gcc/testsuite/rust/execute/torture/wrapping_op2.rs
+++ b/gcc/testsuite/rust/execute/torture/wrapping_op2.rs
@@ -1,3 +1,5 @@
+#![feature(intrinsics)]
+
 extern "rust-intrinsic" {
     pub fn wrapping_add<T>(l: T, r: T) -> T;
     pub fn wrapping_sub<T>(l: T, r: T) -> T;


### PR DESCRIPTION
This commit implemented a feature gate to check `intrinsics`.

gcc/rust/ChangeLog:

	* checks/errors/rust-feature-gate.cc: Add implementation for `void FeatureGate::visit (AST::ExternBlock &block)`. Add `valid_feature` construction process in `FeatureGate::check`.
	* checks/errors/rust-feature-gate.h: Add declaration for `void FeatureGate::visit (AST::ExternBlock &block)`. Add private variable `valid_feature`.
	* checks/errors/rust-feature.h: Change `issue` to `m_issue`.

gcc/testsuite/ChangeLog:

	* rust/compile/const-issue1440.rs: Add crate feature: `intrinsics`.
	* rust/compile/feature_intrinsics.rs: New file.
	* rust/compile/issue-1031.rs: Add crate feature: `intrinsics`.
	* rust/compile/issue-1130.rs: Add crate feature: `intrinsics`.
	* rust/compile/issue-1131.rs: Add crate feature: `intrinsics`.
	* rust/compile/issue-1237.rs: Add crate feature: `intrinsics`.
	* rust/compile/issue-1289.rs: Add crate feature: `intrinsics`.
	* rust/compile/rust-const-blog-issue.rs: Add crate feature: `intrinsics`.
	* rust/compile/torture/intrinsics-3.rs: Add crate feature: `intrinsics`.
	* rust/compile/torture/intrinsics-4.rs: Add crate feature: `intrinsics`.
	* rust/compile/torture/intrinsics-5.rs: Add crate feature: `intrinsics`.
	* rust/compile/torture/intrinsics-6.rs: Add crate feature: `intrinsics`.
	* rust/compile/torture/intrinsics-7.rs: Add crate feature: `intrinsics`.
	* rust/compile/torture/issue-1024.rs: Add crate feature: `intrinsics`.
	* rust/compile/torture/issue-1075.rs: Add crate feature: `intrinsics`.
	* rust/compile/torture/issue-1432.rs: Add crate feature: `intrinsics`.
	* rust/compile/unsafe10.rs: Add crate feature: `intrinsics`.
	* rust/execute/torture/atomic_load.rs: Add crate feature: `intrinsics`.
	* rust/execute/torture/atomic_store.rs: Add crate feature: `intrinsics`.
	* rust/execute/torture/copy_nonoverlapping1.rs: Add crate feature: `intrinsics`.
	* rust/execute/torture/issue-1120.rs: Add crate feature: `intrinsics`.
	* rust/execute/torture/issue-1133.rs: Add crate feature: `intrinsics`.
	* rust/execute/torture/issue-1232.rs: Add crate feature: `intrinsics`.
	* rust/execute/torture/slice-magic.rs: Add crate feature: `intrinsics`.
	* rust/execute/torture/slice-magic2.rs: Add crate feature: `intrinsics`.
	* rust/execute/torture/str-layout1.rs: Add crate feature: `intrinsics`.
	* rust/execute/torture/transmute1.rs: Add crate feature: `intrinsics`.
	* rust/execute/torture/wrapping_op1.rs: Add crate feature: `intrinsics`.
	* rust/execute/torture/wrapping_op2.rs: Add crate feature: `intrinsics`.

Signed-off-by: Xiao Ma <mxlol233@outlook.com>

