### PR TITLE
ci: Run commit format checker on push to `trying` branch

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -2,9 +2,6 @@ status = [
   "build-and-check-ubuntu-64bit",
   "build-and-check-ubuntu-32bit",
   "build-and-check-gcc-48",
-  "check-commit-changelogs",
-  "check-commit-prefixes",
-  "check-commit-signoffs",
 ]
 # Uncomment this to use a two hour timeout.
 # The default is one hour.


### PR DESCRIPTION
ChangeLog:

	* .github/workflows/commit-format.yml: Run job on pushes to `trying`.



This should hopefully stop bors from timing out.