### PR TITLE
lex: Prevent directories in RAIIFile

### DIFF
--- a/gcc/testsuite/rust/compile/issue-1830_bytes.rs
+++ b/gcc/testsuite/rust/compile/issue-1830_bytes.rs
@@ -1,0 +1,8 @@
+#[rustc_builtin_macro]
+macro_rules! include_bytes {
+    () => {{}};
+}
+
+fn main() {
+    include_bytes!(""); // { dg-excess-errors "Is a directory" }
+}

--- a/gcc/testsuite/rust/compile/issue-1830_str.rs
+++ b/gcc/testsuite/rust/compile/issue-1830_str.rs
@@ -1,0 +1,8 @@
+#[rustc_builtin_macro]
+macro_rules! include_str {
+    () => {{}};
+}
+
+fn main() {
+    include_str!(""); // { dg-excess-errors "Is a directory" }
+}


### PR DESCRIPTION
RAIIFile constructor was accepting directory filename. This lead to unattended directory opening in some part of the code (load_file_bytes) which resulted in ice. Since RAIIFile are used for the lexer, removing the ability to open directories with RAIIFile fixes those issues and prevent future mistakes.

gcc/rust/ChangeLog:

	* lex/rust-lex.h: Add requirement for file write permission.

Signed-off-by: Pierre-Emmanuel Patry <pierre-emmanuel.patry@embecosm.com>

Fixes #1830 
Fixes #1842 