### PR TITLE
cli: Update safety warning message

### DIFF
--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -447,7 +447,7 @@ Session::compile_crate (const char *filename)
       "defining the following environment variable (any value will "
       "do)\n\nGCCRS_INCOMPLETE_AND_EXPERIMENTAL_COMPILER_DO_NOT_USE\n\nFor "
       "cargo-gccrs, this means passing\n\n"
-      "GCCRS_EXTRA_FLAGS=\"-frust-incomplete-and-experimental-compiler-do-not-"
+      "GCCRS_EXTRA_ARGS=\"-frust-incomplete-and-experimental-compiler-do-not-"
       "use\"\n\nas an environment variable.");
 
   RAIIFile file_wrap (filename);


### PR DESCRIPTION
The compiler's warning message about the safety flag did not match cargo-gccrs environment variable name anymore.

gcc/rust/ChangeLog:

	* rust-session-manager.cc (Session::compile_crate): Update the environment variable name.

Signed-off-by: Pierre-Emmanuel Patry <pierre-emmanuel.patry@embecosm.com>

Fixes #1829 