### PR TITLE
ci: Add missing `merge_group` trigger for workflow

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -3,6 +3,7 @@ name: GCC Bootstrap Build
 on:
   push:
     branches: [ master ]
+  merge_group:
 
 jobs:
   build:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -7,6 +7,7 @@ on:
       - staging
   pull_request:
     branches: [ master ]
+  merge_group:
 
 jobs:
   build-and-check-ubuntu-64bit:

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -7,6 +7,7 @@ on:
       - staging
   pull_request:
     branches: [ master ]
+  merge_group:
 
 jobs:
   clang-format:

--- a/.github/workflows/commit-format.yml
+++ b/.github/workflows/commit-format.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - gcc-patch-dev
+  merge_group:
 
 jobs:
   check-commit-changelogs:
@@ -26,8 +27,10 @@ jobs:
       
       - name: GCC check PR Commits
         run: |
-          python3 contrib/gcc-changelog/git_check_commit.py origin/${{ github.event.pull_request.base.ref }}..${{ github.event.pull_request.head.sha }}
-
+          if ${{ github.event_name == 'pull_request' }}; then
+            python3 contrib/gcc-changelog/git_check_commit.py origin/${{ github.event.pull_request.base.ref }}..${{ github.event.pull_request.head.sha }}
+          fi
+            
   check-commit-prefixes:
     runs-on: ubuntu-latest
     name: check-gccrs-prefix


### PR DESCRIPTION
Now that we're using the Github merge queue, this is required to not let the queue hanging.

ChangeLog:

	* .github/workflows/bootstrap.yml: Add missing `merge_group` trigger.
	* .github/workflows/ccpp.yml: Likewise.
	* .github/workflows/clang-format.yml: Likewise.
	* .github/workflows/commit-format.yml: Likewise.

This needs to be merged for merge queues to work properly, like we're trying with #1845. I'll merge this quite quickly unless someone has something to say :) This will also be a nice way to ask github to run bootstrap builds once a PR has been approved and sent to the merge queue.