### PR TITLE
Add AST::AltPattern class

### DIFF
--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -1678,6 +1678,10 @@ void
 Dump::visit (SlicePattern &)
 {}
 
+void
+Dump::visit (AltPattern &)
+{}
+
 // rust-stmt.h
 void
 Dump::visit (EmptyStmt &)

--- a/gcc/rust/ast/rust-ast-dump.h
+++ b/gcc/rust/ast/rust-ast-dump.h
@@ -293,6 +293,7 @@ private:
   void visit (TuplePattern &pattern);
   void visit (GroupedPattern &pattern);
   void visit (SlicePattern &pattern);
+  void visit (AltPattern &pattern);
 
   // rust-stmt.h
   void visit (EmptyStmt &stmt);

--- a/gcc/rust/ast/rust-ast-full-decls.h
+++ b/gcc/rust/ast/rust-ast-full-decls.h
@@ -249,6 +249,7 @@ class TuplePatternItemsRanged;
 class TuplePattern;
 class GroupedPattern;
 class SlicePattern;
+class AltPattern;
 
 // rust-type.h
 class TraitBound;

--- a/gcc/rust/ast/rust-ast-visitor.h
+++ b/gcc/rust/ast/rust-ast-visitor.h
@@ -203,6 +203,7 @@ public:
   virtual void visit (TuplePattern &pattern) = 0;
   virtual void visit (GroupedPattern &pattern) = 0;
   virtual void visit (SlicePattern &pattern) = 0;
+  virtual void visit (AltPattern &pattern) = 0;
 
   // rust-stmt.h
   virtual void visit (EmptyStmt &stmt) = 0;

--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -2705,6 +2705,17 @@ SlicePattern::as_string () const
 }
 
 std::string
+AltPattern::as_string () const
+{
+  std::string str ("AltPattern: ");
+
+  for (const auto &pattern : alts)
+    str += "\n " + pattern->as_string ();
+
+  return str;
+}
+
+std::string
 TuplePatternItemsMultiple::as_string () const
 {
   std::string str;
@@ -5645,6 +5656,12 @@ GroupedPattern::accept_vis (ASTVisitor &vis)
 
 void
 SlicePattern::accept_vis (ASTVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+void
+AltPattern::accept_vis (ASTVisitor &vis)
 {
   vis.visit (*this);
 }

--- a/gcc/rust/ast/rust-pattern.h
+++ b/gcc/rust/ast/rust-pattern.h
@@ -763,7 +763,7 @@ struct StructPatternElements
 {
 private:
   // bool has_struct_pattern_fields;
-  std::vector<std::unique_ptr<StructPatternField> > fields;
+  std::vector<std::unique_ptr<StructPatternField>> fields;
 
   bool has_struct_pattern_etc;
   std::vector<Attribute> struct_pattern_etc_attrs;
@@ -788,7 +788,7 @@ public:
 
   // Constructor for StructPatternElements with both (potentially)
   StructPatternElements (
-    std::vector<std::unique_ptr<StructPatternField> > fields,
+    std::vector<std::unique_ptr<StructPatternField>> fields,
     std::vector<Attribute> etc_attrs)
     : fields (std::move (fields)), has_struct_pattern_etc (true),
       struct_pattern_etc_attrs (std::move (etc_attrs))
@@ -796,7 +796,7 @@ public:
 
   // Constructor for StructPatternElements with no StructPatternEtc
   StructPatternElements (
-    std::vector<std::unique_ptr<StructPatternField> > fields)
+    std::vector<std::unique_ptr<StructPatternField>> fields)
     : fields (std::move (fields)), has_struct_pattern_etc (false),
       struct_pattern_etc_attrs ()
   {}
@@ -832,18 +832,17 @@ public:
   static StructPatternElements create_empty ()
   {
     return StructPatternElements (
-      std::vector<std::unique_ptr<StructPatternField> > ());
+      std::vector<std::unique_ptr<StructPatternField>> ());
   }
 
   std::string as_string () const;
 
   // TODO: seems kinda dodgy. Think of better way.
-  std::vector<std::unique_ptr<StructPatternField> > &
-  get_struct_pattern_fields ()
+  std::vector<std::unique_ptr<StructPatternField>> &get_struct_pattern_fields ()
   {
     return fields;
   }
-  const std::vector<std::unique_ptr<StructPatternField> > &
+  const std::vector<std::unique_ptr<StructPatternField>> &
   get_struct_pattern_fields () const
   {
     return fields;
@@ -956,10 +955,10 @@ protected:
 // Class for non-ranged tuple struct pattern patterns
 class TupleStructItemsNoRange : public TupleStructItems
 {
-  std::vector<std::unique_ptr<Pattern> > patterns;
+  std::vector<std::unique_ptr<Pattern>> patterns;
 
 public:
-  TupleStructItemsNoRange (std::vector<std::unique_ptr<Pattern> > patterns)
+  TupleStructItemsNoRange (std::vector<std::unique_ptr<Pattern>> patterns)
     : patterns (std::move (patterns))
   {}
 
@@ -991,8 +990,8 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: seems kinda dodgy. Think of better way.
-  std::vector<std::unique_ptr<Pattern> > &get_patterns () { return patterns; }
-  const std::vector<std::unique_ptr<Pattern> > &get_patterns () const
+  std::vector<std::unique_ptr<Pattern>> &get_patterns () { return patterns; }
+  const std::vector<std::unique_ptr<Pattern>> &get_patterns () const
   {
     return patterns;
   }
@@ -1011,12 +1010,12 @@ protected:
 // Class for ranged tuple struct pattern patterns
 class TupleStructItemsRange : public TupleStructItems
 {
-  std::vector<std::unique_ptr<Pattern> > lower_patterns;
-  std::vector<std::unique_ptr<Pattern> > upper_patterns;
+  std::vector<std::unique_ptr<Pattern>> lower_patterns;
+  std::vector<std::unique_ptr<Pattern>> upper_patterns;
 
 public:
-  TupleStructItemsRange (std::vector<std::unique_ptr<Pattern> > lower_patterns,
-			 std::vector<std::unique_ptr<Pattern> > upper_patterns)
+  TupleStructItemsRange (std::vector<std::unique_ptr<Pattern>> lower_patterns,
+			 std::vector<std::unique_ptr<Pattern>> upper_patterns)
     : lower_patterns (std::move (lower_patterns)),
       upper_patterns (std::move (upper_patterns))
   {}
@@ -1056,21 +1055,21 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: seems kinda dodgy. Think of better way.
-  std::vector<std::unique_ptr<Pattern> > &get_lower_patterns ()
+  std::vector<std::unique_ptr<Pattern>> &get_lower_patterns ()
   {
     return lower_patterns;
   }
-  const std::vector<std::unique_ptr<Pattern> > &get_lower_patterns () const
+  const std::vector<std::unique_ptr<Pattern>> &get_lower_patterns () const
   {
     return lower_patterns;
   }
 
   // TODO: seems kinda dodgy. Think of better way.
-  std::vector<std::unique_ptr<Pattern> > &get_upper_patterns ()
+  std::vector<std::unique_ptr<Pattern>> &get_upper_patterns ()
   {
     return upper_patterns;
   }
-  const std::vector<std::unique_ptr<Pattern> > &get_upper_patterns () const
+  const std::vector<std::unique_ptr<Pattern>> &get_upper_patterns () const
   {
     return upper_patterns;
   }
@@ -1233,10 +1232,10 @@ TuplePatternItemsSingle(*this);
 // Class representing TuplePattern patterns where there are multiple patterns
 class TuplePatternItemsMultiple : public TuplePatternItems
 {
-  std::vector<std::unique_ptr<Pattern> > patterns;
+  std::vector<std::unique_ptr<Pattern>> patterns;
 
 public:
-  TuplePatternItemsMultiple (std::vector<std::unique_ptr<Pattern> > patterns)
+  TuplePatternItemsMultiple (std::vector<std::unique_ptr<Pattern>> patterns)
     : patterns (std::move (patterns))
   {}
 
@@ -1268,8 +1267,8 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: seems kinda dodgy. Think of better way.
-  std::vector<std::unique_ptr<Pattern> > &get_patterns () { return patterns; }
-  const std::vector<std::unique_ptr<Pattern> > &get_patterns () const
+  std::vector<std::unique_ptr<Pattern>> &get_patterns () { return patterns; }
+  const std::vector<std::unique_ptr<Pattern>> &get_patterns () const
   {
     return patterns;
   }
@@ -1291,13 +1290,12 @@ protected:
 // Class representing TuplePattern patterns where there are a range of patterns
 class TuplePatternItemsRanged : public TuplePatternItems
 {
-  std::vector<std::unique_ptr<Pattern> > lower_patterns;
-  std::vector<std::unique_ptr<Pattern> > upper_patterns;
+  std::vector<std::unique_ptr<Pattern>> lower_patterns;
+  std::vector<std::unique_ptr<Pattern>> upper_patterns;
 
 public:
-  TuplePatternItemsRanged (
-    std::vector<std::unique_ptr<Pattern> > lower_patterns,
-    std::vector<std::unique_ptr<Pattern> > upper_patterns)
+  TuplePatternItemsRanged (std::vector<std::unique_ptr<Pattern>> lower_patterns,
+			   std::vector<std::unique_ptr<Pattern>> upper_patterns)
     : lower_patterns (std::move (lower_patterns)),
       upper_patterns (std::move (upper_patterns))
   {}
@@ -1338,21 +1336,21 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: seems kinda dodgy. Think of better way.
-  std::vector<std::unique_ptr<Pattern> > &get_lower_patterns ()
+  std::vector<std::unique_ptr<Pattern>> &get_lower_patterns ()
   {
     return lower_patterns;
   }
-  const std::vector<std::unique_ptr<Pattern> > &get_lower_patterns () const
+  const std::vector<std::unique_ptr<Pattern>> &get_lower_patterns () const
   {
     return lower_patterns;
   }
 
   // TODO: seems kinda dodgy. Think of better way.
-  std::vector<std::unique_ptr<Pattern> > &get_upper_patterns ()
+  std::vector<std::unique_ptr<Pattern>> &get_upper_patterns ()
   {
     return upper_patterns;
   }
-  const std::vector<std::unique_ptr<Pattern> > &get_upper_patterns () const
+  const std::vector<std::unique_ptr<Pattern>> &get_upper_patterns () const
   {
     return upper_patterns;
   }
@@ -1503,14 +1501,14 @@ protected:
 // AST node representing patterns that can match slices and arrays
 class SlicePattern : public Pattern
 {
-  std::vector<std::unique_ptr<Pattern> > items;
+  std::vector<std::unique_ptr<Pattern>> items;
   Location locus;
   NodeId node_id;
 
 public:
   std::string as_string () const override;
 
-  SlicePattern (std::vector<std::unique_ptr<Pattern> > items, Location locus)
+  SlicePattern (std::vector<std::unique_ptr<Pattern>> items, Location locus)
     : items (std::move (items)), locus (locus),
       node_id (Analysis::Mappings::get ()->get_next_node_id ())
   {}
@@ -1546,8 +1544,8 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: seems kinda dodgy. Think of better way.
-  std::vector<std::unique_ptr<Pattern> > &get_items () { return items; }
-  const std::vector<std::unique_ptr<Pattern> > &get_items () const
+  std::vector<std::unique_ptr<Pattern>> &get_items () { return items; }
+  const std::vector<std::unique_ptr<Pattern>> &get_items () const
   {
     return items;
   }

--- a/gcc/rust/checks/errors/rust-feature-gate.h
+++ b/gcc/rust/checks/errors/rust-feature-gate.h
@@ -169,6 +169,7 @@ public:
   void visit (AST::TuplePattern &pattern) override {}
   void visit (AST::GroupedPattern &pattern) override {}
   void visit (AST::SlicePattern &pattern) override {}
+  void visit (AST::AltPattern &pattern) override {}
   void visit (AST::EmptyStmt &stmt) override {}
   void visit (AST::LetStmt &stmt) override {}
   void visit (AST::ExprStmtWithoutBlock &stmt) override {}

--- a/gcc/rust/expand/rust-attribute-visitor.cc
+++ b/gcc/rust/expand/rust-attribute-visitor.cc
@@ -3152,6 +3152,20 @@ AttrVisitor::visit (AST::SlicePattern &pattern)
       // TODO: quit stripping now? or keep going?
     }
 }
+void
+AttrVisitor::visit (AST::AltPattern &pattern)
+{
+  // can't strip individual patterns, only sub-patterns
+  for (auto &alt : pattern.get_alts ())
+    {
+      alt->accept_vis (*this);
+
+      if (alt->is_marked_for_strip ())
+	rust_error_at (alt->get_locus (),
+		       "cannot strip pattern in this position");
+      // TODO: quit stripping now? or keep going?
+    }
+}
 
 void
 AttrVisitor::visit (AST::EmptyStmt &)

--- a/gcc/rust/expand/rust-attribute-visitor.h
+++ b/gcc/rust/expand/rust-attribute-visitor.h
@@ -258,6 +258,7 @@ public:
   void visit (AST::TuplePattern &pattern) override;
   void visit (AST::GroupedPattern &pattern) override;
   void visit (AST::SlicePattern &pattern) override;
+  void visit (AST::AltPattern &pattern) override;
 
   void visit (AST::EmptyStmt &) override;
   void visit (AST::LetStmt &stmt) override;

--- a/gcc/rust/hir/rust-ast-lower-base.cc
+++ b/gcc/rust/hir/rust-ast-lower-base.cc
@@ -461,6 +461,9 @@ ASTLoweringBase::visit (AST::GroupedPattern &)
 void
 ASTLoweringBase::visit (AST::SlicePattern &)
 {}
+void
+ASTLoweringBase::visit (AST::AltPattern &)
+{}
 
 // rust-stmt.h
 void

--- a/gcc/rust/hir/rust-ast-lower-base.h
+++ b/gcc/rust/hir/rust-ast-lower-base.h
@@ -231,6 +231,7 @@ public:
   virtual void visit (AST::TuplePattern &pattern);
   virtual void visit (AST::GroupedPattern &pattern);
   virtual void visit (AST::SlicePattern &pattern);
+  virtual void visit (AST::AltPattern &pattern);
 
   // rust-stmt.h
   virtual void visit (AST::EmptyStmt &stmt);

--- a/gcc/rust/resolve/rust-ast-resolve-base.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-base.cc
@@ -583,6 +583,10 @@ ResolverBase::visit (AST::SlicePattern &)
 {}
 
 void
+ResolverBase::visit (AST::AltPattern &)
+{}
+
+void
 ResolverBase::visit (AST::EmptyStmt &)
 {}
 

--- a/gcc/rust/resolve/rust-ast-resolve-base.h
+++ b/gcc/rust/resolve/rust-ast-resolve-base.h
@@ -178,6 +178,7 @@ public:
   void visit (AST::TuplePattern &);
   void visit (AST::GroupedPattern &);
   void visit (AST::SlicePattern &);
+  void visit (AST::AltPattern &);
 
   void visit (AST::EmptyStmt &);
   void visit (AST::LetStmt &);

--- a/gcc/rust/resolve/rust-early-name-resolver.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver.cc
@@ -1053,6 +1053,13 @@ EarlyNameResolver::visit (AST::SlicePattern &pattern)
 }
 
 void
+EarlyNameResolver::visit (AST::AltPattern &pattern)
+{
+  for (auto &alt : pattern.get_alts ())
+    alt->accept_vis (*this);
+}
+
+void
 EarlyNameResolver::visit (AST::EmptyStmt &)
 {}
 

--- a/gcc/rust/resolve/rust-early-name-resolver.h
+++ b/gcc/rust/resolve/rust-early-name-resolver.h
@@ -249,6 +249,7 @@ private:
   virtual void visit (AST::TuplePattern &pattern);
   virtual void visit (AST::GroupedPattern &pattern);
   virtual void visit (AST::SlicePattern &pattern);
+  virtual void visit (AST::AltPattern &pattern);
   virtual void visit (AST::EmptyStmt &stmt);
   virtual void visit (AST::LetStmt &stmt);
   virtual void visit (AST::ExprStmtWithoutBlock &stmt);

--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -767,6 +767,10 @@ void
 AttributeChecker::visit (AST::SlicePattern &)
 {}
 
+void
+AttributeChecker::visit (AST::AltPattern &)
+{}
+
 // rust-stmt.h
 void
 AttributeChecker::visit (AST::EmptyStmt &)

--- a/gcc/rust/util/rust-attributes.h
+++ b/gcc/rust/util/rust-attributes.h
@@ -242,6 +242,7 @@ private:
   void visit (AST::TuplePattern &pattern);
   void visit (AST::GroupedPattern &pattern);
   void visit (AST::SlicePattern &pattern);
+  void visit (AST::AltPattern &pattern);
 
   // rust-stmt.h
   void visit (AST::EmptyStmt &stmt);


### PR DESCRIPTION
Adds AST::AltPattern to represent alternate patterns (ex: ```12 | 13```).

Addresses #1808