### PR TITLE
diagnostic: Refactor Error class

### DIFF
--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -4073,7 +4073,7 @@ Module::load_items ()
   inner_attrs = parser.parse_inner_attributes ();
   auto parsed_items = parser.parse_items ();
   for (const auto &error : parser.get_errors ())
-    error.emit_error ();
+    error.emit ();
 
   items = std::move (parsed_items);
   kind = ModuleKind::LOADED;

--- a/gcc/rust/checks/errors/privacy/rust-visibility-resolver.cc
+++ b/gcc/rust/checks/errors/privacy/rust-visibility-resolver.cc
@@ -63,7 +63,7 @@ VisibilityResolver::resolve_module_path (const HIR::SimplePath &restriction,
   NodeId ref_node_id = UNKNOWN_NODEID;
   if (!resolver.lookup_resolved_name (ast_node_id, &ref_node_id))
     {
-      invalid_path.emit_error ();
+      invalid_path.emit ();
       return false;
     }
   // FIXME: Add a hint here if we can find the path in another scope, such as
@@ -77,7 +77,7 @@ VisibilityResolver::resolve_module_path (const HIR::SimplePath &restriction,
   auto module = mappings.lookup_module (ref);
   if (!module)
     {
-      invalid_path.emit_error ();
+      invalid_path.emit ();
       return false;
     }
 

--- a/gcc/rust/expand/rust-macro-builtins.cc
+++ b/gcc/rust/expand/rust-macro-builtins.cc
@@ -736,7 +736,7 @@ MacroBuiltin::include_handler (Location invoc_locus, AST::MacroInvocData &invoc)
   bool has_error = !parser.get_errors ().empty ();
 
   for (const auto &error : parser.get_errors ())
-    error.emit_error ();
+    error.emit ();
 
   if (has_error)
     {

--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -848,7 +848,7 @@ parse_many (Parser<MacroInvocLexer> &parser, TokenId &delimiter,
       if (node.is_error ())
 	{
 	  for (auto err : parser.get_errors ())
-	    err.emit_error ();
+	    err.emit ();
 
 	  return AST::Fragment::create_error ();
 	}
@@ -991,7 +991,7 @@ transcribe_type (Parser<MacroInvocLexer> &parser)
 
   auto type = parser.parse_type (true);
   for (auto err : parser.get_errors ())
-    err.emit_error ();
+    err.emit ();
 
   auto end = lexer.get_offs ();
 

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -444,7 +444,7 @@ Parser<ManagedTokenSource>::parse_crate ()
 
   // emit all errors
   for (const auto &error : error_table)
-    error.emit_error ();
+    error.emit ();
 
   return std::unique_ptr<AST::Crate> (
     new AST::Crate (std::move (items), std::move (inner_attrs)));

--- a/gcc/rust/rust-diagnostics.cc
+++ b/gcc/rust/rust-diagnostics.cc
@@ -337,14 +337,49 @@ rust_debug_loc (const Location location, const char *fmt, ...)
 }
 
 namespace Rust {
-Error::Error (const Location location, const char *fmt, ...) : locus (location)
+
+/**
+ * This function takes ownership of `args` and calls `va_end` on it
+ */
+static Error
+va_constructor (Error::Kind kind, Location locus, const char *fmt, va_list args)
+  RUST_ATTRIBUTE_GCC_DIAG (3, 0);
+
+static Error
+va_constructor (Error::Kind kind, Location locus, const char *fmt, va_list args)
+{
+  std::string message = expand_message (fmt, args);
+  message.shrink_to_fit ();
+  va_end (args);
+
+  return Error (kind, locus, message);
+}
+
+Error::Error (const Location location, const char *fmt, ...)
+  : kind (Kind::Err), locus (location)
 {
   va_list ap;
-
   va_start (ap, fmt);
-  message = expand_message (fmt, ap);
-  va_end (ap);
 
-  message.shrink_to_fit ();
+  *this = va_constructor (Kind::Err, location, fmt, ap);
 }
+
+Error
+Error::Hint (const Location location, const char *fmt, ...)
+{
+  va_list ap;
+  va_start (ap, fmt);
+
+  return va_constructor (Kind::Hint, location, fmt, ap);
+}
+
+Error
+Error::Fatal (const Location location, const char *fmt, ...)
+{
+  va_list ap;
+  va_start (ap, fmt);
+
+  return va_constructor (Kind::FatalErr, location, fmt, ap);
+}
+
 } // namespace Rust

--- a/gcc/rust/rust-diagnostics.h
+++ b/gcc/rust/rust-diagnostics.h
@@ -132,27 +132,69 @@ namespace Rust {
  * errors to be ignored, e.g. if backtracking. */
 struct Error
 {
+  enum class Kind
+  {
+    Hint,
+    Err,
+    FatalErr,
+  };
+
+  Kind kind;
   Location locus;
   std::string message;
   // TODO: store more stuff? e.g. node id?
 
-  Error (Location locus, std::string message)
-    : locus (locus), message (std::move (message))
+  Error (Kind kind, Location locus, std::string message)
+    : kind (kind), locus (locus), message (std::move (message))
   {
     message.shrink_to_fit ();
+  }
+
+  Error (Location locus, std::string message)
+  {
+    Error (Kind::Err, locus, std::move (message));
+  }
+
+  static Error Hint (Location locus, std::string message)
+  {
+    return Error (Kind::Hint, locus, std::move (message));
+  }
+
+  static Error Fatal (Location locus, std::string message)
+  {
+    return Error (Kind::FatalErr, locus, std::move (message));
   }
 
   // TODO: the attribute part might be incorrect
   Error (Location locus, const char *fmt,
 	 ...) /*RUST_ATTRIBUTE_GCC_DIAG (2, 3)*/ RUST_ATTRIBUTE_GCC_DIAG (3, 4);
 
-  // Irreversibly emits the error as an error.
-  void emit_error () const { rust_error_at (locus, "%s", message.c_str ()); }
+  /**
+   * printf-like overload of Error::Hint
+   */
+  static Error Hint (Location locus, const char *fmt, ...)
+    RUST_ATTRIBUTE_GCC_DIAG (2, 3);
 
-  // Irreversibly emits the error as a fatal error.
-  void emit_fatal_error () const
+  /**
+   * printf-like overload of Error::Fatal
+   */
+  static Error Fatal (Location locus, const char *fmt, ...)
+    RUST_ATTRIBUTE_GCC_DIAG (2, 3);
+
+  void emit () const
   {
-    rust_fatal_error (locus, "%s", message.c_str ());
+    switch (kind)
+      {
+      case Kind::Hint:
+	rust_inform (locus, "%s", message.c_str ());
+	break;
+      case Kind::Err:
+	rust_error_at (locus, "%s", message.c_str ());
+	break;
+      case Kind::FatalErr:
+	rust_fatal_error (locus, "%s", message.c_str ());
+	break;
+      }
   }
 };
 } // namespace Rust

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -199,7 +199,7 @@ Session::handle_option (
 	  else
 	    {
 	      rust_assert (!error.message.empty ());
-	      error.emit_error ();
+	      error.emit ();
 	    }
 	}
       else
@@ -397,7 +397,7 @@ Session::handle_crate_name (const AST::Crate &parsed_crate)
       if (!validate_crate_name (msg_str, error))
 	{
 	  error.locus = attr.get_locus ();
-	  error.emit_error ();
+	  error.emit ();
 	  continue;
 	}
 
@@ -418,7 +418,7 @@ Session::handle_crate_name (const AST::Crate &parsed_crate)
   if (!options.crate_name_set_manually
       && !validate_crate_name (options.crate_name, error))
     {
-      error.emit_error ();
+      error.emit ();
       rust_inform (linemap->get_location (0),
 		   "crate name inferred from this file");
     }


### PR DESCRIPTION
The class now allows for more variants including a `Hint` one which then gets emitted by calling `rust_inform`. This allows us to display hints/tips/notes in backtracking contexts such as the parser.

gcc/rust/ChangeLog:

	* rust-diagnostics.h (struct Error): Add new Kind enum and various new static constructors to allow for hints as well.
	* rust-diagnostics.cc (Error::Error): Use new `kind` field properly.
	* checks/errors/privacy/rust-visibility-resolver.cc (VisibilityResolver::resolve_module_path): Use new Error API.
	* expand/rust-macro-builtins.cc (MacroBuiltin::include_handler): Likewise.
	* expand/rust-macro-expand.cc (parse_many): Likewise. (transcribe_type): Likewise.
	* parse/rust-parse-impl.h (Parser::parse_crate): Likewise.
	* rust-session-manager.cc (Session::handle_crate_name): Likewise.

