### PR TITLE
Fix up DejaGnu directives in 'rust/compile/issue-1830_{bytes,str}.rs' test cases [#1838]

### DIFF
--- a/gcc/testsuite/rust/compile/issue-1830_bytes.rs
+++ b/gcc/testsuite/rust/compile/issue-1830_bytes.rs
@@ -4,5 +4,6 @@ macro_rules! include_bytes {
 }
 
 fn main() {
-    include_bytes!(""); // { dg-excess-errors "Is a directory" }
+    include_bytes!("");
+    // { dg-error {cannot open filename [^\n\r]+: Is a directory} {} { target *-*-* } 0 }
 }

--- a/gcc/testsuite/rust/compile/issue-1830_str.rs
+++ b/gcc/testsuite/rust/compile/issue-1830_str.rs
@@ -4,5 +4,6 @@ macro_rules! include_str {
 }
 
 fn main() {
-    include_str!(""); // { dg-excess-errors "Is a directory" }
+    include_str!("");
+    // { dg-error {cannot open filename [^\n\r]+: Is a directory} {} { target *-*-* } 0 }
 }


### PR DESCRIPTION
'dg-excess-errors' "indicates that the test is expected to fail due to compiler messages that are not handled by 'dg-error', [etc.]".  It's argument doesn't specify the message to match but just just a comment.  Here, however, we'd like to match specific compiler messages, so we should use 'dg-error', etc.  Use the magic line number zero as the compiler error diagnostic doesn't tell which line the error occurred on (separate issue to resolve).  This gives us:

    -XFAIL: rust/compile/issue-1830_str.rs (test for excess errors)
    +PASS: rust/compile/issue-1830_bytes.rs  at line 8 (test for errors, line )
    +PASS: rust/compile/issue-1830_bytes.rs (test for excess errors)
    -XFAIL: rust/compile/issue-1830_bytes.rs (test for excess errors)
    +PASS: rust/compile/issue-1830_str.rs  at line 8 (test for errors, line )
    +PASS: rust/compile/issue-1830_str.rs (test for excess errors)

Fix-up for recent GCC/Rust master branch #1838
commit cf9ed4001eec6a22686d19a13f7de8ac94f9cb2a
"testsuite: Add empty string macro test".

	gcc/testsuite/
	* rust/compile/issue-1830_bytes.rs: Fix up DejaGnu directives.
	* rust/compile/issue-1830_str.rs: Likewise.
