### PR TITLE
Add feature gate for "rustc_attri".

### DIFF
--- a/gcc/rust/checks/errors/rust-feature-gate.cc
+++ b/gcc/rust/checks/errors/rust-feature-gate.cc
@@ -105,4 +105,54 @@ FeatureGate::visit (AST::ExternBlock &block)
     }
 }
 
+void
+FeatureGate::check_rustc_attri (const std::vector<AST::Attribute> &attributes)
+{
+  for (const AST::Attribute &attr : attributes)
+    {
+      auto name = attr.get_path ().as_string ();
+      if (name.rfind ("rustc_", 0) == 0)
+	{
+	  gate (Feature::Name::RUSTC_ATTRS, attr.get_locus (),
+		"internal implementation detail");
+	}
+    }
+}
+
+void
+FeatureGate::visit (AST::MacroRulesDefinition &rules_def)
+{
+  check_rustc_attri (rules_def.get_outer_attrs ());
+}
+
+void
+FeatureGate::visit (AST::InherentImpl &impl)
+{
+  for (const auto &item : impl.get_impl_items ())
+    {
+      item->accept_vis (*this);
+    }
+}
+
+void
+FeatureGate::visit (AST::TraitImpl &impl)
+{
+  for (const auto &item : impl.get_impl_items ())
+    {
+      item->accept_vis (*this);
+    }
+}
+
+void
+FeatureGate::visit (AST::Method &method)
+{
+  check_rustc_attri (method.get_outer_attrs ());
+}
+
+void
+FeatureGate::visit (AST::Function &function)
+{
+  check_rustc_attri (function.get_outer_attrs ());
+}
+
 } // namespace Rust

--- a/gcc/rust/checks/errors/rust-feature-gate.h
+++ b/gcc/rust/checks/errors/rust-feature-gate.h
@@ -25,8 +25,6 @@
 
 namespace Rust {
 
-struct Feature;
-
 class FeatureGate : public AST::ASTVisitor
 {
 public:
@@ -109,14 +107,14 @@ public:
   void visit (AST::TypeParam &param) override {}
   void visit (AST::LifetimeWhereClauseItem &item) override {}
   void visit (AST::TypeBoundWhereClauseItem &item) override {}
-  void visit (AST::Method &method) override {}
+  void visit (AST::Method &method) override;
   void visit (AST::Module &module) override {}
   void visit (AST::ExternCrate &crate) override {}
   void visit (AST::UseTreeGlob &use_tree) override {}
   void visit (AST::UseTreeList &use_tree) override {}
   void visit (AST::UseTreeRebind &use_tree) override {}
   void visit (AST::UseDeclaration &use_decl) override {}
-  void visit (AST::Function &function) override {}
+  void visit (AST::Function &function) override;
   void visit (AST::TypeAlias &type_alias) override {}
   void visit (AST::StructStruct &struct_item) override {}
   void visit (AST::TupleStruct &tuple_struct) override {}
@@ -133,15 +131,15 @@ public:
   void visit (AST::TraitItemConst &item) override {}
   void visit (AST::TraitItemType &item) override {}
   void visit (AST::Trait &trait) override {}
-  void visit (AST::InherentImpl &impl) override {}
-  void visit (AST::TraitImpl &impl) override {}
+  void visit (AST::InherentImpl &impl) override;
+  void visit (AST::TraitImpl &impl) override;
   void visit (AST::ExternalStaticItem &item) override {}
   void visit (AST::ExternalFunctionItem &item) override {}
   void visit (AST::ExternBlock &block) override;
   void visit (AST::MacroMatchFragment &match) override {}
   void visit (AST::MacroMatchRepetition &match) override {}
   void visit (AST::MacroMatcher &matcher) override {}
-  void visit (AST::MacroRulesDefinition &rules_def) override {}
+  void visit (AST::MacroRulesDefinition &rules_def) override;
   void visit (AST::MacroInvocation &macro_invoc) override {}
   void visit (AST::MetaItemPath &meta_item) override {}
   void visit (AST::MetaItemSeq &meta_item) override {}
@@ -191,6 +189,7 @@ public:
 
 private:
   void gate (Feature::Name name, Location loc, const std::string &error_msg);
+  void check_rustc_attri (const std::vector<AST::Attribute> &attributes);
   std::set<Feature::Name> valid_features;
 };
 } // namespace Rust

--- a/gcc/testsuite/rust/compile/builtin_macro_compile_error.rs
+++ b/gcc/testsuite/rust/compile/builtin_macro_compile_error.rs
@@ -1,3 +1,5 @@
+#![feature(rustc_attrs)]
+
 #[rustc_builtin_macro]
 macro_rules! compile_error {
   () => {{}};

--- a/gcc/testsuite/rust/compile/builtin_macro_concat.rs
+++ b/gcc/testsuite/rust/compile/builtin_macro_concat.rs
@@ -1,3 +1,5 @@
+#![feature(rustc_attrs)]
+
 #[rustc_builtin_macro]
 macro_rules! concat {
     () => {{}};

--- a/gcc/testsuite/rust/compile/builtin_macro_eager1.rs
+++ b/gcc/testsuite/rust/compile/builtin_macro_eager1.rs
@@ -1,4 +1,5 @@
 // { dg-additional-options "-fdump-tree-gimple" }
+#![feature(rustc_attrs)]
 
 #[rustc_builtin_macro]
 macro_rules! concat {

--- a/gcc/testsuite/rust/compile/builtin_macro_eager2.rs
+++ b/gcc/testsuite/rust/compile/builtin_macro_eager2.rs
@@ -1,3 +1,5 @@
+#![feature(rustc_attrs)]
+
 #[rustc_builtin_macro]
 macro_rules! env {
     () => {};

--- a/gcc/testsuite/rust/compile/builtin_macro_env.rs
+++ b/gcc/testsuite/rust/compile/builtin_macro_env.rs
@@ -1,3 +1,5 @@
+#![feature(rustc_attrs)]
+
 #[rustc_builtin_macro]
 macro_rules! env {
   () => {{}};

--- a/gcc/testsuite/rust/compile/builtin_macro_include_bytes.rs
+++ b/gcc/testsuite/rust/compile/builtin_macro_include_bytes.rs
@@ -1,3 +1,5 @@
+#![feature(rustc_attrs)]
+
 #[rustc_builtin_macro]
 macro_rules! include_bytes {
   () => {{}};

--- a/gcc/testsuite/rust/compile/builtin_macro_include_str.rs
+++ b/gcc/testsuite/rust/compile/builtin_macro_include_str.rs
@@ -1,3 +1,5 @@
+#![feature(rustc_attrs)]
+
 #[rustc_builtin_macro]
 macro_rules! include_str {
   () => {{}};

--- a/gcc/testsuite/rust/compile/builtin_macro_not_found.rs
+++ b/gcc/testsuite/rust/compile/builtin_macro_not_found.rs
@@ -1,3 +1,5 @@
+#![feature(rustc_attrs)]
+
 #[rustc_builtin_macro]
 macro_rules! crabby_crab_carb { // { dg-error "cannot find a built-in macro with name .crabby_crab_carb." }
     () => {{}};

--- a/gcc/testsuite/rust/compile/builtin_macro_recurse2.rs
+++ b/gcc/testsuite/rust/compile/builtin_macro_recurse2.rs
@@ -1,4 +1,5 @@
 // { dg-additional-options "-fdump-tree-gimple" }
+#![feature(rustc_attrs)]
 
 #[rustc_builtin_macro]
 macro_rules! concat {

--- a/gcc/testsuite/rust/compile/feature_rust_attri0.rs
+++ b/gcc/testsuite/rust/compile/feature_rust_attri0.rs
@@ -1,0 +1,11 @@
+#[rustc_builtin_macro] //{ dg-error "internal implementation detail. " "" { target *-*-* }  }
+macro_rules! line {
+    () => {{}};
+}
+
+fn main() -> i32 {
+    let a = line!();
+    print(a);
+
+    0
+}

--- a/gcc/testsuite/rust/compile/feature_rust_attri1.rs
+++ b/gcc/testsuite/rust/compile/feature_rust_attri1.rs
@@ -1,0 +1,13 @@
+
+pub struct NotI8(i8);
+
+impl NotI8 {
+    #[rustc_inherit_overflow_checks] //{ dg-error "internal implementation detail" "" { target *-*-* }  }
+    pub fn add(self, other: NotI8) -> NotI8 {
+        NotI8(self.0 + other.0)
+    }
+}
+
+fn main() -> i32 {
+    0
+}

--- a/gcc/testsuite/rust/compile/include_empty.rs
+++ b/gcc/testsuite/rust/compile/include_empty.rs
@@ -1,3 +1,5 @@
+#![feature(rustc_attrs)]
+
 #[rustc_builtin_macro]
 macro_rules! include {
     () => {};

--- a/gcc/testsuite/rust/compile/issue-1830_bytes.rs
+++ b/gcc/testsuite/rust/compile/issue-1830_bytes.rs
@@ -1,3 +1,5 @@
+#![feature(rustc_attrs)]
+
 #[rustc_builtin_macro]
 macro_rules! include_bytes {
     () => {{}};

--- a/gcc/testsuite/rust/compile/issue-1830_str.rs
+++ b/gcc/testsuite/rust/compile/issue-1830_str.rs
@@ -1,3 +1,5 @@
+#![feature(rustc_attrs)]
+
 #[rustc_builtin_macro]
 macro_rules! include_str {
     () => {{}};

--- a/gcc/testsuite/rust/compile/macro42.rs
+++ b/gcc/testsuite/rust/compile/macro42.rs
@@ -1,4 +1,6 @@
 // { dg-additional-options "-w -frust-cfg=A" }
+#![feature(rustc_attrs)]
+
 #[rustc_builtin_macro]
 macro_rules! cfg {
     () => {{}};

--- a/gcc/testsuite/rust/execute/torture/builtin_macro_cfg.rs
+++ b/gcc/testsuite/rust/execute/torture/builtin_macro_cfg.rs
@@ -1,5 +1,7 @@
 // { dg-additional-options "-w -frust-cfg=A" }
 // { dg-output "A\r*\n" }
+#![feature(rustc_attrs)]
+
 #[rustc_builtin_macro]
 macro_rules! cfg {
     () => {{}};

--- a/gcc/testsuite/rust/execute/torture/builtin_macro_concat.rs
+++ b/gcc/testsuite/rust/execute/torture/builtin_macro_concat.rs
@@ -1,4 +1,6 @@
 // { dg-output "\r*\ntest10btrue2.15\r*\ntest10bfalse2.151\r*\n" }
+#![feature(rustc_attrs)]
+
 #[rustc_builtin_macro]
 macro_rules! concat {
     () => {{}};

--- a/gcc/testsuite/rust/execute/torture/builtin_macro_env.rs
+++ b/gcc/testsuite/rust/execute/torture/builtin_macro_env.rs
@@ -1,5 +1,7 @@
 // { dg-output "VALUE\r*\nVALUE\r*\n" }
 // { dg-set-compiler-env-var ENV_MACRO_TEST "VALUE" }
+#![feature(rustc_attrs)]
+
 #[rustc_builtin_macro]
 macro_rules! env {
     () => {{}};

--- a/gcc/testsuite/rust/execute/torture/builtin_macro_include_bytes.rs
+++ b/gcc/testsuite/rust/execute/torture/builtin_macro_include_bytes.rs
@@ -1,4 +1,6 @@
 // { dg-output "104\r*\n33\r*\n1\r*\n" }
+#![feature(rustc_attrs)]
+
 #[rustc_builtin_macro]
 macro_rules! include_bytes {
     () => {{}};

--- a/gcc/testsuite/rust/execute/torture/builtin_macro_include_str.rs
+++ b/gcc/testsuite/rust/execute/torture/builtin_macro_include_str.rs
@@ -1,4 +1,6 @@
 // { dg-output "hello, include!\r*\n" }
+#![feature(rustc_attrs)]
+
 #[rustc_builtin_macro]
 macro_rules! include_str {
     () => {{}};

--- a/gcc/testsuite/rust/execute/torture/builtin_macro_line.rs
+++ b/gcc/testsuite/rust/execute/torture/builtin_macro_line.rs
@@ -1,4 +1,6 @@
-// { dg-output "18\r*\n21\r*\n" }
+// { dg-output "20\r*\n23\r*\n" }
+#![feature(rustc_attrs)]
+
 extern "C" {
     fn printf(fmt: *const i8, ...);
 }

--- a/gcc/testsuite/rust/execute/torture/builtin_macros1.rs
+++ b/gcc/testsuite/rust/execute/torture/builtin_macros1.rs
@@ -1,4 +1,6 @@
 // { dg-output "rust/execute/torture/builtin_macros1.rs\r*" }
+#![feature(rustc_attrs)]
+
 #[rustc_builtin_macro]
 macro_rules! file {
     () => {{}};

--- a/gcc/testsuite/rust/execute/torture/builtin_macros3.rs
+++ b/gcc/testsuite/rust/execute/torture/builtin_macros3.rs
@@ -1,4 +1,6 @@
 // { dg-output "14\r*\n42\r*\n" }
+#![feature(rustc_attrs)]
+
 #[rustc_builtin_macro]
 macro_rules! column {
     () => {{}};

--- a/gcc/testsuite/rust/execute/torture/macros29.rs
+++ b/gcc/testsuite/rust/execute/torture/macros29.rs
@@ -1,4 +1,6 @@
 // { dg-output "1\r*\n" }
+#![feature(rustc_attrs)]
+
 #[rustc_builtin_macro]
 macro_rules! concat {
     () => {{}};

--- a/gcc/testsuite/rust/execute/torture/macros30.rs
+++ b/gcc/testsuite/rust/execute/torture/macros30.rs
@@ -1,4 +1,6 @@
 // { dg-output "1\r*\n" }
+#![feature(rustc_attrs)]
+
 #[rustc_builtin_macro]
 macro_rules! concat {
     () => {{}};

--- a/gcc/testsuite/rust/execute/torture/macros31.rs
+++ b/gcc/testsuite/rust/execute/torture/macros31.rs
@@ -1,5 +1,7 @@
 // { dg-additional-options "-w -frust-cfg=A" }
 // { dg-output "A\r*\nB\r*\n" }
+#![feature(rustc_attrs)]
+
 #[rustc_builtin_macro]
 macro_rules! cfg {
     () => {{}};


### PR DESCRIPTION
This commit implemented a basic feature gate to check some attributes for `rustc_attri`.

gcc/rust/ChangeLog:

	* checks/errors/rust-feature-gate.cc: Add implementations for `rustc_attri`.
	* checks/errors/rust-feature-gate.h: Likewise.

gcc/testsuite/ChangeLog:

	* rust/compile/builtin_macro_compile_error.rs: Add crate feature `rustc_attri`.
	* rust/compile/builtin_macro_concat.rs: Likewise.
	* rust/compile/builtin_macro_eager1.rs: Likewise.
	* rust/compile/builtin_macro_eager2.rs: Likewise.
	* rust/compile/builtin_macro_env.rs: Likewise.
	* rust/compile/builtin_macro_include_bytes.rs: Likewise.
	* rust/compile/builtin_macro_include_str.rs: Likewise.
	* rust/compile/builtin_macro_not_found.rs: Likewise.
	* rust/compile/builtin_macro_recurse2.rs: Likewise.
	* rust/compile/feature_rust_attri0.rs:New file.
	* rust/compile/feature_rust_attri1.rs:New file.
	* rust/compile/include_empty.rs:Add crate feature `rustc_attri`.
	* rust/compile/issue-1830_bytes.rs:Likewise.
	* rust/compile/issue-1830_str.rs:Likewise.
	* rust/compile/macro42.rs:Likewise.
	* rust/execute/torture/builtin_macro_cfg.rs: Likewise.
	* rust/execute/torture/builtin_macro_concat.rs: Likewise.
	* rust/execute/torture/builtin_macro_env.rs: Likewise.
	* rust/execute/torture/builtin_macro_include_bytes.rs: Likewise.
	* rust/execute/torture/builtin_macro_include_str.rs: Likewise.
	* rust/execute/torture/builtin_macro_line.rs: Likewise.
	* rust/execute/torture/builtin_macros1.rs: Likewise.
	* rust/execute/torture/builtin_macros3.rs: Likewise.
	* rust/execute/torture/macros29.rs:Likewise.
	* rust/execute/torture/macros30.rs:Likewise.
	* rust/execute/torture/macros31.rs:Likewise.


