### PR TITLE
parser: Allow parsing of qualified type path as nested generic argument

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -6834,11 +6834,13 @@ Parser<ManagedTokenSource>::parse_qualified_path_type (
   if (locus == Linemap::unknown_location ())
     {
       locus = lexer.peek_token ()->get_locus ();
+
+      if (lexer.peek_token ()->get_id () == LEFT_SHIFT)
+	lexer.split_current_token (LEFT_ANGLE, LEFT_ANGLE);
+
+      // skip after somewhere?
       if (!skip_token (LEFT_ANGLE))
-	{
-	  // skip after somewhere?
-	  return AST::QualifiedPathType::create_error ();
-	}
+	return AST::QualifiedPathType::create_error ();
     }
 
   // parse type (required)
@@ -9219,6 +9221,7 @@ Parser<ManagedTokenSource>::parse_type (bool save_errors)
     case LEFT_SQUARE:
       // slice type or array type - requires further disambiguation
       return parse_slice_or_array_type ();
+    case LEFT_SHIFT:
       case LEFT_ANGLE: {
 	// qualified path in type
 	AST::QualifiedPathInType path = parse_qualified_path_in_type ();
@@ -10085,6 +10088,7 @@ Parser<ManagedTokenSource>::parse_type_no_bounds ()
     case LEFT_SQUARE:
       // slice type or array type - requires further disambiguation
       return parse_slice_or_array_type ();
+    case LEFT_SHIFT:
       case LEFT_ANGLE: {
 	// qualified path in type
 	AST::QualifiedPathInType path = parse_qualified_path_in_type ();
@@ -10598,6 +10602,7 @@ Parser<ManagedTokenSource>::parse_range_pattern_bound ()
 	return std::unique_ptr<AST::RangePatternBoundPath> (
 	  new AST::RangePatternBoundPath (std::move (path)));
       }
+    case LEFT_SHIFT:
       case LEFT_ANGLE: {
 	// qualified path in expression
 	AST::QualifiedPathInExpression path
@@ -10697,6 +10702,7 @@ Parser<ManagedTokenSource>::parse_pattern ()
     case LEFT_SQUARE:
       // slice pattern
       return parse_slice_pattern ();
+    case LEFT_SHIFT:
       case LEFT_ANGLE: {
 	// qualified path in expression or qualified range pattern bound
 	AST::QualifiedPathInExpression path
@@ -12730,6 +12736,7 @@ Parser<ManagedTokenSource>::null_denotation (const_TokenPtr tok,
        * tokens and whatever. */
       /* FIXME: could also be path expression (and hence macro expression,
        * struct/enum expr) */
+    case LEFT_SHIFT:
       case LEFT_ANGLE: {
 	// qualified path
 	// HACK: add outer attrs to path

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -6375,6 +6375,9 @@ template <typename ManagedTokenSource>
 AST::GenericArgs
 Parser<ManagedTokenSource>::parse_path_generic_args ()
 {
+  if (lexer.peek_token ()->get_id () == LEFT_SHIFT)
+    lexer.split_current_token (LEFT_ANGLE, LEFT_ANGLE);
+
   if (!skip_token (LEFT_ANGLE))
     {
       // skip after somewhere?
@@ -6549,6 +6552,7 @@ Parser<ManagedTokenSource>::parse_type_path_segment ()
   const_TokenPtr t = lexer.peek_token ();
   switch (t->get_id ())
     {
+    case LEFT_SHIFT:
       case LEFT_ANGLE: {
 	// parse generic args
 	AST::GenericArgs generic_args = parse_path_generic_args ();

--- a/gcc/testsuite/rust/compile/nested_generic.rs
+++ b/gcc/testsuite/rust/compile/nested_generic.rs
@@ -1,0 +1,4 @@
+pub struct A<T>(T);
+pub struct B<T>(T);
+
+pub fn foo(_: A<B<i32>>) {}

--- a/gcc/testsuite/rust/compile/parse_associated_type_as_generic_arg.rs
+++ b/gcc/testsuite/rust/compile/parse_associated_type_as_generic_arg.rs
@@ -1,0 +1,24 @@
+// { dg-additional-options "-fsyntax-only" }
+
+trait Foo {
+    type A;
+
+    fn foo();
+}
+
+struct S;
+
+impl Foo for S {
+    type A = i32;
+
+    fn foo() {}
+}
+
+enum Maybe<T> {
+    Something(T),
+    Nothing,
+}
+
+fn foo() -> Maybe<<S as Foo>::A> {
+    Maybe::Something(15)
+}

--- a/gcc/testsuite/rust/compile/parse_associated_type_as_generic_arg2.rs
+++ b/gcc/testsuite/rust/compile/parse_associated_type_as_generic_arg2.rs
@@ -1,0 +1,24 @@
+// { dg-additional-options "-fsyntax-only" }
+
+trait Foo {
+    type A;
+
+    fn foo();
+}
+
+struct S;
+
+impl Foo for S {
+    type A = ();
+
+    fn foo() {}
+}
+
+enum Maybe<T> {
+    Something(T),
+    Nothing,
+}
+
+fn main() {
+    let a: Maybe<<S as Foo>::A> = Maybe::Something(());
+}

--- a/gcc/testsuite/rust/compile/parse_associated_type_as_generic_arg3.rs
+++ b/gcc/testsuite/rust/compile/parse_associated_type_as_generic_arg3.rs
@@ -1,0 +1,59 @@
+// { dg-additional-options "-fsyntax-only" }
+
+trait Bar {
+    type B;
+
+    fn bar();
+}
+
+trait Foo {
+    type A;
+
+    fn foo();
+}
+
+trait Toto {
+    type C;
+
+    fn toto();
+}
+
+trait Tata {
+    type D;
+    fn tata();
+}
+
+impl Toto for u32 {
+    type C = f32;
+
+    fn toto() {}
+}
+
+impl Tata for f32 {
+    type D = u32;
+
+    fn tata() {}
+}
+
+struct S;
+
+impl Bar for i32 {
+    type B = u32;
+
+    fn bar() {}
+}
+
+impl Foo for S {
+    type A = i32;
+
+    fn foo() {}
+}
+
+enum Maybe<T> {
+    Something(T),
+    Nothing,
+}
+
+fn foo() -> Maybe<<<<<S as Foo>::A as Bar>::B as Toto>::C as Tata>::D> {
+    Maybe::Something(15)
+}

--- a/gcc/testsuite/rust/compile/path_as_generic_arg.rs
+++ b/gcc/testsuite/rust/compile/path_as_generic_arg.rs
@@ -1,0 +1,12 @@
+pub enum Result<T, E> {
+    Ok(T),
+    Err(E),
+}
+
+pub mod module {
+    pub struct E;
+}
+
+pub fn foo() -> Result<(), module::E> {
+    Result::Err(module::E)
+}


### PR DESCRIPTION
Let's take the example of lexing `Option<<T as Iterator>::Item>` and look at the first few tokens. Originally, `Option<<T` was lexed as 3 tokens:

* IDENTIFIER(Option)
* LEFT_SHIFT
* IDENTIFIER(T)

The parser did not allow a list of generic arguments to start with a left shift, and rejected the above type. We are now splitting the left shift into two left angles, as this allows complex generic arguments and overall makes sense parsing wise. Thus, the above list becomes:

* IDENTIFIER(Option)
* LEFT_ANGLE
* LEFT_ANGLE
* IDENTIFIER(T)

and `<T as Iterator>` is properly parsed as a qualified path.

Fixes #1815
Fixed #1809

Addresses #1524

gcc/rust/ChangeLog:

	* parse/rust-parse-impl.h (Parser::parse_path_generic_args): Split leading `LEFT_SHIFT` token into two `LEFT_ANGLE` tokens when parsing generic arguments. (Parser::parse_type_path_segment): Allow `LEFT_ANGLE` as starting token for parsing generic arguments.

gcc/testsuite/ChangeLog:

	* rust/compile/parse_associated_type_as_generic_arg.rs: New test.
	* rust/compile/parse_associated_type_as_generic_arg2.rs: New test.
	* rust/compile/path_as_generic_arg.rs: New test.
	* rust/compile/nested_generic.rs: New test.

@sun-jacobi I accidentally fixed your issue while investigating something different. Sorry :(