### PR TITLE
parser: Parse auto_traits

### DIFF
--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -3399,6 +3399,7 @@ protected:
 class Trait : public VisItem
 {
   bool has_unsafe;
+  bool has_auto;
   Identifier name;
   std::vector<std::unique_ptr<GenericParam>> generic_params;
   std::vector<std::unique_ptr<TypeParamBound>> type_param_bounds;
@@ -3428,9 +3429,10 @@ public:
   Identifier get_identifier () const { return name; }
 
   bool is_unsafe () const { return has_unsafe; }
+  bool is_auto () const { return has_auto; }
 
   // Mega-constructor
-  Trait (Identifier name, bool is_unsafe,
+  Trait (Identifier name, bool is_unsafe, bool is_auto,
 	 std::vector<std::unique_ptr<GenericParam>> generic_params,
 	 std::vector<std::unique_ptr<TypeParamBound>> type_param_bounds,
 	 WhereClause where_clause,
@@ -3438,7 +3440,7 @@ public:
 	 std::vector<Attribute> outer_attrs, std::vector<Attribute> inner_attrs,
 	 Location locus)
     : VisItem (std::move (vis), std::move (outer_attrs)),
-      has_unsafe (is_unsafe), name (std::move (name)),
+      has_unsafe (is_unsafe), has_auto (is_auto), name (std::move (name)),
       generic_params (std::move (generic_params)),
       type_param_bounds (std::move (type_param_bounds)),
       where_clause (std::move (where_clause)),
@@ -3448,9 +3450,9 @@ public:
 
   // Copy constructor with vector clone
   Trait (Trait const &other)
-    : VisItem (other), has_unsafe (other.has_unsafe), name (other.name),
-      where_clause (other.where_clause), inner_attrs (other.inner_attrs),
-      locus (other.locus)
+    : VisItem (other), has_unsafe (other.has_unsafe), has_auto (other.has_auto),
+      name (other.name), where_clause (other.where_clause),
+      inner_attrs (other.inner_attrs), locus (other.locus)
   {
     generic_params.reserve (other.generic_params.size ());
     for (const auto &e : other.generic_params)
@@ -3471,6 +3473,7 @@ public:
     VisItem::operator= (other);
     name = other.name;
     has_unsafe = other.has_unsafe;
+    has_auto = other.has_auto;
     where_clause = other.where_clause;
     inner_attrs = other.inner_attrs;
     locus = other.locus;

--- a/gcc/rust/checks/errors/rust-feature.cc
+++ b/gcc/rust/checks/errors/rust-feature.cc
@@ -53,7 +53,10 @@ const std::map<std::string, Feature::Name> Feature::name_hash_map = {
   {"intrinsics", Feature::Name::INTRINSICS},
   {"rustc_attrs", Feature::Name::RUSTC_ATTRS},
   {"decl_macro", Feature::Name::DECL_MACRO},
-};
+  // TODO: Rename to "auto_traits" when supporting
+  // later Rust versions
+  {"optin_builtin_traits", Feature::Name::AUTO_TRAITS},
+}; // namespace Rust
 
 Optional<Feature::Name>
 Feature::as_name (const std::string &name)

--- a/gcc/rust/checks/errors/rust-feature.h
+++ b/gcc/rust/checks/errors/rust-feature.h
@@ -41,6 +41,7 @@ public:
     INTRINSICS,
     RUSTC_ATTRS,
     DECL_MACRO,
+    AUTO_TRAITS,
   };
 
   const std::string &as_string () { return m_name_str; }

--- a/gcc/rust/lex/rust-token.h
+++ b/gcc/rust/lex/rust-token.h
@@ -149,7 +149,8 @@ enum PrimitiveCoreType
   /* have "weak" union and 'static keywords? */                                \
   RS_TOKEN_KEYWORD (ABSTRACT, "abstract") /* unused */                         \
   RS_TOKEN_KEYWORD (AS, "as")                                                  \
-  RS_TOKEN_KEYWORD (ASYNC, "async")   /* unused */                             \
+  RS_TOKEN_KEYWORD (ASYNC, "async") /* unused */                               \
+  RS_TOKEN_KEYWORD (AUTO, "auto")                                              \
   RS_TOKEN_KEYWORD (BECOME, "become") /* unused */                             \
   RS_TOKEN_KEYWORD (BOX, "box")	      /* unused */                             \
   RS_TOKEN_KEYWORD (BREAK, "break")                                            \

--- a/gcc/testsuite/rust/compile/auto_trait_invalid.rs
+++ b/gcc/testsuite/rust/compile/auto_trait_invalid.rs
@@ -1,0 +1,16 @@
+// #![feature(auto_traits)] // not present in Rust 1.49 yet
+
+#![feature(optin_builtin_traits)]
+
+unsafe auto trait Invalid { // { dg-error "associated items are forbidden within auto traits" }
+    fn foo(); // { dg-message "remove this item" }
+
+    fn bar() {} // { dg-message "remove this item" }
+
+    type Foo; // { dg-message "remove this item" }
+
+    const FOO: i32; // { dg-message "remove this item" }
+
+    const BAR: i32 = 15; // { dg-message "remove this item" }
+}
+// { dg-error "failed to parse item in crate" "" {target *-*-* } .+1 }

--- a/gcc/testsuite/rust/compile/auto_trait_valid.rs
+++ b/gcc/testsuite/rust/compile/auto_trait_valid.rs
@@ -1,0 +1,10 @@
+// #![feature(auto_traits)] // not present in Rust 1.49 yet
+
+#![feature(optin_builtin_traits)]
+
+auto trait MegaSend {}
+pub auto trait MegaSync {}
+unsafe auto trait SuperSync {}
+pub unsafe auto trait SuperSend {}
+
+fn main() {}


### PR DESCRIPTION
This adds enough handling to start parsing `auto` traits but not handle
them in the AST, lowering phase or HIR yet.

The feature is named `optin_builtin_traits` in Rust 1.49 but changes to
`auto_traits` later down the line. So we'll need to take care of this later
on.

Fixes #1814

gcc/rust/ChangeLog:

        * ast/rust-item.h (class Trait): Add `has_auto` field.
        * checks/errors/rust-feature.cc: Add handling for `feature(optin_builtin_traits)`
        * checks/errors/rust-feature.h: Likewise.
        * lex/rust-token.h: Add `auto` keyword token.
        * parse/rust-parse-impl.h (Parser::parse_vis_item): Parse auto traits
        on `auto` keyword.
        (Parser::parse_trait): Add `is_auto_trait` optional parameter.
        * parse/rust-parse.h: Likewise.

gcc/testsuite/ChangeLog:

        * rust/compile/auto_trait_invalid.rs: New test.
        * rust/compile/auto_trait_valid.rs: New test.
        
Only review the last commit as the other two are part of earlier PRs.