### PR TITLE
Unsafe block parsing fix

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -6131,7 +6131,15 @@ Parser<ManagedTokenSource>::parse_stmt (ParseRestrictions restrictions)
       /* if any of these (should be all possible VisItem prefixes), parse a
        * VisItem can't parse item because would require reparsing outer
        * attributes */
-      return parse_vis_item (std::move (outer_attrs));
+      // may also be unsafe block
+      if (lexer.peek_token (1)->get_id () == LEFT_CURLY)
+	{
+	  return parse_expr_stmt (std::move (outer_attrs), restrictions);
+	}
+      else
+	{
+	  return parse_vis_item (std::move (outer_attrs));
+	}
       break;
     case SUPER:
     case SELF:

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -7188,18 +7188,9 @@ Parser<ManagedTokenSource>::parse_expr_stmt (AST::AttrVec outer_attrs,
 	  }
       }
       case UNSAFE: {
-	/* FIXME: are there any expressions without blocks that can have
-	 * unsafe as their first token? Or is unsafe the only one? */
-	// safe side for now
-	if (lexer.peek_token (1)->get_id () == LEFT_CURLY)
-	  {
-	    return parse_expr_stmt_with_block (std::move (outer_attrs));
-	  }
-	else
-	  {
-	    return parse_expr_stmt_without_block (std::move (outer_attrs),
-						  restrictions);
-	  }
+	// unsafe block
+	// https://doc.rust-lang.org/reference/unsafe-keyword.html
+	return parse_expr_stmt_with_block (std::move (outer_attrs));
       }
     default:
       // not a parse expr with block, so must be expr without block

--- a/gcc/testsuite/rust/compile/issue-1422.rs
+++ b/gcc/testsuite/rust/compile/issue-1422.rs
@@ -1,0 +1,7 @@
+macro_rules! test {
+    () => { unsafe {} };
+}
+
+fn main() {
+    test!();
+}


### PR DESCRIPTION
Fixes #1422 and removes a ```FIXME```.