### PR TITLE
Added AST Node AST::InlineAsm

### DIFF
--- a/gcc/rust/ast/rust-ast-full-decls.h
+++ b/gcc/rust/ast/rust-ast-full-decls.h
@@ -149,6 +149,7 @@ struct MatchCase;
 class MatchExpr;
 class AwaitExpr;
 class AsyncBlockExpr;
+class InlineAsm;
 
 // rust-stmt.h
 class EmptyStmt;


### PR DESCRIPTION
Fixes #1567
Created a AST node InlineAsm similar to the one found in rustc. As there is no Symbol struct/class in gccrs I have made every instance of Symbol a string.

Signed-off-by: M V V S Manoj Kumar <mvvsmanojkumar@gmail.com>

gcc/rust/ChangeLog:

	* ast/rust-ast-full-decls.h (class InlineAsm):Added class declaration.
	* ast/rust-expr.h (class InlineAsm):Added class definition.

The rustc guide for reference [here](https://rustc-dev-guide.rust-lang.org/asm.html#ast)
I did do a `git gcc-verify` to check if everything was alright with the change log. do let me know if I missed any thing :)
