### PR TITLE
Added HIR::InlineAsm

### DIFF
--- a/gcc/rust/ast/rust-ast-full-decls.h
+++ b/gcc/rust/ast/rust-ast-full-decls.h
@@ -145,6 +145,14 @@ struct MatchCase;
 class MatchExpr;
 class AwaitExpr;
 class AsyncBlockExpr;
+enum class InlineAsmOptions;
+struct AnonConst;
+struct InlineAsmRegOrRegClass;
+struct InlineAsmOperand;
+struct InlineAsmPlaceHolder;
+struct InlineAsmTemplatePiece;
+struct TupleClobber;
+struct TupleTemplateStr;
 class InlineAsm;
 
 // rust-stmt.h

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -4413,135 +4413,135 @@ protected:
   }
 };
 
+// Inline-assembly specific options
+enum class InlineAsmOptions
+{
+  PURE = 1 << 0,
+  NOMEM = 1 << 1,
+  READONLY = 1 << 2,
+  PRESERVES_FLAGS = 1 << 3,
+  NORETURN = 1 << 4,
+  NOSTACK = 1 << 5,
+  ATT_SYNTAX = 1 << 6,
+  RAW = 1 << 7,
+  MAY_UNWIND = 1 << 8,
+};
+
+struct AnonConst
+{
+  NodeId id;
+  std::unique_ptr<Expr> value;
+};
+
+struct InlineAsmRegOrRegClass
+{
+  enum Type
+  {
+    Reg,
+    RegClass,
+  };
+
+  struct Reg
+  {
+    std::string Symbol;
+  };
+
+  struct RegClass
+  {
+    std::string Symbol;
+  };
+
+  Identifier name;
+  Location locus;
+};
+
+struct InlineAsmOperand
+{
+  enum RegisterType
+  {
+    In,
+    Out,
+    InOut,
+    SplitInOut,
+    Const,
+    Sym,
+  };
+
+  struct In
+  {
+    InlineAsmRegOrRegClass reg;
+    std::unique_ptr<Expr> expr;
+  };
+
+  struct Out
+  {
+    InlineAsmRegOrRegClass reg;
+    bool late;
+    std::unique_ptr<Expr> expr; // can be null
+  };
+
+  struct InOut
+  {
+    InlineAsmRegOrRegClass reg;
+    bool late;
+    std::unique_ptr<Expr> expr; // this can't be null
+  };
+
+  struct SplitInOut
+  {
+    InlineAsmRegOrRegClass reg;
+    bool late;
+    std::unique_ptr<Expr> in_expr;
+    std::unique_ptr<Expr> out_expr; // could be null
+  };
+
+  struct Const
+  {
+    AnonConst anon_const;
+  };
+
+  struct Sym
+  {
+    std::unique_ptr<Expr> sym;
+  };
+  Location locus;
+};
+
+struct InlineAsmPlaceHolder
+{
+  size_t operand_idx;
+  char modifier; // can be null
+  Location locus;
+};
+
+struct InlineAsmTemplatePiece
+{
+  bool is_placeholder;
+  union
+  {
+    std::string string;
+    InlineAsmPlaceHolder placeholder;
+  };
+};
+
+struct TupleClobber
+{
+  // as gccrs still doesen't contain a symbol class I have put them as strings
+  std::string symbol;
+  Location loc;
+};
+
+struct TupleTemplateStr
+{
+  // as gccrs still doesen't contain a symbol class I have put them as strings
+  std::string symbol;
+  std::string optional_symbol;
+  Location loc;
+};
+
 // Inline Assembly Node
 class InlineAsm : public ExprWithoutBlock
 {
-  // Inline-assembly specific options
-  enum InlineAsmOptions
-  {
-    PURE = 1 << 0,
-    NOMEM = 1 << 1,
-    READONLY = 1 << 2,
-    PRESERVES_FLAGS = 1 << 3,
-    NORETURN = 1 << 4,
-    NOSTACK = 1 << 5,
-    ATT_SYNTAX = 1 << 6,
-    RAW = 1 << 7,
-    MAY_UNWIND = 1 << 8,
-  };
-
-  struct AnonConst
-  {
-    NodeId id;
-    std::unique_ptr<Expr> value;
-  };
-
-  struct InlineAsmRegOrRegClass
-  {
-    enum Type
-    {
-      Reg,
-      RegClass,
-    };
-
-    struct Reg
-    {
-      std::string Symbol;
-    };
-
-    struct RegClass
-    {
-      std::string Symbol;
-    };
-
-    Identifier name;
-    Location locus;
-  };
-
-  struct InlineAsmOperand
-  {
-    enum RegisterType
-    {
-      In,
-      Out,
-      InOut,
-      SplitInOut,
-      Const,
-      Sym,
-    };
-
-    struct In
-    {
-      InlineAsmRegOrRegClass reg;
-      std::unique_ptr<Expr> expr;
-    };
-
-    struct Out
-    {
-      InlineAsmRegOrRegClass reg;
-      bool late;
-      std::unique_ptr<Expr> expr; // can be null
-    };
-
-    struct InOut
-    {
-      InlineAsmRegOrRegClass reg;
-      bool late;
-      std::unique_ptr<Expr> expr; // this can't be null
-    };
-
-    struct SplitInOut
-    {
-      InlineAsmRegOrRegClass reg;
-      bool late;
-      std::unique_ptr<Expr> in_expr;
-      std::unique_ptr<Expr> out_expr; // could be null
-    };
-
-    struct Const
-    {
-      AnonConst anon_const;
-    };
-
-    struct Sym
-    {
-      std::unique_ptr<Expr> sym;
-    };
-    Location locus;
-  };
-
-  struct InlineAsmPlaceHolder
-  {
-    size_t operand_idx;
-    char modifier; // can be null
-    Location locus;
-  };
-
-  struct InlineAsmTemplatePiece
-  {
-    bool is_placeholder;
-    union
-    {
-      std::string string;
-      InlineAsmPlaceHolder placeholder;
-    };
-  };
-
-  struct TupleClobber
-  {
-    // as gccrs still doesen't contain a symbol class I have put them as strings
-    std::string symbol;
-    Location loc;
-  };
-
-  struct TupleTemplateStr
-  {
-    // as gccrs still doesen't contain a symbol class I have put them as strings
-    std::string symbol;
-    std::string optional_symbol;
-    Location loc;
-  };
-
 public:
   std::vector<InlineAsmTemplatePiece> template_;
   std::vector<TupleTemplateStr> template_strs;
@@ -4550,6 +4550,7 @@ public:
   InlineAsmOptions options;
   std::vector<Location> line_spans;
 };
+
 } // namespace AST
 } // namespace Rust
 

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -3889,6 +3889,94 @@ private:
   Location locus;
 };
 
+class InlineAsmReg
+{
+  enum Kind
+  {
+    X86,
+    Arm,
+    AArch64,
+    RiscV,
+    Nvptx,
+    PowerPC,
+    Hexagon,
+    Mips,
+    S390x,
+    SpirV,
+    Wasm,
+    Bpf,
+    Avr,
+    Msp430,
+    // Placeholder for invalid register constraints for the current target
+    Err,
+  };
+
+  // this placeholder is to be removed when the definations
+  // of the above enums are made in a later PR/patch.
+  std::string placeholder;
+};
+
+class InlineAsmRegClass
+{
+  enum Type
+  {
+    X86,
+    Arm,
+    AArch64,
+    RiscV,
+    Nvptx,
+    PowerPC,
+    Hexagon,
+    Mips,
+    S390x,
+    SpirV,
+    Wasm,
+    Bpf,
+    Avr,
+    Msp430,
+    // Placeholder for invalid register constraints for the current target
+    Err,
+  };
+
+  // this placeholder is to be removed when the definations
+  // of the above enums are made in a later PR/patch.
+  std::string placeholder;
+};
+
+struct InlineAsmRegOrRegClass
+{
+  enum Type
+  {
+    Reg,      // links to struct Register
+    RegClass, // links to struct RegisterClass
+  };
+
+  struct Register
+  {
+    InlineAsmReg Reg;
+  };
+
+  struct RegisterClass
+  {
+    InlineAsmRegClass RegClass;
+  };
+
+  Identifier name;
+  Location locus;
+};
+
+// Inline Assembly Node
+class InlineAsm : public ExprWithoutBlock
+{
+  NodeId id;
+
+public:
+  std::vector<AST::InlineAsmTemplatePiece> template_;
+  std::vector<AST::TupleTemplateStr> template_strs;
+  std::vector<AST::InlineAsmOperand> operands;
+  AST::InlineAsmOptions options;
+  std::vector<Location> line_spans;
+};
 } // namespace HIR
 } // namespace Rust
 

--- a/gcc/rust/hir/tree/rust-hir-full-decls.h
+++ b/gcc/rust/hir/tree/rust-hir-full-decls.h
@@ -124,6 +124,10 @@ struct MatchCase;
 class MatchExpr;
 class AwaitExpr;
 class AsyncBlockExpr;
+class InlineAsmReg;
+class InlineAsmRegClass;
+struct InlineAsmRegOrRegClass;
+class InlineAsm;
 
 // rust-stmt.h
 class EmptyStmt;


### PR DESCRIPTION
Fixes Issue #1568 
This is HIR equivalent Node for AST::InineAsm.As gccrs doesn't have a symbol class, I have made every instance of it a string.

Signed-off-by: M V V S Manoj Kumar <mvvsmanojkumar@gmail.com>

gcc/rust/ChangeLog:

	* hir/tree/rust-hir-expr.h (class InlineAsm):Added class declaration.
	* hir/tree/rust-hir-full-decls.h (class InlineAsm):Added class definition.

The rustc guide for reference [here](https://rustc-dev-guide.rust-lang.org/asm.html#hir)
Do go through this an tell me if I need to include something or could add anything else. Once you review it, I'll remove the comments, such as

```
  //   pub enum InlineAsmRegClass {
  //     X86(X86InlineAsmRegClass),
  //     Arm(ArmInlineAsmRegClass),
  //     AArch64(AArch64InlineAsmRegClass),
  //     RiscV(RiscVInlineAsmRegClass),
  //     Nvptx(NvptxInlineAsmRegClass),
  //     PowerPC(PowerPCInlineAsmRegClass),
  //     Hexagon(HexagonInlineAsmRegClass),
  //     Mips(MipsInlineAsmRegClass),
  //     S390x(S390xInlineAsmRegClass),
  //     SpirV(SpirVInlineAsmRegClass),
  //     Wasm(WasmInlineAsmRegClass),
  //     Bpf(BpfInlineAsmRegClass),
  //     Avr(AvrInlineAsmRegClass),
  //     Msp430(Msp430InlineAsmRegClass),
  //     // Placeholder for invalid register constraints for the current target
  //     Err,
  // }

/*
pub struct InlineAsm<'hir> {
    pub template: &'hir [InlineAsmTemplatePiece],
    pub template_strs: &'hir [(Symbol, Option<Symbol>, Span)],
    pub operands: &'hir [(InlineAsmOperand<'hir>, Span)],
    pub options: InlineAsmOptions,
    pub line_spans: &'hir [Span],
}*/

```
These are just for my reference, these structures needed to be added in later PR.
