### PR TITLE
macro_invoc_lexer: Add `split_current_token` implementation

### DIFF
--- a/gcc/rust/expand/rust-macro-invoc-lexer.cc
+++ b/gcc/rust/expand/rust-macro-invoc-lexer.cc
@@ -1,4 +1,5 @@
 #include "rust-macro-invoc-lexer.h"
+#include "rust-token.h"
 
 namespace Rust {
 
@@ -19,12 +20,22 @@ MacroInvocLexer::skip_token (int n)
 }
 
 void
-MacroInvocLexer::split_current_token (TokenId new_left __attribute__ ((unused)),
-				      TokenId new_right
-				      __attribute__ ((unused)))
+MacroInvocLexer::split_current_token (TokenId new_left, TokenId new_right)
 {
-  // FIXME
-  gcc_unreachable ();
+  auto &current_token = token_stream.at (offs);
+  auto current_pos = token_stream.begin () + offs;
+
+  auto l_tok = Token::make (new_left, current_token->get_locus ());
+  auto r_tok = Token::make (new_right, current_token->get_locus ());
+
+  token_stream.erase (current_pos);
+
+  // `insert` inserts before the specified position, so we insert the right one
+  // then the left
+  token_stream.insert (current_pos,
+		       std::unique_ptr<AST::Token> (new AST::Token (r_tok)));
+  token_stream.insert (current_pos,
+		       std::unique_ptr<AST::Token> (new AST::Token (l_tok)));
 }
 
 std::vector<std::unique_ptr<AST::Token>>

--- a/gcc/testsuite/rust/compile/expand_macro_qual_path_in_type.rs
+++ b/gcc/testsuite/rust/compile/expand_macro_qual_path_in_type.rs
@@ -1,0 +1,62 @@
+// this SEGVs in lowering for now
+// { dg-additional-options "-frust-compile-until=nameresolution" }
+
+macro_rules! forward_ref_binop {
+    (impl $imp:ident, $method:ident for $t:ty, $u:ty) => {
+        forward_ref_binop!(impl $imp, $method for $t, $u,
+                #[stable(feature = "rust1", since = "1.0.0")]);
+    };
+    (impl $imp:ident, $method:ident for $t:ty, $u:ty, #[$attr:meta]) => {
+        #[$attr]
+        impl<'a> $imp<$u> for &'a $t {
+            type Output = <$t as $imp<$u>>::Output;
+
+            #[inline]
+            fn $method(self, other: $u) -> <$t as $imp<$u>>::Output {
+                $imp::$method(*self, other)
+            }
+        }
+
+        #[$attr]
+        impl<'a> $imp<&'a $u> for $t {
+            type Output = <$t as $imp<$u>>::Output;
+
+            #[inline]
+            fn $method(self, other: &'a $u) -> <$t as $imp<$u>>::Output {
+                $imp::$method(self, *other)
+            }
+        }
+
+        #[$attr]
+        impl<'a, 'b> $imp<&'a $u> for &'b $t {
+            type Output = <$t as $imp<$u>>::Output;
+
+            #[inline]
+            fn $method(self, other: &'a $u) -> <$t as $imp<$u>>::Output {
+                $imp::$method(*self, *other)
+            }
+        }
+    }
+}
+
+#[lang = "add"]
+pub trait Add<RHS = Self> {
+    type Output;
+
+    fn add(self, rhs: RHS) -> Self::Output;
+}
+
+macro_rules! add_impl {
+    ($($t:ty)*) => ($(
+        #[stable(feature = "rust1", since = "1.0.0")]
+        impl Add for $t {
+            type Output = $t;
+
+            fn add(self, other: $t) -> $t { self + other }
+        }
+
+        forward_ref_binop! { impl Add, add for $t, $t }
+    )*)
+}
+
+add_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* expand/rust-macro-invoc-lexer.cc (MacroInvocLexer::split_current_token): Add proper implementation.

gcc/testsuite/ChangeLog:

	* rust/compile/expand_macro_qual_path_in_type.rs: New test.

Fixes #1894 