### PR TITLE
ci: Run GCC 4.8 job in Ubuntu 18.04 container

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -166,14 +166,18 @@ jobs:
 
   build-and-check-gcc-48:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
+    container: ubuntu:18.04
+    env:
+      # otherwise we hang when installing tzdata
+      DEBIAN_FRONTEND: noninteractive
     steps:
     - uses: actions/checkout@v2
 
     - name: Install Deps
       run: |
-          sudo apt-get update;
-          sudo apt-get install -y \
+          apt-get update;
+          apt-get install -y \
                   automake \
                   autoconf \
                   libtool \


### PR DESCRIPTION
We should probably think about building GCC 4.8 from source from time to time and hosting the image on our Dockerhub, but I think this is okay as well for now.

ChangeLog:

	* .github/workflows/ccpp.yml: Run GCC 4.8 action in Ubuntu 18.04 container

Fixes #1900 

The choice was between using the GCC 4.8 image which was last updated... 7 years ago, and this Ubuntu image which was updated three weeks ago. I think this should just be a temporary solution however.