### PR TITLE
typecheck: Refactor unify_site

### DIFF
--- a/gcc/rust/typecheck/rust-autoderef.cc
+++ b/gcc/rust/typecheck/rust-autoderef.cc
@@ -265,9 +265,9 @@ resolve_operator_overload_fn (
 	  fn = static_cast<TyTy::FnType *> (lookup);
 
 	  Location unify_locus = mappings->lookup_location (ty->get_ref ());
-	  TypeCheckBase::unify_site (
-	    ty->get_ref (), TyTy::TyWithLocation (fn->get_self_type ()),
-	    TyTy::TyWithLocation (adjusted_self), unify_locus);
+	  unify_site (ty->get_ref (),
+		      TyTy::TyWithLocation (fn->get_self_type ()),
+		      TyTy::TyWithLocation (adjusted_self), unify_locus);
 
 	  lookup = fn;
 	}

--- a/gcc/rust/typecheck/rust-hir-trait-resolve.cc
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.cc
@@ -499,10 +499,10 @@ AssociatedImplTrait::setup_associated_types (
   // the type correctly as our receiver may be generic and we are inferring its
   // generic arguments and this Self might be the concrete version or vice
   // versa.
-  auto result = TypeCheckBase::unify_site (
-    get_impl_block ()->get_mappings ().get_hirid (),
-    TyTy::TyWithLocation (receiver), TyTy::TyWithLocation (impl_self_infer),
-    impl_predicate.get_locus ());
+  auto result = unify_site (get_impl_block ()->get_mappings ().get_hirid (),
+			    TyTy::TyWithLocation (receiver),
+			    TyTy::TyWithLocation (impl_self_infer),
+			    impl_predicate.get_locus ());
   rust_assert (result->get_kind () != TyTy::TypeKind::ERROR);
   TyTy::BaseType *self_result = result;
 
@@ -527,9 +527,8 @@ AssociatedImplTrait::setup_associated_types (
       TyTy::BaseType *b = hrtb_bound_arguments.at (i);
 
       result
-	= TypeCheckBase::unify_site (a->get_ref (), TyTy::TyWithLocation (a),
-				     TyTy::TyWithLocation (b),
-				     impl_predicate.get_locus ());
+	= unify_site (a->get_ref (), TyTy::TyWithLocation (a),
+		      TyTy::TyWithLocation (b), impl_predicate.get_locus ());
       rust_assert (result->get_kind () != TyTy::TypeKind::ERROR);
     }
 

--- a/gcc/rust/typecheck/rust-hir-type-check-base.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.cc
@@ -17,13 +17,12 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-hir-type-check-base.h"
-#include "rust-hir-type-check-item.h"
-#include "rust-hir-type-check-type.h"
+#include "rust-casts.h"
+#include "rust-coercion.h"
 #include "rust-hir-type-check-expr.h"
 #include "rust-hir-type-check-implitem.h"
-#include "rust-coercion.h"
-#include "rust-unify.h"
-#include "rust-casts.h"
+#include "rust-hir-type-check-item.h"
+#include "rust-hir-type-check-type.h"
 
 namespace Rust {
 namespace Resolver {
@@ -351,20 +350,6 @@ TypeCheckBase::parse_repr_options (const AST::AttrVec &attrs, Location locus)
 }
 
 TyTy::BaseType *
-TypeCheckBase::unify_site (HirId id, TyTy::TyWithLocation lhs,
-			   TyTy::TyWithLocation rhs, Location unify_locus)
-{
-  TyTy::BaseType *expected = lhs.get_ty ();
-  TyTy::BaseType *expr = rhs.get_ty ();
-
-  rust_debug ("unify_site id={%u} expected={%s} expr={%s}", id,
-	      expected->debug_str ().c_str (), expr->debug_str ().c_str ());
-
-  return UnifyRules::Resolve (lhs, rhs, unify_locus, true /*commit*/,
-			      true /*emit_error*/);
-}
-
-TyTy::BaseType *
 TypeCheckBase::coercion_site (HirId id, TyTy::TyWithLocation lhs,
 			      TyTy::TyWithLocation rhs, Location locus)
 {
@@ -434,7 +419,7 @@ TypeCheckBase::cast_site (HirId id, TyTy::TyWithLocation from,
 
 void
 TypeCheckBase::resolve_generic_params (
-  const std::vector<std::unique_ptr<HIR::GenericParam>> &generic_params,
+  const std::vector<std::unique_ptr<HIR::GenericParam> > &generic_params,
   std::vector<TyTy::SubstitutionParamMapping> &substitutions)
 {
   for (auto &generic_param : generic_params)

--- a/gcc/rust/typecheck/rust-hir-type-check-base.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.h
@@ -20,10 +20,10 @@
 #define RUST_HIR_TYPE_CHECK_BASE
 
 #include "rust-diagnostics.h"
-#include "rust-hir-type-check.h"
-#include "rust-name-resolver.h"
-#include "rust-hir-visitor.h"
 #include "rust-hir-map.h"
+#include "rust-hir-type-check.h"
+#include "rust-hir-visitor.h"
+#include "rust-name-resolver.h"
 
 namespace Rust {
 namespace Resolver {
@@ -33,10 +33,6 @@ class TypeCheckBase
 {
 public:
   virtual ~TypeCheckBase () {}
-
-  static TyTy::BaseType *unify_site (HirId id, TyTy::TyWithLocation lhs,
-				     TyTy::TyWithLocation rhs,
-				     Location unify_locus);
 
   static TyTy::BaseType *coercion_site (HirId id, TyTy::TyWithLocation lhs,
 					TyTy::TyWithLocation rhs,
@@ -66,7 +62,7 @@ protected:
 						 Location locus);
 
   void resolve_generic_params (
-    const std::vector<std::unique_ptr<HIR::GenericParam>> &generic_params,
+    const std::vector<std::unique_ptr<HIR::GenericParam> > &generic_params,
     std::vector<TyTy::SubstitutionParamMapping> &substitutions);
 
   Analysis::Mappings *mappings;

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -18,11 +18,11 @@
 
 #include "rust-hir-type-check.h"
 #include "rust-hir-full.h"
-#include "rust-hir-type-check-item.h"
+#include "rust-hir-inherent-impl-overlap.h"
 #include "rust-hir-type-check-expr.h"
+#include "rust-hir-type-check-item.h"
 #include "rust-hir-type-check-pattern.h"
 #include "rust-hir-type-check-struct-field.h"
-#include "rust-hir-inherent-impl-overlap.h"
 
 extern bool
 saw_errors (void);
@@ -64,9 +64,8 @@ TypeResolution::Resolve (HIR::Crate &crate)
     else
       {
 	auto result
-	  = TypeCheckBase::unify_site (id, TyTy::TyWithLocation (ty),
-				       TyTy::TyWithLocation (default_type),
-				       Location ());
+	  = unify_site (id, TyTy::TyWithLocation (ty),
+			TyTy::TyWithLocation (default_type), Location ());
 	rust_assert (result);
 	rust_assert (result->get_kind () != TyTy::TypeKind::ERROR);
 	result->set_ref (id);
@@ -142,10 +141,9 @@ TraitItemReference::get_type_from_constant (
       TyTy::BaseType *expr
 	= TypeCheckExpr::Resolve (constant.get_expr ().get ());
 
-      return TypeCheckBase::unify_site (constant.get_mappings ().get_hirid (),
-					TyTy::TyWithLocation (type),
-					TyTy::TyWithLocation (expr),
-					constant.get_locus ());
+      return unify_site (constant.get_mappings ().get_hirid (),
+			 TyTy::TyWithLocation (type),
+			 TyTy::TyWithLocation (expr), constant.get_locus ());
     }
   return type;
 }

--- a/gcc/rust/typecheck/rust-type-util.cc
+++ b/gcc/rust/typecheck/rust-type-util.cc
@@ -18,12 +18,13 @@
 
 #include "rust-type-util.h"
 #include "rust-diagnostics.h"
-#include "rust-hir-type-check.h"
-#include "rust-name-resolver.h"
-#include "rust-hir-visitor.h"
 #include "rust-hir-map.h"
-#include "rust-hir-type-check-item.h"
 #include "rust-hir-type-check-implitem.h"
+#include "rust-hir-type-check-item.h"
+#include "rust-hir-type-check.h"
+#include "rust-hir-visitor.h"
+#include "rust-name-resolver.h"
+#include "rust-unify.h"
 
 namespace Rust {
 namespace Resolver {
@@ -102,6 +103,20 @@ query_type (HirId reference, TyTy::BaseType **result)
   context->query_completed (reference);
 
   return false;
+}
+
+TyTy::BaseType *
+unify_site (HirId id, TyTy::TyWithLocation lhs, TyTy::TyWithLocation rhs,
+	    Location unify_locus)
+{
+  TyTy::BaseType *expected = lhs.get_ty ();
+  TyTy::BaseType *expr = rhs.get_ty ();
+
+  rust_debug ("unify_site id={%u} expected={%s} expr={%s}", id,
+	      expected->debug_str ().c_str (), expr->debug_str ().c_str ());
+
+  return UnifyRules::Resolve (lhs, rhs, unify_locus, true /*commit*/,
+			      true /*emit_error*/);
 }
 
 } // namespace Resolver

--- a/gcc/rust/typecheck/rust-type-util.h
+++ b/gcc/rust/typecheck/rust-type-util.h
@@ -20,6 +20,7 @@
 #define RUST_TYPE_UTIL
 
 #include "rust-mapping-common.h"
+#include "rust-tyty.h"
 
 namespace Rust {
 
@@ -31,6 +32,10 @@ namespace Resolver {
 
 extern bool
 query_type (HirId reference, TyTy::BaseType **result);
+
+TyTy::BaseType *
+unify_site (HirId id, TyTy::TyWithLocation lhs, TyTy::TyWithLocation rhs,
+	    Location unify_locus);
 
 } // namespace Resolver
 } // namespace Rust

--- a/gcc/rust/typecheck/rust-tyty-call.cc
+++ b/gcc/rust/typecheck/rust-tyty-call.cc
@@ -316,9 +316,10 @@ TypeCheckMethodCallExpr::go (FnType *ref, Analysis::NodeMapping call_mappings,
 BaseType *
 TypeCheckMethodCallExpr::check (FnType &type)
 {
-  Resolver::TypeCheckBase::unify_site (
-    call_mappings.get_hirid (), TyWithLocation (type.get_self_type ()),
-    TyWithLocation (adjusted_self, receiver_locus), call_locus);
+  Resolver::unify_site (call_mappings.get_hirid (),
+			TyWithLocation (type.get_self_type ()),
+			TyWithLocation (adjusted_self, receiver_locus),
+			call_locus);
 
   // +1 for the receiver self
   size_t num_args_to_call = arguments.size () + 1;


### PR DESCRIPTION
Refactor unify_site to be a simple function in rust-type-util.h.

gcc/rust/ChangeLog:

	* typecheck/rust-autoderef.cc: Remove TypeCheckBase qualifier.
	* typecheck/rust-hir-trait-resolve.cc: Remove TypeCheckBase qualifier.
	* typecheck/rust-hir-type-check-base.cc (TypeCheckBase::unify_site): Remove unify_site.
	* typecheck/rust-hir-type-check-base.h: Remove unify_site header.
	* typecheck/rust-hir-type-check.cc (TypeResolution::Resolve): Remove TypeCheckBase qualifier.
	* typecheck/rust-type-util.cc (unify_site): Add unify_site function.
	* typecheck/rust-type-util.h (unify_site): Add unify_site prototype.
	* typecheck/rust-tyty-call.cc (TypeCheckMethodCallExpr::check): Remove TypeCheckBase qualifier.

Fixes #1881 