### PR TITLE
cfg!() eager expansion

### DIFF
--- a/gcc/testsuite/rust/compile/builtin_macro_eager4.rs
+++ b/gcc/testsuite/rust/compile/builtin_macro_eager4.rs
@@ -1,0 +1,22 @@
+#![feature(rustc_attrs)]
+
+#[rustc_builtin_macro]
+macro_rules! cfg {
+  () => {{}};
+}
+
+macro_rules! a{
+  () => {"test"};
+}
+
+
+fn main () {
+  let os = "linux";
+  cfg!(); // { dg-error "cfg-pattern required" }
+  cfg!(1); // { dg-error "expected identifier" }
+  cfg!(windows); // shoud not error
+  cfg!(target_os = "linux"); //should not error
+  cfg!(a!()); // {dg-error "expected 1 cfg-pattern"}
+  cfg!(a!(), windows); // {dg-error "expected 1 cfg-pattern"}
+
+}


### PR DESCRIPTION
Fixed #1792 

Signed-off-by: Zheyuan Chen sephirotheca17@gmail.com
```
gcc/ChangeLog/
* rust/expand/rust-macro-builtins.cc: modify cfg_handler() to expand cfg! eagerly`
* testsuite/rust/compile/builtin_macro_eager4.rs: add test for cfg! macro`
```

**Question**: If we have something like `cfg!(foo!(), bar!())`, which has multiple arguments, do we need to return error, or just simply return the eager expansion. 
I tested `env` macro with `env!(a!(), a!(), a!())`, and gccrs does not emit any error(it will definitely emit error in rustc as `env!` only accepts 1 or 2 arugments ). So I assume we don't check the correctness(for now at least) for eager expansion when we have macro as argument?