### PR TITLE
typecheck: Refactor cast_site

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-base.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.cc
@@ -17,7 +17,6 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-hir-type-check-base.h"
-#include "rust-casts.h"
 #include "rust-hir-type-check-expr.h"
 #include "rust-hir-type-check-implitem.h"
 #include "rust-hir-type-check-item.h"
@@ -346,40 +345,6 @@ TypeCheckBase::parse_repr_options (const AST::AttrVec &attrs, Location locus)
     }
 
   return repr;
-}
-
-TyTy::BaseType *
-TypeCheckBase::cast_site (HirId id, TyTy::TyWithLocation from,
-			  TyTy::TyWithLocation to, Location cast_locus)
-{
-  rust_debug ("cast_site id={%u} from={%s} to={%s}", id,
-	      from.get_ty ()->debug_str ().c_str (),
-	      to.get_ty ()->debug_str ().c_str ());
-
-  auto context = TypeCheckContext::get ();
-  if (from.get_ty ()->get_kind () == TyTy::TypeKind::ERROR
-      || to.get_ty ()->get_kind () == TyTy::TypeKind::ERROR)
-    return to.get_ty ();
-
-  // do the cast
-  auto result = TypeCastRules::resolve (cast_locus, from, to);
-
-  // we assume error has already been emitted
-  if (result.is_error ())
-    return to.get_ty ();
-
-  // the result needs to be unified
-  TyTy::BaseType *casted_result = result.tyty;
-  rust_debug ("cast_default_unify(a={%s}, b={%s})",
-	      casted_result->debug_str ().c_str (),
-	      to.get_ty ()->debug_str ().c_str ());
-
-  TyTy::BaseType *casted
-    = unify_site (id, to,
-		  TyTy::TyWithLocation (casted_result, from.get_locus ()),
-		  cast_locus);
-  context->insert_cast_autoderef_mappings (id, std::move (result.adjustments));
-  return casted;
 }
 
 void

--- a/gcc/rust/typecheck/rust-hir-type-check-base.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.h
@@ -34,10 +34,6 @@ class TypeCheckBase
 public:
   virtual ~TypeCheckBase () {}
 
-  static TyTy::BaseType *cast_site (HirId id, TyTy::TyWithLocation from,
-				    TyTy::TyWithLocation to,
-				    Location cast_locus);
-
 protected:
   TypeCheckBase ();
 

--- a/gcc/rust/typecheck/rust-type-util.cc
+++ b/gcc/rust/typecheck/rust-type-util.cc
@@ -24,6 +24,7 @@
 #include "rust-hir-type-check.h"
 #include "rust-hir-visitor.h"
 #include "rust-name-resolver.h"
+#include "rust-casts.h"
 #include "rust-unify.h"
 #include "rust-coercion.h"
 
@@ -152,6 +153,40 @@ coercion_site (HirId id, TyTy::TyWithLocation lhs, TyTy::TyWithLocation rhs,
 		  locus);
   context->insert_autoderef_mappings (id, std::move (result.adjustments));
   return coerced;
+}
+
+TyTy::BaseType *
+cast_site (HirId id, TyTy::TyWithLocation from, TyTy::TyWithLocation to,
+	   Location cast_locus)
+{
+  rust_debug ("cast_site id={%u} from={%s} to={%s}", id,
+	      from.get_ty ()->debug_str ().c_str (),
+	      to.get_ty ()->debug_str ().c_str ());
+
+  auto context = TypeCheckContext::get ();
+  if (from.get_ty ()->get_kind () == TyTy::TypeKind::ERROR
+      || to.get_ty ()->get_kind () == TyTy::TypeKind::ERROR)
+    return to.get_ty ();
+
+  // do the cast
+  auto result = TypeCastRules::resolve (cast_locus, from, to);
+
+  // we assume error has already been emitted
+  if (result.is_error ())
+    return to.get_ty ();
+
+  // the result needs to be unified
+  TyTy::BaseType *casted_result = result.tyty;
+  rust_debug ("cast_default_unify(a={%s}, b={%s})",
+	      casted_result->debug_str ().c_str (),
+	      to.get_ty ()->debug_str ().c_str ());
+
+  TyTy::BaseType *casted
+    = unify_site (id, to,
+		  TyTy::TyWithLocation (casted_result, from.get_locus ()),
+		  cast_locus);
+  context->insert_cast_autoderef_mappings (id, std::move (result.adjustments));
+  return casted;
 }
 
 } // namespace Resolver

--- a/gcc/rust/typecheck/rust-type-util.h
+++ b/gcc/rust/typecheck/rust-type-util.h
@@ -41,6 +41,10 @@ TyTy::BaseType *
 coercion_site (HirId id, TyTy::TyWithLocation lhs, TyTy::TyWithLocation rhs,
 	       Location coercion_locus);
 
+TyTy::BaseType *
+cast_site (HirId id, TyTy::TyWithLocation from, TyTy::TyWithLocation to,
+	   Location cast_locus);
+
 } // namespace Resolver
 } // namespace Rust
 


### PR DESCRIPTION
Refactor cast_site to be a simple function in rust-type-util.h.

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-base.cc (TypeCheckBase::cast_site): Remove cast_site.
	* typecheck/rust-hir-type-check-base.h: Remove cast_site prototype.
	* typecheck/rust-type-util.cc (cast_site): Add cast_site.
	* typecheck/rust-type-util.h (cast_site): Add cast_site prototype.

Fixes #1883 