### PR TITLE
Add feature gate definition for `extern_types`.

### DIFF
--- a/gcc/rust/checks/errors/rust-feature-gate.cc
+++ b/gcc/rust/checks/errors/rust-feature-gate.cc
@@ -103,6 +103,10 @@ FeatureGate::visit (AST::ExternBlock &block)
 	gate (Feature::Name::INTRINSICS, block.get_locus (),
 	      "intrinsics are subject to change");
     }
+  for (const auto &item : block.get_extern_items ())
+    {
+      item->accept_vis (*this);
+    }
 }
 
 void
@@ -153,6 +157,15 @@ void
 FeatureGate::visit (AST::Function &function)
 {
   check_rustc_attri (function.get_outer_attrs ());
+}
+
+void
+FeatureGate::visit (AST::ExternalTypeItem &item)
+{
+  // TODO(mxlol233): The gating needs a complete visiting chain to activate
+  // `AST::ExternalTypeItem`.
+  gate (Feature::Name::EXTERN_TYPES, item.get_locus (),
+	"extern types are experimental");
 }
 
 } // namespace Rust

--- a/gcc/rust/checks/errors/rust-feature-gate.h
+++ b/gcc/rust/checks/errors/rust-feature-gate.h
@@ -133,7 +133,7 @@ public:
   void visit (AST::Trait &trait) override {}
   void visit (AST::InherentImpl &impl) override;
   void visit (AST::TraitImpl &impl) override;
-  void visit (AST::ExternalTypeItem &item) override {}
+  void visit (AST::ExternalTypeItem &item) override;
   void visit (AST::ExternalStaticItem &item) override {}
   void visit (AST::ExternalFunctionItem &item) override {}
   void visit (AST::ExternBlock &block) override;

--- a/gcc/rust/checks/errors/rust-feature.cc
+++ b/gcc/rust/checks/errors/rust-feature.cc
@@ -43,6 +43,10 @@ Feature::create (Feature::Name name)
       return Feature (Feature::Name::DECL_MACRO, Feature::State::ACCEPTED,
 		      "decl_macro", "1.0.0", 0,
 		      Optional<CompileOptions::Edition>::none (), "");
+    case Feature::Name::EXTERN_TYPES:
+      return Feature (Feature::Name::EXTERN_TYPES, Feature::State::ACTIVE,
+		      "extern_types", "1.23.0", 43467,
+		      Optional<CompileOptions::Edition>::none (), "");
     default:
       gcc_unreachable ();
     }
@@ -56,6 +60,7 @@ const std::map<std::string, Feature::Name> Feature::name_hash_map = {
   // TODO: Rename to "auto_traits" when supporting
   // later Rust versions
   {"optin_builtin_traits", Feature::Name::AUTO_TRAITS},
+  {"extern_types", Feature::Name::EXTERN_TYPES},
 }; // namespace Rust
 
 Optional<Feature::Name>

--- a/gcc/rust/checks/errors/rust-feature.h
+++ b/gcc/rust/checks/errors/rust-feature.h
@@ -42,6 +42,7 @@ public:
     RUSTC_ATTRS,
     DECL_MACRO,
     AUTO_TRAITS,
+    EXTERN_TYPES,
   };
 
   const std::string &as_string () { return m_name_str; }

--- a/gcc/testsuite/rust/compile/feature_extern_types.rs
+++ b/gcc/testsuite/rust/compile/feature_extern_types.rs
@@ -1,0 +1,8 @@
+extern "C" {
+    type F; //{ dg-error "extern types are experimental." "" { target *-*-* }  }
+}
+
+
+fn main() {
+
+}


### PR DESCRIPTION
This commit add a basic implementation to gating `ExternalTypeItem` AST node.

gcc/rust/ChangeLog:

	* checks/errors/rust-feature-gate.cc: Add definition for `extern_types`.
	* checks/errors/rust-feature-gate.h: Likewise.
	* checks/errors/rust-feature.cc: Likewise.
	* checks/errors/rust-feature.h: Likewise.

See #1925.