### PR TITLE
Generic pointers coerceable

### DIFF
--- a/gcc/rust/backend/rust-compile-base.h
+++ b/gcc/rust/backend/rust-compile-base.h
@@ -40,11 +40,11 @@ protected:
 protected:
   Context *get_context () { return ctx; }
 
-  tree coercion_site (HirId id, tree rvalue, const TyTy::BaseType *actual,
-		      const TyTy::BaseType *expected, Location lvalue_locus,
+  tree coercion_site (HirId id, tree rvalue, TyTy::BaseType *actual,
+		      TyTy::BaseType *expected, Location lvalue_locus,
 		      Location rvalue_locus);
-  tree coercion_site1 (tree rvalue, const TyTy::BaseType *actual,
-		       const TyTy::BaseType *expected, Location lvalue_locus,
+  tree coercion_site1 (tree rvalue, TyTy::BaseType *actual,
+		       TyTy::BaseType *expected, Location lvalue_locus,
 		       Location rvalue_locus);
 
   tree coerce_to_dyn_object (tree compiled_ref, const TyTy::BaseType *actual,

--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -26,7 +26,7 @@
 #include "rust-compile-block.h"
 #include "rust-compile-implitem.h"
 #include "rust-constexpr.h"
-#include "rust-unify.h"
+#include "rust-type-util.h"
 #include "rust-gcc.h"
 
 #include "fold-const.h"
@@ -2007,10 +2007,9 @@ CompileExpr::resolve_method_address (TyTy::FnType *fntype, HirId ref,
 	{
 	  TyTy::BaseType *infer_impl_call
 	    = candidate_call->infer_substitions (expr_locus);
-	  monomorphized = Resolver::UnifyRules::Resolve (
-	    TyTy::TyWithLocation (infer_impl_call),
-	    TyTy::TyWithLocation (fntype), expr_locus, true /* commit */,
-	    true /* emit_errors */);
+	  monomorphized
+	    = Resolver::unify_site (ref, TyTy::TyWithLocation (infer_impl_call),
+				    TyTy::TyWithLocation (fntype), expr_locus);
 	}
 
       return CompileInherentImplItem::Compile (impl_item, ctx, monomorphized);

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -54,10 +54,9 @@ CompileCrate::go ()
 // Shared methods in compilation
 
 tree
-HIRCompileBase::coercion_site (HirId id, tree rvalue,
-			       const TyTy::BaseType *rval,
-			       const TyTy::BaseType *lval,
-			       Location lvalue_locus, Location rvalue_locus)
+HIRCompileBase::coercion_site (HirId id, tree rvalue, TyTy::BaseType *rval,
+			       TyTy::BaseType *lval, Location lvalue_locus,
+			       Location rvalue_locus)
 {
   std::vector<Resolver::Adjustment> *adjustments = nullptr;
   bool ok = ctx->get_tyctx ()->lookup_autoderef_mappings (id, &adjustments);
@@ -70,15 +69,15 @@ HIRCompileBase::coercion_site (HirId id, tree rvalue,
 }
 
 tree
-HIRCompileBase::coercion_site1 (tree rvalue, const TyTy::BaseType *rval,
-				const TyTy::BaseType *lval,
-				Location lvalue_locus, Location rvalue_locus)
+HIRCompileBase::coercion_site1 (tree rvalue, TyTy::BaseType *rval,
+				TyTy::BaseType *lval, Location lvalue_locus,
+				Location rvalue_locus)
 {
   if (rvalue == error_mark_node)
     return error_mark_node;
 
-  const TyTy::BaseType *actual = rval->destructure ();
-  const TyTy::BaseType *expected = lval->destructure ();
+  TyTy::BaseType *actual = rval->destructure ();
+  TyTy::BaseType *expected = lval->destructure ();
 
   if (expected->get_kind () == TyTy::TypeKind::REF)
     {

--- a/gcc/rust/typecheck/rust-autoderef.cc
+++ b/gcc/rust/typecheck/rust-autoderef.cc
@@ -26,7 +26,7 @@ namespace Resolver {
 
 static bool
 resolve_operator_overload_fn (
-  Analysis::RustLangItem::ItemType lang_item_type, const TyTy::BaseType *ty,
+  Analysis::RustLangItem::ItemType lang_item_type, TyTy::BaseType *ty,
   TyTy::FnType **resolved_fn, HIR::ImplItem **impl_item,
   Adjustment::AdjustmentType *requires_ref_adjustment);
 
@@ -40,7 +40,7 @@ Adjuster::adjust_type (const std::vector<Adjustment> &adjustments)
 }
 
 Adjustment
-Adjuster::try_deref_type (const TyTy::BaseType *ty,
+Adjuster::try_deref_type (TyTy::BaseType *ty,
 			  Analysis::RustLangItem::ItemType deref_lang_item)
 {
   HIR::ImplItem *impl_item = nullptr;
@@ -85,7 +85,7 @@ Adjuster::try_deref_type (const TyTy::BaseType *ty,
 }
 
 Adjustment
-Adjuster::try_raw_deref_type (const TyTy::BaseType *ty)
+Adjuster::try_raw_deref_type (TyTy::BaseType *ty)
 {
   bool is_valid_type = ty->get_kind () == TyTy::TypeKind::REF;
   if (!is_valid_type)
@@ -99,7 +99,7 @@ Adjuster::try_raw_deref_type (const TyTy::BaseType *ty)
 }
 
 Adjustment
-Adjuster::try_unsize_type (const TyTy::BaseType *ty)
+Adjuster::try_unsize_type (TyTy::BaseType *ty)
 {
   bool is_valid_type = ty->get_kind () == TyTy::TypeKind::ARRAY;
   if (!is_valid_type)
@@ -121,7 +121,7 @@ Adjuster::try_unsize_type (const TyTy::BaseType *ty)
 
 static bool
 resolve_operator_overload_fn (
-  Analysis::RustLangItem::ItemType lang_item_type, const TyTy::BaseType *ty,
+  Analysis::RustLangItem::ItemType lang_item_type, TyTy::BaseType *ty,
   TyTy::FnType **resolved_fn, HIR::ImplItem **impl_item,
   Adjustment::AdjustmentType *requires_ref_adjustment)
 {
@@ -292,9 +292,9 @@ AutoderefCycle::try_hook (const TyTy::BaseType &)
 {}
 
 bool
-AutoderefCycle::cycle (const TyTy::BaseType *receiver)
+AutoderefCycle::cycle (TyTy::BaseType *receiver)
 {
-  const TyTy::BaseType *r = receiver;
+  TyTy::BaseType *r = receiver;
   while (true)
     {
       rust_debug ("autoderef try 1: {%s}", r->debug_str ().c_str ());
@@ -382,7 +382,7 @@ AutoderefCycle::cycle (const TyTy::BaseType *receiver)
 }
 
 bool
-AutoderefCycle::try_autoderefed (const TyTy::BaseType *r)
+AutoderefCycle::try_autoderefed (TyTy::BaseType *r)
 {
   try_hook (*r);
 

--- a/gcc/rust/typecheck/rust-autoderef.h
+++ b/gcc/rust/typecheck/rust-autoderef.h
@@ -40,15 +40,15 @@ public:
   };
 
   // ctor for all adjustments except derefs
-  Adjustment (AdjustmentType type, const TyTy::BaseType *actual,
-	      const TyTy::BaseType *expected)
+  Adjustment (AdjustmentType type, TyTy::BaseType *actual,
+	      TyTy::BaseType *expected)
     : Adjustment (type, actual, expected, nullptr, nullptr,
 		  AdjustmentType::ERROR)
   {}
 
   static Adjustment get_op_overload_deref_adjustment (
-    AdjustmentType type, const TyTy::BaseType *actual,
-    const TyTy::BaseType *expected, TyTy::FnType *fn, HIR::ImplItem *deref_item,
+    AdjustmentType type, TyTy::BaseType *actual, TyTy::BaseType *expected,
+    TyTy::FnType *fn, HIR::ImplItem *deref_item,
     Adjustment::AdjustmentType requires_ref_adjustment)
   {
     rust_assert (type == DEREF || type == DEREF_MUT);
@@ -58,8 +58,8 @@ public:
 
   AdjustmentType get_type () const { return type; }
 
-  const TyTy::BaseType *get_actual () const { return actual; }
-  const TyTy::BaseType *get_expected () const { return expected; }
+  TyTy::BaseType *get_actual () const { return actual; }
+  TyTy::BaseType *get_expected () const { return expected; }
 
   std::string as_string () const
   {
@@ -110,8 +110,8 @@ public:
   HIR::ImplItem *get_deref_hir_item () const { return deref_item; }
 
 private:
-  Adjustment (AdjustmentType type, const TyTy::BaseType *actual,
-	      const TyTy::BaseType *expected, TyTy::FnType *deref_operator_fn,
+  Adjustment (AdjustmentType type, TyTy::BaseType *actual,
+	      TyTy::BaseType *expected, TyTy::FnType *deref_operator_fn,
 	      HIR::ImplItem *deref_item,
 	      Adjustment::AdjustmentType requires_ref_adjustment)
     : type (type), actual (actual), expected (expected),
@@ -120,8 +120,8 @@ private:
   {}
 
   AdjustmentType type;
-  const TyTy::BaseType *actual;
-  const TyTy::BaseType *expected;
+  TyTy::BaseType *actual;
+  TyTy::BaseType *expected;
 
   // - only used for deref operator_overloads
   //
@@ -140,12 +140,12 @@ public:
   TyTy::BaseType *adjust_type (const std::vector<Adjustment> &adjustments);
 
   static Adjustment
-  try_deref_type (const TyTy::BaseType *ty,
+  try_deref_type (TyTy::BaseType *ty,
 		  Analysis::RustLangItem::ItemType deref_lang_item);
 
-  static Adjustment try_raw_deref_type (const TyTy::BaseType *ty);
+  static Adjustment try_raw_deref_type (TyTy::BaseType *ty);
 
-  static Adjustment try_unsize_type (const TyTy::BaseType *ty);
+  static Adjustment try_unsize_type (TyTy::BaseType *ty);
 
 private:
   const TyTy::BaseType *base;
@@ -158,15 +158,15 @@ protected:
 
   virtual ~AutoderefCycle ();
 
-  virtual bool select (const TyTy::BaseType &autoderefed) = 0;
+  virtual bool select (TyTy::BaseType &autoderefed) = 0;
 
   // optional: this is a chance to hook in to grab predicate items on the raw
   // type
   virtual void try_hook (const TyTy::BaseType &);
 
-  virtual bool cycle (const TyTy::BaseType *receiver);
+  virtual bool cycle (TyTy::BaseType *receiver);
 
-  bool try_autoderefed (const TyTy::BaseType *r);
+  bool try_autoderefed (TyTy::BaseType *r);
 
   bool autoderef_flag;
   std::vector<Adjustment> adjustments;

--- a/gcc/rust/typecheck/rust-casts.cc
+++ b/gcc/rust/typecheck/rust-casts.cc
@@ -39,7 +39,8 @@ TypeCastRules::check ()
 {
   // https://github.com/rust-lang/rust/blob/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/compiler/rustc_typeck/src/check/cast.rs#L565-L582
   auto possible_coercion
-    = TypeCoercionRules::TryCoerce (from.get_ty (), to.get_ty (), locus);
+    = TypeCoercionRules::TryCoerce (from.get_ty (), to.get_ty (), locus,
+				    true /*allow-autoderef*/);
   if (!possible_coercion.is_error ())
     return possible_coercion;
 

--- a/gcc/rust/typecheck/rust-coercion.cc
+++ b/gcc/rust/typecheck/rust-coercion.cc
@@ -373,7 +373,7 @@ TypeCoercionRules::coerce_unsized (TyTy::BaseType *source,
 }
 
 bool
-TypeCoercionRules::select (const TyTy::BaseType &autoderefed)
+TypeCoercionRules::select (TyTy::BaseType &autoderefed)
 {
   rust_debug (
     "autoderef type-coercion select autoderefed={%s} can_eq expected={%s}",

--- a/gcc/rust/typecheck/rust-coercion.cc
+++ b/gcc/rust/typecheck/rust-coercion.cc
@@ -25,25 +25,26 @@ namespace Resolver {
 
 TypeCoercionRules::CoercionResult
 TypeCoercionRules::Coerce (TyTy::BaseType *receiver, TyTy::BaseType *expected,
-			   Location locus)
+			   Location locus, bool allow_autoderef)
 {
-  TypeCoercionRules resolver (expected, locus, true);
+  TypeCoercionRules resolver (expected, locus, true, allow_autoderef);
   bool ok = resolver.do_coercion (receiver);
   return ok ? resolver.try_result : CoercionResult::get_error ();
 }
 
 TypeCoercionRules::CoercionResult
 TypeCoercionRules::TryCoerce (TyTy::BaseType *receiver,
-			      TyTy::BaseType *expected, Location locus)
+			      TyTy::BaseType *expected, Location locus,
+			      bool allow_autoderef)
 {
-  TypeCoercionRules resolver (expected, locus, false);
+  TypeCoercionRules resolver (expected, locus, false, allow_autoderef);
   bool ok = resolver.do_coercion (receiver);
   return ok ? resolver.try_result : CoercionResult::get_error ();
 }
 
 TypeCoercionRules::TypeCoercionRules (TyTy::BaseType *expected, Location locus,
-				      bool emit_errors)
-  : AutoderefCycle (false), mappings (Analysis::Mappings::get ()),
+				      bool emit_errors, bool allow_autoderef)
+  : AutoderefCycle (!allow_autoderef), mappings (Analysis::Mappings::get ()),
     context (TypeCheckContext::get ()), expected (expected), locus (locus),
     try_result (CoercionResult::get_error ()), emit_errors (emit_errors)
 {}

--- a/gcc/rust/typecheck/rust-coercion.h
+++ b/gcc/rust/typecheck/rust-coercion.h
@@ -71,7 +71,7 @@ protected:
   TypeCoercionRules (TyTy::BaseType *expected, Location locus, bool emit_errors,
 		     bool allow_autoderef);
 
-  bool select (const TyTy::BaseType &autoderefed) override;
+  bool select (TyTy::BaseType &autoderefed) override;
 
   bool do_coercion (TyTy::BaseType *receiver);
 

--- a/gcc/rust/typecheck/rust-coercion.h
+++ b/gcc/rust/typecheck/rust-coercion.h
@@ -69,7 +69,7 @@ public:
 
 protected:
   TypeCoercionRules (TyTy::BaseType *expected, Location locus, bool emit_errors,
-		     bool allow_autoderef);
+		     bool allow_autoderef, bool try_flag);
 
   bool select (TyTy::BaseType &autoderefed) override;
 
@@ -87,6 +87,7 @@ private:
   // mutable fields
   CoercionResult try_result;
   bool emit_errors;
+  bool try_flag;
 };
 
 } // namespace Resolver

--- a/gcc/rust/typecheck/rust-coercion.h
+++ b/gcc/rust/typecheck/rust-coercion.h
@@ -42,10 +42,12 @@ public:
   };
 
   static CoercionResult Coerce (TyTy::BaseType *receiver,
-				TyTy::BaseType *expected, Location locus);
+				TyTy::BaseType *expected, Location locus,
+				bool allow_autoderef);
 
   static CoercionResult TryCoerce (TyTy::BaseType *receiver,
-				   TyTy::BaseType *expected, Location locus);
+				   TyTy::BaseType *expected, Location locus,
+				   bool allow_autoderef);
 
   CoercionResult coerce_unsafe_ptr (TyTy::BaseType *receiver,
 				    TyTy::PointerType *expected,
@@ -66,8 +68,8 @@ public:
   void object_unsafe_error (Location expr_locus, Location lhs, Location rhs);
 
 protected:
-  TypeCoercionRules (TyTy::BaseType *expected, Location locus,
-		     bool emit_errors);
+  TypeCoercionRules (TyTy::BaseType *expected, Location locus, bool emit_errors,
+		     bool allow_autoderef);
 
   bool select (const TyTy::BaseType &autoderefed) override;
 

--- a/gcc/rust/typecheck/rust-hir-dot-operator.cc
+++ b/gcc/rust/typecheck/rust-hir-dot-operator.cc
@@ -29,7 +29,7 @@ MethodResolver::MethodResolver (bool autoderef_flag,
 {}
 
 std::set<MethodCandidate>
-MethodResolver::Probe (const TyTy::BaseType *receiver,
+MethodResolver::Probe (TyTy::BaseType *receiver,
 		       const HIR::PathIdentSegment &segment_name,
 		       bool autoderef_flag)
 {
@@ -46,7 +46,7 @@ MethodResolver::try_hook (const TyTy::BaseType &r)
 }
 
 bool
-MethodResolver::select (const TyTy::BaseType &receiver)
+MethodResolver::select (TyTy::BaseType &receiver)
 {
   struct impl_item_candidate
   {

--- a/gcc/rust/typecheck/rust-hir-dot-operator.h
+++ b/gcc/rust/typecheck/rust-hir-dot-operator.h
@@ -54,8 +54,7 @@ public:
   };
 
   static std::set<MethodCandidate>
-  Probe (const TyTy::BaseType *receiver,
-	 const HIR::PathIdentSegment &segment_name,
+  Probe (TyTy::BaseType *receiver, const HIR::PathIdentSegment &segment_name,
 	 bool autoderef_flag = false);
 
   static std::vector<predicate_candidate> get_predicate_items (
@@ -68,7 +67,7 @@ protected:
 
   void try_hook (const TyTy::BaseType &r) override;
 
-  bool select (const TyTy::BaseType &receiver) override;
+  bool select (TyTy::BaseType &receiver) override;
 
 private:
   // search

--- a/gcc/rust/typecheck/rust-hir-dot-operator.h
+++ b/gcc/rust/typecheck/rust-hir-dot-operator.h
@@ -70,6 +70,10 @@ protected:
   bool select (TyTy::BaseType &receiver) override;
 
 private:
+  std::vector<Adjustment>
+  append_adjustments (const std::vector<Adjustment> &adjustments) const;
+
+private:
   // search
   const HIR::PathIdentSegment &segment_name;
   std::vector<MethodResolver::predicate_candidate> predicate_items;

--- a/gcc/rust/typecheck/rust-hir-type-check.h
+++ b/gcc/rust/typecheck/rust-hir-type-check.h
@@ -84,6 +84,7 @@ public:
 		    TyTy::BaseType *type);
   void insert_implicit_type (TyTy::BaseType *type);
   bool lookup_type (HirId id, TyTy::BaseType **type) const;
+  void clear_type (TyTy::BaseType *ty);
 
   void insert_implicit_type (HirId id, TyTy::BaseType *type);
 

--- a/gcc/rust/typecheck/rust-type-util.cc
+++ b/gcc/rust/typecheck/rust-type-util.cc
@@ -186,7 +186,8 @@ coercion_site (HirId id, TyTy::TyWithLocation lhs, TyTy::TyWithLocation rhs,
     return expr;
 
   // can we autoderef it?
-  auto result = TypeCoercionRules::Coerce (expr, expected, locus);
+  auto result = TypeCoercionRules::Coerce (expr, expected, locus,
+					   true /*allow-autodref*/);
 
   // the result needs to be unified
   TyTy::BaseType *receiver = expr;

--- a/gcc/rust/typecheck/rust-type-util.cc
+++ b/gcc/rust/typecheck/rust-type-util.cc
@@ -117,8 +117,57 @@ unify_site (HirId id, TyTy::TyWithLocation lhs, TyTy::TyWithLocation rhs,
   rust_debug ("unify_site id={%u} expected={%s} expr={%s}", id,
 	      expected->debug_str ().c_str (), expr->debug_str ().c_str ());
 
+  std::vector<UnifyRules::CommitSite> commits;
+  std::vector<UnifyRules::InferenceSite> infers;
   return UnifyRules::Resolve (lhs, rhs, unify_locus, true /*commit*/,
-			      true /*emit_error*/);
+			      true /*emit_error*/, false /*infer*/, commits,
+			      infers);
+}
+
+TyTy::BaseType *
+unify_site_and (HirId id, TyTy::TyWithLocation lhs, TyTy::TyWithLocation rhs,
+		Location unify_locus, bool emit_errors, bool commit_if_ok,
+		bool implicit_infer_vars, bool cleanup)
+{
+  TypeCheckContext &context = *TypeCheckContext::get ();
+
+  TyTy::BaseType *expected = lhs.get_ty ();
+  TyTy::BaseType *expr = rhs.get_ty ();
+
+  rust_debug (
+    "unify_site_and commit %s infer %s id={%u} expected={%s} expr={%s}",
+    commit_if_ok ? "true" : "false", implicit_infer_vars ? "true" : "false", id,
+    expected->debug_str ().c_str (), expr->debug_str ().c_str ());
+
+  std::vector<UnifyRules::CommitSite> commits;
+  std::vector<UnifyRules::InferenceSite> infers;
+  TyTy::BaseType *result
+    = UnifyRules::Resolve (lhs, rhs, unify_locus, false /*commit inline*/,
+			   emit_errors, implicit_infer_vars, commits, infers);
+  bool ok = result->get_kind () != TyTy::TypeKind::ERROR;
+  if (ok && commit_if_ok)
+    {
+      for (auto &c : commits)
+	{
+	  UnifyRules::commit (c.lhs, c.rhs, c.resolved);
+	}
+    }
+  else if (cleanup)
+    {
+      // FIXME
+      // reset the get_next_hir_id
+
+      for (auto &i : infers)
+	{
+	  i.param->set_ref (i.pref);
+	  i.param->set_ty_ref (i.ptyref);
+
+	  // remove the inference variable
+	  context.clear_type (i.infer);
+	  delete i.infer;
+	}
+    }
+  return result;
 }
 
 TyTy::BaseType *

--- a/gcc/rust/typecheck/rust-type-util.h
+++ b/gcc/rust/typecheck/rust-type-util.h
@@ -30,12 +30,17 @@ class BaseType;
 
 namespace Resolver {
 
-extern bool
+bool
 query_type (HirId reference, TyTy::BaseType **result);
 
 TyTy::BaseType *
 unify_site (HirId id, TyTy::TyWithLocation lhs, TyTy::TyWithLocation rhs,
 	    Location unify_locus);
+
+TyTy::BaseType *
+unify_site_and (HirId id, TyTy::TyWithLocation lhs, TyTy::TyWithLocation rhs,
+		Location unify_locus, bool emit_errors, bool commit_if_ok,
+		bool implicit_infer_vars, bool cleanup);
 
 TyTy::BaseType *
 coercion_site (HirId id, TyTy::TyWithLocation lhs, TyTy::TyWithLocation rhs,

--- a/gcc/rust/typecheck/rust-typecheck-context.cc
+++ b/gcc/rust/typecheck/rust-typecheck-context.cc
@@ -109,6 +109,16 @@ TypeCheckContext::lookup_type (HirId id, TyTy::BaseType **type) const
 }
 
 void
+TypeCheckContext::clear_type (TyTy::BaseType *ty)
+{
+  auto it = resolved.find (ty->get_ref ());
+  if (it == resolved.end ())
+    return;
+
+  resolved.erase (it);
+}
+
+void
 TypeCheckContext::insert_type_by_node_id (NodeId ref, HirId id)
 {
   rust_assert (node_id_refs.find (ref) == node_id_refs.end ());

--- a/gcc/rust/typecheck/rust-tyty-cmp.h
+++ b/gcc/rust/typecheck/rust-tyty-cmp.h
@@ -28,10 +28,6 @@
 namespace Rust {
 namespace TyTy {
 
-// we need to fix this properly by implementing the match for assembling
-// candidates
-extern bool autoderef_cmp_flag;
-
 class BaseCmp : public TyConstVisitor
 {
 public:
@@ -1271,9 +1267,6 @@ public:
     auto other_base_type = type.get_base ();
 
     bool mutability_ok = base->is_mutable () ? type.is_mutable () : true;
-    if (autoderef_cmp_flag)
-      mutability_ok = base->mutability () == type.mutability ();
-
     if (!mutability_ok)
       {
 	BaseCmp::visit (type);
@@ -1320,9 +1313,6 @@ public:
     auto other_base_type = type.get_base ();
 
     bool mutability_ok = base->is_mutable () ? type.is_mutable () : true;
-    if (autoderef_cmp_flag)
-      mutability_ok = base->mutability () == type.mutability ();
-
     if (!mutability_ok)
       {
 	BaseCmp::visit (type);
@@ -1401,7 +1391,7 @@ public:
 
   void visit (const ArrayType &) override { ok = true; }
 
-  void visit (const SliceType &) override { ok = !autoderef_cmp_flag; }
+  void visit (const SliceType &) override { ok = true; }
 
   void visit (const BoolType &) override { ok = true; }
 

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -38,19 +38,6 @@
 namespace Rust {
 namespace TyTy {
 
-bool autoderef_cmp_flag = false;
-
-void
-set_cmp_autoderef_mode ()
-{
-  autoderef_cmp_flag = true;
-}
-void
-reset_cmp_autoderef_mode ()
-{
-  autoderef_cmp_flag = false;
-}
-
 std::string
 TypeKindFormat::to_string (TypeKind kind)
 {

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -1111,6 +1111,30 @@ ADTType::as_string () const
 }
 
 bool
+ADTType::is_concrete () const
+{
+  if (is_unit ())
+    {
+      return !needs_substitution ();
+    }
+
+  for (auto &variant : variants)
+    {
+      bool is_num_variant
+	= variant->get_variant_type () == VariantDef::VariantType::NUM;
+      if (is_num_variant)
+	continue;
+
+      for (auto &field : variant->get_fields ())
+	{
+	  if (!field->is_concrete ())
+	    return false;
+	}
+    }
+  return true;
+}
+
+bool
 ADTType::can_eq (const BaseType *other, bool emit_errors) const
 {
   ADTCmp r (this, emit_errors);

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -604,23 +604,7 @@ public:
     return identifier + subst_as_string ();
   }
 
-  bool is_concrete () const override final
-  {
-    if (is_unit ())
-      {
-	return !needs_substitution ();
-      }
-
-    for (auto &variant : variants)
-      {
-	for (auto &field : variant->get_fields ())
-	  {
-	    if (!field->is_concrete ())
-	      return false;
-	  }
-      }
-    return true;
-  }
+  bool is_concrete () const override final;
 
   BaseType *clone () const final override;
   BaseType *monomorphized_clone () const final override;

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -77,11 +77,6 @@ public:
   static std::string to_string (TypeKind kind);
 };
 
-extern void
-set_cmp_autoderef_mode ();
-extern void
-reset_cmp_autoderef_mode ();
-
 class TyVisitor;
 class TyConstVisitor;
 class BaseType : public TypeBoundsMappings

--- a/gcc/rust/typecheck/rust-unify.cc
+++ b/gcc/rust/typecheck/rust-unify.cc
@@ -141,7 +141,7 @@ UnifyRules::go ()
   // check bounds
   if (ltype->num_specified_bounds () > 0)
     {
-      if (!ltype->bounds_compatible (*rtype, locus, true))
+      if (!ltype->bounds_compatible (*rtype, locus, emit_error))
 	{
 	  // already emitted an error
 	  emit_error = false;

--- a/gcc/rust/typecheck/rust-unify.cc
+++ b/gcc/rust/typecheck/rust-unify.cc
@@ -153,12 +153,22 @@ UnifyRules::go ()
     {
       bool rgot_param = rtype->get_kind () == TyTy::TypeKind::PARAM;
       bool lhs_is_infer_var = ltype->get_kind () == TyTy::TypeKind::INFER;
-      bool expected_is_concrete = ltype->is_concrete () && !lhs_is_infer_var;
+      bool lhs_is_general_infer_var
+	= lhs_is_infer_var
+	  && static_cast<TyTy::InferType *> (ltype)->get_infer_kind ()
+	       == TyTy::InferType::GENERAL;
+      bool expected_is_concrete
+	= ltype->is_concrete () && !lhs_is_general_infer_var;
       bool rneeds_infer = expected_is_concrete && rgot_param;
 
       bool lgot_param = ltype->get_kind () == TyTy::TypeKind::PARAM;
       bool rhs_is_infer_var = rtype->get_kind () == TyTy::TypeKind::INFER;
-      bool receiver_is_concrete = rtype->is_concrete () && !rhs_is_infer_var;
+      bool rhs_is_general_infer_var
+	= rhs_is_infer_var
+	  && static_cast<TyTy::InferType *> (rtype)->get_infer_kind ()
+	       == TyTy::InferType::GENERAL;
+      bool receiver_is_concrete
+	= rtype->is_concrete () && !rhs_is_general_infer_var;
       bool lneeds_infer = receiver_is_concrete && lgot_param;
 
       if (rneeds_infer)

--- a/gcc/rust/typecheck/rust-unify.h
+++ b/gcc/rust/typecheck/rust-unify.h
@@ -28,9 +28,25 @@ namespace Resolver {
 class UnifyRules
 {
 public:
+  struct InferenceSite
+  {
+    HirId pref;
+    HirId ptyref;
+    TyTy::ParamType *param;
+    TyTy::InferType *infer;
+  };
+  struct CommitSite
+  {
+    TyTy::BaseType *lhs;
+    TyTy::BaseType *rhs;
+    TyTy::BaseType *resolved;
+  };
+
   static TyTy::BaseType *Resolve (TyTy::TyWithLocation lhs,
 				  TyTy::TyWithLocation rhs, Location locus,
-				  bool commit_flag, bool emit_error);
+				  bool commit_flag, bool emit_error, bool infer,
+				  std::vector<CommitSite> &commits,
+				  std::vector<InferenceSite> &infers);
 
   static void commit (TyTy::BaseType *base, TyTy::BaseType *other,
 		      TyTy::BaseType *resolved);
@@ -69,7 +85,9 @@ protected:
 
 private:
   UnifyRules (TyTy::TyWithLocation lhs, TyTy::TyWithLocation rhs,
-	      Location locus, bool commit_flag, bool emit_error);
+	      Location locus, bool commit_flag, bool emit_error, bool infer,
+	      std::vector<CommitSite> &commits,
+	      std::vector<InferenceSite> &infers);
 
   void emit_type_mismatch () const;
 
@@ -83,6 +101,9 @@ private:
   Location locus;
   bool commit_flag;
   bool emit_error;
+  bool infer_flag;
+  std::vector<CommitSite> &commits;
+  std::vector<InferenceSite> &infers;
 
   Analysis::Mappings &mappings;
   TypeCheckContext &context;

--- a/gcc/rust/typecheck/rust-unify.h
+++ b/gcc/rust/typecheck/rust-unify.h
@@ -32,6 +32,9 @@ public:
 				  TyTy::TyWithLocation rhs, Location locus,
 				  bool commit_flag, bool emit_error);
 
+  static void commit (TyTy::BaseType *base, TyTy::BaseType *other,
+		      TyTy::BaseType *resolved);
+
 protected:
   TyTy::BaseType *expect_inference_variable (TyTy::InferType *ltype,
 					     TyTy::BaseType *rtype);
@@ -69,7 +72,7 @@ private:
 	      Location locus, bool commit_flag, bool emit_error);
 
   void emit_type_mismatch () const;
-  void commit (TyTy::BaseType *resolved);
+
   TyTy::BaseType *go ();
 
   TyTy::BaseType *get_base ();

--- a/gcc/testsuite/rust/compile/issue-1901.rs
+++ b/gcc/testsuite/rust/compile/issue-1901.rs
@@ -1,0 +1,33 @@
+mod intrinsics {
+    extern "rust-intrinsic" {
+        pub fn offset<T>(ptr: *const T, count: isize) -> *const T;
+    }
+}
+
+mod ptr {
+    #[lang = "const_ptr"]
+    impl<T> *const T {
+        pub unsafe fn offset(self, count: isize) -> *const T {
+            intrinsics::offset(self, count)
+        }
+    }
+
+    #[lang = "mut_ptr"]
+    impl<T> *mut T {
+        pub unsafe fn offset(self, count: isize) -> *mut T {
+            intrinsics::offset(self, count) as *mut T
+        }
+    }
+}
+
+pub fn test_const(x: *const u8) {
+    unsafe {
+        x.offset(1);
+    }
+}
+
+pub fn test_mut(x: *mut u8) {
+    unsafe {
+        x.offset(1);
+    }
+}

--- a/gcc/testsuite/rust/compile/issue-1930.rs
+++ b/gcc/testsuite/rust/compile/issue-1930.rs
@@ -1,0 +1,4 @@
+// { dg-options "-w" }
+fn test<T>(x: *mut T) {
+    let x = x as *mut u8;
+}


### PR DESCRIPTION
In order to fix the following issues we need to begin the journey to get rid of
the can_eq interface as well as the autoderef_flag hack inside it. In non-generic
contexts in order to call const pointer lang item methods the can_eq interface
was not possible to infer that these types are valid. This patch set adds a new
unify_and interface so that we can optionally inject inference variables and only
commit them when everything is ok and on failure cleanup. So during method
resolution and picking we can now pick using our TryCoerce interface instead
of the bad can_eq one.

Fixes #1903 #1901 #878
Addresses #1895 