### PR TITLE
parser: Parse external type item

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -3983,6 +3983,34 @@ Parser<ManagedTokenSource>::parse_lifetime ()
     }
 }
 
+template <typename ManagedTokenSource>
+std::unique_ptr<AST::ExternalTypeItem>
+Parser<ManagedTokenSource>::parse_external_type_item (AST::Visibility vis,
+						      AST::AttrVec outer_attrs)
+{
+  Location locus = lexer.peek_token ()->get_locus ();
+  skip_token (TYPE);
+
+  const_TokenPtr alias_name_tok = expect_token (IDENTIFIER);
+  if (alias_name_tok == nullptr)
+    {
+      Error error (lexer.peek_token ()->get_locus (),
+		   "could not parse identifier in external opaque type");
+      add_error (std::move (error));
+
+      skip_after_semicolon ();
+      return nullptr;
+    }
+
+  if (!skip_token (SEMICOLON))
+    return nullptr;
+
+  return std::unique_ptr<AST::ExternalTypeItem> (
+    new AST::ExternalTypeItem (std::move (alias_name_tok->get_str ()),
+			       std::move (vis), std::move (outer_attrs),
+			       std::move (locus)));
+}
+
 // Parses a "type alias" (typedef) item.
 template <typename ManagedTokenSource>
 std::unique_ptr<AST::TypeAlias>
@@ -6044,6 +6072,9 @@ Parser<ManagedTokenSource>::parse_external_item ()
 	    std::move (variadic_attrs), std::move (vis),
 	    std::move (outer_attrs), locus));
       }
+    case TYPE:
+      return parse_external_type_item (std::move (vis),
+				       std::move (outer_attrs));
     default:
       // error
       add_error (

--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -273,6 +273,8 @@ private:
   template <typename EndTokenPred>
   std::vector<AST::Lifetime> parse_lifetime_bounds (EndTokenPred is_end_token);
   AST::Lifetime parse_lifetime ();
+  std::unique_ptr<AST::ExternalTypeItem>
+  parse_external_type_item (AST::Visibility vis, AST::AttrVec outer_attrs);
   std::unique_ptr<AST::TypeAlias> parse_type_alias (AST::Visibility vis,
 						    AST::AttrVec outer_attrs);
   std::unique_ptr<AST::Struct> parse_struct (AST::Visibility vis,

--- a/gcc/testsuite/rust/compile/extern_type_item.rs
+++ b/gcc/testsuite/rust/compile/extern_type_item.rs
@@ -1,0 +1,5 @@
+// { dg-additional-options "-fsyntax-only" }
+
+extern "C" {
+    type F;
+}

--- a/gcc/testsuite/rust/compile/extern_type_item_missing_semi.rs
+++ b/gcc/testsuite/rust/compile/extern_type_item_missing_semi.rs
@@ -1,0 +1,7 @@
+// { dg-additional-options "-fsyntax-only" }
+
+extern "C" {
+    type F;
+    type E // { dg-error "failed to parse" }
+} // { dg-error "expecting" }
+// { dg-error "failed to parse item in crate" ""  { target *-*-* } .-1 }


### PR DESCRIPTION
Add the code to parse type item declaration within an extern block.

gcc/rust/ChangeLog:

	* parse/rust-parse-impl.h (Parser::parse_external_type_item): Add function to parser an external type item. (Parser::parse_external_item): Add identification and parsing for external type items.
	* parse/rust-parse.h: Add parser_external_type_item prototype.

Fixes #1917 