### PR TITLE
Add `RestPattern` AST node

### DIFF
--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -1610,6 +1610,10 @@ void
 Dump::visit (WildcardPattern &)
 {}
 
+void
+Dump::visit (RestPattern &)
+{}
+
 // void Dump::visit(RangePatternBound& ){}
 
 void

--- a/gcc/rust/ast/rust-ast-dump.h
+++ b/gcc/rust/ast/rust-ast-dump.h
@@ -273,6 +273,7 @@ private:
   void visit (LiteralPattern &pattern);
   void visit (IdentifierPattern &pattern);
   void visit (WildcardPattern &pattern);
+  void visit (RestPattern &pattern);
   // void visit(RangePatternBound& bound);
   void visit (RangePatternBoundLiteral &bound);
   void visit (RangePatternBoundPath &bound);

--- a/gcc/rust/ast/rust-ast-full-decls.h
+++ b/gcc/rust/ast/rust-ast-full-decls.h
@@ -228,6 +228,7 @@ class MetaListNameValueStr;
 class LiteralPattern;
 class IdentifierPattern;
 class WildcardPattern;
+class RestPattern;
 class RangePatternBound;
 class RangePatternBoundLiteral;
 class RangePatternBoundPath;

--- a/gcc/rust/ast/rust-ast-visitor.h
+++ b/gcc/rust/ast/rust-ast-visitor.h
@@ -183,6 +183,7 @@ public:
   virtual void visit (LiteralPattern &pattern) = 0;
   virtual void visit (IdentifierPattern &pattern) = 0;
   virtual void visit (WildcardPattern &pattern) = 0;
+  virtual void visit (RestPattern &pattern) = 0;
   // virtual void visit(RangePatternBound& bound) = 0;
   virtual void visit (RangePatternBoundLiteral &bound) = 0;
   virtual void visit (RangePatternBoundPath &bound) = 0;

--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -5575,6 +5575,12 @@ WildcardPattern::accept_vis (ASTVisitor &vis)
 }
 
 void
+RestPattern::accept_vis (ASTVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+void
 RangePatternBoundLiteral::accept_vis (ASTVisitor &vis)
 {
   vis.visit (*this);

--- a/gcc/rust/ast/rust-pattern.h
+++ b/gcc/rust/ast/rust-pattern.h
@@ -191,6 +191,20 @@ protected:
   }
 };
 
+class RestPattern : public Pattern
+{
+  Location locus;
+
+public:
+  std::string as_string () const override { return ".."; }
+
+  RestPattern (Location locus) : locus (locus) {}
+
+  Location get_locus () const override final { return locus; }
+
+  void accept_vis (ASTVisitor &vis) override;
+};
+
 // Base range pattern bound (lower or upper limit) - abstract
 class RangePatternBound
 {

--- a/gcc/rust/checks/errors/rust-feature-gate.h
+++ b/gcc/rust/checks/errors/rust-feature-gate.h
@@ -151,6 +151,7 @@ public:
   void visit (AST::LiteralPattern &pattern) override {}
   void visit (AST::IdentifierPattern &pattern) override {}
   void visit (AST::WildcardPattern &pattern) override {}
+  void visit (AST::RestPattern &pattern) override {}
   void visit (AST::RangePatternBoundLiteral &bound) override {}
   void visit (AST::RangePatternBoundPath &bound) override {}
   void visit (AST::RangePatternBoundQualPath &bound) override {}

--- a/gcc/rust/expand/rust-attribute-visitor.cc
+++ b/gcc/rust/expand/rust-attribute-visitor.cc
@@ -2937,6 +2937,11 @@ AttrVisitor::visit (AST::WildcardPattern &)
   // not possible
 }
 void
+AttrVisitor::visit (AST::RestPattern &)
+{
+  // not possible
+}
+void
 AttrVisitor::visit (AST::RangePatternBoundLiteral &)
 {
   // not possible

--- a/gcc/rust/expand/rust-attribute-visitor.h
+++ b/gcc/rust/expand/rust-attribute-visitor.h
@@ -242,6 +242,7 @@ public:
   void visit (AST::LiteralPattern &) override;
   void visit (AST::IdentifierPattern &pattern) override;
   void visit (AST::WildcardPattern &) override;
+  void visit (AST::RestPattern &) override;
   void visit (AST::RangePatternBoundLiteral &) override;
   void visit (AST::RangePatternBoundPath &bound) override;
   void visit (AST::RangePatternBoundQualPath &bound) override;

--- a/gcc/rust/hir/rust-ast-lower-base.cc
+++ b/gcc/rust/hir/rust-ast-lower-base.cc
@@ -409,6 +409,9 @@ ASTLoweringBase::visit (AST::IdentifierPattern &)
 void
 ASTLoweringBase::visit (AST::WildcardPattern &)
 {}
+void
+ASTLoweringBase::visit (AST::RestPattern &)
+{}
 //  void ASTLoweringBase::visit(RangePatternBoundbound) {}
 void
 ASTLoweringBase::visit (AST::RangePatternBoundLiteral &)

--- a/gcc/rust/hir/rust-ast-lower-base.h
+++ b/gcc/rust/hir/rust-ast-lower-base.h
@@ -211,6 +211,7 @@ public:
   virtual void visit (AST::LiteralPattern &pattern);
   virtual void visit (AST::IdentifierPattern &pattern);
   virtual void visit (AST::WildcardPattern &pattern);
+  virtual void visit (AST::RestPattern &pattern);
   //  virtual void visit(RangePatternBound& bound);
   virtual void visit (AST::RangePatternBoundLiteral &bound);
   virtual void visit (AST::RangePatternBoundPath &bound);

--- a/gcc/rust/resolve/rust-ast-resolve-base.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-base.cc
@@ -519,6 +519,10 @@ ResolverBase::visit (AST::WildcardPattern &)
 {}
 
 void
+ResolverBase::visit (AST::RestPattern &)
+{}
+
+void
 ResolverBase::visit (AST::RangePatternBoundLiteral &)
 {}
 

--- a/gcc/rust/resolve/rust-ast-resolve-base.h
+++ b/gcc/rust/resolve/rust-ast-resolve-base.h
@@ -158,6 +158,7 @@ public:
   void visit (AST::LiteralPattern &);
   void visit (AST::IdentifierPattern &);
   void visit (AST::WildcardPattern &);
+  void visit (AST::RestPattern &);
 
   void visit (AST::RangePatternBoundLiteral &);
   void visit (AST::RangePatternBoundPath &);

--- a/gcc/rust/resolve/rust-early-name-resolver.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver.cc
@@ -957,6 +957,10 @@ EarlyNameResolver::visit (AST::WildcardPattern &)
 {}
 
 void
+EarlyNameResolver::visit (AST::RestPattern &)
+{}
+
+void
 EarlyNameResolver::visit (AST::RangePatternBoundLiteral &)
 {}
 

--- a/gcc/rust/resolve/rust-early-name-resolver.h
+++ b/gcc/rust/resolve/rust-early-name-resolver.h
@@ -233,6 +233,7 @@ private:
   virtual void visit (AST::LiteralPattern &pattern);
   virtual void visit (AST::IdentifierPattern &pattern);
   virtual void visit (AST::WildcardPattern &pattern);
+  virtual void visit (AST::RestPattern &pattern);
   virtual void visit (AST::RangePatternBoundLiteral &bound);
   virtual void visit (AST::RangePatternBoundPath &bound);
   virtual void visit (AST::RangePatternBoundQualPath &bound);

--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -695,6 +695,10 @@ void
 AttributeChecker::visit (AST::WildcardPattern &)
 {}
 
+void
+AttributeChecker::visit (AST::RestPattern &)
+{}
+
 // void AttributeChecker::visit(RangePatternBound& ){}
 
 void

--- a/gcc/rust/util/rust-attributes.h
+++ b/gcc/rust/util/rust-attributes.h
@@ -222,6 +222,7 @@ private:
   void visit (AST::LiteralPattern &pattern);
   void visit (AST::IdentifierPattern &pattern);
   void visit (AST::WildcardPattern &pattern);
+  void visit (AST::RestPattern &pattern);
   // void visit(RangePatternBound& bound);
   void visit (AST::RangePatternBoundLiteral &bound);
   void visit (AST::RangePatternBoundPath &bound);


### PR DESCRIPTION
Add the RestPattern AST node representing `..` code in some rust context. This commit also provides the different visitors for this node.

gcc/rust/ChangeLog:

	* ast/rust-ast-dump.cc (Dump::visit): Add visitor.
	* ast/rust-ast-dump.h: Add visitor prototype.
	* ast/rust-ast-full-decls.h (class RestPattern): Add forward declaration for class RestPattern.
	* ast/rust-ast-visitor.h: Add visitor prototype.
	* ast/rust-ast.cc (RestPattern::accept_vis): Add function to accept a foreign visitor.
	* ast/rust-pattern.h (class RestPattern): Add class RestPattern.
	* checks/errors/rust-feature-gate.h: Add visitor prototype.
	* expand/rust-attribute-visitor.cc (AttrVisitor::visit): Add visitor implementation.
	* expand/rust-attribute-visitor.h: Add visitor prototype.
	* hir/rust-ast-lower-base.cc (ASTLoweringBase::visit): Add visitor implementation.
	* hir/rust-ast-lower-base.h: Add visitor prototype.
	* resolve/rust-ast-resolve-base.cc (ResolverBase::visit): Add visitor implementation.
	* resolve/rust-ast-resolve-base.h: Add visitor prototype.
	* resolve/rust-early-name-resolver.cc (EarlyNameResolver::visit): Add visitor implementation.
	* resolve/rust-early-name-resolver.h: Add visitor prototype.
	* util/rust-attributes.cc (AttributeChecker::visit): Add visitor implementation.
	* util/rust-attributes.h: Add visitor prototype.

Fixes #1936 