### PR TITLE
Fix casting error behind generics [WIP]

### DIFF
--- a/gcc/rust/typecheck/rust-casts.cc
+++ b/gcc/rust/typecheck/rust-casts.cc
@@ -60,15 +60,16 @@ TypeCastRules::cast_rules ()
   // https://github.com/rust-lang/rust/blob/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/compiler/rustc_typeck/src/check/cast.rs#L596
   // https://github.com/rust-lang/rust/blob/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/compiler/rustc_typeck/src/check/cast.rs#L654
 
-  rust_debug ("cast_rules from={%s} to={%s}",
-	      from.get_ty ()->debug_str ().c_str (),
+  TyTy::BaseType *from_type = from.get_ty ()->destructure ();
+
+  rust_debug ("cast_rules from={%s} to={%s}", from_type->debug_str ().c_str (),
 	      to.get_ty ()->debug_str ().c_str ());
 
-  switch (from.get_ty ()->get_kind ())
+  switch (from_type->get_kind ())
     {
       case TyTy::TypeKind::INFER: {
 	TyTy::InferType *from_infer
-	  = static_cast<TyTy::InferType *> (from.get_ty ());
+	  = static_cast<TyTy::InferType *> (from_type);
 	switch (from_infer->get_infer_kind ())
 	  {
 	  case TyTy::InferType::InferTypeKind::GENERAL:

--- a/gcc/testsuite/rust/compile/cast_generics.rs
+++ b/gcc/testsuite/rust/compile/cast_generics.rs
@@ -1,0 +1,8 @@
+fn test<T>(a: T) -> T {
+  a
+}
+
+fn main() {
+  let t: i32 = test(123 as i32) as i32;
+  // { dg-warning "unused name" "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
Fixes #1897 

gcc/rust/ChangeLog:
```
* typecheck/rust-casts.cc (TypeCastRules::cast_rules): Perform destructure on `from` type
```

gcc/testsuite/ChangeLog:
```
* rust/compile/cast_generics.rs: New test.
```