### PR TITLE
Fix bootstrap compile error

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -4013,9 +4013,8 @@ Parser<ManagedTokenSource>::parse_external_type_item (AST::Visibility vis,
     return nullptr;
 
   return std::unique_ptr<AST::ExternalTypeItem> (
-    new AST::ExternalTypeItem (std::move (alias_name_tok->get_str ()),
-			       std::move (vis), std::move (outer_attrs),
-			       std::move (locus)));
+    new AST::ExternalTypeItem (alias_name_tok->get_str (), std::move (vis),
+			       std::move (outer_attrs), std::move (locus)));
 }
 
 // Parses a "type alias" (typedef) item.


### PR DESCRIPTION
The recent changes in the parser bringing the parsing of extern type items also brought a compilation error when boostrapping the compiler.

gcc/rust/ChangeLog:

	* parse/rust-parse-impl.h (Parser::parse_external_type_item): Fix compilation error due to unnecessary move.

Fixes #1939 