### PR TITLE
Parse rest pattern in slices

### DIFF
--- a/gcc/rust/ast/rust-pattern.h
+++ b/gcc/rust/ast/rust-pattern.h
@@ -194,15 +194,26 @@ protected:
 class RestPattern : public Pattern
 {
   Location locus;
+  NodeId node_id;
 
 public:
   std::string as_string () const override { return ".."; }
 
-  RestPattern (Location locus) : locus (locus) {}
+  RestPattern (Location locus)
+    : locus (locus), node_id (Analysis::Mappings::get ()->get_next_node_id ())
+  {}
 
   Location get_locus () const override final { return locus; }
 
   void accept_vis (ASTVisitor &vis) override;
+
+  NodeId get_pattern_node_id () const override final { return node_id; }
+
+protected:
+  RestPattern *clone_pattern_impl () const override
+  {
+    return new RestPattern (*this);
+  }
 };
 
 // Base range pattern bound (lower or upper limit) - abstract

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -10737,6 +10737,10 @@ Parser<ManagedTokenSource>::parse_pattern_no_alt ()
       lexer.skip_token ();
       return std::unique_ptr<AST::WildcardPattern> (
 	new AST::WildcardPattern (t->get_locus ()));
+    case DOT_DOT:
+      lexer.skip_token ();
+      return std::unique_ptr<AST::RestPattern> (
+	new AST::RestPattern (t->get_locus ()));
     case REF:
     case MUT:
       return parse_identifier_pattern ();

--- a/gcc/testsuite/rust/compile/slice_rest_pattern.rs
+++ b/gcc/testsuite/rust/compile/slice_rest_pattern.rs
@@ -1,0 +1,8 @@
+// { dg-options "-fsyntax-only" }
+fn foo(a: &[u32]) {
+    match a {
+        [first, ..] => {}
+        [.., last] => {}
+        _ => {}
+    }
+}


### PR DESCRIPTION
This PR introduces the parsing code for `..` commonly known as `RestPattern`.

Fixes #1918 