### PR TITLE
hir: Add ExportedMacro node and handling.

### DIFF
--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -70,6 +70,7 @@ public:
   void visit (HIR::LetStmt &) override {}
   void visit (HIR::ExprStmtWithoutBlock &) override {}
   void visit (HIR::ExprStmtWithBlock &) override {}
+  void visit (HIR::ExportedMacro &) override {}
 
 protected:
   CompileItem (Context *ctx, TyTy::BaseType *concrete, Location ref_locus)

--- a/gcc/rust/backend/rust-compile-stmt.h
+++ b/gcc/rust/backend/rust-compile-stmt.h
@@ -56,6 +56,7 @@ public:
   void visit (HIR::ImplBlock &) override {}
   void visit (HIR::ExternBlock &) override {}
   void visit (HIR::EmptyStmt &) override {}
+  void visit (HIR::ExportedMacro &) override {}
 
 private:
   CompileStmt (Context *ctx);

--- a/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
+++ b/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
@@ -761,5 +761,9 @@ PrivacyReporter::visit (HIR::ExprStmtWithBlock &stmt)
   stmt.get_expr ()->accept_vis (*this);
 }
 
+void
+PrivacyReporter::visit (HIR::ExportedMacro &)
+{}
+
 } // namespace Privacy
 } // namespace Rust

--- a/gcc/rust/checks/errors/privacy/rust-privacy-reporter.h
+++ b/gcc/rust/checks/errors/privacy/rust-privacy-reporter.h
@@ -157,6 +157,7 @@ types
   virtual void visit (HIR::LetStmt &stmt);
   virtual void visit (HIR::ExprStmtWithoutBlock &stmt);
   virtual void visit (HIR::ExprStmtWithBlock &stmt);
+  virtual void visit (HIR::ExportedMacro &macro);
 
   Analysis::Mappings &mappings;
   Rust::Resolver::Resolver &resolver;

--- a/gcc/rust/checks/errors/privacy/rust-pub-restricted-visitor.cc
+++ b/gcc/rust/checks/errors/privacy/rust-pub-restricted-visitor.cc
@@ -178,5 +178,12 @@ PubRestrictedVisitor::visit (HIR::ExternBlock &block)
 			block.get_locus ());
 }
 
+void
+PubRestrictedVisitor::visit (HIR::ExportedMacro &macro)
+{
+  is_restriction_valid (macro.get_mappings ().get_nodeid (),
+			macro.get_locus ());
+}
+
 } // namespace Privacy
 } // namespace Rust

--- a/gcc/rust/checks/errors/privacy/rust-pub-restricted-visitor.h
+++ b/gcc/rust/checks/errors/privacy/rust-pub-restricted-visitor.h
@@ -103,6 +103,7 @@ public:
   virtual void visit (HIR::Trait &trait);
   virtual void visit (HIR::ImplBlock &impl);
   virtual void visit (HIR::ExternBlock &block);
+  virtual void visit (HIR::ExportedMacro &macro);
 
 private:
   /* Stack of ancestor modules visited by this visitor */

--- a/gcc/rust/checks/errors/privacy/rust-reachability.cc
+++ b/gcc/rust/checks/errors/privacy/rust-reachability.cc
@@ -230,6 +230,10 @@ void
 ReachabilityVisitor::visit (HIR::ExternBlock &)
 {}
 
+void
+ReachabilityVisitor::visit (HIR::ExportedMacro &macro)
+{}
+
 // FIXME: How can we visit Blocks in the current configuration? Have a full
 // visitor?
 } // namespace Privacy

--- a/gcc/rust/checks/errors/privacy/rust-reachability.h
+++ b/gcc/rust/checks/errors/privacy/rust-reachability.h
@@ -75,6 +75,7 @@ public:
   virtual void visit (HIR::Trait &trait);
   virtual void visit (HIR::ImplBlock &impl);
   virtual void visit (HIR::ExternBlock &block);
+  virtual void visit (HIR::ExportedMacro &macro);
 
 private:
   ReachLevel current_level;

--- a/gcc/rust/checks/errors/privacy/rust-visibility-resolver.cc
+++ b/gcc/rust/checks/errors/privacy/rust-visibility-resolver.cc
@@ -241,5 +241,11 @@ void
 VisibilityResolver::visit (HIR::ExternBlock &)
 {}
 
+void
+VisibilityResolver::visit (HIR::ExportedMacro &macro)
+{
+  resolve_and_update (&macro);
+}
+
 } // namespace Privacy
 } // namespace Rust

--- a/gcc/rust/checks/errors/privacy/rust-visibility-resolver.h
+++ b/gcc/rust/checks/errors/privacy/rust-visibility-resolver.h
@@ -90,6 +90,7 @@ public:
   virtual void visit (HIR::Trait &trait);
   virtual void visit (HIR::ImplBlock &impl);
   virtual void visit (HIR::ExternBlock &block);
+  virtual void visit (HIR::ExportedMacro &macro);
 
 private:
   Analysis::Mappings &mappings;

--- a/gcc/rust/checks/errors/rust-const-checker.cc
+++ b/gcc/rust/checks/errors/rust-const-checker.cc
@@ -927,5 +927,9 @@ void
 ConstChecker::visit (BareFunctionType &)
 {}
 
+void
+ConstChecker::visit (ExportedMacro &)
+{}
+
 } // namespace HIR
 } // namespace Rust

--- a/gcc/rust/checks/errors/rust-const-checker.h
+++ b/gcc/rust/checks/errors/rust-const-checker.h
@@ -205,6 +205,7 @@ private:
   virtual void visit (SliceType &type) override;
   virtual void visit (InferredType &type) override;
   virtual void visit (BareFunctionType &type) override;
+  virtual void visit (ExportedMacro &macro) override;
 };
 
 } // namespace HIR

--- a/gcc/rust/checks/errors/rust-unsafe-checker.cc
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.cc
@@ -984,5 +984,9 @@ void
 UnsafeChecker::visit (BareFunctionType &)
 {}
 
+void
+UnsafeChecker::visit (ExportedMacro &)
+{}
+
 } // namespace HIR
 } // namespace Rust

--- a/gcc/rust/checks/errors/rust-unsafe-checker.h
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.h
@@ -187,6 +187,7 @@ private:
   virtual void visit (SliceType &type) override;
   virtual void visit (InferredType &type) override;
   virtual void visit (BareFunctionType &type) override;
+  virtual void visit (ExportedMacro &macro) override;
 };
 
 } // namespace HIR

--- a/gcc/rust/hir/rust-ast-lower-item.cc
+++ b/gcc/rust/hir/rust-ast-lower-item.cc
@@ -691,6 +691,28 @@ ASTLoweringItem::visit (AST::ExternBlock &extern_block)
   translated = lower_extern_block (extern_block);
 }
 
+void
+ASTLoweringItem::visit (AST::MacroRulesDefinition &def)
+{
+  bool is_export = false;
+  for (const auto &attr : def.get_outer_attrs ())
+    if (attr.get_path ().as_string () == "macro_export")
+      is_export = true;
+
+  if (is_export)
+    {
+      auto crate_num = mappings->get_current_crate ();
+      Analysis::NodeMapping mapping (crate_num, def.get_node_id (),
+				     mappings->get_next_hir_id (crate_num),
+				     mappings->get_next_localdef_id (
+				       crate_num));
+      auto locus = def.get_locus ();
+
+      translated
+	= new HIR::ExportedMacro (mapping, def.get_outer_attrs (), locus);
+    }
+}
+
 HIR::SimplePath
 ASTLoweringSimplePath::translate (const AST::SimplePath &path)
 {

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -56,6 +56,7 @@ public:
   void visit (AST::Trait &trait) override;
   void visit (AST::TraitImpl &impl_block) override;
   void visit (AST::ExternBlock &extern_block) override;
+  void visit (AST::MacroRulesDefinition &macro) override;
 
 private:
   ASTLoweringItem () : translated (nullptr) {}

--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -657,5 +657,8 @@ Dump::visit (InferredType &)
 void
 Dump::visit (BareFunctionType &)
 {}
+void
+Dump::visit (ExportedMacro &)
+{}
 } // namespace HIR
 } // namespace Rust

--- a/gcc/rust/hir/rust-hir-dump.h
+++ b/gcc/rust/hir/rust-hir-dump.h
@@ -184,6 +184,7 @@ private:
   virtual void visit (SliceType &) override;
   virtual void visit (InferredType &) override;
   virtual void visit (BareFunctionType &) override;
+  virtual void visit (ExportedMacro &) override;
 };
 
 } // namespace HIR

--- a/gcc/rust/hir/tree/rust-hir-full-decls.h
+++ b/gcc/rust/hir/tree/rust-hir-full-decls.h
@@ -35,6 +35,9 @@ class Lifetime;
 class GenericParam;
 class LifetimeParam;
 
+// FIXME: ARTHUR: Move this somewhere else
+class ExportedMacro;
+
 class TraitItem;
 class ImplItem;
 struct Crate;

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -3224,6 +3224,27 @@ protected:
   }*/
 };
 
+class ExportedMacro : public VisItem
+{
+  Location locus;
+
+public:
+  ExportedMacro (Analysis::NodeMapping mapping, AST::AttrVec outer_attrs,
+		 Location locus)
+    : VisItem (mapping, Visibility (Visibility::PUBLIC),
+	       std::move (outer_attrs)),
+      locus (locus)
+  {}
+
+  virtual Location get_locus () const override;
+  virtual ItemKind get_item_kind () const override;
+  virtual ExportedMacro *clone_item_impl () const override;
+
+  void accept_vis (HIRFullVisitor &vis) override;
+  void accept_vis (HIRStmtVisitor &vis) override;
+  void accept_vis (HIRVisItemVisitor &vis) override;
+};
+
 } // namespace HIR
 } // namespace Rust
 

--- a/gcc/rust/hir/tree/rust-hir-visitor.h
+++ b/gcc/rust/hir/tree/rust-hir-visitor.h
@@ -157,6 +157,7 @@ public:
   virtual void visit (SliceType &type) = 0;
   virtual void visit (InferredType &type) = 0;
   virtual void visit (BareFunctionType &type) = 0;
+  virtual void visit (ExportedMacro &macro) = 0;
 };
 
 class HIRFullVisitorBase : public HIRFullVisitor
@@ -311,6 +312,7 @@ public:
   virtual void visit (SliceType &) override {}
   virtual void visit (InferredType &) override {}
   virtual void visit (BareFunctionType &) override {}
+  virtual void visit (ExportedMacro &) override {}
 };
 
 class HIRExternalItemVisitor
@@ -345,6 +347,7 @@ public:
   virtual void visit (Trait &trait) = 0;
   virtual void visit (ImplBlock &impl) = 0;
   virtual void visit (ExternBlock &block) = 0;
+  virtual void visit (ExportedMacro &macro) = 0;
 };
 
 class HIRImplVisitor
@@ -404,6 +407,7 @@ public:
   virtual void visit (LetStmt &stmt) = 0;
   virtual void visit (ExprStmtWithoutBlock &stmt) = 0;
   virtual void visit (ExprStmtWithBlock &stmt) = 0;
+  virtual void visit (ExportedMacro &macro) = 0;
 };
 
 class HIRExpressionVisitor

--- a/gcc/rust/hir/tree/rust-hir.cc
+++ b/gcc/rust/hir/tree/rust-hir.cc
@@ -5243,5 +5243,41 @@ void
 ConstGenericParam::accept_vis (HIRFullVisitor &)
 {}
 
+void
+ExportedMacro::accept_vis (HIRVisItemVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+void
+ExportedMacro::accept_vis (HIRFullVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+void
+ExportedMacro::accept_vis (HIRStmtVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+Location
+ExportedMacro::get_locus () const
+{
+  return locus;
+}
+
+Item::ItemKind
+ExportedMacro::get_item_kind () const
+{
+  return ItemKind::MacroExport;
+}
+
+ExportedMacro *
+ExportedMacro::clone_item_impl () const
+{
+  return new ExportedMacro (*this);
+}
+
 } // namespace HIR
 } // namespace Rust

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -191,6 +191,7 @@ public:
     Trait,
     Impl,
     Module,
+    MacroExport,
   };
 
   virtual ItemKind get_item_kind () const = 0;

--- a/gcc/rust/metadata/rust-export-metadata.cc
+++ b/gcc/rust/metadata/rust-export-metadata.cc
@@ -169,6 +169,7 @@ public:
   void visit (HIR::StaticItem &) override {}
   void visit (HIR::ImplBlock &) override {}
   void visit (HIR::ExternBlock &) override {}
+  void visit (HIR::ExportedMacro &) override {}
 
   void visit (HIR::Trait &trait) override { ctx.emit_trait (trait); }
 

--- a/gcc/rust/typecheck/rust-hir-type-check-item.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.h
@@ -50,6 +50,7 @@ public:
   // nothing to do
   void visit (HIR::ExternCrate &) override {}
   void visit (HIR::UseDeclaration &) override {}
+  void visit (HIR::ExportedMacro &) override {}
 
 protected:
   std::vector<TyTy::SubstitutionParamMapping>

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.cc
@@ -149,6 +149,10 @@ TypeCheckStmt::visit (HIR::QualifiedPathInType &path)
 }
 
 void
+TypeCheckStmt::visit (HIR::ExportedMacro &path)
+{}
+
+void
 TypeCheckStmt::visit (HIR::TupleStruct &struct_decl)
 {
   infered = TypeCheckItem::Resolve (struct_decl);

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.h
@@ -47,6 +47,7 @@ public:
   void visit (HIR::ImplBlock &impl) override;
   void visit (HIR::TypePath &path) override;
   void visit (HIR::QualifiedPathInType &path) override;
+  void visit (HIR::ExportedMacro &path) override;
 
   // FIXME
   // this seems like it should not be part of this visitor

--- a/gcc/rust/typecheck/rust-tycheck-dump.h
+++ b/gcc/rust/typecheck/rust-tycheck-dump.h
@@ -196,6 +196,8 @@ public:
     dump += "ctor: " + type_string (expr.get_mappings ());
   }
 
+  void visit (HIR::ExportedMacro &) override {}
+
 protected:
   std::string type_string (const Analysis::NodeMapping &mappings)
   {

--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -41,6 +41,7 @@ static const BuiltinAttrDefinition __definitions[]
      {"repr", CODE_GENERATION},
      {"path", EXPANSION},
      {"macro_use", NAME_RESOLUTION},
+     {"macro_export", CODE_GENERATION}, // FIXME: And NAME_RESOLUTION as well
      // FIXME: This is not implemented yet, see
      // https://github.com/Rust-GCC/gccrs/issues/1475
      {"target_feature", CODE_GENERATION},


### PR DESCRIPTION
This HIR node represents macros which should be exported into the final Rust metadata files. Because our metadata exporter operates on the HIR, while macros are inherently tied to the AST, we need a way to propagate exported macros up until the metadata export pass on the HIR. Hence the existence of this class, whose sole purpose is to keep enough information for the metadata exporter to retrieve the original AST::MacroRulesDefinition. Handling for actually exporting these macros will come later.

gcc/rust/ChangeLog:

	* hir/tree/rust-hir-item.h (class ExportedMacro): Add new ExportedMacro class.
	* hir/tree/rust-hir.cc (ExportedMacro::accept_vis): New function.
	(ExportedMacro::get_locus): Likewise.
	(ExportedMacro::get_item_kind): Likewise.
	(ExportedMacro::clone_item_impl): Likewise.
	* hir/tree/rust-hir-full-decls.h (class ExportedMacro): Forward declare class.
	* backend/rust-compile-item.h: Add visitor for ExportedMacro.
	* backend/rust-compile-stmt.h: Likewise.
	* checks/errors/privacy/rust-privacy-reporter.cc (PrivacyReporter::visit): Likewise.
	* checks/errors/privacy/rust-privacy-reporter.h: Likewise.
	* checks/errors/privacy/rust-pub-restricted-visitor.cc (PubRestrictedVisitor::visit): Likewise.
	* checks/errors/privacy/rust-pub-restricted-visitor.h: Likewise.
	* checks/errors/privacy/rust-reachability.cc (ReachabilityVisitor::visit): Likewise.
	* checks/errors/privacy/rust-reachability.h: Likewise.
	* checks/errors/privacy/rust-visibility-resolver.cc (VisibilityResolver::visit): Likewise.
	* checks/errors/privacy/rust-visibility-resolver.h: Likewise.
	* checks/errors/rust-const-checker.cc (ConstChecker::visit): Likewise.
	* checks/errors/rust-const-checker.h: Likewise.
	* checks/errors/rust-unsafe-checker.cc (UnsafeChecker::visit): Likewise.
	* checks/errors/rust-unsafe-checker.h: Likewise.
	* hir/rust-ast-lower-item.cc (ASTLoweringItem::visit): Likewise.
	* hir/rust-ast-lower-item.h: Likewise.
	* hir/rust-hir-dump.cc (Dump::visit): Likewise.
	* hir/rust-hir-dump.h: Likewise.
	* hir/tree/rust-hir-visitor.h: Likewise.
	* metadata/rust-export-metadata.cc: Likewise.
	* typecheck/rust-hir-type-check-item.h: Likewise.
	* typecheck/rust-hir-type-check-stmt.cc (TypeCheckStmt::visit): Likewise.
	* typecheck/rust-hir-type-check-stmt.h: Likewise.
	* typecheck/rust-tycheck-dump.h: Likewise.
	* hir/tree/rust-hir.h: Add new ItemKind::MacroExport variant.
	* util/rust-attributes.cc: Add #[macro_export] attribute.

