### PR TITLE
gccrs: add uninit intrinsic

### DIFF
--- a/gcc/rust/backend/rust-builtins.cc
+++ b/gcc/rust/backend/rust-builtins.cc
@@ -249,6 +249,12 @@ BuiltinsContext::setup ()
 					    size_type_node, NULL_TREE),
 		  0);
 
+  define_builtin ("memset", BUILT_IN_MEMSET, "__builtin_memset", "memset",
+		  build_function_type_list (void_type_node, ptr_type_node,
+					    integer_type_node, size_type_node,
+					    NULL_TREE),
+		  0);
+
   define_builtin ("prefetch", BUILT_IN_PREFETCH, "__builtin_prefetch",
 		  "prefetch",
 		  build_varargs_function_type_list (

--- a/gcc/testsuite/rust/compile/torture/uninit-intrinsic-1.rs
+++ b/gcc/testsuite/rust/compile/torture/uninit-intrinsic-1.rs
@@ -1,0 +1,21 @@
+mod intrinsics {
+    extern "rust-intrinsic" {
+        pub fn uninit<T>() -> T;
+    }
+}
+
+mod mem {
+    pub unsafe fn uninitialized<T>() -> T {
+        intrinsics::uninit()
+    }
+}
+
+struct Foo(i32, i32);
+// { dg-warning "struct is never constructed: .Foo." "" { target *-*-* } .-1 }
+// FIXME ^^ above is a bad-warning
+
+impl Foo {
+    pub fn new() -> Self {
+        unsafe { mem::uninitialized::<Foo>() }
+    }
+}


### PR DESCRIPTION
Following an investigation from rustc and discussions on zulip the recommendation was that for uninit we memset to 0x01 which is less likely to be a null ptr but still an invalid reference.

Fixes #1899