### PR TITLE
Parse if let expressions correctly

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -13090,7 +13090,7 @@ Parser<ManagedTokenSource>::null_denotation (const_TokenPtr tok,
       return parse_block_expr (std::move (outer_attrs), tok->get_locus ());
     case IF:
       // if or if let, so more lookahead to find out
-      if (lexer.peek_token (1)->get_id () == LET)
+      if (lexer.peek_token ()->get_id () == LET)
 	{
 	  // if let expr
 	  return parse_if_let_expr (std::move (outer_attrs), tok->get_locus ());

--- a/gcc/testsuite/rust/compile/if_let_expr.rs
+++ b/gcc/testsuite/rust/compile/if_let_expr.rs
@@ -1,0 +1,19 @@
+// { dg-options "-fsyntax-only" }
+
+pub enum Option<T> {
+    None,
+    Some(T),
+}
+
+fn main() {
+    let x = Option::Some(3);
+    let a = if let Option::Some(1) = x {
+        1
+    } else if x == Option::Some(2) {
+        2
+    } else if let Option::Some(y) = x {
+        y
+    } else {
+        -1
+    };
+}


### PR DESCRIPTION
The current token was passed as a parameter and therefore out of the lexer's queue. Matching the next token against `let` was an error as `let` was in fact the current token because of this parameter.

Fixes #1904 