### PR TITLE
parser: Fix while let expr parsing

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -8373,7 +8373,7 @@ Parser<ManagedTokenSource>::parse_while_let_loop_expr (AST::AttrVec outer_attrs,
     locus = lexer.peek_token ()->get_locus ();
   else
     locus = label.get_locus ();
-  skip_token (WHILE);
+  maybe_skip_token (WHILE);
 
   /* check for possible accidental recognition of a while loop as a while let
    * loop */
@@ -13104,9 +13104,16 @@ Parser<ManagedTokenSource>::null_denotation (const_TokenPtr tok,
       return parse_loop_expr (std::move (outer_attrs), AST::LoopLabel::error (),
 			      tok->get_locus ());
     case WHILE:
-      return parse_while_loop_expr (std::move (outer_attrs),
-				    AST::LoopLabel::error (),
-				    tok->get_locus ());
+      if (lexer.peek_token ()->get_id () == LET)
+	{
+	  return parse_while_let_loop_expr (std::move (outer_attrs));
+	}
+      else
+	{
+	  return parse_while_loop_expr (std::move (outer_attrs),
+					AST::LoopLabel::error (),
+					tok->get_locus ());
+	}
     case MATCH_TOK:
       // also an expression with block
       return parse_match_expr (std::move (outer_attrs), tok->get_locus ());

--- a/gcc/testsuite/rust/compile/while_let_expr.rs
+++ b/gcc/testsuite/rust/compile/while_let_expr.rs
@@ -1,0 +1,13 @@
+// { dg-options "-fsyntax-only" }
+
+pub enum Option<T> {
+    None,
+    Some(T),
+}
+
+fn main() {
+    let mut x = Option::Some(3);
+    let a = while let Option::Some(1) = x {
+        x = Option::None;
+    };
+}


### PR DESCRIPTION
While let expr return unit but are valid construct in rust, they should therefore be included in the parsing code.

Fixes #1949 