### PR TITLE
Parse zero sized slice pattern

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -11133,7 +11133,15 @@ std::unique_ptr<AST::SlicePattern>
 Parser<ManagedTokenSource>::parse_slice_pattern ()
 {
   Location square_locus = lexer.peek_token ()->get_locus ();
+  std::vector<std::unique_ptr<AST::Pattern>> patterns;
   skip_token (LEFT_SQUARE);
+
+  if (lexer.peek_token ()->get_id () == RIGHT_SQUARE)
+    {
+      skip_token (RIGHT_SQUARE);
+      return std::unique_ptr<AST::SlicePattern> (
+	new AST::SlicePattern (std::move (patterns), square_locus));
+    }
 
   // parse initial pattern (required)
   std::unique_ptr<AST::Pattern> initial_pattern = parse_pattern ();
@@ -11146,7 +11154,6 @@ Parser<ManagedTokenSource>::parse_slice_pattern ()
       return nullptr;
     }
 
-  std::vector<std::unique_ptr<AST::Pattern>> patterns;
   patterns.push_back (std::move (initial_pattern));
 
   const_TokenPtr t = lexer.peek_token ();

--- a/gcc/testsuite/rust/compile/zero_sized_slice.rs
+++ b/gcc/testsuite/rust/compile/zero_sized_slice.rs
@@ -1,0 +1,5 @@
+// { dg-options "-fsyntax-only" }
+
+fn foo() {
+    let [] = [0; 0];
+}


### PR DESCRIPTION
Zero sized slice pattern are now checked before attempting to parse any pattern inside the slice.

Fixes #1920 