### PR TITLE
Fix `FeatureGate::gate` will crash on 32-bit x86.

### DIFF
--- a/gcc/rust/checks/errors/rust-feature-gate.cc
+++ b/gcc/rust/checks/errors/rust-feature-gate.cc
@@ -75,8 +75,8 @@ FeatureGate::gate (Feature::Name name, Location loc,
       if (issue > 0)
 	{
 	  const char *fmt_str
-	    = "%s. see issue %ld "
-	      "<https://github.com/rust-lang/rust/issues/%ld> for more "
+	    = "%s. see issue %u "
+	      "<https://github.com/rust-lang/rust/issues/%u> for more "
 	      "information. add `#![feature(%s)]` to the crate attributes to "
 	      "enable.";
 	  rust_error_at (loc, fmt_str, error_msg.c_str (), issue, issue,

--- a/gcc/rust/checks/errors/rust-feature.h
+++ b/gcc/rust/checks/errors/rust-feature.h
@@ -49,14 +49,14 @@ public:
   Name name () { return m_name; }
   const std::string &description () { return m_description; }
   State state () { return m_state; }
-  uint64_t issue () { return m_issue; }
+  unsigned issue () { return m_issue; }
 
   static Optional<Name> as_name (const std::string &name);
   static Feature create (Name name);
 
 private:
   Feature (Name name, State state, const char *name_str,
-	   const char *rustc_since, uint64_t issue_number,
+	   const char *rustc_since, unsigned issue_number,
 	   const Optional<CompileOptions::Edition> &edition,
 	   const char *description)
     : m_state (state), m_name (name), m_name_str (name_str),
@@ -68,7 +68,7 @@ private:
   Name m_name;
   std::string m_name_str;
   std::string m_rustc_since;
-  uint64_t m_issue;
+  unsigned m_issue;
   Optional<CompileOptions::Edition> edition;
   std::string m_description;
 


### PR DESCRIPTION
Fix #1952 
gcc/rust/ChangeLog:

	* checks/errors/rust-feature-gate.cc: Adjust 'ld'->'u'.
	* checks/errors/rust-feature.h: Adjust
	the type of `m_issue`: 'uint64_t' -> 'unsigned'.

