### PR TITLE
enr: Fetch module items during early name resolution

### DIFF
--- a/gcc/rust/expand/rust-attribute-visitor.cc
+++ b/gcc/rust/expand/rust-attribute-visitor.cc
@@ -2148,15 +2148,6 @@ AttrVisitor::visit (AST::Module &module)
 	}
     }
 
-  // Parse the module's items if they haven't been expanded and the file
-  // should be parsed (i.e isn't hidden behind an untrue or impossible cfg
-  // directive)
-  if (!module.is_marked_for_strip ()
-      && module.get_kind () == AST::Module::ModuleKind::UNLOADED)
-    {
-      module.load_items ();
-    }
-
   // strip items if required
   expand_pointer_allow_strip (module.get_items ());
 }

--- a/gcc/rust/resolve/rust-early-name-resolver.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver.cc
@@ -581,6 +581,12 @@ EarlyNameResolver::visit (AST::Method &method)
 void
 EarlyNameResolver::visit (AST::Module &module)
 {
+  // Parse the module's items if they haven't been expanded and the file
+  // should be parsed (i.e isn't hidden behind an untrue or impossible cfg
+  // directive)
+  if (module.get_kind () == AST::Module::UNLOADED)
+    module.load_items ();
+
   scoped (module.get_node_id (), [&module, this] () {
     for (auto &item : module.get_items ())
       item->accept_vis (*this);


### PR DESCRIPTION
This is important as public macros can be present in other modules,
which would otherwise not be loaded until the expansion phase
happening right after the early name resolution.

gcc/rust/ChangeLog:

	* resolve/rust-early-name-resolver.cc (EarlyNameResolver::visit): Move
	unloaded module item loading to...
	* expand/rust-attribute-visitor.cc (AttrVisitor::visit): ...here.

Addresse #1077