### PR TITLE
Add ExportedMacroCollector

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -162,6 +162,7 @@ GRS_OBJS = \
     rust/rust-compile-base.o \
     rust/rust-tree.o \
     rust/rust-compile-context.o \
+	rust/rust-exported-macro-collector.o \
     rust/rust-export-metadata.o \
     rust/rust-imports.o \
     rust/rust-import-archive.o \

--- a/gcc/rust/metadata/rust-export-metadata.cc
+++ b/gcc/rust/metadata/rust-export-metadata.cc
@@ -23,6 +23,7 @@
 #include "rust-ast-dump.h"
 #include "rust-abi.h"
 #include "rust-object-export.h"
+#include "rust-exported-macro-collector.h"
 
 #include "md5.h"
 
@@ -205,6 +206,8 @@ PublicInterface::ExportTo (HIR::Crate &crate, const std::string &output_path)
 void
 PublicInterface::gather_export_data ()
 {
+  ExportedMacroCollector (crate).collect ();
+
   ExportVisItems visitor (context);
   for (auto &item : crate.items)
     {

--- a/gcc/rust/metadata/rust-exported-macro-collector.cc
+++ b/gcc/rust/metadata/rust-exported-macro-collector.cc
@@ -1,0 +1,115 @@
+// Copyright (C) 2020-2023 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-exported-macro-collector.h"
+#include "rust-hir.h"
+#include "rust-hir-expr.h"
+#include "rust-hir-item.h"
+
+namespace Rust {
+namespace Metadata {
+
+ExportedMacroCollector::ExportedMacroCollector (HIR::Crate &crate)
+  : crate (crate)
+{}
+
+void
+ExportedMacroCollector::collect ()
+{
+  for (auto &item : crate.items)
+    if (item->get_hir_kind () == HIR::Node::VIS_ITEM)
+      static_cast<HIR::VisItem *> (item.get ())->accept_vis (*this);
+
+  for (auto macro : exported_macros)
+    crate.items.emplace_back (macro);
+}
+
+void
+ExportedMacroCollector::visit (HIR::ExportedMacro &macro)
+{
+  exported_macros.emplace_back (&macro);
+}
+
+void
+ExportedMacroCollector::visit (HIR::Module &module)
+{
+  for (auto &item : module.get_items ())
+    if (item->get_hir_kind () == HIR::Node::VIS_ITEM)
+      static_cast<HIR::VisItem *> (item.get ())->accept_vis (*this);
+}
+
+void
+ExportedMacroCollector::visit (HIR::Function &function)
+{
+  auto &block = function.get_definition ();
+
+  for (auto &stmt : block->get_statements ())
+    if (stmt->get_hir_kind () == HIR::Node::VIS_ITEM)
+      static_cast<HIR::VisItem *> (stmt.get ())->accept_vis (*this);
+}
+
+void
+ExportedMacroCollector::visit (HIR::ExternCrate &crate)
+{}
+
+void
+ExportedMacroCollector::visit (HIR::UseDeclaration &use_decl)
+{}
+
+void
+ExportedMacroCollector::visit (HIR::TypeAlias &type_alias)
+{}
+
+void
+ExportedMacroCollector::visit (HIR::StructStruct &struct_item)
+{}
+
+void
+ExportedMacroCollector::visit (HIR::TupleStruct &tuple_struct)
+{}
+
+void
+ExportedMacroCollector::visit (HIR::Enum &enum_item)
+{}
+
+void
+ExportedMacroCollector::visit (HIR::Union &union_item)
+{}
+
+void
+ExportedMacroCollector::visit (HIR::ConstantItem &const_item)
+{}
+
+void
+ExportedMacroCollector::visit (HIR::StaticItem &static_item)
+{}
+
+void
+ExportedMacroCollector::visit (HIR::Trait &trait)
+{}
+
+void
+ExportedMacroCollector::visit (HIR::ImplBlock &impl)
+{}
+
+void
+ExportedMacroCollector::visit (HIR::ExternBlock &block)
+{}
+
+} // namespace Metadata
+} // namespace Rust

--- a/gcc/rust/metadata/rust-exported-macro-collector.h
+++ b/gcc/rust/metadata/rust-exported-macro-collector.h
@@ -1,0 +1,54 @@
+// Copyright (C) 2020-2023 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-system.h"
+#include "rust-hir-visitor.h"
+#include "rust-hir-full-decls.h"
+
+namespace Rust {
+namespace Metadata {
+
+class ExportedMacroCollector : HIR::HIRVisItemVisitor
+{
+public:
+  ExportedMacroCollector (HIR::Crate &crate);
+  void collect ();
+
+private:
+  HIR::Crate &crate;
+  std::vector<HIR::Item *> exported_macros;
+
+  virtual void visit (HIR::Module &module);
+  virtual void visit (HIR::ExternCrate &crate);
+  virtual void visit (HIR::UseDeclaration &use_decl);
+  virtual void visit (HIR::Function &function);
+  virtual void visit (HIR::TypeAlias &type_alias);
+  virtual void visit (HIR::StructStruct &struct_item);
+  virtual void visit (HIR::TupleStruct &tuple_struct);
+  virtual void visit (HIR::Enum &enum_item);
+  virtual void visit (HIR::Union &union_item);
+  virtual void visit (HIR::ConstantItem &const_item);
+  virtual void visit (HIR::StaticItem &static_item);
+  virtual void visit (HIR::Trait &trait);
+  virtual void visit (HIR::ImplBlock &impl);
+  virtual void visit (HIR::ExternBlock &block);
+  virtual void visit (HIR::ExportedMacro &macro);
+};
+
+} // namespace Metadata
+} // namespace Rust


### PR DESCRIPTION
Exported macros need to be placed at the root of the crate for metadata
export purposes. This visitor goes through various items susceptibles of
containing exported macros and inserts them at the end of the top-level
items vector within the crate.
    
gcc/rust/ChangeLog:
    
        * Make-lang.in: Add rust-exported-macro-collector.o.
        * metadata/rust-exported-macro-collector.cc: New file.
        * metadata/rust-exported-macro-collector.h: New file.
        * metadata/rust-export-metadata.cc (PublicInterface::gather_export_data):
        Gather public macros before exporting metadata.

Addresses #1077
Needs #1947 so only review the last commit