### PR TITLE
gccrs: Take advantage of our new unify_and to inject inference

### DIFF
--- a/gcc/rust/typecheck/rust-hir-trait-resolve.cc
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.cc
@@ -497,10 +497,12 @@ AssociatedImplTrait::setup_associated_types (
   // the type correctly as our receiver may be generic and we are inferring its
   // generic arguments and this Self might be the concrete version or vice
   // versa.
-  auto result = unify_site (get_impl_block ()->get_mappings ().get_hirid (),
-			    TyTy::TyWithLocation (receiver),
-			    TyTy::TyWithLocation (impl_self_infer),
-			    impl_predicate.get_locus ());
+  auto result = unify_site_and (get_impl_block ()->get_mappings ().get_hirid (),
+				TyTy::TyWithLocation (receiver),
+				TyTy::TyWithLocation (impl_self_infer),
+				impl_predicate.get_locus (),
+				true /*emit-errors*/, true /*commit-if-ok*/,
+				true /*infer*/, true /*cleanup-on-fail*/);
   rust_assert (result->get_kind () != TyTy::TypeKind::ERROR);
   TyTy::BaseType *self_result = result;
 
@@ -525,8 +527,10 @@ AssociatedImplTrait::setup_associated_types (
       TyTy::BaseType *b = hrtb_bound_arguments.at (i);
 
       result
-	= unify_site (a->get_ref (), TyTy::TyWithLocation (a),
-		      TyTy::TyWithLocation (b), impl_predicate.get_locus ());
+	= unify_site_and (a->get_ref (), TyTy::TyWithLocation (a),
+			  TyTy::TyWithLocation (b), impl_predicate.get_locus (),
+			  true /*emit-errors*/, true /*commit-if-ok*/,
+			  true /*infer*/, true /*cleanup-on-fail*/);
       rust_assert (result->get_kind () != TyTy::TypeKind::ERROR);
     }
 


### PR DESCRIPTION
Wen computing higher ranked trait bounds where there are multiple type params and ones which are not bound entirely on the impl-type we need to inject inference variables as required to compute the types. The inference variables we inject are missing the callbacks that we can compute the bounds properly so this is the first part of the fix.

Addresses #1893

Signed-off-by: Philip Herron <herron.philip@googlemail.com>

gcc/rust/ChangeLog:

	* typecheck/rust-hir-trait-resolve.cc: use unify_and infer