### PR TITLE
Add length checking for tuple patterns. Resolves issue Rust-GCC#1849

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-pattern.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-pattern.h
@@ -51,6 +51,10 @@ private:
 				 Analysis::NodeMapping mappings,
 				 Location locus);
 
+  void emit_pattern_size_error (const HIR::Pattern &pattern,
+				size_t expected_field_count,
+				size_t got_field_count);
+
   TyTy::BaseType *parent;
   TyTy::BaseType *infered;
 };

--- a/gcc/testsuite/rust/compile/tuple_mismatch.rs
+++ b/gcc/testsuite/rust/compile/tuple_mismatch.rs
@@ -1,0 +1,13 @@
+fn main() {
+    let (_,) = 1; // { dg-error "expected <integer>, found tuple" }
+    let (_,) = (1, 2); // { dg-error "expected a tuple with 2 elements, found one with 1 element" }
+    let (_, _) = (1, 2, 3); // { dg-error "expected a tuple with 3 elements, found one with 2 elements" }
+    let (_, _) = (1,); // { dg-error "expected a tuple with 1 element, found one with 2 elements" }
+}
+
+// The lhs and rhs sizes don't match, but we still resolve 'a' to be bool, we don't
+// error out immediately once we notice the size mismatch.
+fn foo() -> i32 { // { dg-error "expected .i32. got .bool." }
+    let (a, _) = (true, 2, 3); // { dg-error "expected a tuple with 3 elements, found one with 2 elements" }
+    a
+}


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-pattern.cc (TypeCheckPattern::visit): Add length checking for tuple patters.

gcc/testsuite/ChangeLog:

	* rust/compile/tuple_mismatch.rs: New test.

Signed-off-by: Nikos Alexandris <nikos-alexandris@protonmail.com>