### PR TITLE
Cleanup and Assertion

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-type.cc
+++ b/gcc/rust/hir/rust-ast-lower-type.cc
@@ -108,11 +108,8 @@ ASTLowerTypePath::visit (AST::TypePath &path)
     {
       translated_segment = nullptr;
       seg->accept_vis (*this);
-      if (translated_segment == nullptr)
-	{
-	  rust_fatal_error (seg->get_locus (),
-			    "failed to translate AST TypePathSegment");
-	}
+      rust_assert (translated_segment != nullptr);
+
       translated_segments.push_back (
 	std::unique_ptr<HIR::TypePathSegment> (translated_segment));
     }
@@ -158,12 +155,8 @@ ASTLowerQualifiedPathInType::visit (AST::QualifiedPathInType &path)
 
   translated_segment = nullptr;
   path.get_associated_segment ()->accept_vis (*this);
-  if (translated_segment == nullptr)
-    {
-      rust_fatal_error (path.get_associated_segment ()->get_locus (),
-			"failed to translate AST TypePathSegment");
-      return;
-    }
+  rust_assert (translated_segment != nullptr);
+
   std::unique_ptr<HIR::TypePathSegment> associated_segment (translated_segment);
 
   std::vector<std::unique_ptr<HIR::TypePathSegment>> translated_segments;
@@ -171,11 +164,8 @@ ASTLowerQualifiedPathInType::visit (AST::QualifiedPathInType &path)
     {
       translated_segment = nullptr;
       seg->accept_vis (*this);
-      if (translated_segment == nullptr)
-	{
-	  rust_fatal_error (seg->get_locus (),
-			    "failed to translte AST TypePathSegment");
-	}
+      rust_assert (translated_segment != nullptr);
+
       translated_segments.push_back (
 	std::unique_ptr<HIR::TypePathSegment> (translated_segment));
     }

--- a/gcc/rust/rust-object-export.cc
+++ b/gcc/rust/rust-object-export.cc
@@ -1,5 +1,4 @@
-/* rust-backend.c -- Rust frontend interface to gcc backend.
-   Copyright (C) 2010-2023 Free Software Foundation, Inc.
+/* Copyright (C) 2010-2023 Free Software Foundation, Inc.
 
    This file is part of GCC.
 


### PR DESCRIPTION
 Fixes issue - #784 & #580 

 - Clean up the `rust-backend.c` from `gcc/rust/rust-object-export.c`.
 - Make all `rust_fatal_error` to assertion in`rust-ast-lower-type.cc`.