### PR TITLE
Add stringify macro expansion

### DIFF
--- a/gcc/rust/ast/rust-macro.cc
+++ b/gcc/rust/ast/rust-macro.cc
@@ -42,6 +42,9 @@ builtin_macro_from_string (const std::string &identifier)
   if (identifier == "include_str")
     return BuiltinMacro::IncludeStr;
 
+  if (identifier == "stringify")
+    return BuiltinMacro::Stringify;
+
   if (identifier == "compile_error")
     return BuiltinMacro::CompileError;
 

--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -589,6 +589,7 @@ enum class BuiltinMacro
   Column,
   IncludeBytes,
   IncludeStr,
+  Stringify,
   CompileError,
   Concat,
   Env,

--- a/gcc/rust/expand/rust-macro-builtins.h
+++ b/gcc/rust/expand/rust-macro-builtins.h
@@ -79,6 +79,9 @@ public:
   static AST::Fragment include_str_handler (Location invoc_locus,
 					    AST::MacroInvocData &invoc);
 
+  static AST::Fragment stringify_handler (Location invoc_locus,
+					  AST::MacroInvocData &invoc);
+
   static AST::Fragment compile_error_handler (Location invoc_locus,
 					      AST::MacroInvocData &invoc);
 

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -856,6 +856,7 @@ Mappings::insert_macro_def (AST::MacroRulesDefinition *macro)
       {"column", MacroBuiltin::column_handler},
       {"include_bytes", MacroBuiltin::include_bytes_handler},
       {"include_str", MacroBuiltin::include_str_handler},
+      {"stringify", MacroBuiltin::stringify_handler},
       {"compile_error", MacroBuiltin::compile_error_handler},
       {"concat", MacroBuiltin::concat_handler},
       {"env", MacroBuiltin::env_handler},

--- a/gcc/testsuite/rust/compile/stringify.rs
+++ b/gcc/testsuite/rust/compile/stringify.rs
@@ -1,0 +1,10 @@
+#![feature(rustc_attrs)]
+
+#[rustc_builtin_macro]
+macro_rules! stringify {
+    () => {};
+}
+
+fn main() {
+    let _a = stringify!(sample text with parenthesis () and things! This will become a "string".);
+}

--- a/gcc/testsuite/rust/execute/torture/builtin_macro_stringify.rs
+++ b/gcc/testsuite/rust/execute/torture/builtin_macro_stringify.rs
@@ -1,0 +1,34 @@
+// { dg-output "a! ()" }
+#![feature(rustc_attrs)]
+
+#[rustc_builtin_macro]
+macro_rules! stringify {
+    () => {};
+}
+
+macro_rules! a {
+    () => {
+        " foo"
+    };
+}
+
+extern "C" {
+    fn printf(fmt: *const i8, ...);
+}
+
+fn print(s: &str) {
+    unsafe {
+        printf(
+            "%s" as *const str as *const i8,
+            s as *const str as *const i8,
+        );
+    }
+}
+
+fn main() -> i32 {
+    let a = stringify!(a!());
+
+    print(a);
+
+    0
+}


### PR DESCRIPTION
Add the stringify macro expansion as well as some tests.

gcc/rust/ChangeLog:

	* ast/rust-macro.cc (builtin_macro_from_string): Add identifier identification.
	* ast/rust-macro.h (enum class): Add Stringify builtin macro type.
	* expand/rust-macro-builtins.cc (make_macro_path_str): Add path for builtin stringify macro. (MacroBuiltin::stringify_handler): Add handler for builtin stringify macro.
	* expand/rust-macro-builtins.h: Add stringify handler's prototype.
	* util/rust-hir-map.cc (Mappings::insert_macro_def): Add stringify handler to builtin hir map.

gcc/testsuite/ChangeLog:

	* rust/compile/stringify.rs: Add a basic test with some text.
	* rust/compile/stringify_macro.rs: Verify the text is left as is without any other macro expansion.

Fixes #1968 
Related to #927 