### PR TITLE
typecheck: Add basic typechecking for ReferenceType

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-pattern.h
+++ b/gcc/rust/hir/tree/rust-hir-pattern.h
@@ -477,6 +477,12 @@ public:
     return PatternType::REFERENCE;
   }
 
+  std::unique_ptr<Pattern> &get_referenced_pattern ()
+  {
+    rust_assert (pattern != nullptr);
+    return pattern;
+  }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */

--- a/gcc/rust/resolve/rust-ast-resolve-pattern.h
+++ b/gcc/rust/resolve/rust-ast-resolve-pattern.h
@@ -75,6 +75,11 @@ public:
     pattern.get_pattern_in_parens ()->accept_vis (*this);
   }
 
+  void visit (AST::ReferencePattern &pattern) override
+  {
+    pattern.get_referenced_pattern ()->accept_vis (*this);
+  }
+
   // cases in a match expression
   void visit (AST::PathInExpression &pattern) override;
 

--- a/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
@@ -410,8 +410,13 @@ TypeCheckPattern::visit (HIR::QualifiedPathInExpression &pattern)
 void
 TypeCheckPattern::visit (HIR::ReferencePattern &pattern)
 {
-  rust_sorry_at (pattern.get_locus (),
-		 "type checking qualified path patterns not supported");
+  if (parent->get_kind () != TyTy::TypeKind::REF)
+    rust_error_at (pattern.get_locus (), "expected %s, found reference",
+		   parent->as_string ().c_str ());
+
+  TyTy::ReferenceType *ref_ty_ty = static_cast<TyTy::ReferenceType *> (parent);
+  TypeCheckPattern::Resolve (pattern.get_referenced_pattern ().get (),
+			     ref_ty_ty->get_base ());
 }
 
 void

--- a/gcc/testsuite/rust/compile/ref_pattern_fn_param.rs
+++ b/gcc/testsuite/rust/compile/ref_pattern_fn_param.rs
@@ -1,0 +1,1 @@
+fn f(&b: i32) {} // { dg-error "expected i32, found reference" }


### PR DESCRIPTION
provide basic resolve and typechecking for `ReferencePattern`.