### PR TITLE
Impl `Rust::HIR::Dump::visit`

### DIFF
--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -238,7 +238,22 @@ Dump::visit (BlockExpr &block_expr)
   stream << "BlockExpr: [";
   indentation.increment ();
   stream << std::endl;
+
   // TODO: inner attributes
+  stream << std::string (indent, indent_char);
+  stream << "inner attributes: ";
+  if (!block_expr.inner_attrs.empty ())
+    {
+      for (const auto &attr : block_expr.inner_attrs)
+	{
+	  stream << std::endl;
+	  stream << std::string (indent, indent_char);
+	  stream << attr.as_string ();
+	  // stream << attr.accept_vis(*self);
+	}
+    }
+
+  stream << std::endl;
 
   // statements
   if (block_expr.has_statements ())

--- a/gcc/rust/hir/rust-hir-dump.h
+++ b/gcc/rust/hir/rust-hir-dump.h
@@ -37,6 +37,7 @@ private:
   Indent indentation;
   std::ostream &stream;
 
+  void visit (AST::Attribute &attribute);
   virtual void visit (Lifetime &) override;
   virtual void visit (LifetimeParam &) override;
   virtual void visit (PathInExpression &) override;


### PR DESCRIPTION
In my opinion, `Session::dump_hir` is to dump items in one crate using `items->as_string()`  while `Session::dump_hir_pretty` is to dump items with identation using `items->accept_vis()`. So the diff between two dump methods are mainly identation (e.g. hierarchy)? (If it's incorrect, please tell me the right one). 
My plan is implementing some `HIR::Dump::visit()` based on `as_string()`.  In first commit, I dump inner attrs for `Dump::visit(BlockExpr &)` according to [BlockExpr::as_string()](https://github.com/Rust-GCC/gccrs/blob/2c1e7b55dab5564f92d890c4953f9fd387bb30d7/gcc/rust/hir/tree/rust-hir.cc#L929-#L943). 

I wonder if I am on the right track. Please give some suggestions. Thank you!