### PR TITLE
Unify AST and HIR dump indentation

### DIFF
--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -21,27 +21,6 @@
 namespace Rust {
 namespace AST {
 
-Indent::Indent () : tabs (0) {}
-
-std::ostream &
-operator<< (std::ostream &stream, const Indent &indent)
-{
-  return stream << std::string (indent.tabs, '\t');
-}
-
-void
-Indent::increment ()
-{
-  tabs++;
-}
-
-void
-Indent::decrement ()
-{
-  rust_assert (tabs != 0);
-  tabs--;
-}
-
 Dump::Dump (std::ostream &stream) : stream (stream), indentation (Indent ()) {}
 
 void

--- a/gcc/rust/ast/rust-ast-dump.h
+++ b/gcc/rust/ast/rust-ast-dump.h
@@ -19,27 +19,13 @@
 #include "rust-ast-visitor.h"
 #include "rust-ast.h"
 #include "rust-ast-full.h"
+#include "rust-dump.h"
 
 #ifndef RUST_AST_DUMP_H
 #define RUST_AST_DUMP_H
 
 namespace Rust {
 namespace AST {
-
-// TODO: We might want to reuse this class somewhere else
-class Indent
-{
-public:
-  Indent ();
-
-  friend std::ostream &operator<< (std::ostream &stream, const Indent &indent);
-
-  void increment ();
-  void decrement ();
-
-private:
-  size_t tabs;
-};
 
 class Dump : public ASTVisitor
 {

--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -30,16 +30,16 @@ Dump::go (HIR::Crate &crate)
   // inner attributes
   if (!crate.inner_attrs.empty ())
     {
-      indentation.increment();
+      indentation.increment ();
       stream << indentation;
       stream << "inner_attrs: [";
       for (auto &attr : crate.inner_attrs)
 	stream << attr.as_string ();
       stream << "]," << std::endl;
-      indentation.decrement();
+      indentation.decrement ();
     }
 
-  indentation.increment();
+  indentation.increment ();
   stream << indentation;
   //
 
@@ -53,14 +53,14 @@ Dump::go (HIR::Crate &crate)
     }
   stream << indentation;
   stream << "]," << std::endl;
-  indentation.decrement();
+  indentation.decrement ();
   //
 
-  indentation.increment();
+  indentation.increment ();
   stream << indentation;
   stream << "node_mappings: ";
   stream << crate.get_mappings ().as_string ();
-  indentation.decrement();
+  indentation.decrement ();
 
   stream << "\n}" << std::endl;
 }
@@ -236,7 +236,7 @@ void
 Dump::visit (BlockExpr &block_expr)
 {
   stream << "BlockExpr: [";
-  indentation.increment();
+  indentation.increment ();
   stream << std::endl;
   // TODO: inner attributes
 
@@ -246,21 +246,18 @@ Dump::visit (BlockExpr &block_expr)
       auto &stmts = block_expr.get_statements ();
       for (auto &stmt : stmts)
 	{
-	  stream << indentation;
-	  stream << "Stmt: {\n";
+	  stream << indentation << "Stmt: {\n";
 	  // stream << indentation;
 	  stmt->accept_vis (*this);
 	  stream << "\n";
-	  stream << indentation;
-	  stream << "}\n";
+	  stream << indentation << "}\n";
 	}
     }
 
   // // TODO: print tail expression if exists
 
-  indentation.decrement();
-  stream << indentation;
-  stream << "]";
+  indentation.decrement ();
+  stream << indentation << "]";
 }
 
 void
@@ -376,21 +373,18 @@ Dump::visit (UseDeclaration &)
 void
 Dump::visit (Function &func)
 {
-  indentation.increment();
-  stream << indentation;
-  stream << "Function {" << std::endl;
-  indentation.increment();
+  indentation.increment ();
+  stream << indentation << "Function {" << std::endl;
+  indentation.increment ();
 
   // function name
-  stream << indentation;
-  stream << "func_name: ";
+  stream << indentation << "func_name: ";
   auto func_name = func.get_function_name ();
   stream << func_name;
   stream << ",\n";
 
   // return type
-  stream << indentation;
-  stream << "return_type: ";
+  stream << indentation << "return_type: ";
   if (func.has_return_type ())
     {
       auto &ret_type = func.get_return_type ();
@@ -405,36 +399,30 @@ Dump::visit (Function &func)
   // function params
   if (func.has_function_params ())
     {
-      stream << indentation;
-      stream << "params: [\n";
-      indentation.increment();
+      stream << indentation << "params: [\n";
+      indentation.increment ();
       auto &func_params = func.get_function_params ();
       for (const auto &item : func_params)
 	{
-	  stream << indentation;
-	  stream << item.as_string ();
-	  stream << ",\n";
+	  stream << indentation << item.as_string () << ",\n";
 	}
 
       // parameter node mappings
-      stream << indentation;
-      stream << "node_mappings: [\n";
+      stream << indentation << "node_mappings: [\n";
       for (const auto &item : func_params)
 	{
 	  auto nmap = item.get_mappings ();
-	  indentation.increment();
+	  indentation.increment ();
 	  stream << indentation;
 	  auto pname = item.param_name->as_string ();
 	  stream << pname << ": ";
 	  stream << nmap.as_string () << ",\n";
-	  indentation.decrement();
+	  indentation.decrement ();
 	}
-      stream << indentation;
-      stream << "],";
-      indentation.decrement();
+      stream << indentation << "],";
+      indentation.decrement ();
       stream << "\n";
-      stream << indentation;
-      stream << "],";
+      stream << indentation << "],";
       stream << "\n";
     }
 
@@ -445,17 +433,15 @@ Dump::visit (Function &func)
 
   // func node mappings
   stream << "\n";
-  stream << indentation;
-  stream << "node_mappings: ";
+  stream << indentation << "node_mappings: ";
   stream << func.get_impl_mappings ().as_string ();
-  indentation.decrement();
+  indentation.decrement ();
   stream << "\n";
-  stream << indentation;
-  stream << "}" << std::endl;
+  stream << indentation << "}" << std::endl;
   // TODO: get function definition and visit block
 
   // stream << std::endl;
-  indentation.decrement();
+  indentation.decrement ();
 }
 void
 Dump::visit (TypeAlias &)
@@ -590,11 +576,10 @@ Dump::visit (EmptyStmt &)
 void
 Dump::visit (LetStmt &let_stmt)
 {
-  indentation.increment();
+  indentation.increment ();
   // TODO: outer attributes
-  stream << indentation;
-  stream << "LetStmt: {\n";
-  indentation.increment();
+  stream << indentation << "LetStmt: {\n";
+  indentation.increment ();
   stream << indentation;
 
   auto var_pattern = let_stmt.get_pattern ();
@@ -610,20 +595,18 @@ Dump::visit (LetStmt &let_stmt)
   if (let_stmt.has_init_expr ())
     {
       stream << " = Expr: {\n ";
-      indentation.increment();
+      indentation.increment ();
       stream << indentation;
       auto expr = let_stmt.get_init_expr ();
       expr->accept_vis (*this);
       stream << "\n";
-      stream << indentation;
-      indentation.decrement();
-      stream << "}\n";
+      stream << indentation << "}\n";
+      indentation.decrement ();
     }
-  indentation.decrement();
-  stream << indentation;
-  stream << "}\n";
+  indentation.decrement ();
+  stream << indentation << "}\n";
 
-  indentation.decrement();
+  indentation.decrement ();
 }
 void
 Dump::visit (ExprStmtWithoutBlock &expr_stmt)

--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -21,7 +21,7 @@
 namespace Rust {
 namespace HIR {
 
-Dump::Dump (std::ostream &stream) : stream (stream), indent (0) {}
+Dump::Dump (std::ostream &stream) : stream (stream) {}
 
 void
 Dump::go (HIR::Crate &crate)
@@ -30,37 +30,37 @@ Dump::go (HIR::Crate &crate)
   // inner attributes
   if (!crate.inner_attrs.empty ())
     {
-      indent++;
-      stream << std::string (indent, indent_char);
+      indentation.increment();
+      stream << indentation;
       stream << "inner_attrs: [";
       for (auto &attr : crate.inner_attrs)
 	stream << attr.as_string ();
       stream << "]," << std::endl;
-      indent--;
+      indentation.decrement();
     }
 
-  indent++;
-  stream << std::string (indent, indent_char);
+  indentation.increment();
+  stream << indentation;
   //
 
   stream << "items: [";
 
-  stream << std::string (indent, indent_char);
+  stream << indentation;
   for (const auto &item : crate.items)
     {
       stream << std::endl;
       item->accept_vis (*this);
     }
-  stream << std::string (indent, indent_char);
+  stream << indentation;
   stream << "]," << std::endl;
-  indent--;
+  indentation.decrement();
   //
 
-  indent++;
-  stream << std::string (indent, indent_char);
+  indentation.increment();
+  stream << indentation;
   stream << "node_mappings: ";
   stream << crate.get_mappings ().as_string ();
-  indent--;
+  indentation.decrement();
 
   stream << "\n}" << std::endl;
 }
@@ -157,9 +157,9 @@ Dump::visit (ArithmeticOrLogicalExpr &aole)
 
   aole.visit_lhs (*this);
   stream << "\n";
-  stream << std::string (indent, indent_char);
+  stream << indentation;
   stream << operator_str << "\n";
-  stream << std::string (indent, indent_char);
+  stream << indentation;
   aole.visit_rhs (*this);
 }
 void
@@ -236,7 +236,7 @@ void
 Dump::visit (BlockExpr &block_expr)
 {
   stream << "BlockExpr: [";
-  indent++;
+  indentation.increment();
   stream << std::endl;
   // TODO: inner attributes
 
@@ -246,20 +246,20 @@ Dump::visit (BlockExpr &block_expr)
       auto &stmts = block_expr.get_statements ();
       for (auto &stmt : stmts)
 	{
-	  stream << std::string (indent, indent_char);
+	  stream << indentation;
 	  stream << "Stmt: {\n";
-	  // stream << std::string (indent, indent_char);
+	  // stream << indentation;
 	  stmt->accept_vis (*this);
 	  stream << "\n";
-	  stream << std::string (indent, indent_char);
+	  stream << indentation;
 	  stream << "}\n";
 	}
     }
 
   // // TODO: print tail expression if exists
 
-  indent--;
-  stream << std::string (indent, indent_char);
+  indentation.decrement();
+  stream << indentation;
   stream << "]";
 }
 
@@ -376,20 +376,20 @@ Dump::visit (UseDeclaration &)
 void
 Dump::visit (Function &func)
 {
-  indent++;
-  stream << std::string (indent, indent_char);
+  indentation.increment();
+  stream << indentation;
   stream << "Function {" << std::endl;
-  indent++;
+  indentation.increment();
 
   // function name
-  stream << std::string (indent, indent_char);
+  stream << indentation;
   stream << "func_name: ";
   auto func_name = func.get_function_name ();
   stream << func_name;
   stream << ",\n";
 
   // return type
-  stream << std::string (indent, indent_char);
+  stream << indentation;
   stream << "return_type: ";
   if (func.has_return_type ())
     {
@@ -405,57 +405,57 @@ Dump::visit (Function &func)
   // function params
   if (func.has_function_params ())
     {
-      stream << std::string (indent, indent_char);
+      stream << indentation;
       stream << "params: [\n";
-      indent++;
+      indentation.increment();
       auto &func_params = func.get_function_params ();
       for (const auto &item : func_params)
 	{
-	  stream << std::string (indent, indent_char);
+	  stream << indentation;
 	  stream << item.as_string ();
 	  stream << ",\n";
 	}
 
       // parameter node mappings
-      stream << std::string (indent, indent_char);
+      stream << indentation;
       stream << "node_mappings: [\n";
       for (const auto &item : func_params)
 	{
 	  auto nmap = item.get_mappings ();
-	  indent++;
-	  stream << std::string (indent, indent_char);
+	  indentation.increment();
+	  stream << indentation;
 	  auto pname = item.param_name->as_string ();
 	  stream << pname << ": ";
 	  stream << nmap.as_string () << ",\n";
-	  indent--;
+	  indentation.decrement();
 	}
-      stream << std::string (indent, indent_char);
+      stream << indentation;
       stream << "],";
-      indent--;
+      indentation.decrement();
       stream << "\n";
-      stream << std::string (indent, indent_char);
+      stream << indentation;
       stream << "],";
       stream << "\n";
     }
 
   // function body
-  stream << std::string (indent, indent_char);
+  stream << indentation;
   auto &func_body = func.get_definition ();
   func_body->accept_vis (*this);
 
   // func node mappings
   stream << "\n";
-  stream << std::string (indent, indent_char);
+  stream << indentation;
   stream << "node_mappings: ";
   stream << func.get_impl_mappings ().as_string ();
-  indent--;
+  indentation.decrement();
   stream << "\n";
-  stream << std::string (indent, indent_char);
+  stream << indentation;
   stream << "}" << std::endl;
   // TODO: get function definition and visit block
 
   // stream << std::endl;
-  indent--;
+  indentation.decrement();
 }
 void
 Dump::visit (TypeAlias &)
@@ -590,12 +590,12 @@ Dump::visit (EmptyStmt &)
 void
 Dump::visit (LetStmt &let_stmt)
 {
-  indent++;
+  indentation.increment();
   // TODO: outer attributes
-  stream << std::string (indent, indent_char);
+  stream << indentation;
   stream << "LetStmt: {\n";
-  indent++;
-  stream << std::string (indent, indent_char);
+  indentation.increment();
+  stream << indentation;
 
   auto var_pattern = let_stmt.get_pattern ();
   stream << var_pattern->as_string ();
@@ -610,20 +610,20 @@ Dump::visit (LetStmt &let_stmt)
   if (let_stmt.has_init_expr ())
     {
       stream << " = Expr: {\n ";
-      indent++;
-      stream << std::string (indent, indent_char);
+      indentation.increment();
+      stream << indentation;
       auto expr = let_stmt.get_init_expr ();
       expr->accept_vis (*this);
       stream << "\n";
-      stream << std::string (indent, indent_char);
-      indent--;
+      stream << indentation;
+      indentation.decrement();
       stream << "}\n";
     }
-  indent--;
-  stream << std::string (indent, indent_char);
+  indentation.decrement();
+  stream << indentation;
   stream << "}\n";
 
-  indent--;
+  indentation.decrement();
 }
 void
 Dump::visit (ExprStmtWithoutBlock &expr_stmt)

--- a/gcc/rust/hir/rust-hir-dump.h
+++ b/gcc/rust/hir/rust-hir-dump.h
@@ -22,6 +22,7 @@
 #include "rust-hir-visitor.h"
 #include "rust-hir.h"
 #include "rust-hir-full.h"
+#include "rust-dump.h"
 
 namespace Rust {
 namespace HIR {
@@ -33,9 +34,8 @@ public:
   void go (HIR::Crate &crate);
 
 private:
+  Indent indentation;
   std::ostream &stream;
-  std::size_t indent; // current indentation level
-  char indent_char = '\t';
 
   virtual void visit (Lifetime &) override;
   virtual void visit (LifetimeParam &) override;

--- a/gcc/rust/util/rust-dump.h
+++ b/gcc/rust/util/rust-dump.h
@@ -1,0 +1,51 @@
+// Copyright (C) 2021-2023 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+// Common definitions useful for textual dump of IRs (AST and HIR).
+
+#ifndef RUST_DUMP_H
+#define RUST_DUMP_H
+
+#include "rust-system.h"
+
+namespace Rust {
+
+class Indent
+{
+public:
+  Indent () = default;
+
+  friend std::ostream &operator<< (std::ostream &stream, const Indent &indent)
+  {
+    return stream << std::string (indent.tabs, '\t');
+  };
+
+  void increment () { tabs++; };
+
+  void decrement ()
+  {
+    rust_assert (tabs != 0);
+    tabs--;
+  };
+
+private:
+  size_t tabs = 0;
+};
+} // namespace Rust
+
+#endif


### PR DESCRIPTION
Relates to #1976 (#1976 should be rebased before merging)

make check-rust passed on every commit

Please check the changelog - I have done it for the first time.