### PR TITLE
resolve: Handle multiple bindings to the same identifier

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-expr.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.cc
@@ -207,9 +207,14 @@ ResolveExpr::visit (AST::IfLetExpr &expr)
   resolver->push_new_type_rib (resolver->get_type_scope ().peek ());
   resolver->push_new_label_rib (resolver->get_type_scope ().peek ());
 
+  // FIXME: this declaration should be removed after refactoring
+  // parse_match_arm_patterns output into an AltPattern
+  std::vector<PatternBinding> bindings
+    = {PatternBinding (PatternBoundCtx::Or, std::set<Identifier> ())};
+
   for (auto &pattern : expr.get_patterns ())
     {
-      PatternDeclaration::go (pattern.get (), Rib::ItemType::Var);
+      PatternDeclaration::go (pattern.get (), Rib::ItemType::Var, bindings);
     }
 
   ResolveExpr::go (expr.get_if_block ().get (), prefix, canonical_prefix);
@@ -517,10 +522,15 @@ ResolveExpr::visit (AST::MatchExpr &expr)
 	ResolveExpr::go (arm.get_guard_expr ().get (), prefix,
 			 canonical_prefix);
 
+      // FIXME: this declaration should be removed after refactoring
+      // parse_match_arms_patterns output into a single AltPattern
+      std::vector<PatternBinding> bindings
+	= {PatternBinding (PatternBoundCtx::Or, std::set<Identifier> ())};
+
       // insert any possible new patterns
       for (auto &pattern : arm.get_patterns ())
 	{
-	  PatternDeclaration::go (pattern.get (), Rib::ItemType::Var);
+	  PatternDeclaration::go (pattern.get (), Rib::ItemType::Var, bindings);
 	}
 
       // resolve the body
@@ -576,9 +586,12 @@ ResolveExpr::visit (AST::ClosureExprInner &expr)
   resolver->push_new_type_rib (resolver->get_type_scope ().peek ());
   resolver->push_new_label_rib (resolver->get_type_scope ().peek ());
 
+  std::vector<PatternBinding> bindings
+    = {PatternBinding (PatternBoundCtx::Product, std::set<Identifier> ())};
+
   for (auto &p : expr.get_params ())
     {
-      resolve_closure_param (p);
+      resolve_closure_param (p, bindings);
     }
 
   resolver->push_closure_context (expr.get_node_id ());
@@ -604,9 +617,12 @@ ResolveExpr::visit (AST::ClosureExprInnerTyped &expr)
   resolver->push_new_type_rib (resolver->get_type_scope ().peek ());
   resolver->push_new_label_rib (resolver->get_type_scope ().peek ());
 
+  std::vector<PatternBinding> bindings
+    = {PatternBinding (PatternBoundCtx::Product, std::set<Identifier> ())};
+
   for (auto &p : expr.get_params ())
     {
-      resolve_closure_param (p);
+      resolve_closure_param (p, bindings);
     }
 
   ResolveType::go (expr.get_return_type ().get ());
@@ -624,9 +640,11 @@ ResolveExpr::visit (AST::ClosureExprInnerTyped &expr)
 }
 
 void
-ResolveExpr::resolve_closure_param (AST::ClosureParam &param)
+ResolveExpr::resolve_closure_param (AST::ClosureParam &param,
+				    std::vector<PatternBinding> &bindings)
 {
-  PatternDeclaration::go (param.get_pattern ().get (), Rib::ItemType::Param);
+  PatternDeclaration::go (param.get_pattern ().get (), Rib::ItemType::Param,
+			  bindings);
 
   if (param.has_type_given ())
     ResolveType::go (param.get_type ().get ());

--- a/gcc/rust/resolve/rust-ast-resolve-expr.h
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.h
@@ -20,6 +20,7 @@
 #define RUST_AST_RESOLVE_EXPR_H
 
 #include "rust-ast-resolve-base.h"
+#include "rust-ast-resolve-pattern.h"
 #include "rust-ast-full.h"
 
 namespace Rust {
@@ -79,7 +80,8 @@ public:
   void visit (AST::ClosureExprInnerTyped &expr) override;
 
 protected:
-  void resolve_closure_param (AST::ClosureParam &param);
+  void resolve_closure_param (AST::ClosureParam &param,
+			      std::vector<PatternBinding> &bindings);
 
 private:
   ResolveExpr (const CanonicalPath &prefix,

--- a/gcc/rust/resolve/rust-ast-resolve-item.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-item.cc
@@ -77,13 +77,16 @@ ResolveTraitItems::visit (AST::TraitItemFunc &func)
   if (function.has_return_type ())
     ResolveType::go (function.get_return_type ().get ());
 
+  std::vector<PatternBinding> bindings
+    = {PatternBinding (PatternBoundCtx::Product, std::set<Identifier> ())};
+
   // we make a new scope so the names of parameters are resolved and shadowed
   // correctly
   for (auto &param : function.get_function_params ())
     {
       ResolveType::go (param.get_type ().get ());
-      PatternDeclaration::go (param.get_pattern ().get (),
-			      Rib::ItemType::Param);
+      PatternDeclaration::go (param.get_pattern ().get (), Rib::ItemType::Param,
+			      bindings);
     }
 
   if (function.has_where_clause ())
@@ -141,13 +144,16 @@ ResolveTraitItems::visit (AST::TraitItemMethod &func)
   ResolveType::go (&self_type_path);
   PatternDeclaration::go (&self_pattern, Rib::ItemType::Param);
 
+  std::vector<PatternBinding> bindings
+    = {PatternBinding (PatternBoundCtx::Product, std::set<Identifier> ())};
+
   // we make a new scope so the names of parameters are resolved and shadowed
   // correctly
   for (auto &param : function.get_function_params ())
     {
       ResolveType::go (param.get_type ().get ());
-      PatternDeclaration::go (param.get_pattern ().get (),
-			      Rib::ItemType::Param);
+      PatternDeclaration::go (param.get_pattern ().get (), Rib::ItemType::Param,
+			      bindings);
     }
 
   if (function.has_where_clause ())
@@ -496,13 +502,16 @@ ResolveItem::visit (AST::Function &function)
   if (function.has_return_type ())
     ResolveType::go (function.get_return_type ().get ());
 
+  std::vector<PatternBinding> bindings
+    = {PatternBinding (PatternBoundCtx::Product, std::set<Identifier> ())};
+
   // we make a new scope so the names of parameters are resolved and shadowed
   // correctly
   for (auto &param : function.get_function_params ())
     {
       ResolveType::go (param.get_type ().get ());
-      PatternDeclaration::go (param.get_pattern ().get (),
-			      Rib::ItemType::Param);
+      PatternDeclaration::go (param.get_pattern ().get (), Rib::ItemType::Param,
+			      bindings);
     }
 
   // resolve the function body
@@ -633,13 +642,16 @@ ResolveItem::visit (AST::Method &method)
   ResolveType::go (&self_type_path);
   PatternDeclaration::go (&self_pattern, Rib::ItemType::Param);
 
+  std::vector<PatternBinding> bindings
+    = {PatternBinding (PatternBoundCtx::Product, std::set<Identifier> ())};
+
   // we make a new scope so the names of parameters are resolved and shadowed
   // correctly
   for (auto &param : method.get_function_params ())
     {
       ResolveType::go (param.get_type ().get ());
-      PatternDeclaration::go (param.get_pattern ().get (),
-			      Rib::ItemType::Param);
+      PatternDeclaration::go (param.get_pattern ().get (), Rib::ItemType::Param,
+			      bindings);
     }
 
   // resolve any where clause items

--- a/gcc/rust/resolve/rust-ast-resolve-stmt.h
+++ b/gcc/rust/resolve/rust-ast-resolve-stmt.h
@@ -344,13 +344,16 @@ public:
     if (function.has_return_type ())
       ResolveType::go (function.get_return_type ().get ());
 
+    std::vector<PatternBinding> bindings
+      = {PatternBinding (PatternBoundCtx::Product, std::set<Identifier> ())};
+
     // we make a new scope so the names of parameters are resolved and shadowed
     // correctly
     for (auto &param : function.get_function_params ())
       {
 	ResolveType::go (param.get_type ().get ());
 	PatternDeclaration::go (param.get_pattern ().get (),
-				Rib::ItemType::Param);
+				Rib::ItemType::Param, bindings);
       }
 
     // resolve the function body

--- a/gcc/testsuite/rust/compile/multiple_bindings1.rs
+++ b/gcc/testsuite/rust/compile/multiple_bindings1.rs
@@ -1,0 +1,29 @@
+fn f1(i: i32, i: i32) {}
+// { dg-error "identifier .i. is bound more than once in the same parameter list .E0415." "" { target *-*-* } .-1 }
+
+trait Foo {
+  fn f2(i: i32, i: i32) {}
+  // { dg-error "identifier .i. is bound more than once in the same parameter list .E0415." "" { target *-*-* } .-1 }
+}
+
+trait Bar {
+  fn f3(i: i32, j: i32) {}
+}
+
+struct S;
+
+impl S {
+  fn f4(i: i32, i: i32) {}
+  // { dg-error "identifier .i. is bound more than once in the same parameter list .E0415." "" { target *-*-* } .-1 }
+}
+
+impl Bar for S {
+  fn f3(i: i32, i: i32) {}
+  // { dg-error "identifier .i. is bound more than once in the same parameter list .E0415." "" { target *-*-* } .-1 }
+}
+
+fn main() {
+  let _ = |i, i| {};
+  // { dg-error "identifier .i. is bound more than once in the same parameter list .E0415." "" { target *-*-* } .-1 }
+}
+


### PR DESCRIPTION
This is an attempt to provide handling for multiple bindings to the same identifier. It works for function and closure parameters only for now (i.e. E0415). Additionally, it lays down the base for resolving `AltPattern` bindings.

I followed rustc's implementation for the most part.
https://github.com/rust-lang/rust/blob/master/compiler/rustc_resolve/src/late.rs#L3168.

If initially approved, I'll extend it for pattern bindings as well (i.e. E0416) and add tests.

Partially addresses #1136 