### PR TITLE
gccrs: Rename compiler proper to crab1

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ make
 Running the compiler itself without make install we can simply invoke the compiler proper:
 
 ```bash
-$ ./gcc/rust1 test.rs -frust-debug -frust-dump-parse -Warray-bounds -dumpbase test.rs -mtune=generic -march=x86-64 -O0 -version -fdump-tree-gimple -o test.s -L/lib/x86_64-linux-gnu -L/lib/../lib64 -L/usr/lib/x86_64-linux-gnu -L/usr/lib/../lib64 -frust-incomplete-and-experimental-compiler-do-not-use
+$ ./gcc/crab1 test.rs -frust-debug -frust-dump-parse -Warray-bounds -dumpbase test.rs -mtune=generic -march=x86-64 -O0 -version -fdump-tree-gimple -o test.s -L/lib/x86_64-linux-gnu -L/lib/../lib64 -L/usr/lib/x86_64-linux-gnu -L/usr/lib/../lib64 -frust-incomplete-and-experimental-compiler-do-not-use
 ```
 
 To invoke the compiler driver (gccrs) we need to:
@@ -147,20 +147,20 @@ $ ../gccrs/configure --prefix=$HOME/gccrs-install --disable-bootstrap --enable-m
 ```
 
 ### GDB
-You can directly invoke `gdb` on the `rust1` compiler process (you can find the
+You can directly invoke `gdb` on the `crab1` compiler process (you can find the
 exact command adding `--verbose` to your `gccrs` invocation):
 ```bash
 $ gccrs test.rs -O0 -S -o arithmetic_expressions1.s --verbose
 ...
- /some/path/../../rust1 test.rs -quiet -dumpbase arithmetic_expressions1.rs -dumpbase-ext .rs
+ /some/path/../../crab1 test.rs -quiet -dumpbase arithmetic_expressions1.rs -dumpbase-ext .rs
  -mtune=generic -march=x86-64 -O0 -w -version -fdiagnostics-color=never -fno-diagnostics-show-caret -fno-diagnostics-show-line-numbers -fdiagnostics-urls=never -fdiagnostics-path-format=separate-events -o test.s -L/lib/x86_64-linux-gnu -L/lib/../lib64 -L/usr/lib/x86_64-linux-gnu
 ...
-$ gdb --args  /some/path/../../rust1 test.rs -quiet -dumpbase arithmetic_expressions1.rs -dumpbase-ext .rs
+$ gdb --args  /some/path/../../crab1 test.rs -quiet -dumpbase arithmetic_expressions1.rs -dumpbase-ext .rs
  -mtune=generic -march=x86-64 -O0 -w -version -fdiagnostics-color=never -fno-diagnostics-show-caret -fno-diagnostics-show-line-numbers -fdiagnostics-urls=never -fdiagnostics-path-format=separate-events -o test.s -L/lib/x86_64-linux-gnu -L/lib/../lib64 -L/usr/lib/x86_64-linux-gnu
 ```
 
 Or simply add the `-wrapper gdb,--args` option.
-This will call each subcommand in `gdb` and you simply have to break/debug in `rust1`:
+This will call each subcommand in `gdb` and you simply have to break/debug in `crab1`:
 ```bash
 $ gccrs test.rs -O0 -S -o arithmetic_expressions1.s -wrapper gdb,--args
 ```

--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -33,9 +33,9 @@ GCCRS_INSTALL_NAME := $(shell echo gccrs|sed '$(program_transform_name)')
 GCCRS_TARGET_INSTALL_NAME := $(target_noncanonical)-$(shell echo gccrs|sed '$(program_transform_name)')
 
 # Define the names for selecting rust in LANGUAGES.
-rust: rust1$(exeext)
+rust: crab1$(exeext)
 
-rust.serial = rust1$(exeext)
+rust.serial = crab1$(exeext)
 
 # Tell GNU make to ignore files by these names if they exist.
 .PHONY: rust
@@ -177,8 +177,8 @@ RUST_ALL_OBJS = $(GRS_OBJS) $(RUST_TARGET_OBJS)
 
 rust_OBJS = $(RUST_ALL_OBJS) rust/rustspec.o
 
-# The compiler itself is called rust1 (formerly grs1)
-rust1$(exeext): $(RUST_ALL_OBJS) attribs.o $(BACKEND) $(LIBDEPS) $(rust.prev)
+# The compiler itself is called crab1
+crab1$(exeext): $(RUST_ALL_OBJS) attribs.o $(BACKEND) $(LIBDEPS) $(rust.prev)
 	@$(call LINK_PROGRESS,$(INDEX.rust),start)
 	+$(LLINKER) $(ALL_LINKERFLAGS) $(LDFLAGS) -o $@ \
 	      $(RUST_ALL_OBJS) attribs.o $(BACKEND) $(LIBS) $(BACKENDLIBS)
@@ -285,7 +285,7 @@ rust.uninstall:
 selftest-rust: s-selftest-rust
 
 RUST_SELFTEST_FLAGS = -xrust -frust-incomplete-and-experimental-compiler-do-not-use $(SELFTEST_FLAGS)
-RUST_SELFTEST_DEPS = rust1$(exeext) $(SELFTEST_DEPS)
+RUST_SELFTEST_DEPS = crab1$(exeext) $(SELFTEST_DEPS)
 
 # Run the rust selftests
 s-selftest-rust: $(RUST_SELFTEST_DEPS)

--- a/gcc/rust/config-lang.in
+++ b/gcc/rust/config-lang.in
@@ -25,7 +25,7 @@
 # compilers	- value to add to $(COMPILERS)
 
 language="rust"
-compilers="rust1\$(exeext)"
+compilers="crab1\$(exeext)"
 
 build_by_default="no"
 

--- a/gcc/rust/lang-specs.h
+++ b/gcc/rust/lang-specs.h
@@ -22,5 +22,5 @@
 
 {".rs", "@rust", 0, 1, 0},
   {"@rust",
-   "rust1 %i %(cc1_options) %{I*} %{L*} %D %{!fsyntax-only:%(invoke_as)}", 0, 1,
+   "crab1 %i %(cc1_options) %{I*} %{L*} %D %{!fsyntax-only:%(invoke_as)}", 0, 1,
    0},

--- a/gcc/rust/rustspec.cc
+++ b/gcc/rust/rustspec.cc
@@ -159,8 +159,8 @@ lang_specific_driver (struct cl_decoded_option **in_decoded_options,
     }
 
   /* If we didn't see a -o option, add one.  This is because we need
-     the driver to pass all .rs files to rust1.  Without a -o option the
-     driver will invoke rust1 separately for each input file.  FIXME:
+     the driver to pass all .rs files to crab1.  Without a -o option the
+     driver will invoke crab1 separately for each input file.  FIXME:
      This should probably use some other interface to force the driver
      to set combine_inputs.  */
   if (!saw_opt_o)


### PR DESCRIPTION
ChangeLog:

	* README.md (process): Rename `rust1` to `crab1` in examples.

gcc/rust/ChangeLog:

	* Make-lang.in: Rename `rust1` to `crab1`.
	* config-lang.in: Likewise.
	* lang-specs.h: Likewise.
	* rustspec.cc (lang_specific_driver): Likewise.
