### PR TITLE
Lower public macros to mappings

### DIFF
--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -70,7 +70,6 @@ public:
   void visit (HIR::LetStmt &) override {}
   void visit (HIR::ExprStmtWithoutBlock &) override {}
   void visit (HIR::ExprStmtWithBlock &) override {}
-  void visit (HIR::ExportedMacro &) override {}
 
 protected:
   CompileItem (Context *ctx, TyTy::BaseType *concrete, Location ref_locus)

--- a/gcc/rust/backend/rust-compile-stmt.h
+++ b/gcc/rust/backend/rust-compile-stmt.h
@@ -56,7 +56,6 @@ public:
   void visit (HIR::ImplBlock &) override {}
   void visit (HIR::ExternBlock &) override {}
   void visit (HIR::EmptyStmt &) override {}
-  void visit (HIR::ExportedMacro &) override {}
 
 private:
   CompileStmt (Context *ctx);

--- a/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
+++ b/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
@@ -728,9 +728,5 @@ PrivacyReporter::visit (HIR::ExprStmtWithBlock &stmt)
   stmt.get_expr ()->accept_vis (*this);
 }
 
-void
-PrivacyReporter::visit (HIR::ExportedMacro &)
-{}
-
 } // namespace Privacy
 } // namespace Rust

--- a/gcc/rust/checks/errors/privacy/rust-privacy-reporter.h
+++ b/gcc/rust/checks/errors/privacy/rust-privacy-reporter.h
@@ -153,7 +153,6 @@ types
   virtual void visit (HIR::LetStmt &stmt);
   virtual void visit (HIR::ExprStmtWithoutBlock &stmt);
   virtual void visit (HIR::ExprStmtWithBlock &stmt);
-  virtual void visit (HIR::ExportedMacro &macro);
 
   Analysis::Mappings &mappings;
   Rust::Resolver::Resolver &resolver;

--- a/gcc/rust/checks/errors/privacy/rust-pub-restricted-visitor.cc
+++ b/gcc/rust/checks/errors/privacy/rust-pub-restricted-visitor.cc
@@ -178,12 +178,5 @@ PubRestrictedVisitor::visit (HIR::ExternBlock &block)
 			block.get_locus ());
 }
 
-void
-PubRestrictedVisitor::visit (HIR::ExportedMacro &macro)
-{
-  is_restriction_valid (macro.get_mappings ().get_nodeid (),
-			macro.get_locus ());
-}
-
 } // namespace Privacy
 } // namespace Rust

--- a/gcc/rust/checks/errors/privacy/rust-pub-restricted-visitor.h
+++ b/gcc/rust/checks/errors/privacy/rust-pub-restricted-visitor.h
@@ -103,7 +103,6 @@ public:
   virtual void visit (HIR::Trait &trait);
   virtual void visit (HIR::ImplBlock &impl);
   virtual void visit (HIR::ExternBlock &block);
-  virtual void visit (HIR::ExportedMacro &macro);
 
 private:
   /* Stack of ancestor modules visited by this visitor */

--- a/gcc/rust/checks/errors/privacy/rust-reachability.cc
+++ b/gcc/rust/checks/errors/privacy/rust-reachability.cc
@@ -230,10 +230,6 @@ void
 ReachabilityVisitor::visit (HIR::ExternBlock &)
 {}
 
-void
-ReachabilityVisitor::visit (HIR::ExportedMacro &macro)
-{}
-
 // FIXME: How can we visit Blocks in the current configuration? Have a full
 // visitor?
 } // namespace Privacy

--- a/gcc/rust/checks/errors/privacy/rust-reachability.h
+++ b/gcc/rust/checks/errors/privacy/rust-reachability.h
@@ -75,7 +75,6 @@ public:
   virtual void visit (HIR::Trait &trait);
   virtual void visit (HIR::ImplBlock &impl);
   virtual void visit (HIR::ExternBlock &block);
-  virtual void visit (HIR::ExportedMacro &macro);
 
 private:
   ReachLevel current_level;

--- a/gcc/rust/checks/errors/privacy/rust-visibility-resolver.cc
+++ b/gcc/rust/checks/errors/privacy/rust-visibility-resolver.cc
@@ -241,11 +241,5 @@ void
 VisibilityResolver::visit (HIR::ExternBlock &)
 {}
 
-void
-VisibilityResolver::visit (HIR::ExportedMacro &macro)
-{
-  resolve_and_update (&macro);
-}
-
 } // namespace Privacy
 } // namespace Rust

--- a/gcc/rust/checks/errors/privacy/rust-visibility-resolver.h
+++ b/gcc/rust/checks/errors/privacy/rust-visibility-resolver.h
@@ -90,7 +90,6 @@ public:
   virtual void visit (HIR::Trait &trait);
   virtual void visit (HIR::ImplBlock &impl);
   virtual void visit (HIR::ExternBlock &block);
-  virtual void visit (HIR::ExportedMacro &macro);
 
 private:
   Analysis::Mappings &mappings;

--- a/gcc/rust/checks/errors/rust-const-checker.cc
+++ b/gcc/rust/checks/errors/rust-const-checker.cc
@@ -894,9 +894,5 @@ void
 ConstChecker::visit (BareFunctionType &)
 {}
 
-void
-ConstChecker::visit (ExportedMacro &)
-{}
-
 } // namespace HIR
 } // namespace Rust

--- a/gcc/rust/checks/errors/rust-const-checker.h
+++ b/gcc/rust/checks/errors/rust-const-checker.h
@@ -201,7 +201,6 @@ private:
   virtual void visit (SliceType &type) override;
   virtual void visit (InferredType &type) override;
   virtual void visit (BareFunctionType &type) override;
-  virtual void visit (ExportedMacro &macro) override;
 };
 
 } // namespace HIR

--- a/gcc/rust/checks/errors/rust-unsafe-checker.cc
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.cc
@@ -951,9 +951,5 @@ void
 UnsafeChecker::visit (BareFunctionType &)
 {}
 
-void
-UnsafeChecker::visit (ExportedMacro &)
-{}
-
 } // namespace HIR
 } // namespace Rust

--- a/gcc/rust/checks/errors/rust-unsafe-checker.h
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.h
@@ -183,7 +183,6 @@ private:
   virtual void visit (SliceType &type) override;
   virtual void visit (InferredType &type) override;
   virtual void visit (BareFunctionType &type) override;
-  virtual void visit (ExportedMacro &macro) override;
 };
 
 } // namespace HIR

--- a/gcc/rust/hir/rust-ast-lower-base.cc
+++ b/gcc/rust/hir/rust-ast-lower-base.cc
@@ -970,5 +970,21 @@ ASTLoweringBase::lower_extern_block (AST::ExternBlock &extern_block)
   return hir_extern_block;
 }
 
+void
+ASTLoweringBase::lower_macro_definition (AST::MacroRulesDefinition &def)
+{
+  auto is_export = false;
+  for (const auto &attr : def.get_outer_attrs ())
+    if (attr.get_path ().as_string () == "macro_export")
+      is_export = true;
+
+  if (is_export)
+    {
+      mappings->insert_exported_macro (def);
+      mappings->insert_ast_item (&def);
+      mappings->insert_location (def.get_node_id (), def.get_locus ());
+    }
+}
+
 } // namespace HIR
 } // namespace Rust

--- a/gcc/rust/hir/rust-ast-lower-base.h
+++ b/gcc/rust/hir/rust-ast-lower-base.h
@@ -318,6 +318,9 @@ protected:
   HIR::ExternBlock *lower_extern_block (AST::ExternBlock &extern_block);
 
   HIR::ClosureParam lower_closure_param (AST::ClosureParam &param);
+
+  /* Lower a macro definition if it should be exported */
+  void lower_macro_definition (AST::MacroRulesDefinition &def);
 };
 
 } // namespace HIR

--- a/gcc/rust/hir/rust-ast-lower-item.cc
+++ b/gcc/rust/hir/rust-ast-lower-item.cc
@@ -708,9 +708,7 @@ ASTLoweringItem::visit (AST::ExternBlock &extern_block)
 void
 ASTLoweringItem::visit (AST::MacroRulesDefinition &def)
 {
-  for (const auto &attr : def.get_outer_attrs ())
-    if (attr.get_path ().as_string () == "macro_export")
-      mappings->insert_exported_macro (def);
+  lower_macro_definition (def);
 }
 
 HIR::SimplePath

--- a/gcc/rust/hir/rust-ast-lower-item.cc
+++ b/gcc/rust/hir/rust-ast-lower-item.cc
@@ -705,28 +705,6 @@ ASTLoweringItem::visit (AST::ExternBlock &extern_block)
   translated = lower_extern_block (extern_block);
 }
 
-void
-ASTLoweringItem::visit (AST::MacroRulesDefinition &def)
-{
-  bool is_export = false;
-  for (const auto &attr : def.get_outer_attrs ())
-    if (attr.get_path ().as_string () == "macro_export")
-      is_export = true;
-
-  if (is_export)
-    {
-      auto crate_num = mappings->get_current_crate ();
-      Analysis::NodeMapping mapping (crate_num, def.get_node_id (),
-				     mappings->get_next_hir_id (crate_num),
-				     mappings->get_next_localdef_id (
-				       crate_num));
-      auto locus = def.get_locus ();
-
-      translated
-	= new HIR::ExportedMacro (mapping, def.get_outer_attrs (), locus);
-    }
-}
-
 HIR::SimplePath
 ASTLoweringSimplePath::translate (const AST::SimplePath &path)
 {

--- a/gcc/rust/hir/rust-ast-lower-item.cc
+++ b/gcc/rust/hir/rust-ast-lower-item.cc
@@ -705,6 +705,14 @@ ASTLoweringItem::visit (AST::ExternBlock &extern_block)
   translated = lower_extern_block (extern_block);
 }
 
+void
+ASTLoweringItem::visit (AST::MacroRulesDefinition &def)
+{
+  for (const auto &attr : def.get_outer_attrs ())
+    if (attr.get_path ().as_string () == "macro_export")
+      mappings->insert_exported_macro (def);
+}
+
 HIR::SimplePath
 ASTLoweringSimplePath::translate (const AST::SimplePath &path)
 {

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -44,7 +44,6 @@ public:
   void visit (AST::Trait &trait) override;
   void visit (AST::TraitImpl &impl_block) override;
   void visit (AST::ExternBlock &extern_block) override;
-  void visit (AST::MacroRulesDefinition &macro) override;
 
 private:
   ASTLoweringItem () : translated (nullptr) {}

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -44,6 +44,7 @@ public:
   void visit (AST::Trait &trait) override;
   void visit (AST::TraitImpl &impl_block) override;
   void visit (AST::ExternBlock &extern_block) override;
+  void visit (AST::MacroRulesDefinition &rules_def) override;
 
 private:
   ASTLoweringItem () : translated (nullptr) {}

--- a/gcc/rust/hir/rust-ast-lower-stmt.cc
+++ b/gcc/rust/hir/rust-ast-lower-stmt.cc
@@ -32,7 +32,9 @@ ASTLoweringStmt::translate (AST::Stmt *stmt, bool *terminated)
   ASTLoweringStmt resolver;
   stmt->accept_vis (resolver);
 
-  rust_assert (resolver.translated != nullptr);
+  if (!resolver.translated)
+    return nullptr;
+
   *terminated = resolver.terminated;
   resolver.mappings->insert_location (
     resolver.translated->get_mappings ().get_hirid (),
@@ -404,6 +406,12 @@ void
 ASTLoweringStmt::visit (AST::ExternBlock &extern_block)
 {
   translated = lower_extern_block (extern_block);
+}
+
+void
+ASTLoweringStmt::visit (AST::MacroRulesDefinition &def)
+{
+  lower_macro_definition (def);
 }
 
 } // namespace HIR

--- a/gcc/rust/hir/rust-ast-lower-stmt.h
+++ b/gcc/rust/hir/rust-ast-lower-stmt.h
@@ -42,6 +42,7 @@ public:
   void visit (AST::EmptyStmt &empty) override;
   void visit (AST::Function &function) override;
   void visit (AST::ExternBlock &extern_block) override;
+  void visit (AST::MacroRulesDefinition &extern_block) override;
 
 private:
   ASTLoweringStmt () : translated (nullptr), terminated (false) {}

--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -72,7 +72,7 @@ ASTLowering::Resolve (AST::Crate &astCrate)
 std::unique_ptr<HIR::Crate>
 ASTLowering::go ()
 {
-  std::vector<std::unique_ptr<HIR::Item> > items;
+  std::vector<std::unique_ptr<HIR::Item>> items;
 
   for (auto it = astCrate.items.begin (); it != astCrate.items.end (); it++)
     {
@@ -95,14 +95,11 @@ ASTLowering::go ()
 void
 ASTLoweringBlock::visit (AST::BlockExpr &expr)
 {
-  std::vector<std::unique_ptr<HIR::Stmt> > block_stmts;
+  std::vector<std::unique_ptr<HIR::Stmt>> block_stmts;
   bool block_did_terminate = false;
 
   for (auto &s : expr.get_statements ())
     {
-      if (s->get_ast_kind () == AST::Kind::MACRO_RULES_DEFINITION)
-	continue;
-
       if (s->get_ast_kind () == AST::Kind::MACRO_INVOCATION)
 	rust_fatal_error (
 	  s->get_locus (),
@@ -115,8 +112,10 @@ ASTLoweringBlock::visit (AST::BlockExpr &expr)
 
       bool terminated = false;
       auto translated_stmt = ASTLoweringStmt::translate (s.get (), &terminated);
-      block_stmts.push_back (std::unique_ptr<HIR::Stmt> (translated_stmt));
       block_did_terminate |= terminated;
+
+      if (translated_stmt)
+	block_stmts.push_back (std::unique_ptr<HIR::Stmt> (translated_stmt));
     }
 
   if (expr.has_tail_expr () && block_did_terminate)
@@ -230,7 +229,7 @@ ASTLoweringIfBlock::visit (AST::IfExprConseqIf &expr)
 void
 ASTLoweringIfLetBlock::visit (AST::IfLetExpr &expr)
 {
-  std::vector<std::unique_ptr<HIR::Pattern> > patterns;
+  std::vector<std::unique_ptr<HIR::Pattern>> patterns;
   for (auto &pattern : expr.get_patterns ())
     {
       HIR::Pattern *ptrn = ASTLoweringPattern::translate (pattern.get ());
@@ -372,7 +371,7 @@ ASTLoweringExprWithBlock::visit (AST::MatchExpr &expr)
 	    match_case.get_arm ().get_guard_expr ().get ());
 	}
 
-      std::vector<std::unique_ptr<HIR::Pattern> > match_arm_patterns;
+      std::vector<std::unique_ptr<HIR::Pattern>> match_arm_patterns;
       for (auto &pattern : match_case.get_arm ().get_patterns ())
 	{
 	  HIR::Pattern *ptrn = ASTLoweringPattern::translate (pattern.get ());

--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -697,8 +697,5 @@ Dump::visit (InferredType &)
 void
 Dump::visit (BareFunctionType &)
 {}
-void
-Dump::visit (ExportedMacro &)
-{}
 } // namespace HIR
 } // namespace Rust

--- a/gcc/rust/hir/rust-hir-dump.h
+++ b/gcc/rust/hir/rust-hir-dump.h
@@ -181,7 +181,6 @@ private:
   virtual void visit (SliceType &) override;
   virtual void visit (InferredType &) override;
   virtual void visit (BareFunctionType &) override;
-  virtual void visit (ExportedMacro &) override;
 };
 
 } // namespace HIR

--- a/gcc/rust/hir/tree/rust-hir-full-decls.h
+++ b/gcc/rust/hir/tree/rust-hir-full-decls.h
@@ -35,9 +35,6 @@ class Lifetime;
 class GenericParam;
 class LifetimeParam;
 
-// FIXME: ARTHUR: Move this somewhere else
-class ExportedMacro;
-
 class TraitItem;
 class ImplItem;
 struct Crate;

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -3226,27 +3226,6 @@ protected:
   }*/
 };
 
-class ExportedMacro : public VisItem
-{
-  Location locus;
-
-public:
-  ExportedMacro (Analysis::NodeMapping mapping, AST::AttrVec outer_attrs,
-		 Location locus)
-    : VisItem (mapping, Visibility (Visibility::PUBLIC),
-	       std::move (outer_attrs)),
-      locus (locus)
-  {}
-
-  virtual Location get_locus () const override;
-  virtual ItemKind get_item_kind () const override;
-  virtual ExportedMacro *clone_item_impl () const override;
-
-  void accept_vis (HIRFullVisitor &vis) override;
-  void accept_vis (HIRStmtVisitor &vis) override;
-  void accept_vis (HIRVisItemVisitor &vis) override;
-};
-
 } // namespace HIR
 } // namespace Rust
 

--- a/gcc/rust/hir/tree/rust-hir-visitor.h
+++ b/gcc/rust/hir/tree/rust-hir-visitor.h
@@ -153,7 +153,6 @@ public:
   virtual void visit (SliceType &type) = 0;
   virtual void visit (InferredType &type) = 0;
   virtual void visit (BareFunctionType &type) = 0;
-  virtual void visit (ExportedMacro &macro) = 0;
 };
 
 class HIRFullVisitorBase : public HIRFullVisitor
@@ -304,7 +303,6 @@ public:
   virtual void visit (SliceType &) override {}
   virtual void visit (InferredType &) override {}
   virtual void visit (BareFunctionType &) override {}
-  virtual void visit (ExportedMacro &) override {}
 };
 
 class HIRExternalItemVisitor
@@ -339,7 +337,6 @@ public:
   virtual void visit (Trait &trait) = 0;
   virtual void visit (ImplBlock &impl) = 0;
   virtual void visit (ExternBlock &block) = 0;
-  virtual void visit (ExportedMacro &macro) = 0;
 };
 
 class HIRImplVisitor
@@ -399,7 +396,6 @@ public:
   virtual void visit (LetStmt &stmt) = 0;
   virtual void visit (ExprStmtWithoutBlock &stmt) = 0;
   virtual void visit (ExprStmtWithBlock &stmt) = 0;
-  virtual void visit (ExportedMacro &macro) = 0;
 };
 
 class HIRExpressionVisitor

--- a/gcc/rust/hir/tree/rust-hir.cc
+++ b/gcc/rust/hir/tree/rust-hir.cc
@@ -5180,41 +5180,5 @@ void
 ConstGenericParam::accept_vis (HIRFullVisitor &)
 {}
 
-void
-ExportedMacro::accept_vis (HIRVisItemVisitor &vis)
-{
-  vis.visit (*this);
-}
-
-void
-ExportedMacro::accept_vis (HIRFullVisitor &vis)
-{
-  vis.visit (*this);
-}
-
-void
-ExportedMacro::accept_vis (HIRStmtVisitor &vis)
-{
-  vis.visit (*this);
-}
-
-Location
-ExportedMacro::get_locus () const
-{
-  return locus;
-}
-
-Item::ItemKind
-ExportedMacro::get_item_kind () const
-{
-  return ItemKind::MacroExport;
-}
-
-ExportedMacro *
-ExportedMacro::clone_item_impl () const
-{
-  return new ExportedMacro (*this);
-}
-
 } // namespace HIR
 } // namespace Rust

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -191,7 +191,6 @@ public:
     Trait,
     Impl,
     Module,
-    MacroExport,
   };
 
   virtual ItemKind get_item_kind () const = 0;

--- a/gcc/rust/metadata/rust-export-metadata.cc
+++ b/gcc/rust/metadata/rust-export-metadata.cc
@@ -144,6 +144,21 @@ ExportContext::emit_function (const HIR::Function &fn)
   public_interface_buffer += oss.str ();
 }
 
+void
+ExportContext::emit_macro (NodeId macro)
+{
+  std::stringstream oss;
+  AST::Dump dumper (oss);
+
+  AST::Item *item;
+  auto ok = mappings->lookup_ast_item (macro, &item);
+  rust_assert (ok);
+
+  dumper.go (*item);
+
+  public_interface_buffer += oss.str ();
+}
+
 const std::string &
 ExportContext::get_interface_buffer () const
 {
@@ -215,6 +230,9 @@ PublicInterface::gather_export_data ()
       if (is_crate_public (vis_item))
 	vis_item.accept_vis (visitor);
     }
+
+  for (const auto &macro : mappings.get_exported_macros ())
+    context.emit_macro (macro);
 }
 
 void

--- a/gcc/rust/metadata/rust-export-metadata.cc
+++ b/gcc/rust/metadata/rust-export-metadata.cc
@@ -169,7 +169,6 @@ public:
   void visit (HIR::StaticItem &) override {}
   void visit (HIR::ImplBlock &) override {}
   void visit (HIR::ExternBlock &) override {}
-  void visit (HIR::ExportedMacro &) override {}
 
   void visit (HIR::Trait &trait) override { ctx.emit_trait (trait); }
 

--- a/gcc/rust/metadata/rust-export-metadata.h
+++ b/gcc/rust/metadata/rust-export-metadata.h
@@ -41,8 +41,14 @@ public:
   const HIR::Module &pop_module_scope ();
 
   void emit_trait (const HIR::Trait &trait);
-
   void emit_function (const HIR::Function &fn);
+
+  /**
+   * Macros are a bit particular - they only live at the AST level, so we can
+   * directly refer to them using their NodeId. There's no need to keep an HIR
+   * node for them.
+   */
+  void emit_macro (NodeId macro);
 
   const std::string &get_interface_buffer () const;
 

--- a/gcc/rust/typecheck/rust-hir-type-check-item.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.h
@@ -50,7 +50,6 @@ public:
   // nothing to do
   void visit (HIR::ExternCrate &) override {}
   void visit (HIR::UseDeclaration &) override {}
-  void visit (HIR::ExportedMacro &) override {}
 
 protected:
   std::vector<TyTy::SubstitutionParamMapping>

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.cc
@@ -148,10 +148,6 @@ TypeCheckStmt::visit (HIR::QualifiedPathInType &path)
 }
 
 void
-TypeCheckStmt::visit (HIR::ExportedMacro &path)
-{}
-
-void
 TypeCheckStmt::visit (HIR::TupleStruct &struct_decl)
 {
   infered = TypeCheckItem::Resolve (struct_decl);

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.h
@@ -47,7 +47,6 @@ public:
   void visit (HIR::ImplBlock &impl) override;
   void visit (HIR::TypePath &path) override;
   void visit (HIR::QualifiedPathInType &path) override;
-  void visit (HIR::ExportedMacro &path) override;
 
   // FIXME
   // this seems like it should not be part of this visitor

--- a/gcc/rust/typecheck/rust-tycheck-dump.h
+++ b/gcc/rust/typecheck/rust-tycheck-dump.h
@@ -196,8 +196,6 @@ public:
     dump += "ctor: " + type_string (expr.get_mappings ());
   }
 
-  void visit (HIR::ExportedMacro &) override {}
-
 protected:
   std::string type_string (const Analysis::NodeMapping &mappings)
   {

--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -41,7 +41,6 @@ static const BuiltinAttrDefinition __definitions[]
      {"repr", CODE_GENERATION},
      {"path", EXPANSION},
      {"macro_use", NAME_RESOLUTION},
-     {"macro_export", CODE_GENERATION}, // FIXME: And NAME_RESOLUTION as well
      // FIXME: This is not implemented yet, see
      // https://github.com/Rust-GCC/gccrs/issues/1475
      {"target_feature", CODE_GENERATION},

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -942,6 +942,18 @@ Mappings::lookup_macro_invocation (AST::MacroInvocation &invoc,
 }
 
 void
+Mappings::insert_exported_macro (AST::MacroRulesDefinition &def)
+{
+  exportedMacros.emplace_back (def.get_node_id ());
+}
+
+std::vector<NodeId> &
+Mappings::get_exported_macros ()
+{
+  return exportedMacros;
+}
+
+void
 Mappings::insert_visibility (NodeId id, Privacy::ModuleVisibility visibility)
 {
   visibility_map.insert ({id, visibility});

--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -279,6 +279,9 @@ public:
   bool lookup_macro_invocation (AST::MacroInvocation &invoc,
 				AST::MacroRulesDefinition **def);
 
+  void insert_exported_macro (AST::MacroRulesDefinition &def);
+  std::vector<NodeId> &get_exported_macros ();
+
   void insert_visibility (NodeId id, Privacy::ModuleVisibility visibility);
   bool lookup_visibility (NodeId id, Privacy::ModuleVisibility &def);
 
@@ -350,6 +353,7 @@ private:
   // macros
   std::map<NodeId, AST::MacroRulesDefinition *> macroMappings;
   std::map<NodeId, AST::MacroRulesDefinition *> macroInvocations;
+  std::vector<NodeId> exportedMacros;
 
   // crate names
   std::map<CrateNum, std::string> crate_names;


### PR DESCRIPTION
@philberty as you pointed out in #1958, using the mappings to store exported macros ends up being shorter and cleaner. This PR should probably be split in two so I'll keep it as a draft for now.

This correctly exports public macros to .rox files. I'll spend some time adding tests to ensure this behavior is respected.

- Revert "hir: Add ExportedMacro node and handling."
- mappings: Keep exported macro IDs
- lowering: Add lowering of exported macros
