### PR TITLE
ci: Do not run `check-gccrs-prefix` on PRs to master

### DIFF
--- a/.github/workflows/commit-format.yml
+++ b/.github/workflows/commit-format.yml
@@ -34,10 +34,10 @@ jobs:
   check-commit-prefixes:
     runs-on: ubuntu-latest
     name: check-gccrs-prefix
+    if: ${{ github.base_ref == 'gcc-patch-dev' }} # master commits don't need the gccrs prefix
     
     steps:
       - uses: actions/checkout@v3
-        if: ${{ github.base_ref == 'gcc-patch-dev' }} # master commits don't need the gccrs prefix
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0


### PR DESCRIPTION
ChangeLog:

	* .github/workflows/commit-format.yml: Skip job on PRs to master.

Addresses #1853