### PR TITLE
resolve: Add name resolution for AltPattern

### DIFF
--- a/gcc/testsuite/rust/compile/torture/alt_patterns1.rs
+++ b/gcc/testsuite/rust/compile/torture/alt_patterns1.rs
@@ -1,0 +1,15 @@
+enum E {
+  A(i32),
+  B(i32, i32),
+}
+
+fn foo((E::A(a) | E::B(mut a, _)): E) {}
+// { dg-error "variable .a. is bound inconsistently across pattern alternatives .E0409." "" { target *-*-* } .-1 }
+
+fn bar((E::A(a) | E::B(mut b, a)): E) {}
+// { dg-error "variable .b. is not bound in all patterns .E0408." "" { target *-*-* } .-1 }
+
+fn baz_correct((a, (E::A(c) | (E::A(c) | E::B(_, c)) | E::B(c, _)), b): (i32, E, u8)) {}
+
+fn baz_wrong((a, (E::A(c) | (E::A(c) | E::B(_, c)) | E::B(c, z)), b): (i32, E, u8)) {}
+// { dg-error "variable .z. is not bound in all patterns .E0408." "" { target *-*-* } .-1 }


### PR DESCRIPTION
~Doesn't even fix~ Addresses #1136

The main changes in this commit can be logically split into two parts:

1) Pushing new pattern binding contexts in alt patterns. At the start   
of each AltPattern we push an 'Or' context which represents the relation
between the bindings of different alts.

   Before we resolve each alt arm we need to push a 'Product' context to represent
   the relation between the bindings of this specific alt arm and each other.
   This 'Product' context is removed after the alt arm visit and the its bindings
   are pushed into the 'Or' context.

   Eventually, the 'Or' context is removed as well after it fulfills its duty.
   Its bindings are then pushed into the previous context similarly and so on.

2) Checking for consistent bindings between the alt arms which is handled
by check_bindings_consistency. The info necessary for this check is held
by binding_info_map inside PatternDeclaration class. The binding_info_map
only holds bindings for one alt arm at a time. After every alt arm visit, 
these bindings info are pushed into a vec (that contains all alt arms info
and will eventually be passed to check_bindings_consistency) and emptied out
for the next alt arm visit. At the end, all the info from all the alt arms
are pushed again into binding_info in addition to the initial bindings that
were there before the alt arms visits, this way the binding_info will contain
all the binding_info present in the AltPattern (as it should).

In addition to that, some refactors were made (e.g. add_new_binding function)    
and some errors emitted, no biggie.