### PR TITLE
Unify HIR::IfLetExprConseqIf{,Let} into HIR::IfLetExprConseqElse

### DIFF
--- a/gcc/rust/backend/rust-compile-block.h
+++ b/gcc/rust/backend/rust-compile-block.h
@@ -100,8 +100,6 @@ public:
   void visit (HIR::IfExprConseqIfLet &) override {}
   void visit (HIR::IfLetExpr &) override {}
   void visit (HIR::IfLetExprConseqElse &) override {}
-  void visit (HIR::IfLetExprConseqIf &) override {}
-  void visit (HIR::IfLetExprConseqIfLet &) override {}
   void visit (HIR::MatchExpr &) override {}
   void visit (HIR::AwaitExpr &) override {}
   void visit (HIR::AsyncBlockExpr &) override {}
@@ -188,8 +186,6 @@ public:
   void visit (HIR::IfExprConseqIfLet &) override {}
   void visit (HIR::IfLetExpr &) override {}
   void visit (HIR::IfLetExprConseqElse &) override {}
-  void visit (HIR::IfLetExprConseqIf &) override {}
-  void visit (HIR::IfLetExprConseqIfLet &) override {}
   void visit (HIR::MatchExpr &) override {}
   void visit (HIR::AwaitExpr &) override {}
   void visit (HIR::AsyncBlockExpr &) override {}

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -80,8 +80,6 @@ public:
   void visit (HIR::IfExprConseqIfLet &) override {}
   void visit (HIR::IfLetExpr &) override {}
   void visit (HIR::IfLetExprConseqElse &) override {}
-  void visit (HIR::IfLetExprConseqIf &) override {}
-  void visit (HIR::IfLetExprConseqIfLet &) override {}
 
   // lets not worry about async yet....
   void visit (HIR::AwaitExpr &) override {}

--- a/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
+++ b/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
@@ -579,22 +579,6 @@ PrivacyReporter::visit (HIR::IfLetExprConseqElse &)
 }
 
 void
-PrivacyReporter::visit (HIR::IfLetExprConseqIf &)
-{
-  // TODO: We need to visit the if_let_expr
-  // TODO: We need to visit the if_block as well
-  // TODO: We need to visit the else_block as well
-}
-
-void
-PrivacyReporter::visit (HIR::IfLetExprConseqIfLet &)
-{
-  // TODO: We need to visit the if_let_expr
-  // TODO: We need to visit the if_block as well
-  // TODO: We need to visit the else_block as well
-}
-
-void
 PrivacyReporter::visit (HIR::MatchExpr &expr)
 {
   expr.get_scrutinee_expr ()->accept_vis (*this);

--- a/gcc/rust/checks/errors/privacy/rust-privacy-reporter.h
+++ b/gcc/rust/checks/errors/privacy/rust-privacy-reporter.h
@@ -126,8 +126,6 @@ types
   virtual void visit (HIR::IfExprConseqIfLet &expr);
   virtual void visit (HIR::IfLetExpr &expr);
   virtual void visit (HIR::IfLetExprConseqElse &expr);
-  virtual void visit (HIR::IfLetExprConseqIf &expr);
-  virtual void visit (HIR::IfLetExprConseqIfLet &expr);
   virtual void visit (HIR::MatchExpr &expr);
   virtual void visit (HIR::AwaitExpr &expr);
   virtual void visit (HIR::AsyncBlockExpr &expr);

--- a/gcc/rust/checks/errors/rust-const-checker.cc
+++ b/gcc/rust/checks/errors/rust-const-checker.cc
@@ -533,22 +533,6 @@ ConstChecker::visit (IfLetExprConseqElse &expr)
 }
 
 void
-ConstChecker::visit (IfLetExprConseqIf &expr)
-{
-  expr.get_scrutinee_expr ()->accept_vis (*this);
-  expr.get_if_block ()->accept_vis (*this);
-}
-
-void
-ConstChecker::visit (IfLetExprConseqIfLet &expr)
-{
-  expr.get_scrutinee_expr ()->accept_vis (*this);
-  expr.get_if_block ()->accept_vis (*this);
-
-  // TODO: Visit conseq if let expression
-}
-
-void
 ConstChecker::visit (MatchExpr &expr)
 {
   expr.get_scrutinee_expr ()->accept_vis (*this);

--- a/gcc/rust/checks/errors/rust-const-checker.h
+++ b/gcc/rust/checks/errors/rust-const-checker.h
@@ -133,8 +133,6 @@ private:
   virtual void visit (IfExprConseqIfLet &expr) override;
   virtual void visit (IfLetExpr &expr) override;
   virtual void visit (IfLetExprConseqElse &expr) override;
-  virtual void visit (IfLetExprConseqIf &expr) override;
-  virtual void visit (IfLetExprConseqIfLet &expr) override;
   virtual void visit (MatchExpr &expr) override;
   virtual void visit (AwaitExpr &expr) override;
   virtual void visit (AsyncBlockExpr &expr) override;

--- a/gcc/rust/checks/errors/rust-unsafe-checker.cc
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.cc
@@ -635,22 +635,6 @@ UnsafeChecker::visit (IfLetExprConseqElse &expr)
 }
 
 void
-UnsafeChecker::visit (IfLetExprConseqIf &expr)
-{
-  expr.get_scrutinee_expr ()->accept_vis (*this);
-  expr.get_if_block ()->accept_vis (*this);
-}
-
-void
-UnsafeChecker::visit (IfLetExprConseqIfLet &expr)
-{
-  expr.get_scrutinee_expr ()->accept_vis (*this);
-  expr.get_if_block ()->accept_vis (*this);
-
-  // TODO: Visit conseq if let expression
-}
-
-void
 UnsafeChecker::visit (MatchExpr &expr)
 {
   expr.get_scrutinee_expr ()->accept_vis (*this);

--- a/gcc/rust/checks/errors/rust-unsafe-checker.h
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.h
@@ -115,8 +115,6 @@ private:
   virtual void visit (IfExprConseqIfLet &expr) override;
   virtual void visit (IfLetExpr &expr) override;
   virtual void visit (IfLetExprConseqElse &expr) override;
-  virtual void visit (IfLetExprConseqIf &expr) override;
-  virtual void visit (IfLetExprConseqIfLet &expr) override;
   virtual void visit (MatchExpr &expr) override;
   virtual void visit (AwaitExpr &expr) override;
   virtual void visit (AsyncBlockExpr &expr) override;

--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -320,12 +320,6 @@ Dump::visit (IfLetExpr &)
 void
 Dump::visit (IfLetExprConseqElse &)
 {}
-void
-Dump::visit (IfLetExprConseqIf &)
-{}
-void
-Dump::visit (IfLetExprConseqIfLet &)
-{}
 
 void
 Dump::visit (MatchExpr &)

--- a/gcc/rust/hir/rust-hir-dump.h
+++ b/gcc/rust/hir/rust-hir-dump.h
@@ -100,8 +100,6 @@ private:
   virtual void visit (IfExprConseqIfLet &) override;
   virtual void visit (IfLetExpr &) override;
   virtual void visit (IfLetExprConseqElse &) override;
-  virtual void visit (IfLetExprConseqIf &) override;
-  virtual void visit (IfLetExprConseqIfLet &) override;
 
   virtual void visit (MatchExpr &) override;
   virtual void visit (AwaitExpr &) override;

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -3584,7 +3584,7 @@ protected:
  * end */
 class IfLetExprConseqElse : public IfLetExpr
 {
-  std::unique_ptr<BlockExpr> else_block;
+  std::unique_ptr<ExprWithBlock> else_block;
 
 public:
   std::string as_string () const override;
@@ -3602,7 +3602,7 @@ public:
 
   // copy constructor with clone
   IfLetExprConseqElse (IfLetExprConseqElse const &other)
-    : IfLetExpr (other), else_block (other.else_block->clone_block_expr ())
+    : IfLetExpr (other), else_block (other.else_block->clone_expr_with_block ())
   {}
 
   // overload assignment operator to clone
@@ -3612,7 +3612,7 @@ public:
     // match_arm_patterns = other.match_arm_patterns;
     // value = other.value->clone_expr();
     // if_block = other.if_block->clone_block_expr();
-    else_block = other.else_block->clone_block_expr ();
+    else_block = other.else_block->clone_expr_with_block ();
     // outer_attrs = other.outer_attrs;
 
     return *this;
@@ -3645,140 +3645,6 @@ protected:
   IfLetExprConseqElse *clone_if_let_expr_impl () const override
   {
     return new IfLetExprConseqElse (*this);
-  }
-};
-
-/* HIR node representing "if let" expression with an "else if" expression at the
- * end */
-class IfLetExprConseqIf : public IfLetExpr
-{
-  std::unique_ptr<IfExpr> if_expr;
-
-public:
-  std::string as_string () const override;
-
-  IfLetExprConseqIf (Analysis::NodeMapping mappings,
-		     std::vector<std::unique_ptr<Pattern> > match_arm_patterns,
-		     std::unique_ptr<Expr> value,
-		     std::unique_ptr<BlockExpr> if_block,
-		     std::unique_ptr<IfExpr> if_expr, Location locus)
-    : IfLetExpr (std::move (mappings), std::move (match_arm_patterns),
-		 std::move (value), std::move (if_block), locus),
-      if_expr (std::move (if_expr))
-  {}
-  // again, outer attributes not allowed
-
-  // copy constructor with clone
-  IfLetExprConseqIf (IfLetExprConseqIf const &other)
-    : IfLetExpr (other), if_expr (other.if_expr->clone_if_expr ())
-  {}
-
-  // overload assignment operator to clone
-  IfLetExprConseqIf &operator= (IfLetExprConseqIf const &other)
-  {
-    IfLetExpr::operator= (other);
-    // match_arm_patterns = other.match_arm_patterns;
-    // value = other.value->clone_expr();
-    // if_block = other.if_block->clone_block_expr();
-    if_expr = other.if_expr->clone_if_expr ();
-
-    return *this;
-  }
-
-  // move constructors
-  IfLetExprConseqIf (IfLetExprConseqIf &&other) = default;
-  IfLetExprConseqIf &operator= (IfLetExprConseqIf &&other) = default;
-
-  void accept_vis (HIRFullVisitor &vis) override;
-  void accept_vis (HIRExpressionVisitor &vis) override;
-
-protected:
-  /* Use covariance to implement clone function as returning this object rather
-   * than base */
-  IfLetExprConseqIf *clone_expr_impl () const override
-  {
-    return new IfLetExprConseqIf (*this);
-  }
-
-  /* Use covariance to implement clone function as returning this object rather
-   * than base */
-  IfLetExprConseqIf *clone_expr_with_block_impl () const override
-  {
-    return new IfLetExprConseqIf (*this);
-  }
-
-  /* Use covariance to implement clone function as returning this object rather
-   * than base */
-  IfLetExprConseqIf *clone_if_let_expr_impl () const override
-  {
-    return new IfLetExprConseqIf (*this);
-  }
-};
-
-/* HIR node representing "if let" expression with an "else if let" expression at
- * the end */
-class IfLetExprConseqIfLet : public IfLetExpr
-{
-  std::unique_ptr<IfLetExpr> if_let_expr;
-
-public:
-  std::string as_string () const override;
-
-  IfLetExprConseqIfLet (
-    Analysis::NodeMapping mappings,
-    std::vector<std::unique_ptr<Pattern> > match_arm_patterns,
-    std::unique_ptr<Expr> value, std::unique_ptr<BlockExpr> if_block,
-    std::unique_ptr<IfLetExpr> if_let_expr, Location locus)
-    : IfLetExpr (std::move (mappings), std::move (match_arm_patterns),
-		 std::move (value), std::move (if_block), locus),
-      if_let_expr (std::move (if_let_expr))
-  {}
-  // outer attributes not allowed
-
-  // copy constructor with clone
-  IfLetExprConseqIfLet (IfLetExprConseqIfLet const &other)
-    : IfLetExpr (other), if_let_expr (other.if_let_expr->clone_if_let_expr ())
-  {}
-
-  // overload assignment operator to clone
-  IfLetExprConseqIfLet &operator= (IfLetExprConseqIfLet const &other)
-  {
-    IfLetExpr::operator= (other);
-    // match_arm_patterns = other.match_arm_patterns;
-    // value = other.value->clone_expr();
-    // if_block = other.if_block->clone_block_expr();
-    if_let_expr = other.if_let_expr->clone_if_let_expr ();
-
-    return *this;
-  }
-
-  // move constructors
-  IfLetExprConseqIfLet (IfLetExprConseqIfLet &&other) = default;
-  IfLetExprConseqIfLet &operator= (IfLetExprConseqIfLet &&other) = default;
-
-  void accept_vis (HIRFullVisitor &vis) override;
-  void accept_vis (HIRExpressionVisitor &vis) override;
-
-protected:
-  /* Use covariance to implement clone function as returning this object rather
-   * than base */
-  IfLetExprConseqIfLet *clone_expr_impl () const override
-  {
-    return new IfLetExprConseqIfLet (*this);
-  }
-
-  /* Use covariance to implement clone function as returning this object rather
-   * than base */
-  IfLetExprConseqIfLet *clone_expr_with_block_impl () const override
-  {
-    return new IfLetExprConseqIfLet (*this);
-  }
-
-  /* Use covariance to implement clone function as returning this object rather
-   * than base */
-  IfLetExprConseqIfLet *clone_if_let_expr_impl () const override
-  {
-    return new IfLetExprConseqIfLet (*this);
   }
 };
 

--- a/gcc/rust/hir/tree/rust-hir-full-decls.h
+++ b/gcc/rust/hir/tree/rust-hir-full-decls.h
@@ -121,8 +121,6 @@ class IfExprConseqIf;
 class IfLetExpr;
 class IfExprConseqIfLet;
 class IfLetExprConseqElse;
-class IfLetExprConseqIf;
-class IfLetExprConseqIfLet;
 struct MatchArm;
 // class MatchCase;
 // class MatchCaseBlockExpr;

--- a/gcc/rust/hir/tree/rust-hir-visitor.h
+++ b/gcc/rust/hir/tree/rust-hir-visitor.h
@@ -85,8 +85,6 @@ public:
   virtual void visit (IfExprConseqIfLet &expr) = 0;
   virtual void visit (IfLetExpr &expr) = 0;
   virtual void visit (IfLetExprConseqElse &expr) = 0;
-  virtual void visit (IfLetExprConseqIf &expr) = 0;
-  virtual void visit (IfLetExprConseqIfLet &expr) = 0;
   virtual void visit (MatchExpr &expr) = 0;
   virtual void visit (AwaitExpr &expr) = 0;
   virtual void visit (AsyncBlockExpr &expr) = 0;
@@ -228,8 +226,6 @@ public:
   virtual void visit (IfExprConseqIfLet &) override {}
   virtual void visit (IfLetExpr &) override {}
   virtual void visit (IfLetExprConseqElse &) override {}
-  virtual void visit (IfLetExprConseqIf &) override {}
-  virtual void visit (IfLetExprConseqIfLet &) override {}
 
   virtual void visit (MatchExpr &) override {}
   virtual void visit (AwaitExpr &) override {}
@@ -464,8 +460,6 @@ public:
   virtual void visit (IfExprConseqIfLet &expr) = 0;
   virtual void visit (IfLetExpr &expr) = 0;
   virtual void visit (IfLetExprConseqElse &expr) = 0;
-  virtual void visit (IfLetExprConseqIf &expr) = 0;
-  virtual void visit (IfLetExprConseqIfLet &expr) = 0;
   virtual void visit (MatchExpr &expr) = 0;
   virtual void visit (AwaitExpr &expr) = 0;
   virtual void visit (AsyncBlockExpr &expr) = 0;

--- a/gcc/rust/hir/tree/rust-hir.cc
+++ b/gcc/rust/hir/tree/rust-hir.cc
@@ -1580,27 +1580,7 @@ IfLetExprConseqElse::as_string () const
 {
   std::string str = IfLetExpr::as_string ();
 
-  str += "\n Else block expr: " + else_block->as_string ();
-
-  return str;
-}
-
-std::string
-IfLetExprConseqIf::as_string () const
-{
-  std::string str = IfLetExpr::as_string ();
-
-  str += "\n Else if expr: \n  " + if_expr->as_string ();
-
-  return str;
-}
-
-std::string
-IfLetExprConseqIfLet::as_string () const
-{
-  std::string str = IfLetExpr::as_string ();
-
-  str += "\n Else if let expr: \n  " + if_let_expr->as_string ();
+  str += "\n Else expr: " + else_block->as_string ();
 
   return str;
 }
@@ -4162,18 +4142,6 @@ IfLetExprConseqElse::accept_vis (HIRFullVisitor &vis)
 }
 
 void
-IfLetExprConseqIf::accept_vis (HIRFullVisitor &vis)
-{
-  vis.visit (*this);
-}
-
-void
-IfLetExprConseqIfLet::accept_vis (HIRFullVisitor &vis)
-{
-  vis.visit (*this);
-}
-
-void
 MatchExpr::accept_vis (HIRFullVisitor &vis)
 {
   vis.visit (*this);
@@ -4919,18 +4887,6 @@ CallExpr::accept_vis (HIRExpressionVisitor &vis)
 
 void
 RangeFromToInclExpr::accept_vis (HIRExpressionVisitor &vis)
-{
-  vis.visit (*this);
-}
-
-void
-IfLetExprConseqIfLet::accept_vis (HIRExpressionVisitor &vis)
-{
-  vis.visit (*this);
-}
-
-void
-IfLetExprConseqIf::accept_vis (HIRExpressionVisitor &vis)
 {
   vis.visit (*this);
 }

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -78,8 +78,6 @@ public:
   void visit (HIR::ForLoopExpr &) override {}
   void visit (HIR::IfExprConseqIfLet &) override {}
   void visit (HIR::IfLetExprConseqElse &) override {}
-  void visit (HIR::IfLetExprConseqIf &) override {}
-  void visit (HIR::IfLetExprConseqIfLet &) override {}
   void visit (HIR::AwaitExpr &) override {}
   void visit (HIR::AsyncBlockExpr &) override {}
 


### PR DESCRIPTION
This should allow for 'if let' expressions to be lowered more easily.