### PR TITLE
hir: Compile `MatchExpr` to if statements

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -932,335 +932,18 @@ CompileExpr::visit (HIR::AssignmentExpr &expr)
   ctx->add_statement (assignment);
 }
 
-// Helper for sort_tuple_patterns.
-// Determine whether Patterns a and b are really the same pattern.
-// FIXME: This is a nasty hack to avoid properly implementing a comparison
-//        for Patterns, which we really probably do want at some point.
-static bool
-patterns_mergeable (HIR::Pattern *a, HIR::Pattern *b)
-{
-  if (!a || !b)
-    return false;
-
-  HIR::Pattern::PatternType pat_type = a->get_pattern_type ();
-  if (b->get_pattern_type () != pat_type)
-    return false;
-
-  switch (pat_type)
-    {
-      case HIR::Pattern::PatternType::PATH: {
-	// FIXME: this is far too naive
-	HIR::PathPattern &aref = *static_cast<HIR::PathPattern *> (a);
-	HIR::PathPattern &bref = *static_cast<HIR::PathPattern *> (b);
-	if (aref.get_num_segments () != bref.get_num_segments ())
-	  return false;
-
-	const auto &asegs = aref.get_segments ();
-	const auto &bsegs = bref.get_segments ();
-	for (size_t i = 0; i < asegs.size (); i++)
-	  {
-	    if (asegs[i].as_string () != bsegs[i].as_string ())
-	      return false;
-	  }
-	return true;
-      }
-      break;
-      case HIR::Pattern::PatternType::LITERAL: {
-	HIR::LiteralPattern &aref = *static_cast<HIR::LiteralPattern *> (a);
-	HIR::LiteralPattern &bref = *static_cast<HIR::LiteralPattern *> (b);
-	return aref.get_literal ().is_equal (bref.get_literal ());
-      }
-      break;
-      case HIR::Pattern::PatternType::IDENTIFIER: {
-	// TODO
-      }
-      break;
-    case HIR::Pattern::PatternType::WILDCARD:
-      return true;
-      break;
-
-      // TODO
-
-    default:;
-    }
-  return false;
-}
-
-// A little container for rearranging the patterns and cases in a match
-// expression while simplifying.
-struct PatternMerge
-{
-  std::unique_ptr<HIR::MatchCase> wildcard;
-  std::vector<std::unique_ptr<HIR::Pattern>> heads;
-  std::vector<std::vector<HIR::MatchCase>> cases;
-};
-
-// Helper for simplify_tuple_match.
-// For each tuple pattern in a given match, pull out the first elt of the
-// tuple and construct a new MatchCase with the remaining tuple elts as the
-// pattern. Return a mapping from each _unique_ first tuple element to a
-// vec of cases for a new match.
-//
-// FIXME: This used to be a std::map<Pattern, Vec<MatchCase>>, but it doesn't
-// actually work like we want - the Pattern includes an HIR ID, which is unique
-// per Pattern object. This means we don't have a good means for comparing
-// Patterns. It would probably be best to actually implement a means of
-// properly comparing patterns, and then use an actual map.
-//
-static struct PatternMerge
-sort_tuple_patterns (HIR::MatchExpr &expr)
-{
-  rust_assert (expr.get_scrutinee_expr ()->get_expression_type ()
-	       == HIR::Expr::ExprType::Tuple);
-
-  struct PatternMerge result;
-  result.wildcard = nullptr;
-  result.heads = std::vector<std::unique_ptr<HIR::Pattern>> ();
-  result.cases = std::vector<std::vector<HIR::MatchCase>> ();
-
-  for (auto &match_case : expr.get_match_cases ())
-    {
-      HIR::MatchArm &case_arm = match_case.get_arm ();
-
-      // FIXME: Note we are only dealing with the first pattern in the arm.
-      // The patterns vector in the arm might hold many patterns, which are the
-      // patterns separated by the '|' token. Rustc abstracts these as "Or"
-      // patterns, and part of its simplification process is to get rid of them.
-      // We should get rid of the ORs too, maybe here or earlier than here?
-      auto pat = case_arm.get_patterns ()[0]->clone_pattern ();
-
-      // Record wildcards so we can add them in inner matches.
-      if (pat->get_pattern_type () == HIR::Pattern::PatternType::WILDCARD)
-	{
-	  // The *whole* pattern is a wild card (_).
-	  result.wildcard
-	    = std::unique_ptr<HIR::MatchCase> (new HIR::MatchCase (match_case));
-	  continue;
-	}
-
-      rust_assert (pat->get_pattern_type ()
-		   == HIR::Pattern::PatternType::TUPLE);
-
-      auto ref = *static_cast<HIR::TuplePattern *> (pat.get ());
-
-      rust_assert (ref.has_tuple_pattern_items ());
-
-      auto items
-	= HIR::TuplePattern (ref).get_items ()->clone_tuple_pattern_items ();
-      if (items->get_pattern_type ()
-	  == HIR::TuplePatternItems::TuplePatternItemType::MULTIPLE)
-	{
-	  auto items_ref
-	    = *static_cast<HIR::TuplePatternItemsMultiple *> (items.get ());
-
-	  // Pop the first pattern out
-	  auto patterns = std::vector<std::unique_ptr<HIR::Pattern>> ();
-	  auto first = items_ref.get_patterns ()[0]->clone_pattern ();
-	  for (auto p = items_ref.get_patterns ().begin () + 1;
-	       p != items_ref.get_patterns ().end (); p++)
-	    {
-	      patterns.push_back ((*p)->clone_pattern ());
-	    }
-
-	  // if there is only one pattern left, don't make a tuple out of it
-	  std::unique_ptr<HIR::Pattern> result_pattern;
-	  if (patterns.size () == 1)
-	    {
-	      result_pattern = std::move (patterns[0]);
-	    }
-	  else
-	    {
-	      auto new_items = std::unique_ptr<HIR::TuplePatternItems> (
-		new HIR::TuplePatternItemsMultiple (std::move (patterns)));
-
-	      // Construct a TuplePattern from the rest of the patterns
-	      result_pattern = std::unique_ptr<HIR::Pattern> (
-		new HIR::TuplePattern (ref.get_pattern_mappings (),
-				       std::move (new_items),
-				       ref.get_locus ()));
-	    }
-
-	  // I don't know why we need to make foo separately here but
-	  // using the { new_tuple } syntax in new_arm constructor does not
-	  // compile.
-	  auto foo = std::vector<std::unique_ptr<HIR::Pattern>> ();
-	  foo.emplace_back (std::move (result_pattern));
-	  HIR::MatchArm new_arm (std::move (foo), Location (), nullptr,
-				 AST::AttrVec ());
-
-	  HIR::MatchCase new_case (match_case.get_mappings (), new_arm,
-				   match_case.get_expr ()->clone_expr ());
-
-	  bool pushed = false;
-	  for (size_t i = 0; i < result.heads.size (); i++)
-	    {
-	      if (patterns_mergeable (result.heads[i].get (), first.get ()))
-		{
-		  result.cases[i].push_back (new_case);
-		  pushed = true;
-		}
-	    }
-
-	  if (!pushed)
-	    {
-	      result.heads.push_back (std::move (first));
-	      result.cases.push_back ({new_case});
-	    }
-	}
-      else /* TuplePatternItemType::RANGED */
-	{
-	  // FIXME
-	  gcc_unreachable ();
-	}
-    }
-
-  return result;
-}
-
 // Helper for CompileExpr::visit (HIR::MatchExpr).
-// Given a MatchExpr where the scrutinee is some kind of tuple, build an
-// equivalent match where only one element of the tuple is examined at a time.
-// This resulting match can then be lowered to a SWITCH_EXPR tree directly.
-//
-// The approach is as follows:
-// 1. Split the scrutinee and each pattern into the first (head) and the
-//    rest (tail).
-// 2. Build a mapping of unique pattern heads to the cases (tail and expr)
-//    that shared that pattern head in the original match.
-//    (This is the job of sort_tuple_patterns ()).
-// 3. For each unique pattern head, build a new MatchCase where the pattern
-//    is the unique head, and the expression is a new match where:
-//    - The scrutinee is the tail of the original scrutinee
-//    - The cases are are those built by the mapping in step 2, i.e. the
-//      tails of the patterns and the corresponing expressions from the
-//      original match expression.
-// 4. Do this recursively for each inner match, until there is nothing more
-//    to simplify.
-// 5. Build the resulting match which scrutinizes the head of the original
-//    scrutinee, using the cases built in step 3.
-static HIR::MatchExpr
-simplify_tuple_match (HIR::MatchExpr &expr)
-{
-  if (expr.get_scrutinee_expr ()->get_expression_type ()
-      != HIR::Expr::ExprType::Tuple)
-    return expr;
-
-  auto ref = *static_cast<HIR::TupleExpr *> (expr.get_scrutinee_expr ().get ());
-
-  auto &tail = ref.get_tuple_elems ();
-  rust_assert (tail.size () > 1);
-
-  auto head = std::move (tail[0]);
-  tail.erase (tail.begin (), tail.begin () + 1);
-
-  // e.g.
-  // match (tupA, tupB, tupC) {
-  //   (a1, b1, c1) => { blk1 },
-  //   (a2, b2, c2) => { blk2 },
-  //   (a1, b3, c3) => { blk3 },
-  // }
-  // tail = (tupB, tupC)
-  // head = tupA
-
-  // Make sure the tail is only a tuple if it consists of at least 2 elements.
-  std::unique_ptr<HIR::Expr> remaining;
-  if (tail.size () == 1)
-    remaining = std::move (tail[0]);
-  else
-    remaining = std::unique_ptr<HIR::Expr> (
-      new HIR::TupleExpr (ref.get_mappings (), std::move (tail),
-			  AST::AttrVec (), ref.get_outer_attrs (),
-			  ref.get_locus ()));
-
-  // e.g.
-  // a1 -> [(b1, c1) => { blk1 },
-  //        (b3, c3) => { blk3 }]
-  // a2 -> [(b2, c2) => { blk2 }]
-  struct PatternMerge map = sort_tuple_patterns (expr);
-
-  std::vector<HIR::MatchCase> cases;
-  // Construct the inner match for each unique first elt of the tuple
-  // patterns
-  for (size_t i = 0; i < map.heads.size (); i++)
-    {
-      auto inner_match_cases = map.cases[i];
-
-      // If there is a wildcard at the outer match level, then need to
-      // propegate the wildcard case into *every* inner match.
-      // FIXME: It is probably not correct to add this unconditionally, what if
-      // we have a pattern like (a, _, c)? Then there is already a wildcard in
-      // the inner matches, and having two will cause two 'default:' blocks
-      // which is an error.
-      if (map.wildcard != nullptr)
-	{
-	  inner_match_cases.push_back (*(map.wildcard.get ()));
-	}
-
-      // match (tupB, tupC) {
-      //   (b1, c1) => { blk1 },
-      //   (b3, c3) => { blk3 }
-      // }
-      HIR::MatchExpr inner_match (expr.get_mappings (),
-				  remaining->clone_expr (), inner_match_cases,
-				  AST::AttrVec (), expr.get_outer_attrs (),
-				  expr.get_locus ());
-
-      inner_match = simplify_tuple_match (inner_match);
-
-      auto outer_arm_pat = std::vector<std::unique_ptr<HIR::Pattern>> ();
-      outer_arm_pat.emplace_back (map.heads[i]->clone_pattern ());
-
-      HIR::MatchArm outer_arm (std::move (outer_arm_pat), expr.get_locus ());
-
-      // Need to move the inner match to the heap and put it in a unique_ptr to
-      // build the actual match case of the outer expression
-      // auto inner_expr = std::unique_ptr<HIR::Expr> (new HIR::MatchExpr
-      // (inner_match));
-      auto inner_expr = inner_match.clone_expr ();
-
-      // a1 => match (tupB, tupC) { ... }
-      HIR::MatchCase outer_case (expr.get_mappings (), outer_arm,
-				 std::move (inner_expr));
-
-      cases.push_back (outer_case);
-    }
-
-  // If there was a wildcard, make sure to include it at the outer match level
-  // too.
-  if (map.wildcard != nullptr)
-    {
-      cases.push_back (*(map.wildcard.get ()));
-    }
-
-  // match tupA {
-  //   a1 => match (tupB, tupC) {
-  //     (b1, c1) => { blk1 },
-  //     (b3, c3) => { blk3 }
-  //   }
-  //   a2 => match (tupB, tupC) {
-  //     (b2, c2) => { blk2 }
-  //   }
-  // }
-  HIR::MatchExpr outer_match (expr.get_mappings (), std::move (head), cases,
-			      AST::AttrVec (), expr.get_outer_attrs (),
-			      expr.get_locus ());
-
-  return outer_match;
-}
-
-// Helper for CompileExpr::visit (HIR::MatchExpr).
-// Check that the scrutinee of EXPR is a valid kind of expression to match on.
-// Return the TypeKind of the scrutinee if it is valid, or TyTy::TypeKind::ERROR
-// if not.
-static TyTy::TypeKind
-check_match_scrutinee (HIR::MatchExpr &expr, Context *ctx)
+// Checks the validity of the scrutinee type and match expression type.
+// Return the BaseType of the expression if all is valid, or NULL otherwise.
+static TyTy::BaseType *
+check_match_expr_type (HIR::MatchExpr &expr, Context *ctx)
 {
   TyTy::BaseType *scrutinee_expr_tyty = nullptr;
   if (!ctx->get_tyctx ()->lookup_type (
 	expr.get_scrutinee_expr ()->get_mappings ().get_hirid (),
 	&scrutinee_expr_tyty))
     {
-      return TyTy::TypeKind::ERROR;
+      return NULL;
     }
 
   TyTy::TypeKind scrutinee_kind = scrutinee_expr_tyty->get_kind ();
@@ -1271,8 +954,8 @@ check_match_scrutinee (HIR::MatchExpr &expr, Context *ctx)
 
   if (scrutinee_kind == TyTy::TypeKind::ADT)
     {
-      // this will need to change but for now the first pass implementation,
-      // lets assert this is the case
+      // FIXME: this will need to change but for now the first pass
+      // implementation, lets assert that this is the case
       TyTy::ADTType *adt = static_cast<TyTy::ADTType *> (scrutinee_expr_tyty);
       rust_assert (adt->is_enum ());
       rust_assert (adt->number_of_variants () > 0);
@@ -1289,230 +972,162 @@ check_match_scrutinee (HIR::MatchExpr &expr, Context *ctx)
   if (!ctx->get_tyctx ()->lookup_type (expr.get_mappings ().get_hirid (),
 				       &expr_tyty))
     {
-      return TyTy::TypeKind::ERROR;
+      return NULL;
+    }
+  return expr_tyty;
+}
+
+// The entry point of compiling MatchExpr into an if statement
+tree
+SimplifyMatchExpr::go (HIR::MatchExpr &expr, Context *ctx, Bvariable *result)
+{
+  SimplifyMatchExpr compiler (expr, ctx, result);
+  return compiler.simplify_remaining_cases (0);
+}
+
+// Helper for simplify_remaining_cases.
+// Responsible for transforming a match_case's final expression into a compiled
+// block. If expr is not a BlockExpr, then we'll need to create a block and add
+// the final expression explicitly as a statement.
+tree
+SimplifyMatchExpr::compile_case_expr (HIR::Expr *expr)
+{
+  if (expr->get_expression_type () == HIR::Expr::ExprType::Block)
+    {
+      auto block_expr = static_cast<HIR::BlockExpr *> (expr);
+      return CompileBlock::compile (block_expr, ctx, result);
     }
 
-  return scrutinee_kind;
+  tree fndecl = ctx->peek_fn ().fndecl;
+  Location start_location = expr->get_locus ();
+  Location end_location = expr->get_locus ();
+
+  tree enclosing_scope = ctx->peek_enclosing_scope ();
+  tree new_block = ctx->get_backend ()->block (fndecl, enclosing_scope, {},
+					       start_location, end_location);
+  ctx->push_block (new_block);
+
+  tree compiled_expr = CompileExpr::Compile (expr, ctx);
+  if (compiled_expr != nullptr)
+    {
+      if (result == nullptr)
+	{
+	  ctx->add_statement (compiled_expr);
+	}
+      else
+	{
+	  tree result_reference
+	    = ctx->get_backend ()->var_expression (result, expr->get_locus ());
+
+	  tree assignment
+	    = ctx->get_backend ()->assignment_statement (result_reference,
+							 compiled_expr,
+							 expr->get_locus ());
+	  ctx->add_statement (assignment);
+	}
+    }
+
+  ctx->pop_block ();
+  return new_block;
+}
+
+// Contains the main logic of compiling match expressions. The algorithm works
+// as follows:
+// 1. Get the condition for the if statement from
+// CompileMatchArmPattern::Compile
+// 2. Get the then_block from compile_case_expr.
+// 3. Create a new block (else block)
+// 4. Get the remaining if statements recursively from simplify_remaining_cases
+//    and add them to the else block. The base case is at the last match case.
+//    It will return a simple if statement with no else block.
+// 5. Return a new if statement from the elements in the previous steps.
+tree
+SimplifyMatchExpr::simplify_remaining_cases (size_t case_index)
+{
+  auto &match_scrutinee_expr = expr.get_scrutinee_expr ();
+  tree compiled_scrutinee
+    = CompileExpr::Compile (match_scrutinee_expr.get (), ctx);
+  auto &match_cases = expr.get_match_cases ();
+
+  tree fndecl = ctx->peek_fn ().fndecl;
+  tree enclosing_scope = ctx->peek_enclosing_scope ();
+
+  auto &match_case = match_cases[case_index];
+  auto &match_arm = match_case.get_arm ();
+
+  auto &pattern = match_arm.get_patterns ()[0];
+  CompilePatternBindings::Compile (pattern.get (), compiled_scrutinee, ctx);
+  tree condition
+    = CompileMatchArmPattern::Compile (pattern.get (), compiled_scrutinee, ctx,
+				       match_scrutinee_expr->get_locus ());
+
+  if (condition == NULL)
+    return NULL;
+
+  auto then_block = compile_case_expr (match_case.get_expr ().get ());
+
+  if (case_index == match_cases.size () - 1)
+    {
+      return ctx->get_backend ()->if_statement (fndecl, condition, then_block,
+						NULL, match_arm.get_locus ());
+    }
+
+  tree else_block = ctx->get_backend ()->block (fndecl, enclosing_scope, {},
+						Location (), Location ());
+  ctx->push_block (else_block);
+
+  tree else_stmt = simplify_remaining_cases (case_index + 1);
+
+  if (else_stmt == NULL)
+    return NULL;
+
+  ctx->add_statement (else_stmt);
+  ctx->pop_block ();
+
+  return ctx->get_backend ()->if_statement (fndecl, condition, then_block,
+					    else_block, match_arm.get_locus ());
 }
 
 void
 CompileExpr::visit (HIR::MatchExpr &expr)
 {
-  // https://gcc.gnu.org/onlinedocs/gccint/Basic-Statements.html#Basic-Statements
-  // TODO
-  // SWITCH_ALL_CASES_P is true if the switch includes a default label or the
-  // case label ranges cover all possible values of the condition expression
-
-  TyTy::TypeKind scrutinee_kind = check_match_scrutinee (expr, ctx);
-  if (scrutinee_kind == TyTy::TypeKind::ERROR)
+  TyTy::BaseType *expr_tyty = check_match_expr_type (expr, ctx);
+  if (expr_tyty == NULL)
     {
       translated = error_mark_node;
       return;
     }
 
-  TyTy::BaseType *expr_tyty = nullptr;
-  if (!ctx->get_tyctx ()->lookup_type (expr.get_mappings ().get_hirid (),
-				       &expr_tyty))
-    {
-      translated = error_mark_node;
-      return;
-    }
-
-  fncontext fnctx = ctx->peek_fn ();
   Bvariable *tmp = NULL;
   bool needs_temp = !expr_tyty->is_unit ();
   if (needs_temp)
     {
       tree enclosing_scope = ctx->peek_enclosing_scope ();
+      tree fndecl = ctx->peek_fn ().fndecl;
       tree block_type = TyTyResolveCompile::compile (ctx, expr_tyty);
 
       bool is_address_taken = false;
       tree ret_var_stmt = nullptr;
-      tmp = ctx->get_backend ()->temporary_variable (
-	fnctx.fndecl, enclosing_scope, block_type, NULL, is_address_taken,
-	expr.get_locus (), &ret_var_stmt);
+      tmp = ctx->get_backend ()->temporary_variable (fndecl, enclosing_scope,
+						     block_type, NULL,
+						     is_address_taken,
+						     expr.get_locus (),
+						     &ret_var_stmt);
       ctx->add_statement (ret_var_stmt);
     }
 
-  // lets compile the scrutinee expression
-  tree match_scrutinee_expr
-    = CompileExpr::Compile (expr.get_scrutinee_expr ().get (), ctx);
+  tree if_stmt = SimplifyMatchExpr::go (expr, ctx, tmp);
 
-  tree match_scrutinee_expr_qualifier_expr;
-  if (TyTy::is_primitive_type_kind (scrutinee_kind))
+  if (if_stmt == NULL)
     {
-      match_scrutinee_expr_qualifier_expr = match_scrutinee_expr;
-    }
-  else if (scrutinee_kind == TyTy::TypeKind::ADT)
-    {
-      // need to access qualifier the field, if we use QUAL_UNION_TYPE this
-      // would be DECL_QUALIFIER i think. For now this will just access the
-      // first record field and its respective qualifier because it will always
-      // be set because this is all a big special union
-      tree scrutinee_first_record_expr
-	= ctx->get_backend ()->struct_field_expression (
-	  match_scrutinee_expr, 0, expr.get_scrutinee_expr ()->get_locus ());
-      match_scrutinee_expr_qualifier_expr
-	= ctx->get_backend ()->struct_field_expression (
-	  scrutinee_first_record_expr, 0,
-	  expr.get_scrutinee_expr ()->get_locus ());
-    }
-  else if (scrutinee_kind == TyTy::TypeKind::TUPLE)
-    {
-      // match on tuple becomes a series of nested switches, with one level
-      // for each element of the tuple from left to right.
-      auto exprtype = expr.get_scrutinee_expr ()->get_expression_type ();
-      switch (exprtype)
-	{
-	  case HIR::Expr::ExprType::Tuple: {
-	    // Build an equivalent expression which is nicer to lower.
-	    HIR::MatchExpr outer_match = simplify_tuple_match (expr);
-
-	    // We've rearranged the match into something that lowers better
-	    // to GENERIC trees.
-	    // For actually doing the lowering we need to compile the match
-	    // we've just made. But we're half-way through compiling the
-	    // original one.
-	    // ...
-	    // For now, let's just replace the original with the rearranged one
-	    // we just made, and compile that instead. What could go wrong? :)
-	    //
-	    // FIXME: What about when we decide a temporary is needed above?
-	    //        We might have already pushed a statement for it that
-	    //        we no longer need. Probably need to rearrange the order
-	    //        of these steps.
-	    expr = outer_match;
-
-	    scrutinee_kind = check_match_scrutinee (expr, ctx);
-	    if (scrutinee_kind == TyTy::TypeKind::ERROR)
-	      {
-		translated = error_mark_node;
-		return;
-	      }
-
-	    // Now compile the scrutinee of the simplified match.
-	    // FIXME: this part is duplicated from above.
-	    match_scrutinee_expr
-	      = CompileExpr::Compile (expr.get_scrutinee_expr ().get (), ctx);
-
-	    if (TyTy::is_primitive_type_kind (scrutinee_kind))
-	      {
-		match_scrutinee_expr_qualifier_expr = match_scrutinee_expr;
-	      }
-	    else if (scrutinee_kind == TyTy::TypeKind::ADT)
-	      {
-		// need to access qualifier the field, if we use QUAL_UNION_TYPE
-		// this would be DECL_QUALIFIER i think. For now this will just
-		// access the first record field and its respective qualifier
-		// because it will always be set because this is all a big
-		// special union
-		tree scrutinee_first_record_expr
-		  = ctx->get_backend ()->struct_field_expression (
-		    match_scrutinee_expr, 0,
-		    expr.get_scrutinee_expr ()->get_locus ());
-		match_scrutinee_expr_qualifier_expr
-		  = ctx->get_backend ()->struct_field_expression (
-		    scrutinee_first_record_expr, 0,
-		    expr.get_scrutinee_expr ()->get_locus ());
-	      }
-	    else
-	      {
-		// FIXME: There are other cases, but it better not be a Tuple
-		gcc_unreachable ();
-	      }
-	  }
-	  break;
-
-	  case HIR::Expr::ExprType::Path: {
-	    // FIXME
-	    gcc_unreachable ();
-	  }
-	  break;
-
-	default:
-	  gcc_unreachable ();
-	}
-    }
-  else
-    {
-      // FIXME: match on other types of expressions not yet implemented.
-      gcc_unreachable ();
+      translated = error_mark_node;
+      return;
     }
 
-  // setup the end label so the cases can exit properly
-  tree fndecl = fnctx.fndecl;
-  Location end_label_locus = expr.get_locus (); // FIXME
-  tree end_label
-    = ctx->get_backend ()->label (fndecl,
-				  "" /* empty creates an artificial label */,
-				  end_label_locus);
-  tree end_label_decl_statement
-    = ctx->get_backend ()->label_definition_statement (end_label);
-
-  // setup the switch-body-block
-  Location start_location; // FIXME
-  Location end_location;   // FIXME
-  tree enclosing_scope = ctx->peek_enclosing_scope ();
-  tree switch_body_block
-    = ctx->get_backend ()->block (fndecl, enclosing_scope, {}, start_location,
-				  end_location);
-  ctx->push_block (switch_body_block);
-
-  for (auto &kase : expr.get_match_cases ())
-    {
-      // for now lets just get single pattern's working
-      HIR::MatchArm &kase_arm = kase.get_arm ();
-      rust_assert (kase_arm.get_patterns ().size () > 0);
-
-      // generate implicit label
-      Location arm_locus = kase_arm.get_locus ();
-      tree case_label = ctx->get_backend ()->label (
-	fndecl, "" /* empty creates an artificial label */, arm_locus);
-
-      // setup the bindings for the block
-      for (auto &kase_pattern : kase_arm.get_patterns ())
-	{
-	  tree switch_kase_expr
-	    = CompilePatternCaseLabelExpr::Compile (kase_pattern.get (),
-						    case_label, ctx);
-	  ctx->add_statement (switch_kase_expr);
-
-	  CompilePatternBindings::Compile (kase_pattern.get (),
-					   match_scrutinee_expr, ctx);
-	}
-
-      // compile the expr and setup the assignment if required when tmp != NULL
-      tree kase_expr_tree = CompileExpr::Compile (kase.get_expr ().get (), ctx);
-      if (tmp != NULL)
-	{
-	  tree result_reference
-	    = ctx->get_backend ()->var_expression (tmp, arm_locus);
-	  tree assignment
-	    = ctx->get_backend ()->assignment_statement (result_reference,
-							 kase_expr_tree,
-							 arm_locus);
-	  ctx->add_statement (assignment);
-	}
-
-      // go to end label
-      tree goto_end_label = build1_loc (arm_locus.gcc_location (), GOTO_EXPR,
-					void_type_node, end_label);
-      ctx->add_statement (goto_end_label);
-    }
-
-  // setup the switch expression
-  tree match_body = ctx->pop_block ();
-  tree match_expr_stmt
-    = build2_loc (expr.get_locus ().gcc_location (), SWITCH_EXPR,
-		  TREE_TYPE (match_scrutinee_expr_qualifier_expr),
-		  match_scrutinee_expr_qualifier_expr, match_body);
-  ctx->add_statement (match_expr_stmt);
-  ctx->add_statement (end_label_decl_statement);
+  ctx->add_statement (if_stmt);
 
   if (tmp != NULL)
-    {
-      translated = ctx->get_backend ()->var_expression (tmp, expr.get_locus ());
-    }
+    translated = ctx->get_backend ()->var_expression (tmp, expr.get_locus ());
 }
 
 void

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -157,6 +157,24 @@ private:
   tree translated;
 };
 
+class SimplifyMatchExpr
+{
+public:
+  static tree go (HIR::MatchExpr &expr, Context *ctx, Bvariable *result);
+
+  tree compile_case_expr (HIR::Expr *expr);
+  tree simplify_remaining_cases (size_t case_index);
+
+private:
+  SimplifyMatchExpr (HIR::MatchExpr &expr, Context *ctx, Bvariable *result)
+    : expr (expr), ctx (ctx), result (result)
+  {}
+
+  HIR::MatchExpr &expr;
+  Context *ctx;
+  Bvariable *result;
+};
+
 } // namespace Compile
 } // namespace Rust
 

--- a/gcc/testsuite/rust/execute/torture/match_tuple2.rs
+++ b/gcc/testsuite/rust/execute/torture/match_tuple2.rs
@@ -1,0 +1,34 @@
+// { dg-output "x:10\ny:20\n" }
+
+extern "C" {
+  fn printf(s: *const i8, ...);
+}
+
+enum Foo {
+  A,
+  B,
+}
+
+fn inspect(x: (Foo, u8)) -> i32 {
+  match x {
+      (Foo::A, 1) => { return 5; }
+      (Foo::A, 2) => { return 10; }
+      (Foo::B, 2) => { return 15; }
+      _ => { return 20; }
+  }
+  return 25;
+}
+
+fn main () -> i32 {
+  let x = inspect((Foo::A, 2));
+  let y = inspect((Foo::B, 1));
+
+  unsafe {
+      printf("x:%d\n" as *const str as *const i8, x);
+  }
+  unsafe {
+      printf("y:%d\n" as *const str as *const i8, y);
+  }
+
+  y - x - 10
+}

--- a/gcc/testsuite/rust/execute/torture/match_tuple3.rs
+++ b/gcc/testsuite/rust/execute/torture/match_tuple3.rs
@@ -1,0 +1,19 @@
+enum Foo {
+  A,
+  B,
+}
+
+fn inspect(f: ((Foo, i32), (Foo, i32))) -> i32
+{
+  match f {
+    ((Foo::A, 1), (Foo::B, _)) => { return 1; }
+    ((Foo::A, _), (Foo::A, 10)) => { return 10; }
+    ((Foo::A, _), (Foo::A, _)) => { return 100; }
+    ((Foo::B, 5), _) => { return 1000; }
+    _ => { return 100000; }
+  }
+}
+
+fn main() -> i32 {
+  inspect(((Foo::A, 1), (Foo::B, 3))) + inspect(((Foo::B, 5), (Foo::A, 10))) - 1001
+}


### PR DESCRIPTION
The main purpose of this commit is to refactor the old switch-based logic we
had for compiling match expressions and use an if-statement-based approach.

So, naturally, the old logic was removed in this commit. That includes
`sort_tuple_patterns`, `simplify_tuple_match`, `PatternMerge` and `patterns_mergeable`.

In the new approach, each arm is transformed into an if statement. And for
any if statement, there are two main components: the condition and the then_block.

The entity responsible for handling the condition is `CompileMatchArmCondition`.
It's a class that traverses down the arm pattern and the match scrutinee expression
simultaneously. Whenever it meets a base-case in the pattern (i.e. expression or identifier
but identifiers are not handled for now), it takes the respective field of the scrutinee
and returns a backend comparison expression for them.

As for the then_block, it's compiled by `SimplifyMatchExpr::compile_case_expr`.
This function transforms the `HIR::Expr` match case final expression
into a backend block so it can be used easily inside the if_statement. In case
the expr is of type `BlockExpr`, then we can easily compile it using `CompileBlock::compile`.
Otherwise, we'll have to create a new block and add the expression as a statement.

Now we have the means of creating the if statements. All that's left is to glue the
multiple match arms (if_statements) together, and that's where
`SimplifyMatchExpr::simplify_remaining_cases` comes in. It compiles the condition and
then_block with the help of the functions mentioned earlier. As for the else_block,
it should contain the if_statements for the remaining match arms. So
`simplify_remaining_cases` calculates the else_block recursively by calling itself.
After that it returns the compiled if_statement with the condition, then_block, and
else_block.
