### PR TITLE
Add error message for AltPattern in let statements

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-pattern.cc
+++ b/gcc/rust/hir/rust-ast-lower-pattern.cc
@@ -25,9 +25,10 @@ namespace HIR {
 ASTLoweringPattern::ASTLoweringPattern () : translated (nullptr) {}
 
 HIR::Pattern *
-ASTLoweringPattern::translate (AST::Pattern *pattern)
+ASTLoweringPattern::translate (AST::Pattern *pattern, bool is_let_top_level)
 {
   ASTLoweringPattern resolver;
+  resolver.is_let_top_level = is_let_top_level;
   pattern->accept_vis (resolver);
 
   rust_assert (resolver.translated != nullptr);
@@ -315,6 +316,11 @@ ASTLoweringPattern::visit (AST::AltPattern &pattern)
 
   translated
     = new HIR::AltPattern (mapping, std::move (alts), pattern.get_locus ());
+
+  if (is_let_top_level)
+    rust_error_at (pattern.get_locus (),
+		   "top level alternate patterns are not allowed for %<let%> "
+		   "bindings - use an outer grouped pattern");
 }
 
 } // namespace HIR

--- a/gcc/rust/hir/rust-ast-lower-pattern.h
+++ b/gcc/rust/hir/rust-ast-lower-pattern.h
@@ -29,7 +29,8 @@ class ASTLoweringPattern : public ASTLoweringBase
   using Rust::HIR::ASTLoweringBase::visit;
 
 public:
-  static HIR::Pattern *translate (AST::Pattern *pattern);
+  static HIR::Pattern *translate (AST::Pattern *pattern,
+				  bool is_let_top_level = false);
 
   void visit (AST::IdentifierPattern &pattern) override;
   void visit (AST::PathInExpression &pattern) override;
@@ -48,6 +49,7 @@ private:
   ASTLoweringPattern ();
 
   HIR::Pattern *translated;
+  bool is_let_top_level;
 };
 
 } // namespace HIR

--- a/gcc/rust/hir/rust-ast-lower-stmt.cc
+++ b/gcc/rust/hir/rust-ast-lower-stmt.cc
@@ -108,7 +108,7 @@ void
 ASTLoweringStmt::visit (AST::LetStmt &stmt)
 {
   HIR::Pattern *variables
-    = ASTLoweringPattern::translate (stmt.get_pattern ().get ());
+    = ASTLoweringPattern::translate (stmt.get_pattern ().get (), true);
   HIR::Type *type = stmt.has_type ()
 		      ? ASTLoweringType::translate (stmt.get_type ().get ())
 		      : nullptr;

--- a/gcc/testsuite/rust/compile/let_alt.rs
+++ b/gcc/testsuite/rust/compile/let_alt.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let _a | _a = 12;
+    // { dg-error "top level alternate patterns are not allowed" "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
Changes the ```rust_sorry_at``` for ```AltPattern``` in ```let``` statements to a ```rust_error_at```.