### PR TITLE
gccrs: Cleanup unused headers

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-implitem.h
+++ b/gcc/rust/hir/rust-ast-lower-implitem.h
@@ -19,9 +19,7 @@
 #ifndef RUST_AST_LOWER_IMPLITEM_H
 #define RUST_AST_LOWER_IMPLITEM_H
 
-#include "rust-diagnostics.h"
 #include "rust-ast-lower-type.h"
-#include "rust-ast-lower-stmt.h"
 #include "rust-ast-lower-expr.h"
 #include "rust-ast-lower-pattern.h"
 #include "rust-ast-lower-block.h"

--- a/gcc/rust/hir/rust-ast-lower-item.cc
+++ b/gcc/rust/hir/rust-ast-lower-item.cc
@@ -17,6 +17,15 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-ast-lower-item.h"
+#include "rust-diagnostics.h"
+#include "rust-ast-lower.h"
+#include "rust-ast-lower-base.h"
+#include "rust-ast-lower-enumitem.h"
+#include "rust-ast-lower-type.h"
+#include "rust-ast-lower-implitem.h"
+#include "rust-ast-lower-expr.h"
+#include "rust-ast-lower-pattern.h"
+#include "rust-ast-lower-block.h"
 
 namespace Rust {
 namespace HIR {

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -19,19 +19,7 @@
 #ifndef RUST_AST_LOWER_ITEM
 #define RUST_AST_LOWER_ITEM
 
-#include "rust-diagnostics.h"
-
-#include "rust-ast-lower.h"
 #include "rust-ast-lower-base.h"
-#include "rust-ast-lower-enumitem.h"
-#include "rust-ast-lower-type.h"
-#include "rust-ast-lower-implitem.h"
-#include "rust-ast-lower-stmt.h"
-#include "rust-ast-lower-expr.h"
-#include "rust-ast-lower-pattern.h"
-#include "rust-ast-lower-block.h"
-#include "rust-ast-lower-extern.h"
-#include "rust-hir-full-decls.h"
 
 namespace Rust {
 namespace HIR {

--- a/gcc/rust/hir/rust-ast-lower-stmt.cc
+++ b/gcc/rust/hir/rust-ast-lower-stmt.cc
@@ -17,6 +17,11 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-ast-lower-stmt.h"
+#include "rust-ast-lower-enumitem.h"
+#include "rust-ast-lower-type.h"
+#include "rust-ast-lower-block.h"
+#include "rust-ast-lower-expr.h"
+#include "rust-ast-lower-pattern.h"
 
 namespace Rust {
 namespace HIR {

--- a/gcc/rust/hir/rust-ast-lower-stmt.h
+++ b/gcc/rust/hir/rust-ast-lower-stmt.h
@@ -19,14 +19,7 @@
 #ifndef RUST_AST_LOWER_STMT
 #define RUST_AST_LOWER_STMT
 
-#include "rust-diagnostics.h"
-
 #include "rust-ast-lower-base.h"
-#include "rust-ast-lower-enumitem.h"
-#include "rust-ast-lower-type.h"
-#include "rust-ast-lower-block.h"
-#include "rust-ast-lower-expr.h"
-#include "rust-ast-lower-pattern.h"
 
 namespace Rust {
 namespace HIR {

--- a/gcc/rust/hir/rust-ast-lower-type.h
+++ b/gcc/rust/hir/rust-ast-lower-type.h
@@ -20,7 +20,6 @@
 #define RUST_AST_LOWER_TYPE
 
 #include "rust-ast-lower-base.h"
-#include "rust-diagnostics.h"
 #include "rust-ast-lower-expr.h"
 
 namespace Rust {

--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -18,7 +18,7 @@
 
 #include "rust-ast-lower.h"
 #include "rust-ast-lower-item.h"
-#include "rust-ast-lower-implitem.h"
+#include "rust-ast-lower-stmt.h"
 #include "rust-ast-lower-expr.h"
 #include "rust-ast-lower-block.h"
 #include "rust-ast-lower-type.h"

--- a/gcc/rust/hir/rust-ast-lower.h
+++ b/gcc/rust/hir/rust-ast-lower.h
@@ -20,9 +20,8 @@
 #define RUST_HIR_LOWER
 
 #include "rust-system.h"
-#include "rust-ast-full.h"
-#include "rust-ast-visitor.h"
-#include "rust-hir-full.h"
+#include "rust-ast-full-decls.h"
+#include "rust-hir-full-decls.h"
 
 namespace Rust {
 namespace HIR {

--- a/gcc/rust/resolve/rust-ast-resolve-expr.h
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.h
@@ -21,7 +21,6 @@
 
 #include "rust-ast-resolve-base.h"
 #include "rust-ast-resolve-pattern.h"
-#include "rust-ast-full.h"
 
 namespace Rust {
 namespace Resolver {

--- a/gcc/rust/resolve/rust-ast-resolve-item.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-item.cc
@@ -17,7 +17,11 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-ast-resolve-item.h"
+#include "rust-ast-resolve-toplevel.h"
+#include "rust-ast-resolve-type.h"
+#include "rust-ast-resolve-pattern.h"
 #include "rust-ast-resolve-path.h"
+
 #include "selftest.h"
 
 namespace Rust {

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -21,11 +21,7 @@
 
 #include "rust-ast-full-decls.h"
 #include "rust-ast-resolve-base.h"
-#include "rust-ast-full.h"
-#include "rust-ast-resolve-toplevel.h"
-#include "rust-ast-resolve-type.h"
-#include "rust-ast-resolve-pattern.h"
-#include "rust-ast-resolve-stmt.h"
+
 #include "config.h"
 
 namespace Rust {

--- a/gcc/rust/resolve/rust-ast-resolve-stmt.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-stmt.cc
@@ -18,6 +18,7 @@
 
 #include "rust-ast-resolve-item.h"
 #include "rust-ast-resolve-stmt.h"
+#include "rust-ast-resolve-implitem.h"
 
 namespace Rust {
 namespace Resolver {

--- a/gcc/rust/resolve/rust-ast-resolve-stmt.h
+++ b/gcc/rust/resolve/rust-ast-resolve-stmt.h
@@ -20,7 +20,6 @@
 #define RUST_AST_RESOLVE_STMT_H
 
 #include "rust-ast-resolve-base.h"
-#include "rust-ast-full.h"
 #include "rust-ast-resolve-type.h"
 #include "rust-ast-resolve-pattern.h"
 #include "rust-ast-resolve-expr.h"

--- a/gcc/rust/resolve/rust-ast-resolve-struct-expr-field.h
+++ b/gcc/rust/resolve/rust-ast-resolve-struct-expr-field.h
@@ -20,7 +20,6 @@
 #define RUST_AST_RESOLVE_STRUCT_EXPR_FIELD
 
 #include "rust-ast-resolve-base.h"
-#include "rust-ast-full.h"
 
 namespace Rust {
 namespace Resolver {

--- a/gcc/rust/resolve/rust-ast-resolve-toplevel.h
+++ b/gcc/rust/resolve/rust-ast-resolve-toplevel.h
@@ -20,11 +20,8 @@
 #define RUST_AST_RESOLVE_TOPLEVEL_H
 
 #include "rust-ast-resolve-base.h"
-#include "rust-ast-resolve-type.h"
 #include "rust-ast-resolve-implitem.h"
-#include "rust-ast-full.h"
 #include "rust-name-resolver.h"
-#include "rust-session-manager.h"
 
 namespace Rust {
 namespace Resolver {

--- a/gcc/rust/resolve/rust-ast-resolve-type.h
+++ b/gcc/rust/resolve/rust-ast-resolve-type.h
@@ -21,7 +21,6 @@
 
 #include "rust-ast-resolve-base.h"
 #include "rust-ast-resolve-expr.h"
-#include "rust-ast-full.h"
 
 namespace Rust {
 namespace Resolver {

--- a/gcc/rust/resolve/rust-ast-resolve.h
+++ b/gcc/rust/resolve/rust-ast-resolve.h
@@ -20,7 +20,6 @@
 #define RUST_AST_RESOLVE_H
 
 #include "rust-name-resolver.h"
-#include "rust-ast-full.h"
 #include "rust-hir-map.h"
 
 namespace Rust {


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* hir/rust-ast-lower-implitem.h (RUST_AST_LOWER_IMPLITEM_H): cleanup header usage
	* hir/rust-ast-lower-item.cc: likewise
	* hir/rust-ast-lower-item.h (RUST_AST_LOWER_ITEM): likewise
	* hir/rust-ast-lower-stmt.cc: likewise
	* hir/rust-ast-lower-stmt.h (RUST_AST_LOWER_STMT): likewise
	* hir/rust-ast-lower-type.h: likewise
	* hir/rust-ast-lower.cc: likewise
	* hir/rust-ast-lower.h: likewise
	* resolve/rust-ast-resolve-expr.h: likewise
	* resolve/rust-ast-resolve-item.cc: likewise
	* resolve/rust-ast-resolve-item.h: likewise
	* resolve/rust-ast-resolve-stmt.cc: likewise
	* resolve/rust-ast-resolve-stmt.h: likewise
	* resolve/rust-ast-resolve-struct-expr-field.h: likewise
	* resolve/rust-ast-resolve-toplevel.h: likewise
	* resolve/rust-ast-resolve-type.h: likewise
	* resolve/rust-ast-resolve.h: likewise
