### PR TITLE
ast: Dump each MacroRule properly without the extra semicolon

### DIFF
--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -1532,7 +1532,6 @@ Dump::visit (MacroRule &rule)
   visit (rule.get_matcher ());
   stream << " => ";
   visit (rule.get_transcriber ().get_token_tree ());
-  stream << ";";
 }
 
 void


### PR DESCRIPTION
Having the extra semicolon causes parsing errors when importing macros
exported using the AST dump, as no rule expects multiple tokens after a
single macro rule definition.

gcc/rust/ChangeLog:

	* ast/rust-ast-dump.cc (Dump::visit): Remove extraneous semicolon when
	dumping macro rules.

