### PR TITLE
gccrs: Fix ICE on parsing trait object missing dyn keyword

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-item.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.cc
@@ -456,7 +456,17 @@ TypeCheckItem::visit (HIR::Module &module)
 void
 TypeCheckItem::visit (HIR::Trait &trait)
 {
-  TraitResolver::Resolve (trait);
+  TraitReference *trait_ref = TraitResolver::Resolve (trait);
+  if (trait_ref->is_error ())
+    {
+      infered = new TyTy::ErrorType (trait.get_mappings ().get_hirid ());
+      return;
+    }
+
+  RustIdent ident{CanonicalPath::create_empty (), trait.get_locus ()};
+  infered = new TyTy::DynamicObjectType (
+    trait.get_mappings ().get_hirid (), ident,
+    {TyTy::TypeBoundPredicate (*trait_ref, trait.get_locus ())});
 }
 
 void

--- a/gcc/testsuite/rust/compile/issue-2037.rs
+++ b/gcc/testsuite/rust/compile/issue-2037.rs
@@ -1,0 +1,13 @@
+trait Foo {
+    fn bar(&mut self, other: &mut Foo);
+}
+
+struct Baz;
+
+impl Foo for Baz {
+    fn bar(&mut self, other: &Foo) {}
+    // { dg-error "expected" "" { target *-*-* } .-1 }
+    // { dg-error "method .bar. has an incompatible type for trait .Foo." "" { target *-*-* } .-2 }
+}
+
+fn main() {}


### PR DESCRIPTION
Trait objects are not required to use the 'dyn' keyword though it is depreciated in later editions/version of Rustc. This patch handles the case when we query the type for an HIR::Item which happens to be an HIR::Trait and return a trait object or error.

Fixes #2037

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-item.cc (TypeCheckItem::visit): return a TraitObject

gcc/testsuite/ChangeLog:

	* rust/compile/issue-2037.rs: New test.