### PR TITLE
docker: Do not run update-alternatives on invalid path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,11 +64,6 @@ RUN /bin/sh -c set -ex; \
     echo '/usr/local/lib64' > /etc/ld.so.conf.d/local-lib64.conf; \
     ldconfig -v
 
-RUN /bin/sh -c set -ex; \
-    dpkg-divert --divert /usr/bin/gcc.orig --rename /usr/bin/gcc; \
-    dpkg-divert --divert /usr/bin/g++.orig --rename /usr/bin/g++; \
-    update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 999
-
 FROM rust:latest
 COPY --from=gcc-builder /usr/ /usr/
 COPY --from=gcc-builder /GCCRS_BUILD /GCCRS_BUILD


### PR DESCRIPTION
We do not need to set the system's compiler to `gccrs`, as we are mostly
interested in *having* gccrs - not necessarily using it as a C and C++
compiler as well.

ChangeLog:

	* Dockerfile: Remove update-alternatives invocation.

Fixes #2047