### PR TITLE
Add proper support for `pub(crate)`

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -413,7 +413,7 @@ public:
   {
     std::vector<AST::SimplePathSegment> single_segments
       = {AST::SimplePathSegment (std::move (str), locus)};
-    return SimplePath (std::move (single_segments));
+    return SimplePath (std::move (single_segments), false, locus);
   }
 
   const std::vector<SimplePathSegment> &get_segments () const

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -642,7 +642,7 @@ public:
   }
 
   // Returns whether a visibility has a path
-  bool has_path () const { return !(is_error ()) && vis_type == PUB_IN_PATH; }
+  bool has_path () const { return !is_error () && vis_type >= PUB_CRATE; }
 
   // Returns whether visibility is public or not.
   bool is_public () const { return vis_type != PRIV && !is_error (); }

--- a/gcc/rust/checks/errors/privacy/rust-visibility-resolver.cc
+++ b/gcc/rust/checks/errors/privacy/rust-visibility-resolver.cc
@@ -74,6 +74,16 @@ VisibilityResolver::resolve_module_path (const HIR::SimplePath &restriction,
   HirId ref;
   rust_assert (mappings.lookup_node_to_hir (ref_node_id, &ref));
 
+  auto crate = mappings.get_ast_crate (mappings.get_current_crate ());
+
+  // we may be dealing with pub(crate)
+  if (ref_node_id == crate.get_node_id ())
+    // FIXME: What do we do here? There isn't a DefId for the Crate, so can we
+    // actually do anything?
+    // We basically want to return true always but just when exporting export
+    // these items as private?
+    return true;
+
   auto module = mappings.lookup_module (ref);
   if (!module)
     {

--- a/gcc/rust/resolve/rust-ast-resolve-path.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-path.cc
@@ -283,6 +283,8 @@ ResolvePath::resolve_path (AST::SimplePath *expr)
 	  previous_resolved_node_id = module_scope_id;
 	  resolver->insert_resolved_name (segment.get_node_id (),
 					  module_scope_id);
+	  resolved_node_id = module_scope_id;
+
 	  continue;
 	}
       else if (segment.is_super_path_seg ())
@@ -298,6 +300,8 @@ ResolvePath::resolve_path (AST::SimplePath *expr)
 	  previous_resolved_node_id = module_scope_id;
 	  resolver->insert_resolved_name (segment.get_node_id (),
 					  module_scope_id);
+	  resolved_node_id = module_scope_id;
+
 	  continue;
 	}
 

--- a/gcc/testsuite/rust/compile/privacy8.rs
+++ b/gcc/testsuite/rust/compile/privacy8.rs
@@ -1,0 +1,1 @@
+pub(crate) struct Foo; // { dg-warning "struct is never constructed" }


### PR DESCRIPTION
- ast: Fix location for pub(crate)
- resolver: Allow SimplePath to resolve to their root segment
- privacy: Check for pub(crate) when resolving visibility path.

Fixes #2000
Fixes #1448

This causes the function to return true and the checks to pass, but it
requires more thinking - how should we deal with pub(crate) in the current system?
Should we simply treat it as a pub item in the current crate, but export it as
a private item in the metadata?

I'll look into this more in the coming days.
