### PR TITLE
gccrs: Fix bad cast error to bool

### DIFF
--- a/gcc/rust/typecheck/rust-casts.cc
+++ b/gcc/rust/typecheck/rust-casts.cc
@@ -80,7 +80,6 @@ TypeCastRules::cast_rules ()
 	    switch (to.get_ty ()->get_kind ())
 	      {
 	      case TyTy::TypeKind::CHAR:
-	      case TyTy::TypeKind::BOOL:
 	      case TyTy::TypeKind::USIZE:
 	      case TyTy::TypeKind::ISIZE:
 	      case TyTy::TypeKind::UINT:

--- a/gcc/testsuite/rust/compile/cast4.rs
+++ b/gcc/testsuite/rust/compile/cast4.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let a: i32 = 123;
+    let u = a as bool;
+    // { dg-error "invalid cast .i32. to .bool." "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
In rust is not allowed to cast from int to bool. This patch handles the case when we cast a integer to bool with 'as bool'

Fixes #2026

gcc/rust/ChangeLog:

	* typecheck/rust-casts.cc (TypeCastRules::cast_rules): BOOL removed from switch cases

gcc/testsuite/ChangeLog:

	* rust/compile/cast4.rs: New test.

Here is a checklist to help you with your PR.

- [x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- [x] Read contributing guidlines
- [x] `make check-rust` passes locally
- [x] Run `clang-format`
- [x] Added any relevant test cases to `gcc/testsuite/rust/`

<img width="862" alt="Screenshot 2023-03-29 at 01 15 40" src="https://user-images.githubusercontent.com/100081325/228405275-be038484-a758-4810-8fb3-e9b3832139ac.png">
