### PR TITLE
Fix bad handling of generic lifetimes

### DIFF
--- a/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
+++ b/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
@@ -201,7 +201,7 @@ PrivacyReporter::check_base_type_privacy (Analysis::NodeMapping &node_mappings,
     case TyTy::INFER:
       return;
     case TyTy::ERROR:
-      rust_unreachable ();
+      return;
     }
 }
 

--- a/gcc/rust/resolve/rust-ast-resolve-item.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-item.cc
@@ -142,13 +142,8 @@ ResolveTraitItems::visit (AST::TraitItemMethod &func)
 
   if (self_param.has_type ())
     {
-      if (self_param.get_has_ref ())
-	{
-	  // FIXME is this true?
-	  rust_error_at (
-	    self_param.get_locus (),
-	    "it is not possible to mark self as reference and specify type");
-	}
+      // This shouldn't happen the parser should already error for this
+      rust_assert (!self_param.get_has_ref ());
       ResolveType::go (self_param.get_type ().get ());
     }
   else
@@ -655,13 +650,8 @@ ResolveItem::visit (AST::Method &method)
 
   if (self_param.has_type ())
     {
-      if (self_param.get_has_ref ())
-	{
-	  // FIXME is this true?
-	  rust_error_at (
-	    self_param.get_locus (),
-	    "it is not possible to mark self as reference and specify type");
-	}
+      // This shouldn't happen the parser should already error for this
+      rust_assert (!self_param.get_has_ref ());
       ResolveType::go (self_param.get_type ().get ());
     }
   else

--- a/gcc/rust/resolve/rust-ast-resolve-item.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-item.cc
@@ -138,15 +138,30 @@ ResolveTraitItems::visit (AST::TraitItemMethod &func)
 				       self_param.get_has_ref (),
 				       self_param.get_is_mut (),
 				       std::unique_ptr<AST::Pattern> (nullptr));
-
-  std::vector<std::unique_ptr<AST::TypePathSegment>> segments;
-  segments.push_back (std::unique_ptr<AST::TypePathSegment> (
-    new AST::TypePathSegment ("Self", false, self_param.get_locus ())));
-
-  AST::TypePath self_type_path (std::move (segments), self_param.get_locus ());
-
-  ResolveType::go (&self_type_path);
   PatternDeclaration::go (&self_pattern, Rib::ItemType::Param);
+
+  if (self_param.has_type ())
+    {
+      if (self_param.get_has_ref ())
+	{
+	  // FIXME is this true?
+	  rust_error_at (
+	    self_param.get_locus (),
+	    "it is not possible to mark self as reference and specify type");
+	}
+      ResolveType::go (self_param.get_type ().get ());
+    }
+  else
+    {
+      // here we implicitly make self have a type path of Self
+      std::vector<std::unique_ptr<AST::TypePathSegment>> segments;
+      segments.push_back (std::unique_ptr<AST::TypePathSegment> (
+	new AST::TypePathSegment ("Self", false, self_param.get_locus ())));
+
+      AST::TypePath self_type_path (std::move (segments),
+				    self_param.get_locus ());
+      ResolveType::go (&self_type_path);
+    }
 
   std::vector<PatternBinding> bindings
     = {PatternBinding (PatternBoundCtx::Product, std::set<Identifier> ())};
@@ -636,15 +651,30 @@ ResolveItem::visit (AST::Method &method)
 				       self_param.get_has_ref (),
 				       self_param.get_is_mut (),
 				       std::unique_ptr<AST::Pattern> (nullptr));
-
-  std::vector<std::unique_ptr<AST::TypePathSegment>> segments;
-  segments.push_back (std::unique_ptr<AST::TypePathSegment> (
-    new AST::TypePathSegment ("Self", false, self_param.get_locus ())));
-
-  AST::TypePath self_type_path (std::move (segments), self_param.get_locus ());
-
-  ResolveType::go (&self_type_path);
   PatternDeclaration::go (&self_pattern, Rib::ItemType::Param);
+
+  if (self_param.has_type ())
+    {
+      if (self_param.get_has_ref ())
+	{
+	  // FIXME is this true?
+	  rust_error_at (
+	    self_param.get_locus (),
+	    "it is not possible to mark self as reference and specify type");
+	}
+      ResolveType::go (self_param.get_type ().get ());
+    }
+  else
+    {
+      // here we implicitly make self have a type path of Self
+      std::vector<std::unique_ptr<AST::TypePathSegment>> segments;
+      segments.push_back (std::unique_ptr<AST::TypePathSegment> (
+	new AST::TypePathSegment ("Self", false, self_param.get_locus ())));
+
+      AST::TypePath self_type_path (std::move (segments),
+				    self_param.get_locus ());
+      ResolveType::go (&self_type_path);
+    }
 
   std::vector<PatternBinding> bindings
     = {PatternBinding (PatternBoundCtx::Product, std::set<Identifier> ())};

--- a/gcc/rust/typecheck/rust-hir-type-check-path.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-path.cc
@@ -280,14 +280,6 @@ TypeCheckExpr::resolve_root_path (HIR::PathInExpression &expr, size_t *offset,
       // turbo-fish segment path::<ty>
       if (seg.has_generic_args ())
 	{
-	  if (!lookup->has_subsititions_defined ())
-	    {
-	      rust_error_at (expr.get_locus (),
-			     "substitutions not supported for %s",
-			     root_tyty->as_string ().c_str ());
-	      return new TyTy::ErrorType (expr.get_mappings ().get_hirid ());
-	    }
-
 	  lookup = SubstMapper::Resolve (lookup, expr.get_locus (),
 					 &seg.get_generic_args ());
 	  if (lookup->get_kind () == TyTy::TypeKind::ERROR)
@@ -456,13 +448,6 @@ TypeCheckExpr::resolve_segments (NodeId root_resolved_node_id,
 
       if (seg.has_generic_args ())
 	{
-	  if (!tyseg->has_subsititions_defined ())
-	    {
-	      rust_error_at (expr_locus, "substitutions not supported for %s",
-			     tyseg->as_string ().c_str ());
-	      return;
-	    }
-
 	  tyseg = SubstMapper::Resolve (tyseg, expr_locus,
 					&seg.get_generic_args ());
 	  if (tyseg->get_kind () == TyTy::TypeKind::ERROR)

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -398,17 +398,10 @@ TypeCheckType::resolve_root_path (HIR::TypePath &path, size_t *offset,
 	  HIR::TypePathSegmentGeneric *generic_segment
 	    = static_cast<HIR::TypePathSegmentGeneric *> (seg.get ());
 
-	  if (!lookup->has_subsititions_defined ())
-	    {
-	      rust_error_at (path.get_locus (),
-			     "TypePath %s declares generic arguments but the "
-			     "type %s does not have any",
-			     path.as_string ().c_str (),
-			     lookup->as_string ().c_str ());
-	      return new TyTy::ErrorType (lookup->get_ref ());
-	    }
 	  lookup = SubstMapper::Resolve (lookup, path.get_locus (),
 					 &generic_segment->get_generic_args ());
+	  if (lookup->get_kind () == TyTy::TypeKind::ERROR)
+	    return new TyTy::ErrorType (seg->get_mappings ().get_hirid ());
 	}
       else if (lookup->needs_generic_substitutions ())
 	{
@@ -493,13 +486,6 @@ TypeCheckType::resolve_segments (
 	{
 	  HIR::TypePathSegmentGeneric *generic_segment
 	    = static_cast<HIR::TypePathSegmentGeneric *> (seg.get ());
-
-	  if (!tyseg->has_subsititions_defined ())
-	    {
-	      rust_error_at (expr_locus, "substitutions not supported for %s",
-			     tyseg->as_string ().c_str ());
-	      return new TyTy::ErrorType (expr_id);
-	    }
 
 	  tyseg = SubstMapper::Resolve (tyseg, expr_locus,
 					&generic_segment->get_generic_args ());

--- a/gcc/rust/typecheck/rust-tyty-bounds.cc
+++ b/gcc/rust/typecheck/rust-tyty-bounds.cc
@@ -271,7 +271,7 @@ namespace TyTy {
 
 TypeBoundPredicate::TypeBoundPredicate (
   const Resolver::TraitReference &trait_reference, Location locus)
-  : SubstitutionRef ({}, SubstitutionArgumentMappings::error ()),
+  : SubstitutionRef ({}, SubstitutionArgumentMappings::empty ()),
     reference (trait_reference.get_mappings ().get_defid ()), locus (locus),
     error_flag (false)
 {
@@ -286,7 +286,7 @@ TypeBoundPredicate::TypeBoundPredicate (
 
 TypeBoundPredicate::TypeBoundPredicate (
   DefId reference, std::vector<SubstitutionParamMapping> subst, Location locus)
-  : SubstitutionRef ({}, SubstitutionArgumentMappings::error ()),
+  : SubstitutionRef ({}, SubstitutionArgumentMappings::empty ()),
     reference (reference), locus (locus), error_flag (false)
 {
   substitutions.clear ();
@@ -299,7 +299,7 @@ TypeBoundPredicate::TypeBoundPredicate (
 }
 
 TypeBoundPredicate::TypeBoundPredicate (const TypeBoundPredicate &other)
-  : SubstitutionRef ({}, SubstitutionArgumentMappings::error ()),
+  : SubstitutionRef ({}, SubstitutionArgumentMappings::empty ()),
     reference (other.reference), locus (other.locus),
     error_flag (other.error_flag)
 {
@@ -337,7 +337,7 @@ TypeBoundPredicate::operator= (const TypeBoundPredicate &other)
   reference = other.reference;
   locus = other.locus;
   error_flag = other.error_flag;
-  used_arguments = SubstitutionArgumentMappings::error ();
+  used_arguments = SubstitutionArgumentMappings::empty ();
 
   substitutions.clear ();
   for (const auto &p : other.get_substs ())

--- a/gcc/rust/typecheck/rust-tyty-subst.cc
+++ b/gcc/rust/typecheck/rust-tyty-subst.cc
@@ -236,16 +236,17 @@ SubstitutionArg::as_string () const
 SubstitutionArgumentMappings::SubstitutionArgumentMappings (
   std::vector<SubstitutionArg> mappings,
   std::map<std::string, BaseType *> binding_args, Location locus,
-  ParamSubstCb param_subst_cb, bool trait_item_flag)
+  ParamSubstCb param_subst_cb, bool trait_item_flag, bool error_flag)
   : mappings (mappings), binding_args (binding_args), locus (locus),
-    param_subst_cb (param_subst_cb), trait_item_flag (trait_item_flag)
+    param_subst_cb (param_subst_cb), trait_item_flag (trait_item_flag),
+    error_flag (error_flag)
 {}
 
 SubstitutionArgumentMappings::SubstitutionArgumentMappings (
   const SubstitutionArgumentMappings &other)
   : mappings (other.mappings), binding_args (other.binding_args),
     locus (other.locus), param_subst_cb (nullptr),
-    trait_item_flag (other.trait_item_flag)
+    trait_item_flag (other.trait_item_flag), error_flag (other.error_flag)
 {}
 
 SubstitutionArgumentMappings &
@@ -257,6 +258,7 @@ SubstitutionArgumentMappings::operator= (
   locus = other.locus;
   param_subst_cb = nullptr;
   trait_item_flag = other.trait_item_flag;
+  error_flag = other.error_flag;
 
   return *this;
 }
@@ -264,13 +266,21 @@ SubstitutionArgumentMappings::operator= (
 SubstitutionArgumentMappings
 SubstitutionArgumentMappings::error ()
 {
-  return SubstitutionArgumentMappings ({}, {}, Location (), nullptr, false);
+  return SubstitutionArgumentMappings ({}, {}, Location (), nullptr, false,
+				       true);
+}
+
+SubstitutionArgumentMappings
+SubstitutionArgumentMappings::empty ()
+{
+  return SubstitutionArgumentMappings ({}, {}, Location (), nullptr, false,
+				       false);
 }
 
 bool
 SubstitutionArgumentMappings::is_error () const
 {
-  return mappings.size () == 0;
+  return error_flag;
 }
 
 bool

--- a/gcc/rust/typecheck/rust-tyty-subst.h
+++ b/gcc/rust/typecheck/rust-tyty-subst.h
@@ -109,7 +109,8 @@ public:
 				std::map<std::string, BaseType *> binding_args,
 				Location locus,
 				ParamSubstCb param_subst_cb = nullptr,
-				bool trait_item_flag = false);
+				bool trait_item_flag = false,
+				bool error_flag = false);
 
   SubstitutionArgumentMappings (const SubstitutionArgumentMappings &other);
   SubstitutionArgumentMappings &
@@ -120,6 +121,7 @@ public:
     = default;
 
   static SubstitutionArgumentMappings error ();
+  static SubstitutionArgumentMappings empty ();
 
   bool is_error () const;
 
@@ -161,6 +163,7 @@ private:
   Location locus;
   ParamSubstCb param_subst_cb;
   bool trait_item_flag;
+  bool error_flag;
 };
 
 class SubstitutionRef

--- a/gcc/testsuite/rust/compile/const_generics_5.rs
+++ b/gcc/testsuite/rust/compile/const_generics_5.rs
@@ -1,15 +1,12 @@
-// bogus errors but shows the type checking system needs to support const
-// generics with defaults
-
+// { dg-options "-w" }
 struct Foo<const N: usize = { 14 }>;
 
 const M: usize = 15;
-type N = Foo<3>; // { dg-error "TypePath Foo<> declares generic arguments but the type Foo{Foo {}} does not have any" }
+type N = Foo<3>;
 
 fn main() {
-    let _: Foo<15> = Foo; // { dg-error "TypePath Foo<> declares generic arguments but the type Foo{Foo {}} does not have any" }
-    let _: Foo<{ M }> = Foo; // { dg-error "TypePath Foo<> declares generic arguments but the type Foo{Foo {}} does not have any" }
-    let _: Foo<M> = Foo; // { dg-error "TypePath Foo<> declares generic arguments but the type Foo{Foo {}} does not have any" }
-
-    let _: Foo<N> = Foo; // { dg-error "TypePath Foo<N> declares generic arguments but the type Foo{Foo {}} does not have any" }
+    let _: Foo<15> = Foo;
+    let _: Foo<{ M }> = Foo;
+    let _: Foo<M> = Foo;
+    // let _: Foo<N> = Foo; this causes an ICE we need to do const generics
 }

--- a/gcc/testsuite/rust/compile/issue-2039.rs
+++ b/gcc/testsuite/rust/compile/issue-2039.rs
@@ -1,0 +1,22 @@
+// { dg-options "-w" }
+pub struct Lexer<'a> {
+    input: &'a str,
+}
+
+impl<'a> Lexer<'a> {
+    pub fn new(input: &'a str) -> Lexer<'a> {
+        Lexer { input: input }
+    }
+}
+
+struct Parser<'a> {
+    lexer: &'a mut Lexer<'a>,
+}
+
+impl<'a> Parser<'a> {
+    pub fn new(lexer: &'a mut Lexer) -> Parser<'a> {
+        Parser { lexer: lexer }
+    }
+}
+
+fn main() {}

--- a/gcc/testsuite/rust/compile/issue-2043.rs
+++ b/gcc/testsuite/rust/compile/issue-2043.rs
@@ -1,0 +1,12 @@
+struct Foo<'a> {
+    // { dg-warning "struct is never constructed: .Foo." "" { target *-*-* } .-1 }
+    data: &'a [u8],
+}
+
+impl<'a> Foo<'a> {
+    fn bar(self: &mut Foo<'a>) {}
+    // { dg-warning "associated function is never used: .bar." "" { target *-*-* } .-1 }
+    // { dg-warning "unused name .self." "" { target *-*-* } .-2 }
+}
+
+fn main() {}


### PR DESCRIPTION
There were a few small issues going on here:

  - Missing name resolution for self parameters with a specified type
  - When we handle lifetime generics the argument mappings were empty
    - They ended up being treated as errors wrongly but there is a difference between empty and error
  - Remove bad check for does type support generics we can rely on the type's error handling here

Fixes #2039 #2043 