### PR TITLE
gccrs: fix ICE when closure body is not a block

### DIFF
--- a/gcc/testsuite/rust/execute/torture/issue-2052.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-2052.rs
@@ -1,0 +1,15 @@
+#[lang = "fn_once"]
+pub trait FnOnce<Args> {
+    #[lang = "fn_once_output"]
+    type Output;
+
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+}
+
+pub fn f() -> i32 {
+    (|| 42)()
+}
+
+pub fn main() -> i32 {
+    f() - 42
+}


### PR DESCRIPTION
Fixes: #2052

gcc/rust/ChangeLog:

	* backend/rust-compile-expr.cc (CompileExpr::generate_closure_function):
	  when its not a block we dont have any ribs to generate locals from

gcc/testsuite/ChangeLog:

	* rust/execute/torture/issue-2052.rs: New test.