### PR TITLE
gccrs: Add missing known attribute stable

### DIFF
--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -46,7 +46,8 @@ static const BuiltinAttrDefinition __definitions[]
      {"target_feature", CODE_GENERATION},
      // From now on, these are reserved by the compiler and gated through
      // #![feature(rustc_attrs)]
-     {"rustc_inherit_overflow_checks", CODE_GENERATION}};
+     {"rustc_inherit_overflow_checks", CODE_GENERATION},
+     {"stable", STATIC_ANALYSIS}};
 
 BuiltinAttributeMappings *
 BuiltinAttributeMappings::get ()


### PR DESCRIPTION
Fixes #2025

gcc/rust/ChangeLog:

	* util/rust-attributes.cc: Add stable to the table of known attributes

