### PR TITLE
enr: Handle #[macro_use] attribute properly

### DIFF
--- a/gcc/testsuite/rust/compile/macro_use1.rs
+++ b/gcc/testsuite/rust/compile/macro_use1.rs
@@ -1,0 +1,15 @@
+#[macro_use]
+mod foo {
+    macro_rules! a {
+        () => {};
+    }
+
+    macro_rules! b {
+        () => {};
+    }
+}
+
+fn main() {
+    a!();
+    b!();
+}

--- a/gcc/testsuite/rust/execute/torture/macro_use1.rs
+++ b/gcc/testsuite/rust/execute/torture/macro_use1.rs
@@ -1,0 +1,18 @@
+#[macro_use]
+mod foo {
+    macro_rules! a {
+        () => {
+            15
+        };
+    }
+
+    macro_rules! b {
+        () => {
+            14
+        };
+    }
+}
+
+fn main() -> i32 {
+    a!() + b!() - 29
+}


### PR DESCRIPTION
This commit adds the basics related to handling the #[macro_use] attribute in our current expansion pipeline.

This does not yet support nested #[macro_use] modules or the variant specifying identifiers (#[macro_use(foo, bar)]) but is enough for libcore 1.49 module macro imports.

Addresses #1077 

gcc/rust/ChangeLog:

	* resolve/rust-early-name-resolver.cc (is_macro_export): New function.
	(is_macro_use_module): New function.
	(EarlyNameResolver::visit): Add base handling for #[macro_use] on modules.

gcc/testsuite/ChangeLog:

	* rust/compile/macro_use1.rs: New test.
	* rust/execute/torture/macro_use1.rs: New test.

We are now no longer getting errors about macros not being found in libcore, and have instead went to some builtin macros not existing, so, progress!