### PR TITLE
gccrs: Fix bad cast as a char

### DIFF
--- a/gcc/rust/typecheck/rust-casts.cc
+++ b/gcc/rust/typecheck/rust-casts.cc
@@ -64,7 +64,6 @@ TypeCastRules::cast_rules ()
 
   rust_debug ("cast_rules from={%s} to={%s}", from_type->debug_str ().c_str (),
 	      to.get_ty ()->debug_str ().c_str ());
-
   switch (from_type->get_kind ())
     {
       case TyTy::TypeKind::INFER: {
@@ -79,7 +78,21 @@ TypeCastRules::cast_rules ()
 	  case TyTy::InferType::InferTypeKind::INTEGRAL:
 	    switch (to.get_ty ()->get_kind ())
 	      {
-	      case TyTy::TypeKind::CHAR:
+		case TyTy::TypeKind::CHAR: {
+		  // only u8 and char
+		  bool was_uint
+		    = from.get_ty ()->get_kind () == TyTy::TypeKind::UINT;
+		  bool was_u8
+		    = was_uint
+		      && (static_cast<TyTy::UintType *> (from.get_ty ())
+			    ->get_uint_kind ()
+			  == TyTy::UintType::UintKind::U8);
+		  if (was_u8)
+		    return TypeCoercionRules::CoercionResult{
+		      {}, to.get_ty ()->clone ()};
+		}
+		break;
+
 	      case TyTy::TypeKind::USIZE:
 	      case TyTy::TypeKind::ISIZE:
 	      case TyTy::TypeKind::UINT:

--- a/gcc/testsuite/rust/compile/cast5.rs
+++ b/gcc/testsuite/rust/compile/cast5.rs
@@ -1,0 +1,12 @@
+fn main() {
+    const A: char = 0x1F888 as char;
+    // { dg-error "invalid cast .<integer>. to .char." "" { target *-*-* } .-1 }
+    const B: char = 129160 as char;
+    // { dg-error "invalid cast .<integer>. to .char." "" { target *-*-* } .-1 }
+    const C: i32 = 42;
+    const D: char = C as char;
+    // { dg-error "invalid cast .i32. to .char." "" { target *-*-* } .-1 }
+    const E: char = '\u{01F888}';
+    const F: u8 = 42; 
+    const G: char= F as char;
+}


### PR DESCRIPTION
In rust cast to char is allowed only from u8 type. This patch handles fix the case when the type is infered from an integer value, allowing only the u8 case'

Fixes #2027

gcc/rust/ChangeLog:

	* typecheck/rust-casts.cc (TypeCastRules::cast_rules): case INTEGRAL handles TypeKind::CHAR

gcc/testsuite/ChangeLog:

	* rust/compile/cast5.rs: New test.

- [x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- [x] Read contributing guidlines
- [x] `make check-rust` passes locally
- [x] Run `clang-format`
- [x] Added any relevant test cases to `gcc/testsuite/rust/`