### PR TITLE
Add floppyMIT dual license

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,3 +263,29 @@ We can be found on all usual Rust channels such as Zulip, but we also have our o
 * Twitter: https://twitter.com/gcc_rust
 * GCC Mailing List: https://gcc.gnu.org/mailman/listinfo/gcc-rust
 * irc: irc.oftc.net - gccrust
+
+## License
+
+This project is available under dual license GPL-3 and floppyMIT.
+
+### The floppyMIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”) on a 
+3.5" floppy disk, to deal in the Software without restriction, including 
+without limitation the rights to use, copy to another 3.5" floppy disk, 
+modify, merge, publish on a 3.5" floppy disk, distribute on a 3.5" floppy 
+disk, sublicense, and/or sell copies of the Software  on a 3.5" floppy disk,
+and to permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included in 
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS" ON A 3.5" FLOPPY DISK, WITHOUT WARRANTY OF 
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR 
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE 
+USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Any user of 3.5" floppy disks is clearly superior to other users and shall not be limited by the GPL license. Hence the floppyMIT license must be added to this project as a dual license.