### PR TITLE
gccrs: Fix ICE using constructors for intilizers in statics

### DIFF
--- a/gcc/rust/backend/rust-compile-item.cc
+++ b/gcc/rust/backend/rust-compile-item.cc
@@ -18,9 +18,7 @@
 
 #include "rust-compile-item.h"
 #include "rust-compile-implitem.h"
-#include "rust-compile-expr.h"
 #include "rust-compile-extern.h"
-#include "rust-constexpr.h"
 
 namespace Rust {
 namespace Compile {
@@ -66,7 +64,9 @@ CompileItem::visit (HIR::StaticItem &var)
     = ctx->get_backend ()->global_variable (name, asm_name, type, is_external,
 					    is_hidden, in_unique_section,
 					    var.get_locus ());
-  ctx->get_backend ()->global_variable_set_init (static_global, value);
+
+  tree init = value == error_mark_node ? error_mark_node : DECL_INITIAL (value);
+  ctx->get_backend ()->global_variable_set_init (static_global, init);
 
   ctx->insert_var_decl (var.get_mappings ().get_hirid (), static_global);
   ctx->push_var (static_global);

--- a/gcc/testsuite/rust/execute/torture/issue-2080.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-2080.rs
@@ -1,0 +1,26 @@
+// { dg-output "hello world: gccrs\n" }
+// { dg-additional-options "-w" }
+static TEST_1: &str = "gccrs";
+static TEST_2: i32 = 123;
+
+struct Foo(i32, bool);
+static TEST_3: Foo = Foo(123, false);
+
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+fn main() -> i32 {
+    unsafe {
+        let a1 = "hello world: %s\n";
+        let b1 = a1 as *const str;
+        let c1 = b1 as *const i8;
+
+        let a2 = TEST_1;
+        let b2 = a2 as *const str;
+        let c2 = b2 as *const i8;
+
+        printf(c1, c2);
+    }
+    0
+}


### PR DESCRIPTION
We are getting constant expressions for the initilizers for static items this hits an assertion in the GCC middle-end which is looking for a constructor so we need to unwrap the constant expression using DECL_INITIAL as the initilizer to the global static.

Fixes #2080

gcc/rust/ChangeLog:

	* backend/rust-compile-item.cc (CompileItem::visit): unwrap the constant expression

gcc/testsuite/ChangeLog:

	* rust/execute/torture/issue-2080.rs: New test.