### PR TITLE
break rust 💥

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -39,7 +39,7 @@ class ASTVisitor;
 using AttrVec = std::vector<Attribute>;
 
 // The available kinds of AST Nodes
-enum Kind
+enum class Kind
 {
   UNKNOWN,
   MACRO_RULES_DEFINITION,

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -44,6 +44,7 @@ enum class Kind
   UNKNOWN,
   MACRO_RULES_DEFINITION,
   MACRO_INVOCATION,
+  IDENTIFIER,
 };
 
 class Visitable
@@ -1071,6 +1072,8 @@ public:
   {
     outer_attrs = std::move (new_attrs);
   }
+
+  Kind get_ast_kind () const override { return Kind::IDENTIFIER; }
 
 protected:
   // Clone method implementation

--- a/gcc/rust/expand/rust-macro-builtins.cc
+++ b/gcc/rust/expand/rust-macro-builtins.cc
@@ -612,7 +612,7 @@ MacroBuiltin::concat_handler (Location invoc_locus, AST::MacroInvocData &invoc)
   for (auto &expr : expanded_expr)
     {
       if (!expr->is_literal ()
-	  && expr->get_ast_kind () != AST::MACRO_INVOCATION)
+	  && expr->get_ast_kind () != AST::Kind::MACRO_INVOCATION)
 	{
 	  has_error = true;
 	  rust_error_at (expr->get_locus (), "expected a literal");

--- a/gcc/rust/resolve/rust-ast-resolve-expr.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.cc
@@ -29,9 +29,9 @@ namespace Resolver {
 
 void
 ResolveExpr::go (AST::Expr *expr, const CanonicalPath &prefix,
-		 const CanonicalPath &canonical_prefix)
+		 const CanonicalPath &canonical_prefix, bool funny_error)
 {
-  ResolveExpr resolver (prefix, canonical_prefix);
+  ResolveExpr resolver (prefix, canonical_prefix, funny_error);
   expr->accept_vis (resolver);
 }
 
@@ -643,8 +643,10 @@ ResolveExpr::resolve_closure_param (AST::ClosureParam &param,
 }
 
 ResolveExpr::ResolveExpr (const CanonicalPath &prefix,
-			  const CanonicalPath &canonical_prefix)
-  : ResolverBase (), prefix (prefix), canonical_prefix (canonical_prefix)
+			  const CanonicalPath &canonical_prefix,
+			  bool funny_error)
+  : ResolverBase (), prefix (prefix), canonical_prefix (canonical_prefix),
+    funny_error (funny_error)
 {}
 
 } // namespace Resolver

--- a/gcc/rust/resolve/rust-ast-resolve-expr.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.cc
@@ -23,6 +23,7 @@
 #include "rust-ast-resolve-type.h"
 #include "rust-ast-resolve-pattern.h"
 #include "rust-ast-resolve-path.h"
+#include "diagnostic.h"
 
 namespace Rust {
 namespace Resolver {
@@ -105,6 +106,45 @@ ResolveExpr::visit (AST::AssignmentExpr &expr)
   VerifyAsignee::go (expr.get_left_expr ().get ());
 }
 
+/* The "break rust" Easter egg.
+
+   Backstory: once upon a time, there used to be a bug in rustc: it would ICE
+   during typechecking on a 'break' with an expression outside of a loop.  The
+   issue has been reported [0] and fixed [1], but in recognition of this, as a
+   special Easter egg, "break rust" was made to intentionally cause an ICE.
+
+   [0]: https://github.com/rust-lang/rust/issues/43162
+   [1]: https://github.com/rust-lang/rust/pull/43745
+
+   This was made in a way that does not break valid programs: namely, it only
+   happens when the 'break' is outside of a loop (so invalid anyway).
+
+   GCC Rust supports this essential feature as well, but in a slightly
+   different way.  Instead of delaying the error until type checking, we emit
+   it here in the resolution phase.  We, too, only do this to programs that
+   are already invalid: we only emit our funny ICE if the name "rust" (which
+   must be immediately inside a break-with-a-value expression) fails to
+   resolve.  Note that "break (rust)" does not trigger our ICE, only using
+   "break rust" directly does, and only if there's no "rust" in scope.  We do
+   this in the same way regardless of whether the "break" is outside of a loop
+   or inside one.
+
+   As a GNU extension, we also support "break gcc", much to the same effect,
+   subject to the same rules.  */
+
+/* The finalizer for our funny ICE.  This prints a custom message instead of
+   the default bug reporting instructions, as there is no bug to report.  */
+
+static void ATTRIBUTE_NORETURN
+funny_ice_finalizer (diagnostic_context *context, diagnostic_info *diagnostic,
+		     diagnostic_t diag_kind)
+{
+  gcc_assert (diag_kind == DK_ICE_NOBT);
+  default_diagnostic_finalizer (context, diagnostic, diag_kind);
+  fnotice (stderr, "You have broken GCC Rust. This is a feature.\n");
+  exit (ICE_EXIT_CODE);
+}
+
 void
 ResolveExpr::visit (AST::IdentifierExpr &expr)
 {
@@ -119,6 +159,17 @@ ResolveExpr::visit (AST::IdentifierExpr &expr)
 	     &resolved_node))
     {
       resolver->insert_resolved_type (expr.get_node_id (), resolved_node);
+    }
+  else if (funny_error)
+    {
+      /* This was a "break rust" or "break gcc", and the identifier failed to
+	 resolve.  Emit a funny ICE.  We set the finalizer to our custom one,
+	 and use the lower-level emit_diagnostic () instead of the more common
+	 internal_error_no_backtrace () in order to pass our locus.  */
+      diagnostic_finalizer (global_dc) = funny_ice_finalizer;
+      emit_diagnostic (DK_ICE_NOBT, expr.get_locus ().gcc_location (), -1,
+		       "are you trying to break %s? how dare you?",
+		       expr.as_string ().c_str ());
     }
   else
     {
@@ -376,7 +427,24 @@ ResolveExpr::visit (AST::BreakExpr &expr)
     }
 
   if (expr.has_break_expr ())
-    ResolveExpr::go (expr.get_break_expr ().get (), prefix, canonical_prefix);
+    {
+      bool funny_error = false;
+      AST::Expr &break_expr = *expr.get_break_expr ().get ();
+      if (break_expr.get_ast_kind () == AST::Kind::IDENTIFIER)
+	{
+	  /* This is a break with an expression, and the expression is just a
+	     single identifier.  See if the identifier is either "rust" or
+	     "gcc", in which case we have "break rust" or "break gcc", and so
+	     may need to emit our funny error.  We cannot yet emit the error
+	     here though, because the identifier may still be in scope, and
+	     ICE'ing on valid programs would not be very funny.  */
+	  std::string ident
+	    = static_cast<AST::IdentifierExpr &> (break_expr).as_string ();
+	  if (ident == "rust" || ident == "gcc")
+	    funny_error = true;
+	}
+      ResolveExpr::go (&break_expr, prefix, canonical_prefix, funny_error);
+    }
 }
 
 void

--- a/gcc/rust/resolve/rust-ast-resolve-expr.h
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.h
@@ -31,7 +31,8 @@ class ResolveExpr : public ResolverBase
 
 public:
   static void go (AST::Expr *expr, const CanonicalPath &prefix,
-		  const CanonicalPath &canonical_prefix);
+		  const CanonicalPath &canonical_prefix,
+		  bool funny_error = false);
 
   void visit (AST::TupleIndexExpr &expr) override;
   void visit (AST::TupleExpr &expr) override;
@@ -83,10 +84,11 @@ protected:
 
 private:
   ResolveExpr (const CanonicalPath &prefix,
-	       const CanonicalPath &canonical_prefix);
+	       const CanonicalPath &canonical_prefix, bool funny_error);
 
   const CanonicalPath &prefix;
   const CanonicalPath &canonical_prefix;
+  bool funny_error;
 };
 
 } // namespace Resolver

--- a/gcc/testsuite/lib/prune.exp
+++ b/gcc/testsuite/lib/prune.exp
@@ -158,6 +158,7 @@ proc prune_file_path { text } {
 proc prune_ices { text } {
   regsub -all "(^|\n)\[^\n\]*: internal compiler error:.*\nSee \[^\n\]*" $text "" text
   regsub -all "(^|\n|')*Internal compiler error:.*\nSee \[^\n\]*" $text "" text
+  regsub -all "(^|\n)\[^\n\]*: internal compiler error:.*\nYou have broken GCC Rust. This is a feature." $text "" text
   return $text
 }
 

--- a/gcc/testsuite/rust/compile/break-rust1.rs
+++ b/gcc/testsuite/rust/compile/break-rust1.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let rust = "crab";
+    let res = loop {
+        // { dg-warning "unused name" "" { target *-*-* } .-1 }
+        break rust;
+    };
+}

--- a/gcc/testsuite/rust/compile/break-rust2.rs
+++ b/gcc/testsuite/rust/compile/break-rust2.rs
@@ -1,0 +1,4 @@
+fn main() {
+    break (rust);
+    // { dg-error "failed to find name: rust" "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/compile/break-rust3.rs
+++ b/gcc/testsuite/rust/compile/break-rust3.rs
@@ -1,0 +1,4 @@
+fn main() {
+    break rust;
+    // { dg-ice "are you trying to break rust? how dare you?" }
+}


### PR DESCRIPTION
Since https://github.com/Rust-GCC/gccrs/issues/1996 has received positive feedback, here's a tentative implementation 😄

TODO:
- [x] Better / funnier error message
  * Suggestions welcome!
  * ...or is the current one fine?
  * It would be nice to make it a little bit more explicit that this is not _really_ an ICE, there is no bug to report, etc.
    * rustc says: "the compiler expectedly panicked. this is a feature."
- [x] Fix/verify Changelog entries
  * I've no idea how to do GNU-style changelogs! I've read [this doc](https://www.gnu.org/prep/standards/html_node/Change-Logs.html) and skimmed through some other gccrs commits, and tried to write some entries based on that
  * glibc people have accepted my patches without Changelog entries; are they really required?
- [x] Try to make the error point at the whole statement and not just the name
  * Or... is it worth it?
- [x] Tests!
  * `make check-rust` seems to pass locally, that's a start
  * Need to test that `break rust` and `break gcc` still compile just fine if `rust`/`gcc` is actually in scope
  * Need to test that `break (rust)` still causes the old error
  * How do I even test for something that is supposed to ICE?
- [x] clang-format is angry with me, need to appease it