### PR TITLE
parser: macro: reject separator in `?` repetition

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -2237,6 +2237,16 @@ Parser<ManagedTokenSource>::parse_macro_match_repetition ()
     case QUESTION_MARK:
       op = AST::MacroMatchRepetition::ZERO_OR_ONE;
       lexer.skip_token ();
+
+      if (separator != nullptr)
+	{
+	  add_error (
+	    Error (separator->get_locus (),
+		   "the %<?%> macro repetition operator does not take a "
+		   "separator"));
+	  separator = nullptr;
+	}
+
       break;
     default:
       add_error (

--- a/gcc/testsuite/rust/compile/macro-issue2092.rs
+++ b/gcc/testsuite/rust/compile/macro-issue2092.rs
@@ -1,0 +1,4 @@
+macro_rules! foo {
+    // { dg-error "does not take a separator" "#2092" { target *-*-*} .+1 }
+    ($(a),?) => {};
+}


### PR DESCRIPTION
A matcher like `$(a),?` is no longer accepted.

Fixes #2092.

gcc/rust/ChangeLog:

        * parse/rust-parse-impl.h
        (Parser<ManagedTokenSource>::parse_macro_match_repetition):
        reject separator in `?` repetition

gcc/testsuite/ChangeLog:

        * rust/compile/macro-issue2092.rs: New test.