### PR TITLE
Fix StructExprStructFields tokenstream

### DIFF
--- a/gcc/rust/ast/rust-ast-tokenstream.cc
+++ b/gcc/rust/ast/rust-ast-tokenstream.cc
@@ -1109,11 +1109,6 @@ void
 TokenStream::visit (StructExprStruct &expr)
 {
   visit (expr.get_struct_name ());
-  tokens.push_back (Rust::Token::make (LEFT_CURLY, expr.get_locus ()));
-  // FIXME: Reference says it should have fields but node doesn't have them for
-  // now. We need to disambiguate with StructExprUnit and visit fields.
-  gcc_unreachable ();
-  tokens.push_back (Rust::Token::make (RIGHT_CURLY, Location ()));
 }
 
 void
@@ -1159,6 +1154,8 @@ TokenStream::visit (StructBase &base)
 void
 TokenStream::visit (StructExprStructFields &expr)
 {
+  visit (expr.get_struct_name ());
+  tokens.push_back (Rust::Token::make (LEFT_CURLY, expr.get_locus ()));
   visit_items_joined_by_separator (expr.get_fields (), COMMA);
   if (expr.has_struct_base ())
     {
@@ -1169,6 +1166,7 @@ TokenStream::visit (StructExprStructFields &expr)
     {
       trailing_comma ();
     }
+  tokens.push_back (Rust::Token::make (RIGHT_CURLY, expr.get_locus ()));
 }
 
 void


### PR DESCRIPTION
StructExprStructFields inherit from StructExprStruct and shall output the struct name and curly braces.