### PR TITLE
libproc_macro: Add literal type

### DIFF
--- a/libgrust/libproc_macro/Makefile.am
+++ b/libgrust/libproc_macro/Makefile.am
@@ -51,7 +51,8 @@ AM_MAKEFLAGS = \
 toolexeclib_LTLIBRARIES = libproc_macro.la
 
 libproc_macro_la_SOURCES = \
-	proc_macro.cc
+	proc_macro.cc \
+	literal.cc
 
 include_HEADERS = \
 	proc_macro.h

--- a/libgrust/libproc_macro/Makefile.in
+++ b/libgrust/libproc_macro/Makefile.in
@@ -138,7 +138,7 @@ am__installdirs = "$(DESTDIR)$(toolexeclibdir)" \
 	"$(DESTDIR)$(includedir)"
 LTLIBRARIES = $(toolexeclib_LTLIBRARIES)
 libproc_macro_la_LIBADD =
-am_libproc_macro_la_OBJECTS = proc_macro.lo
+am_libproc_macro_la_OBJECTS = proc_macro.lo literal.lo
 libproc_macro_la_OBJECTS = $(am_libproc_macro_la_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
@@ -385,7 +385,8 @@ AM_MAKEFLAGS = \
 
 toolexeclib_LTLIBRARIES = libproc_macro.la
 libproc_macro_la_SOURCES = \
-	proc_macro.cc
+	proc_macro.cc \
+	literal.cc
 
 include_HEADERS = \
 	proc_macro.h
@@ -468,6 +469,7 @@ mostlyclean-compile:
 distclean-compile:
 	-rm -f *.tab.c
 
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/literal.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/proc_macro.Plo@am__quote@
 
 .cc.o:

--- a/libgrust/libproc_macro/literal.cc
+++ b/libgrust/libproc_macro/literal.cc
@@ -25,7 +25,6 @@
 #include <cstdlib>
 
 namespace Literal {
-
 extern "C" {
 
 void
@@ -55,23 +54,13 @@ Literal__drop (Literal *lit)
 Literal
 Literal__string (const unsigned char *str, std::uint64_t len)
 {
-  unsigned char *data = new unsigned char[len];
-  StringPayload str_payload = {data, len};
-  std::memcpy (data, str, len);
-  LiteralPayload payload;
-  payload.string_payload = str_payload;
-  return {STRING, payload};
+  return Literal::make_string (str, len);
 }
 
 Literal
 Literal__byte_string (const std::uint8_t *bytes, std::uint64_t len)
 {
-  std::uint8_t *data = new std::uint8_t[len];
-  ByteStringPayload bstr_payload = {data, len};
-  std::memcpy (data, bytes, len);
-  LiteralPayload payload;
-  payload.byte_string_payload = bstr_payload;
-  return {BYTE_STRING, payload};
+  return Literal::make_byte_string (bytes, len);
 }
 
 bool
@@ -82,4 +71,214 @@ Literal__from_string (const unsigned char *str, std::uint64_t len, Literal *lit)
   return false;
 }
 }
+
+Literal
+Literal::make_unsigned (UnsignedSuffixPayload p)
+{
+  LiteralPayload payload;
+  payload.unsigned_payload = p;
+  return {UNSIGNED, payload};
+}
+
+Literal
+Literal::make_signed (SignedSuffixPayload p)
+{
+  LiteralPayload payload;
+  payload.signed_payload = p;
+  return {SIGNED, payload};
+}
+
+Literal
+Literal::clone () const
+{
+  Literal lit = *this;
+  switch (this->tag)
+    {
+    case STRING:
+      lit.payload.string_payload.data
+	= new unsigned char[lit.payload.string_payload.len];
+      std::memcpy (lit.payload.string_payload.data,
+		   this->payload.string_payload.data,
+		   lit.payload.string_payload.len);
+      break;
+    case BYTE_STRING:
+      lit.payload.byte_string_payload.data
+	= new uint8_t[lit.payload.byte_string_payload.size];
+      std::memcpy (lit.payload.byte_string_payload.data,
+		   this->payload.byte_string_payload.data,
+		   lit.payload.byte_string_payload.size);
+      break;
+    default:
+      break;
+    }
+  return lit;
+}
+
+Literal
+Literal::make_u8 (std::uint8_t value, bool suffixed)
+{
+  UnsignedPayload unsigned_payload;
+  unsigned_payload.unsigned8 = value;
+  Unsigned val{UNSIGNED_8, unsigned_payload};
+  UnsignedSuffixPayload payload{val, suffixed};
+
+  return make_unsigned (payload);
+}
+
+Literal
+Literal::make_u16 (std::uint16_t value, bool suffixed)
+{
+  UnsignedPayload unsigned_payload;
+  unsigned_payload.unsigned16 = value;
+  Unsigned val{UNSIGNED_16, unsigned_payload};
+  UnsignedSuffixPayload payload{val, suffixed};
+
+  return make_unsigned (payload);
+}
+
+Literal
+Literal::make_u32 (std::uint32_t value, bool suffixed)
+{
+  UnsignedPayload unsigned_payload;
+  unsigned_payload.unsigned32 = value;
+  Unsigned val{UNSIGNED_32, unsigned_payload};
+  UnsignedSuffixPayload payload{val, suffixed};
+
+  return make_unsigned (payload);
+}
+
+Literal
+Literal::make_u64 (std::uint64_t value, bool suffixed)
+{
+  UnsignedPayload unsigned_payload;
+  unsigned_payload.unsigned64 = value;
+  Unsigned val{UNSIGNED_64, unsigned_payload};
+  UnsignedSuffixPayload payload{val, suffixed};
+
+  return make_unsigned (payload);
+}
+
+Literal
+Literal::make_i8 (std::int8_t value, bool suffixed)
+{
+  SignedPayload signed_payload;
+  signed_payload.signed8 = value;
+  Signed val{SIGNED_8, signed_payload};
+  SignedSuffixPayload payload{val, suffixed};
+
+  return make_signed (payload);
+}
+
+Literal
+Literal::make_i16 (std::int16_t value, bool suffixed)
+{
+  SignedPayload signed_payload;
+  signed_payload.signed16 = value;
+  Signed val{SIGNED_16, signed_payload};
+  SignedSuffixPayload payload{val, suffixed};
+
+  return make_signed (payload);
+}
+
+Literal
+Literal::make_i32 (std::int32_t value, bool suffixed)
+{
+  SignedPayload signed_payload;
+  signed_payload.signed32 = value;
+  Signed val{SIGNED_32, signed_payload};
+  SignedSuffixPayload payload = {val, suffixed};
+
+  return make_signed (payload);
+}
+
+Literal
+Literal::make_i64 (std::int64_t value, bool suffixed)
+{
+  SignedPayload signed_payload;
+  signed_payload.signed64 = value;
+  Signed val{SIGNED_64, signed_payload};
+  SignedSuffixPayload payload{val, suffixed};
+
+  return make_signed (payload);
+}
+
+Literal
+Literal::make_string (const std::string &str)
+{
+  return make_string (reinterpret_cast<const unsigned char *> (str.c_str ()),
+		      str.length ());
+}
+
+Literal
+Literal::make_string (const unsigned char *str, std::uint64_t len)
+{
+  unsigned char *data = new unsigned char[len];
+  StringPayload str_payload = {data, len};
+  std::memcpy (data, str, len);
+  LiteralPayload payload;
+  payload.string_payload = str_payload;
+  return {STRING, payload};
+}
+
+Literal
+Literal::make_byte_string (const std::vector<std::uint8_t> &vec)
+{
+  return make_byte_string (vec.data (), vec.size ());
+}
+
+Literal
+Literal::make_byte_string (const std::uint8_t *bytes, std::uint64_t len)
+{
+  std::uint8_t *data = new std::uint8_t[len];
+  ByteStringPayload bstr_payload = {data, len};
+  std::memcpy (data, bytes, len);
+  LiteralPayload payload;
+  payload.byte_string_payload = bstr_payload;
+  return {BYTE_STRING, payload};
+}
+
+Literal
+Literal::make_f32 (float value, bool suffixed)
+{
+  Float32Payload f{value, suffixed};
+  LiteralPayload payload;
+  payload.float32_payload = f;
+  return {FLOAT32, payload};
+}
+
+Literal
+Literal::make_f64 (double value, bool suffixed)
+{
+  Float64Payload f{value, suffixed};
+  LiteralPayload payload;
+  payload.float64_payload = f;
+  return {FLOAT64, payload};
+}
+
+Literal
+Literal::make_char (std::uint32_t ch)
+{
+  LiteralPayload payload;
+  payload.char_payload = ch;
+  return {CHAR, payload};
+}
+
+Literal
+Literal::make_usize (std::uint64_t value, bool suffixed)
+{
+  UsizePayload p{value, suffixed};
+  LiteralPayload payload;
+  payload.usize_payload = p;
+  return {USIZE, payload};
+}
+
+Literal
+Literal::make_isize (std::int64_t value, bool suffixed)
+{
+  IsizePayload p{value, suffixed};
+  LiteralPayload payload;
+  payload.isize_payload = p;
+  return {ISIZE, payload};
+}
+
 } // namespace Literal

--- a/libgrust/libproc_macro/literal.cc
+++ b/libgrust/libproc_macro/literal.cc
@@ -22,6 +22,9 @@
 
 #include "literal.h"
 #include <cstring>
+#include <cstdlib>
+
+namespace Literal {
 
 extern "C" {
 
@@ -75,6 +78,8 @@ bool
 Literal__from_string (const unsigned char *str, std::uint64_t len, Literal *lit)
 {
   // FIXME: implement this function with parser
+  std::abort ();
   return false;
 }
 }
+} // namespace Literal

--- a/libgrust/libproc_macro/literal.cc
+++ b/libgrust/libproc_macro/literal.cc
@@ -1,0 +1,80 @@
+// Copyright (C) 2023 Free Software Foundation, Inc.
+//
+// This file is part of the GNU Proc Macro Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// Under Section 7 of GPL version 3, you are granted additional
+// permissions described in the GCC Runtime Library Exception, version
+// 3.1, as published by the Free Software Foundation.
+
+// You should have received a copy of the GNU General Public License and
+// a copy of the GCC Runtime Library Exception along with this program;
+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+// <http://www.gnu.org/licenses/>.
+
+#include "literal.h"
+#include <cstring>
+
+extern "C" {
+
+void
+Literal__drop (Literal *lit)
+{
+  switch (lit->tag)
+    {
+    case STRING:
+      delete lit->payload.string_payload.data;
+      lit->payload.string_payload.len = 0;
+      break;
+    case BYTE_STRING:
+      delete lit->payload.byte_string_payload.data;
+      lit->payload.byte_string_payload.size = 0;
+      break;
+    case CHAR:
+    case UNSIGNED:
+    case SIGNED:
+    case USIZE:
+    case ISIZE:
+    case FLOAT32:
+    case FLOAT64:
+      break;
+    }
+}
+
+Literal
+Literal__string (const unsigned char *str, std::uint64_t len)
+{
+  unsigned char *data = new unsigned char[len];
+  StringPayload str_payload = {data, len};
+  std::memcpy (data, str, len);
+  LiteralPayload payload;
+  payload.string_payload = str_payload;
+  return {STRING, payload};
+}
+
+Literal
+Literal__byte_string (const std::uint8_t *bytes, std::uint64_t len)
+{
+  std::uint8_t *data = new std::uint8_t[len];
+  ByteStringPayload bstr_payload = {data, len};
+  std::memcpy (data, bytes, len);
+  LiteralPayload payload;
+  payload.byte_string_payload = bstr_payload;
+  return {BYTE_STRING, payload};
+}
+
+bool
+Literal__from_string (const unsigned char *str, std::uint64_t len, Literal *lit)
+{
+  // FIXME: implement this function with parser
+  return false;
+}
+}

--- a/libgrust/libproc_macro/literal.h
+++ b/libgrust/libproc_macro/literal.h
@@ -25,6 +25,7 @@
 
 #include <cstdint>
 
+namespace Literal {
 enum UnsignedTag
 {
   UNSIGNED_8,
@@ -172,5 +173,6 @@ bool
 Literal__from_string (const unsigned char *str, std::uint64_t len,
 		      Literal *lit);
 }
+} // namespace Literal
 
 #endif /* ! LITERAL_H */

--- a/libgrust/libproc_macro/literal.h
+++ b/libgrust/libproc_macro/literal.h
@@ -1,0 +1,161 @@
+// Copyright (C) 2023 Free Software Foundation, Inc.
+//
+// This file is part of the GNU Proc Macro Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// Under Section 7 of GPL version 3, you are granted additional
+// permissions described in the GCC Runtime Library Exception, version
+// 3.1, as published by the Free Software Foundation.
+
+// You should have received a copy of the GNU General Public License and
+// a copy of the GCC Runtime Library Exception along with this program;
+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef LITERAL_H
+#define LITERAL_H
+
+#include <cstdint>
+
+enum UnsignedTag
+{
+  UNSIGNED_8,
+  UNSIGNED_16,
+  UNSIGNED_32,
+  UNSIGNED_64,
+  UNSIGNED_128
+};
+
+struct Payload128
+{
+  std::uint64_t low;
+  std::uint64_t high;
+};
+
+union UnsignedPayload
+{
+  std::uint8_t unsigned8;
+  std::uint16_t unsigned16;
+  std::uint32_t unsigned32;
+  std::uint64_t unsigned64;
+  Payload128 unsigned128;
+};
+
+struct Unsigned
+{
+  UnsignedTag tag;
+  UnsignedPayload payload;
+};
+
+enum SignedTag
+{
+  SIGNED_8,
+  SIGNED_16,
+  SIGNED_32,
+  SIGNED_64,
+  SIGNED_128
+};
+
+union SignedPayload
+{
+  std::int8_t signed8;
+  std::int16_t signed16;
+  std::int32_t signed32;
+  std::int64_t signed64;
+};
+
+struct Signed
+{
+  SignedTag tag;
+  SignedPayload payload;
+};
+
+enum LiteralTag
+{
+  STRING,
+  BYTE_STRING,
+  CHAR,
+  UNSIGNED,
+  SIGNED,
+  USIZE,
+  ISIZE,
+  FLOAT32,
+  FLOAT64
+};
+
+struct StringPayload
+{
+  unsigned char *data;
+  std::uint64_t len;
+};
+
+struct ByteStringPayload
+{
+  std::uint8_t *data;
+  std::uint64_t size;
+};
+
+struct UnsignedSuffixPayload
+{
+  Unsigned value;
+  bool suffix;
+};
+
+struct SignedSuffixPayload
+{
+  Signed value;
+  bool suffix;
+};
+
+struct UsizePayload
+{
+  std::uint64_t value;
+  bool suffix;
+};
+
+struct IsizePayload
+{
+  std::int64_t value;
+  bool suffix;
+};
+
+struct Float32Payload
+{
+  float value;
+  bool suffix;
+};
+
+struct Float64Payload
+{
+  double value;
+  bool suffix;
+};
+
+union LiteralPayload
+{
+  StringPayload string_payload;
+  ByteStringPayload byte_string_payload;
+  std::uint32_t char_payload;
+  UnsignedSuffixPayload unsigned_payload;
+  SignedSuffixPayload signed_payload;
+  UsizePayload usize_payload;
+  IsizePayload isize_payload;
+  Float32Payload float32_payload;
+  Float64Payload float64_payload;
+};
+
+struct Literal
+{
+  LiteralTag tag;
+  LiteralPayload payload;
+};
+
+#endif /* ! LITERAL_H */

--- a/libgrust/libproc_macro/literal.h
+++ b/libgrust/libproc_macro/literal.h
@@ -24,6 +24,8 @@
 #define LITERAL_H
 
 #include <cstdint>
+#include <string>
+#include <vector>
 
 namespace Literal {
 enum UnsignedTag
@@ -157,6 +159,35 @@ struct Literal
 {
   LiteralTag tag;
   LiteralPayload payload;
+
+public:
+  Literal clone () const;
+
+  static Literal make_u8 (std::uint8_t value, bool suffixed = false);
+  static Literal make_u16 (std::uint16_t value, bool suffixed = false);
+  static Literal make_u32 (std::uint32_t value, bool suffixed = false);
+  static Literal make_u64 (std::uint64_t value, bool suffixed = false);
+
+  static Literal make_i8 (std::int8_t value, bool suffixed = false);
+  static Literal make_i16 (std::int16_t value, bool suffixed = false);
+  static Literal make_i32 (std::int32_t value, bool suffixed = false);
+  static Literal make_i64 (std::int64_t value, bool suffixed = false);
+
+  static Literal make_string (const std::string &str);
+  static Literal make_string (const unsigned char *str, std::uint64_t len);
+  static Literal make_byte_string (const std::vector<std::uint8_t> &vec);
+  static Literal make_byte_string (const std::uint8_t *bytes,
+				   std::uint64_t len);
+
+  static Literal make_f32 (float value, bool suffixed = false);
+  static Literal make_f64 (double value, bool suffixed = false);
+
+  static Literal make_char (std::uint32_t ch);
+  static Literal make_usize (std::uint64_t value, bool suffixed = false);
+  static Literal make_isize (std::int64_t value, bool suffixed = false);
+
+  static Literal make_unsigned (UnsignedSuffixPayload p);
+  static Literal make_signed (SignedSuffixPayload p);
 };
 
 extern "C" {

--- a/libgrust/libproc_macro/literal.h
+++ b/libgrust/libproc_macro/literal.h
@@ -158,4 +158,19 @@ struct Literal
   LiteralPayload payload;
 };
 
+extern "C" {
+void
+Literal__drop (Literal *lit);
+
+Literal
+Literal__string (const unsigned char *str, std::uint64_t len);
+
+Literal
+Literal__byte_string (const std::uint8_t *bytes, std::uint64_t len);
+
+bool
+Literal__from_string (const unsigned char *str, std::uint64_t len,
+		      Literal *lit);
+}
+
 #endif /* ! LITERAL_H */

--- a/libgrust/libproc_macro/proc_macro.cc
+++ b/libgrust/libproc_macro/proc_macro.cc
@@ -1,7 +1,23 @@
-#include "proc_macro.h"
+// Copyright (C) 2023 Free Software Foundation, Inc.
+//
+// This file is part of the GNU Proc Macro Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
 
-int
-test ()
-{
-  return 0;
-}
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// Under Section 7 of GPL version 3, you are granted additional
+// permissions described in the GCC Runtime Library Exception, version
+// 3.1, as published by the Free Software Foundation.
+
+// You should have received a copy of the GNU General Public License and
+// a copy of the GCC Runtime Library Exception along with this program;
+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+// <http://www.gnu.org/licenses/>.
+
+#include "proc_macro.h"

--- a/libgrust/libproc_macro/proc_macro.h
+++ b/libgrust/libproc_macro/proc_macro.h
@@ -23,4 +23,6 @@
 #ifndef PROC_MACRO_H
 #define PROC_MACRO_H
 
+#include "literal.h"
+
 #endif /* ! PROC_MACRO_H */

--- a/libgrust/libproc_macro/proc_macro.h
+++ b/libgrust/libproc_macro/proc_macro.h
@@ -1,7 +1,26 @@
+// Copyright (C) 2023 Free Software Foundation, Inc.
+//
+// This file is part of the GNU Proc Macro Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// Under Section 7 of GPL version 3, you are granted additional
+// permissions described in the GCC Runtime Library Exception, version
+// 3.1, as published by the Free Software Foundation.
+
+// You should have received a copy of the GNU General Public License and
+// a copy of the GCC Runtime Library Exception along with this program;
+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+// <http://www.gnu.org/licenses/>.
+
 #ifndef PROC_MACRO_H
 #define PROC_MACRO_H
-
-int
-test ();
 
 #endif /* ! PROC_MACRO_H */

--- a/libgrust/libproc_macro/rust/bridge/literal.rs
+++ b/libgrust/libproc_macro/rust/bridge/literal.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use LexError;
 
 extern "C" {
-    fn Literal__drop(literal: *const Literal);
+    fn Literal__drop(literal: *mut Literal);
     fn Literal__string(str: *const c_uchar, len: u64) -> Literal;
     fn Literal__byte_string(bytes: *const u8, len: u64) -> Literal;
     fn Literal__from_string(str: *const c_uchar, len: u64, lit: *mut Literal) -> bool;
@@ -230,7 +230,7 @@ impl Drop for Literal {
     fn drop(&mut self) {
         match self {
             Literal::String { .. } | Literal::ByteString { .. } => unsafe {
-                Literal__drop(self as *const Literal)
+                Literal__drop(self as *mut Literal)
             },
             _ => (),
         }


### PR DESCRIPTION
Add `Literal` type matching the rust's one.
