### PR TITLE
display error when trait functions are declared const. Fixes #2040

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -5614,8 +5614,9 @@ Parser<ManagedTokenSource>::parse_trait_impl_item ()
 	case UNSAFE:
 	case EXTERN_TOK:
 	case FN_TOK:
-	  return parse_trait_impl_function_or_method (visibility,
-						      std::move (outer_attrs));
+	  add_error (Error (t->get_locus (),
+			    "trait functions cannot be declared const"));
+	  return nullptr;
 	default:
 	  add_error (Error (
 	    t->get_locus (),

--- a/gcc/testsuite/rust/compile/issue-2040.rs
+++ b/gcc/testsuite/rust/compile/issue-2040.rs
@@ -1,0 +1,12 @@
+trait Foo {
+    fn f() -> u32;
+}
+
+impl Foo for u32 {
+    const fn f() -> u32 { 22 } 
+        // { dg-error "trait functions cannot be declared const" "" {target *-*-* } .-1 }
+        // { dg-error {failed to parse trait impl item in trait impl} "" { target *-*-* } .-2 }
+        // { dg-error {failed to parse item in crate} "" { target *-*-* } .-3 }
+} 
+
+fn main() { } 


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* parse/rust-parse-impl.h (Parser::parse_trait_impl_item): not allow const fns in traits

gcc/testsuite/ChangeLog:

	* rust/compile/issue-2040.rs: New test.
