### PR TITLE
Deleted the as_string AST dump

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -15189,13 +15189,4 @@ Parser<ManagedTokenSource>::done_end ()
   const_TokenPtr t = lexer.peek_token ();
   return (t->get_id () == RIGHT_CURLY || t->get_id () == END_OF_FILE);
 }
-
-// Parses crate and dumps AST to stderr, recursively.
-template <typename ManagedTokenSource>
-void
-Parser<ManagedTokenSource>::debug_dump_ast_output (AST::Crate &crate,
-						   std::ostream &out)
-{
-  out << crate.as_string ();
-}
 } // namespace Rust

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -283,7 +283,7 @@ Session::enable_dump (std::string arg)
     {
       rust_error_at (
 	Location (),
-	"dump option was not given a name. choose %<lex%>, %<parse%>, "
+	"dump option was not given a name. choose %<lex%>, "
 	"%<register_plugins%>, %<injection%>, %<expansion%>, %<resolution%>,"
 	" %<target_options%>, %<hir%>, or %<all%>");
       return false;
@@ -296,10 +296,6 @@ Session::enable_dump (std::string arg)
   else if (arg == "lex")
     {
       options.enable_dump_option (CompileOptions::LEXER_DUMP);
-    }
-  else if (arg == "parse")
-    {
-      options.enable_dump_option (CompileOptions::PARSER_AST_DUMP);
     }
   else if (arg == "ast-pretty")
     {
@@ -495,10 +491,6 @@ Session::compile_crate (const char *filename)
   handle_crate_name (*ast_crate.get ());
 
   // dump options except lexer dump
-  if (options.dump_option_enabled (CompileOptions::PARSER_AST_DUMP))
-    {
-      dump_ast (parser, *ast_crate.get ());
-    }
   if (options.dump_option_enabled (CompileOptions::AST_DUMP_TOKENSTREAM))
     {
       dump_tokenstream (*ast_crate.get ());
@@ -572,7 +564,6 @@ Session::compile_crate (const char *filename)
     {
       // dump AST with expanded stuff
       rust_debug ("BEGIN POST-EXPANSION AST DUMP");
-      dump_ast_expanded (parser, parsed_crate);
       dump_ast_pretty (parsed_crate, true);
       rust_debug ("END POST-EXPANSION AST DUMP");
     }
@@ -895,22 +886,6 @@ Session::expansion (AST::Crate &crate)
 }
 
 void
-Session::dump_ast (Parser<Lexer> &parser, AST::Crate &crate) const
-{
-  std::ofstream out;
-  out.open (kASTDumpFile);
-  if (out.fail ())
-    {
-      rust_error_at (Linemap::unknown_location (), "cannot open %s:%m; ignored",
-		     kASTDumpFile);
-      return;
-    }
-
-  parser.debug_dump_ast_output (crate, out);
-  out.close ();
-}
-
-void
 Session::dump_ast_pretty (AST::Crate &crate, bool expanded) const
 {
   std::ofstream out;
@@ -947,22 +922,6 @@ Session::dump_tokenstream (AST::Crate &crate) const
     {
       out << token->as_string () << " ";
     }
-  out.close ();
-}
-
-void
-Session::dump_ast_expanded (Parser<Lexer> &parser, AST::Crate &crate) const
-{
-  std::ofstream out;
-  out.open (kASTExpandedDumpFile);
-  if (out.fail ())
-    {
-      rust_error_at (Linemap::unknown_location (), "cannot open %s:%m; ignored",
-		     kASTExpandedDumpFile);
-      return;
-    }
-
-  parser.debug_dump_ast_output (crate, out);
   out.close ();
 }
 

--- a/gcc/rust/rust-session-manager.h
+++ b/gcc/rust/rust-session-manager.h
@@ -166,7 +166,6 @@ struct CompileOptions
   enum DumpOption
   {
     LEXER_DUMP,
-    PARSER_AST_DUMP,
     AST_DUMP_PRETTY,
     AST_DUMP_TOKENSTREAM,
     REGISTER_PLUGINS_DUMP,
@@ -226,7 +225,6 @@ struct CompileOptions
   void enable_all_dump_options ()
   {
     enable_dump_option (DumpOption::LEXER_DUMP);
-    enable_dump_option (DumpOption::PARSER_AST_DUMP);
     enable_dump_option (DumpOption::AST_DUMP_PRETTY);
     enable_dump_option (DumpOption::AST_DUMP_TOKENSTREAM);
     enable_dump_option (DumpOption::REGISTER_PLUGINS_DUMP);
@@ -343,10 +341,8 @@ private:
   bool enable_dump (std::string arg);
 
   void dump_lex (Parser<Lexer> &parser) const;
-  void dump_ast (Parser<Lexer> &parser, AST::Crate &crate) const;
   void dump_ast_pretty (AST::Crate &crate, bool expanded = false) const;
   void dump_tokenstream (AST::Crate &crate) const;
-  void dump_ast_expanded (Parser<Lexer> &parser, AST::Crate &crate) const;
   void dump_hir (HIR::Crate &crate) const;
   void dump_hir_pretty (HIR::Crate &crate) const;
   void dump_type_resolution (HIR::Crate &crate) const;


### PR DESCRIPTION
Fixes #2022 
Removed the Session::dump_ast function, and all the elements associated with it.

gcc/rust/ChangeLog:

	* rust-session-manager.cc (Session::enable_dump): Removed else if (arg == "parse").
	(Session::compile_crate): Removed the statement that called the dump_ast.
	(Session::dump_ast): Removed dump_ast function.
	* rust-session-manager.h (struct CompileOptions): Removed the PARSER_AST_DUMP option.

Signed-off-by: M V V S Manoj Kumar <mvvsmanojkumar@gmail.com>


Do let me know if I need to change something or missed anything .

