### PR TITLE
Placate clang-format, 'gcc/rust/rust-lang.cc:grs_langhook_type_for_mode'

### DIFF
--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -236,16 +236,16 @@ grs_langhook_type_for_mode (machine_mode mode, int unsignedp)
   /* See (a) <https://github.com/Rust-GCC/gccrs/issues/1713>
      "Test failure on msp430-elfbare target", and
      (b) <https://gcc.gnu.org/PR46805>
-     "ICE: SIGSEGV in optab_for_tree_code (optabs.c:407) with -O -fno-tree-scev-cprop -ftree-vectorize"
+     "ICE: SIGSEGV in optab_for_tree_code (optabs.c:407) with -O
+     -fno-tree-scev-cprop -ftree-vectorize"
      -- we have to support "random" modes/types here.
      TODO Clean all this up (either locally, or preferably per PR46805:
-     "Ideally we'd never use lang_hooks.types.type_for_mode (or _for_size) in the
-     middle-end but had a pure middle-end based implementation".  */
-  for (size_t i = 0; i < NUM_INT_N_ENTS; i ++)
-    if (int_n_enabled_p[i]
-	&& mode == int_n_data[i].m)
+     "Ideally we'd never use lang_hooks.types.type_for_mode (or _for_size) in
+     the middle-end but had a pure middle-end based implementation".  */
+  for (size_t i = 0; i < NUM_INT_N_ENTS; i++)
+    if (int_n_enabled_p[i] && mode == int_n_data[i].m)
       return (unsignedp ? int_n_trees[i].unsigned_type
-	      : int_n_trees[i].signed_type);
+			: int_n_trees[i].signed_type);
 
   /* gcc_unreachable */
   return NULL;


### PR DESCRIPTION
Yesterday's commit 3757e8d71794cece4a5c9d08245b7ad111044853 "Merge commit 6baa95c9c5b3fea96fd22d03d961db4e4cf48d88' into HEAD [#2112]" brought in the #1713 change from GCC upstream master branch that broke the rules (via code copied verbatim from elsehwhere in GCC).

	gcc/rust/
	* rust-lang.cc (grs_langhook_type_for_mode): Placate clang-format.
