### PR TITLE
libproc_macro: Add Ident type

### DIFF
--- a/libgrust/libproc_macro/Makefile.am
+++ b/libgrust/libproc_macro/Makefile.am
@@ -52,6 +52,7 @@ toolexeclib_LTLIBRARIES = libproc_macro.la
 
 libproc_macro_la_SOURCES = \
 	proc_macro.cc \
+	ident.cc \
 	literal.cc
 
 include_HEADERS = \

--- a/libgrust/libproc_macro/Makefile.in
+++ b/libgrust/libproc_macro/Makefile.in
@@ -138,7 +138,7 @@ am__installdirs = "$(DESTDIR)$(toolexeclibdir)" \
 	"$(DESTDIR)$(includedir)"
 LTLIBRARIES = $(toolexeclib_LTLIBRARIES)
 libproc_macro_la_LIBADD =
-am_libproc_macro_la_OBJECTS = proc_macro.lo literal.lo
+am_libproc_macro_la_OBJECTS = proc_macro.lo ident.lo literal.lo
 libproc_macro_la_OBJECTS = $(am_libproc_macro_la_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
@@ -386,6 +386,7 @@ AM_MAKEFLAGS = \
 toolexeclib_LTLIBRARIES = libproc_macro.la
 libproc_macro_la_SOURCES = \
 	proc_macro.cc \
+	ident.cc \
 	literal.cc
 
 include_HEADERS = \
@@ -469,6 +470,7 @@ mostlyclean-compile:
 distclean-compile:
 	-rm -f *.tab.c
 
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ident.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/literal.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/proc_macro.Plo@am__quote@
 

--- a/libgrust/libproc_macro/ident.cc
+++ b/libgrust/libproc_macro/ident.cc
@@ -23,7 +23,10 @@
 
 #include <cstring>
 
+namespace Ident {
+
 extern "C" {
+
 Ident
 Ident__new (unsigned char *str, std::uint64_t len)
 {
@@ -72,3 +75,5 @@ Ident::make_ident (const unsigned char *str, std::uint64_t len, bool raw)
   std::memcpy (val, str, len);
   return {raw, val, len};
 }
+
+} // namespace Ident

--- a/libgrust/libproc_macro/ident.cc
+++ b/libgrust/libproc_macro/ident.cc
@@ -1,0 +1,56 @@
+// Copyright (C) 2023 Free Software Foundation, Inc.
+//
+// This file is part of the GNU Proc Macro Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// Under Section 7 of GPL version 3, you are granted additional
+// permissions described in the GCC Runtime Library Exception, version
+// 3.1, as published by the Free Software Foundation.
+
+// You should have received a copy of the GNU General Public License and
+// a copy of the GCC Runtime Library Exception along with this program;
+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+// <http://www.gnu.org/licenses/>.
+#include "ident.h"
+
+#include <cstring>
+
+extern "C" {
+Ident
+Ident__new (unsigned char *str, std::uint64_t len)
+{
+  unsigned char *val = new unsigned char[len];
+  std::memcpy (val, str, len);
+  return {false, val, len};
+}
+
+Ident
+Ident__new_raw (unsigned char *str, std::uint64_t len)
+{
+  unsigned char *val = new unsigned char[len];
+  std::memcpy (val, str, len);
+  return {true, val, len};
+}
+
+void
+Ident__drop (Ident *ident)
+{
+  delete[] ident->val;
+}
+
+Ident
+Ident__clone (const Ident *ident)
+{
+  unsigned char *val = new unsigned char[ident->len];
+  std::memcpy (val, ident->val, ident->len);
+  return {ident->is_raw, val, ident->len};
+}
+}

--- a/libgrust/libproc_macro/ident.cc
+++ b/libgrust/libproc_macro/ident.cc
@@ -27,17 +27,13 @@ extern "C" {
 Ident
 Ident__new (unsigned char *str, std::uint64_t len)
 {
-  unsigned char *val = new unsigned char[len];
-  std::memcpy (val, str, len);
-  return {false, val, len};
+  return Ident::make_ident (str, len);
 }
 
 Ident
 Ident__new_raw (unsigned char *str, std::uint64_t len)
 {
-  unsigned char *val = new unsigned char[len];
-  std::memcpy (val, str, len);
-  return {true, val, len};
+  return Ident::make_ident (str, len, true);
 }
 
 void
@@ -49,8 +45,30 @@ Ident__drop (Ident *ident)
 Ident
 Ident__clone (const Ident *ident)
 {
-  unsigned char *val = new unsigned char[ident->len];
-  std::memcpy (val, ident->val, ident->len);
-  return {ident->is_raw, val, ident->len};
+  return ident->clone ();
 }
+}
+
+Ident
+Ident::clone () const
+{
+  unsigned char *val = new unsigned char[this->len];
+  std::memcpy (val, this->val, this->len);
+  return {this->is_raw, val, this->len};
+}
+
+Ident
+Ident::make_ident (std::string str, bool raw)
+{
+  return Ident::make_ident (reinterpret_cast<const unsigned char *> (
+			      str.c_str ()),
+			    str.length (), raw);
+}
+
+Ident
+Ident::make_ident (const unsigned char *str, std::uint64_t len, bool raw)
+{
+  unsigned char *val = new unsigned char[len];
+  std::memcpy (val, str, len);
+  return {raw, val, len};
 }

--- a/libgrust/libproc_macro/ident.h
+++ b/libgrust/libproc_macro/ident.h
@@ -33,6 +33,12 @@ struct Ident
   unsigned char *val;
   // Length in bytes
   std::uint64_t len;
+
+public:
+  Ident clone () const;
+  static Ident make_ident (std::string str, bool raw = false);
+  static Ident make_ident (const unsigned char *str, std::uint64_t len,
+			   bool raw = false);
 };
 
 extern "C" {

--- a/libgrust/libproc_macro/ident.h
+++ b/libgrust/libproc_macro/ident.h
@@ -26,6 +26,8 @@
 #include <cstdint>
 #include <string>
 
+namespace Ident {
+
 struct Ident
 {
   bool is_raw;
@@ -55,5 +57,7 @@ Ident__drop (Ident *ident);
 Ident
 Ident__clone (const Ident *ident);
 }
+
+} // namespace Ident
 
 #endif /* ! IDENT_H */

--- a/libgrust/libproc_macro/ident.h
+++ b/libgrust/libproc_macro/ident.h
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 Free Software Foundation, Inc.
+//
+// This file is part of the GNU Proc Macro Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// Under Section 7 of GPL version 3, you are granted additional
+// permissions described in the GCC Runtime Library Exception, version
+// 3.1, as published by the Free Software Foundation.
+
+// You should have received a copy of the GNU General Public License and
+// a copy of the GCC Runtime Library Exception along with this program;
+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef IDENT_H
+#define IDENT_H
+
+#include <cstdint>
+#include <string>
+
+struct Ident
+{
+  bool is_raw;
+  // TODO: Adapt this to UTF-8
+  unsigned char *val;
+  // Length in bytes
+  std::uint64_t len;
+};
+
+extern "C" {
+
+Ident
+Ident__new (unsigned char *str, std::uint64_t len);
+
+Ident
+Ident__new_raw (unsigned char *str, std::uint64_t len);
+
+void
+Ident__drop (Ident *ident);
+
+Ident
+Ident__clone (const Ident *ident);
+}
+
+#endif /* ! IDENT_H */

--- a/libgrust/libproc_macro/rust/bridge/ident.rs
+++ b/libgrust/libproc_macro/rust/bridge/ident.rs
@@ -6,7 +6,7 @@ use std::fmt;
 extern "C" {
     fn Ident__new(string: *const c_uchar, len: u64) -> Ident;
     fn Ident__new_raw(string: *const c_uchar, len: u64) -> Ident;
-    fn Ident__drop(ident: *const Ident);
+    fn Ident__drop(ident: *mut Ident);
     fn Ident__clone(ident: *const Ident) -> Ident;
 }
 
@@ -38,7 +38,7 @@ impl Ident {
 
 impl Drop for Ident {
     fn drop(&mut self) {
-        unsafe { Ident__drop(self as *const Ident) }
+        unsafe { Ident__drop(self as *mut Ident) }
     }
 }
 


### PR DESCRIPTION
Add Ident cpp representation and high level interface.

Needs #2104 