### PR TITLE
Rust: Make 'tree'-level 'MAIN_NAME_P' work

### DIFF
--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -523,6 +523,12 @@ HIRCompileBase::compile_function (
 
   // we don't mangle the main fn since we haven't implemented the main shim
   bool is_main_fn = fn_name.compare ("main") == 0;
+  if (is_main_fn)
+    {
+      rust_assert (!main_identifier_node);
+      /* So that 'MAIN_NAME_P' works.  */
+      main_identifier_node = get_identifier (ir_symbol_name.c_str ());
+    }
   std::string asm_name = fn_name;
 
   unsigned int flags = 0;

--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -523,6 +523,9 @@ HIRCompileBase::compile_function (
 
   // we don't mangle the main fn since we haven't implemented the main shim
   bool is_main_fn = fn_name.compare ("main") == 0;
+  if (is_main_fn)
+    /* So that 'MAIN_NAME_P' works.  */
+    ir_symbol_name = fn_name;
   std::string asm_name = fn_name;
 
   unsigned int flags = 0;

--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -523,9 +523,6 @@ HIRCompileBase::compile_function (
 
   // we don't mangle the main fn since we haven't implemented the main shim
   bool is_main_fn = fn_name.compare ("main") == 0;
-  if (is_main_fn)
-    /* So that 'MAIN_NAME_P' works.  */
-    ir_symbol_name = fn_name;
   std::string asm_name = fn_name;
 
   unsigned int flags = 0;

--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -38,7 +38,6 @@
 #include "rust-privacy-ctx.h"
 #include "rust-ast-resolve-item.h"
 #include "rust-optional.h"
-#include "stringpool.h"
 
 #include <mpfr.h>
 // note: header files must be in this order or else forward declarations don't
@@ -124,8 +123,6 @@ grs_langhook_init (void)
    built-in functions. The parameter (signed_char = false) specifies
    whether char is signed.  */
   build_common_tree_nodes (false);
-
-  main_identifier_node = get_identifier ("main");
 
   // Builds built-ins for middle-end after all front-end built-ins are already
   // instantiated

--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -38,6 +38,7 @@
 #include "rust-privacy-ctx.h"
 #include "rust-ast-resolve-item.h"
 #include "rust-optional.h"
+#include "stringpool.h"
 
 #include <mpfr.h>
 // note: header files must be in this order or else forward declarations don't
@@ -123,6 +124,8 @@ grs_langhook_init (void)
    built-in functions. The parameter (signed_char = false) specifies
    whether char is signed.  */
   build_common_tree_nodes (false);
+
+  main_identifier_node = get_identifier ("main");
 
   // Builds built-ins for middle-end after all front-end built-ins are already
   // instantiated


### PR DESCRIPTION
A thing I discovered while testing GCC/Rust for GCN target (AMD GPUs).  (Not a typical thing anybody would do -- but it should, and now does, work.)  See the Git commit log for details.

The first variant, commit 41c7e1d0a707f97327f097022e9e6fa7f6f13533 "Rust: Make 'tree'-level 'MAIN_NAME_P' work" would be the classic way of addressing this: set `main_identifier_node` to `main` as part of the front end setup, and then we need the `gcc/rust/backend/rust-compile-base.cc:HIRCompileBase::compile_function` bit, because the `main` function otherwise doesn't actually have the name `main`, but has the crate name prefixed, and only the `DECL_ASSEMBLER_NAME` forced to `main` (to satisfy the actual C library-level linkage, I suppose).

But then I came up with the second variant, commit 705de6d54ca95b8277a15fe9a2255af6168ae086 "Rust: Make 'tree'-level 'MAIN_NAME_P' work", which simply does set `main_identifier_node` to the actual `main` function name, with the crate name prefixed.

I didn't drop the first variant (bit instead `git revert`ed it), so that we have it available in Git history, in case it's actually preferable over the second variant.
