### PR TITLE
Lower ErrorPropagationExpr from AST to HIR

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-expr.cc
+++ b/gcc/rust/hir/rust-ast-lower-expr.cc
@@ -674,6 +674,21 @@ ASTLoweringExpr::visit (AST::DereferenceExpr &expr)
 }
 
 void
+ASTLoweringExpr::visit (AST::ErrorPropagationExpr &expr)
+{
+  HIR::Expr *propagating_expr
+    = ASTLoweringExpr::translate (expr.get_propagating_expr ().get ());
+
+  auto crate_num = mappings->get_current_crate ();
+  Analysis::NodeMapping mapping (crate_num, expr.get_node_id (),
+				 mappings->get_next_hir_id (crate_num),
+				 UNKNOWN_LOCAL_DEFID);
+  translated = new HIR::ErrorPropagationExpr (
+    mapping, std::unique_ptr<HIR::Expr> (propagating_expr),
+    expr.get_outer_attrs (), expr.get_locus ());
+}
+
+void
 ASTLoweringExpr::visit (AST::MatchExpr &expr)
 {
   translated = ASTLoweringExprWithBlock::translate (&expr, &terminated);

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -111,6 +111,7 @@ public:
   void visit (AST::ContinueExpr &expr) override;
   void visit (AST::BorrowExpr &expr) override;
   void visit (AST::DereferenceExpr &expr) override;
+  void visit (AST::ErrorPropagationExpr &expr) override;
   void visit (AST::MatchExpr &expr) override;
   void visit (AST::RangeFromToExpr &expr) override;
   void visit (AST::RangeFromExpr &expr) override;


### PR DESCRIPTION
[I have no idea what I'm doing](https://github.com/vkurilin/ihniwid), but using a `?` was causing an ICE and now it does not (I get regular errors instead), so, good? A step towards https://github.com/Rust-GCC/gccrs/issues/166 perhaps?