### PR TITLE
Various tokenstream fixes

### DIFF
--- a/gcc/rust/ast/rust-ast-tokenstream.cc
+++ b/gcc/rust/ast/rust-ast-tokenstream.cc
@@ -745,8 +745,10 @@ TokenStream::visit (PathIdentSegment &segment)
 void
 TokenStream::visit (QualifiedPathInExpression &path)
 {
+  visit (path.get_qualified_path_type ());
   for (auto &segment : path.get_segments ())
     {
+      tokens.push_back (Rust::Token::make (SCOPE_RESOLUTION, Location ()));
       visit (segment);
     }
 }

--- a/gcc/rust/ast/rust-ast-tokenstream.cc
+++ b/gcc/rust/ast/rust-ast-tokenstream.cc
@@ -771,11 +771,11 @@ TokenStream::visit (QualifiedPathInType &path)
 {
   visit (path.get_qualified_path_type ());
 
-  tokens.push_back (Rust::Token::make (COLON, Location ()));
+  tokens.push_back (Rust::Token::make (SCOPE_RESOLUTION, Location ()));
   visit (path.get_associated_segment ());
   for (auto &segment : path.get_segments ())
     {
-      tokens.push_back (Rust::Token::make (COLON, Location ()));
+      tokens.push_back (Rust::Token::make (SCOPE_RESOLUTION, Location ()));
       visit (segment);
     }
 }

--- a/gcc/rust/ast/rust-ast-tokenstream.cc
+++ b/gcc/rust/ast/rust-ast-tokenstream.cc
@@ -1978,10 +1978,7 @@ TokenStream::visit_function_common (std::unique_ptr<Type> &return_type,
 
   if (block)
     {
-      if (return_type)
-	{
-	  visit (block);
-	}
+      visit (block);
     }
   else
     {

--- a/gcc/rust/lex/rust-token.cc
+++ b/gcc/rust/lex/rust-token.cc
@@ -148,7 +148,7 @@ Token::as_string () const
 	case BYTE_CHAR_LITERAL:
 	  return "b'" + get_str () + "'";
 	case LIFETIME:
-	  return "''" + get_str ();
+	  return "'" + get_str ();
 	case INT_LITERAL:
 	  if (get_type_hint () == CORETYPE_UNKNOWN)
 	    return get_str ();

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -1222,7 +1222,7 @@ Parser<ManagedTokenSource>::parse_outer_attribute ()
   auto input = std::move (std::get<1> (values));
   auto loc = std::get<2> (values);
   auto actual_attribute
-    = AST::Attribute (std::move (path), std::move (input), loc, true);
+    = AST::Attribute (std::move (path), std::move (input), loc, false);
 
   if (lexer.peek_token ()->get_id () != RIGHT_SQUARE)
     return AST::Attribute::create_empty ();


### PR DESCRIPTION
Upon looking at #2122 I discovered a bug in `QualifiedPathInTypes`, the scope resolution token was wrong, a colon was used instead. Whilst investigating the bug I found a few more.

- Fix a case were outer attributes were incorrectly set as inner attributes
- Fix the lifetime token string representation to use a single quote alone
- Fix the output of a function's body when there is no return type.
- Fix missing path in function call tokenstream output
- Fix the original bug around scope resolution token output