### PR TITLE
Add frust-extern option

### DIFF
--- a/gcc/rust/lang.opt
+++ b/gcc/rust/lang.opt
@@ -58,6 +58,10 @@ frust-crate=
 Rust Joined RejectNegative
 -frust-crate=<name>             Set the crate name for the compilation
 
+frust-extern=
+Rust RejectNegative Joined
+-frust-extern=              Specify where an external library is located
+
 frust-debug
 Rust Var(flag_rust_debug)
 Dump various Rust front end internals.

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -190,6 +190,11 @@ Session::handle_option (
       }
       break;
 
+      case OPT_frust_extern_: {
+	std::string input (arg);
+	ret = handle_extern_option (input);
+      }
+      break;
     case OPT_frust_crate_:
       // set the crate name
       if (arg != nullptr)
@@ -247,6 +252,20 @@ Session::handle_option (
     }
 
   return ret;
+}
+
+bool
+Session::handle_extern_option (std::string &input)
+{
+  auto pos = input.find ('=');
+  if (std::string::npos == pos)
+    return false;
+
+  std::string libname = input.substr (0, pos);
+  std::string path = input.substr (pos + 1);
+
+  extern_crates.insert ({libname, path});
+  return true;
 }
 
 bool

--- a/gcc/rust/rust-session-manager.h
+++ b/gcc/rust/rust-session-manager.h
@@ -290,6 +290,7 @@ struct Session
   /* This should really be in a per-crate storage area but it is wiped with
    * every file so eh. */
   std::string injected_crate_name;
+  std::map<std::string, std::string> extern_crates;
 
   /* extra files get included during late stages of compilation (e.g. macro
    * expansion) */
@@ -370,6 +371,8 @@ private:
 
   // handle cfg_option
   bool handle_cfg_option (std::string &data);
+
+  bool handle_extern_option (std::string &data);
 };
 
 } // namespace Rust


### PR DESCRIPTION
Add a new option to gather extern crates location.

gcc/rust/ChangeLog:

	* lang.opt: Add frust-extern option.
	* rust-session-manager.cc (Session::handle_extern_option): Add frust-extern option handler.
	* rust-session-manager.h (struct Session): Add an unordered map to store library name and locations.