### PR TITLE
parser: Parse reference patterns correctly

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -10949,7 +10949,7 @@ Parser<ManagedTokenSource>::parse_reference_pattern ()
     }
 
   // parse pattern to get reference of (required)
-  std::unique_ptr<AST::Pattern> pattern = parse_pattern ();
+  std::unique_ptr<AST::Pattern> pattern = parse_pattern_no_alt ();
   if (pattern == nullptr)
     {
       Error error (lexer.peek_token ()->get_locus (),

--- a/gcc/testsuite/rust/compile/issue-1807.rs
+++ b/gcc/testsuite/rust/compile/issue-1807.rs
@@ -1,0 +1,6 @@
+// { dg-additional-options "-fsyntax-only" }
+
+fn main() {
+    let is_zero = &|&&d: &&u8| -> bool { d == b'0' };
+    let lambda = |&c| c != b'9';
+}


### PR DESCRIPTION
Reference patterns cannot contain AltPatterns per the Rust reference,
so we should not call into `parse_pattern` to parse the referenced pattern,
but rather the more restrictive `parse_pattern_no_alt`.

gcc/rust/ChangeLog:

	* parse/rust-parse-impl.h (Parser::parse_reference_pattern): Do not
	call into `parse_pattern` anymore.

gcc/testsuite/ChangeLog:

	* rust/compile/issue-1807.rs: New test.

Fixes #1807