### PR TITLE
Add libgrust to clang-format checker

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -21,6 +21,6 @@ jobs:
     - name: Check clang-format
       uses: DoozyX/clang-format-lint-action@v0.11
       with:
-        source: 'gcc/rust/'
+        source: 'gcc/rust/ libgrust/'
         extensions: 'h,cc'
         clangFormatVersion: 10


### PR DESCRIPTION
Add the libgrust directory to the clang-format github action.

ChangeLog:

	* .github/workflows/clang-format.yml: Add libgrust directory.

Fixes #2148 