### PR TITLE
Proc macro type

### DIFF
--- a/libgrust/libproc_macro/proc_macro.cc
+++ b/libgrust/libproc_macro/proc_macro.cc
@@ -21,3 +21,32 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "proc_macro.h"
+
+namespace ProcMacro {
+
+Procmacro
+Procmacro::make_derive (const char *trait_name, const char **attributes,
+			std::uint64_t size, CustomDeriveMacro macro)
+{
+  ProcmacroPayload payload;
+  payload.custom_derive = {trait_name, attributes, size, macro};
+  return {CUSTOM_DERIVE, payload};
+}
+
+Procmacro
+Procmacro::make_attribute (const char *name, AttributeMacro macro)
+{
+  ProcmacroPayload payload;
+  payload.attribute = {name, macro};
+  return {ATTR, payload};
+}
+
+Procmacro
+Procmacro::make_bang (const char *name, BangMacro macro)
+{
+  ProcmacroPayload payload;
+  payload.bang = {name, macro};
+  return {BANG, payload};
+}
+
+} // namespace ProcMacro

--- a/libgrust/libproc_macro/proc_macro.h
+++ b/libgrust/libproc_macro/proc_macro.h
@@ -42,9 +42,9 @@ using BangMacro = TokenStream (*) (TokenStream);
 struct CustomDerivePayload
 {
   // TODO: UTF-8 function name
-  char *trait_name;
+  const char *trait_name;
   // TODO: UTF-8 attributes
-  char **attributes;
+  const char **attributes;
   std::uint64_t attr_size;
   CustomDeriveMacro macro;
 };
@@ -52,13 +52,13 @@ struct CustomDerivePayload
 struct AttrPayload
 {
   // TODO: UTF-8 function name
-  char *name;
+  const char *name;
   AttributeMacro macro;
 };
 
 struct BangPayload
 {
-  char *name;
+  const char *name;
   BangMacro macro;
 };
 }
@@ -81,6 +81,12 @@ struct Procmacro
 {
   ProcmacroTag tag;
   ProcmacroPayload payload;
+
+public:
+  Procmacro make_derive (const char *trait_name, const char **attribute,
+			 std::uint64_t size, CustomDeriveMacro macro);
+  Procmacro make_attribute (const char *name, AttributeMacro macro);
+  Procmacro make_bang (const char *name, BangMacro macro);
 };
 
 } // namespace ProcMacro

--- a/libgrust/libproc_macro/proc_macro.h
+++ b/libgrust/libproc_macro/proc_macro.h
@@ -23,11 +23,66 @@
 #ifndef PROC_MACRO_H
 #define PROC_MACRO_H
 
+#include <cstdint>
 #include "literal.h"
 #include "tokenstream.h"
 #include "tokentree.h"
 #include "group.h"
 #include "punct.h"
 #include "ident.h"
+
+namespace ProcMacro {
+
+extern "C" {
+
+using CustomDeriveMacro = TokenStream (*) (TokenStream);
+using AttributeMacro = TokenStream (*) (TokenStream, TokenStream);
+using BangMacro = TokenStream (*) (TokenStream);
+
+struct CustomDerivePayload
+{
+  // TODO: UTF-8 function name
+  char *trait_name;
+  // TODO: UTF-8 attributes
+  char **attributes;
+  std::uint64_t attr_size;
+  CustomDeriveMacro macro;
+};
+
+struct AttrPayload
+{
+  // TODO: UTF-8 function name
+  char *name;
+  AttributeMacro macro;
+};
+
+struct BangPayload
+{
+  char *name;
+  BangMacro macro;
+};
+}
+
+enum ProcmacroTag
+{
+  CUSTOM_DERIVE,
+  ATTR,
+  BANG,
+};
+
+union ProcmacroPayload
+{
+  CustomDerivePayload custom_derive;
+  AttrPayload attribute;
+  BangPayload bang;
+};
+
+struct Procmacro
+{
+  ProcmacroTag tag;
+  ProcmacroPayload payload;
+};
+
+} // namespace ProcMacro
 
 #endif /* ! PROC_MACRO_H */


### PR DESCRIPTION
Add a proc_macro type to identify the location of a proc macro function in the proc macro library. This model is slightly based upon the rustc format, the main difference resides within the fact we do not use a bridge/server communication but instead a function pointer directly to the macro function.