### PR TITLE
builtin: Cleanup handling of builtin macros

### DIFF
--- a/gcc/rust/ast/rust-macro.cc
+++ b/gcc/rust/ast/rust-macro.cc
@@ -21,47 +21,5 @@
 namespace Rust {
 namespace AST {
 
-BuiltinMacro
-builtin_macro_from_string (const std::string &identifier)
-{
-  if (identifier == "assert")
-    return BuiltinMacro::Assert;
-
-  if (identifier == "file")
-    return BuiltinMacro::File;
-
-  if (identifier == "line")
-    return BuiltinMacro::Line;
-
-  if (identifier == "column")
-    return BuiltinMacro::Column;
-
-  if (identifier == "include_bytes")
-    return BuiltinMacro::IncludeBytes;
-
-  if (identifier == "include_str")
-    return BuiltinMacro::IncludeStr;
-
-  if (identifier == "stringify")
-    return BuiltinMacro::Stringify;
-
-  if (identifier == "compile_error")
-    return BuiltinMacro::CompileError;
-
-  if (identifier == "concat")
-    return BuiltinMacro::Concat;
-
-  if (identifier == "env")
-    return BuiltinMacro::Env;
-
-  if (identifier == "cfg")
-    return BuiltinMacro::Cfg;
-
-  if (identifier == "include")
-    return BuiltinMacro::Include;
-
-  gcc_unreachable ();
-}
-
 } // namespace AST
 } // namespace Rust

--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -25,6 +25,7 @@
 #include "rust-location.h"
 #include "rust-item.h"
 #include "rust-make-unique.h"
+#include "rust-macro-builtins.h"
 
 namespace Rust {
 namespace AST {
@@ -577,28 +578,6 @@ protected:
     return new MacroRulesDefinition (*this);
   }
 };
-
-/**
- * All builtin macros possible
- */
-enum class BuiltinMacro
-{
-  Assert,
-  File,
-  Line,
-  Column,
-  IncludeBytes,
-  IncludeStr,
-  Stringify,
-  CompileError,
-  Concat,
-  Env,
-  Cfg,
-  Include
-};
-
-BuiltinMacro
-builtin_macro_from_string (const std::string &identifier);
 
 /* AST node of a macro invocation, which is replaced by the macro result at
  * compile time. This is technically a sum-type/tagged-union, which represents

--- a/gcc/rust/expand/rust-macro-builtins.cc
+++ b/gcc/rust/expand/rust-macro-builtins.cc
@@ -29,6 +29,7 @@
 #include "rust-macro.h"
 #include "rust-parse.h"
 #include "rust-session-manager.h"
+#include "bi-map.h"
 
 namespace Rust {
 namespace {

--- a/gcc/rust/expand/rust-macro-builtins.h
+++ b/gcc/rust/expand/rust-macro-builtins.h
@@ -23,6 +23,51 @@
 #include "rust-ast-fragment.h"
 #include "rust-location.h"
 
+namespace Rust {
+
+// FIXME: Add a BuiltinMacro class which contains a name (or should it?), a
+// transcriber and extra info if necessary
+// then make a global map<string, BuiltinMacro>
+
+/**
+ * All builtin macros possible
+ */
+enum class BuiltinMacro
+{
+  Assert,
+  File,
+  Line,
+  Column,
+  IncludeBytes,
+  IncludeStr,
+  Stringify,
+  CompileError,
+  Concat,
+  Env,
+  OptionEnv,
+  Cfg,
+  Include,
+  FormatArgs,
+  FormatArgsNl,
+  ConcatIdents,
+  ModulePath,
+  Asm,
+  LlvmAsm,
+  GlobalAsm,
+  LogSyntax,
+  TraceMacros,
+  Test,
+  Bench,
+  TestCase,
+  GlobalAllocator,
+  CfgAccessible,
+  RustcDecodable,
+  RustcEncodable,
+};
+
+BuiltinMacro
+builtin_macro_from_string (const std::string &identifier);
+
 /**
  * This class provides a list of builtin macros implemented by the compiler.
  * The functions defined are called "builtin transcribers" in that they replace
@@ -59,11 +104,13 @@
  * This map is built as a static variable in the `insert_macro_def()` method
  * of the `Mappings` class.
  */
-
-namespace Rust {
 class MacroBuiltin
 {
 public:
+  static std::unordered_map<
+    std::string, std::function<AST::Fragment (Location, AST::MacroInvocData &)>>
+    builtin_transcribers;
+
   static AST::Fragment assert_handler (Location invoc_locus,
 				       AST::MacroInvocData &invoc);
 
@@ -99,7 +146,20 @@ public:
 
   static AST::Fragment line_handler (Location invoc_locus,
 				     AST::MacroInvocData &invoc);
+
+  static AST::Fragment sorry (Location invoc_locus, AST::MacroInvocData &invoc);
 };
 } // namespace Rust
+
+namespace std {
+template <> struct hash<Rust::BuiltinMacro>
+{
+  size_t operator() (const Rust::BuiltinMacro &macro) const noexcept
+  {
+    return hash<std::underlying_type<Rust::BuiltinMacro>::type> () (
+      static_cast<std::underlying_type<Rust::BuiltinMacro>::type> (macro));
+  }
+};
+} // namespace std
 
 #endif // RUST_MACRO_BUILTINS_H

--- a/gcc/rust/resolve/rust-early-name-resolver.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver.cc
@@ -19,6 +19,7 @@
 #include "rust-early-name-resolver.h"
 #include "rust-ast-full.h"
 #include "rust-name-resolver.h"
+#include "rust-macro-builtins.h"
 
 namespace Rust {
 namespace Resolver {
@@ -873,7 +874,7 @@ EarlyNameResolver::visit (AST::MacroInvocation &invoc)
   if (is_builtin)
     {
       auto builtin_kind
-	= AST::builtin_macro_from_string (rules_def->get_rule_name ());
+	= builtin_macro_from_string (rules_def->get_rule_name ());
       invoc.map_to_builtin (builtin_kind);
     }
 

--- a/gcc/rust/util/bi-map.h
+++ b/gcc/rust/util/bi-map.h
@@ -1,0 +1,48 @@
+// Copyright (C) 2020-2023 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-system.h"
+
+#ifndef BIMAP_H
+#define BIMAP_H
+
+// very simple bi-directional hashmap
+template <typename K, typename V> class BiMap
+{
+  using v_iter = typename std::unordered_map<K, V>::const_iterator;
+  using k_iter = typename std::unordered_map<V, K>::const_iterator;
+
+public:
+  BiMap (std::unordered_map<K, V> &&original) : map (std::move (original))
+  {
+    for (auto &kv : map)
+      rmap.insert ({kv.second, kv.first});
+  }
+
+  const v_iter lookup (const K &key) const { return map.find (key); }
+  const k_iter lookup (const V &key) const { return rmap.find (key); }
+
+  bool is_iter_ok (const v_iter &iter) const { return iter != map.end (); }
+  bool is_iter_ok (const k_iter &iter) const { return iter != rmap.end (); }
+
+private:
+  std::unordered_map<K, V> map;
+  std::unordered_map<V, K> rmap;
+};
+
+#endif // !BIMAP_H

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -868,23 +868,6 @@ Mappings::iterate_trait_items (
 void
 Mappings::insert_macro_def (AST::MacroRulesDefinition *macro)
 {
-  static std::map<
-    std::string, std::function<AST::Fragment (Location, AST::MacroInvocData &)>>
-    builtin_macros = {
-      {"assert", MacroBuiltin::assert_handler},
-      {"file", MacroBuiltin::file_handler},
-      {"line", MacroBuiltin::line_handler},
-      {"column", MacroBuiltin::column_handler},
-      {"include_bytes", MacroBuiltin::include_bytes_handler},
-      {"include_str", MacroBuiltin::include_str_handler},
-      {"stringify", MacroBuiltin::stringify_handler},
-      {"compile_error", MacroBuiltin::compile_error_handler},
-      {"concat", MacroBuiltin::concat_handler},
-      {"env", MacroBuiltin::env_handler},
-      {"cfg", MacroBuiltin::cfg_handler},
-      {"include", MacroBuiltin::include_handler},
-    };
-
   auto outer_attrs = macro->get_outer_attrs ();
   bool should_be_builtin
     = std::any_of (outer_attrs.begin (), outer_attrs.end (),
@@ -893,8 +876,9 @@ Mappings::insert_macro_def (AST::MacroRulesDefinition *macro)
 		   });
   if (should_be_builtin)
     {
-      auto builtin = builtin_macros.find (macro->get_rule_name ());
-      if (builtin != builtin_macros.end ())
+      auto builtin
+	= MacroBuiltin::builtin_transcribers.find (macro->get_rule_name ());
+      if (builtin != MacroBuiltin::builtin_transcribers.end ())
 	macro->set_builtin_transcriber (builtin->second);
       else
 	rust_error_at (macro->get_locus (),


### PR DESCRIPTION
This commit regroups information related to builtin macros in one place instead
of spreading it over multiple files. It also adds a simple bi-directional
hashmap in order to perform lookups from a key as well as a value.

gcc/rust/ChangeLog:

	* ast/rust-macro.cc (builtin_macro_from_string): Move function.
	* ast/rust-macro.h (enum class): Move enum.
	(builtin_macro_from_string): Move function.
	* expand/rust-macro-builtins.cc (builtin_macro_from_string): New function.
	(make_macro_path_str): Use new bi-map.
	(parse_single_string_literal): Use new `BuiltinMacro` enum.
	(MacroBuiltin::include_bytes_handler): Likewise.
	(MacroBuiltin::include_str_handler): Likewise.
	(MacroBuiltin::compile_error_handler): Likewise.
	(MacroBuiltin::concat_handler): Likewise.
	(MacroBuiltin::env_handler): Likewise.
	(MacroBuiltin::include_handler): Likewise.
	(MacroBuiltin::sorry): New function.
	* expand/rust-macro-builtins.h (enum class): Move enum here.
	(builtin_macro_from_string): New function declaration.
	* resolve/rust-early-name-resolver.cc (EarlyNameResolver::visit): Use
	new function.
	* util/rust-hir-map.cc (Mappings::insert_macro_def): Remove old
	builtin macro map.

