### PR TITLE
Modularize libproc macro

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -182,11 +182,14 @@ RUST_ALL_OBJS = $(GRS_OBJS) $(RUST_TARGET_OBJS)
 
 rust_OBJS = $(RUST_ALL_OBJS) rust/rustspec.o
 
+RUST_LDFLAGS = $(LDFLAGS) -L./../libgrust/libproc_macro
+RUST_LIBDEPS = $(LIBDEPS) ../libgrust/libproc_macro/libproc_macro.a
+
 # The compiler itself is called crab1
-crab1$(exeext): $(RUST_ALL_OBJS) attribs.o $(BACKEND) $(LIBDEPS) $(rust.prev)
+crab1$(exeext): $(RUST_ALL_OBJS) attribs.o $(BACKEND) $(RUST_LIBDEPS) $(rust.prev)
 	@$(call LINK_PROGRESS,$(INDEX.rust),start)
-	+$(LLINKER) $(ALL_LINKERFLAGS) $(LDFLAGS) -o $@ \
-	      $(RUST_ALL_OBJS) attribs.o $(BACKEND) $(LIBS) $(BACKENDLIBS)
+	+$(LLINKER) $(ALL_LINKERFLAGS) $(RUST_LDFLAGS) -o $@ \
+	      $(RUST_ALL_OBJS) attribs.o $(BACKEND) $(LIBS) ../libgrust/libproc_macro/libproc_macro.a $(BACKENDLIBS)
 	@$(call LINK_PROGRESS,$(INDEX.rust),end)
 
 # Build hooks.
@@ -355,7 +358,8 @@ RUST_INCLUDES = -I $(srcdir)/rust \
 	-I $(srcdir)/rust/checks/errors \
 	-I $(srcdir)/rust/checks/errors/privacy \
 	-I $(srcdir)/rust/util \
-        -I $(srcdir)/rust/metadata
+        -I $(srcdir)/rust/metadata \
+		-I $(srcdir)/../libgrust
 
 # add files that require cross-folder includes - currently rust-lang.o, rust-lex.o
 CFLAGS-rust/rust-lang.o += $(RUST_INCLUDES)

--- a/libgrust/Makefile.am
+++ b/libgrust/Makefile.am
@@ -11,9 +11,6 @@ TOP_GCCDIR := $(shell cd $(top_srcdir) && cd .. && pwd)
 GCC_DIR = $(TOP_GCCDIR)/gcc
 RUST_SRC = $(GCC_DIR)/rust
 
-toolexeclibdir=@toolexeclibdir@
-toolexecdir=@toolexecdir@
-
 SUBDIRS = libproc_macro
 
 RUST_BUILDDIR := $(shell pwd)
@@ -62,7 +59,6 @@ AM_MAKEFLAGS = \
 	"DESTDIR=$(DESTDIR)" \
 	"WERROR=$(WERROR)" \
         "TARGET_LIB_PATH=$(TARGET_LIB_PATH)" \
-        "TARGET_LIB_PATH_librust=$(TARGET_LIB_PATH_librust)" \
-	"LIBTOOL=$(RUST_BUILDDIR)/libtool"
+        "TARGET_LIB_PATH_librust=$(TARGET_LIB_PATH_librust)"
 
 include $(top_srcdir)/../multilib.am

--- a/libgrust/Makefile.in
+++ b/libgrust/Makefile.in
@@ -350,8 +350,7 @@ AM_MAKEFLAGS = \
 	"DESTDIR=$(DESTDIR)" \
 	"WERROR=$(WERROR)" \
         "TARGET_LIB_PATH=$(TARGET_LIB_PATH)" \
-        "TARGET_LIB_PATH_librust=$(TARGET_LIB_PATH_librust)" \
-	"LIBTOOL=$(RUST_BUILDDIR)/libtool"
+        "TARGET_LIB_PATH_librust=$(TARGET_LIB_PATH_librust)"
 
 MULTISRCTOP = 
 MULTIBUILDTOP = 

--- a/libgrust/libproc_macro/Makefile.am
+++ b/libgrust/libproc_macro/Makefile.am
@@ -45,8 +45,7 @@ AM_MAKEFLAGS = \
 	"NM_FOR_TARGET=$(NM_FOR_TARGET)" \
 	"DESTDIR=$(DESTDIR)" \
 	"WERROR=$(WERROR)" \
-        "TARGET_LIB_PATH=$(TARGET_LIB_PATH)" \
-        "TARGET_LIB_PATH_libgm2=$(TARGET_LIB_PATH_libgm2)"
+        "TARGET_LIB_PATH=$(TARGET_LIB_PATH)"
 
 toolexeclib_LTLIBRARIES = libproc_macro.la
 

--- a/libgrust/libproc_macro/Makefile.am
+++ b/libgrust/libproc_macro/Makefile.am
@@ -2,8 +2,8 @@ SUFFIXES = .cc .o .a .lo .la
 
 ACLOCAL_AMFLAGS = -I .. -I ../../config
 
-toolexeclibdir=@toolexeclibdir@
-toolexecdir=@toolexecdir@
+AR = @AR@
+AR_FLAGS = rc
 
 # Work around what appears to be a GNU make bug handling MAKEFLAGS
 # values defined in terms of make variables, as is the case for CC and
@@ -47,17 +47,17 @@ AM_MAKEFLAGS = \
 	"WERROR=$(WERROR)" \
         "TARGET_LIB_PATH=$(TARGET_LIB_PATH)"
 
-toolexeclib_LTLIBRARIES = libproc_macro.la
 
-libproc_macro_la_SOURCES = \
-	proc_macro.cc \
-	ident.cc \
-	punct.cc \
-	group.cc \
-	tokentree.cc \
-	tokenstream.cc \
-	literal.cc
+TARGETLIB = ./libproc_macro.a
+LIBOBJS = @LIBOBJS@
+objext = @OBJEXT@
 
-include_HEADERS = \
-	proc_macro.h
+REQUIRED_OFILES =							\
+	./proc_macro.$(objext) ./literal.$(objext) ./group.$(objext) ./ident.$(objext) ./punct.$(objext) ./tokenstream.$(objext) ./tokentree.$(objext)
 
+all: $(TARGETLIB)
+
+$(TARGETLIB): $(REQUIRED_OFILES) $(LIBOBJS)
+	-rm -f $(TARGETLIB)
+	$(AR) $(AR_FLAGS) $(TARGETLIB) \
+	  $(REQUIRED_OFILES) $(EXTRA_OFILES) $(LIBOBJS)

--- a/libgrust/libproc_macro/Makefile.in
+++ b/libgrust/libproc_macro/Makefile.in
@@ -381,8 +381,7 @@ AM_MAKEFLAGS = \
 	"NM_FOR_TARGET=$(NM_FOR_TARGET)" \
 	"DESTDIR=$(DESTDIR)" \
 	"WERROR=$(WERROR)" \
-        "TARGET_LIB_PATH=$(TARGET_LIB_PATH)" \
-        "TARGET_LIB_PATH_libgm2=$(TARGET_LIB_PATH_libgm2)"
+        "TARGET_LIB_PATH=$(TARGET_LIB_PATH)"
 
 toolexeclib_LTLIBRARIES = libproc_macro.la
 libproc_macro_la_SOURCES = \

--- a/libgrust/libproc_macro/Makefile.in
+++ b/libgrust/libproc_macro/Makefile.in
@@ -13,8 +13,6 @@
 # PARTICULAR PURPOSE.
 
 @SET_MAKE@
-
-
 VPATH = @srcdir@
 am__is_gnu_make = { \
   if test -z '$(MAKELEVEL)'; then \
@@ -103,48 +101,10 @@ am__aclocal_m4_deps = $(top_srcdir)/../config/acx.m4 \
 	$(top_srcdir)/../lt~obsolete.m4 $(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
-DIST_COMMON = $(srcdir)/Makefile.am $(include_HEADERS)
+DIST_COMMON = $(srcdir)/Makefile.am
 mkinstalldirs = $(SHELL) $(top_srcdir)/../mkinstalldirs
 CONFIG_CLEAN_FILES =
 CONFIG_CLEAN_VPATH_FILES =
-am__vpath_adj_setup = srcdirstrip=`echo "$(srcdir)" | sed 's|.|.|g'`;
-am__vpath_adj = case $$p in \
-    $(srcdir)/*) f=`echo "$$p" | sed "s|^$$srcdirstrip/||"`;; \
-    *) f=$$p;; \
-  esac;
-am__strip_dir = f=`echo $$p | sed -e 's|^.*/||'`;
-am__install_max = 40
-am__nobase_strip_setup = \
-  srcdirstrip=`echo "$(srcdir)" | sed 's/[].[^$$\\*|]/\\\\&/g'`
-am__nobase_strip = \
-  for p in $$list; do echo "$$p"; done | sed -e "s|$$srcdirstrip/||"
-am__nobase_list = $(am__nobase_strip_setup); \
-  for p in $$list; do echo "$$p $$p"; done | \
-  sed "s| $$srcdirstrip/| |;"' / .*\//!s/ .*/ ./; s,\( .*\)/[^/]*$$,\1,' | \
-  $(AWK) 'BEGIN { files["."] = "" } { files[$$2] = files[$$2] " " $$1; \
-    if (++n[$$2] == $(am__install_max)) \
-      { print $$2, files[$$2]; n[$$2] = 0; files[$$2] = "" } } \
-    END { for (dir in files) print dir, files[dir] }'
-am__base_list = \
-  sed '$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;s/\n/ /g' | \
-  sed '$$!N;$$!N;$$!N;$$!N;s/\n/ /g'
-am__uninstall_files_from_dir = { \
-  test -z "$$files" \
-    || { test ! -d "$$dir" && test ! -f "$$dir" && test ! -r "$$dir"; } \
-    || { echo " ( cd '$$dir' && rm -f" $$files ")"; \
-         $(am__cd) "$$dir" && rm -f $$files; }; \
-  }
-am__installdirs = "$(DESTDIR)$(toolexeclibdir)" \
-	"$(DESTDIR)$(includedir)"
-LTLIBRARIES = $(toolexeclib_LTLIBRARIES)
-libproc_macro_la_LIBADD =
-am_libproc_macro_la_OBJECTS = proc_macro.lo ident.lo punct.lo group.lo \
-	tokentree.lo tokenstream.lo literal.lo
-libproc_macro_la_OBJECTS = $(am_libproc_macro_la_OBJECTS)
-AM_V_lt = $(am__v_lt_@AM_V@)
-am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
-am__v_lt_0 = --silent
-am__v_lt_1 = 
 AM_V_P = $(am__v_P_@AM_V@)
 am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
 am__v_P_0 = false
@@ -157,54 +117,13 @@ AM_V_at = $(am__v_at_@AM_V@)
 am__v_at_ = $(am__v_at_@AM_DEFAULT_V@)
 am__v_at_0 = @
 am__v_at_1 = 
-DEFAULT_INCLUDES = -I.@am__isrc@
-depcomp = $(SHELL) $(top_srcdir)/../depcomp
-am__depfiles_maybe = depfiles
-am__mv = mv -f
-CXXCOMPILE = $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) \
-	$(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS)
-LTCXXCOMPILE = $(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) \
-	$(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) \
-	$(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) \
-	$(AM_CXXFLAGS) $(CXXFLAGS)
-AM_V_CXX = $(am__v_CXX_@AM_V@)
-am__v_CXX_ = $(am__v_CXX_@AM_DEFAULT_V@)
-am__v_CXX_0 = @echo "  CXX     " $@;
-am__v_CXX_1 = 
-CXXLD = $(CXX)
-CXXLINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) \
-	$(LIBTOOLFLAGS) --mode=link $(CXXLD) $(AM_CXXFLAGS) \
-	$(CXXFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
-AM_V_CXXLD = $(am__v_CXXLD_@AM_V@)
-am__v_CXXLD_ = $(am__v_CXXLD_@AM_DEFAULT_V@)
-am__v_CXXLD_0 = @echo "  CXXLD   " $@;
-am__v_CXXLD_1 = 
-SOURCES = $(libproc_macro_la_SOURCES)
+SOURCES =
 am__can_run_installinfo = \
   case $$AM_UPDATE_INFO_DIR in \
     n|no|NO) false;; \
     *) (install-info --version) >/dev/null 2>&1;; \
   esac
-HEADERS = $(include_HEADERS)
 am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
-# Read a list of newline-separated strings from the standard input,
-# and print each of them once, without duplicates.  Input order is
-# *not* preserved.
-am__uniquify_input = $(AWK) '\
-  BEGIN { nonempty = 0; } \
-  { items[$$0] = 1; nonempty = 1; } \
-  END { if (nonempty) { for (i in items) print i; }; } \
-'
-# Make sure the list of sources is unique.  This is necessary because,
-# e.g., the same source file might be shared among _SOURCES variables
-# for different programs/libraries.
-am__define_uniq_tagged_files = \
-  list='$(am__tagged_files)'; \
-  unique=`for i in $$list; do \
-    if test -f "$$i"; then echo $$i; else echo $(srcdir)/$$i; fi; \
-  done | $(am__uniquify_input)`
-ETAGS = etags
-CTAGS = ctags
 ACLOCAL = @ACLOCAL@
 AMTAR = @AMTAR@
 AM_DEFAULT_VERBOSITY = @AM_DEFAULT_VERBOSITY@
@@ -340,6 +259,7 @@ top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 SUFFIXES = .cc .o .a .lo .la
 ACLOCAL_AMFLAGS = -I .. -I ../../config
+AR_FLAGS = rc
 
 # Work around what appears to be a GNU make bug handling MAKEFLAGS
 # values defined in terms of make variables, as is the case for CC and
@@ -383,23 +303,15 @@ AM_MAKEFLAGS = \
 	"WERROR=$(WERROR)" \
         "TARGET_LIB_PATH=$(TARGET_LIB_PATH)"
 
-toolexeclib_LTLIBRARIES = libproc_macro.la
-libproc_macro_la_SOURCES = \
-	proc_macro.cc \
-	ident.cc \
-	punct.cc \
-	group.cc \
-	tokentree.cc \
-	tokenstream.cc \
-	literal.cc
-
-include_HEADERS = \
-	proc_macro.h
+TARGETLIB = ./libproc_macro.a
+objext = @OBJEXT@
+REQUIRED_OFILES = \
+	./proc_macro.$(objext) ./literal.$(objext) ./group.$(objext) ./ident.$(objext) ./punct.$(objext) ./tokenstream.$(objext) ./tokentree.$(objext)
 
 all: all-am
 
 .SUFFIXES:
-.SUFFIXES: .cc .o .a .lo .la .obj
+.SUFFIXES: .cc .o .a .lo .la
 $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__configure_deps)
 	@for dep in $?; do \
 	  case '$(am__configure_deps)' in \
@@ -430,164 +342,21 @@ $(ACLOCAL_M4): @MAINTAINER_MODE_TRUE@ $(am__aclocal_m4_deps)
 	cd $(top_builddir) && $(MAKE) $(AM_MAKEFLAGS) am--refresh
 $(am__aclocal_m4_deps):
 
-install-toolexeclibLTLIBRARIES: $(toolexeclib_LTLIBRARIES)
-	@$(NORMAL_INSTALL)
-	@list='$(toolexeclib_LTLIBRARIES)'; test -n "$(toolexeclibdir)" || list=; \
-	list2=; for p in $$list; do \
-	  if test -f $$p; then \
-	    list2="$$list2 $$p"; \
-	  else :; fi; \
-	done; \
-	test -z "$$list2" || { \
-	  echo " $(MKDIR_P) '$(DESTDIR)$(toolexeclibdir)'"; \
-	  $(MKDIR_P) "$(DESTDIR)$(toolexeclibdir)" || exit 1; \
-	  echo " $(LIBTOOL) $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=install $(INSTALL) $(INSTALL_STRIP_FLAG) $$list2 '$(DESTDIR)$(toolexeclibdir)'"; \
-	  $(LIBTOOL) $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=install $(INSTALL) $(INSTALL_STRIP_FLAG) $$list2 "$(DESTDIR)$(toolexeclibdir)"; \
-	}
-
-uninstall-toolexeclibLTLIBRARIES:
-	@$(NORMAL_UNINSTALL)
-	@list='$(toolexeclib_LTLIBRARIES)'; test -n "$(toolexeclibdir)" || list=; \
-	for p in $$list; do \
-	  $(am__strip_dir) \
-	  echo " $(LIBTOOL) $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=uninstall rm -f '$(DESTDIR)$(toolexeclibdir)/$$f'"; \
-	  $(LIBTOOL) $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=uninstall rm -f "$(DESTDIR)$(toolexeclibdir)/$$f"; \
-	done
-
-clean-toolexeclibLTLIBRARIES:
-	-test -z "$(toolexeclib_LTLIBRARIES)" || rm -f $(toolexeclib_LTLIBRARIES)
-	@list='$(toolexeclib_LTLIBRARIES)'; \
-	locs=`for p in $$list; do echo $$p; done | \
-	      sed 's|^[^/]*$$|.|; s|/[^/]*$$||; s|$$|/so_locations|' | \
-	      sort -u`; \
-	test -z "$$locs" || { \
-	  echo rm -f $${locs}; \
-	  rm -f $${locs}; \
-	}
-
-libproc_macro.la: $(libproc_macro_la_OBJECTS) $(libproc_macro_la_DEPENDENCIES) $(EXTRA_libproc_macro_la_DEPENDENCIES) 
-	$(AM_V_CXXLD)$(CXXLINK) -rpath $(toolexeclibdir) $(libproc_macro_la_OBJECTS) $(libproc_macro_la_LIBADD) $(LIBS)
-
-mostlyclean-compile:
-	-rm -f *.$(OBJEXT)
-
-distclean-compile:
-	-rm -f *.tab.c
-
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/group.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ident.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/literal.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/proc_macro.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/punct.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/tokenstream.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/tokentree.Plo@am__quote@
-
-.cc.o:
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXXCOMPILE) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $<
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='$<' object='$@' libtool=no @AMDEPBACKSLASH@
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXXCOMPILE) -c -o $@ $<
-
-.cc.obj:
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXXCOMPILE) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ `$(CYGPATH_W) '$<'`
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='$<' object='$@' libtool=no @AMDEPBACKSLASH@
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXXCOMPILE) -c -o $@ `$(CYGPATH_W) '$<'`
-
-.cc.lo:
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LTCXXCOMPILE) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $<
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/$*.Tpo $(DEPDIR)/$*.Plo
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='$<' object='$@' libtool=yes @AMDEPBACKSLASH@
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LTCXXCOMPILE) -c -o $@ $<
-
 mostlyclean-libtool:
 	-rm -f *.lo
 
 clean-libtool:
 	-rm -rf .libs _libs
-install-includeHEADERS: $(include_HEADERS)
-	@$(NORMAL_INSTALL)
-	@list='$(include_HEADERS)'; test -n "$(includedir)" || list=; \
-	if test -n "$$list"; then \
-	  echo " $(MKDIR_P) '$(DESTDIR)$(includedir)'"; \
-	  $(MKDIR_P) "$(DESTDIR)$(includedir)" || exit 1; \
-	fi; \
-	for p in $$list; do \
-	  if test -f "$$p"; then d=; else d="$(srcdir)/"; fi; \
-	  echo "$$d$$p"; \
-	done | $(am__base_list) | \
-	while read files; do \
-	  echo " $(INSTALL_HEADER) $$files '$(DESTDIR)$(includedir)'"; \
-	  $(INSTALL_HEADER) $$files "$(DESTDIR)$(includedir)" || exit $$?; \
-	done
+tags TAGS:
 
-uninstall-includeHEADERS:
-	@$(NORMAL_UNINSTALL)
-	@list='$(include_HEADERS)'; test -n "$(includedir)" || list=; \
-	files=`for p in $$list; do echo $$p; done | sed -e 's|^.*/||'`; \
-	dir='$(DESTDIR)$(includedir)'; $(am__uninstall_files_from_dir)
+ctags CTAGS:
 
-ID: $(am__tagged_files)
-	$(am__define_uniq_tagged_files); mkid -fID $$unique
-tags: tags-am
-TAGS: tags
+cscope cscopelist:
 
-tags-am: $(TAGS_DEPENDENCIES) $(am__tagged_files)
-	set x; \
-	here=`pwd`; \
-	$(am__define_uniq_tagged_files); \
-	shift; \
-	if test -z "$(ETAGS_ARGS)$$*$$unique"; then :; else \
-	  test -n "$$unique" || unique=$$empty_fix; \
-	  if test $$# -gt 0; then \
-	    $(ETAGS) $(ETAGSFLAGS) $(AM_ETAGSFLAGS) $(ETAGS_ARGS) \
-	      "$$@" $$unique; \
-	  else \
-	    $(ETAGS) $(ETAGSFLAGS) $(AM_ETAGSFLAGS) $(ETAGS_ARGS) \
-	      $$unique; \
-	  fi; \
-	fi
-ctags: ctags-am
-
-CTAGS: ctags
-ctags-am: $(TAGS_DEPENDENCIES) $(am__tagged_files)
-	$(am__define_uniq_tagged_files); \
-	test -z "$(CTAGS_ARGS)$$unique" \
-	  || $(CTAGS) $(CTAGSFLAGS) $(AM_CTAGSFLAGS) $(CTAGS_ARGS) \
-	     $$unique
-
-GTAGS:
-	here=`$(am__cd) $(top_builddir) && pwd` \
-	  && $(am__cd) $(top_srcdir) \
-	  && gtags -i $(GTAGS_ARGS) "$$here"
-cscopelist: cscopelist-am
-
-cscopelist-am: $(am__tagged_files)
-	list='$(am__tagged_files)'; \
-	case "$(srcdir)" in \
-	  [\\/]* | ?:[\\/]*) sdir="$(srcdir)" ;; \
-	  *) sdir=$(subdir)/$(srcdir) ;; \
-	esac; \
-	for i in $$list; do \
-	  if test -f "$$i"; then \
-	    echo "$(subdir)/$$i"; \
-	  else \
-	    echo "$$sdir/$$i"; \
-	  fi; \
-	done >> $(top_builddir)/cscope.files
-
-distclean-tags:
-	-rm -f TAGS ID GTAGS GRTAGS GSYMS GPATH tags
 check-am: all-am
 check: check-am
-all-am: Makefile $(LTLIBRARIES) $(HEADERS)
+all-am: Makefile
 installdirs:
-	for dir in "$(DESTDIR)$(toolexeclibdir)" "$(DESTDIR)$(includedir)"; do \
-	  test -z "$$dir" || $(MKDIR_P) "$$dir"; \
-	done
 install: install-am
 install-exec: install-exec-am
 install-data: install-data-am
@@ -620,14 +389,11 @@ maintainer-clean-generic:
 	@echo "it deletes files that may require special tools to rebuild."
 clean: clean-am
 
-clean-am: clean-generic clean-libtool clean-toolexeclibLTLIBRARIES \
-	mostlyclean-am
+clean-am: clean-generic clean-libtool mostlyclean-am
 
 distclean: distclean-am
-	-rm -rf ./$(DEPDIR)
 	-rm -f Makefile
-distclean-am: clean-am distclean-compile distclean-generic \
-	distclean-tags
+distclean-am: clean-am distclean-generic
 
 dvi: dvi-am
 
@@ -641,13 +407,13 @@ info: info-am
 
 info-am:
 
-install-data-am: install-includeHEADERS
+install-data-am:
 
 install-dvi: install-dvi-am
 
 install-dvi-am:
 
-install-exec-am: install-toolexeclibLTLIBRARIES
+install-exec-am:
 
 install-html: install-html-am
 
@@ -670,14 +436,12 @@ install-ps-am:
 installcheck-am:
 
 maintainer-clean: maintainer-clean-am
-	-rm -rf ./$(DEPDIR)
 	-rm -f Makefile
 maintainer-clean-am: distclean-am maintainer-clean-generic
 
 mostlyclean: mostlyclean-am
 
-mostlyclean-am: mostlyclean-compile mostlyclean-generic \
-	mostlyclean-libtool
+mostlyclean-am: mostlyclean-generic mostlyclean-libtool
 
 pdf: pdf-am
 
@@ -687,29 +451,31 @@ ps: ps-am
 
 ps-am:
 
-uninstall-am: uninstall-includeHEADERS \
-	uninstall-toolexeclibLTLIBRARIES
+uninstall-am:
 
 .MAKE: install-am install-strip
 
-.PHONY: CTAGS GTAGS TAGS all all-am check check-am clean clean-generic \
-	clean-libtool clean-toolexeclibLTLIBRARIES cscopelist-am ctags \
-	ctags-am distclean distclean-compile distclean-generic \
-	distclean-libtool distclean-tags dvi dvi-am html html-am info \
-	info-am install install-am install-data install-data-am \
-	install-dvi install-dvi-am install-exec install-exec-am \
-	install-html install-html-am install-includeHEADERS \
-	install-info install-info-am install-man install-pdf \
-	install-pdf-am install-ps install-ps-am install-strip \
-	install-toolexeclibLTLIBRARIES installcheck installcheck-am \
-	installdirs maintainer-clean maintainer-clean-generic \
-	mostlyclean mostlyclean-compile mostlyclean-generic \
-	mostlyclean-libtool pdf pdf-am ps ps-am tags tags-am uninstall \
-	uninstall-am uninstall-includeHEADERS \
-	uninstall-toolexeclibLTLIBRARIES
+.PHONY: all all-am check check-am clean clean-generic clean-libtool \
+	cscopelist-am ctags-am distclean distclean-generic \
+	distclean-libtool dvi dvi-am html html-am info info-am install \
+	install-am install-data install-data-am install-dvi \
+	install-dvi-am install-exec install-exec-am install-html \
+	install-html-am install-info install-info-am install-man \
+	install-pdf install-pdf-am install-ps install-ps-am \
+	install-strip installcheck installcheck-am installdirs \
+	maintainer-clean maintainer-clean-generic mostlyclean \
+	mostlyclean-generic mostlyclean-libtool pdf pdf-am ps ps-am \
+	tags-am uninstall uninstall-am
 
 .PRECIOUS: Makefile
 
+
+all: $(TARGETLIB)
+
+$(TARGETLIB): $(REQUIRED_OFILES) $(LIBOBJS)
+	-rm -f $(TARGETLIB)
+	$(AR) $(AR_FLAGS) $(TARGETLIB) \
+	  $(REQUIRED_OFILES) $(EXTRA_OFILES) $(LIBOBJS)
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.

--- a/libgrust/libproc_macro/group.cc
+++ b/libgrust/libproc_macro/group.cc
@@ -22,6 +22,7 @@
 
 #include "group.h"
 
+namespace ProcMacro {
 namespace Group {
 
 Group
@@ -37,3 +38,4 @@ Group::drop (Group *g)
 }
 
 } // namespace Group
+} // namespace ProcMacro

--- a/libgrust/libproc_macro/group.cc
+++ b/libgrust/libproc_macro/group.cc
@@ -23,10 +23,9 @@
 #include "group.h"
 
 namespace ProcMacro {
-namespace Group {
 
 Group
-Group::make_group (TokenStream::TokenStream stream, Delimiter delim)
+Group::make_group (TokenStream stream, Delimiter delim)
 {
   return {delim, stream};
 }
@@ -37,5 +36,4 @@ Group::drop (Group *g)
   TokenStream::TokenStream::drop (&g->stream);
 }
 
-} // namespace Group
 } // namespace ProcMacro

--- a/libgrust/libproc_macro/group.h
+++ b/libgrust/libproc_macro/group.h
@@ -25,6 +25,7 @@
 
 #include "tokenstream.h"
 
+namespace ProcMacro {
 namespace Group {
 
 enum Delimiter
@@ -47,5 +48,6 @@ public:
 };
 
 } // namespace Group
+} // namespace ProcMacro
 
 #endif /* ! GROUP_H */

--- a/libgrust/libproc_macro/group.h
+++ b/libgrust/libproc_macro/group.h
@@ -26,28 +26,26 @@
 #include "tokenstream.h"
 
 namespace ProcMacro {
-namespace Group {
 
 enum Delimiter
 {
-  Parenthesis,
-  Brace,
-  Bracket,
-  None,
+  PARENTHESIS,
+  BRACE,
+  BRACKET,
+  NONE,
 };
 
 struct Group
 {
   Delimiter delimiter;
-  TokenStream::TokenStream stream;
+  TokenStream stream;
 
 public:
-  static Group make_group (TokenStream::TokenStream stream, Delimiter delim);
+  static Group make_group (TokenStream stream, Delimiter delim);
 
   static void drop (Group *g);
 };
 
-} // namespace Group
 } // namespace ProcMacro
 
 #endif /* ! GROUP_H */

--- a/libgrust/libproc_macro/ident.cc
+++ b/libgrust/libproc_macro/ident.cc
@@ -23,6 +23,7 @@
 
 #include <cstring>
 
+namespace ProcMacro {
 namespace Ident {
 
 extern "C" {
@@ -84,3 +85,4 @@ Ident::drop (Ident *ident)
 }
 
 } // namespace Ident
+} // namespace ProcMacro

--- a/libgrust/libproc_macro/ident.cc
+++ b/libgrust/libproc_macro/ident.cc
@@ -24,7 +24,6 @@
 #include <cstring>
 
 namespace ProcMacro {
-namespace Ident {
 
 extern "C" {
 
@@ -84,5 +83,4 @@ Ident::drop (Ident *ident)
   ident->len = 0;
 }
 
-} // namespace Ident
 } // namespace ProcMacro

--- a/libgrust/libproc_macro/ident.h
+++ b/libgrust/libproc_macro/ident.h
@@ -27,7 +27,6 @@
 #include <string>
 
 namespace ProcMacro {
-namespace Ident {
 
 struct Ident
 {
@@ -61,7 +60,6 @@ Ident
 Ident__clone (const Ident *ident);
 }
 
-} // namespace Ident
 } // namespace ProcMacro
 
 #endif /* ! IDENT_H */

--- a/libgrust/libproc_macro/ident.h
+++ b/libgrust/libproc_macro/ident.h
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <string>
 
+namespace ProcMacro {
 namespace Ident {
 
 struct Ident
@@ -61,5 +62,6 @@ Ident__clone (const Ident *ident);
 }
 
 } // namespace Ident
+} // namespace ProcMacro
 
 #endif /* ! IDENT_H */

--- a/libgrust/libproc_macro/literal.cc
+++ b/libgrust/libproc_macro/literal.cc
@@ -24,6 +24,7 @@
 #include <cstring>
 #include <cstdlib>
 
+namespace ProcMacro {
 namespace Literal {
 
 void
@@ -289,3 +290,4 @@ Literal::make_isize (std::int64_t value, bool suffixed)
 }
 
 } // namespace Literal
+} // namespace ProcMacro

--- a/libgrust/libproc_macro/literal.cc
+++ b/libgrust/libproc_macro/literal.cc
@@ -25,7 +25,6 @@
 #include <cstdlib>
 
 namespace ProcMacro {
-namespace Literal {
 
 void
 Literal::drop (Literal *lit)
@@ -289,5 +288,4 @@ Literal::make_isize (std::int64_t value, bool suffixed)
   return {ISIZE, payload};
 }
 
-} // namespace Literal
 } // namespace ProcMacro

--- a/libgrust/libproc_macro/literal.h
+++ b/libgrust/libproc_macro/literal.h
@@ -27,6 +27,7 @@
 #include <string>
 #include <vector>
 
+namespace ProcMacro {
 namespace Literal {
 enum UnsignedTag
 {
@@ -207,5 +208,6 @@ Literal__from_string (const unsigned char *str, std::uint64_t len,
 		      Literal *lit);
 }
 } // namespace Literal
+} // namespace ProcMacro
 
 #endif /* ! LITERAL_H */

--- a/libgrust/libproc_macro/literal.h
+++ b/libgrust/libproc_macro/literal.h
@@ -28,7 +28,6 @@
 #include <vector>
 
 namespace ProcMacro {
-namespace Literal {
 enum UnsignedTag
 {
   UNSIGNED_8,
@@ -187,10 +186,11 @@ public:
   static Literal make_usize (std::uint64_t value, bool suffixed = false);
   static Literal make_isize (std::int64_t value, bool suffixed = false);
 
+  static void drop (Literal *lit);
+
+private:
   static Literal make_unsigned (UnsignedSuffixPayload p);
   static Literal make_signed (SignedSuffixPayload p);
-
-  static void drop (Literal *lit);
 };
 
 extern "C" {
@@ -207,7 +207,6 @@ bool
 Literal__from_string (const unsigned char *str, std::uint64_t len,
 		      Literal *lit);
 }
-} // namespace Literal
 } // namespace ProcMacro
 
 #endif /* ! LITERAL_H */

--- a/libgrust/libproc_macro/proc_macro.h
+++ b/libgrust/libproc_macro/proc_macro.h
@@ -24,5 +24,10 @@
 #define PROC_MACRO_H
 
 #include "literal.h"
+#include "tokenstream.h"
+#include "tokentree.h"
+#include "group.h"
+#include "punct.h"
+#include "ident.h"
 
 #endif /* ! PROC_MACRO_H */

--- a/libgrust/libproc_macro/punct.cc
+++ b/libgrust/libproc_macro/punct.cc
@@ -24,7 +24,6 @@
 #include <cstdlib>
 
 namespace ProcMacro {
-namespace Punct {
 
 Punct
 Punct::make_punct (std::uint32_t ch, Spacing spacing)
@@ -32,5 +31,4 @@ Punct::make_punct (std::uint32_t ch, Spacing spacing)
   return {ch, spacing};
 }
 
-} // namespace Punct
 } // namespace ProcMacro

--- a/libgrust/libproc_macro/punct.cc
+++ b/libgrust/libproc_macro/punct.cc
@@ -23,6 +23,7 @@
 #include "punct.h"
 #include <cstdlib>
 
+namespace ProcMacro {
 namespace Punct {
 
 Punct
@@ -32,3 +33,4 @@ Punct::make_punct (std::uint32_t ch, Spacing spacing)
 }
 
 } // namespace Punct
+} // namespace ProcMacro

--- a/libgrust/libproc_macro/punct.h
+++ b/libgrust/libproc_macro/punct.h
@@ -25,6 +25,7 @@
 
 #include <cstdint>
 
+namespace ProcMacro {
 namespace Punct {
 
 enum Spacing
@@ -43,5 +44,6 @@ public:
 };
 
 } // namespace Punct
+} // namespace ProcMacro
 
 #endif /* ! PUNCT_H */

--- a/libgrust/libproc_macro/punct.h
+++ b/libgrust/libproc_macro/punct.h
@@ -26,12 +26,11 @@
 #include <cstdint>
 
 namespace ProcMacro {
-namespace Punct {
 
 enum Spacing
 {
-  Alone,
-  Joint
+  ALONE,
+  JOINT
 };
 
 struct Punct
@@ -40,10 +39,9 @@ struct Punct
   Spacing spacing;
 
 public:
-  static Punct make_punct (std::uint32_t ch, Spacing spacing = Spacing::Alone);
+  static Punct make_punct (std::uint32_t ch, Spacing spacing = Spacing::ALONE);
 };
 
-} // namespace Punct
 } // namespace ProcMacro
 
 #endif /* ! PUNCT_H */

--- a/libgrust/libproc_macro/tokenstream.cc
+++ b/libgrust/libproc_macro/tokenstream.cc
@@ -25,6 +25,7 @@
 
 #include <cstring>
 
+namespace ProcMacro {
 namespace TokenStream {
 
 TokenStream
@@ -117,3 +118,4 @@ TokenStream__drop (TokenStream *stream)
 }
 
 } // namespace TokenStream
+} // namespace ProcMacro

--- a/libgrust/libproc_macro/tokenstream.cc
+++ b/libgrust/libproc_macro/tokenstream.cc
@@ -26,10 +26,9 @@
 #include <cstring>
 
 namespace ProcMacro {
-namespace TokenStream {
 
 TokenStream
-TokenStream::make_tokenstream (std::vector<TokenTree::TokenTree> vec)
+TokenStream::make_tokenstream (std::vector<TokenTree> vec)
 {
   auto stream = make_tokenstream (vec.size ());
   for (auto tt : vec)
@@ -42,7 +41,7 @@ TokenStream::make_tokenstream (std::vector<TokenTree::TokenTree> vec)
 TokenStream
 TokenStream::make_tokenstream (std::uint64_t capacity)
 {
-  auto *data = new TokenTree::TokenTree[capacity];
+  auto *data = new TokenTree[capacity];
   return {data, 0, capacity};
 }
 
@@ -50,14 +49,14 @@ void
 TokenStream::grow (std::uint64_t delta)
 {
   auto new_capacity = capacity + delta;
-  auto *new_data = new TokenTree::TokenTree[new_capacity];
+  auto *new_data = new TokenTree[new_capacity];
   std::memcpy (new_data, data, size);
   delete[] data;
   data = new_data;
 }
 
 void
-TokenStream::push (TokenTree::TokenTree tree)
+TokenStream::push (TokenTree tree)
 {
   if (size == capacity)
     grow (capacity);
@@ -90,7 +89,7 @@ TokenStream__with_capacity (std::uint64_t capacity)
 }
 
 extern "C" void
-TokenSream__push (TokenStream *stream, TokenTree::TokenTree tree)
+TokenSream__push (TokenStream *stream, TokenTree tree)
 {
   stream->push (tree);
 }
@@ -106,7 +105,7 @@ TokenStream__from_string (unsigned char *str, std::uint64_t len,
 extern "C" TokenStream
 TokenStream__clone (const TokenStream *ts)
 {
-  auto *data = new TokenTree::TokenTree[ts->capacity];
+  auto *data = new TokenTree[ts->capacity];
   std::memcpy (data, ts->data, ts->size);
   return {data, ts->size, ts->capacity};
 }
@@ -117,5 +116,4 @@ TokenStream__drop (TokenStream *stream)
   TokenStream::drop (stream);
 }
 
-} // namespace TokenStream
 } // namespace ProcMacro

--- a/libgrust/libproc_macro/tokenstream.h
+++ b/libgrust/libproc_macro/tokenstream.h
@@ -27,29 +27,22 @@
 #include <vector>
 
 namespace ProcMacro {
-namespace TokenTree {
 struct TokenTree;
-}
-
-namespace TokenStream {
-
-const std::int64_t DEFAULT_CAPACITY = 0;
 
 struct TokenStream
 {
-  TokenTree::TokenTree *data;
+  TokenTree *data;
   std::uint64_t size;
   std::uint64_t capacity;
 
 public:
   void grow (std::uint64_t delta);
-  void push (TokenTree::TokenTree tree);
+  void push (TokenTree tree);
 
   TokenStream clone () const;
 
-  static TokenStream make_tokenstream (std::vector<TokenTree::TokenTree> vec);
-  static TokenStream make_tokenstream (std::uint64_t capacity
-				       = DEFAULT_CAPACITY);
+  static TokenStream make_tokenstream (std::vector<TokenTree> vec);
+  static TokenStream make_tokenstream (std::uint64_t capacity = 1);
 
   static void drop (TokenStream *stream);
 };
@@ -61,7 +54,7 @@ extern "C" TokenStream
 TokenStream__with_capacity (std::uint64_t capacity);
 
 extern "C" void
-TokenSream__push (TokenStream *stream, TokenTree::TokenTree tree);
+TokenSream__push (TokenStream *stream, TokenTree tree);
 
 extern "C" bool
 TokenStream__from_string (unsigned char *str, std::uint64_t len,
@@ -73,7 +66,6 @@ TokenStream__clone (const TokenStream *ts);
 extern "C" void
 TokenStream__drop (TokenStream *stream);
 
-} // namespace TokenStream
 } // namespace ProcMacro
 
 #endif /* ! TOKENSTREAM_H */

--- a/libgrust/libproc_macro/tokenstream.h
+++ b/libgrust/libproc_macro/tokenstream.h
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <vector>
 
+namespace ProcMacro {
 namespace TokenTree {
 struct TokenTree;
 }
@@ -73,5 +74,6 @@ extern "C" void
 TokenStream__drop (TokenStream *stream);
 
 } // namespace TokenStream
+} // namespace ProcMacro
 
 #endif /* ! TOKENSTREAM_H */

--- a/libgrust/libproc_macro/tokentree.cc
+++ b/libgrust/libproc_macro/tokentree.cc
@@ -23,10 +23,9 @@
 #include "tokentree.h"
 
 namespace ProcMacro {
-namespace TokenTree {
 
 TokenTree
-TokenTree::make_tokentree (Group::Group group)
+TokenTree::make_tokentree (Group group)
 {
   TokenTreePayload payload;
   payload.group = group;
@@ -34,7 +33,7 @@ TokenTree::make_tokentree (Group::Group group)
 }
 
 TokenTree
-TokenTree::make_tokentree (Ident::Ident ident)
+TokenTree::make_tokentree (Ident ident)
 {
   TokenTreePayload payload;
   payload.ident = ident;
@@ -42,7 +41,7 @@ TokenTree::make_tokentree (Ident::Ident ident)
 }
 
 TokenTree
-TokenTree::make_tokentree (Punct::Punct punct)
+TokenTree::make_tokentree (Punct punct)
 {
   TokenTreePayload payload;
   payload.punct = punct;
@@ -50,7 +49,7 @@ TokenTree::make_tokentree (Punct::Punct punct)
 }
 
 TokenTree
-TokenTree::make_tokentree (Literal::Literal literal)
+TokenTree::make_tokentree (Literal literal)
 {
   TokenTreePayload payload;
   payload.literal = literal;
@@ -76,5 +75,4 @@ TokenTree::drop (TokenTree *tt)
     }
 }
 
-} // namespace TokenTree
 } // namespace ProcMacro

--- a/libgrust/libproc_macro/tokentree.cc
+++ b/libgrust/libproc_macro/tokentree.cc
@@ -22,6 +22,7 @@
 
 #include "tokentree.h"
 
+namespace ProcMacro {
 namespace TokenTree {
 
 TokenTree
@@ -76,3 +77,4 @@ TokenTree::drop (TokenTree *tt)
 }
 
 } // namespace TokenTree
+} // namespace ProcMacro

--- a/libgrust/libproc_macro/tokentree.h
+++ b/libgrust/libproc_macro/tokentree.h
@@ -28,6 +28,7 @@
 #include "punct.h"
 #include "literal.h"
 
+namespace ProcMacro {
 namespace TokenTree {
 
 enum TokenTreeTag
@@ -61,5 +62,6 @@ public:
 };
 
 } // namespace TokenTree
+} // namespace ProcMacro
 
 #endif /* ! TOKENTREE_H */

--- a/libgrust/libproc_macro/tokentree.h
+++ b/libgrust/libproc_macro/tokentree.h
@@ -29,7 +29,6 @@
 #include "literal.h"
 
 namespace ProcMacro {
-namespace TokenTree {
 
 enum TokenTreeTag
 {
@@ -41,10 +40,10 @@ enum TokenTreeTag
 
 union TokenTreePayload
 {
-  Group::Group group;
-  Ident::Ident ident;
-  Punct::Punct punct;
-  Literal::Literal literal;
+  Group group;
+  Ident ident;
+  Punct punct;
+  Literal literal;
 };
 
 struct TokenTree
@@ -53,15 +52,14 @@ struct TokenTree
   TokenTreePayload payload;
 
 public:
-  static TokenTree make_tokentree (Group::Group group);
-  static TokenTree make_tokentree (Ident::Ident ident);
-  static TokenTree make_tokentree (Punct::Punct punct);
-  static TokenTree make_tokentree (Literal::Literal literal);
+  static TokenTree make_tokentree (Group group);
+  static TokenTree make_tokentree (Ident ident);
+  static TokenTree make_tokentree (Punct punct);
+  static TokenTree make_tokentree (Literal literal);
 
   static void drop (TokenTree *tt);
 };
 
-} // namespace TokenTree
 } // namespace ProcMacro
 
 #endif /* ! TOKENTREE_H */


### PR DESCRIPTION
Refactor a bit the global structure of libproc_macro to make is more usable and fix the link issue against the compiler.