### PR TITLE
Track self as part of TypeBoundPredicate

### DIFF
--- a/gcc/rust/typecheck/rust-autoderef.cc
+++ b/gcc/rust/typecheck/rust-autoderef.cc
@@ -164,7 +164,7 @@ resolve_operator_overload_fn (
   // handle the case where we are within the impl block for this
   // lang_item otherwise we end up with a recursive operator overload
   // such as the i32 operator overload trait
-  TypeCheckContextItem &fn_context = context->peek_context ();
+  TypeCheckContextItem fn_context = context->peek_context ();
   if (fn_context.get_type () == TypeCheckContextItem::ItemType::IMPL_ITEM)
     {
       auto &impl_item = fn_context.get_impl_item ();

--- a/gcc/rust/typecheck/rust-hir-type-check-base.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.h
@@ -37,7 +37,8 @@ protected:
 
   TraitReference *resolve_trait_path (HIR::TypePath &);
 
-  TyTy::TypeBoundPredicate get_predicate_from_bound (HIR::TypePath &path);
+  TyTy::TypeBoundPredicate
+  get_predicate_from_bound (HIR::TypePath &path, HIR::Type *associated_self);
 
   bool check_for_unconstrained (
     const std::vector<TyTy::SubstitutionParamMapping> &params_to_constrain,

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -1595,8 +1595,7 @@ TypeCheckExpr::resolve_operator_overload (
     return false;
 
   auto segment = HIR::PathIdentSegment (associated_item_name);
-  auto candidates
-    = MethodResolver::Probe (lhs, HIR::PathIdentSegment (associated_item_name));
+  auto candidates = MethodResolver::Probe (lhs, segment);
 
   bool have_implementation_for_lang_item = candidates.size () > 0;
   if (!have_implementation_for_lang_item)

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -1457,7 +1457,7 @@ TypeCheckExpr::visit (HIR::MatchExpr &expr)
 void
 TypeCheckExpr::visit (HIR::ClosureExpr &expr)
 {
-  TypeCheckContextItem &current_context = context->peek_context ();
+  TypeCheckContextItem current_context = context->peek_context ();
   TyTy::FnType *current_context_fndecl = current_context.get_context_type ();
 
   HirId ref = expr.get_mappings ().get_hirid ();
@@ -1624,7 +1624,7 @@ TypeCheckExpr::resolve_operator_overload (
   // handle the case where we are within the impl block for this lang_item
   // otherwise we end up with a recursive operator overload such as the i32
   // operator overload trait
-  TypeCheckContextItem &fn_context = context->peek_context ();
+  TypeCheckContextItem fn_context = context->peek_context ();
   if (fn_context.get_type () == TypeCheckContextItem::ItemType::IMPL_ITEM)
     {
       auto &impl_item = fn_context.get_impl_item ();

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -1572,7 +1572,7 @@ TypeCheckExpr::visit (HIR::ClosureExpr &expr)
   args.get_type_args ().push_back (std::unique_ptr<HIR::Type> (implicit_tuple));
 
   // apply the arguments
-  predicate.apply_generic_arguments (&args);
+  predicate.apply_generic_arguments (&args, false);
 
   // finally inherit the trait bound
   infered->inherit_bounds ({predicate});

--- a/gcc/rust/typecheck/rust-hir-type-check-item.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.cc
@@ -501,7 +501,8 @@ TypeCheckItem::resolve_impl_block_substitutions (HIR::ImplBlock &impl_block,
 
       // we don't error out here see: gcc/testsuite/rust/compile/traits2.rs
       // for example
-      specified_bound = get_predicate_from_bound (*ref.get ());
+      specified_bound
+	= get_predicate_from_bound (*ref.get (), impl_block.get_type ().get ());
     }
 
   TyTy::BaseType *self = TypeCheckType::Resolve (impl_block.get_type ().get ());
@@ -537,7 +538,8 @@ TypeCheckItem::validate_trait_impl_block (
 
       // we don't error out here see: gcc/testsuite/rust/compile/traits2.rs
       // for example
-      specified_bound = get_predicate_from_bound (*ref.get ());
+      specified_bound
+	= get_predicate_from_bound (*ref.get (), impl_block.get_type ().get ());
     }
 
   bool is_trait_impl_block = !trait_reference->is_error ();

--- a/gcc/rust/typecheck/rust-hir-type-check.h
+++ b/gcc/rust/typecheck/rust-hir-type-check.h
@@ -35,11 +35,19 @@ public:
     ITEM,
     IMPL_ITEM,
     TRAIT_ITEM,
+    ERROR
   };
 
   TypeCheckContextItem (HIR::Function *item);
   TypeCheckContextItem (HIR::ImplBlock *impl_block, HIR::Function *item);
   TypeCheckContextItem (HIR::TraitItemFunc *trait_item);
+  TypeCheckContextItem (const TypeCheckContextItem &other);
+
+  TypeCheckContextItem &operator= (const TypeCheckContextItem &other);
+
+  static TypeCheckContextItem get_error ();
+
+  bool is_error () const;
 
   ItemType get_type () const;
 
@@ -54,6 +62,8 @@ public:
   DefId get_defid () const;
 
 private:
+  TypeCheckContextItem ();
+
   union Item
   {
     HIR::Function *item;

--- a/gcc/rust/typecheck/rust-hir-type-check.h
+++ b/gcc/rust/typecheck/rust-hir-type-check.h
@@ -90,7 +90,7 @@ public:
   bool lookup_type_by_node_id (NodeId ref, HirId *id);
 
   TyTy::BaseType *peek_return_type ();
-  TypeCheckContextItem &peek_context ();
+  TypeCheckContextItem peek_context ();
   void push_return_type (TypeCheckContextItem item,
 			 TyTy::BaseType *return_type);
   void pop_return_type ();

--- a/gcc/rust/typecheck/rust-hir-type-check.h
+++ b/gcc/rust/typecheck/rust-hir-type-check.h
@@ -91,6 +91,7 @@ public:
   void insert_type_by_node_id (NodeId ref, HirId id);
   bool lookup_type_by_node_id (NodeId ref, HirId *id);
 
+  bool have_function_context () const;
   TyTy::BaseType *peek_return_type ();
   TypeCheckContextItem peek_context ();
   void push_return_type (TypeCheckContextItem item,

--- a/gcc/rust/typecheck/rust-hir-type-check.h
+++ b/gcc/rust/typecheck/rust-hir-type-check.h
@@ -51,6 +51,8 @@ public:
 
   TyTy::FnType *get_context_type ();
 
+  DefId get_defid () const;
+
 private:
   union Item
   {

--- a/gcc/rust/typecheck/rust-typecheck-context.cc
+++ b/gcc/rust/typecheck/rust-typecheck-context.cc
@@ -157,7 +157,7 @@ TypeCheckContext::pop_return_type ()
   return_type_stack.pop_back ();
 }
 
-TypeCheckContextItem &
+TypeCheckContextItem
 TypeCheckContext::peek_context ()
 {
   rust_assert (!return_type_stack.empty ());

--- a/gcc/rust/typecheck/rust-typecheck-context.cc
+++ b/gcc/rust/typecheck/rust-typecheck-context.cc
@@ -576,5 +576,23 @@ TypeCheckContextItem::get_context_type ()
   return static_cast<TyTy::FnType *> (lookup);
 }
 
+DefId
+TypeCheckContextItem::get_defid () const
+{
+  switch (get_type ())
+    {
+    case ITEM:
+      return item.item->get_mappings ().get_defid ();
+
+    case IMPL_ITEM:
+      return item.impl_item.second->get_mappings ().get_defid ();
+
+    case TRAIT_ITEM:
+      return item.trait_item->get_mappings ().get_defid ();
+    }
+
+  return UNKNOWN_DEFID;
+}
+
 } // namespace Resolver
 } // namespace Rust

--- a/gcc/rust/typecheck/rust-typecheck-context.cc
+++ b/gcc/rust/typecheck/rust-typecheck-context.cc
@@ -525,6 +525,71 @@ TypeCheckContextItem::TypeCheckContextItem (HIR::TraitItemFunc *trait_item)
   : type (ItemType::TRAIT_ITEM), item (trait_item)
 {}
 
+TypeCheckContextItem::TypeCheckContextItem (const TypeCheckContextItem &other)
+  : type (other.type), item (other.item)
+{
+  switch (other.type)
+    {
+    case ITEM:
+      item.item = other.item.item;
+      break;
+
+    case IMPL_ITEM:
+      item.impl_item = other.item.impl_item;
+      break;
+
+    case TRAIT_ITEM:
+      item.trait_item = other.item.trait_item;
+      break;
+
+    case ERROR:
+      item.item = nullptr;
+      break;
+    }
+}
+
+TypeCheckContextItem::TypeCheckContextItem ()
+  : type (ItemType::ERROR), item (static_cast<HIR::Function *> (nullptr))
+{}
+
+TypeCheckContextItem &
+TypeCheckContextItem::operator= (const TypeCheckContextItem &other)
+{
+  type = other.type;
+  switch (other.type)
+    {
+    case ITEM:
+      item.item = other.item.item;
+      break;
+
+    case IMPL_ITEM:
+      item.impl_item = other.item.impl_item;
+      break;
+
+    case TRAIT_ITEM:
+      item.trait_item = other.item.trait_item;
+      break;
+
+    case ERROR:
+      item.item = nullptr;
+      break;
+    }
+
+  return *this;
+}
+
+TypeCheckContextItem
+TypeCheckContextItem::get_error ()
+{
+  return TypeCheckContextItem ();
+}
+
+bool
+TypeCheckContextItem::is_error () const
+{
+  return type == ERROR;
+}
+
 HIR::Function *
 TypeCheckContextItem::get_item ()
 {
@@ -571,6 +636,10 @@ TypeCheckContextItem::get_context_type ()
     case TRAIT_ITEM:
       reference = get_trait_item ()->get_mappings ().get_hirid ();
       break;
+
+    case ERROR:
+      gcc_unreachable ();
+      return nullptr;
     }
 
   rust_assert (reference != UNKNOWN_HIRID);
@@ -595,6 +664,9 @@ TypeCheckContextItem::get_defid () const
 
     case TRAIT_ITEM:
       return item.trait_item->get_mappings ().get_defid ();
+
+    case ERROR:
+      return UNKNOWN_DEFID;
     }
 
   return UNKNOWN_DEFID;

--- a/gcc/rust/typecheck/rust-typecheck-context.cc
+++ b/gcc/rust/typecheck/rust-typecheck-context.cc
@@ -136,6 +136,12 @@ TypeCheckContext::lookup_type_by_node_id (NodeId ref, HirId *id)
   return true;
 }
 
+bool
+TypeCheckContext::have_function_context () const
+{
+  return !return_type_stack.empty ();
+}
+
 TyTy::BaseType *
 TypeCheckContext::peek_return_type ()
 {

--- a/gcc/rust/typecheck/rust-tyty-bounds.h
+++ b/gcc/rust/typecheck/rust-tyty-bounds.h
@@ -20,6 +20,7 @@
 #define RUST_TYTY_BOUNDS_H
 
 #include "rust-location.h"
+#include "rust-mapping-common.h"
 
 namespace Rust {
 
@@ -67,6 +68,8 @@ public:
   std::vector<TypeBoundPredicate> &get_specified_bounds ();
 
   const std::vector<TypeBoundPredicate> &get_specified_bounds () const;
+
+  TypeBoundPredicate lookup_predicate (DefId id);
 
   size_t num_specified_bounds () const;
 

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -408,7 +408,8 @@ public:
   // https://doc.rust-lang.org/reference/items/traits.html#object-safety
   bool is_object_safe (bool emit_error, Location locus) const;
 
-  void apply_generic_arguments (HIR::GenericArgs *generic_args);
+  void apply_generic_arguments (HIR::GenericArgs *generic_args,
+				bool has_associated_self);
 
   bool contains_item (const std::string &search) const;
 

--- a/gcc/testsuite/rust/compile/issue-1893.rs
+++ b/gcc/testsuite/rust/compile/issue-1893.rs
@@ -1,3 +1,4 @@
+// { dg-additional-options "-frust-compile-until=nameresolution" }
 pub enum Option<T> {
     None,
     Some(T),

--- a/gcc/testsuite/rust/compile/traits12.rs
+++ b/gcc/testsuite/rust/compile/traits12.rs
@@ -10,7 +10,7 @@ struct Foo<T> {
 }
 
 impl<T> A for Foo<usize> {
-    // { dg-error "generic item takes at least 1 type arguments but 0 were supplied" "" { target *-*-* } .-1 }
+    // { dg-error "generic item takes at least 2 type arguments but 1 were supplied" "" { target *-*-* } .-1 }
     // { dg-error "unconstrained type parameter" "" { target *-*-* } .-2 }
     type Output = T;
 

--- a/gcc/testsuite/rust/compile/unconstrained_type_param.rs
+++ b/gcc/testsuite/rust/compile/unconstrained_type_param.rs
@@ -9,6 +9,7 @@ impl<X, Y> Foo<X> {
 
 fn main() {
     let a = Foo::test();
-    // { dg-error "Failed to resolve expression of function call" "" { target *-*-* } .-1 }
-    // { dg-error "failed to type resolve expression" "" { target *-*-* } .-2 }
+    // { dg-error "expected" "" { target *-*-* } .-1 }
+    // { dg-error "Failed to resolve expression of function call" "" { target *-*-* } .-2 }
+    // { dg-error "failed to type resolve expression" "" { target *-*-* } .-3 }
 }


### PR DESCRIPTION
This is me bringing to merge my stuff, I almost have #2019 working which is key to getting to the next step of iterators
but we have a few bugs with associated types. More PR's incoming.

    When we handle generic trait bounds we never tracked its associated Self
    type. Its important to remember a Trait Predicate is associated with a type
    this means we end up missing a lot of helpful type information down the
    line relating to higher ranked trait bounds and associated types
    compuations. Remember traits have an implict Generic Type Parameter of Self
    we use this in computing trait defintions so in that case no associated
    type is specified which is to be expected but in all other cases we do
    even if it is generic its still useful type information to keep track of.

Addresses #2019