### PR TITLE
gccrs: Fix ICE during method resolution

### DIFF
--- a/gcc/rust/typecheck/rust-hir-dot-operator.cc
+++ b/gcc/rust/typecheck/rust-hir-dot-operator.cc
@@ -240,8 +240,12 @@ MethodResolver::select (TyTy::BaseType &receiver)
 
     const HIR::Trait *trait = trait_ref->get_hir_trait_ref ();
     HIR::TraitItem *item = item_ref->get_hir_trait_item ();
-    rust_assert (item->get_item_kind () == HIR::TraitItem::TraitItemKind::FUNC);
+    if (item->get_item_kind () != HIR::TraitItem::TraitItemKind::FUNC)
+      return true;
+
     HIR::TraitItemFunc *func = static_cast<HIR::TraitItemFunc *> (item);
+    if (!func->get_decl ().is_method ())
+      return true;
 
     TyTy::BaseType *ty = item_ref->get_tyty ();
     rust_assert (ty->get_kind () == TyTy::TypeKind::FNDEF);

--- a/gcc/testsuite/rust/compile/issue-2139.rs
+++ b/gcc/testsuite/rust/compile/issue-2139.rs
@@ -1,0 +1,16 @@
+pub trait Foo {
+    fn foo();
+}
+
+impl Foo for u16 {
+    fn foo() {
+        <u16 as Foo>::foo()
+    }
+}
+
+fn main() {
+    let a: u16 = 123;
+    a.foo();
+    // { dg-error "failed to resolve method for .foo." "" { target *-*-* } .-1 }
+    // { dg-error "failed to type resolve expression" "" { target *-*-* } .-2 }
+}


### PR DESCRIPTION
We were missing a check for trait item selection to ensure they are actually methods and remove assertion to check if the trait item is a function this is a valid error check not an assertion.

Fixes #2139

gcc/rust/ChangeLog:

	* typecheck/rust-hir-dot-operator.cc (MethodResolver::select): verify it is a method

gcc/testsuite/ChangeLog:

	* rust/compile/issue-2139.rs: New test.
