### PR TITLE
gccrs: Fix ICE in assignment of error type bound predicates

### DIFF
--- a/gcc/rust/typecheck/rust-tyty-bounds.cc
+++ b/gcc/rust/typecheck/rust-tyty-bounds.cc
@@ -343,6 +343,9 @@ TypeBoundPredicate::operator= (const TypeBoundPredicate &other)
   for (const auto &p : other.get_substs ())
     substitutions.push_back (p.clone ());
 
+  if (other.is_error ())
+    return *this;
+
   std::vector<SubstitutionArg> mappings;
   for (size_t i = 0; i < other.used_arguments.get_mappings ().size (); i++)
     {


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* typecheck/rust-tyty-bounds.cc (TypeBoundPredicate::operator=): we are done if other is in an error state

