### PR TITLE
gccrs: Minor tuning in AST dump

### DIFF
--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -554,13 +554,14 @@ Dump::visit (NegationExpr &expr)
   switch (expr.get_expr_type ())
     {
     case NegationOperator::NEGATE:
-      stream << '-';
+      stream << "-(";
       break;
     case NegationOperator::NOT:
-      stream << '!';
+      stream << "!(";
       break;
     }
   visit (expr.get_negated_expr ());
+  stream << ')';
 }
 
 void


### PR DESCRIPTION
Use parentheses to remove any ambiguities when dumping expressions with
unary ! and -.

gcc/rust/ChangeLog:
	* ast/rust-ast-dump.cc (Dump::visit): print parentheses around
	unique expression operand.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>