### PR TITLE
Add accessors to HIR::StructPatternFieldIdentPat

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-pattern.h
+++ b/gcc/rust/hir/tree/rust-hir-pattern.h
@@ -629,6 +629,10 @@ public:
 
   ItemType get_item_type () const override final { return ItemType::IDENT_PAT; }
 
+  Identifier get_identifier () const { return ident; }
+
+  std::unique_ptr<Pattern> &get_pattern () { return ident_pattern; }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */


### PR DESCRIPTION
A small patch to address #2041, split off since it's a shared dependency for two other patches.