### PR TITLE
gccrs: resolve the associated_predicate when mapping Fn traits

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -97,8 +97,8 @@ protected:
 			      TyTy::BaseType *function_tyty,
 			      TyTy::BaseType **result);
 
-  HIR::PathIdentSegment
-  resolve_possible_fn_trait_call_method_name (const TyTy::BaseType &receiver);
+  HIR::PathIdentSegment resolve_possible_fn_trait_call_method_name (
+    TyTy::BaseType &receiver, TyTy::TypeBoundPredicate *associated_predicate);
 
 private:
   TypeCheckExpr ();


### PR DESCRIPTION
This is required to solve #2105

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::resolve_fn_trait_call): return the assoicated predicate
	* typecheck/rust-hir-type-check-expr.h: update prototype
