### PR TITLE
qualified path syntax is used to disambiguate predicates

### DIFF
--- a/gcc/rust/typecheck/rust-hir-trait-reference.cc
+++ b/gcc/rust/typecheck/rust-hir-trait-reference.cc
@@ -442,16 +442,18 @@ TraitReference::satisfies_bound (const TraitReference &reference) const
 }
 
 AssociatedImplTrait::AssociatedImplTrait (TraitReference *trait,
+					  TyTy::TypeBoundPredicate predicate,
 					  HIR::ImplBlock *impl,
 					  TyTy::BaseType *self,
 					  Resolver::TypeCheckContext *context)
-  : trait (trait), impl (impl), self (self), context (context)
+  : trait (trait), predicate (predicate), impl (impl), self (self),
+    context (context)
 {}
 
-TraitReference *
-AssociatedImplTrait::get_trait ()
+TyTy::TypeBoundPredicate &
+AssociatedImplTrait::get_predicate ()
 {
-  return trait;
+  return predicate;
 }
 
 HIR::ImplBlock *
@@ -465,6 +467,7 @@ AssociatedImplTrait::get_self ()
 {
   return self;
 }
+
 const TyTy::BaseType *
 AssociatedImplTrait::get_self () const
 {

--- a/gcc/rust/typecheck/rust-hir-trait-reference.h
+++ b/gcc/rust/typecheck/rust-hir-trait-reference.h
@@ -238,11 +238,12 @@ private:
 class AssociatedImplTrait
 {
 public:
-  AssociatedImplTrait (TraitReference *trait, HIR::ImplBlock *impl,
+  AssociatedImplTrait (TraitReference *trait,
+		       TyTy::TypeBoundPredicate predicate, HIR::ImplBlock *impl,
 		       TyTy::BaseType *self,
 		       Resolver::TypeCheckContext *context);
 
-  TraitReference *get_trait ();
+  TyTy::TypeBoundPredicate &get_predicate ();
 
   HIR::ImplBlock *get_impl_block ();
 
@@ -257,6 +258,7 @@ public:
 
 private:
   TraitReference *trait;
+  TyTy::TypeBoundPredicate predicate;
   HIR::ImplBlock *impl;
   TyTy::BaseType *self;
   Resolver::TypeCheckContext *context;

--- a/gcc/rust/typecheck/rust-hir-type-check-item.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.cc
@@ -607,8 +607,8 @@ TypeCheckItem::validate_trait_impl_block (
     {
       trait_reference->clear_associated_types ();
 
-      AssociatedImplTrait associated (trait_reference, &impl_block, self,
-				      context);
+      AssociatedImplTrait associated (trait_reference, specified_bound,
+				      &impl_block, self, context);
       context->insert_associated_trait_impl (
 	impl_block.get_mappings ().get_hirid (), std::move (associated));
       context->insert_associated_impl_mapping (

--- a/gcc/rust/typecheck/rust-type-util.h
+++ b/gcc/rust/typecheck/rust-type-util.h
@@ -23,11 +23,6 @@
 #include "rust-tyty.h"
 
 namespace Rust {
-
-namespace TyTy {
-class BaseType;
-}
-
 namespace Resolver {
 
 bool
@@ -49,6 +44,11 @@ coercion_site (HirId id, TyTy::TyWithLocation lhs, TyTy::TyWithLocation rhs,
 TyTy::BaseType *
 cast_site (HirId id, TyTy::TyWithLocation from, TyTy::TyWithLocation to,
 	   Location cast_locus);
+
+AssociatedImplTrait *
+lookup_associated_impl_block (const TyTy::TypeBoundPredicate &bound,
+			      const TyTy::BaseType *binding,
+			      bool *ambigious = nullptr);
 
 } // namespace Resolver
 } // namespace Rust

--- a/gcc/rust/typecheck/rust-tyty-bounds.cc
+++ b/gcc/rust/typecheck/rust-tyty-bounds.cc
@@ -680,6 +680,40 @@ TypeBoundPredicate::get_associated_type_items ()
   return items;
 }
 
+bool
+TypeBoundPredicate::is_equal (const TypeBoundPredicate &other) const
+{
+  // check they match the same trait reference
+  if (reference != other.reference)
+    return false;
+
+  // check that the generics match
+  if (get_num_substitutions () != other.get_num_substitutions ())
+    return false;
+
+  // then match the generics applied
+  for (size_t i = 0; i < get_num_substitutions (); i++)
+    {
+      const SubstitutionParamMapping &a = substitutions.at (i);
+      const SubstitutionParamMapping &b = other.substitutions.at (i);
+
+      const ParamType *ap = a.get_param_ty ();
+      const ParamType *bp = b.get_param_ty ();
+
+      const BaseType *apd = ap->destructure ();
+      const BaseType *bpd = bp->destructure ();
+
+      // FIXME use the unify_and infer inteface or try coerce
+      if (!apd->can_eq (bpd, false /*emit_errors*/))
+	{
+	  if (!bpd->can_eq (apd, false /*emit_errors*/))
+	    return false;
+	}
+    }
+
+  return true;
+}
+
 // trait item reference
 
 const Resolver::TraitItemReference *

--- a/gcc/rust/typecheck/rust-tyty-subst.h
+++ b/gcc/rust/typecheck/rust-tyty-subst.h
@@ -318,10 +318,6 @@ public:
   SubstitutionArgumentMappings get_used_arguments () const;
 
 protected:
-  Resolver::AssociatedImplTrait *lookup_associated_impl (
-    const SubstitutionParamMapping &subst, const TypeBoundPredicate &bound,
-    const TyTy::BaseType *binding, bool *error_flag) const;
-
   std::vector<SubstitutionParamMapping> substitutions;
   SubstitutionArgumentMappings used_arguments;
 };

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -438,6 +438,8 @@ public:
   TypeBoundPredicateItem
   lookup_associated_type (const std::string &search) override final;
 
+  bool is_equal (const TypeBoundPredicate &other) const;
+
 private:
   DefId reference;
   Location locus;

--- a/gcc/testsuite/rust/compile/issue-2135.rs
+++ b/gcc/testsuite/rust/compile/issue-2135.rs
@@ -1,0 +1,19 @@
+pub trait Foo<A> {
+    fn foo(self, _: A) -> u16;
+}
+
+impl Foo<u16> for u16 {
+    fn foo(self, _: u16) -> u16 {
+        self
+    }
+}
+
+impl Foo<u8> for u16 {
+    fn foo(self, _: u8) -> u16 {
+        self
+    }
+}
+
+pub fn bar() -> u16 {
+    <u16 as Foo<u16>>::foo(0u16, 0u16)
+}


### PR DESCRIPTION
When resolving a qualified path we need to use the predicate to lookup the
relevant assoicated impl block where possible. The issue here is that
it might not have one due to a valid error in the impl block or it might
be used within a trait this is a valid case. Generally we will be able to
resolve to an impl block then it can grab that type and move on.
    
Fixes #2135