### PR TITLE
gccrs: Add missing compile locals for constants and statics

### DIFF
--- a/gcc/testsuite/rust/compile/issue-2178.rs
+++ b/gcc/testsuite/rust/compile/issue-2178.rs
@@ -1,0 +1,10 @@
+const A: usize = {
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+    let x = 23;
+    x
+};
+
+static B: usize = {
+    let x = 23;
+    x
+};


### PR DESCRIPTION
When we have a block expression for cosntants or statics we need to ensure we compile the locals for the implicit function we generate in GIMPLE before feeding it directly into the constant folder to evaluate the data.

Fixes #2178

gcc/rust/ChangeLog:

	* backend/rust-compile-base.cc: add missing compile_locals call

gcc/testsuite/ChangeLog:

	* rust/compile/issue-2178.rs: New test.
