### PR TITLE
Add rust_sorry_at handling for builtin macros

### DIFF
--- a/gcc/rust/expand/rust-macro-builtins.cc
+++ b/gcc/rust/expand/rust-macro-builtins.cc
@@ -722,6 +722,14 @@ MacroBuiltin::env_handler (Location invoc_locus, AST::MacroInvocData &invoc)
 }
 
 AST::Fragment
+MacroBuiltin::option_env_handler (Location invoc_locus, AST::MacroInvocData &invoc)
+{
+  // TODO
+  rust_sorry_at (invoc_locus, "option_env not supported");
+  return AST::Fragment::create_error ();
+}
+
+AST::Fragment
 MacroBuiltin::cfg_handler (Location invoc_locus, AST::MacroInvocData &invoc)
 {
   // only parse if not already parsed
@@ -758,6 +766,14 @@ MacroBuiltin::cfg_handler (Location invoc_locus, AST::MacroInvocData &invoc)
 
   // FIXME: Do not return an empty token vector here
   return AST::Fragment ({literal_exp}, std::move (tok));
+}
+
+AST::Fragment
+MacroBuiltin::cfg_accessible_handler (Location invoc_locus, AST::MacroInvocData &invoc)
+{
+  // TODO
+  rust_sorry_at (invoc_locus, "cfg_accessible not supported");
+  return AST::Fragment::create_error ();
 }
 
 /* Expand builtin macro include!(), which includes a source file at the current
@@ -876,6 +892,118 @@ MacroBuiltin::stringify_handler (Location invoc_locus,
   auto token
     = make_token (Token::make_string (invoc_locus, std::move (content)));
   return AST::Fragment ({node}, std::move (token));
-} // namespace Rust
+}
+
+AST::Fragment
+MacroBuiltin::format_args_handler (Location invoc_locus, AST::MacroInvocData &invoc)
+{
+  // TODO
+  rust_sorry_at (invoc_locus, "format_args not supported");
+  return AST::Fragment::create_error ();
+}
+
+AST::Fragment
+MacroBuiltin::format_args_nl_handler (Location invoc_locus, AST::MacroInvocData &invoc)
+{
+  // TODO
+  rust_sorry_at (invoc_locus, "format_args_nl not supported");
+  return AST::Fragment::create_error ();
+}
+
+AST::Fragment
+MacroBuiltin::concat_idents_handler (Location invoc_locus, AST::MacroInvocData &invoc)
+{
+  // TODO
+  rust_sorry_at (invoc_locus, "concat_idents not supported");
+  return AST::Fragment::create_error ();
+}
+
+AST::Fragment
+MacroBuiltin::module_path_handler (Location invoc_locus, AST::MacroInvocData &invoc)
+{
+  // TODO
+  rust_sorry_at (invoc_locus, "module_path not supported");
+  return AST::Fragment::create_error ();
+}
+
+AST::Fragment
+MacroBuiltin::llvm_asm_handler (Location invoc_locus, AST::MacroInvocData &invoc)
+{
+  // TODO
+  rust_sorry_at (invoc_locus, "llvm_asm not supported");
+  return AST::Fragment::create_error ();
+}
+
+AST::Fragment
+MacroBuiltin::global_asm_handler (Location invoc_locus, AST::MacroInvocData &invoc)
+{
+  // TODO
+  rust_sorry_at (invoc_locus, "global_asm not supported");
+  return AST::Fragment::create_error ();
+}
+
+AST::Fragment
+MacroBuiltin::log_syntax_handler (Location invoc_locus, AST::MacroInvocData &invoc)
+{
+  // TODO
+  rust_sorry_at (invoc_locus, "log_syntax not supported");
+  return AST::Fragment::create_error ();
+}
+
+AST::Fragment
+MacroBuiltin::trace_macros_handler (Location invoc_locus, AST::MacroInvocData &invoc)
+{
+  // TODO
+  rust_sorry_at (invoc_locus, "trace_macros not supported");
+  return AST::Fragment::create_error ();
+}
+
+AST::Fragment
+MacroBuiltin::test_handler (Location invoc_locus, AST::MacroInvocData &invoc)
+{
+  // TODO
+  rust_sorry_at (invoc_locus, "test not supported");
+  return AST::Fragment::create_error ();
+}
+
+AST::Fragment
+MacroBuiltin::bench_handler (Location invoc_locus, AST::MacroInvocData &invoc)
+{
+  // TODO
+  rust_sorry_at (invoc_locus, "bench not supported");
+  return AST::Fragment::create_error ();
+}
+
+AST::Fragment
+MacroBuiltin::test_case_handler (Location invoc_locus, AST::MacroInvocData &invoc)
+{
+  // TODO
+  rust_sorry_at (invoc_locus, "test_case not supported");
+  return AST::Fragment::create_error ();
+}
+
+AST::Fragment
+MacroBuiltin::global_allocator_handler (Location invoc_locus, AST::MacroInvocData &invoc)
+{
+  // TODO
+  rust_sorry_at (invoc_locus, "global_allocator not supported");
+  return AST::Fragment::create_error ();
+}
+
+AST::Fragment
+MacroBuiltin::rustc_dec_handler (Location invoc_locus, AST::MacroInvocData &invoc)
+{
+  // TODO
+  rust_sorry_at (invoc_locus, "RustcDecode not supported");
+  return AST::Fragment::create_error ();
+}
+
+AST::Fragment
+MacroBuiltin::rustc_enc_handler (Location invoc_locus, AST::MacroInvocData &invoc)
+{
+  // TODO
+  rust_sorry_at (invoc_locus, "RustcEncode not supported");
+  return AST::Fragment::create_error ();
+}
 
 } // namespace Rust

--- a/gcc/rust/expand/rust-macro-builtins.h
+++ b/gcc/rust/expand/rust-macro-builtins.h
@@ -91,14 +91,62 @@ public:
   static AST::Fragment env_handler (Location invoc_locus,
 				    AST::MacroInvocData &invoc);
 
+  static AST::Fragment option_env_handler (Location invoc_locus,
+					   AST::MacroInvocData &invoc);
+
   static AST::Fragment cfg_handler (Location invoc_locus,
 				    AST::MacroInvocData &invoc);
+
+  static AST::Fragment cfg_accessible_handler (Location invoc_locus,
+					       AST::MacroInvocData &invoc);
 
   static AST::Fragment include_handler (Location invoc_locus,
 					AST::MacroInvocData &invoc);
 
   static AST::Fragment line_handler (Location invoc_locus,
 				     AST::MacroInvocData &invoc);
+
+  static AST::Fragment format_args_handler (Location invoc_locus,
+					    AST::MacroInvocData &invoc);
+
+  static AST::Fragment format_args_nl_handler (Location invoc_locus,
+					       AST::MacroInvocData &invoc);
+
+  static AST::Fragment concat_idents_handler (Location invoc_locus,
+					      AST::MacroInvocData &invoc);
+
+  static AST::Fragment module_path_handler (Location invoc_locus,
+					    AST::MacroInvocData &invoc);
+
+  static AST::Fragment llvm_asm_handler (Location invoc_locus,
+					 AST::MacroInvocData &invoc);
+
+  static AST::Fragment global_asm_handler (Location invoc_locus,
+					   AST::MacroInvocData &invoc);
+
+  static AST::Fragment log_syntax_handler (Location invoc_locus,
+					   AST::MacroInvocData &invoc);
+
+  static AST::Fragment trace_macros_handler (Location invoc_locus,
+					     AST::MacroInvocData &invoc);
+
+  static AST::Fragment test_handler (Location invoc_locus,
+				     AST::MacroInvocData &invoc);
+
+  static AST::Fragment bench_handler (Location invoc_locus,
+				      AST::MacroInvocData &invoc);
+
+  static AST::Fragment test_case_handler (Location invoc_locus,
+					  AST::MacroInvocData &invoc);
+
+  static AST::Fragment global_allocator_handler (Location invoc_locus,
+						 AST::MacroInvocData &invoc);
+
+  static AST::Fragment rustc_dec_handler (Location invoc_locus,
+					  AST::MacroInvocData &invoc);
+
+  static AST::Fragment rustc_enc_handler (Location invoc_locus,
+					  AST::MacroInvocData &invoc);
 };
 } // namespace Rust
 

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -868,6 +868,7 @@ Mappings::iterate_trait_items (
 void
 Mappings::insert_macro_def (AST::MacroRulesDefinition *macro)
 {
+  // HACK: Treat attribute macros like regular macros
   static std::map<
     std::string, std::function<AST::Fragment (Location, AST::MacroInvocData &)>>
     builtin_macros = {
@@ -881,8 +882,24 @@ Mappings::insert_macro_def (AST::MacroRulesDefinition *macro)
       {"compile_error", MacroBuiltin::compile_error_handler},
       {"concat", MacroBuiltin::concat_handler},
       {"env", MacroBuiltin::env_handler},
+      {"option_env", MacroBuiltin::option_env_handler},
       {"cfg", MacroBuiltin::cfg_handler},
+      {"cfg_accessible", MacroBuiltin::cfg_accessible_handler},
       {"include", MacroBuiltin::include_handler},
+      {"format_args", MacroBuiltin::format_args_handler},
+      {"format_args_nl", MacroBuiltin::format_args_nl_handler},
+      {"concat_idents", MacroBuiltin::concat_idents_handler},
+      {"module_path", MacroBuiltin::module_path_handler},
+      {"llvm_asm", MacroBuiltin::llvm_asm_handler},
+      {"global_asm", MacroBuiltin::global_asm_handler},
+      {"log_syntax", MacroBuiltin::log_syntax_handler},
+      {"trace_macros", MacroBuiltin::trace_macros_handler},
+      {"test", MacroBuiltin::test_handler},
+      {"bench", MacroBuiltin::bench_handler},
+      {"test_case", MacroBuiltin::test_case_handler},
+      {"global_allocator", MacroBuiltin::global_allocator_handler},
+      {"RustcDecodable", MacroBuiltin::rustc_dec_handler},
+      {"RustcEncodable", MacroBuiltin::rustc_enc_handler},
     };
 
   auto outer_attrs = macro->get_outer_attrs ();


### PR DESCRIPTION
Note: this does treat builtin attribute macros (?) like other builtin macros, since ```libcore``` seems to declare them in the same fashion.