### PR TITLE
Fix "default unsafe fn ..." parsing

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -5686,9 +5686,6 @@ Parser<ManagedTokenSource>::parse_trait_impl_function_or_method (
   // - template?
   Location locus = lexer.peek_token ()->get_locus ();
 
-  // parse function or method qualifiers
-  AST::FunctionQualifiers qualifiers = parse_function_qualifiers ();
-
   auto is_default = false;
   auto t = lexer.peek_token ();
   if (t->get_id () == IDENTIFIER && t->get_str () == "default")
@@ -5696,6 +5693,9 @@ Parser<ManagedTokenSource>::parse_trait_impl_function_or_method (
       is_default = true;
       lexer.skip_token ();
     }
+
+  // parse function or method qualifiers
+  AST::FunctionQualifiers qualifiers = parse_function_qualifiers ();
 
   skip_token (FN_TOK);
 

--- a/gcc/testsuite/rust/compile/parse_specialization.rs
+++ b/gcc/testsuite/rust/compile/parse_specialization.rs
@@ -2,10 +2,12 @@
 
 trait Foo {
     fn bar();
+    unsafe fn bar_u();
 }
 
 struct S;
 
 impl Foo for S {
     default fn bar() {}
+    default unsafe fn bar_u() {}
 }


### PR DESCRIPTION
```default``` appears to come before function/method qualifiers, not after