### PR TITLE
libproc_macro: Change rust literal internals

### DIFF
--- a/gcc/rust/lex/rust-token.h
+++ b/gcc/rust/lex/rust-token.h
@@ -450,4 +450,16 @@ return *str;
 };
 } // namespace Rust
 
+namespace std {
+template <> struct hash<Rust::PrimitiveCoreType>
+{
+  size_t operator() (const Rust::PrimitiveCoreType &coretype) const noexcept
+  {
+    return hash<std::underlying_type<Rust::PrimitiveCoreType>::type> () (
+      static_cast<std::underlying_type<Rust::PrimitiveCoreType>::type> (
+	coretype));
+  }
+};
+} // namespace std
+
 #endif

--- a/gcc/rust/util/rust-token-converter.cc
+++ b/gcc/rust/util/rust-token-converter.cc
@@ -51,23 +51,10 @@ pop_group (std::vector<ProcMacro::TokenStream> &streams,
 }
 
 static void
-dispatch_float_literals (ProcMacro::TokenStream &ts,
-			 const const_TokenPtr &token)
+handle_suffix (ProcMacro::TokenStream &ts, const const_TokenPtr &token,
+	       ProcMacro::LitKind kind)
 {
   auto str = token->as_string ();
-  auto kind = ProcMacro::LitKind::make_float ();
-  auto lookup = suffixes.lookup (token->get_type_hint ());
-  auto suffix = suffixes.is_iter_ok (lookup) ? lookup->second : "";
-  ts.push (ProcMacro::TokenTree::make_tokentree (
-    ProcMacro::Literal::make_literal (kind, str, suffix)));
-}
-
-static void
-dispatch_integer_literals (ProcMacro::TokenStream &ts,
-			   const const_TokenPtr &token)
-{
-  auto str = token->as_string ();
-  auto kind = ProcMacro::LitKind::make_integer ();
   auto lookup = suffixes.lookup (token->get_type_hint ());
   auto suffix = suffixes.is_iter_ok (lookup) ? lookup->second : "";
   ts.push (ProcMacro::TokenTree::make_tokentree (
@@ -85,10 +72,12 @@ convert (const std::vector<const_TokenPtr> &tokens)
 	{
 	// Literals
 	case FLOAT_LITERAL:
-	  dispatch_float_literals (trees.back (), token);
+	  handle_suffix (trees.back (), token,
+			 ProcMacro::LitKind::make_float ());
 	  break;
 	case INT_LITERAL:
-	  dispatch_integer_literals (trees.back (), token);
+	  handle_suffix (trees.back (), token,
+			 ProcMacro::LitKind::make_integer ());
 	  break;
 	case CHAR_LITERAL:
 	  trees.back ().push (ProcMacro::TokenTree::make_tokentree (

--- a/libgrust/libproc_macro/Makefile.am
+++ b/libgrust/libproc_macro/Makefile.am
@@ -53,7 +53,14 @@ LIBOBJS = @LIBOBJS@
 objext = @OBJEXT@
 
 REQUIRED_OFILES =							\
-	./proc_macro.$(objext) ./literal.$(objext) ./group.$(objext) ./ident.$(objext) ./punct.$(objext) ./tokenstream.$(objext) ./tokentree.$(objext)
+	./proc_macro.$(objext) \
+	./literal.$(objext) \
+	./group.$(objext) \
+	./ident.$(objext) \
+	./punct.$(objext) \
+	./tokenstream.$(objext) \
+	./tokentree.$(objext) \
+	./ffistring.$(objext)
 
 all: $(TARGETLIB)
 

--- a/libgrust/libproc_macro/Makefile.in
+++ b/libgrust/libproc_macro/Makefile.in
@@ -306,7 +306,14 @@ AM_MAKEFLAGS = \
 TARGETLIB = ./libproc_macro.a
 objext = @OBJEXT@
 REQUIRED_OFILES = \
-	./proc_macro.$(objext) ./literal.$(objext) ./group.$(objext) ./ident.$(objext) ./punct.$(objext) ./tokenstream.$(objext) ./tokentree.$(objext)
+	./proc_macro.$(objext) \
+	./literal.$(objext) \
+	./group.$(objext) \
+	./ident.$(objext) \
+	./punct.$(objext) \
+	./tokenstream.$(objext) \
+	./tokentree.$(objext) \
+	./ffistring.$(objext)
 
 all: all-am
 

--- a/libgrust/libproc_macro/ffistring.cc
+++ b/libgrust/libproc_macro/ffistring.cc
@@ -1,0 +1,62 @@
+// Copyright (C) 2023 Free Software Foundation, Inc.
+//
+// This file is part of the GNU Proc Macro Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// Under Section 7 of GPL version 3, you are granted additional
+// permissions described in the GCC Runtime Library Exception, version
+// 3.1, as published by the Free Software Foundation.
+
+// You should have received a copy of the GNU General Public License and
+// a copy of the GCC Runtime Library Exception along with this program;
+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+// <http://www.gnu.org/licenses/>.
+
+#include <cstring>
+#include "ffistring.h"
+
+namespace ProcMacro {
+void
+FFIString::drop (FFIString *str)
+{
+  delete[] str->data;
+  str->len = 0;
+}
+
+FFIString
+FFIString::make_ffistring (const std::string &str)
+{
+  return make_ffistring (reinterpret_cast<const unsigned char *> (str.c_str ()),
+			 str.length ());
+}
+
+FFIString
+FFIString::make_ffistring (const unsigned char *data, std::uint64_t len)
+{
+  const unsigned char *inner = new unsigned char[len];
+  return {inner, len};
+}
+
+FFIString
+FFIString::clone () const
+{
+  unsigned char *inner = new unsigned char[this->len];
+  std::memcpy (inner, this->data, this->len);
+  return {inner, this->len};
+}
+
+std::string
+FFIString::to_string () const
+{
+  return std::string (reinterpret_cast<const char *> (this->data), this->len);
+}
+
+} // namespace ProcMacro

--- a/libgrust/libproc_macro/ffistring.cc
+++ b/libgrust/libproc_macro/ffistring.cc
@@ -41,7 +41,8 @@ FFIString::make_ffistring (const std::string &str)
 FFIString
 FFIString::make_ffistring (const unsigned char *data, std::uint64_t len)
 {
-  const unsigned char *inner = new unsigned char[len];
+  unsigned char *inner = new unsigned char[len];
+  std::memcpy (inner, data, len);
   return {inner, len};
 }
 

--- a/libgrust/libproc_macro/ffistring.h
+++ b/libgrust/libproc_macro/ffistring.h
@@ -1,0 +1,55 @@
+// Copyright (C) 2023 Free Software Foundation, Inc.
+//
+// This file is part of the GNU Proc Macro Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// Under Section 7 of GPL version 3, you are granted additional
+// permissions described in the GCC Runtime Library Exception, version
+// 3.1, as published by the Free Software Foundation.
+
+// You should have received a copy of the GNU General Public License and
+// a copy of the GCC Runtime Library Exception along with this program;
+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef FFISTRING_H
+#define FFISTRING_H
+
+#include <cstdint>
+#include <string>
+
+namespace ProcMacro {
+
+struct FFIString
+{
+  const unsigned char *data;
+  std::uint64_t len;
+
+public:
+  FFIString clone () const;
+  std::string to_string () const;
+  static FFIString make_ffistring (const std::string &str);
+  static FFIString make_ffistring (const unsigned char *data,
+				   std::uint64_t len);
+  static void drop (FFIString *str);
+};
+
+extern "C" {
+FFIString
+FFIString__new (const unsigned char *data, std::uint64_t len);
+
+void
+FFIString__drop (FFIString *str);
+}
+
+} // namespace ProcMacro
+
+#endif /* ! FFISTRING_H */

--- a/libgrust/libproc_macro/literal.cc
+++ b/libgrust/libproc_macro/literal.cc
@@ -46,8 +46,7 @@ Literal::drop (Literal *lit)
 Literal
 Literal::clone () const
 {
-  return {this->kind, this->text.clone (), this->has_suffix,
-	  this->suffix.clone ()};
+  return {this->kind, this->text.clone (), this->suffix.clone ()};
 }
 
 Literal
@@ -56,7 +55,7 @@ Literal::make_literal (LitKind kind, const std::string &text,
 {
   auto ffi_text = FFIString::make_ffistring (text);
   auto ffi_suffix = FFIString::make_ffistring (suffix);
-  return {kind, ffi_text, suffix != "", ffi_suffix};
+  return {kind, ffi_text, ffi_suffix};
 }
 
 Literal
@@ -64,7 +63,7 @@ Literal::make_u8 (std::uint8_t value, bool suffixed)
 {
   auto text = FFIString::make_ffistring (std::to_string (value));
   auto suffix = FFIString::make_ffistring (suffixed ? "u8" : "");
-  return {LitKind::make_integer (), text, suffixed, suffix};
+  return {LitKind::make_integer (), text, suffix};
 }
 
 Literal
@@ -72,7 +71,7 @@ Literal::make_u16 (std::uint16_t value, bool suffixed)
 {
   auto text = FFIString::make_ffistring (std::to_string (value));
   auto suffix = FFIString::make_ffistring (suffixed ? "u16" : "");
-  return {LitKind::make_integer (), text, suffixed, suffix};
+  return {LitKind::make_integer (), text, suffix};
 }
 
 Literal
@@ -80,7 +79,7 @@ Literal::make_u32 (std::uint32_t value, bool suffixed)
 {
   auto text = FFIString::make_ffistring (std::to_string (value));
   auto suffix = FFIString::make_ffistring (suffixed ? "u32" : "");
-  return {LitKind::make_integer (), text, suffixed, suffix};
+  return {LitKind::make_integer (), text, suffix};
 }
 
 Literal
@@ -88,7 +87,7 @@ Literal::make_u64 (std::uint64_t value, bool suffixed)
 {
   auto text = FFIString::make_ffistring (std::to_string (value));
   auto suffix = FFIString::make_ffistring (suffixed ? "u64" : "");
-  return {LitKind::make_integer (), text, suffixed, suffix};
+  return {LitKind::make_integer (), text, suffix};
 }
 
 Literal
@@ -96,7 +95,7 @@ Literal::make_i8 (std::int8_t value, bool suffixed)
 {
   auto text = FFIString::make_ffistring (std::to_string (value));
   auto suffix = FFIString::make_ffistring (suffixed ? "i8" : "");
-  return {LitKind::make_integer (), text, suffixed, suffix};
+  return {LitKind::make_integer (), text, suffix};
 }
 
 Literal
@@ -104,7 +103,7 @@ Literal::make_i16 (std::int16_t value, bool suffixed)
 {
   auto text = FFIString::make_ffistring (std::to_string (value));
   auto suffix = FFIString::make_ffistring (suffixed ? "i16" : "");
-  return {LitKind::make_integer (), text, suffixed, suffix};
+  return {LitKind::make_integer (), text, suffix};
 }
 
 Literal
@@ -112,7 +111,7 @@ Literal::make_i32 (std::int32_t value, bool suffixed)
 {
   auto text = FFIString::make_ffistring (std::to_string (value));
   auto suffix = FFIString::make_ffistring (suffixed ? "i32" : "");
-  return {LitKind::make_integer (), text, suffixed, suffix};
+  return {LitKind::make_integer (), text, suffix};
 }
 
 Literal
@@ -120,7 +119,7 @@ Literal::make_i64 (std::int64_t value, bool suffixed)
 {
   auto text = FFIString::make_ffistring (std::to_string (value));
   auto suffix = FFIString::make_ffistring (suffixed ? "i64" : "");
-  return {LitKind::make_integer (), text, suffixed, suffix};
+  return {LitKind::make_integer (), text, suffix};
 }
 
 Literal
@@ -128,7 +127,7 @@ Literal::make_string (const std::string &str)
 {
   auto text = FFIString::make_ffistring (str);
   auto suffix = FFIString::make_ffistring ("");
-  return {LitKind::make_str (), text, false, suffix};
+  return {LitKind::make_str (), text, suffix};
 }
 
 Literal
@@ -137,7 +136,7 @@ Literal::make_byte_string (const std::vector<std::uint8_t> &vec)
   auto text
     = FFIString::make_ffistring (std::string (vec.cbegin (), vec.cend ()));
   auto suffix = FFIString::make_ffistring ("");
-  return {LitKind::make_byte_str (), text, false, suffix};
+  return {LitKind::make_byte_str (), text, suffix};
 }
 
 Literal
@@ -145,7 +144,7 @@ Literal::make_f32 (float value, bool suffixed)
 {
   auto text = FFIString::make_ffistring (std::to_string (value));
   auto suffix = FFIString::make_ffistring (suffixed ? "f32" : "");
-  return {LitKind::make_float (), text, suffixed, suffix};
+  return {LitKind::make_float (), text, suffix};
 }
 
 Literal
@@ -153,7 +152,7 @@ Literal::make_f64 (double value, bool suffixed)
 {
   auto text = FFIString::make_ffistring (std::to_string (value));
   auto suffix = FFIString::make_ffistring (suffixed ? "f64" : "");
-  return {LitKind::make_float (), text, suffixed, suffix};
+  return {LitKind::make_float (), text, suffix};
 }
 
 Literal
@@ -161,7 +160,7 @@ Literal::make_char (std::uint32_t ch)
 {
   auto text = FFIString::make_ffistring (std::to_string ((char) ch));
   auto suffix = FFIString::make_ffistring ("");
-  return {LitKind::make_char (), text, false, suffix};
+  return {LitKind::make_char (), text, suffix};
 }
 
 Literal
@@ -169,7 +168,7 @@ Literal::make_usize (std::uint64_t value, bool suffixed)
 {
   auto text = FFIString::make_ffistring (std::to_string (value));
   auto suffix = FFIString::make_ffistring (suffixed ? "usize" : "");
-  return {LitKind::make_integer (), text, suffixed, suffix};
+  return {LitKind::make_integer (), text, suffix};
 }
 
 Literal
@@ -177,7 +176,7 @@ Literal::make_isize (std::int64_t value, bool suffixed)
 {
   auto text = FFIString::make_ffistring (std::to_string (value));
   auto suffix = FFIString::make_ffistring (suffixed ? "isize" : "");
-  return {LitKind::make_integer (), text, suffixed, suffix};
+  return {LitKind::make_integer (), text, suffix};
 }
 
 LitKind

--- a/libgrust/libproc_macro/literal.cc
+++ b/libgrust/libproc_macro/literal.cc
@@ -26,266 +26,216 @@
 
 namespace ProcMacro {
 
-void
-Literal::drop (Literal *lit)
-{
-  switch (lit->tag)
-    {
-    case STRING:
-      delete[] lit->payload.string_payload.data;
-      lit->payload.string_payload.len = 0;
-      break;
-    case BYTE_STRING:
-      delete[] lit->payload.byte_string_payload.data;
-      lit->payload.byte_string_payload.size = 0;
-      break;
-    case CHAR:
-    case UNSIGNED:
-    case SIGNED:
-    case USIZE:
-    case ISIZE:
-    case FLOAT32:
-    case FLOAT64:
-      break;
-    }
-}
-
 extern "C" {
-
-void
-Literal__drop (Literal *lit)
-{
-  Literal::drop (lit);
-}
-
-Literal
-Literal__string (const unsigned char *str, std::uint64_t len)
-{
-  return Literal::make_string (str, len);
-}
-
-Literal
-Literal__byte_string (const std::uint8_t *bytes, std::uint64_t len)
-{
-  return Literal::make_byte_string (bytes, len);
-}
-
 bool
 Literal__from_string (const unsigned char *str, std::uint64_t len, Literal *lit)
 {
-  // FIXME: implement this function with parser
+  // FIXME: implement this function with lexer
   std::abort ();
   return false;
 }
 }
 
-Literal
-Literal::make_unsigned (UnsignedSuffixPayload p)
+void
+Literal::drop (Literal *lit)
 {
-  LiteralPayload payload;
-  payload.unsigned_payload = p;
-  return {UNSIGNED, payload};
-}
-
-Literal
-Literal::make_signed (SignedSuffixPayload p)
-{
-  LiteralPayload payload;
-  payload.signed_payload = p;
-  return {SIGNED, payload};
+  FFIString::drop (&lit->text);
+  FFIString::drop (&lit->suffix);
 }
 
 Literal
 Literal::clone () const
 {
-  Literal lit = *this;
-  switch (this->tag)
-    {
-    case STRING:
-      lit.payload.string_payload.data
-	= new unsigned char[lit.payload.string_payload.len];
-      std::memcpy (lit.payload.string_payload.data,
-		   this->payload.string_payload.data,
-		   lit.payload.string_payload.len);
-      break;
-    case BYTE_STRING:
-      lit.payload.byte_string_payload.data
-	= new uint8_t[lit.payload.byte_string_payload.size];
-      std::memcpy (lit.payload.byte_string_payload.data,
-		   this->payload.byte_string_payload.data,
-		   lit.payload.byte_string_payload.size);
-      break;
-    default:
-      break;
-    }
-  return lit;
+  return {this->kind, this->text.clone (), this->has_suffix,
+	  this->suffix.clone ()};
+}
+
+Literal
+Literal::make_literal (LitKind kind, const std::string &text,
+		       const std::string &suffix)
+{
+  auto ffi_text = FFIString::make_ffistring (text);
+  auto ffi_suffix = FFIString::make_ffistring (suffix);
+  return {kind, ffi_text, suffix != "", ffi_suffix};
 }
 
 Literal
 Literal::make_u8 (std::uint8_t value, bool suffixed)
 {
-  UnsignedPayload unsigned_payload;
-  unsigned_payload.unsigned8 = value;
-  Unsigned val{UNSIGNED_8, unsigned_payload};
-  UnsignedSuffixPayload payload{val, suffixed};
-
-  return make_unsigned (payload);
+  auto text = FFIString::make_ffistring (std::to_string (value));
+  auto suffix = FFIString::make_ffistring (suffixed ? "u8" : "");
+  return {LitKind::make_integer (), text, suffixed, suffix};
 }
 
 Literal
 Literal::make_u16 (std::uint16_t value, bool suffixed)
 {
-  UnsignedPayload unsigned_payload;
-  unsigned_payload.unsigned16 = value;
-  Unsigned val{UNSIGNED_16, unsigned_payload};
-  UnsignedSuffixPayload payload{val, suffixed};
-
-  return make_unsigned (payload);
+  auto text = FFIString::make_ffistring (std::to_string (value));
+  auto suffix = FFIString::make_ffistring (suffixed ? "u16" : "");
+  return {LitKind::make_integer (), text, suffixed, suffix};
 }
 
 Literal
 Literal::make_u32 (std::uint32_t value, bool suffixed)
 {
-  UnsignedPayload unsigned_payload;
-  unsigned_payload.unsigned32 = value;
-  Unsigned val{UNSIGNED_32, unsigned_payload};
-  UnsignedSuffixPayload payload{val, suffixed};
-
-  return make_unsigned (payload);
+  auto text = FFIString::make_ffistring (std::to_string (value));
+  auto suffix = FFIString::make_ffistring (suffixed ? "u32" : "");
+  return {LitKind::make_integer (), text, suffixed, suffix};
 }
 
 Literal
 Literal::make_u64 (std::uint64_t value, bool suffixed)
 {
-  UnsignedPayload unsigned_payload;
-  unsigned_payload.unsigned64 = value;
-  Unsigned val{UNSIGNED_64, unsigned_payload};
-  UnsignedSuffixPayload payload{val, suffixed};
-
-  return make_unsigned (payload);
+  auto text = FFIString::make_ffistring (std::to_string (value));
+  auto suffix = FFIString::make_ffistring (suffixed ? "u64" : "");
+  return {LitKind::make_integer (), text, suffixed, suffix};
 }
 
 Literal
 Literal::make_i8 (std::int8_t value, bool suffixed)
 {
-  SignedPayload signed_payload;
-  signed_payload.signed8 = value;
-  Signed val{SIGNED_8, signed_payload};
-  SignedSuffixPayload payload{val, suffixed};
-
-  return make_signed (payload);
+  auto text = FFIString::make_ffistring (std::to_string (value));
+  auto suffix = FFIString::make_ffistring (suffixed ? "i8" : "");
+  return {LitKind::make_integer (), text, suffixed, suffix};
 }
 
 Literal
 Literal::make_i16 (std::int16_t value, bool suffixed)
 {
-  SignedPayload signed_payload;
-  signed_payload.signed16 = value;
-  Signed val{SIGNED_16, signed_payload};
-  SignedSuffixPayload payload{val, suffixed};
-
-  return make_signed (payload);
+  auto text = FFIString::make_ffistring (std::to_string (value));
+  auto suffix = FFIString::make_ffistring (suffixed ? "i16" : "");
+  return {LitKind::make_integer (), text, suffixed, suffix};
 }
 
 Literal
 Literal::make_i32 (std::int32_t value, bool suffixed)
 {
-  SignedPayload signed_payload;
-  signed_payload.signed32 = value;
-  Signed val{SIGNED_32, signed_payload};
-  SignedSuffixPayload payload = {val, suffixed};
-
-  return make_signed (payload);
+  auto text = FFIString::make_ffistring (std::to_string (value));
+  auto suffix = FFIString::make_ffistring (suffixed ? "i32" : "");
+  return {LitKind::make_integer (), text, suffixed, suffix};
 }
 
 Literal
 Literal::make_i64 (std::int64_t value, bool suffixed)
 {
-  SignedPayload signed_payload;
-  signed_payload.signed64 = value;
-  Signed val{SIGNED_64, signed_payload};
-  SignedSuffixPayload payload{val, suffixed};
-
-  return make_signed (payload);
+  auto text = FFIString::make_ffistring (std::to_string (value));
+  auto suffix = FFIString::make_ffistring (suffixed ? "i64" : "");
+  return {LitKind::make_integer (), text, suffixed, suffix};
 }
 
 Literal
 Literal::make_string (const std::string &str)
 {
-  return make_string (reinterpret_cast<const unsigned char *> (str.c_str ()),
-		      str.length ());
-}
-
-Literal
-Literal::make_string (const unsigned char *str, std::uint64_t len)
-{
-  unsigned char *data = new unsigned char[len];
-  StringPayload str_payload = {data, len};
-  std::memcpy (data, str, len);
-  LiteralPayload payload;
-  payload.string_payload = str_payload;
-  return {STRING, payload};
+  auto text = FFIString::make_ffistring (str);
+  auto suffix = FFIString::make_ffistring ("");
+  return {LitKind::make_str (), text, false, suffix};
 }
 
 Literal
 Literal::make_byte_string (const std::vector<std::uint8_t> &vec)
 {
-  return make_byte_string (vec.data (), vec.size ());
-}
-
-Literal
-Literal::make_byte_string (const std::uint8_t *bytes, std::uint64_t len)
-{
-  std::uint8_t *data = new std::uint8_t[len];
-  ByteStringPayload bstr_payload = {data, len};
-  std::memcpy (data, bytes, len);
-  LiteralPayload payload;
-  payload.byte_string_payload = bstr_payload;
-  return {BYTE_STRING, payload};
+  auto text
+    = FFIString::make_ffistring (std::string (vec.cbegin (), vec.cend ()));
+  auto suffix = FFIString::make_ffistring ("");
+  return {LitKind::make_byte_str (), text, false, suffix};
 }
 
 Literal
 Literal::make_f32 (float value, bool suffixed)
 {
-  Float32Payload f{value, suffixed};
-  LiteralPayload payload;
-  payload.float32_payload = f;
-  return {FLOAT32, payload};
+  auto text = FFIString::make_ffistring (std::to_string (value));
+  auto suffix = FFIString::make_ffistring (suffixed ? "f32" : "");
+  return {LitKind::make_float (), text, suffixed, suffix};
 }
 
 Literal
 Literal::make_f64 (double value, bool suffixed)
 {
-  Float64Payload f{value, suffixed};
-  LiteralPayload payload;
-  payload.float64_payload = f;
-  return {FLOAT64, payload};
+  auto text = FFIString::make_ffistring (std::to_string (value));
+  auto suffix = FFIString::make_ffistring (suffixed ? "f64" : "");
+  return {LitKind::make_float (), text, suffixed, suffix};
 }
 
 Literal
 Literal::make_char (std::uint32_t ch)
 {
-  LiteralPayload payload;
-  payload.char_payload = ch;
-  return {CHAR, payload};
+  auto text = FFIString::make_ffistring (std::to_string ((char) ch));
+  auto suffix = FFIString::make_ffistring ("");
+  return {LitKind::make_char (), text, false, suffix};
 }
 
 Literal
 Literal::make_usize (std::uint64_t value, bool suffixed)
 {
-  UsizePayload p{value, suffixed};
-  LiteralPayload payload;
-  payload.usize_payload = p;
-  return {USIZE, payload};
+  auto text = FFIString::make_ffistring (std::to_string (value));
+  auto suffix = FFIString::make_ffistring (suffixed ? "usize" : "");
+  return {LitKind::make_integer (), text, suffixed, suffix};
 }
 
 Literal
 Literal::make_isize (std::int64_t value, bool suffixed)
 {
-  IsizePayload p{value, suffixed};
-  LiteralPayload payload;
-  payload.isize_payload = p;
-  return {ISIZE, payload};
+  auto text = FFIString::make_ffistring (std::to_string (value));
+  auto suffix = FFIString::make_ffistring (suffixed ? "isize" : "");
+  return {LitKind::make_integer (), text, suffixed, suffix};
+}
+
+LitKind
+LitKind::make_byte ()
+{
+  LitKindPayload payload;
+  return {BYTE, payload};
+}
+
+LitKind
+LitKind::make_char ()
+{
+  LitKindPayload payload;
+  return {CHAR, payload};
+}
+
+LitKind
+LitKind::make_integer ()
+{
+  LitKindPayload payload;
+  return {INTEGER, payload};
+}
+
+LitKind
+LitKind::make_float ()
+{
+  LitKindPayload payload;
+  return {FLOAT, payload};
+}
+
+LitKind
+LitKind::make_str ()
+{
+  LitKindPayload payload;
+  return {STR, payload};
+}
+
+LitKind
+LitKind::make_str_raw (std::uint8_t val)
+{
+  LitKindPayload payload;
+  payload.str_raw = val;
+  return {STR_RAW, payload};
+}
+
+LitKind
+LitKind::make_byte_str ()
+{
+  LitKindPayload payload;
+  return {BYTE_STR, payload};
+}
+
+LitKind
+LitKind::make_byte_str_raw (std::uint8_t val)
+{
+  LitKindPayload payload;
+  payload.byte_str_raw = val;
+  return {BYTE_STR_RAW, payload};
 }
 
 } // namespace ProcMacro

--- a/libgrust/libproc_macro/literal.h
+++ b/libgrust/libproc_macro/literal.h
@@ -69,12 +69,12 @@ struct Literal
 {
   LitKind kind;
   FFIString text;
-  bool has_suffix;
   FFIString suffix;
   // TODO: Add span once done in rust interface
 
 public:
   Literal clone () const;
+  bool has_suffix () const { return suffix.len != 0; };
 
   static Literal make_literal (const LitKind kind, const std::string &text,
 			       const std::string &suffix = "");

--- a/libgrust/libproc_macro/rust/bridge.rs
+++ b/libgrust/libproc_macro/rust/bridge.rs
@@ -1,3 +1,4 @@
+pub mod ffistring;
 pub mod group;
 pub mod ident;
 pub mod literal;

--- a/libgrust/libproc_macro/rust/bridge/ffistring.rs
+++ b/libgrust/libproc_macro/rust/bridge/ffistring.rs
@@ -16,15 +16,18 @@ pub struct FFIString {
     len: u64,
 }
 
-impl FFIString {
-    pub fn new(string: &str) -> FFIString {
-        unsafe { FFIString__new(string.as_ptr(), string.len() as u64) }
+impl<S> From<S> for FFIString
+where
+    S: AsRef<str>,
+{
+    fn from(s: S) -> Self {
+        unsafe { FFIString__new(s.as_ref().as_ptr(), s.as_ref().len() as u64) }
     }
 }
 
 impl Clone for FFIString {
     fn clone(&self) -> Self {
-        FFIString::new(&self.to_string())
+        FFIString::from(&self.to_string())
     }
 }
 

--- a/libgrust/libproc_macro/rust/bridge/ffistring.rs
+++ b/libgrust/libproc_macro/rust/bridge/ffistring.rs
@@ -1,0 +1,48 @@
+use std::convert::TryInto;
+use std::ffi::c_uchar;
+use std::fmt;
+use std::slice::from_raw_parts;
+use std::str::from_utf8;
+
+extern "C" {
+    fn FFIString__new(data: *const c_uchar, len: u64) -> FFIString;
+    fn FFIString__drop(string: *mut FFIString);
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct FFIString {
+    data: *const c_uchar,
+    len: u64,
+}
+
+impl FFIString {
+    pub fn new(string: &str) -> FFIString {
+        unsafe { FFIString__new(string.as_ptr(), string.len() as u64) }
+    }
+}
+
+impl Clone for FFIString {
+    fn clone(&self) -> Self {
+        FFIString::new(&self.to_string())
+    }
+}
+
+impl Drop for FFIString {
+    fn drop(&mut self) {
+        unsafe {
+            FFIString__drop(self as *mut FFIString);
+        }
+    }
+}
+
+impl fmt::Display for FFIString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(
+            from_utf8(unsafe {
+                from_raw_parts(self.data, self.len.try_into().map_err(|_| fmt::Error)?)
+            })
+            .map_err(|_| fmt::Error)?,
+        )
+    }
+}

--- a/libgrust/libproc_macro/rust/bridge/literal.rs
+++ b/libgrust/libproc_macro/rust/bridge/literal.rs
@@ -28,7 +28,6 @@ pub enum LitKind {
 pub struct Literal {
     kind: LitKind,
     text: FFIString,
-    has_suffix: bool,
     suffix: FFIString,
     // FIXME: Add span, cannot add whilst Span remain an empty type
 }
@@ -39,7 +38,6 @@ macro_rules! suffixed_int_literals {
             Literal {
                 kind : LitKind::Integer,
                 text: FFIString::new(&n.to_string()),
-                has_suffix : true,
                 suffix: FFIString::new(stringify!($kind))
             }
         }
@@ -52,7 +50,6 @@ macro_rules! unsuffixed_int_literals {
             Literal {
                 kind : LitKind::Integer,
                 text: FFIString::new(&n.to_string()),
-                has_suffix : false,
                 suffix: FFIString::new("")
             }
         }
@@ -99,7 +96,6 @@ impl Literal {
         Literal {
             kind: LitKind::Float,
             text: FFIString::new(&repr),
-            has_suffix: false,
             suffix: FFIString::new(""),
         }
     }
@@ -108,7 +104,6 @@ impl Literal {
         Literal {
             kind: LitKind::Float,
             text: FFIString::new(&n.to_string()),
-            has_suffix: true,
             suffix: FFIString::new("f32"),
         }
     }
@@ -122,7 +117,6 @@ impl Literal {
         Literal {
             kind: LitKind::Float,
             text: FFIString::new(&repr),
-            has_suffix: false,
             suffix: FFIString::new(""),
         }
     }
@@ -131,7 +125,6 @@ impl Literal {
         Literal {
             kind: LitKind::Float,
             text: FFIString::new(&n.to_string()),
-            has_suffix: true,
             suffix: FFIString::new("f64"),
         }
     }
@@ -140,7 +133,6 @@ impl Literal {
         Literal {
             kind: LitKind::Str,
             text: FFIString::new(string),
-            has_suffix: false,
             suffix: FFIString::new(""),
         }
     }
@@ -149,7 +141,6 @@ impl Literal {
         Literal {
             kind: LitKind::Char,
             text: FFIString::new(&c.to_string()),
-            has_suffix: false,
             suffix: FFIString::new(""),
         }
     }
@@ -158,7 +149,6 @@ impl Literal {
         Literal {
             kind: LitKind::ByteStr,
             text: FFIString::new(&bytes.escape_ascii().to_string()),
-            has_suffix: false,
             suffix: FFIString::new(""),
         }
     }
@@ -217,9 +207,7 @@ impl fmt::Display for Literal {
             _ => f.write_str(text)?,
         }
 
-        if self.has_suffix {
-            f.write_str(&self.suffix.to_string())?;
-        }
+        f.write_str(&self.suffix.to_string())?;
         Ok(())
     }
 }
@@ -232,7 +220,6 @@ impl FromStr for Literal {
         let mut lit = Literal {
             kind: LitKind::Err,
             text: FFIString::new(""),
-            has_suffix: false,
             suffix: FFIString::new(""),
         };
         // TODO: We might want to pass a LexError by reference to retrieve

--- a/libgrust/libproc_macro/rust/bridge/literal.rs
+++ b/libgrust/libproc_macro/rust/bridge/literal.rs
@@ -37,8 +37,8 @@ macro_rules! suffixed_int_literals {
         pub fn $name(n : $kind) -> Literal {
             Literal {
                 kind : LitKind::Integer,
-                text: FFIString::new(&n.to_string()),
-                suffix: FFIString::new(stringify!($kind))
+                text: FFIString::from(&n.to_string()),
+                suffix: FFIString::from(stringify!($kind))
             }
         }
     )*)
@@ -49,8 +49,8 @@ macro_rules! unsuffixed_int_literals {
         pub fn $name(n : $kind) -> Literal {
             Literal {
                 kind : LitKind::Integer,
-                text: FFIString::new(&n.to_string()),
-                suffix: FFIString::new("")
+                text: FFIString::from(&n.to_string()),
+                suffix: FFIString::from("")
             }
         }
     )*)
@@ -95,16 +95,16 @@ impl Literal {
 
         Literal {
             kind: LitKind::Float,
-            text: FFIString::new(&repr),
-            suffix: FFIString::new(""),
+            text: FFIString::from(&repr),
+            suffix: FFIString::from(""),
         }
     }
 
     pub fn f32_suffixed(n: f32) -> Self {
         Literal {
             kind: LitKind::Float,
-            text: FFIString::new(&n.to_string()),
-            suffix: FFIString::new("f32"),
+            text: FFIString::from(&n.to_string()),
+            suffix: FFIString::from("f32"),
         }
     }
 
@@ -116,40 +116,40 @@ impl Literal {
 
         Literal {
             kind: LitKind::Float,
-            text: FFIString::new(&repr),
-            suffix: FFIString::new(""),
+            text: FFIString::from(&repr),
+            suffix: FFIString::from(""),
         }
     }
 
     pub fn f64_suffixed(n: f64) -> Self {
         Literal {
             kind: LitKind::Float,
-            text: FFIString::new(&n.to_string()),
-            suffix: FFIString::new("f64"),
+            text: FFIString::from(&n.to_string()),
+            suffix: FFIString::from("f64"),
         }
     }
 
     pub fn string(string: &str) -> Self {
         Literal {
             kind: LitKind::Str,
-            text: FFIString::new(string),
-            suffix: FFIString::new(""),
+            text: FFIString::from(string),
+            suffix: FFIString::from(""),
         }
     }
 
     pub fn character(c: char) -> Self {
         Literal {
             kind: LitKind::Char,
-            text: FFIString::new(&c.to_string()),
-            suffix: FFIString::new(""),
+            text: FFIString::from(&c.to_string()),
+            suffix: FFIString::from(""),
         }
     }
 
     pub fn byte_string(bytes: &[u8]) -> Self {
         Literal {
             kind: LitKind::ByteStr,
-            text: FFIString::new(&bytes.escape_ascii().to_string()),
-            suffix: FFIString::new(""),
+            text: FFIString::from(&bytes.escape_ascii().to_string()),
+            suffix: FFIString::from(""),
         }
     }
 
@@ -219,8 +219,8 @@ impl FromStr for Literal {
         // Structure that will be filled in by the cpp
         let mut lit = Literal {
             kind: LitKind::Err,
-            text: FFIString::new(""),
-            suffix: FFIString::new(""),
+            text: FFIString::from(""),
+            suffix: FFIString::from(""),
         };
         // TODO: We might want to pass a LexError by reference to retrieve
         // error information

--- a/libgrust/libproc_macro/rust/bridge/literal.rs
+++ b/libgrust/libproc_macro/rust/bridge/literal.rs
@@ -1,220 +1,166 @@
-use bridge::span::Span;
-use std::convert::{TryFrom, TryInto};
+use bridge::{ffistring::FFIString, span::Span};
+use std::convert::TryInto;
 use std::ffi::c_uchar;
 use std::fmt;
 use std::str::FromStr;
 use LexError;
 
 extern "C" {
-    fn Literal__drop(literal: *mut Literal);
-    fn Literal__string(str: *const c_uchar, len: u64) -> Literal;
-    fn Literal__byte_string(bytes: *const u8, len: u64) -> Literal;
     fn Literal__from_string(str: *const c_uchar, len: u64, lit: *mut Literal) -> bool;
 }
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
-pub enum Unsigned {
-    Unsigned8(u8),
-    Unsigned16(u16),
-    Unsigned32(u32),
-    Unsigned64(u64),
-    // u128 is not ffi safe, hence this representation
-    // https://github.com/rust-lang/rust/issues/54341
-    Unsigned128(u64, u64),
+pub enum LitKind {
+    Byte,
+    Char,
+    Integer,
+    Float,
+    Str,
+    StrRaw(u8),
+    ByteStr,
+    ByteStrRaw(u8),
+    Err,
 }
 
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
-pub enum Signed {
-    Signed8(i8),
-    Signed16(i16),
-    Signed32(i32),
-    Signed64(i64),
-    // i128 is not ffi safe, hence this representation
-    // https://github.com/rust-lang/rust/issues/54341
-    Signed128(u64, u64),
+#[derive(Debug, Clone)]
+pub struct Literal {
+    kind: LitKind,
+    text: FFIString,
+    has_suffix: bool,
+    suffix: FFIString,
+    // FIXME: Add span, cannot add whilst Span remain an empty type
 }
 
-#[repr(C)]
-#[derive(Debug)]
-pub enum Literal {
-    /// String literal internal representation
-    ///
-    /// # Note
-    /// This variant is constructed through FFI
-    #[allow(dead_code)]
-    String {
-        data: *const c_uchar,
-        len: u64,
-    },
-    /// Bytestring literal internal representation
-    ///
-    /// # Note
-    /// This variant is constructed through FFI
-    #[allow(dead_code)]
-    ByteString {
-        data: *const u8,
-        size: u64,
-    },
-    Char(u32),
-    Unsigned(Unsigned, bool),
-    Signed(Signed, bool),
-    Usize(u64, bool),
-    ISize(i64, bool),
-    Float32(f32, bool),
-    Float64(f64, bool),
+macro_rules! suffixed_int_literals {
+    ($($name: ident => $kind: ident,)*) => ($(
+        pub fn $name(n : $kind) -> Literal {
+            Literal {
+                kind : LitKind::Integer,
+                text: FFIString::new(&n.to_string()),
+                has_suffix : true,
+                suffix: FFIString::new(stringify!($kind))
+            }
+        }
+    )*)
+}
+
+macro_rules! unsuffixed_int_literals {
+    ($($name: ident => $kind: ident,)*) => ($(
+        pub fn $name(n : $kind) -> Literal {
+            Literal {
+                kind : LitKind::Integer,
+                text: FFIString::new(&n.to_string()),
+                has_suffix : false,
+                suffix: FFIString::new("")
+            }
+        }
+    )*)
 }
 
 impl Literal {
-    pub fn u8_suffixed(n: u8) -> Self {
-        Literal::Unsigned(Unsigned::Unsigned8(n), true)
+    suffixed_int_literals! {
+        u8_suffixed => u8,
+        u16_suffixed => u16,
+        u32_suffixed => u32,
+        u64_suffixed => u64,
+        u128_suffixed => u128,
+        usize_suffixed => usize,
+        i8_suffixed => i8,
+        i16_suffixed => i16,
+        i32_suffixed => i32,
+        i64_suffixed => i64,
+        i128_suffixed => i128,
+        isize_suffixed => isize,
     }
 
-    pub fn u16_suffixed(n: u16) -> Self {
-        Literal::Unsigned(Unsigned::Unsigned16(n), true)
-    }
-
-    pub fn u32_suffixed(n: u32) -> Self {
-        Literal::Unsigned(Unsigned::Unsigned32(n), true)
-    }
-
-    pub fn u64_suffixed(n: u64) -> Self {
-        Literal::Unsigned(Unsigned::Unsigned64(n), true)
-    }
-
-    pub fn u128_suffixed(n: u128) -> Self {
-        Literal::Unsigned(
-            Unsigned::Unsigned128(
-                (n >> 64).try_into().unwrap(),
-                (n & 0xFFFFFFFFFFFFFFFF).try_into().unwrap(),
-            ),
-            true,
-        )
-    }
-
-    pub fn usize_suffixed(n: usize) -> Self {
-        Literal::Usize(n.try_into().expect("Cannot convert usize to u64"), true)
-    }
-
-    pub fn i8_suffixed(n: i8) -> Self {
-        Literal::Signed(Signed::Signed8(n), true)
-    }
-
-    pub fn i16_suffixed(n: i16) -> Self {
-        Literal::Signed(Signed::Signed16(n), true)
-    }
-
-    pub fn i32_suffixed(n: i32) -> Self {
-        Literal::Signed(Signed::Signed32(n), true)
-    }
-
-    pub fn i64_suffixed(n: i64) -> Self {
-        Literal::Signed(Signed::Signed64(n), true)
-    }
-
-    pub fn i128_suffixed(n: i128) -> Self {
-        Literal::Signed(
-            Signed::Signed128(
-                (n >> 64).try_into().unwrap(),
-                (n & 0xFFFFFFFFFFFFFFFF).try_into().unwrap(),
-            ),
-            true,
-        )
-    }
-
-    pub fn isize_suffixed(n: isize) -> Self {
-        Literal::ISize(n.try_into().expect("Cannot convert isize to i64"), true)
-    }
-
-    // Unsuffixed
-
-    pub fn u8_unsuffixed(n: u8) -> Self {
-        Literal::Unsigned(Unsigned::Unsigned8(n), false)
-    }
-
-    pub fn u16_unsuffixed(n: u16) -> Self {
-        Literal::Unsigned(Unsigned::Unsigned16(n), false)
-    }
-
-    pub fn u32_unsuffixed(n: u32) -> Self {
-        Literal::Unsigned(Unsigned::Unsigned32(n), false)
-    }
-
-    pub fn u64_unsuffixed(n: u64) -> Self {
-        Literal::Unsigned(Unsigned::Unsigned64(n), false)
-    }
-
-    pub fn u128_unsuffixed(n: u128) -> Self {
-        Literal::Unsigned(
-            Unsigned::Unsigned128(
-                (n >> 64).try_into().unwrap(),
-                (n & 0xFFFFFFFFFFFFFFFF).try_into().unwrap(),
-            ),
-            false,
-        )
-    }
-
-    pub fn usize_unsuffixed(n: usize) -> Self {
-        Literal::Usize(n.try_into().expect("Cannot convert usize to u64"), false)
-    }
-
-    pub fn i8_unsuffixed(n: i8) -> Self {
-        Literal::Signed(Signed::Signed8(n), false)
-    }
-
-    pub fn i16_unsuffixed(n: i16) -> Self {
-        Literal::Signed(Signed::Signed16(n), false)
-    }
-
-    pub fn i32_unsuffixed(n: i32) -> Self {
-        Literal::Signed(Signed::Signed32(n), false)
-    }
-
-    pub fn i64_unsuffixed(n: i64) -> Self {
-        Literal::Signed(Signed::Signed64(n), false)
-    }
-
-    pub fn i128_unsuffixed(n: i128) -> Self {
-        Literal::Signed(
-            Signed::Signed128(
-                (n >> 64).try_into().unwrap(),
-                (n & 0xFFFFFFFFFFFFFFFF).try_into().unwrap(),
-            ),
-            false,
-        )
-    }
-
-    pub fn isize_unsuffixed(n: isize) -> Self {
-        Literal::ISize(n.try_into().expect("Cannot convert isize to i64"), false)
+    unsuffixed_int_literals! {
+        u8_unsuffixed => u8,
+        u16_unsuffixed => u16,
+        u32_unsuffixed => u32,
+        u64_unsuffixed => u64,
+        u128_unsuffixed => u128,
+        usize_unsuffixed => usize,
+        i8_unsuffixed => i8,
+        i16_unsuffixed => i16,
+        i32_unsuffixed => i32,
+        i64_unsuffixed => i64,
+        i128_unsuffixed => i128,
+        isize_unsuffixed => isize,
     }
 
     pub fn f32_unsuffixed(n: f32) -> Self {
-        Literal::Float32(n, false)
+        let mut repr = n.to_string();
+        if !repr.contains('.') {
+            repr.push_str(".0");
+        }
+
+        Literal {
+            kind: LitKind::Float,
+            text: FFIString::new(&repr),
+            has_suffix: false,
+            suffix: FFIString::new(""),
+        }
     }
 
     pub fn f32_suffixed(n: f32) -> Self {
-        Literal::Float32(n, true)
+        Literal {
+            kind: LitKind::Float,
+            text: FFIString::new(&n.to_string()),
+            has_suffix: true,
+            suffix: FFIString::new("f32"),
+        }
     }
 
     pub fn f64_unsuffixed(n: f64) -> Self {
-        Literal::Float64(n, false)
+        let mut repr = n.to_string();
+        if !repr.contains('.') {
+            repr.push_str(".0");
+        }
+
+        Literal {
+            kind: LitKind::Float,
+            text: FFIString::new(&repr),
+            has_suffix: false,
+            suffix: FFIString::new(""),
+        }
     }
 
     pub fn f64_suffixed(n: f64) -> Self {
-        Literal::Float64(n, true)
+        Literal {
+            kind: LitKind::Float,
+            text: FFIString::new(&n.to_string()),
+            has_suffix: true,
+            suffix: FFIString::new("f64"),
+        }
     }
 
     pub fn string(string: &str) -> Self {
-        unsafe { Literal__string(string.as_ptr(), string.len().try_into().unwrap()) }
+        Literal {
+            kind: LitKind::Str,
+            text: FFIString::new(string),
+            has_suffix: false,
+            suffix: FFIString::new(""),
+        }
     }
 
     pub fn character(c: char) -> Self {
-        Literal::Char(c.into())
+        Literal {
+            kind: LitKind::Char,
+            text: FFIString::new(&c.to_string()),
+            has_suffix: false,
+            suffix: FFIString::new(""),
+        }
     }
 
     pub fn byte_string(bytes: &[u8]) -> Self {
-        unsafe { Literal__byte_string(bytes.as_ptr(), bytes.len().try_into().unwrap()) }
+        Literal {
+            kind: LitKind::ByteStr,
+            text: FFIString::new(&bytes.escape_ascii().to_string()),
+            has_suffix: false,
+            suffix: FFIString::new(""),
+        }
     }
 
     pub fn span(&self) -> Span {
@@ -226,138 +172,53 @@ impl Literal {
     }
 }
 
-impl Drop for Literal {
-    fn drop(&mut self) {
-        match self {
-            Literal::String { .. } | Literal::ByteString { .. } => unsafe {
-                Literal__drop(self as *mut Literal)
-            },
-            _ => (),
-        }
-    }
-}
-
 impl fmt::Display for Literal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Literal::String { data, len } => {
-                let slice =
-                    unsafe { std::slice::from_raw_parts(*data, (*len).try_into().unwrap()) };
+        let text = &self.text.to_string();
+        match self.kind {
+            LitKind::Byte => {
+                f.write_str("b'")?;
+                f.write_str(text)?;
+                f.write_str("'")?;
+            }
+            LitKind::Char => {
+                f.write_str("'")?;
+                f.write_str(text)?;
+                f.write_str("'")?;
+            }
+            LitKind::Str => {
                 f.write_str("\"")?;
-                f.write_str(std::str::from_utf8(slice).unwrap())?;
+                f.write_str(text)?;
                 f.write_str("\"")?;
             }
-            Literal::ByteString { data, size } => {
+            LitKind::StrRaw(n) => {
+                f.write_str("r")?;
+                for _ in 0..n {
+                    f.write_str("#")?;
+                }
+                f.write_str("\"")?;
+                f.write_str(text)?;
+                f.write_str("\"")?;
+            }
+            LitKind::ByteStr => {
                 f.write_str("b\"")?;
-                let slice =
-                    unsafe { std::slice::from_raw_parts(*data, (*size).try_into().unwrap()) };
-                for &byte in slice {
-                    if byte != b'"' && (b' '..=b'z').contains(&byte) {
-                        char::try_from(byte).unwrap().fmt(f)?;
-                    } else {
-                        write!(f, "\\x{:02x}", byte)?;
-                    }
-                }
-                f.write_str("b\"")?;
+                f.write_str(text)?;
+                f.write_str("\"")?;
             }
-            Literal::Char(val) => {
-                let ch: char = (*val).try_into().unwrap();
-                match ch {
-                    '\'' => f.write_str("'\\''")?,
-                    '\0' => f.write_str("'\\0'")?,
-                    '\n' => f.write_str("'\\n'")?,
-                    ' '..='z' => write!(f, "'{}'", ch)?,
-                    _ => write!(f, "'\\u{:x}'", val)?,
+            LitKind::ByteStrRaw(n) => {
+                f.write_str("br")?;
+                for _ in 0..n {
+                    f.write_str("#")?;
                 }
+                f.write_str("\"")?;
+                f.write_str(text)?;
+                f.write_str("\"")?;
             }
-            Literal::Unsigned(val, suffixed) => match val {
-                Unsigned::Unsigned8(val) => {
-                    val.fmt(f)?;
-                    if *suffixed {
-                        f.write_str("u8")?;
-                    }
-                }
-                Unsigned::Unsigned16(val) => {
-                    val.fmt(f)?;
-                    if *suffixed {
-                        f.write_str("u16")?;
-                    }
-                }
-                Unsigned::Unsigned32(val) => {
-                    val.fmt(f)?;
-                    if *suffixed {
-                        f.write_str("u32")?;
-                    }
-                }
-                Unsigned::Unsigned64(val) => {
-                    val.fmt(f)?;
-                    if *suffixed {
-                        f.write_str("u64")?;
-                    }
-                }
-                Unsigned::Unsigned128(h, l) => {
-                    ((u128::from(*h) << 64) & u128::from(*l)).fmt(f)?;
-                    if *suffixed {
-                        f.write_str("u128")?;
-                    }
-                }
-            },
-            Literal::Signed(val, suffixed) => match val {
-                Signed::Signed8(val) => {
-                    val.fmt(f)?;
-                    if *suffixed {
-                        f.write_str("i8")?;
-                    }
-                }
-                Signed::Signed16(val) => {
-                    val.fmt(f)?;
-                    if *suffixed {
-                        f.write_str("i16")?;
-                    }
-                }
-                Signed::Signed32(val) => {
-                    val.fmt(f)?;
-                    if *suffixed {
-                        f.write_str("i32")?;
-                    }
-                }
-                Signed::Signed64(val) => {
-                    val.fmt(f)?;
-                    if *suffixed {
-                        f.write_str("i64")?;
-                    }
-                }
-                Signed::Signed128(h, l) => {
-                    ((i128::from(*h) << 64) & i128::from(*l)).fmt(f)?;
-                    if *suffixed {
-                        f.write_str("i128")?;
-                    }
-                }
-            },
-            Literal::Usize(val, suffixed) => {
-                val.fmt(f)?;
-                if *suffixed {
-                    f.write_str("usize")?;
-                }
-            }
-            Literal::ISize(val, suffixed) => {
-                val.fmt(f)?;
-                if *suffixed {
-                    f.write_str("isize")?;
-                }
-            }
-            Literal::Float32(val, suffixed) => {
-                val.fmt(f)?;
-                if *suffixed {
-                    f.write_str("f32")?;
-                }
-            }
-            Literal::Float64(val, suffixed) => {
-                val.fmt(f)?;
-                if *suffixed {
-                    f.write_str("f64")?;
-                }
-            }
+            _ => f.write_str(text)?,
+        }
+
+        if self.has_suffix {
+            f.write_str(&self.suffix.to_string())?;
         }
         Ok(())
     }
@@ -367,7 +228,13 @@ impl FromStr for Literal {
     type Err = LexError;
 
     fn from_str(string: &str) -> Result<Self, LexError> {
-        let mut lit = Literal::Char(0);
+        // Structure that will be filled in by the cpp
+        let mut lit = Literal {
+            kind: LitKind::Err,
+            text: FFIString::new(""),
+            has_suffix: false,
+            suffix: FFIString::new(""),
+        };
         // TODO: We might want to pass a LexError by reference to retrieve
         // error information
         if unsafe {
@@ -380,22 +247,6 @@ impl FromStr for Literal {
             Err(LexError)
         } else {
             Ok(lit)
-        }
-    }
-}
-
-impl Clone for Literal {
-    fn clone(&self) -> Self {
-        match self {
-            Literal::String { data, len } => unsafe { Literal__string(*data, *len) },
-            Literal::ByteString { data, size } => unsafe { Literal__byte_string(*data, *size) },
-            Literal::Char(val) => Literal::Char(*val),
-            Literal::Unsigned(val, suffixed) => Literal::Unsigned(*val, *suffixed),
-            Literal::Signed(val, suffixed) => Literal::Signed(*val, *suffixed),
-            Literal::Usize(val, suffixed) => Literal::Usize(*val, *suffixed),
-            Literal::ISize(val, suffixed) => Literal::ISize(*val, *suffixed),
-            Literal::Float32(val, suffixed) => Literal::Float32(*val, *suffixed),
-            Literal::Float64(val, suffixed) => Literal::Float64(*val, *suffixed),
         }
     }
 }


### PR DESCRIPTION
Rust interface literal internals were taking a type and storing that type. This lead to multiple problems such as various conversion from string to int/float/other type as well as dead end on undetermined types (type checker runs at a later stage).


Fixes #2182 
Fixes #2201 