### PR TITLE
Address invalid little-endian-only testcases

### DIFF
--- a/gcc/testsuite/rust/compile/const-issue1440.rs
+++ b/gcc/testsuite/rust/compile/const-issue1440.rs
@@ -40,7 +40,6 @@ macro_rules! impl_uint {
                 }
 
                 pub fn to_le(self) -> Self {
-                    #[cfg(target_endian = "little")]
                     {
                         self
                     }

--- a/gcc/testsuite/rust/compile/torture/issue-1432.rs
+++ b/gcc/testsuite/rust/compile/torture/issue-1432.rs
@@ -44,7 +44,6 @@ macro_rules! impl_uint {
                 }
 
                 pub fn to_le(self) -> Self {
-                    #[cfg(target_endian = "little")]
                     {
                         self
                     }


### PR DESCRIPTION
gcc/testsuite/ChangeLog:

	* rust/compile/const-issue1440.rs: Remove LE conditional compilation.
	* rust/compile/torture/issue-1432.rs: Likewise.

Addresses parts of #2184