### PR TITLE
dump: Dump `TupleIndexExpr`s

### DIFF
--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -782,8 +782,11 @@ Dump::visit (TupleExpr &)
 {}
 
 void
-Dump::visit (TupleIndexExpr &)
-{}
+Dump::visit (TupleIndexExpr &expr)
+{
+  visit (expr.get_tuple_expr ());
+  stream << '.' << expr.get_tuple_index ();
+}
 
 void
 Dump::visit (StructExprStruct &)


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* ast/rust-ast-dump.cc (Dump::visit): Implement dump for
	`TupleIndexExpr`.
