### PR TITLE
ast: Add `outer_attrs` to all `Item`s

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -932,6 +932,11 @@ public:
   // behavior that we have items that can also be expressions?
   bool is_item () const override { return true; }
 
+  virtual std::vector<Attribute> &get_outer_attrs () = 0;
+  virtual const std::vector<Attribute> &get_outer_attrs () const = 0;
+
+  virtual bool has_outer_attrs () const { return !get_outer_attrs ().empty (); }
+
 protected:
   // Clone function implementation as pure virtual method
   virtual Item *clone_item_impl () const = 0;

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -2720,15 +2720,15 @@ protected:
 public:
   Location get_locus () const override final { return locus; }
 
-  // should never be called - error if called
-  void set_outer_attrs (std::vector<Attribute> /* new_attrs */) override
+  std::vector<Attribute> &get_outer_attrs () override final
   {
+    // RangeExpr cannot have any outer attributes
     rust_assert (false);
   }
 
-  std::vector<Attribute> &get_outer_attrs () override
+  // should never be called - error if called
+  void set_outer_attrs (std::vector<Attribute> /* new_attrs */) override
   {
-    // RangeExpr cannot have any outer attributes
     rust_assert (false);
   }
 };

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -979,8 +979,11 @@ public:
   Visibility &get_visibility () { return visibility; }
   const Visibility &get_visibility () const { return visibility; }
 
-  std::vector<Attribute> &get_outer_attrs () { return outer_attrs; }
-  const std::vector<Attribute> &get_outer_attrs () const { return outer_attrs; }
+  std::vector<Attribute> &get_outer_attrs () override { return outer_attrs; }
+  const std::vector<Attribute> &get_outer_attrs () const override
+  {
+    return outer_attrs;
+  }
 };
 
 // Rust module item - abstract base class

--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -541,8 +541,11 @@ public:
   bool is_marked_for_strip () const override { return rule_name.empty (); }
 
   // TODO: this mutable getter seems really dodgy. Think up better way.
-  std::vector<Attribute> &get_outer_attrs () { return outer_attrs; }
-  const std::vector<Attribute> &get_outer_attrs () const { return outer_attrs; }
+  std::vector<Attribute> &get_outer_attrs () override { return outer_attrs; }
+  const std::vector<Attribute> &get_outer_attrs () const override
+  {
+    return outer_attrs;
+  }
 
   std::vector<MacroRule> &get_macro_rules () { return rules; }
   const std::vector<MacroRule> &get_macro_rules () const { return rules; }
@@ -651,7 +654,10 @@ public:
     return invoc_data.is_marked_for_strip ();
   }
 
-  const std::vector<Attribute> &get_outer_attrs () const { return outer_attrs; }
+  const std::vector<Attribute> &get_outer_attrs () const override
+  {
+    return outer_attrs;
+  }
   std::vector<Attribute> &get_outer_attrs () override { return outer_attrs; }
 
   void set_outer_attrs (std::vector<Attribute> new_attrs) override


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* ast/rust-ast.h: Add `outer_attrs` to Node.
	* ast/rust-expr.h: Make use of new inheritance methods.
	* ast/rust-item.h: Likewise.
	* ast/rust-macro.h: Likewise.
	* ast/rust-path.h: Likewise.
	* ast/rust-stmt.h: Likewise.

This PR adds a vector of outer attributes to almost all nodes, which makes procedural macros easier to handle - there is no longer the need to `static_cast` to a node known to have outer attributes.