### PR TITLE
derive: Add base for builtin derives and #[derive(Clone)]

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -87,6 +87,9 @@ GRS_OBJS = \
     rust/rust-macro-expand.o \
     rust/rust-cfg-strip.o \
 	rust/rust-expand-visitor.o \
+	rust/rust-ast-builder.o \
+	rust/rust-derive.o \
+	rust/rust-derive-clone.o \
     rust/rust-macro-invoc-lexer.o \
     rust/rust-macro-substitute-ctx.o \
     rust/rust-macro-builtins.o \

--- a/gcc/rust/ast/rust-ast-builder.cc
+++ b/gcc/rust/ast/rust-ast-builder.cc
@@ -1,0 +1,122 @@
+// Copyright (C) 2020-2023 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-ast-builder.h"
+#include "rust-ast-full.h"
+
+namespace Rust {
+namespace AST {
+
+std::unique_ptr<Expr>
+AstBuilder::call (std::unique_ptr<Expr> &&path,
+		  std::vector<std::unique_ptr<Expr>> &&args)
+{
+  return std::unique_ptr<Expr> (
+    new CallExpr (std::move (path), std::move (args), {}, loc));
+}
+
+std::unique_ptr<Expr>
+AstBuilder::identifier (std::string name)
+{
+  return std::unique_ptr<Expr> (new IdentifierExpr (name, {}, loc));
+}
+
+std::unique_ptr<Expr>
+AstBuilder::tuple_idx (std::string receiver, int idx)
+{
+  return std::unique_ptr<Expr> (
+    new TupleIndexExpr (identifier (receiver), idx, {}, loc));
+}
+
+FunctionQualifiers
+AstBuilder::fn_qualifiers ()
+{
+  return FunctionQualifiers (loc, AsyncConstStatus::NONE, false);
+}
+
+PathExprSegment
+AstBuilder::path_segment (std::string seg)
+{
+  return PathExprSegment (PathIdentSegment (seg, loc), loc);
+}
+
+std::unique_ptr<TypePathSegment>
+AstBuilder::type_path_segment (std::string seg)
+{
+  return std::unique_ptr<TypePathSegment> (
+    new TypePathSegment (seg, false, loc));
+}
+
+std::unique_ptr<Type>
+AstBuilder::single_type_path (std::string type)
+{
+  auto segments = std::vector<std::unique_ptr<TypePathSegment>> ();
+  segments.emplace_back (type_path_segment (type));
+
+  return std::unique_ptr<Type> (new TypePath (std::move (segments), loc));
+}
+
+PathInExpression
+AstBuilder::path_in_expression (std::vector<std::string> &&segments)
+{
+  auto path_segments = std::vector<PathExprSegment> ();
+  for (auto &seg : segments)
+    path_segments.emplace_back (path_segment (seg));
+
+  return PathInExpression (std::move (path_segments), {}, loc);
+}
+
+std::unique_ptr<Expr>
+AstBuilder::struct_expr_struct (std::string struct_name)
+{
+  return std::unique_ptr<Expr> (
+    new StructExprStruct (path_in_expression ({struct_name}), {}, {}, loc));
+}
+
+std::unique_ptr<Expr>
+AstBuilder::block (std::vector<std::unique_ptr<Stmt>> &&stmts,
+		   std::unique_ptr<Expr> &&tail_expr)
+{
+  return std::unique_ptr<Expr> (
+    new BlockExpr (std::move (stmts), std::move (tail_expr), {}, {}, loc, loc));
+}
+
+std::unique_ptr<Stmt>
+AstBuilder::let (std::unique_ptr<Pattern> pattern, std::unique_ptr<Type> type,
+		 std::unique_ptr<Expr> init)
+{
+  return std::unique_ptr<Stmt> (
+    new LetStmt (/* needs a pattern here, not just a name */ nullptr,
+		 std::move (init), std::move (type), {}, loc));
+}
+
+std::unique_ptr<Expr>
+AstBuilder::ref (std::unique_ptr<Expr> &&of, bool mut)
+{
+  return std::unique_ptr<Expr> (
+    new BorrowExpr (std::move (of), mut, /* is double */ false, {}, loc));
+}
+
+std::unique_ptr<Expr>
+AstBuilder::deref (std::unique_ptr<Expr> &&of)
+{
+  return std::unique_ptr<Expr> (new DereferenceExpr (std::move (of), {}, loc));
+}
+
+} // namespace AST
+} // namespace Rust

--- a/gcc/rust/ast/rust-ast-builder.h
+++ b/gcc/rust/ast/rust-ast-builder.h
@@ -1,0 +1,98 @@
+// Copyright (C) 2020-2023 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef AST_BUILDER_H
+#define AST_BUILDER_H
+
+#include "rust-ast-full.h"
+
+namespace Rust {
+namespace AST {
+
+// TODO: Use this builder when expanding regular macros
+/* Builder class with helper methods to create AST nodes. This builder is
+ * tailored towards generating multiple AST nodes from a single location, and
+ * may not be suitable to other purposes */
+class AstBuilder
+{
+public:
+  AstBuilder (Location loc) : loc (loc) {}
+
+  /* Create an identifier expression (`variable`) */
+  std::unique_ptr<Expr> identifier (std::string name);
+
+  /* Create a tuple index expression (`receiver.0`) */
+  std::unique_ptr<Expr> tuple_idx (std::string receiver, int idx);
+
+  /* Create a reference to an expression (`&of`) */
+  std::unique_ptr<Expr> ref (std::unique_ptr<Expr> &&of, bool mut = false);
+
+  /* Create a dereference of an expression (`*of`) */
+  std::unique_ptr<Expr> deref (std::unique_ptr<Expr> &&of);
+
+  /* Create a block with an optional tail expression */
+  std::unique_ptr<Expr> block (std::vector<std::unique_ptr<Stmt>> &&stmts,
+			       std::unique_ptr<Expr> &&tail_expr = nullptr);
+
+  /* Create a let binding with an optional type and initializer (`let <name> :
+   * <type> = <init>`) */
+  std::unique_ptr<Stmt> let (std::unique_ptr<Pattern> pattern,
+			     std::unique_ptr<Type> type = nullptr,
+			     std::unique_ptr<Expr> init = nullptr);
+
+  /**
+   * Create a call expression to a function, struct or enum variant, given its
+   * arguments (`path(arg0, arg1, arg2)`)
+   */
+  std::unique_ptr<Expr> call (std::unique_ptr<Expr> &&path,
+			      std::vector<std::unique_ptr<Expr>> &&args);
+
+  /* Empty function qualifiers, with no specific qualifiers */
+  FunctionQualifiers fn_qualifiers ();
+
+  /* Create a single path segment from one string */
+  PathExprSegment path_segment (std::string seg);
+
+  /* And similarly for type path segments */
+  std::unique_ptr<TypePathSegment> type_path_segment (std::string seg);
+
+  /* Create a Type from a single string - the most basic kind of type in our AST
+   */
+  std::unique_ptr<Type> single_type_path (std::string type);
+
+  /**
+   * Create a path in expression from multiple segments (`Clone::clone`). You
+   * do not need to separate the segments using `::`, you can simply provide a
+   * vector of strings to the functions which will get turned into path segments
+   */
+  PathInExpression path_in_expression (std::vector<std::string> &&segments);
+
+  /* Create a struct expression for unit structs (`S`) */
+  std::unique_ptr<Expr> struct_expr_struct (std::string struct_name);
+
+private:
+  /**
+   * Location of the generated AST nodes
+   */
+  Location loc;
+};
+
+} // namespace AST
+} // namespace Rust
+
+#endif // AST_BUILDER_H

--- a/gcc/rust/expand/rust-derive-clone.cc
+++ b/gcc/rust/expand/rust-derive-clone.cc
@@ -1,0 +1,152 @@
+// Copyright (C) 2020-2023 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-derive-clone.h"
+
+namespace Rust {
+namespace AST {
+
+std::unique_ptr<Expr>
+DeriveClone::clone_call (std::unique_ptr<Expr> &&to_clone)
+{
+  // $crate::core::clone::Clone::clone for the fully qualified path - we don't
+  // link with `core` yet so that might be an issue. Use `Clone::clone` for now?
+  // TODO: Factor this function inside the DeriveAccumulator
+  auto path = std::unique_ptr<Expr> (
+    new PathInExpression (builder.path_in_expression ({"Clone", "clone"})));
+
+  auto args = std::vector<std::unique_ptr<Expr>> ();
+  args.emplace_back (std::move (to_clone));
+
+  return builder.call (std::move (path), std::move (args));
+}
+
+/**
+ * Create the actual "clone" function of the implementation, so
+ *
+ * fn clone(&self) -> Self { <clone_expr> }
+ *
+ */
+std::unique_ptr<TraitImplItem>
+DeriveClone::clone_fn (std::unique_ptr<Expr> &&clone_expr)
+{
+  auto block = std::unique_ptr<BlockExpr> (
+    new BlockExpr ({}, std::move (clone_expr), {}, {}, loc, loc));
+  auto big_self_type = builder.single_type_path ("Self");
+
+  return std::unique_ptr<TraitImplItem> (
+    new Method ("clone", builder.fn_qualifiers (), /* generics */ {},
+		SelfParam (Lifetime::error (), /* is_mut */ false, loc),
+		/* function params */ {}, std::move (big_self_type),
+		WhereClause::create_empty (), std::move (block),
+		Visibility::create_private (), {}, loc));
+}
+
+/**
+ * Create the Clone trait implementation for a type
+ *
+ * impl Clone for <type> {
+ *     <clone_fn>
+ * }
+ *
+ */
+std::unique_ptr<Item>
+DeriveClone::clone_impl (std::unique_ptr<TraitImplItem> &&clone_fn,
+			 std::string name)
+{
+  // should that be `$crate::core::clone::Clone` instead?
+  auto segments = std::vector<std::unique_ptr<TypePathSegment>> ();
+  segments.emplace_back (builder.type_path_segment ("Clone"));
+  auto clone = TypePath (std::move (segments), loc);
+
+  auto trait_items = std::vector<std::unique_ptr<TraitImplItem>> ();
+  trait_items.emplace_back (std::move (clone_fn));
+
+  return std::unique_ptr<Item> (
+    new TraitImpl (clone, /* unsafe */ false,
+		   /* exclam */ false, std::move (trait_items),
+		   /* generics */ {}, builder.single_type_path (name),
+		   WhereClause::create_empty (), Visibility::create_private (),
+		   {}, {}, loc));
+}
+
+// TODO: Create new `make_qualified_call` helper function
+
+DeriveClone::DeriveClone (Location loc)
+  : loc (loc), expanded (nullptr), builder (AstBuilder (loc))
+{}
+
+std::unique_ptr<AST::Item>
+DeriveClone::go (Item &item)
+{
+  item.accept_vis (*this);
+
+  rust_assert (expanded);
+
+  return std::move (expanded);
+}
+
+void
+DeriveClone::visit_tuple (TupleStruct &item)
+{
+  auto cloned_fields = std::vector<std::unique_ptr<Expr>> ();
+
+  for (size_t idx = 0; idx < item.get_fields ().size (); idx++)
+    cloned_fields.emplace_back (
+      clone_call (builder.ref (builder.tuple_idx ("self", idx))));
+
+  auto path = std::unique_ptr<Expr> (new PathInExpression (
+    builder.path_in_expression ({item.get_identifier ()})));
+  auto constructor = builder.call (std::move (path), std::move (cloned_fields));
+
+  expanded
+    = clone_impl (clone_fn (std::move (constructor)), item.get_identifier ());
+}
+
+void
+DeriveClone::visit_struct (StructStruct &item)
+{
+  if (item.is_unit_struct ())
+    {
+      auto unit_ctor = builder.struct_expr_struct (item.get_struct_name ());
+      expanded = clone_impl (clone_fn (std::move (unit_ctor)),
+			     item.get_struct_name ());
+    }
+  else
+    {
+      rust_sorry_at (item.get_locus (), "cannot derive %qs for these items yet",
+		     "Clone");
+    }
+}
+
+void
+DeriveClone::visit_enum (Enum &item)
+{
+  rust_sorry_at (item.get_locus (), "cannot derive %qs for these items yet",
+		 "Clone");
+}
+
+void
+DeriveClone::visit_union (Union &item)
+{
+  rust_sorry_at (item.get_locus (), "cannot derive %qs for these items yet",
+		 "Clone");
+}
+
+} // namespace AST
+} // namespace Rust

--- a/gcc/rust/expand/rust-derive-clone.h
+++ b/gcc/rust/expand/rust-derive-clone.h
@@ -1,0 +1,77 @@
+// Copyright (C) 2020-2023 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_DERIVE_CLONE_H
+#define RUST_DERIVE_CLONE_H
+
+#include "rust-derive.h"
+#include "rust-ast-builder.h"
+
+namespace Rust {
+namespace AST {
+
+class DeriveClone : DeriveVisitor
+{
+public:
+  DeriveClone (Location loc);
+
+  std::unique_ptr<AST::Item> go (Item &item);
+
+private:
+  Location loc;
+  std::unique_ptr<AST::Item> expanded;
+  AstBuilder builder;
+
+  /**
+   * Create a call to "clone". For now, this creates a call to
+   * `Clone::clone`, but should ultimately call into
+   * `::core::clone::Clone::clone`
+   *
+   * Clone::clone(<to_clone>)
+   */
+  std::unique_ptr<Expr> clone_call (std::unique_ptr<Expr> &&to_clone);
+
+  /**
+   * Create the actual "clone" function of the implementation, so
+   *
+   * fn clone(&self) -> Self { <clone_expr> }
+   *
+   */
+  std::unique_ptr<TraitImplItem> clone_fn (std::unique_ptr<Expr> &&clone_expr);
+
+  /**
+   * Create the Clone trait implementation for a type
+   *
+   * impl Clone for <type> {
+   *     <clone_fn>
+   * }
+   *
+   */
+  std::unique_ptr<Item> clone_impl (std::unique_ptr<TraitImplItem> &&clone_fn,
+				    std::string name);
+
+  virtual void visit_struct (StructStruct &item);
+  virtual void visit_tuple (TupleStruct &item);
+  virtual void visit_enum (Enum &item);
+  virtual void visit_union (Union &item);
+};
+
+} // namespace AST
+} // namespace Rust
+
+#endif // ! RUST_DERIVE_CLONE_H

--- a/gcc/rust/expand/rust-derive.cc
+++ b/gcc/rust/expand/rust-derive.cc
@@ -1,0 +1,48 @@
+// Copyright (C) 2020-2023 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-derive.h"
+#include "rust-derive-clone.h"
+
+namespace Rust {
+namespace AST {
+
+std::unique_ptr<Item>
+DeriveVisitor::derive (Item &item, const Attribute &attr,
+		       BuiltinMacro to_derive)
+{
+  switch (to_derive)
+    {
+    case BuiltinMacro::Clone:
+      return DeriveClone (attr.get_locus ()).go (item);
+    case BuiltinMacro::Copy:
+    case BuiltinMacro::Debug:
+    case BuiltinMacro::Default:
+    case BuiltinMacro::Eq:
+    case BuiltinMacro::PartialEq:
+    case BuiltinMacro::Ord:
+    case BuiltinMacro::PartialOrd:
+    case BuiltinMacro::Hash:
+    default:
+      rust_sorry_at (attr.get_locus (), "uninmplemented builtin derive macro");
+      return nullptr;
+    };
+}
+
+} // namespace AST
+} // namespace Rust

--- a/gcc/rust/expand/rust-derive.h
+++ b/gcc/rust/expand/rust-derive.h
@@ -1,0 +1,222 @@
+// Copyright (C) 2020-2023 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef DERIVE_VISITOR_H
+#define DERIVE_VISITOR_H
+
+#include "rust-ast-full.h"
+#include "rust-ast-visitor.h"
+#include "rust-macro-builtins.h"
+
+namespace Rust {
+namespace AST {
+
+/**
+ * The goal of this class is to accumulate and create the required items from a
+ * builtin `#[derive]` macro applied on a struct, enum or union.
+ */
+class DeriveVisitor : public AST::ASTVisitor
+{
+public:
+  static std::unique_ptr<Item> derive (Item &item, const Attribute &derive,
+				       BuiltinMacro to_derive);
+
+private:
+  // the 4 "allowed" visitors, which a derive-visitor can specify and override
+  virtual void visit_struct (StructStruct &struct_item) = 0;
+  virtual void visit_tuple (TupleStruct &tuple_item) = 0;
+  virtual void visit_enum (Enum &enum_item) = 0;
+  virtual void visit_union (Union &enum_item) = 0;
+
+  // all visitors are final, so no deriving class can implement `derive` for
+  // anything other than structs, tuples, enums and unions
+
+  virtual void visit (StructStruct &struct_item) override final
+  {
+    visit_struct (struct_item);
+  }
+
+  virtual void visit (TupleStruct &tuple_struct) override final
+  {
+    visit_tuple (tuple_struct);
+  }
+
+  virtual void visit (Enum &enum_item) override final
+  {
+    visit_enum (enum_item);
+  }
+
+  virtual void visit (Union &union_item) override final
+  {
+    visit_union (union_item);
+  }
+
+  virtual void visit (Token &tok) override final{};
+  virtual void visit (DelimTokenTree &delim_tok_tree) override final{};
+  virtual void visit (AttrInputMetaItemContainer &input) override final{};
+  virtual void visit (AttrInputMacro &expr) override final{};
+  virtual void visit (IdentifierExpr &ident_expr) override final{};
+  virtual void visit (Lifetime &lifetime) override final{};
+  virtual void visit (LifetimeParam &lifetime_param) override final{};
+  virtual void visit (ConstGenericParam &const_param) override final{};
+  virtual void visit (PathInExpression &path) override final{};
+  virtual void visit (TypePathSegment &segment) override final{};
+  virtual void visit (TypePathSegmentGeneric &segment) override final{};
+  virtual void visit (TypePathSegmentFunction &segment) override final{};
+  virtual void visit (TypePath &path) override final{};
+  virtual void visit (QualifiedPathInExpression &path) override final{};
+  virtual void visit (QualifiedPathInType &path) override final{};
+  virtual void visit (LiteralExpr &expr) override final{};
+  virtual void visit (AttrInputLiteral &attr_input) override final{};
+  virtual void visit (MetaItemLitExpr &meta_item) override final{};
+  virtual void visit (MetaItemPathLit &meta_item) override final{};
+  virtual void visit (BorrowExpr &expr) override final{};
+  virtual void visit (DereferenceExpr &expr) override final{};
+  virtual void visit (ErrorPropagationExpr &expr) override final{};
+  virtual void visit (NegationExpr &expr) override final{};
+  virtual void visit (ArithmeticOrLogicalExpr &expr) override final{};
+  virtual void visit (ComparisonExpr &expr) override final{};
+  virtual void visit (LazyBooleanExpr &expr) override final{};
+  virtual void visit (TypeCastExpr &expr) override final{};
+  virtual void visit (AssignmentExpr &expr) override final{};
+  virtual void visit (CompoundAssignmentExpr &expr) override final{};
+  virtual void visit (GroupedExpr &expr) override final{};
+  virtual void visit (ArrayElemsValues &elems) override final{};
+  virtual void visit (ArrayElemsCopied &elems) override final{};
+  virtual void visit (ArrayExpr &expr) override final{};
+  virtual void visit (ArrayIndexExpr &expr) override final{};
+  virtual void visit (TupleExpr &expr) override final{};
+  virtual void visit (TupleIndexExpr &expr) override final{};
+  virtual void visit (StructExprStruct &expr) override final{};
+  virtual void visit (StructExprFieldIdentifier &field) override final{};
+  virtual void visit (StructExprFieldIdentifierValue &field) override final{};
+  virtual void visit (StructExprFieldIndexValue &field) override final{};
+  virtual void visit (StructExprStructFields &expr) override final{};
+  virtual void visit (StructExprStructBase &expr) override final{};
+  virtual void visit (CallExpr &expr) override final{};
+  virtual void visit (MethodCallExpr &expr) override final{};
+  virtual void visit (FieldAccessExpr &expr) override final{};
+  virtual void visit (ClosureExprInner &expr) override final{};
+  virtual void visit (BlockExpr &expr) override final{};
+  virtual void visit (ClosureExprInnerTyped &expr) override final{};
+  virtual void visit (ContinueExpr &expr) override final{};
+  virtual void visit (BreakExpr &expr) override final{};
+  virtual void visit (RangeFromToExpr &expr) override final{};
+  virtual void visit (RangeFromExpr &expr) override final{};
+  virtual void visit (RangeToExpr &expr) override final{};
+  virtual void visit (RangeFullExpr &expr) override final{};
+  virtual void visit (RangeFromToInclExpr &expr) override final{};
+  virtual void visit (RangeToInclExpr &expr) override final{};
+  virtual void visit (ReturnExpr &expr) override final{};
+  virtual void visit (UnsafeBlockExpr &expr) override final{};
+  virtual void visit (LoopExpr &expr) override final{};
+  virtual void visit (WhileLoopExpr &expr) override final{};
+  virtual void visit (WhileLetLoopExpr &expr) override final{};
+  virtual void visit (ForLoopExpr &expr) override final{};
+  virtual void visit (IfExpr &expr) override final{};
+  virtual void visit (IfExprConseqElse &expr) override final{};
+  virtual void visit (IfLetExpr &expr) override final{};
+  virtual void visit (IfLetExprConseqElse &expr) override final{};
+  virtual void visit (MatchExpr &expr) override final{};
+  virtual void visit (AwaitExpr &expr) override final{};
+  virtual void visit (AsyncBlockExpr &expr) override final{};
+  virtual void visit (TypeParam &param) override final{};
+  virtual void visit (LifetimeWhereClauseItem &item) override final{};
+  virtual void visit (TypeBoundWhereClauseItem &item) override final{};
+  virtual void visit (Method &method) override final{};
+  virtual void visit (Module &module) override final{};
+  virtual void visit (ExternCrate &crate) override final{};
+  virtual void visit (UseTreeGlob &use_tree) override final{};
+  virtual void visit (UseTreeList &use_tree) override final{};
+  virtual void visit (UseTreeRebind &use_tree) override final{};
+  virtual void visit (UseDeclaration &use_decl) override final{};
+  virtual void visit (Function &function) override final{};
+  virtual void visit (TypeAlias &type_alias) override final{};
+  virtual void visit (EnumItem &item) override final{};
+  virtual void visit (EnumItemTuple &item) override final{};
+  virtual void visit (EnumItemStruct &item) override final{};
+  virtual void visit (EnumItemDiscriminant &item) override final{};
+  virtual void visit (ConstantItem &const_item) override final{};
+  virtual void visit (StaticItem &static_item) override final{};
+  virtual void visit (TraitItemFunc &item) override final{};
+  virtual void visit (TraitItemMethod &item) override final{};
+  virtual void visit (TraitItemConst &item) override final{};
+  virtual void visit (TraitItemType &item) override final{};
+  virtual void visit (Trait &trait) override final{};
+  virtual void visit (InherentImpl &impl) override final{};
+  virtual void visit (TraitImpl &impl) override final{};
+  virtual void visit (ExternalTypeItem &type) override final{};
+  virtual void visit (ExternalStaticItem &item) override final{};
+  virtual void visit (ExternalFunctionItem &item) override final{};
+  virtual void visit (ExternBlock &block) override final{};
+  virtual void visit (MacroMatchFragment &match) override final{};
+  virtual void visit (MacroMatchRepetition &match) override final{};
+  virtual void visit (MacroMatcher &matcher) override final{};
+  virtual void visit (MacroRulesDefinition &rules_def) override final{};
+  virtual void visit (MacroInvocation &macro_invoc) override final{};
+  virtual void visit (MetaItemPath &meta_item) override final{};
+  virtual void visit (MetaItemSeq &meta_item) override final{};
+  virtual void visit (MetaWord &meta_item) override final{};
+  virtual void visit (MetaNameValueStr &meta_item) override final{};
+  virtual void visit (MetaListPaths &meta_item) override final{};
+  virtual void visit (MetaListNameValueStr &meta_item) override final{};
+  virtual void visit (LiteralPattern &pattern) override final{};
+  virtual void visit (IdentifierPattern &pattern) override final{};
+  virtual void visit (WildcardPattern &pattern) override final{};
+  virtual void visit (RestPattern &pattern) override final{};
+  virtual void visit (RangePatternBoundLiteral &bound) override final{};
+  virtual void visit (RangePatternBoundPath &bound) override final{};
+  virtual void visit (RangePatternBoundQualPath &bound) override final{};
+  virtual void visit (RangePattern &pattern) override final{};
+  virtual void visit (ReferencePattern &pattern) override final{};
+  virtual void visit (StructPatternFieldTuplePat &field) override final{};
+  virtual void visit (StructPatternFieldIdentPat &field) override final{};
+  virtual void visit (StructPatternFieldIdent &field) override final{};
+  virtual void visit (StructPattern &pattern) override final{};
+  virtual void visit (TupleStructItemsNoRange &tuple_items) override final{};
+  virtual void visit (TupleStructItemsRange &tuple_items) override final{};
+  virtual void visit (TupleStructPattern &pattern) override final{};
+  virtual void visit (TuplePatternItemsMultiple &tuple_items) override final{};
+  virtual void visit (TuplePatternItemsRanged &tuple_items) override final{};
+  virtual void visit (TuplePattern &pattern) override final{};
+  virtual void visit (GroupedPattern &pattern) override final{};
+  virtual void visit (SlicePattern &pattern) override final{};
+  virtual void visit (AltPattern &pattern) override final{};
+  virtual void visit (EmptyStmt &stmt) override final{};
+  virtual void visit (LetStmt &stmt) override final{};
+  virtual void visit (ExprStmt &stmt) override final{};
+  virtual void visit (TraitBound &bound) override final{};
+  virtual void visit (ImplTraitType &type) override final{};
+  virtual void visit (TraitObjectType &type) override final{};
+  virtual void visit (ParenthesisedType &type) override final{};
+  virtual void visit (ImplTraitTypeOneBound &type) override final{};
+  virtual void visit (TraitObjectTypeOneBound &type) override final{};
+  virtual void visit (TupleType &type) override final{};
+  virtual void visit (NeverType &type) override final{};
+  virtual void visit (RawPointerType &type) override final{};
+  virtual void visit (ReferenceType &type) override final{};
+  virtual void visit (ArrayType &type) override final{};
+  virtual void visit (SliceType &type) override final{};
+  virtual void visit (InferredType &type) override final{};
+  virtual void visit (BareFunctionType &type) override final{};
+};
+
+} // namespace AST
+} // namespace Rust
+
+#endif // DERIVE_VISITOR_H

--- a/gcc/rust/expand/rust-macro-builtins.cc
+++ b/gcc/rust/expand/rust-macro-builtins.cc
@@ -29,10 +29,10 @@
 #include "rust-macro.h"
 #include "rust-parse.h"
 #include "rust-session-manager.h"
-#include "bi-map.h"
 
 namespace Rust {
-static const BiMap<std::string, BuiltinMacro> builtins = {{
+
+const BiMap<std::string, BuiltinMacro> MacroBuiltin::builtins = {{
   {"assert", BuiltinMacro::Assert},
   {"file", BuiltinMacro::File},
   {"line", BuiltinMacro::Line},
@@ -62,6 +62,16 @@ static const BiMap<std::string, BuiltinMacro> builtins = {{
   {"cfg_accessible", BuiltinMacro::CfgAccessible},
   {"RustcEncodable", BuiltinMacro::RustcDecodable},
   {"RustcDecodable", BuiltinMacro::RustcEncodable},
+  {"Clone", BuiltinMacro::Clone},
+  {"Copy", BuiltinMacro::Copy},
+  {"Debug", BuiltinMacro::Debug},
+  {"Default", BuiltinMacro::Default},
+  {"Eq", BuiltinMacro::Eq},
+  {"PartialEq", BuiltinMacro::PartialEq},
+  {"Ord", BuiltinMacro::Ord},
+  {"PartialOrd", BuiltinMacro::PartialOrd},
+  {"Hash", BuiltinMacro::Hash},
+
 }};
 
 std::unordered_map<
@@ -95,16 +105,14 @@ std::unordered_map<
     {"test_case", MacroBuiltin::sorry},
     {"global_allocator", MacroBuiltin::sorry},
     {"cfg_accessible", MacroBuiltin::sorry},
-    {"RustcEncodable", MacroBuiltin::sorry},
-    {"RustcDecodable", MacroBuiltin::sorry},
 };
 
 // FIXME: This should return an Optional
 BuiltinMacro
 builtin_macro_from_string (const std::string &identifier)
 {
-  auto macro = builtins.lookup (identifier);
-  rust_assert (builtins.is_iter_ok (macro));
+  auto macro = MacroBuiltin::builtins.lookup (identifier);
+  rust_assert (MacroBuiltin::builtins.is_iter_ok (macro));
 
   return macro->second;
 }
@@ -113,8 +121,8 @@ namespace {
 std::string
 make_macro_path_str (BuiltinMacro kind)
 {
-  auto str = builtins.lookup (kind);
-  rust_assert (builtins.is_iter_ok (str));
+  auto str = MacroBuiltin::builtins.lookup (kind);
+  rust_assert (MacroBuiltin::builtins.is_iter_ok (str));
 
   return str->second;
 }

--- a/gcc/rust/expand/rust-macro-builtins.h
+++ b/gcc/rust/expand/rust-macro-builtins.h
@@ -22,6 +22,7 @@
 #include "rust-ast.h"
 #include "rust-ast-fragment.h"
 #include "rust-location.h"
+#include "bi-map.h"
 
 namespace Rust {
 
@@ -63,6 +64,15 @@ enum class BuiltinMacro
   CfgAccessible,
   RustcDecodable,
   RustcEncodable,
+  Clone,
+  Copy,
+  Debug,
+  Default,
+  Eq,
+  PartialEq,
+  Ord,
+  PartialOrd,
+  Hash,
 };
 
 BuiltinMacro
@@ -107,6 +117,7 @@ builtin_macro_from_string (const std::string &identifier);
 class MacroBuiltin
 {
 public:
+  static const BiMap<std::string, BuiltinMacro> builtins;
   static std::unordered_map<
     std::string, std::function<AST::Fragment (Location, AST::MacroInvocData &)>>
     builtin_transcribers;

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -876,14 +876,18 @@ Mappings::insert_macro_def (AST::MacroRulesDefinition *macro)
 		   });
   if (should_be_builtin)
     {
-      auto builtin
+      auto builtin = MacroBuiltin::builtins.lookup (macro->get_rule_name ());
+      if (!MacroBuiltin::builtins.is_iter_ok (builtin))
+	{
+	  rust_error_at (macro->get_locus (),
+			 "cannot find a built-in macro with name %qs",
+			 macro->get_rule_name ().c_str ());
+	  return;
+	}
+
+      auto transcriber
 	= MacroBuiltin::builtin_transcribers.find (macro->get_rule_name ());
-      if (builtin != MacroBuiltin::builtin_transcribers.end ())
-	macro->set_builtin_transcriber (builtin->second);
-      else
-	rust_error_at (macro->get_locus (),
-		       "cannot find a built-in macro with name %qs",
-		       macro->get_rule_name ().c_str ());
+      macro->set_builtin_transcriber (transcriber->second);
     }
 
   auto it = macroMappings.find (macro->get_node_id ());

--- a/gcc/testsuite/rust/compile/derive_macro1.rs
+++ b/gcc/testsuite/rust/compile/derive_macro1.rs
@@ -1,0 +1,12 @@
+pub trait Clone {
+    fn clone(&self) -> Self;
+}
+
+// This warning can be removed once we properly handle implems with #[automatically_derived]
+#[derive(Clone)] // { dg-warning "unused name .self." }
+pub struct S;
+
+fn main() {
+    let s = S;
+    let _s_clone = s.clone();
+}

--- a/gcc/testsuite/rust/compile/derive_macro3.rs
+++ b/gcc/testsuite/rust/compile/derive_macro3.rs
@@ -1,0 +1,21 @@
+pub trait Clone {
+    fn clone(&self) -> Self;
+}
+
+pub trait Copy {}
+
+impl Copy for i32 {}
+
+impl<T> Clone for T
+where
+    T: Copy,
+{
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+fn main() {
+    let a = 15i32;
+    let _ = a.clone();
+}

--- a/gcc/testsuite/rust/compile/macro43.rs
+++ b/gcc/testsuite/rust/compile/macro43.rs
@@ -11,7 +11,8 @@ macro_rules! nonzero_integers {
             /// assert_eq!(size_of::<Option<std::num::NonZeroU32>>(), size_of::<u32>());
             /// ```
             #[stable(feature = "nonzero", since = "1.28.0")]
-            #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+            // not all derive macros are implemented yet, and this test does not test these anyways
+            // #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
             #[repr(transparent)]
             pub struct $Ty(NonZero<$Int>);
 

--- a/gcc/testsuite/rust/execute/torture/derive_macro1.rs
+++ b/gcc/testsuite/rust/execute/torture/derive_macro1.rs
@@ -1,0 +1,23 @@
+pub trait Clone {
+    fn clone(&self) -> Self;
+}
+
+pub trait Copy {}
+
+impl Copy for i32 {}
+
+impl<T> Clone for T
+where
+    T: Copy,
+{
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+fn main() -> i32 {
+    let a = 15i32;
+    let b = a.clone();
+
+    a - b
+}

--- a/gcc/testsuite/rust/execute/torture/derive_macro3.rs
+++ b/gcc/testsuite/rust/execute/torture/derive_macro3.rs
@@ -1,0 +1,19 @@
+pub trait Clone {
+    fn clone(&self) -> Self;
+}
+
+impl Clone for i32 {
+    fn clone(&self) -> i32 {
+        *self
+    }
+}
+
+#[derive(Clone)]
+struct S(i32, i32);
+
+fn main() -> i32 {
+    let a = S(15, 15);
+    let b = a.clone();
+
+    b.0 - b.1
+}


### PR DESCRIPTION
This PR adds basic support for builtin derive macros and, more specifically, deriving Clone on some simple structures (tuple structs and empty structs). Keeping it as a draft as it still needs some work. Needs #2214