### PR TITLE
Handle keyword metavariables during macro expansion

### DIFF
--- a/gcc/rust/lex/rust-token.cc
+++ b/gcc/rust/lex/rust-token.cc
@@ -152,6 +152,9 @@ Token::get_type_hint_str () const
 const std::string &
 Token::get_str () const
 {
+  if (token_id_is_keyword (token_id))
+    return token_id_keyword_string (token_id);
+
   // FIXME: attempt to return null again
   // gcc_assert(str != NULL);
 

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -2146,10 +2146,10 @@ Parser<ManagedTokenSource>::parse_macro_match_fragment ()
 
   Identifier ident = "";
   auto identifier = lexer.peek_token ();
-  if (identifier->has_str ())
-    ident = identifier->get_str ();
+  if (identifier->get_id () == UNDERSCORE)
+    ident = "_";
   else
-    ident = std::string (token_id_to_str (identifier->get_id ()));
+    ident = identifier->get_str ();
 
   if (ident.empty ())
     {

--- a/gcc/testsuite/rust/compile/macro-issue2194.rs
+++ b/gcc/testsuite/rust/compile/macro-issue2194.rs
@@ -1,0 +1,7 @@
+macro_rules! foo {($type:ident) => {
+    let $type = 12;
+}} 
+
+pub fn foo() {
+    foo!(_a);
+}


### PR DESCRIPTION
Fixes #2194