### PR TITLE
gccrs: remove stray semicolon

### DIFF
--- a/gcc/rust/typecheck/rust-hir-trait-reference.cc
+++ b/gcc/rust/typecheck/rust-hir-trait-reference.cc
@@ -37,7 +37,7 @@ bool
 TraitItemReference::is_optional () const
 {
   return optional_flag;
-};
+}
 
 std::string
 TraitItemReference::get_identifier () const


### PR DESCRIPTION
Fix for this warning:

```
../../src/gcc/rust/typecheck/rust-hir-trait-reference.cc:40:2: warning: extra ‘;’ [-Wpedantic]
   40 | };
      |  ^

```
(untested; done via github edit window)