### PR TITLE
gccrs: Fix cast site to not miss type-unifications

### DIFF
--- a/gcc/rust/typecheck/rust-casts.cc
+++ b/gcc/rust/typecheck/rust-casts.cc
@@ -42,7 +42,12 @@ TypeCastRules::check ()
     = TypeCoercionRules::TryCoerce (from.get_ty (), to.get_ty (), locus,
 				    true /*allow-autoderef*/);
   if (!possible_coercion.is_error ())
-    return possible_coercion;
+    {
+      // given the attempt was ok we need to ensure we perform it so that any
+      // inference variables are unified correctly
+      return TypeCoercionRules::Coerce (from.get_ty (), to.get_ty (), locus,
+					true /*allow-autoderef*/);
+    }
 
   // try the simple cast rules
   auto simple_cast = cast_rules ();

--- a/gcc/testsuite/rust/compile/issue-2195.rs
+++ b/gcc/testsuite/rust/compile/issue-2195.rs
@@ -1,0 +1,8 @@
+struct A<T> {
+    // { dg-warning "struct is never constructed" "" { target *-*-* } .-1 }
+    f: *const T,
+}
+
+pub fn cast<T>(a: A<T>) {
+    let z = a.f as *const ();
+}


### PR DESCRIPTION
When attempting casts we can try a type coercion first, this is a TryCoercion which will return a result. In the event this is ok we need to perform a true coercion so that we don't leave missing infeence variable's ununified.

Fixes #2195
