### PR TITLE
Add #[derive(Copy)] support

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -90,6 +90,7 @@ GRS_OBJS = \
 	rust/rust-ast-builder.o \
 	rust/rust-derive.o \
 	rust/rust-derive-clone.o \
+	rust/rust-derive-copy.o \
     rust/rust-macro-invoc-lexer.o \
     rust/rust-macro-substitute-ctx.o \
     rust/rust-macro-builtins.o \

--- a/gcc/rust/expand/rust-derive-copy.cc
+++ b/gcc/rust/expand/rust-derive-copy.cc
@@ -1,0 +1,80 @@
+// Copyright (C) 2020-2023 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-derive-copy.h"
+#include "rust-ast-full.h"
+
+namespace Rust {
+namespace AST {
+
+DeriveCopy::DeriveCopy (Location loc)
+  : loc (loc), builder (AstBuilder (loc)), expanded (nullptr)
+{}
+
+std::unique_ptr<AST::Item>
+DeriveCopy::go (Item &item)
+{
+  item.accept_vis (*this);
+
+  rust_assert (expanded);
+
+  return std::move (expanded);
+}
+
+std::unique_ptr<Item>
+DeriveCopy::copy_impl (std::string name)
+{
+  // `$crate::core::marker::Copy` instead
+  auto segments = std::vector<std::unique_ptr<TypePathSegment>> ();
+  segments.emplace_back (builder.type_path_segment ("Copy"));
+  auto copy = TypePath (std::move (segments), loc);
+
+  return std::unique_ptr<Item> (
+    new TraitImpl (copy, /* unsafe */ false,
+		   /* exclam */ false, /* trait items */ {},
+		   /* generics */ {}, builder.single_type_path (name),
+		   WhereClause::create_empty (), Visibility::create_private (),
+		   {}, {}, loc));
+}
+
+void
+DeriveCopy::visit_struct (StructStruct &item)
+{
+  expanded = copy_impl (item.get_struct_name ());
+}
+
+void
+DeriveCopy::visit_tuple (TupleStruct &item)
+{
+  expanded = copy_impl (item.get_struct_name ());
+}
+
+void
+DeriveCopy::visit_enum (Enum &item)
+{
+  expanded = copy_impl (item.get_identifier ());
+}
+
+void
+DeriveCopy::visit_union (Union &item)
+{
+  expanded = copy_impl (item.get_identifier ());
+}
+
+} // namespace AST
+} // namespace Rust

--- a/gcc/rust/expand/rust-derive-copy.h
+++ b/gcc/rust/expand/rust-derive-copy.h
@@ -16,35 +16,41 @@
 // along with GCC; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
+#ifndef RUST_DERIVE_COPY_H
+#define RUST_DERIVE_COPY_H
+
 #include "rust-derive.h"
-#include "rust-derive-clone.h"
-#include "rust-derive-copy.h"
+#include "rust-ast-builder.h"
 
 namespace Rust {
 namespace AST {
-
-std::unique_ptr<Item>
-DeriveVisitor::derive (Item &item, const Attribute &attr,
-		       BuiltinMacro to_derive)
+class DeriveCopy : DeriveVisitor
 {
-  switch (to_derive)
-    {
-    case BuiltinMacro::Clone:
-      return DeriveClone (attr.get_locus ()).go (item);
-    case BuiltinMacro::Copy:
-      return DeriveCopy (attr.get_locus ()).go (item);
-    case BuiltinMacro::Debug:
-    case BuiltinMacro::Default:
-    case BuiltinMacro::Eq:
-    case BuiltinMacro::PartialEq:
-    case BuiltinMacro::Ord:
-    case BuiltinMacro::PartialOrd:
-    case BuiltinMacro::Hash:
-    default:
-      rust_sorry_at (attr.get_locus (), "uninmplemented builtin derive macro");
-      return nullptr;
-    };
-}
+public:
+  DeriveCopy (Location loc);
+
+  std::unique_ptr<Item> go (Item &);
+
+private:
+  Location loc;
+  AstBuilder builder;
+  std::unique_ptr<Item> expanded;
+
+  /**
+   * Create the Copy impl block for a type. These impl blocks are very simple as
+   * Copy is just a marker trait.
+   *
+   * impl Copy for <type> {}
+   */
+  std::unique_ptr<Item> copy_impl (std::string name);
+
+  virtual void visit_struct (StructStruct &item);
+  virtual void visit_tuple (TupleStruct &item);
+  virtual void visit_enum (Enum &item);
+  virtual void visit_union (Union &item);
+};
 
 } // namespace AST
 } // namespace Rust
+
+#endif // !RUST_DERIVE_COPY_H


### PR DESCRIPTION
Addresses #2172 

From looking at `rustc`'s dump of a simple struct which is `#[derive(Copy)]`, it does not seem like we need to do anything particular like instantiating `AssertParamIsCopy<T>`s for each field's type. So I'm not sure how the "this field does not implement Copy" get generated and when. We'll have to investigate this further