### PR TITLE
derive: Add #[derive(Clone)] for regular structs

### DIFF
--- a/gcc/rust/ast/rust-ast-builder.cc
+++ b/gcc/rust/ast/rust-ast-builder.cc
@@ -118,5 +118,29 @@ AstBuilder::deref (std::unique_ptr<Expr> &&of)
   return std::unique_ptr<Expr> (new DereferenceExpr (std::move (of), {}, loc));
 }
 
+std::unique_ptr<Expr>
+AstBuilder::struct_expr (std::string struct_name,
+			 std::vector<std::unique_ptr<StructExprField>> &&fields)
+{
+  return std::unique_ptr<Expr> (
+    new StructExprStructFields (path_in_expression ({struct_name}),
+				std::move (fields), loc));
+}
+
+std::unique_ptr<StructExprField>
+AstBuilder::struct_expr_field (std::string field_name,
+			       std::unique_ptr<Expr> &&value)
+{
+  return std::unique_ptr<StructExprField> (
+    new StructExprFieldIdentifierValue (field_name, std::move (value), loc));
+}
+
+std::unique_ptr<Expr>
+AstBuilder::field_access (std::unique_ptr<Expr> &&instance, std::string field)
+{
+  return std::unique_ptr<Expr> (
+    new FieldAccessExpr (std::move (instance), field, {}, loc));
+}
+
 } // namespace AST
 } // namespace Rust

--- a/gcc/rust/ast/rust-ast-builder.h
+++ b/gcc/rust/ast/rust-ast-builder.h
@@ -85,6 +85,21 @@ public:
   /* Create a struct expression for unit structs (`S`) */
   std::unique_ptr<Expr> struct_expr_struct (std::string struct_name);
 
+  /**
+   * Create an expression for struct instantiation with fields (`S { a, b: c }`)
+   */
+  std::unique_ptr<Expr>
+  struct_expr (std::string struct_name,
+	       std::vector<std::unique_ptr<StructExprField>> &&fields);
+
+  /* Create a field expression for struct instantiation (`field_name: value`) */
+  std::unique_ptr<StructExprField>
+  struct_expr_field (std::string field_name, std::unique_ptr<Expr> &&value);
+
+  /* Create a field access expression (`instance.field`) */
+  std::unique_ptr<Expr> field_access (std::unique_ptr<Expr> &&instance,
+				      std::string field);
+
 private:
   /**
    * Location of the generated AST nodes

--- a/gcc/testsuite/rust/execute/torture/derive_macro4.rs
+++ b/gcc/testsuite/rust/execute/torture/derive_macro4.rs
@@ -1,0 +1,29 @@
+pub trait Clone {
+    fn clone(&self) -> Self;
+}
+
+#[derive(Clone)]
+struct Foo {
+    a: i32,
+}
+
+#[derive(Clone)]
+struct S {
+    a: i32,
+    b: Foo,
+}
+
+impl Clone for i32 {
+    fn clone(&self) -> Self { *self }
+}
+
+fn main() -> i32 {
+    let s1 = S { a: 15, b: Foo { a: 14 }};
+    let s2 = s1.clone();
+
+    let l = s1.a - s2.a;
+    let r = s1.b.a - s2.b.a;
+
+    // should be 0 if all fields were cloned correctly
+    l + r
+}


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* expand/rust-derive-clone.cc (DeriveClone::visit_struct): Implement proper
	cloning for structs with fields.
	* ast/rust-ast-builder.cc (AstBuilder::struct_expr): New function.
	(AstBuilder::struct_expr_field): Likewise.
	(AstBuilder::field_access): Likewise.
	(AstBuilder::let): Likewise.
	* ast/rust-ast-builder.h: Declare new functions.

gcc/testsuite/ChangeLog:

	* rust/execute/torture/derive_macro4.rs: New test.
