### PR TITLE
builtin-derive-macros: Add dummy builtin transcriber for builtin derive macros.

### DIFF
--- a/gcc/rust/expand/rust-macro-builtins.cc
+++ b/gcc/rust/expand/rust-macro-builtins.cc
@@ -105,6 +105,22 @@ std::unordered_map<
     {"test_case", MacroBuiltin::sorry},
     {"global_allocator", MacroBuiltin::sorry},
     {"cfg_accessible", MacroBuiltin::sorry},
+    /* Derive builtins do not need a real transcriber, but still need one. It
+       will however never be called since builtin derive macros get expanded
+       differently, and benefit from knowing on what kind of items they are
+       applied (struct, enums, unions) rather than receiving a list of tokens
+       like regular builtin macros */
+    {"RustcEncodable", MacroBuiltin::proc_macro_builtin},
+    {"RustcDecodable", MacroBuiltin::proc_macro_builtin},
+    {"Clone", MacroBuiltin::proc_macro_builtin},
+    {"Copy", MacroBuiltin::proc_macro_builtin},
+    {"Debug", MacroBuiltin::proc_macro_builtin},
+    {"Default", MacroBuiltin::proc_macro_builtin},
+    {"Eq", MacroBuiltin::proc_macro_builtin},
+    {"PartialEq", MacroBuiltin::proc_macro_builtin},
+    {"Ord", MacroBuiltin::proc_macro_builtin},
+    {"PartialOrd", MacroBuiltin::proc_macro_builtin},
+    {"Hash", MacroBuiltin::proc_macro_builtin},
 };
 
 // FIXME: This should return an Optional
@@ -929,6 +945,13 @@ MacroBuiltin::sorry (Location invoc_locus, AST::MacroInvocData &invoc)
   rust_sorry_at (invoc_locus, "unimplemented builtin macro: %qs",
 		 invoc.get_path ().as_string ().c_str ());
 
+  return AST::Fragment::create_error ();
+}
+
+AST::Fragment
+MacroBuiltin::proc_macro_builtin (Location, AST::MacroInvocData &)
+{
+  // nothing to do!
   return AST::Fragment::create_error ();
 }
 

--- a/gcc/rust/expand/rust-macro-builtins.h
+++ b/gcc/rust/expand/rust-macro-builtins.h
@@ -159,6 +159,10 @@ public:
 				     AST::MacroInvocData &invoc);
 
   static AST::Fragment sorry (Location invoc_locus, AST::MacroInvocData &invoc);
+
+  /* Builtin procedural macros do not work directly on tokens, but still need an
+   * empty builtin transcriber to be considered proper builtin macros */
+  static AST::Fragment proc_macro_builtin (Location, AST::MacroInvocData &);
 };
 } // namespace Rust
 

--- a/gcc/testsuite/rust/compile/derive_macro7.rs
+++ b/gcc/testsuite/rust/compile/derive_macro7.rs
@@ -1,0 +1,8 @@
+#![feature(rustc_attrs)]
+
+#[rustc_builtin_macro]
+#[stable(feature = "rust1", since = "1.0.0")]
+#[allow_internal_unstable(core_intrinsics, libstd_sys_internals)]
+pub macro RustcDecodable($item:item) {
+    /* compiler built-in */
+}


### PR DESCRIPTION
Fixes #2257.

Derive builtins do not need a real transcriber, but still need one. It
will however never be called since builtin derive macros get expanded
differently, and benefit from knowing on what kind of items they are
applied (struct, enums, unions) rather than receiving a list of tokens
like regular builtin macros.

gcc/rust/ChangeLog:

	* expand/rust-macro-builtins.cc (MacroBuiltin::dummy): New function.
	* expand/rust-macro-builtins.h: Declare it.

gcc/testsuite/ChangeLog:

	* rust/compile/derive_macro7.rs: New test.