### PR TITLE
Add handling of unimplemented derive macros.

### DIFF
--- a/gcc/rust/expand/rust-macro-builtins.cc
+++ b/gcc/rust/expand/rust-macro-builtins.cc
@@ -106,7 +106,7 @@ std::unordered_map<
     {"global_allocator", MacroBuiltin::sorry},
     {"cfg_accessible", MacroBuiltin::sorry},
     /* Derive builtins do not need a real transcriber, but still need one. It
-       will however never be called since builtin derive macros get expanded
+       should however never be called since builtin derive macros get expanded
        differently, and benefit from knowing on what kind of items they are
        applied (struct, enums, unions) rather than receiving a list of tokens
        like regular builtin macros */
@@ -949,9 +949,12 @@ MacroBuiltin::sorry (Location invoc_locus, AST::MacroInvocData &invoc)
 }
 
 AST::Fragment
-MacroBuiltin::proc_macro_builtin (Location, AST::MacroInvocData &)
+MacroBuiltin::proc_macro_builtin (Location invoc_locus,
+				  AST::MacroInvocData &invoc)
 {
-  // nothing to do!
+  rust_error_at (invoc_locus, "cannot invoke derive macro: %qs",
+		 invoc.get_path ().as_string ().c_str ());
+
   return AST::Fragment::create_error ();
 }
 

--- a/gcc/rust/expand/rust-macro-builtins.h
+++ b/gcc/rust/expand/rust-macro-builtins.h
@@ -160,8 +160,8 @@ public:
 
   static AST::Fragment sorry (Location invoc_locus, AST::MacroInvocData &invoc);
 
-  /* Builtin procedural macros do not work directly on tokens, but still need an
-   * empty builtin transcriber to be considered proper builtin macros */
+  /* Builtin procedural macros do not work directly on tokens, but still need a
+   * builtin transcriber to be considered proper builtin macros */
   static AST::Fragment proc_macro_builtin (Location, AST::MacroInvocData &);
 };
 } // namespace Rust

--- a/gcc/testsuite/rust/compile/derive_macro8.rs
+++ b/gcc/testsuite/rust/compile/derive_macro8.rs
@@ -1,0 +1,9 @@
+#![feature(rustc_attrs)]
+#![feature(decl_macro)]
+
+#[rustc_builtin_macro]
+pub macro Copy($i:item) { /* builtin */ }
+
+pub fn foo() {
+    Copy!(); // { dg-error "cannot invoke derive macro" }
+}


### PR DESCRIPTION
This prevents an ICE while attempting to compile ```libcore``` but might need adjustment @CohenArthur