### PR TITLE
ast: dump literals correctly

### DIFF
--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -507,7 +507,34 @@ Dump::visit (QualifiedPathInType &path)
 void
 Dump::visit (LiteralExpr &expr)
 {
-  stream << expr.as_string ();
+  switch (expr.get_lit_type ())
+    {
+    case Literal::CHAR:
+      stream << "'" << expr.as_string () << "'";
+      return;
+
+    case Literal::STRING:
+      stream << "\"" << expr.as_string () << "\"";
+      return;
+
+    case Literal::BYTE:
+      stream << "b'" << expr.as_string () << "'";
+      return;
+
+    case Literal::BYTE_STRING:
+      stream << "b\"" << expr.as_string () << "\"";
+      return;
+
+    case Literal::INT:
+    case Literal::FLOAT:
+    case Literal::BOOL:
+      stream << expr.as_string ();
+      return;
+
+    case Literal::ERROR:
+      stream << "/*ERROR*/";
+      return;
+    }
 }
 
 void


### PR DESCRIPTION
This commit fixes printing of literals based on their type.

Previous implementation printed literals the same, regardless their type. Now we are printing:
  * int, float, bool don't require special printing
  * char        -> `'<char>'`
  * string      -> `"<string>"`
  * byte        -> `b'<byte>'`
  * byte_string -> `b"<byte_string>"`

Fixes #2220