### PR TITLE
gccrs: Respect the concrete type when resolving qualifed path types

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-path.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-path.cc
@@ -89,6 +89,8 @@ TypeCheckExpr::visit (HIR::QualifiedPathInExpression &expr)
     = lookup_associated_impl_block (specified_bound, root);
   if (associated_impl_trait != nullptr)
     {
+      associated_impl_trait->setup_associated_types (root, specified_bound);
+
       for (auto &i :
 	   associated_impl_trait->get_impl_block ()->get_impl_items ())
 	{

--- a/gcc/testsuite/rust/compile/issue-2165.rs
+++ b/gcc/testsuite/rust/compile/issue-2165.rs
@@ -1,0 +1,9 @@
+pub trait Alpha<T = Self> {
+    type Beta;
+}
+
+impl Alpha for u32 {
+    type Beta = u32;
+}
+
+type Delta = <u32 as Alpha<u32>>::Beta;

--- a/gcc/testsuite/rust/compile/issue-2166.rs
+++ b/gcc/testsuite/rust/compile/issue-2166.rs
@@ -1,0 +1,23 @@
+trait Add {
+    type Output;
+
+    fn add(self) -> u32;
+}
+
+impl Add for u32 {
+    type Output = u32;
+
+    fn add(self) -> u32 {
+        // { dg-warning "unused name" "" { target *-*-* } .-1 }
+        0
+    }
+}
+
+impl<'a> Add for &'a u32 {
+    type Output = u32;
+
+    fn add(self) -> <u32 as Add>::Output {
+        // { dg-warning "unused name" "" { target *-*-* } .-1 }
+        0
+    }
+}


### PR DESCRIPTION
Concrete types can resolve to assoicated impl blocks which will allow us to resolve the path to the projection type instead of the placeholder trait associated type which can change. The projection will be fixed and is safer to use.

Fixes #2165 #2166

gcc/rust/ChangeLog:

	* typecheck/rust-hir-trait-resolve.cc: when the bound is concrete keep the mapping
	* typecheck/rust-hir-type-check-path.cc (TypeCheckExpr::visit): add missing call
	* typecheck/rust-hir-type-check-type.cc (TypeCheckType::visit): make this the same as paths

gcc/testsuite/ChangeLog:

	* rust/compile/issue-2165.rs: New test.
	* rust/compile/issue-2166.rs: New test.