### PR TITLE
Fix parsing of statement macros 

### DIFF
--- a/gcc/rust/ast/rust-ast-dump.cc
+++ b/gcc/rust/ast/rust-ast-dump.cc
@@ -1570,8 +1570,11 @@ Dump::visit (MacroRulesDefinition &rules_def)
 }
 
 void
-Dump::visit (MacroInvocation &)
-{}
+Dump::visit (MacroInvocation &invocation)
+{
+  // FIXME: make this accurately reflect the original macro syntax.
+  stream << invocation.get_invoc_data ().as_string ();
+}
 
 void
 Dump::visit (MetaItemPath &)

--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -4223,12 +4223,10 @@ Attribute::is_parsed_to_meta_item () const
 }
 
 void
-BlockExpr::strip_tail_expr ()
+BlockExpr::normalize_tail_expr ()
 {
-  if (expr)
+  if (!expr)
     {
-      expr = nullptr;
-
       // HACK: try to turn the last statement into a tail expression
       if (statements.size () && statements.back ()->is_expr ())
 	{

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -988,8 +988,6 @@ public:
 
   virtual std::vector<Attribute> &get_outer_attrs () = 0;
 
-  virtual Expr *to_stmt () const { return clone_expr_impl (); }
-
   // TODO: think of less hacky way to implement this kind of thing
   // Sets outer attributes.
   virtual void set_outer_attrs (std::vector<Attribute>) = 0;

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -904,6 +904,8 @@ public:
 
   virtual bool is_expr () const { return false; }
 
+  virtual void add_semicolon () {}
+
 protected:
   Stmt () : node_id (Analysis::Mappings::get ()->get_next_node_id ()) {}
 

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -2488,7 +2488,9 @@ public:
   }
 
   // Removes the tail expression from the block.
-  void strip_tail_expr ();
+  void strip_tail_expr () { expr = nullptr; }
+  // Normalizes a trailing statement without a semicolon to a tail expression.
+  void normalize_tail_expr ();
 
   const std::vector<Attribute> &get_outer_attrs () const { return outer_attrs; }
   std::vector<Attribute> &get_outer_attrs () override { return outer_attrs; }

--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -787,6 +787,8 @@ public:
     return new MacroInvocation (*this);
   }
 
+  void add_semicolon () override { is_semi_coloned = true; }
+
 protected:
   Item *clone_item_impl () const override
   {

--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -811,15 +811,6 @@ protected:
   {
     return clone_macro_invocation_impl ();
   }
-
-  Expr *to_stmt () const override
-
-  {
-    auto new_impl = clone_macro_invocation_impl ();
-    new_impl->is_semi_coloned = true;
-
-    return new_impl;
-  }
 };
 
 // more generic meta item path-only form

--- a/gcc/rust/ast/rust-stmt.h
+++ b/gcc/rust/ast/rust-stmt.h
@@ -201,8 +201,9 @@ public:
 
   std::vector<LetStmt *> locals;
 
-  ExprStmt (std::unique_ptr<Expr> expr, Location locus, bool semicolon_followed)
-    : expr (expr->to_stmt ()), locus (locus),
+  ExprStmt (std::unique_ptr<Expr> &&expr, Location locus,
+	    bool semicolon_followed)
+    : expr (std::move (expr)), locus (locus),
       semicolon_followed (semicolon_followed)
   {}
 

--- a/gcc/rust/ast/rust-stmt.h
+++ b/gcc/rust/ast/rust-stmt.h
@@ -192,6 +192,11 @@ public:
   bool is_item () const override final { return false; }
 
   bool is_expr () const override final { return true; }
+
+  // Used for the last statement for statement macros with a trailing
+  // semicolon.
+  void add_semicolon () override final { semicolon_followed = true; }
+
   std::string as_string () const override;
 
   std::vector<LetStmt *> locals;

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -221,7 +221,8 @@ struct MacroExpander
   enum class ContextType
   {
     ITEM,
-    BLOCK,
+    STMT,
+    EXPR,
     EXTERN,
     TYPE,
     TRAIT,

--- a/gcc/rust/hir/rust-ast-lower-block.h
+++ b/gcc/rust/hir/rust-ast-lower-block.h
@@ -33,6 +33,7 @@ public:
   static HIR::BlockExpr *translate (AST::BlockExpr *expr, bool *terminated)
   {
     ASTLoweringBlock resolver;
+    expr->normalize_tail_expr ();
     expr->accept_vis (resolver);
     if (resolver.translated != nullptr)
       {

--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -340,6 +340,17 @@ private:
   null_denotation (const_TokenPtr t, AST::AttrVec outer_attrs = AST::AttrVec (),
 		   ParseRestrictions restrictions = ParseRestrictions ());
   std::unique_ptr<AST::Expr>
+  null_denotation_path (AST::PathInExpression path, AST::AttrVec outer_attrs,
+			ParseRestrictions restrictions = ParseRestrictions ());
+  std::unique_ptr<AST::Expr>
+  null_denotation_not_path (const_TokenPtr t, AST::AttrVec outer_attrs,
+			    ParseRestrictions restrictions
+			    = ParseRestrictions ());
+  std::unique_ptr<AST::Expr>
+  left_denotations (std::unique_ptr<AST::Expr> null_denotation,
+		    int right_binding_power, AST::AttrVec outer_attrs,
+		    ParseRestrictions restrictions = ParseRestrictions ());
+  std::unique_ptr<AST::Expr>
   left_denotation (const_TokenPtr t, std::unique_ptr<AST::Expr> left,
 		   AST::AttrVec outer_attrs = AST::AttrVec (),
 		   ParseRestrictions restrictions = ParseRestrictions ());
@@ -637,12 +648,10 @@ private:
   std::unique_ptr<AST::LetStmt> parse_let_stmt (AST::AttrVec outer_attrs,
 						ParseRestrictions restrictions
 						= ParseRestrictions ());
-  std::unique_ptr<AST::ExprStmt> parse_expr_stmt (AST::AttrVec outer_attrs,
-						  ParseRestrictions restrictions
-						  = ParseRestrictions ());
+  std::unique_ptr<AST::Stmt> parse_expr_stmt (AST::AttrVec outer_attrs,
+					      ParseRestrictions restrictions
+					      = ParseRestrictions ());
   ExprOrStmt parse_stmt_or_expr ();
-  ExprOrStmt parse_macro_invocation_maybe_semi (AST::AttrVec outer_attrs);
-  ExprOrStmt parse_path_based_stmt_or_expr (AST::AttrVec outer_attrs);
 
   // Pattern-related
   std::unique_ptr<AST::Pattern> parse_literal_or_range_pattern ();

--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -87,6 +87,9 @@ struct ParseRestrictions
   bool expr_can_be_null = false;
   bool expr_can_be_stmt = false;
   bool consume_semi = true;
+  /* Macro invocations that are statements can expand without a semicolon after
+   * the final statement, if it's an expression statement. */
+  bool allow_close_after_expr_stmt = false;
 };
 
 // Parser implementation for gccrs.

--- a/gcc/testsuite/rust/compile/braced_macro_arm.rs
+++ b/gcc/testsuite/rust/compile/braced_macro_arm.rs
@@ -1,0 +1,19 @@
+// Braced macro invocations are not allowed as match arms without a semicolon,
+// even though they are allowed as statements without a semicolon.
+
+macro_rules! m {
+    () => { 1 }
+}
+
+fn h(c: bool) {
+    match c {
+        // { dg-error "failed to parse statement or expression in block expression" "" { target *-*-* } .-1 }
+        true => m! {}
+        false => ()
+        // { dg-error "exprwithoutblock requires comma after match case expression in match arm \\(if not final case\\)" "" { target *-*-* } .-1 }
+        // { dg-error "unrecognised token .false. for start of item" "" { target *-*-* } .-2 }
+        // { dg-error "failed to parse item in crate" "" { target *-*-* } .-3 }
+    };
+}
+
+fn main () {}

--- a/gcc/testsuite/rust/compile/braced_macro_statements1.rs
+++ b/gcc/testsuite/rust/compile/braced_macro_statements1.rs
@@ -1,0 +1,15 @@
+macro_rules! m {
+    () => { bar() }
+}
+
+fn bar () {}
+
+fn foo() {
+    m!{}
+    m!{}
+}
+
+fn main() -> i32 {
+    foo();
+    0
+}

--- a/gcc/testsuite/rust/compile/braced_macro_statements2.rs
+++ b/gcc/testsuite/rust/compile/braced_macro_statements2.rs
@@ -1,0 +1,15 @@
+// Output of statement macros is always parsed as a statement, so no semicolon
+// is needed on the inner macro.
+
+macro_rules! m {
+    (macro) => { m!(stmts) };
+    (stmts) => { let x = 3; x - 3 }
+}
+
+fn foo() -> i32 {
+    m!{macro}
+}
+
+fn main() -> i32 {
+    foo()
+}

--- a/gcc/testsuite/rust/compile/braced_macro_statements3.rs
+++ b/gcc/testsuite/rust/compile/braced_macro_statements3.rs
@@ -1,0 +1,11 @@
+macro_rules! unroll {
+    {} => {}
+}
+
+pub fn foo() {
+    let mut _a = 14;
+    unroll! {}
+    let mut _b = 13;
+}
+
+fn main() -> i32 { 0 }

--- a/gcc/testsuite/rust/compile/issue-2225.rs
+++ b/gcc/testsuite/rust/compile/issue-2225.rs
@@ -4,7 +4,7 @@ macro_rules! foo {
 }
 
 macro_rules! bar {
-    () => {let $_a = 12;} // { dg-error "unrecognised token" }
+    () => {let $_a = 12;} // { dg-error "expecting .;. but .\\$. found" }
 }
 
 pub fn main() -> i32 {

--- a/gcc/testsuite/rust/compile/macro53.rs
+++ b/gcc/testsuite/rust/compile/macro53.rs
@@ -1,0 +1,10 @@
+macro_rules! numbers {
+    {} => { 1 2 }
+    // { dg-error "expecting .;. but .integer literal. found" "" { target *-*-* } .-1 }
+}
+
+pub fn foo() {
+    numbers!();
+}
+
+fn main() -> i32 { 0 }


### PR DESCRIPTION
Fixes various bugs in statement macro handling
- Parses braced macros as statements where appropriate
- Checks for semicolons (sometimes) when expanding statement macros
- Handles final statement vs. tail expression changing for macros
- Distinguishes between expression and statement macros in AST

This PR takes an approach similar to rustc (and gccrs before #2206) where statement macros are parsed as statements and the parser "recovers" into parsing an expression when required.  I didn't use the existing block expr vs. non-block expr handling because it doesn't handle match arms correctly (or interpolated expression macros once those are implemented).

Closes #2239 
