### PR TITLE
fixup: Remove obsolete error diagnostic

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -41,13 +41,7 @@ TypeCheckExpr::Resolve (HIR::Expr *expr)
   expr->accept_vis (resolver);
 
   if (resolver.infered == nullptr)
-    {
-      // FIXME
-      // this is an internal error message for debugging and should be removed
-      // at some point
-      rust_error_at (expr->get_locus (), "failed to type resolve expression");
-      return new TyTy::ErrorType (expr->get_mappings ().get_hirid ());
-    }
+    return new TyTy::ErrorType (expr->get_mappings ().get_hirid ());
 
   auto ref = expr->get_mappings ().get_hirid ();
   resolver.infered->set_ref (ref);

--- a/gcc/testsuite/rust/compile/break1.rs
+++ b/gcc/testsuite/rust/compile/break1.rs
@@ -2,5 +2,4 @@ fn main() {
     let a;
     a = 1;
     break a; // { dg-error "cannot 'break' outside of a loop" }
-    // { dg-error "failed to type resolve expression" "" { target *-*-* } .-1 }
 }

--- a/gcc/testsuite/rust/compile/break2.rs
+++ b/gcc/testsuite/rust/compile/break2.rs
@@ -6,7 +6,6 @@ fn main() {
     while b > 10 {
         if (b == 2) {
             break b;  // { dg-error "can only break with a value inside 'loop'" }
-            // { dg-error "failed to type resolve expression" "" { target *-*-* } .-1 }
         }
         c = a + b;
         a = b;

--- a/gcc/testsuite/rust/compile/cfg2.rs
+++ b/gcc/testsuite/rust/compile/cfg2.rs
@@ -9,5 +9,4 @@ fn main() {
     let a = Foo;
     a.test();
     // { dg-error "failed to resolve method for .test." "" { target *-*-* } .-1 }
-    // { dg-error "failed to type resolve expression" "" { target *-*-* } .-2 }
 }

--- a/gcc/testsuite/rust/compile/continue1.rs
+++ b/gcc/testsuite/rust/compile/continue1.rs
@@ -4,7 +4,6 @@ fn main() {
 
     let _fib = {
         continue; // { dg-error "cannot 'continue' outside of a loop" }
-        // { dg-error "failed to type resolve expression" "" { target *-*-* } .-1 }
         123
     };
 }

--- a/gcc/testsuite/rust/compile/generics4.rs
+++ b/gcc/testsuite/rust/compile/generics4.rs
@@ -3,14 +3,10 @@ struct GenericStruct<T>(T, usize);
 fn main() {
     let a2;
     a2 = GenericStruct::<i8, i32>(1, 456); // { dg-error "generic item takes at most 1 type arguments but 2 were supplied" }
-                                           // { dg-error {failed to type resolve expression} "" { target *-*-* } .-1 }
-                                           // { dg-error {Failed to resolve expression of function call} "" { target *-*-* } .-2 }
-                                           // { duplicate _dg-error {failed to type resolve expression} "" { target *-*-* } .-3 }
+                                           // { dg-error {Failed to resolve expression of function call} "" { target *-*-* } .-1 }
 
     let b2: i32 = a2.0;
     // { dg-error {Expected Tuple or ADT got: T\?} "" { target *-*-* } .-1 }
-    // { dg-error {failed to type resolve expression} "" { target *-*-* } .-2 }
     let c2: usize = a2.1;
     // { dg-error {Expected Tuple or ADT got: T\?} "" { target *-*-* } .-1 }
-    // { dg-error {failed to type resolve expression} "" { target *-*-* } .-2 }
 }

--- a/gcc/testsuite/rust/compile/generics6.rs
+++ b/gcc/testsuite/rust/compile/generics6.rs
@@ -24,8 +24,6 @@ impl Foo<f32> {
 
 fn main() {
     let a: i32 = Foo::test(); // { dg-error "multiple applicable items in scope for: test" }
-    // { dg-error {failed to type resolve expression} "" { target *-*-* } .-1 }
-    // { dg-error {Failed to resolve expression of function call} "" { target *-*-* } .-2 }
-    // { duplicate _dg-error {failed to type resolve expression} "" { target *-*-* } .-3 }
+    // { dg-error {Failed to resolve expression of function call} "" { target *-*-* } .-1 }
 }
 

--- a/gcc/testsuite/rust/compile/generics7.rs
+++ b/gcc/testsuite/rust/compile/generics7.rs
@@ -24,5 +24,4 @@ fn main() {
     let a = Foo { a: 123 };
     a.bar();
     // { dg-error "multiple candidates found for method .bar." "" { target *-*-* } .-1 }
-    // { dg-error "failed to type resolve expression" "" { target *-*-* } .-2 }
 }

--- a/gcc/testsuite/rust/compile/issue-2029.rs
+++ b/gcc/testsuite/rust/compile/issue-2029.rs
@@ -5,7 +5,6 @@ fn foo(_: usize) -> Foo {
 
 fn main() {
     match Foo(true) {
-        // { dg-error "failed to type resolve expression" "" { target *-*-* } .-1 }
         foo(x)
         // { dg-error "expected tuple struct/variant, found" "" { target *-*-* } .-1 }
         => ()

--- a/gcc/testsuite/rust/compile/issue-2139.rs
+++ b/gcc/testsuite/rust/compile/issue-2139.rs
@@ -12,5 +12,4 @@ fn main() {
     let a: u16 = 123;
     a.foo();
     // { dg-error "failed to resolve method for .foo." "" { target *-*-* } .-1 }
-    // { dg-error "failed to type resolve expression" "" { target *-*-* } .-2 }
 }

--- a/gcc/testsuite/rust/compile/issue-2190-1.rs
+++ b/gcc/testsuite/rust/compile/issue-2190-1.rs
@@ -7,5 +7,4 @@ trait Deref {
 fn foo<T: Deref<Target = i32>>(t: &T) -> i32 {
     t.max(2)
     // { dg-error "failed to resolve method for .max." "" { target *-*-* } .-1 }
-    // { dg-error "failed to type resolve expression" "" { target *-*-* } .-2 }
 }

--- a/gcc/testsuite/rust/compile/issue-925.rs
+++ b/gcc/testsuite/rust/compile/issue-925.rs
@@ -19,5 +19,4 @@ fn test() {
     let a = S;
     a.foo();
     // { dg-error "multiple candidates found for method .foo." "" { target *-*-* } .-1 }
-    // { dg-error "failed to type resolve expression" "" { target *-*-* } .-2 }
 }

--- a/gcc/testsuite/rust/compile/method1.rs
+++ b/gcc/testsuite/rust/compile/method1.rs
@@ -9,5 +9,4 @@ pub fn main() {
 
     a.test();
     // { dg-error "failed to resolve method for .test." "" { target *-*-* } .-1 }
-    // { dg-error {failed to type resolve expression} "" { target *-*-* } .-2 }
 }

--- a/gcc/testsuite/rust/compile/shadow1.rs
+++ b/gcc/testsuite/rust/compile/shadow1.rs
@@ -3,5 +3,4 @@ fn main() {
     let mut x;
     x = true;
     x = x + 2; // { dg-error "cannot apply this operator to types bool and <integer>"  }
-               // { dg-error {failed to type resolve expression} "" { target *-*-* } .-1 }
 }

--- a/gcc/testsuite/rust/compile/type-bindings1.rs
+++ b/gcc/testsuite/rust/compile/type-bindings1.rs
@@ -4,7 +4,5 @@ fn main() {
     let a;
     a = Foo::<A = i32, B = f32>(123f32);
     // { dg-error "associated type bindings are not allowed here" "" { target *-*-* } .-1 }
-    // { dg-error {failed to type resolve expression} "" { target *-*-* } .-2 }
-    // { dg-error {Failed to resolve expression of function call} "" { target *-*-* } .-3 }
-    // { duplicate _dg-error {failed to type resolve expression} "" { target *-*-* } .-4 }
+    // { dg-error {Failed to resolve expression of function call} "" { target *-*-* } .-2 }
 }

--- a/gcc/testsuite/rust/compile/unary_negation.rs
+++ b/gcc/testsuite/rust/compile/unary_negation.rs
@@ -5,5 +5,4 @@ fn main() {
     let d: i32 = !3;
 
     let e: f32 = -true; // // { dg-error "cannot apply unary - to bool" }
-    // { dg-error {failed to type resolve expression} "" { target *-*-* } .-1 }
 }

--- a/gcc/testsuite/rust/compile/unary_not.rs
+++ b/gcc/testsuite/rust/compile/unary_not.rs
@@ -5,5 +5,4 @@ fn main() {
     let d: i32 = !3;
 
     let e: f32 = !5f32; // { dg-error "cannot apply unary '!' to f32" }
-    // { dg-error {failed to type resolve expression} "" { target *-*-* } .-1 }
 }

--- a/gcc/testsuite/rust/compile/unconstrained_type_param.rs
+++ b/gcc/testsuite/rust/compile/unconstrained_type_param.rs
@@ -11,5 +11,4 @@ fn main() {
     let a = Foo::test();
     // { dg-error "expected" "" { target *-*-* } .-1 }
     // { dg-error "Failed to resolve expression of function call" "" { target *-*-* } .-2 }
-    // { dg-error "failed to type resolve expression" "" { target *-*-* } .-3 }
 }

--- a/gcc/testsuite/rust/compile/usize1.rs
+++ b/gcc/testsuite/rust/compile/usize1.rs
@@ -2,5 +2,4 @@ fn main() {
     let a = [1, 2, 3];
     let b: u32 = 1;
     let c = a[b]; // { dg-error "the type ...integer..CAPACITY.. cannot be indexed by .u32." }
-                  // { dg-error {failed to type resolve expression} "" { target *-*-* } .-1 }
 }


### PR DESCRIPTION
fixes https://github.com/Rust-GCC/gccrs/issues/2064

Remove every `{ dg-error "failed to type resolve expression" }` annotation that causes a failure when running the testsuite.

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-expr.cc: Remove obsolete error diagnostic

gcc/testsuite/ChangeLog:

	* rust/compile/break1.rs: remove dg-error "failed to type resolve expression"
	* rust/compile/break2.rs: Likewise
	* rust/compile/cfg2.rs: Likewise
	* rust/compile/continue1.rs: Likewise
	* rust/compile/generics4.rs: Likewise
	* rust/compile/generics6.rs: Likewise
	* rust/compile/generics7.rs: Likewise
	* rust/compile/issue-2029.rs: Likewise
	* rust/compile/issue-2139.rs: Likewise
	* rust/compile/issue-2190-1.rs: Likewise
	* rust/compile/issue-925.rs: Likewise
	* rust/compile/method1.rs: Likewise
	* rust/compile/shadow1.rs: Likewise
	* rust/compile/type-bindings1.rs: Likewise
	* rust/compile/unary_negation.rs: Likewise
	* rust/compile/unary_not.rs: Likewise
	* rust/compile/unconstrained_type_param.rs: Likewise
	* rust/compile/usize1.rs: Likewise

Signed-off-by: Taiwei Wu <tieway59@foxmail.com>