### PR TITLE
Ignore semicolon following a macro expansion in expression context

### DIFF
--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -911,6 +911,15 @@ transcribe_expression (Parser<MacroInvocLexer> &parser)
   if (expr == nullptr)
     return AST::Fragment::create_error ();
 
+  // FIXME: make this an error for some edititons
+  if (parser.peek_current_token ()->get_id () == SEMICOLON)
+    {
+      rust_warning_at (
+	parser.peek_current_token ()->get_locus (), 0,
+	"trailing semicolon in macro used in expression context");
+      parser.skip_token ();
+    }
+
   auto end = lexer.get_offs ();
 
   return AST::Fragment ({std::move (expr)}, lexer.get_token_slice (start, end));

--- a/gcc/testsuite/rust/compile/macro-issue2273.rs
+++ b/gcc/testsuite/rust/compile/macro-issue2273.rs
@@ -1,0 +1,7 @@
+macro_rules! mac {
+    () => {();} // { dg-warning "trailing semicolon" }
+}
+
+pub fn foo() {
+    mac!()
+}


### PR DESCRIPTION
Fixes #2273