### PR TITLE
derive: Factor common fields inside the base visitor

### DIFF
--- a/gcc/rust/expand/rust-derive-clone.cc
+++ b/gcc/rust/expand/rust-derive-clone.cc
@@ -88,7 +88,7 @@ DeriveClone::clone_impl (std::unique_ptr<TraitImplItem> &&clone_fn,
 // TODO: Create new `make_qualified_call` helper function
 
 DeriveClone::DeriveClone (Location loc)
-  : loc (loc), expanded (nullptr), builder (AstBuilder (loc))
+  : DeriveVisitor (loc), expanded (nullptr)
 {}
 
 std::unique_ptr<AST::Item>

--- a/gcc/rust/expand/rust-derive-clone.h
+++ b/gcc/rust/expand/rust-derive-clone.h
@@ -20,7 +20,6 @@
 #define RUST_DERIVE_CLONE_H
 
 #include "rust-derive.h"
-#include "rust-ast-builder.h"
 
 namespace Rust {
 namespace AST {
@@ -33,9 +32,7 @@ public:
   std::unique_ptr<AST::Item> go (Item &item);
 
 private:
-  Location loc;
-  std::unique_ptr<AST::Item> expanded;
-  AstBuilder builder;
+  std::unique_ptr<Item> expanded;
 
   /**
    * Create a call to "clone". For now, this creates a call to

--- a/gcc/rust/expand/rust-derive-copy.cc
+++ b/gcc/rust/expand/rust-derive-copy.cc
@@ -22,8 +22,7 @@
 namespace Rust {
 namespace AST {
 
-DeriveCopy::DeriveCopy (Location loc)
-  : loc (loc), builder (AstBuilder (loc)), expanded (nullptr)
+DeriveCopy::DeriveCopy (Location loc) : DeriveVisitor (loc), expanded (nullptr)
 {}
 
 std::unique_ptr<AST::Item>

--- a/gcc/rust/expand/rust-derive-copy.h
+++ b/gcc/rust/expand/rust-derive-copy.h
@@ -32,8 +32,6 @@ public:
   std::unique_ptr<Item> go (Item &);
 
 private:
-  Location loc;
-  AstBuilder builder;
   std::unique_ptr<Item> expanded;
 
   /**

--- a/gcc/rust/expand/rust-derive.cc
+++ b/gcc/rust/expand/rust-derive.cc
@@ -23,6 +23,10 @@
 namespace Rust {
 namespace AST {
 
+DeriveVisitor::DeriveVisitor (Location loc)
+  : loc (loc), builder (AstBuilder (loc))
+{}
+
 std::unique_ptr<Item>
 DeriveVisitor::derive (Item &item, const Attribute &attr,
 		       BuiltinMacro to_derive)

--- a/gcc/rust/expand/rust-derive.h
+++ b/gcc/rust/expand/rust-derive.h
@@ -21,6 +21,7 @@
 
 #include "rust-ast-full.h"
 #include "rust-ast-visitor.h"
+#include "rust-ast-builder.h"
 #include "rust-macro-builtins.h"
 
 namespace Rust {
@@ -35,6 +36,12 @@ class DeriveVisitor : public AST::ASTVisitor
 public:
   static std::unique_ptr<Item> derive (Item &item, const Attribute &derive,
 				       BuiltinMacro to_derive);
+
+protected:
+  DeriveVisitor (Location loc);
+
+  Location loc;
+  AstBuilder builder;
 
 private:
   // the 4 "allowed" visitors, which a derive-visitor can specify and override


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* expand/rust-derive.h: Store AstBuilder and location.
	* expand/rust-derive.cc (DeriveVisitor::DeriveVisitor): Update constructor.
	* expand/rust-derive-clone.h: Remove members now stored in `DeriveVisitor`.
	* expand/rust-derive-copy.h: Likewise.
	* expand/rust-derive-clone.cc (DeriveClone::DeriveClone): Update constructor.
	* expand/rust-derive-copy.cc (DeriveCopy::DeriveCopy): Likewise.
