### PR TITLE
gccrs: fortify resolve_method_address to match the types

### DIFF
--- a/gcc/testsuite/rust/compile/issue-2019-2.rs
+++ b/gcc/testsuite/rust/compile/issue-2019-2.rs
@@ -1,0 +1,30 @@
+#[lang = "add"]
+pub trait Add<RHS = Self> {
+    type Output;
+
+    fn add(self, rhs: RHS) -> Self::Output;
+}
+
+impl Add for u32 {
+    type Output = u32;
+
+    fn add(self, other: u32) -> u32 {
+        self + other
+    }
+}
+
+impl<'a> Add<u32> for &'a u32 {
+    type Output = <u32 as Add<u32>>::Output;
+
+    fn add(self, other: u32) -> <u32 as Add<u32>>::Output {
+        Add::add(*self, other)
+    }
+}
+
+impl<'a> Add<&'a u32> for u32 {
+    type Output = <u32 as Add<u32>>::Output;
+
+    fn add(self, other: &'a u32) -> <u32 as Add<u32>>::Output {
+        Add::add(self, *other)
+    }
+}

--- a/gcc/testsuite/rust/compile/issue-2019-3.rs
+++ b/gcc/testsuite/rust/compile/issue-2019-3.rs
@@ -1,0 +1,59 @@
+macro_rules! forward_ref_binop {
+    (impl $imp:ident, $method:ident for $t:ty, $u:ty) => {
+        forward_ref_binop!(impl $imp, $method for $t, $u,
+                #[stable(feature = "rust1", since = "1.0.0")]);
+    };
+    (impl $imp:ident, $method:ident for $t:ty, $u:ty, #[$attr:meta]) => {
+        #[$attr]
+        impl<'a> $imp<$u> for &'a $t {
+            type Output = <$t as $imp<$u>>::Output;
+
+            #[inline]
+            fn $method(self, other: $u) -> <$t as $imp<$u>>::Output {
+                $imp::$method(*self, other)
+            }
+        }
+
+        #[$attr]
+        impl<'a> $imp<&'a $u> for $t {
+            type Output = <$t as $imp<$u>>::Output;
+
+            #[inline]
+            fn $method(self, other: &'a $u) -> <$t as $imp<$u>>::Output {
+                $imp::$method(self, *other)
+            }
+        }
+
+        #[$attr]
+        impl<'a, 'b> $imp<&'a $u> for &'b $t {
+            type Output = <$t as $imp<$u>>::Output;
+
+            #[inline]
+            fn $method(self, other: &'a $u) -> <$t as $imp<$u>>::Output {
+                $imp::$method(*self, *other)
+            }
+        }
+    }
+}
+
+#[lang = "add"]
+pub trait Add<RHS = Self> {
+    type Output;
+
+    fn add(self, rhs: RHS) -> Self::Output;
+}
+
+macro_rules! add_impl {
+    ($($t:ty)*) => ($(
+        #[stable(feature = "rust1", since = "1.0.0")]
+        impl Add for $t {
+            type Output = $t;
+
+            fn add(self, other: $t) -> $t { self + other }
+        }
+
+        forward_ref_binop! { impl Add, add for $t, $t }
+    )*)
+}
+
+add_impl! { usize u8 u16 u32 u64 /*u128*/ isize i8 i16 i32 i64 /*i128*/ f32 f64 }


### PR DESCRIPTION
Fixes #2019

gcc/rust/ChangeLog:

	* backend/rust-compile-base.cc (HIRCompileBase::resolve_method_address): match the fntype to the candidate

gcc/testsuite/ChangeLog:

	* rust/compile/issue-2019-2.rs: New test.
	* rust/compile/issue-2019-3.rs: New test.
