### PR TITLE
ErrorCode[E0433]: Use of Undeclared Crate, Module, or Type

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-path.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-path.cc
@@ -62,9 +62,7 @@ ResolvePath::resolve_path (AST::PathInExpression *expr)
       bool in_middle_of_path = i > 0;
       if (in_middle_of_path && segment.is_lower_self_seg ())
 	{
-	  // error[E0433]: failed to resolve: `self` in paths can only be used
-	  // in start position
-	  rust_error_at (segment.get_locus (),
+	  rust_error_at (segment.get_locus (), ErrorCode ("E0433"),
 			 "failed to resolve: %<%s%> in paths can only be used "
 			 "in start position",
 			 segment.as_string ().c_str ());
@@ -208,7 +206,7 @@ ResolvePath::resolve_path (AST::PathInExpression *expr)
 	}
       else if (is_first_segment)
 	{
-	  rust_error_at (segment.get_locus (),
+	  rust_error_at (segment.get_locus (), ErrorCode ("E0433"),
 			 "Cannot find path %<%s%> in this scope",
 			 segment.as_string ().c_str ());
 	  return UNKNOWN_NODEID;

--- a/gcc/rust/resolve/rust-ast-resolve-type.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-type.cc
@@ -98,9 +98,7 @@ ResolveRelativeTypePath::go (AST::TypePath &path, NodeId &resolved_node_id)
       bool in_middle_of_path = i > 0;
       if (in_middle_of_path && segment->is_lower_self_seg ())
 	{
-	  // error[E0433]: failed to resolve: `self` in paths can only be used
-	  // in start position
-	  rust_error_at (segment->get_locus (),
+	  rust_error_at (segment->get_locus (), ErrorCode ("E0433"),
 			 "failed to resolve: %<%s%> in paths can only be used "
 			 "in start position",
 			 segment->as_string ().c_str ());


### PR DESCRIPTION
Added rustc E0433 error code. Failed to resolve: Use of Undeclared Crate, Module, or Type

https://github.com/MahadMuhammad/gccrs/assets/95980383/204f81a1-312c-42d0-93f6-af5b199f2f60

gcc/rust/ChangeLog:

	* gcc/rust/resolve/rust-ast-resolve-path.cc : Added ErrorCode("E0433") to 'rust_error_at' function.
	* gcc/rust/resolve/rust-ast-resolve-type.cc : Added ErrorCode("E0433") to 'rust_error_at' function.

Signed-off-by: Muhammad Mahad <mahadtxt@gmail.com>