### PR TITLE
TryFrom trait bound issue

### DIFF
--- a/gcc/rust/typecheck/rust-hir-trait-resolve.cc
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.cc
@@ -513,11 +513,9 @@ AssociatedImplTrait::setup_associated_types (
 	? SubstMapperInternal::Resolve (associated_self, infer_arguments)
 	: associated_self;
 
-  // FIXME this needs to do a lookup for the trait-reference DefId instead of
-  // assuming its the first one in the list
-  rust_assert (associated_self->num_specified_bounds () > 0);
-  TyTy::TypeBoundPredicate &impl_predicate
-    = associated_self->get_specified_bounds ().at (0);
+  const TyTy::TypeBoundPredicate &impl_predicate
+    = associated_self->lookup_predicate (bound.get_id ());
+  rust_assert (!impl_predicate.is_error ());
 
   // infer the arguments on the predicate
   std::vector<TyTy::BaseType *> impl_trait_predicate_args;

--- a/gcc/rust/typecheck/rust-hir-type-check-item.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.cc
@@ -73,6 +73,51 @@ TypeCheckItem::ResolveImplBlockSelf (HIR::ImplBlock &impl_block)
   return resolver.resolve_impl_block_self (impl_block);
 }
 
+TyTy::BaseType *
+TypeCheckItem::ResolveImplBlockSelfWithInference (HIR::ImplBlock &impl,
+						  Location locus)
+{
+  TypeCheckItem resolver;
+
+  bool failed_flag = false;
+  std::vector<TyTy::SubstitutionParamMapping> substitutions
+    = resolver.resolve_impl_block_substitutions (impl, failed_flag);
+  if (failed_flag)
+    {
+      return new TyTy::ErrorType (impl.get_mappings ().get_hirid ());
+    }
+
+  // now that we have the param mappings we need to query the self type
+  TyTy::BaseType *self = resolver.resolve_impl_block_self (impl);
+
+  // nothing to do
+  if (substitutions.empty () || self->is_concrete ())
+    return self;
+
+  // generate inference variables for the subst-param-mappings
+  std::vector<TyTy::SubstitutionArg> args;
+  for (auto &p : substitutions)
+    {
+      if (p.needs_substitution ())
+	{
+	  TyTy::TyVar infer_var = TyTy::TyVar::get_implicit_infer_var (locus);
+	  args.push_back (TyTy::SubstitutionArg (&p, infer_var.get_tyty ()));
+	}
+      else
+	{
+	  TyTy::ParamType *param = p.get_param_ty ();
+	  TyTy::BaseType *resolved = param->destructure ();
+	  args.push_back (TyTy::SubstitutionArg (&p, resolved));
+	}
+    }
+
+  // create argument mappings
+  TyTy::SubstitutionArgumentMappings infer_arguments (std::move (args), {},
+						      locus);
+
+  return SubstMapperInternal::Resolve (self, infer_arguments);
+}
+
 void
 TypeCheckItem::visit (HIR::TypeAlias &alias)
 {

--- a/gcc/rust/typecheck/rust-hir-type-check-item.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.h
@@ -35,6 +35,9 @@ public:
 
   static TyTy::BaseType *ResolveImplBlockSelf (HIR::ImplBlock &impl_block);
 
+  static TyTy::BaseType *
+  ResolveImplBlockSelfWithInference (HIR::ImplBlock &impl, Location locus);
+
   void visit (HIR::Module &module) override;
   void visit (HIR::Function &function) override;
   void visit (HIR::TypeAlias &alias) override;

--- a/gcc/rust/typecheck/rust-hir-type-check-item.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.h
@@ -35,8 +35,9 @@ public:
 
   static TyTy::BaseType *ResolveImplBlockSelf (HIR::ImplBlock &impl_block);
 
-  static TyTy::BaseType *
-  ResolveImplBlockSelfWithInference (HIR::ImplBlock &impl, Location locus);
+  static TyTy::BaseType *ResolveImplBlockSelfWithInference (
+    HIR::ImplBlock &impl, Location locus,
+    TyTy::SubstitutionArgumentMappings *infer_arguments);
 
   void visit (HIR::Module &module) override;
   void visit (HIR::Function &function) override;

--- a/gcc/rust/typecheck/rust-hir-type-check-path.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-path.cc
@@ -415,11 +415,8 @@ TypeCheckExpr::resolve_segments (NodeId root_resolved_node_id,
 	    = context->lookup_associated_trait_impl (impl_block_id,
 						     &associated);
 	  TyTy::BaseType *impl_block_ty
-	    = TypeCheckItem::ResolveImplBlockSelf (*associated_impl_block);
-
-	  if (impl_block_ty->needs_generic_substitutions ())
-	    impl_block_ty
-	      = SubstMapper::InferSubst (impl_block_ty, seg.get_locus ());
+	    = TypeCheckItem::ResolveImplBlockSelfWithInference (
+	      *associated_impl_block, seg.get_locus ());
 
 	  prev_segment = unify_site (seg.get_mappings ().get_hirid (),
 				     TyTy::TyWithLocation (prev_segment),

--- a/gcc/rust/typecheck/rust-hir-type-check-path.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-path.cc
@@ -431,23 +431,15 @@ TypeCheckExpr::resolve_segments (NodeId root_resolved_node_id,
 	      // we need to setup with apropriate bounds
 	      HIR::TypePath &bound_path
 		= *associated->get_impl_block ()->get_trait_ref ().get ();
+	      const auto &trait_ref = *TraitResolver::Resolve (bound_path);
+	      rust_assert (!trait_ref.is_error ());
 
-	      // generate an implicit HIR Type we can apply to the predicate
-	      HirId implicit_id = mappings->get_next_hir_id ();
-	      context->insert_implicit_type (implicit_id, impl_block_ty);
-
-	      Analysis::NodeMapping mappings (expr_mappings.get_crate_num (),
-					      expr_mappings.get_nodeid (),
-					      implicit_id,
-					      expr_mappings.get_local_defid ());
-	      HIR::TypePath *implicit_self_bound
-		= new HIR::TypePath (mappings, {},
-				     Linemap::predeclared_location (), false);
-
-	      TyTy::TypeBoundPredicate predicate
-		= get_predicate_from_bound (bound_path, implicit_self_bound);
-	      impl_block_ty
-		= associated->setup_associated_types (prev_segment, predicate);
+	      const auto &predicate
+		= impl_block_ty->lookup_predicate (trait_ref.get_defid ());
+	      if (!predicate.is_error ())
+		impl_block_ty
+		  = associated->setup_associated_types (prev_segment,
+							predicate);
 	    }
 	}
 

--- a/gcc/rust/typecheck/rust-hir-type-check-path.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-path.cc
@@ -414,9 +414,16 @@ TypeCheckExpr::resolve_segments (NodeId root_resolved_node_id,
 	  bool found_impl_trait
 	    = context->lookup_associated_trait_impl (impl_block_id,
 						     &associated);
+
+	  auto mappings = TyTy::SubstitutionArgumentMappings::error ();
 	  TyTy::BaseType *impl_block_ty
 	    = TypeCheckItem::ResolveImplBlockSelfWithInference (
-	      *associated_impl_block, seg.get_locus ());
+	      *associated_impl_block, seg.get_locus (), &mappings);
+
+	  // we need to apply the arguments to the segment type so they get
+	  // unified properly
+	  if (!mappings.is_error ())
+	    tyseg = SubstMapperInternal::Resolve (tyseg, mappings);
 
 	  prev_segment = unify_site (seg.get_mappings ().get_hirid (),
 				     TyTy::TyWithLocation (prev_segment),

--- a/gcc/rust/typecheck/rust-hir-type-check-path.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-path.cc
@@ -427,9 +427,7 @@ TypeCheckExpr::resolve_segments (NodeId root_resolved_node_id,
 				     seg.get_locus ());
 	  bool ok = prev_segment->get_kind () != TyTy::TypeKind::ERROR;
 	  if (!ok)
-	    {
-	      return;
-	    }
+	    return;
 
 	  if (found_impl_trait)
 	    {

--- a/gcc/rust/typecheck/rust-tyty-subst.cc
+++ b/gcc/rust/typecheck/rust-tyty-subst.cc
@@ -168,10 +168,14 @@ SubstitutionParamMapping::override_context ()
 SubstitutionArg::SubstitutionArg (const SubstitutionParamMapping *param,
 				  BaseType *argument)
   : param (param), argument (argument)
-{}
+{
+  if (param != nullptr)
+    original_param = param->get_param_ty ();
+}
 
 SubstitutionArg::SubstitutionArg (const SubstitutionArg &other)
-  : param (other.param), argument (other.argument)
+  : param (other.param), original_param (other.original_param),
+    argument (other.argument)
 {}
 
 SubstitutionArg &
@@ -179,6 +183,8 @@ SubstitutionArg::operator= (const SubstitutionArg &other)
 {
   param = other.param;
   argument = other.argument;
+  original_param = other.original_param;
+
   return *this;
 }
 
@@ -198,6 +204,12 @@ const SubstitutionParamMapping *
 SubstitutionArg::get_param_mapping () const
 {
   return param;
+}
+
+const ParamType *
+SubstitutionArg::get_param_ty () const
+{
+  return original_param;
 }
 
 SubstitutionArg
@@ -227,7 +239,7 @@ SubstitutionArg::is_conrete () const
 std::string
 SubstitutionArg::as_string () const
 {
-  return param->as_string ()
+  return original_param->as_string ()
 	 + (argument != nullptr ? ":" + argument->as_string () : "");
 }
 
@@ -289,9 +301,7 @@ SubstitutionArgumentMappings::get_argument_for_symbol (
 {
   for (auto &mapping : mappings)
     {
-      const SubstitutionParamMapping *param = mapping.get_param_mapping ();
-      const ParamType *p = param->get_param_ty ();
-
+      const ParamType *p = mapping.get_param_ty ();
       if (p->get_symbol ().compare (param_to_find->get_symbol ()) == 0)
 	{
 	  *argument = mapping;

--- a/gcc/rust/typecheck/rust-tyty-subst.h
+++ b/gcc/rust/typecheck/rust-tyty-subst.h
@@ -87,6 +87,8 @@ public:
 
   const SubstitutionParamMapping *get_param_mapping () const;
 
+  const ParamType *get_param_ty () const;
+
   static SubstitutionArg error ();
 
   bool is_error () const;
@@ -97,6 +99,7 @@ public:
 
 private:
   const SubstitutionParamMapping *param;
+  const ParamType *original_param;
   BaseType *argument;
 };
 

--- a/gcc/testsuite/rust/compile/issue-1893.rs
+++ b/gcc/testsuite/rust/compile/issue-1893.rs
@@ -1,4 +1,3 @@
-// { dg-additional-options "-frust-compile-until=nameresolution" }
 pub enum Option<T> {
     None,
     Some(T),
@@ -10,10 +9,8 @@ pub enum Result<T, E> {
 }
 
 pub trait TryFrom<T> {
-    /// The type returned in the event of a conversion error.
     type Error;
 
-    /// Performs the conversion.
     fn try_from(value: T) -> Result<Self, Self::Error>;
 }
 


### PR DESCRIPTION
This was a bug I have been trying to fix for at least 2 months. There were many small
things going wrong in the type-system so it took me to fix:

- https://github.com/Rust-GCC/gccrs/issues/2036
- https://github.com/Rust-GCC/gccrs/issues/2019
- https://github.com/Rust-GCC/gccrs/issues/2165
- https://github.com/Rust-GCC/gccrs/issues/2166

Those issues were all part of the fix for this. This patch set also contains a few fixes to get #1893 working. The main
issue was a nasty issue in how we do generics there is more information about it in the commit. As most generics use the
symbol T we basically didn't notice this most of the time they mostly worked but when you have a generic such as: <Self, T>
Then we try to substitute it with <T,U> we iterated in a loop of Self and T and replaced Self with T so it became <T,T> then
we needed to track the binding for the 2nd argument of T to become U but because we kept a pointer to the parameters for the
argument mappings meant it would have replaced with the first T argument again meaning the parameter U got lost completely. A
better explanation is in the commit messages.

Fixes #1893 