### PR TITLE
ErrorCode[E0277] Type Does Not Implement Expected Trait

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -867,7 +867,8 @@ TypeCheckExpr::visit (HIR::ArrayIndexExpr &expr)
   RichLocation r (expr.get_locus ());
   r.add_range (expr.get_array_expr ()->get_locus ());
   r.add_range (expr.get_index_expr ()->get_locus ());
-  rust_error_at (r, "the type %<%s%> cannot be indexed by %<%s%>",
+  rust_error_at (r, ErrorCode ("E0277"),
+		 "the type %<%s%> cannot be indexed by %<%s%>",
 		 array_expr_ty->get_name ().c_str (),
 		 index_expr_ty->get_name ().c_str ());
 }

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -396,7 +396,7 @@ BaseType::bounds_compatible (const BaseType &other, Location locus,
 
       if (emit_error)
 	{
-	  rust_error_at (r,
+	  rust_error_at (r, ErrorCode ("E0277"),
 			 "bounds not satisfied for %s %<%s%> is not satisfied",
 			 other.get_name ().c_str (), missing_preds.c_str ());
 	  // rust_assert (!emit_error);


### PR DESCRIPTION
### Type Does Not Implement Expected Trait - the type [{integer}] cannot be indexed by u32


- Tested code from rustc [E0277](https://doc.rust-lang.org/error_codes/E0277.html):
```rust
// here we declare the Foo trait with a bar method
trait Foo {
    fn bar(&self);
}

// we now declare a function which takes an object implementing the Foo trait
fn some_func<T: Foo>(foo: T) {
    foo.bar();
}

fn main() {
    // we now call the method with the i32 type, which doesn't implement
    // the Foo trait
    some_func(5i32); // error: the trait bound `i32 : Foo` is not satisfied
}
``` 
---
- Output:
```bash
mahad@linux:~/Desktop/mahad/mahad-testsuite$ ../gccrs-build/gcc/crab1 E0277.rs -frust-incomplete-and-experimental-compiler-do-not-use
E0277.rs:14:15: error: bounds not satisfied for i32 ‘Foo’ is not satisfied [E0277]
    7 | fn some_func<T: Foo>(foo: T) {
      |                 ~~~
......
   14 |     some_func(5i32); // error: the trait bound `i32 : Foo` is not satisfied
      |               ^~~~

Analyzing compilation unit

Time variable                                   usr           sys          wall           GGC
 TOTAL                              :   0.00          0.00          0.00          146k
Extra diagnostic checks enabled; compiler may run slowly.
Configure with --enable-checking=release to disable checks.
```
---

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::visit): passed "E0277"
	* typecheck/rust-tyty.cc (BaseType::bounds_compatible): passed "E0277"

Signed-off-by: Muhammad Mahad <[mahadtxt@gmail.com](mailto:mahadtxt@gmail.com)>