### PR TITLE
Fix lexing byte literal

### DIFF
--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -1727,6 +1727,12 @@ Lexer::parse_byte_char (Location loc)
       // otherwise, get character from direct input character
       byte_char = current_char;
 
+      if (byte_char.value > 0x7f)
+	{
+	  rust_error_at (get_current_location (),
+			 "non-ASCII character in %<byte char%>");
+	}
+
       skip_input ();
       current_char = peek_input ();
       length++;
@@ -1749,8 +1755,6 @@ Lexer::parse_byte_char (Location loc)
   current_column += length;
 
   loc += length - 1;
-
-  // TODO: error when byte_char is non ASCII
   return Token::make_byte_char (loc, byte_char.value);
 }
 

--- a/gcc/testsuite/rust/compile/bytecharstring.rs
+++ b/gcc/testsuite/rust/compile/bytecharstring.rs
@@ -5,4 +5,7 @@ fn main ()
 
   let _c = '\xef';        // { dg-error "out of range" }
   let _s = "Foo\xEFBar";  // { dg-error "out of range" }
+
+  let _ = b'あ';          // { dg-error " non-ASCII character" }
+  let _ = b'🦀';          // { dg-error " non-ASCII character" }
 }


### PR DESCRIPTION
closes #2308
```
gcc/rust/ChangeLog:

	* lex/rust-lex.cc (Lexer::parse_byte_char):add check for range of codepoint

gcc/testsuite/ChangeLog:

	* rust/compile/bytecharstring.rs:add test for it
```

NOTE: this pr depends on (includes commit from) PR https://github.com/Rust-GCC/gccrs/pull/2307
so please merge this after PR https://github.com/Rust-GCC/gccrs/pull/2307 is merged