### PR TITLE
gccrs: Add method selection to operator overloading

### DIFF
--- a/gcc/rust/typecheck/rust-autoderef.cc
+++ b/gcc/rust/typecheck/rust-autoderef.cc
@@ -170,18 +170,20 @@ resolve_operator_overload_fn (
 	}
     }
 
-  bool have_implementation_for_lang_item = resolved_candidates.size () > 0;
+  auto selected_candidates
+    = MethodResolver::Select (resolved_candidates, lhs, {});
+  bool have_implementation_for_lang_item = selected_candidates.size () > 0;
   if (!have_implementation_for_lang_item)
     return false;
 
-  if (resolved_candidates.size () > 1)
+  if (selected_candidates.size () > 1)
     {
       // no need to error out as we are just trying to see if there is a fit
       return false;
     }
 
   // Get the adjusted self
-  MethodCandidate candidate = *resolved_candidates.begin ();
+  MethodCandidate candidate = *selected_candidates.begin ();
   Adjuster adj (lhs);
   TyTy::BaseType *adjusted_self = adj.adjust_type (candidate.adjustments);
 

--- a/gcc/rust/typecheck/rust-hir-dot-operator.h
+++ b/gcc/rust/typecheck/rust-hir-dot-operator.h
@@ -57,6 +57,10 @@ public:
   Probe (TyTy::BaseType *receiver, const HIR::PathIdentSegment &segment_name,
 	 bool autoderef_flag = false);
 
+  static std::set<MethodCandidate>
+  Select (std::set<MethodCandidate> &candidates, TyTy::BaseType *receiver,
+	  std::vector<TyTy::BaseType *> arguments);
+
   static std::vector<predicate_candidate> get_predicate_items (
     const HIR::PathIdentSegment &segment_name, const TyTy::BaseType &receiver,
     const std::vector<TyTy::TypeBoundPredicate> &specified_bounds);

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -1618,11 +1618,17 @@ TypeCheckExpr::resolve_operator_overload (
 	}
     }
 
-  bool have_implementation_for_lang_item = resolved_candidates.size () > 0;
+  std::vector<TyTy::BaseType *> select_args = {};
+  if (rhs != nullptr)
+    select_args = {rhs};
+  auto selected_candidates
+    = MethodResolver::Select (resolved_candidates, lhs, select_args);
+
+  bool have_implementation_for_lang_item = selected_candidates.size () > 0;
   if (!have_implementation_for_lang_item)
     return false;
 
-  if (resolved_candidates.size () > 1)
+  if (selected_candidates.size () > 1)
     {
       // mutliple candidates
       RichLocation r (expr.get_locus ());
@@ -1636,7 +1642,7 @@ TypeCheckExpr::resolve_operator_overload (
     }
 
   // Get the adjusted self
-  MethodCandidate candidate = *resolved_candidates.begin ();
+  MethodCandidate candidate = *selected_candidates.begin ();
   Adjuster adj (lhs);
   TyTy::BaseType *adjusted_self = adj.adjust_type (candidate.adjustments);
 

--- a/gcc/rust/typecheck/rust-type-util.cc
+++ b/gcc/rust/typecheck/rust-type-util.cc
@@ -232,6 +232,24 @@ coercion_site (HirId id, TyTy::TyWithLocation lhs, TyTy::TyWithLocation rhs,
 }
 
 TyTy::BaseType *
+try_coercion (HirId id, TyTy::TyWithLocation lhs, TyTy::TyWithLocation rhs,
+	      Location locus)
+{
+  TyTy::BaseType *expected = lhs.get_ty ();
+  TyTy::BaseType *expr = rhs.get_ty ();
+
+  rust_debug ("try_coercion_site id={%u} expected={%s} expr={%s}", id,
+	      expected->debug_str ().c_str (), expr->debug_str ().c_str ());
+
+  auto result = TypeCoercionRules::TryCoerce (expr, expected, locus,
+					      true /*allow-autodref*/);
+  if (result.is_error ())
+    return new TyTy::ErrorType (id);
+
+  return result.tyty;
+}
+
+TyTy::BaseType *
 cast_site (HirId id, TyTy::TyWithLocation from, TyTy::TyWithLocation to,
 	   Location cast_locus)
 {

--- a/gcc/rust/typecheck/rust-type-util.h
+++ b/gcc/rust/typecheck/rust-type-util.h
@@ -46,6 +46,10 @@ coercion_site (HirId id, TyTy::TyWithLocation lhs, TyTy::TyWithLocation rhs,
 	       Location coercion_locus);
 
 TyTy::BaseType *
+try_coercion (HirId id, TyTy::TyWithLocation lhs, TyTy::TyWithLocation rhs,
+	      Location coercion_locus);
+
+TyTy::BaseType *
 cast_site (HirId id, TyTy::TyWithLocation from, TyTy::TyWithLocation to,
 	   Location cast_locus);
 

--- a/gcc/testsuite/rust/compile/issue-2304.rs
+++ b/gcc/testsuite/rust/compile/issue-2304.rs
@@ -1,0 +1,23 @@
+#[lang = "add"]
+pub trait Add<RHS = Self> {
+    type Output;
+
+    fn add(self, rhs: RHS) -> Self::Output;
+}
+macro_rules! add_impl {
+    ($($t:ty)*) => ($(
+        impl Add for $t {
+            type Output = $t;
+
+            fn add(self, other: $t) -> $t { self + other }
+        }
+    )*)
+}
+
+add_impl! { usize u8 u16 u32 u64  /*isize i8 i16 i32 i64*/  f32 f64 }
+
+pub fn test() {
+    let x: usize = 123;
+    let mut i = 0;
+    let _bug = i + x;
+}


### PR DESCRIPTION
When we do operator overloading we can get multiple candidates and we need to use the optional arguments to filter the candidates event further. In the bug we had:

  ```<integer> + <usize>```

Without the Add impl blocks for the primitive interger types we unify against the rhs to figure out that the lhs should be a usize but when we are using the impl blocks we need to use the rhs to ensure that its possible to coerce the rhs to the expected fntype parameter to filter the candidates.

Fixes #2304

gcc/rust/ChangeLog:

	* typecheck/rust-autoderef.cc: use new selection filter
	* typecheck/rust-hir-dot-operator.cc (MethodResolver::Select): new slection Filter
	* typecheck/rust-hir-dot-operator.h: New select prototype
	* typecheck/rust-hir-type-check-expr.cc: call select
	* typecheck/rust-type-util.cc (try_coercion): new helper
	* typecheck/rust-type-util.h (try_coercion): helper prototype

gcc/testsuite/ChangeLog:

	* rust/compile/issue-2304.rs: New test.