### PR TITLE
gccrs: Stop autoderef of raw pointer types

### DIFF
--- a/gcc/rust/typecheck/rust-autoderef.cc
+++ b/gcc/rust/typecheck/rust-autoderef.cc
@@ -334,7 +334,6 @@ AutoderefCycle::cycle (TyTy::BaseType *receiver)
 	return false;
 
       // try unsize
-
       Adjustment unsize = Adjuster::try_unsize_type (r);
       if (!unsize.is_error ())
 	{
@@ -347,6 +346,13 @@ AutoderefCycle::cycle (TyTy::BaseType *receiver)
 	    return true;
 
 	  adjustments.pop_back ();
+	}
+
+      bool is_ptr = receiver->get_kind () == TyTy::TypeKind::POINTER;
+      if (is_ptr)
+	{
+	  // deref of raw pointers is unsafe
+	  return false;
 	}
 
       Adjustment deref


### PR DESCRIPTION
It is unsafe to deref raw pointers during autoderef this adds a check to stop autoderef early when we are about to try and deref pointers.

Fixes #2015

gcc/rust/ChangeLog:

	* typecheck/rust-autoderef.cc (AutoderefCycle::cycle): add check for pointers
