### PR TITLE
[E0023] Incorrect Number of Fields in Pattern Extraction

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
@@ -112,7 +112,7 @@ TypeCheckPattern::visit (HIR::TupleStructPattern &pattern)
 	if (items_no_range.get_patterns ().size () != variant->num_fields ())
 	  {
 	    rust_error_at (
-	      pattern.get_locus (),
+	      pattern.get_locus (), ErrorCode ("E0023"),
 	      "this pattern has %lu fields but the corresponding "
 	      "tuple variant has %lu field",
 	      (unsigned long) items_no_range.get_patterns ().size (),


### PR DESCRIPTION
### ErrorCode[E0023]: Incorrect Number of Fields in Pattern Extraction
- The pattern has `x` fields, but the corresponding tuple variant has `y` field.

### Code Tested:
```rust
// https://doc.rust-lang.org/error_codes/E0023.html
fn main() {
    enum Fruit {
        Apple(u32, u32),
        Pear(u32),
    }

    let x = Fruit::Apple(1, 2);

    match x {
        Fruit::Apple(a) => {} // error! : this pattern has 1 fields but the corresponding tuple variant has 2 field
        _ => {}
    }
}
```
### Output:
```bash
mahad@linux:~/Desktop/mahad/gccrs-build$ gcc/crab1 ../mahad-testsuite/E0023.rs -frust-incomplete-and-experimental-compiler-do-not-use
../mahad-testsuite/E0023.rs:11:5: error: this pattern has 1 fields but the corresponding tuple variant has 2 field [E0023]
   11 |     Fruit::Apple(a) => {}, // error!
      |     ^~~~~

Analyzing compilation unit

Time variable                                   usr           sys          wall           GGC
 TOTAL                              :   0.00          0.00          0.00          146k
Extra diagnostic checks enabled; compiler may run slowly.
Configure with --enable-checking=release to disable checks.
```

### Running testcases:
- [`gcc/testsuite/rust/compile/match1.rs`](https://github.com/MahadMuhammad/gccrs/blob/E0023/gcc/testsuite/rust/compile/match1.rs)
```bash
/mahad/gccrs/gcc/testsuite/rust/compile/match1.rs:12:9: error: this pattern has 2 fields but the corresponding tuple variant has 1 field [E0023]
compiler exited with status 1
```

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-pattern.cc (TypeCheckPattern::visit): called rust_error_at

Signed-off-by: Muhammad Mahad <[mahadtxt@gmail.com](mailto:mahadtxt@gmail.com)>