### PR TITLE
[E0026] Non-Existent Field Extraction in Struct Pattern

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
@@ -204,7 +204,7 @@ TypeCheckPattern::visit (HIR::StructPattern &pattern)
 	    if (!variant->lookup_field (ident.get_identifier (), &field,
 					nullptr))
 	      {
-		rust_error_at (ident.get_locus (),
+		rust_error_at (ident.get_locus (), ErrorCode ("E0026"),
 			       "variant %s does not have a field named %s",
 			       variant->get_identifier ().c_str (),
 			       ident.get_identifier ().c_str ());
@@ -225,7 +225,7 @@ TypeCheckPattern::visit (HIR::StructPattern &pattern)
 	    if (!variant->lookup_field (ident.get_identifier (), &field,
 					nullptr))
 	      {
-		rust_error_at (ident.get_locus (),
+		rust_error_at (ident.get_locus (), ErrorCode ("E0026"),
 			       "variant %s does not have a field named %s",
 			       variant->get_identifier ().c_str (),
 			       ident.get_identifier ().c_str ());


### PR DESCRIPTION
Non-Existent Field Extraction in Struct Pattern
variant `Foo::D` does not have a field named `b`

### Code Tested from [E0026](https://doc.rust-lang.org/error_codes/E0026.html)
```rust
// https://doc.rust-lang.org/error_codes/E0026.html
fn main() {
    struct Thing {
        x: u32,
        y: u32,
    }

    let thing = Thing { x: 0, y: 0 };

    match thing {
        Thing { x, z } => {} // error: `Thing::z` field doesn't exist
    }
}
```
### Output:
```bash
mahad@linux:~/Desktop/mahad/gccrs-build$ gcc/crab1 ../mahad-testsuite/E0026.rs -frust-incomplete-and-experimental-compiler-do-not-use
../mahad-testsuite/E0026.rs:11:20: error: variant Thing does not have a field named z [E0026]
   11 |         Thing { x, z } => {} // error: `Thing::z` field doesn't exist
      |                    ^
../mahad-testsuite/E0026.rs:11:9: error: pattern does not mention fields y
   11 |         Thing { x, z } => {} // error: `Thing::z` field doesn't exist
      |         ^~~~~

Analyzing compilation unit

Time variable                                   usr           sys          wall           GGC
 TOTAL                              :   0.00          0.00          0.00          146k
Extra diagnostic checks enabled; compiler may run slowly.
Configure with --enable-checking=release to disable checks.
```
### Running testcases:
- [`gcc/testsuite/rust/compile/match3.rs`](https://github.com/MahadMuhammad/gccrs/blob/E0026/gcc/testsuite/rust/compile/match3.rs)
```bash
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/match3.rs:13:18: error: variant D does not have a field named z [E0026]
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/match3.rs:13:9: error: pattern does not mention fields x, y
compiler exited with status 1
```

**gcc/rust/ChangeLog:**

	* typecheck/rust-hir-type-check-pattern.cc (TypeCheckPattern::visit): called rust_error_at

