### PR TITLE
[E0027] struct pattern fails to specify struct's fields

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
@@ -263,7 +263,8 @@ TypeCheckPattern::visit (HIR::StructPattern &pattern)
 	  i++;
 	}
 
-      rust_error_at (pattern.get_locus (), "pattern does not mention fields %s",
+      rust_error_at (pattern.get_locus (), ErrorCode ("E0027"),
+		     "pattern does not mention fields %s",
 		     missing_fields_str.c_str ());
     }
 }


### PR DESCRIPTION
### struct pattern fails to specify struct's fields
A pattern for a struct fails to specify a sub-pattern for every one of the struct's fields. - pattern does not mention fields `x`, `y`


#### Code tested:
```rust
// https://doc.rust-lang.org/error_codes/E0027.html
#![allow(unused)]
fn main() {
    struct Dog {
        name: u32,
        age: u32,
    }

    let d = Dog { name: 1, age: 8 };

    // This is incorrect.
    match d {
        Dog { age: x } => {}
    }
}
```
#### Output:
```rust
mahad@linux:~/Desktop/mahad/gccrs-build$ gcc/crab1 ../mahad-testsuite/E0027.rs -frust-incomplete-and-experimental-compiler-do-not-use
../mahad-testsuite/E0027.rs:13:9: error: pattern does not mention fields name [E0027]
   13 |         Dog { age: x } => {}
      |         ^~~

Analyzing compilation unit

Time variable                                   usr           sys          wall           GGC
 TOTAL                              :   0.00          0.00          0.00          146k
Extra diagnostic checks enabled; compiler may run slowly.
Configure with --enable-checking=release to disable checks.
```
#### Running testcases:
- [`gcc/testsuite/rust/compile/match2.rs`](https://github.com/MahadMuhammad/gccrs/blob/E0027/gcc/testsuite/rust/compile/match2.rs)
- [`gcc/testsuite/rust/compile/match3.rs`](https://github.com/MahadMuhammad/gccrs/blob/E0027/gcc/testsuite/rust/compile/match3.rs)
```rust
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/match2.rs:13:9: error: pattern does not mention fields x [E0027]
compiler exited with status 1

/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/match3.rs:13:18: error: variant D does not have a field named z [E0026]
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/match3.rs:13:9: error: pattern does not mention fields x, y [E0027]
compiler exited with status 1
```


#### gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-pattern.cc (TypeCheckPattern::visit): called rust_error_at

---
