### PR TITLE
Missing tests for utf-8 identifiers

### DIFF
--- a/gcc/testsuite/rust/compile/torture/raw_identifiers.rs
+++ b/gcc/testsuite/rust/compile/torture/raw_identifiers.rs
@@ -1,3 +1,11 @@
 pub fn square(num: i32) -> i32 {
     r#num * num
 }
+
+pub fn kimchi() -> i32 {
+    // UTF-8 raw indentifiers
+    let r#김치 = 1;
+    let r#泡菜 = 1;
+    let r#кимчи = 1;
+    r#김치 + r#泡菜 + r#кимчи
+}

--- a/gcc/testsuite/rust/compile/torture/utf8_identifiers.rs
+++ b/gcc/testsuite/rust/compile/torture/utf8_identifiers.rs
@@ -1,0 +1,18 @@
+pub fn f() {
+    let crab = ();
+
+    let Κάβουρας = 0.001;
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+    let 게 = "";
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+    let سلطعون = 0.;
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+
+    let _: &'かに () = &crab;
+}
+
+pub fn g<'β, γ>() {}
+
+struct _S {
+    δ: i32
+}


### PR DESCRIPTION
Addresses https://github.com/Rust-GCC/gccrs/issues/2287

This pr is going to be rebased after https://github.com/Rust-GCC/gccrs/pull/2307 is merged

```
gcc/testsuite/ChangeLog:

	* rust/compile/torture/raw_identifiers.rs: New test.
	* rust/compile/torture/utf8_identifiers.rs: New test.

Signed-off-by: Raiki Tamura <tamaron1203@gmail.com>
```