### PR TITLE
nr2.0: Add complex testcases

### DIFF
--- a/gcc/testsuite/rust/compile/name_resolution1.rs
+++ b/gcc/testsuite/rust/compile/name_resolution1.rs
@@ -1,0 +1,9 @@
+fn outer() {
+    inner();
+
+    fn inner() {}
+}
+
+fn main() {
+    outer();
+}

--- a/gcc/testsuite/rust/compile/name_resolution2.rs
+++ b/gcc/testsuite/rust/compile/name_resolution2.rs
@@ -1,0 +1,13 @@
+struct Bar;
+
+trait Foo {
+    fn bar(&self) {} // { dg-warning "unused name" }
+}
+
+pub fn outer() {
+    impl Foo for Bar {}
+}
+
+fn main() {
+    Bar.bar();
+}

--- a/gcc/testsuite/rust/compile/name_resolution3.rs
+++ b/gcc/testsuite/rust/compile/name_resolution3.rs
@@ -1,0 +1,9 @@
+pub const BAR: u32 = { // { dg-warning "unused name" }
+    let ret = outer();
+
+    const fn outer() -> u32 {
+        0
+    }
+
+    ret
+};

--- a/gcc/testsuite/rust/compile/name_resolution4.rs
+++ b/gcc/testsuite/rust/compile/name_resolution4.rs
@@ -1,0 +1,13 @@
+trait Foo {
+    fn foo(&self) {} // { dg-warning "unused name" }
+}
+
+struct Bar;
+
+pub fn bar() {
+    impl Foo for Bar {}
+}
+
+fn main() {
+    Bar.foo();
+}

--- a/gcc/testsuite/rust/compile/name_resolution5.rs
+++ b/gcc/testsuite/rust/compile/name_resolution5.rs
@@ -1,0 +1,15 @@
+fn bar() {
+    foo();
+
+    fn foo() {
+        fn bar2() {
+            foo();
+        }
+
+        bar2();
+    }
+}
+
+fn main() {
+    bar();
+}


### PR DESCRIPTION
gcc/testsuite/ChangeLog:

	* rust/compile/name_resolution1.rs: New test.
	* rust/compile/name_resolution2.rs: New test.
	* rust/compile/name_resolution3.rs: New test.
	* rust/compile/name_resolution4.rs: New test.
	* rust/compile/name_resolution5.rs: New test.

Co-authored-by: @GuillaumeGomez

This PR adds some interesting test cases that our name resolution already handles properly, but that the reimplementation must handle too