### PR TITLE
Fix bad generic inference on unsafe pointer casts

### DIFF
--- a/gcc/rust/typecheck/rust-casts.cc
+++ b/gcc/rust/typecheck/rust-casts.cc
@@ -40,13 +40,15 @@ TypeCastRules::check ()
   // https://github.com/rust-lang/rust/blob/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/compiler/rustc_typeck/src/check/cast.rs#L565-L582
   auto possible_coercion
     = TypeCoercionRules::TryCoerce (from.get_ty (), to.get_ty (), locus,
-				    true /*allow-autoderef*/);
+				    true /*allow-autoderef*/,
+				    true /*is_cast_site*/);
   if (!possible_coercion.is_error ())
     {
       // given the attempt was ok we need to ensure we perform it so that any
       // inference variables are unified correctly
       return TypeCoercionRules::Coerce (from.get_ty (), to.get_ty (), locus,
-					true /*allow-autoderef*/);
+					true /*allow-autoderef*/,
+					true /*is_cast_site*/);
     }
 
   // try the simple cast rules

--- a/gcc/rust/typecheck/rust-coercion.h
+++ b/gcc/rust/typecheck/rust-coercion.h
@@ -43,11 +43,13 @@ public:
 
   static CoercionResult Coerce (TyTy::BaseType *receiver,
 				TyTy::BaseType *expected, Location locus,
-				bool allow_autoderef);
+				bool allow_autoderef,
+				bool is_cast_site = false);
 
   static CoercionResult TryCoerce (TyTy::BaseType *receiver,
 				   TyTy::BaseType *expected, Location locus,
-				   bool allow_autoderef);
+				   bool allow_autoderef,
+				   bool is_cast_site = false);
 
   CoercionResult coerce_unsafe_ptr (TyTy::BaseType *receiver,
 				    TyTy::PointerType *expected,
@@ -69,7 +71,7 @@ public:
 
 protected:
   TypeCoercionRules (TyTy::BaseType *expected, Location locus, bool emit_errors,
-		     bool allow_autoderef, bool try_flag);
+		     bool allow_autoderef, bool try_flag, bool is_cast_site);
 
   bool select (TyTy::BaseType &autoderefed) override;
 
@@ -88,6 +90,7 @@ private:
   CoercionResult try_result;
   bool emit_errors;
   bool try_flag;
+  bool is_cast_site;
 };
 
 } // namespace Resolver

--- a/gcc/rust/typecheck/rust-hir-trait-reference.h
+++ b/gcc/rust/typecheck/rust-hir-trait-reference.h
@@ -253,7 +253,8 @@ public:
 
   TyTy::BaseType *
   setup_associated_types (const TyTy::BaseType *self,
-			  const TyTy::TypeBoundPredicate &bound);
+			  const TyTy::TypeBoundPredicate &bound,
+			  TyTy::SubstitutionArgumentMappings *args = nullptr);
 
   void reset_associated_types ();
 

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -214,6 +214,8 @@ TypeCheckType::visit (HIR::QualifiedPathInType &path)
     }
 
   // we try to look for the real impl item if possible
+  TyTy::SubstitutionArgumentMappings args
+    = TyTy::SubstitutionArgumentMappings::error ();
   HIR::ImplItem *impl_item = nullptr;
   if (root->is_concrete ())
     {
@@ -223,7 +225,8 @@ TypeCheckType::visit (HIR::QualifiedPathInType &path)
 	= lookup_associated_impl_block (specified_bound, root);
       if (associated_impl_trait != nullptr)
 	{
-	  associated_impl_trait->setup_associated_types (root, specified_bound);
+	  associated_impl_trait->setup_associated_types (root, specified_bound,
+							 &args);
 
 	  for (auto &i :
 	       associated_impl_trait->get_impl_block ()->get_impl_items ())
@@ -260,6 +263,12 @@ TypeCheckType::visit (HIR::QualifiedPathInType &path)
 	  // FIXME
 	  // I think query_type should error if required here anyway
 	  return;
+	}
+
+      if (!args.is_error ())
+	{
+	  // apply the args
+	  translated = SubstMapperInternal::Resolve (translated, args);
 	}
 
       root_resolved_node_id = impl_item->get_impl_mappings ().get_nodeid ();


### PR DESCRIPTION
I copied swap_nonoverlapping badly from libcore which uses an unsafe
pointer case of x as *mut u8, I thought this was x as *mut T when i was
copying code form libcore this caused new infererence variables to be
introduced which actually automatically turned this swap_nonoverlapping
function to turn into a swap_nonoverlapping<u8> and lost the general
generic one in the type system context.

Rust allows for you to cast any pointer to another pointer of different
base type. The rules here are really subtle though because we need to
handle the case where we do really need to unify the types here there
are a few cases to consider but the main three are:

  *u32 vs *u32 -> valid pointers match = simple coercion

  *<?> vs *u8 -> inference variable unified with u8 which is valid

  *T vs *u8 -> invalid coercion as the element types don't match
            -> But this is a valid cast site

The code for casts try a coercion first then if that was sucsessful goes
on to perform a real coercion. Otherwise it follows the cast rules. The
bug here was that we saw the case of *T vs *u8 the try coercion used
inference variables to match T vs u8 but this will cause a cascase of
bad inference variables which we don't want when we perform the simple
coercion.

Fixes #2330