### PR TITLE
Refactoring in prevision of the HIR dump changes

### DIFF
--- a/gcc/rust/backend/rust-compile-block.cc
+++ b/gcc/rust/backend/rust-compile-block.cc
@@ -108,8 +108,10 @@ CompileConditionalBlocks::visit (HIR::IfExpr &expr)
 {
   fncontext fnctx = ctx->peek_fn ();
   tree fndecl = fnctx.fndecl;
-  tree condition_expr = CompileExpr::Compile (expr.get_if_condition (), ctx);
-  tree then_block = CompileBlock::compile (expr.get_if_block (), ctx, result);
+  tree condition_expr
+    = CompileExpr::Compile (expr.get_if_condition ().get (), ctx);
+  tree then_block
+    = CompileBlock::compile (expr.get_if_block ().get (), ctx, result);
 
   translated
     = ctx->get_backend ()->if_statement (fndecl, condition_expr, then_block,
@@ -121,8 +123,10 @@ CompileConditionalBlocks::visit (HIR::IfExprConseqElse &expr)
 {
   fncontext fnctx = ctx->peek_fn ();
   tree fndecl = fnctx.fndecl;
-  tree condition_expr = CompileExpr::Compile (expr.get_if_condition (), ctx);
-  tree then_block = CompileBlock::compile (expr.get_if_block (), ctx, result);
+  tree condition_expr
+    = CompileExpr::Compile (expr.get_if_condition ().get (), ctx);
+  tree then_block
+    = CompileBlock::compile (expr.get_if_block ().get (), ctx, result);
 
   // else block
   std::vector<Bvariable *> locals;
@@ -134,7 +138,8 @@ CompileConditionalBlocks::visit (HIR::IfExprConseqElse &expr)
   ctx->push_block (else_block);
 
   tree else_stmt_decl
-    = CompileExprWithBlock::compile (expr.get_else_block (), ctx, result);
+    = CompileExprWithBlock::compile (expr.get_else_block ().get (), ctx,
+				     result);
 
   ctx->add_statement (else_stmt_decl);
 

--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -143,8 +143,8 @@ void
 CompileExpr::visit (HIR::ArithmeticOrLogicalExpr &expr)
 {
   auto op = expr.get_expr_type ();
-  auto lhs = CompileExpr::Compile (expr.get_lhs (), ctx);
-  auto rhs = CompileExpr::Compile (expr.get_rhs (), ctx);
+  auto lhs = CompileExpr::Compile (expr.get_lhs ().get (), ctx);
+  auto rhs = CompileExpr::Compile (expr.get_rhs ().get (), ctx);
 
   // this might be an operator overload situation lets check
   TyTy::FnType *fntype;
@@ -155,7 +155,8 @@ CompileExpr::visit (HIR::ArithmeticOrLogicalExpr &expr)
       auto lang_item_type
 	= Analysis::RustLangItem::OperatorToLangItem (expr.get_expr_type ());
       translated = resolve_operator_overload (lang_item_type, expr, lhs, rhs,
-					      expr.get_lhs (), expr.get_rhs ());
+					      expr.get_lhs ().get (),
+					      expr.get_rhs ().get ());
       return;
     }
 
@@ -258,8 +259,8 @@ void
 CompileExpr::visit (HIR::ComparisonExpr &expr)
 {
   auto op = expr.get_expr_type ();
-  auto lhs = CompileExpr::Compile (expr.get_lhs (), ctx);
-  auto rhs = CompileExpr::Compile (expr.get_rhs (), ctx);
+  auto lhs = CompileExpr::Compile (expr.get_lhs ().get (), ctx);
+  auto rhs = CompileExpr::Compile (expr.get_rhs ().get (), ctx);
   auto location = expr.get_locus ();
 
   translated
@@ -270,8 +271,8 @@ void
 CompileExpr::visit (HIR::LazyBooleanExpr &expr)
 {
   auto op = expr.get_expr_type ();
-  auto lhs = CompileExpr::Compile (expr.get_lhs (), ctx);
-  auto rhs = CompileExpr::Compile (expr.get_rhs (), ctx);
+  auto lhs = CompileExpr::Compile (expr.get_lhs ().get (), ctx);
+  auto rhs = CompileExpr::Compile (expr.get_rhs ().get (), ctx);
   auto location = expr.get_locus ();
 
   translated
@@ -908,8 +909,8 @@ CompileExpr::visit (HIR::LiteralExpr &expr)
 void
 CompileExpr::visit (HIR::AssignmentExpr &expr)
 {
-  auto lvalue = CompileExpr::Compile (expr.get_lhs (), ctx);
-  auto rvalue = CompileExpr::Compile (expr.get_rhs (), ctx);
+  auto lvalue = CompileExpr::Compile (expr.get_lhs ().get (), ctx);
+  auto rvalue = CompileExpr::Compile (expr.get_rhs ().get (), ctx);
 
   // assignments are coercion sites so lets convert the rvalue if necessary
   TyTy::BaseType *expected = nullptr;
@@ -2553,8 +2554,9 @@ CompileExpr::visit (HIR::RangeFromToInclExpr &expr)
 void
 CompileExpr::visit (HIR::ArrayIndexExpr &expr)
 {
-  tree array_reference = CompileExpr::Compile (expr.get_array_expr (), ctx);
-  tree index = CompileExpr::Compile (expr.get_index_expr (), ctx);
+  tree array_reference
+    = CompileExpr::Compile (expr.get_array_expr ().get (), ctx);
+  tree index = CompileExpr::Compile (expr.get_index_expr ().get (), ctx);
 
   // this might be an core::ops::index lang item situation
   TyTy::FnType *fntype;
@@ -2565,8 +2567,8 @@ CompileExpr::visit (HIR::ArrayIndexExpr &expr)
       auto lang_item_type = Analysis::RustLangItem::ItemType::INDEX;
       tree operator_overload_call
 	= resolve_operator_overload (lang_item_type, expr, array_reference,
-				     index, expr.get_array_expr (),
-				     expr.get_index_expr ());
+				     index, expr.get_array_expr ().get (),
+				     expr.get_index_expr ().get ());
 
       tree actual_type = TREE_TYPE (operator_overload_call);
       bool can_indirect = TYPE_PTR_P (actual_type) || TYPE_REF_P (actual_type);

--- a/gcc/rust/backend/rust-compile-item.cc
+++ b/gcc/rust/backend/rust-compile-item.cc
@@ -47,7 +47,7 @@ CompileItem::visit (HIR::StaticItem &var)
     var.get_mappings ().get_nodeid (), &canonical_path);
   rust_assert (ok);
 
-  HIR::Expr *const_value_expr = var.get_expr ();
+  HIR::Expr *const_value_expr = var.get_expr ().get ();
   ctx->push_const_context ();
   tree value = compile_constant_item (resolved_type, canonical_path,
 				      const_value_expr, var.get_locus ());
@@ -94,7 +94,7 @@ CompileItem::visit (HIR::ConstantItem &constant)
     constant.get_mappings ().get_nodeid (), &canonical_path);
   rust_assert (ok);
 
-  HIR::Expr *const_value_expr = constant.get_expr ();
+  HIR::Expr *const_value_expr = constant.get_expr ().get ();
   ctx->push_const_context ();
   tree const_expr
     = compile_constant_item (resolved_type, canonical_path, const_value_expr,

--- a/gcc/rust/backend/rust-compile-struct-field-expr.cc
+++ b/gcc/rust/backend/rust-compile-struct-field-expr.cc
@@ -51,13 +51,13 @@ CompileStructExprField::Compile (HIR::StructExprField *field, Context *ctx)
 void
 CompileStructExprField::visit (HIR::StructExprFieldIdentifierValue &field)
 {
-  translated = CompileExpr::Compile (field.get_value (), ctx);
+  translated = CompileExpr::Compile (field.get_value ().get (), ctx);
 }
 
 void
 CompileStructExprField::visit (HIR::StructExprFieldIndexValue &field)
 {
-  translated = CompileExpr::Compile (field.get_value (), ctx);
+  translated = CompileExpr::Compile (field.get_value ().get (), ctx);
 }
 
 void

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -43,7 +43,7 @@ CompileCrate::Compile (HIR::Crate &crate, Context *ctx)
 void
 CompileCrate::go ()
 {
-  for (auto &item : crate.items)
+  for (auto &item : crate.get_items ())
     CompileItem::compile (item.get (), ctx);
 }
 

--- a/gcc/rust/checks/errors/privacy/rust-privacy-check.cc
+++ b/gcc/rust/checks/errors/privacy/rust-privacy-check.cc
@@ -45,9 +45,7 @@ Resolver::resolve (HIR::Crate &crate)
 
   auto visitor = ReachabilityVisitor (ctx, *ty_ctx);
 
-  const auto &items = crate.items;
-
-  for (auto &item : items)
+  for (auto &item : crate.get_items ())
     {
       if (item->get_hir_kind () == HIR::Node::VIS_ITEM)
 	{

--- a/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
+++ b/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
@@ -608,7 +608,7 @@ void
 PrivacyReporter::visit (HIR::Function &function)
 {
   for (auto &param : function.get_function_params ())
-    check_type_privacy (param.get_type ());
+    check_type_privacy (param.get_type ().get ());
 
   function.get_definition ()->accept_vis (*this);
 }

--- a/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
+++ b/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
@@ -34,7 +34,7 @@ PrivacyReporter::PrivacyReporter (
 void
 PrivacyReporter::go (HIR::Crate &crate)
 {
-  for (auto &item : crate.items)
+  for (auto &item : crate.get_items ())
     item->accept_vis (*this);
 }
 

--- a/gcc/rust/checks/errors/privacy/rust-pub-restricted-visitor.cc
+++ b/gcc/rust/checks/errors/privacy/rust-pub-restricted-visitor.cc
@@ -57,7 +57,7 @@ PubRestrictedVisitor::go (HIR::Crate &crate)
   // FIXME: When do we insert `super`? `self`?
   // We need wrapper function for these
 
-  for (auto &item : crate.items)
+  for (auto &item : crate.get_items ())
     {
       if (item->get_hir_kind () == HIR::Node::VIS_ITEM)
 	{

--- a/gcc/rust/checks/errors/privacy/rust-visibility-resolver.cc
+++ b/gcc/rust/checks/errors/privacy/rust-visibility-resolver.cc
@@ -37,7 +37,7 @@ VisibilityResolver::go (HIR::Crate &crate)
 
   current_module = crate.get_mappings ().get_defid ();
 
-  for (auto &item : crate.items)
+  for (auto &item : crate.get_items ())
     {
       if (item->get_hir_kind () == HIR::Node::VIS_ITEM)
 	{

--- a/gcc/rust/checks/errors/rust-const-checker.cc
+++ b/gcc/rust/checks/errors/rust-const-checker.cc
@@ -33,7 +33,7 @@ ConstChecker::ConstChecker ()
 void
 ConstChecker::go (HIR::Crate &crate)
 {
-  for (auto &item : crate.items)
+  for (auto &item : crate.get_items ())
     item->accept_vis (*this);
 }
 

--- a/gcc/rust/checks/errors/rust-unsafe-checker.cc
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.cc
@@ -34,7 +34,7 @@ UnsafeChecker::UnsafeChecker ()
 void
 UnsafeChecker::go (HIR::Crate &crate)
 {
-  for (auto &item : crate.items)
+  for (auto &item : crate.get_items ())
     item->accept_vis (*this);
 }
 

--- a/gcc/rust/checks/lints/rust-lint-marklive.cc
+++ b/gcc/rust/checks/lints/rust-lint-marklive.cc
@@ -41,10 +41,8 @@ public:
   static std::vector<HirId> find (HIR::Crate &crate)
   {
     FindEntryPoint findEntryPoint;
-    for (auto it = crate.items.begin (); it != crate.items.end (); it++)
-      {
-	it->get ()->accept_vis (findEntryPoint);
-      }
+    for (auto &it : crate.get_items ())
+      it->accept_vis (findEntryPoint);
     return findEntryPoint.getEntryPoint ();
   }
 

--- a/gcc/rust/checks/lints/rust-lint-scan-deadcode.h
+++ b/gcc/rust/checks/lints/rust-lint-scan-deadcode.h
@@ -44,10 +44,8 @@ public:
   {
     std::set<HirId> live_symbols = Analysis::MarkLive::Analysis (crate);
     ScanDeadcode sdc (live_symbols);
-    for (auto it = crate.items.begin (); it != crate.items.end (); it++)
-      {
-	it->get ()->accept_vis (sdc);
-      }
+    for (auto &it : crate.get_items ())
+      it.get ()->accept_vis (sdc);
   };
 
   void visit (HIR::Function &function) override

--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -28,12 +28,12 @@ Dump::go (HIR::Crate &crate)
 {
   stream << "Crate {" << std::endl;
   // inner attributes
-  if (!crate.inner_attrs.empty ())
+  if (!crate.get_inner_attrs ().empty ())
     {
       indentation.increment ();
       stream << indentation;
       stream << "inner_attrs: [";
-      for (auto &attr : crate.inner_attrs)
+      for (auto &attr : crate.get_inner_attrs ())
 	stream << attr.as_string ();
       stream << "]," << std::endl;
       indentation.decrement ();
@@ -272,11 +272,11 @@ Dump::visit (BlockExpr &block_expr)
 
   indentation.increment ();
   // TODO: inner attributes
-  if (!block_expr.inner_attrs.empty ())
+  if (!block_expr.get_inner_attrs ().empty ())
     {
       stream << indentation << "inner_attrs: [";
       indentation.increment ();
-      for (auto &attr : block_expr.inner_attrs)
+      for (auto &attr : block_expr.get_inner_attrs ())
 	{
 	  stream << "\n";
 	  stream << indentation;

--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -46,7 +46,7 @@ Dump::go (HIR::Crate &crate)
   stream << "items: [";
 
   stream << indentation;
-  for (const auto &item : crate.items)
+  for (const auto &item : crate.get_items ())
     {
       stream << std::endl;
       item->accept_vis (*this);

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -3755,6 +3755,8 @@ public:
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRExpressionVisitor &vis) override;
 
+  std::unique_ptr<Expr> &get_awaited_expr () { return awaited_expr; }
+
   ExprType get_expression_type () const final override
   {
     return ExprType::Await;
@@ -3808,6 +3810,9 @@ public:
   std::string as_string () const override;
 
   Location get_locus () const override final { return locus; }
+
+  bool get_has_move () const { return has_move; }
+  std::unique_ptr<BlockExpr> &get_block_expr () { return block_expr; }
 
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRExpressionVisitor &vis) override;

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -387,8 +387,8 @@ public:
   void visit_lhs (HIRFullVisitor &vis) { main_or_left_expr->accept_vis (vis); }
   void visit_rhs (HIRFullVisitor &vis) { right_expr->accept_vis (vis); }
 
-  Expr *get_lhs () { return main_or_left_expr.get (); }
-  Expr *get_rhs () { return right_expr.get (); }
+  std::unique_ptr<Expr> &get_lhs () { return main_or_left_expr; }
+  std::unique_ptr<Expr> &get_rhs () { return right_expr; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather
@@ -459,8 +459,8 @@ public:
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRExpressionVisitor &vis) override;
 
-  Expr *get_lhs () { return main_or_left_expr.get (); }
-  Expr *get_rhs () { return right_expr.get (); }
+  std::unique_ptr<Expr> &get_lhs () { return main_or_left_expr; }
+  std::unique_ptr<Expr> &get_rhs () { return right_expr; }
 
   ExprType get_kind () { return expr_type; }
 
@@ -533,9 +533,8 @@ public:
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRExpressionVisitor &vis) override;
 
-  Expr *get_lhs () { return main_or_left_expr.get (); }
-
-  Expr *get_rhs () { return right_expr.get (); }
+  std::unique_ptr<Expr> &get_lhs () { return main_or_left_expr; }
+  std::unique_ptr<Expr> &get_rhs () { return right_expr; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather
@@ -667,8 +666,8 @@ public:
   void visit_lhs (HIRFullVisitor &vis) { main_or_left_expr->accept_vis (vis); }
   void visit_rhs (HIRFullVisitor &vis) { right_expr->accept_vis (vis); }
 
-  Expr *get_lhs () { return main_or_left_expr.get (); }
-  Expr *get_rhs () { return right_expr.get (); }
+  std::unique_ptr<Expr> &get_lhs () { return main_or_left_expr; }
+  std::unique_ptr<Expr> &get_rhs () { return right_expr; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather
@@ -1039,7 +1038,10 @@ public:
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRExpressionVisitor &vis) override;
 
-  ArrayElems *get_internal_elements () { return internal_elements.get (); };
+  std::unique_ptr<ArrayElems> &get_internal_elements ()
+  {
+    return internal_elements;
+  };
 
   ExprType get_expression_type () const override final
   {
@@ -1105,8 +1107,8 @@ public:
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRExpressionVisitor &vis) override;
 
-  Expr *get_array_expr () { return array_expr.get (); }
-  Expr *get_index_expr () { return index_expr.get (); }
+  std::unique_ptr<Expr> &get_array_expr () { return array_expr; }
+  std::unique_ptr<Expr> &get_index_expr () { return index_expr; }
 
   ExprType get_expression_type () const override final
   {
@@ -1516,7 +1518,7 @@ protected:
 public:
   std::string as_string () const override;
 
-  Expr *get_value () { return value.get (); }
+  std::unique_ptr<Expr> &get_value () { return value; }
 };
 
 // Identifier and value variant of StructExprField HIR node
@@ -3252,8 +3254,8 @@ public:
   void vis_if_condition (HIRFullVisitor &vis) { condition->accept_vis (vis); }
   void vis_if_block (HIRFullVisitor &vis) { if_block->accept_vis (vis); }
 
-  Expr *get_if_condition () { return condition.get (); }
-  BlockExpr *get_if_block () { return if_block.get (); }
+  std::unique_ptr<Expr> &get_if_condition () { return condition; }
+  std::unique_ptr<BlockExpr> &get_if_block () { return if_block; }
 
   ExprType get_expression_type () const final override { return ExprType::If; }
 
@@ -3316,7 +3318,7 @@ public:
 
   void vis_else_block (HIRFullVisitor &vis) { else_block->accept_vis (vis); }
 
-  ExprWithBlock *get_else_block () { return else_block.get (); }
+  std::unique_ptr<ExprWithBlock> &get_else_block () { return else_block; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -1965,6 +1965,7 @@ public:
   }
 
   std::vector<std::unique_ptr<EnumItem>> &get_variants () { return items; }
+  WhereClause &get_where_clause () { return where_clause; }
 
 protected:
   /* Use covariance to implement clone function as returning this object
@@ -2638,7 +2639,10 @@ public:
     return trait_items;
   }
 
+  WhereClause &get_where_clause () { return where_clause; }
+
   Identifier get_name () const { return name; }
+  bool is_unsafe () const { return unsafety == Unsafety::Unsafe; }
 
   // Mega-constructor
   Trait (Analysis::NodeMapping mappings, Identifier name, Unsafety unsafety,
@@ -2894,6 +2898,7 @@ public:
   virtual void accept_vis (HIRFullVisitor &vis) = 0;
   virtual void accept_vis (HIRExternalItemVisitor &vis) = 0;
 
+  Visibility &get_visibility () { return visibility; }
   Analysis::NodeMapping get_mappings () const { return mappings; }
 
   Identifier get_item_name () const { return item_name; }

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -551,9 +551,9 @@ public:
 
   Location get_locus () const { return locus; }
 
-  Pattern *get_param_name () { return param_name.get (); }
+  std::unique_ptr<Pattern> &get_param_name () { return param_name; }
 
-  Type *get_type () { return type.get (); }
+  std::unique_ptr<Type> &get_type () { return type; }
 
   const Analysis::NodeMapping &get_mappings () const { return mappings; }
 };
@@ -2129,9 +2129,9 @@ public:
   void accept_vis (HIRImplVisitor &vis) override;
   void accept_vis (HIRVisItemVisitor &vis) override;
 
-  Type *get_type () { return type.get (); }
+  std::unique_ptr<Type> &get_type () { return type; }
 
-  Expr *get_expr () { return const_expr.get (); }
+  std::unique_ptr<Expr> &get_expr () { return const_expr; }
 
   Identifier get_identifier () const { return identifier; }
 
@@ -2225,9 +2225,9 @@ public:
 
   bool is_mut () const { return mut == Mutability::Mut; }
 
-  Expr *get_expr () { return expr.get (); }
+  std::unique_ptr<Expr> &get_expr () { return expr; }
 
-  Type *get_type () { return type.get (); }
+  std::unique_ptr<Type> &get_type () { return type; }
 
   ItemKind get_item_kind () const override { return ItemKind::Static; }
 

--- a/gcc/rust/hir/tree/rust-hir-type.h
+++ b/gcc/rust/hir/tree/rust-hir-type.h
@@ -570,9 +570,9 @@ public:
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRTypeVisitor &vis) override;
 
-  Type *get_element_type () { return elem_type.get (); }
+  std::unique_ptr<Type> &get_element_type () { return elem_type; }
 
-  Expr *get_size_expr () { return size.get (); }
+  std::unique_ptr<Expr> &get_size_expr () { return size; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -65,6 +65,12 @@ public:
     : inner_attrs (std::move (inner_attrs)){};
 };
 
+class FullVisitable
+{
+public:
+  virtual void accept_vis (HIRFullVisitor &vis) = 0;
+};
+
 // forward decl for use in token tree method
 class Token;
 
@@ -155,9 +161,11 @@ public:
 
 /* Base statement abstract class. Note that most "statements" are not allowed in
  * top-level module scope - only a subclass of statements called "items" are. */
-class Stmt : public Node
+class Stmt : public Node, public FullVisitable
 {
 public:
+  using FullVisitable::accept_vis;
+
   // Unique pointer custom clone function
   std::unique_ptr<Stmt> clone_stmt () const
   {
@@ -170,7 +178,6 @@ public:
 
   virtual std::string as_string () const = 0;
 
-  virtual void accept_vis (HIRFullVisitor &vis) = 0;
   virtual void accept_vis (HIRStmtVisitor &vis) = 0;
 
   virtual Location get_locus () const = 0;
@@ -253,8 +260,11 @@ protected:
 class ExprWithoutBlock;
 
 // Base expression HIR node - abstract
-class Expr : public Node
+class Expr : public Node, public FullVisitable
 {
+public:
+  using FullVisitable::accept_vis;
+
 protected:
   AST::AttrVec outer_attrs;
   Analysis::NodeMapping mappings;
@@ -322,7 +332,6 @@ public:
   virtual ExprType get_expression_type () const = 0;
 
   virtual void accept_vis (HIRExpressionVisitor &vis) = 0;
-  virtual void accept_vis (HIRFullVisitor &vis) = 0;
 
 protected:
   // Constructor
@@ -374,9 +383,11 @@ public:
 };
 
 // Pattern base HIR node
-class Pattern : public Node
+class Pattern : public Node, public FullVisitable
 {
 public:
+  using FullVisitable::accept_vis;
+
   enum PatternType
   {
     PATH,
@@ -407,7 +418,6 @@ public:
 
   virtual std::string as_string () const = 0;
 
-  virtual void accept_vis (HIRFullVisitor &vis) = 0;
   virtual void accept_vis (HIRPatternVisitor &vis) = 0;
 
   virtual Analysis::NodeMapping get_pattern_mappings () const = 0;
@@ -425,9 +435,10 @@ protected:
 class TraitBound;
 
 // Base class for types as represented in HIR - abstract
-class Type : public Node
+class Type : public Node, public FullVisitable
 {
 public:
+  using FullVisitable::accept_vis;
   // Unique pointer custom clone function
   std::unique_ptr<Type> clone_type () const
   {
@@ -450,7 +461,6 @@ public:
   /* as pointer, shouldn't require definition beforehand, only forward
    * declaration. */
 
-  virtual void accept_vis (HIRFullVisitor &vis) = 0;
   virtual void accept_vis (HIRTypeVisitor &vis) = 0;
 
   virtual Analysis::NodeMapping get_mappings () const { return mappings; }
@@ -497,9 +507,10 @@ protected:
 
 /* Abstract base class representing a type param bound - Lifetime and TraitBound
  * extends it */
-class TypeParamBound
+class TypeParamBound : public FullVisitable
 {
 public:
+  using FullVisitable::accept_vis;
   enum BoundType
   {
     LIFETIME,
@@ -515,8 +526,6 @@ public:
   }
 
   virtual std::string as_string () const = 0;
-
-  virtual void accept_vis (HIRFullVisitor &vis) = 0;
 
   virtual Analysis::NodeMapping get_mappings () const = 0;
 
@@ -590,9 +599,11 @@ protected:
 
 /* Base generic parameter in HIR. Abstract - can be represented by a Lifetime or
  * Type param */
-class GenericParam
+class GenericParam : public FullVisitable
 {
 public:
+  using FullVisitable::accept_vis;
+
   virtual ~GenericParam () {}
 
   enum class GenericKind
@@ -609,8 +620,6 @@ public:
   }
 
   virtual std::string as_string () const = 0;
-
-  virtual void accept_vis (HIRFullVisitor &vis) = 0;
 
   virtual Location get_locus () const = 0;
 
@@ -768,9 +777,10 @@ private:
 };
 
 // Item used in trait declarations - abstract base class
-class TraitItem : public Node
+class TraitItem : public Node, public FullVisitable
 {
 public:
+  using FullVisitable::accept_vis;
   enum TraitItemKind
   {
     FUNC,
@@ -800,7 +810,6 @@ public:
   virtual std::string as_string () const = 0;
 
   virtual void accept_vis (HIRTraitItemVisitor &vis) = 0;
-  virtual void accept_vis (HIRFullVisitor &vis) = 0;
 
   virtual const std::string trait_identifier () const = 0;
 
@@ -814,9 +823,10 @@ public:
   virtual const AST::AttrVec &get_outer_attrs () const = 0;
 };
 
-class ImplItem : public Node
+class ImplItem : public Node, public FullVisitable
 {
 public:
+  using FullVisitable::accept_vis;
   enum ImplItemType
   {
     FUNCTION,
@@ -837,7 +847,6 @@ public:
   virtual std::string as_string () const = 0;
 
   virtual void accept_vis (HIRImplVisitor &vis) = 0;
-  virtual void accept_vis (HIRFullVisitor &vis) = 0;
   virtual void accept_vis (HIRStmtVisitor &vis) = 0;
 
   virtual Analysis::NodeMapping get_impl_mappings () const = 0;

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -863,18 +863,18 @@ protected:
 };
 
 // A crate HIR object - holds all the data for a single compilation unit
-struct Crate : public WithInnerAttrs
+class Crate : public WithInnerAttrs
 {
   // dodgy spacing required here
   /* TODO: is it better to have a vector of items here or a module (implicit
    * top-level one)? */
-  std::vector<std::unique_ptr<Item> > items;
+  std::vector<std::unique_ptr<Item>> items;
 
   Analysis::NodeMapping mappings;
 
 public:
   // Constructor
-  Crate (std::vector<std::unique_ptr<Item> > items, AST::AttrVec inner_attrs,
+  Crate (std::vector<std::unique_ptr<Item>> items, AST::AttrVec inner_attrs,
 	 Analysis::NodeMapping mappings)
     : WithInnerAttrs (std::move (inner_attrs)), items (std::move (items)),
       mappings (mappings)
@@ -912,6 +912,7 @@ public:
   std::string as_string () const;
 
   const Analysis::NodeMapping &get_mappings () const { return mappings; }
+  std::vector<std::unique_ptr<Item>> &get_items () { return items; }
 };
 
 // Base path expression HIR node - abstract

--- a/gcc/rust/metadata/rust-export-metadata.cc
+++ b/gcc/rust/metadata/rust-export-metadata.cc
@@ -220,7 +220,7 @@ void
 PublicInterface::gather_export_data ()
 {
   ExportVisItems visitor (context);
-  for (auto &item : crate.items)
+  for (auto &item : crate.get_items ())
     {
       bool is_vis_item = item->get_hir_kind () == HIR::Node::BaseKind::VIS_ITEM;
       if (!is_vis_item)

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -224,8 +224,8 @@ TypeCheckExpr::visit (HIR::AssignmentExpr &expr)
 {
   infered = TyTy::TupleType::get_unit_type (expr.get_mappings ().get_hirid ());
 
-  auto lhs = TypeCheckExpr::Resolve (expr.get_lhs ());
-  auto rhs = TypeCheckExpr::Resolve (expr.get_rhs ());
+  auto lhs = TypeCheckExpr::Resolve (expr.get_lhs ().get ());
+  auto rhs = TypeCheckExpr::Resolve (expr.get_rhs ().get ());
 
   coercion_site (expr.get_mappings ().get_hirid (),
 		 TyTy::TyWithLocation (lhs, expr.get_lhs ()->get_locus ()),
@@ -280,8 +280,8 @@ TypeCheckExpr::visit (HIR::LiteralExpr &expr)
 void
 TypeCheckExpr::visit (HIR::ArithmeticOrLogicalExpr &expr)
 {
-  auto lhs = TypeCheckExpr::Resolve (expr.get_lhs ());
-  auto rhs = TypeCheckExpr::Resolve (expr.get_rhs ());
+  auto lhs = TypeCheckExpr::Resolve (expr.get_lhs ().get ());
+  auto rhs = TypeCheckExpr::Resolve (expr.get_rhs ().get ());
 
   auto lang_item_type
     = Analysis::RustLangItem::OperatorToLangItem (expr.get_expr_type ());
@@ -326,8 +326,8 @@ TypeCheckExpr::visit (HIR::ArithmeticOrLogicalExpr &expr)
 void
 TypeCheckExpr::visit (HIR::ComparisonExpr &expr)
 {
-  auto lhs = TypeCheckExpr::Resolve (expr.get_lhs ());
-  auto rhs = TypeCheckExpr::Resolve (expr.get_rhs ());
+  auto lhs = TypeCheckExpr::Resolve (expr.get_lhs ().get ());
+  auto rhs = TypeCheckExpr::Resolve (expr.get_rhs ().get ());
 
   unify_site (expr.get_mappings ().get_hirid (),
 	      TyTy::TyWithLocation (lhs, expr.get_lhs ()->get_locus ()),
@@ -341,8 +341,8 @@ TypeCheckExpr::visit (HIR::ComparisonExpr &expr)
 void
 TypeCheckExpr::visit (HIR::LazyBooleanExpr &expr)
 {
-  auto lhs = TypeCheckExpr::Resolve (expr.get_lhs ());
-  auto rhs = TypeCheckExpr::Resolve (expr.get_rhs ());
+  auto lhs = TypeCheckExpr::Resolve (expr.get_lhs ().get ());
+  auto rhs = TypeCheckExpr::Resolve (expr.get_rhs ().get ());
 
   // we expect the lhs and rhs must be bools at this point
   TyTy::BaseType *boolean_node = nullptr;
@@ -433,8 +433,8 @@ TypeCheckExpr::visit (HIR::NegationExpr &expr)
 void
 TypeCheckExpr::visit (HIR::IfExpr &expr)
 {
-  TypeCheckExpr::Resolve (expr.get_if_condition ());
-  TypeCheckExpr::Resolve (expr.get_if_block ());
+  TypeCheckExpr::Resolve (expr.get_if_condition ().get ());
+  TypeCheckExpr::Resolve (expr.get_if_block ().get ());
 
   infered = TyTy::TupleType::get_unit_type (expr.get_mappings ().get_hirid ());
 }
@@ -442,9 +442,10 @@ TypeCheckExpr::visit (HIR::IfExpr &expr)
 void
 TypeCheckExpr::visit (HIR::IfExprConseqElse &expr)
 {
-  TypeCheckExpr::Resolve (expr.get_if_condition ());
-  auto if_blk_resolved = TypeCheckExpr::Resolve (expr.get_if_block ());
-  auto else_blk_resolved = TypeCheckExpr::Resolve (expr.get_else_block ());
+  TypeCheckExpr::Resolve (expr.get_if_condition ().get ());
+  auto if_blk_resolved = TypeCheckExpr::Resolve (expr.get_if_block ().get ());
+  auto else_blk_resolved
+    = TypeCheckExpr::Resolve (expr.get_else_block ().get ());
 
   if (if_blk_resolved->get_kind () == TyTy::NEVER)
     infered = else_blk_resolved;
@@ -808,11 +809,11 @@ TypeCheckExpr::visit (HIR::RangeFromToInclExpr &expr)
 void
 TypeCheckExpr::visit (HIR::ArrayIndexExpr &expr)
 {
-  auto array_expr_ty = TypeCheckExpr::Resolve (expr.get_array_expr ());
+  auto array_expr_ty = TypeCheckExpr::Resolve (expr.get_array_expr ().get ());
   if (array_expr_ty->get_kind () == TyTy::TypeKind::ERROR)
     return;
 
-  auto index_expr_ty = TypeCheckExpr::Resolve (expr.get_index_expr ());
+  auto index_expr_ty = TypeCheckExpr::Resolve (expr.get_index_expr ().get ());
   if (index_expr_ty->get_kind () == TyTy::TypeKind::ERROR)
     return;
 

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.cc
@@ -271,13 +271,12 @@ TypeCheckImplItem::visit (HIR::Function &function)
   for (auto &param : function.get_function_params ())
     {
       // get the name as well required for later on
-      auto param_tyty = TypeCheckType::Resolve (param.get_type ());
-      params.push_back (
-	std::pair<HIR::Pattern *, TyTy::BaseType *> (param.get_param_name (),
-						     param_tyty));
+      auto param_tyty = TypeCheckType::Resolve (param.get_type ().get ());
+      params.push_back (std::pair<HIR::Pattern *, TyTy::BaseType *> (
+	param.get_param_name ().get (), param_tyty));
 
       context->insert_type (param.get_mappings (), param_tyty);
-      TypeCheckPattern::Resolve (param.get_param_name (), param_tyty);
+      TypeCheckPattern::Resolve (param.get_param_name ().get (), param_tyty);
     }
 
   const CanonicalPath *canonical_path = nullptr;
@@ -324,8 +323,9 @@ TypeCheckImplItem::visit (HIR::Function &function)
 void
 TypeCheckImplItem::visit (HIR::ConstantItem &constant)
 {
-  TyTy::BaseType *type = TypeCheckType::Resolve (constant.get_type ());
-  TyTy::BaseType *expr_type = TypeCheckExpr::Resolve (constant.get_expr ());
+  TyTy::BaseType *type = TypeCheckType::Resolve (constant.get_type ().get ());
+  TyTy::BaseType *expr_type
+    = TypeCheckExpr::Resolve (constant.get_expr ().get ());
 
   TyTy::BaseType *unified = unify_site (
     constant.get_mappings ().get_hirid (),

--- a/gcc/rust/typecheck/rust-hir-type-check-item.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.cc
@@ -355,8 +355,8 @@ TypeCheckItem::visit (HIR::Union &union_decl)
 void
 TypeCheckItem::visit (HIR::StaticItem &var)
 {
-  TyTy::BaseType *type = TypeCheckType::Resolve (var.get_type ());
-  TyTy::BaseType *expr_type = TypeCheckExpr::Resolve (var.get_expr ());
+  TyTy::BaseType *type = TypeCheckType::Resolve (var.get_type ().get ());
+  TyTy::BaseType *expr_type = TypeCheckExpr::Resolve (var.get_expr ().get ());
 
   TyTy::BaseType *unified
     = coercion_site (var.get_mappings ().get_hirid (),
@@ -371,8 +371,9 @@ TypeCheckItem::visit (HIR::StaticItem &var)
 void
 TypeCheckItem::visit (HIR::ConstantItem &constant)
 {
-  TyTy::BaseType *type = TypeCheckType::Resolve (constant.get_type ());
-  TyTy::BaseType *expr_type = TypeCheckExpr::Resolve (constant.get_expr ());
+  TyTy::BaseType *type = TypeCheckType::Resolve (constant.get_type ().get ());
+  TyTy::BaseType *expr_type
+    = TypeCheckExpr::Resolve (constant.get_expr ().get ());
 
   TyTy::BaseType *unified = unify_site (
     constant.get_mappings ().get_hirid (),
@@ -461,13 +462,12 @@ TypeCheckItem::visit (HIR::Function &function)
   for (auto &param : function.get_function_params ())
     {
       // get the name as well required for later on
-      auto param_tyty = TypeCheckType::Resolve (param.get_type ());
-      params.push_back (
-	std::pair<HIR::Pattern *, TyTy::BaseType *> (param.get_param_name (),
-						     param_tyty));
+      auto param_tyty = TypeCheckType::Resolve (param.get_type ().get ());
+      params.push_back (std::pair<HIR::Pattern *, TyTy::BaseType *> (
+	param.get_param_name ().get (), param_tyty));
 
       context->insert_type (param.get_mappings (), param_tyty);
-      TypeCheckPattern::Resolve (param.get_param_name (), param_tyty);
+      TypeCheckPattern::Resolve (param.get_param_name ().get (), param_tyty);
     }
 
   const CanonicalPath *canonical_path = nullptr;

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.cc
@@ -59,8 +59,9 @@ TypeCheckStmt::visit (HIR::ExternBlock &extern_block)
 void
 TypeCheckStmt::visit (HIR::ConstantItem &constant)
 {
-  TyTy::BaseType *type = TypeCheckType::Resolve (constant.get_type ());
-  TyTy::BaseType *expr_type = TypeCheckExpr::Resolve (constant.get_expr ());
+  TyTy::BaseType *type = TypeCheckType::Resolve (constant.get_type ().get ());
+  TyTy::BaseType *expr_type
+    = TypeCheckExpr::Resolve (constant.get_expr ().get ());
 
   infered = coercion_site (
     constant.get_mappings ().get_hirid (),

--- a/gcc/rust/typecheck/rust-hir-type-check-struct.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-struct.cc
@@ -258,7 +258,7 @@ TypeCheckStructExpr::visit (HIR::StructExprFieldIdentifierValue &field)
       return;
     }
 
-  TyTy::BaseType *value = TypeCheckExpr::Resolve (field.get_value ());
+  TyTy::BaseType *value = TypeCheckExpr::Resolve (field.get_value ().get ());
   Location value_locus = field.get_value ()->get_locus ();
 
   HirId coercion_site_id = field.get_mappings ().get_hirid ();
@@ -295,7 +295,7 @@ TypeCheckStructExpr::visit (HIR::StructExprFieldIndexValue &field)
       return;
     }
 
-  TyTy::BaseType *value = TypeCheckExpr::Resolve (field.get_value ());
+  TyTy::BaseType *value = TypeCheckExpr::Resolve (field.get_value ().get ());
   Location value_locus = field.get_value ()->get_locus ();
 
   HirId coercion_site_id = field.get_mappings ().get_hirid ();

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -604,7 +604,7 @@ TypeCheckType::visit (HIR::TraitObjectType &type)
 void
 TypeCheckType::visit (HIR::ArrayType &type)
 {
-  auto capacity_type = TypeCheckExpr::Resolve (type.get_size_expr ());
+  auto capacity_type = TypeCheckExpr::Resolve (type.get_size_expr ().get ());
   if (capacity_type->get_kind () == TyTy::TypeKind::ERROR)
     return;
 
@@ -619,7 +619,8 @@ TypeCheckType::visit (HIR::ArrayType &type)
 				    type.get_size_expr ()->get_locus ()),
 	      type.get_size_expr ()->get_locus ());
 
-  TyTy::BaseType *base = TypeCheckType::Resolve (type.get_element_type ());
+  TyTy::BaseType *base
+    = TypeCheckType::Resolve (type.get_element_type ().get ());
   translated = new TyTy::ArrayType (type.get_mappings ().get_hirid (),
 				    type.get_locus (), *type.get_size_expr (),
 				    TyTy::TyVar (base->get_ref ()));

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -33,8 +33,8 @@ namespace Resolver {
 void
 TypeResolution::Resolve (HIR::Crate &crate)
 {
-  for (auto it = crate.items.begin (); it != crate.items.end (); it++)
-    TypeCheckItem::Resolve (*it->get ());
+  for (auto &it : crate.get_items ())
+    TypeCheckItem::Resolve (*it);
 
   if (saw_errors ())
     return;

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -259,13 +259,12 @@ TraitItemReference::get_type_from_fn (/*const*/ HIR::TraitItemFunc &fn) const
   for (auto &param : function.get_function_params ())
     {
       // get the name as well required for later on
-      auto param_tyty = TypeCheckType::Resolve (param.get_type ());
-      params.push_back (
-	std::pair<HIR::Pattern *, TyTy::BaseType *> (param.get_param_name (),
-						     param_tyty));
+      auto param_tyty = TypeCheckType::Resolve (param.get_type ().get ());
+      params.push_back (std::pair<HIR::Pattern *, TyTy::BaseType *> (
+	param.get_param_name ().get (), param_tyty));
 
       context->insert_type (param.get_mappings (), param_tyty);
-      TypeCheckPattern::Resolve (param.get_param_name (), param_tyty);
+      TypeCheckPattern::Resolve (param.get_param_name ().get (), param_tyty);
     }
 
   auto mappings = Analysis::Mappings::get ();


### PR DESCRIPTION
The pending HIR dump pass change requires some simple refactoring. These are
mainly repetitive changes (use inheritance, add missing methods to access
private fields, make life of visitor a bit easier, ...)