### PR TITLE
Fix type hint propagation

### DIFF
--- a/gcc/rust/ast/rust-pattern.h
+++ b/gcc/rust/ast/rust-pattern.h
@@ -39,9 +39,10 @@ public:
       node_id (Analysis::Mappings::get ()->get_next_node_id ())
   {}
 
-  LiteralPattern (std::string val, Literal::LitType type, Location locus)
-    : lit (Literal (std::move (val), type, PrimitiveCoreType::CORETYPE_STR)),
-      locus (locus), node_id (Analysis::Mappings::get ()->get_next_node_id ())
+  LiteralPattern (std::string val, Literal::LitType type, Location locus,
+		  PrimitiveCoreType type_hint)
+    : lit (Literal (std::move (val), type, type_hint)), locus (locus),
+      node_id (Analysis::Mappings::get ()->get_next_node_id ())
   {}
 
   Location get_locus () const override final { return locus; }

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -10397,7 +10397,8 @@ Parser<ManagedTokenSource>::parse_literal_or_range_pattern ()
       // literal pattern
       return std::unique_ptr<AST::LiteralPattern> (
 	new AST::LiteralPattern (range_lower->get_str (), type,
-				 range_lower->get_locus ()));
+				 range_lower->get_locus (),
+				 range_lower->get_type_hint ()));
     }
 }
 
@@ -10559,11 +10560,13 @@ Parser<ManagedTokenSource>::parse_pattern_no_alt ()
     case TRUE_LITERAL:
       lexer.skip_token ();
       return std::unique_ptr<AST::LiteralPattern> (
-	new AST::LiteralPattern ("true", AST::Literal::BOOL, t->get_locus ()));
+	new AST::LiteralPattern ("true", AST::Literal::BOOL, t->get_locus (),
+				 t->get_type_hint ()));
     case FALSE_LITERAL:
       lexer.skip_token ();
       return std::unique_ptr<AST::LiteralPattern> (
-	new AST::LiteralPattern ("false", AST::Literal::BOOL, t->get_locus ()));
+	new AST::LiteralPattern ("false", AST::Literal::BOOL, t->get_locus (),
+				 t->get_type_hint ()));
     case CHAR_LITERAL:
     case BYTE_CHAR_LITERAL:
     case INT_LITERAL:
@@ -10573,12 +10576,12 @@ Parser<ManagedTokenSource>::parse_pattern_no_alt ()
       lexer.skip_token ();
       return std::unique_ptr<AST::LiteralPattern> (
 	new AST::LiteralPattern (t->get_str (), AST::Literal::STRING,
-				 t->get_locus ()));
+				 t->get_locus (), t->get_type_hint ()));
     case BYTE_STRING_LITERAL:
       lexer.skip_token ();
       return std::unique_ptr<AST::LiteralPattern> (
 	new AST::LiteralPattern (t->get_str (), AST::Literal::BYTE_STRING,
-				 t->get_locus ()));
+				 t->get_locus (), t->get_type_hint ()));
     // raw string and raw byte string literals too if they are readded to
     // lexer
     case MINUS:


### PR DESCRIPTION
Type hint was not propagated properly in literals, being replaced by a default `str` instead.

Needs #2340 