### PR TITLE
abi: Add testcase for using "Rust" as ABI string

### DIFF
--- a/gcc/testsuite/rust/compile/rust_abi.rs
+++ b/gcc/testsuite/rust/compile/rust_abi.rs
@@ -1,0 +1,1 @@
+pub fn f(_: extern "Rust" fn()) {}


### PR DESCRIPTION
gcc/testsuite/ChangeLog:

	* rust/compile/rust_abi.rs: New test.
