### PR TITLE
gccrs: fix ICE with inserting autoderef mappings

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -2893,7 +2893,8 @@ CompileExpr::generate_possible_fn_trait_call (HIR::CallExpr &expr,
     }
 
   // need to apply any autoderef's to the self argument
-  HirId autoderef_mappings_id = expr.get_mappings ().get_hirid ();
+  HIR::Expr *fnexpr = expr.get_fnexpr ();
+  HirId autoderef_mappings_id = fnexpr->get_mappings ().get_hirid ();
   std::vector<Resolver::Adjustment> *adjustments = nullptr;
   bool ok = ctx->get_tyctx ()->lookup_autoderef_mappings (autoderef_mappings_id,
 							  &adjustments);

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -1910,7 +1910,8 @@ TypeCheckExpr::resolve_fn_trait_call (HIR::CallExpr &expr,
   // store the adjustments for code-generation to know what to do which must be
   // stored onto the receiver to so as we don't trigger duplicate deref mappings
   // ICE when an argument is a method call
-  HirId autoderef_mappings_id = expr.get_mappings ().get_hirid ();
+  HIR::Expr *fnexpr = expr.get_fnexpr ();
+  HirId autoderef_mappings_id = fnexpr->get_mappings ().get_hirid ();
   context->insert_autoderef_mappings (autoderef_mappings_id,
 				      std::move (candidate.adjustments));
   context->insert_receiver (expr.get_mappings ().get_hirid (), receiver_tyty);


### PR DESCRIPTION
We were using the call-expr id for the autoderef mappings but this doesn't work when the call expression itself is part of a coercion-site so this changes the code to use the call-expression function path expression for the id instead which will not be duplicated again.

Addresses #2105

gcc/rust/ChangeLog:

	* backend/rust-compile-expr.cc (CompileExpr::generate_possible_fn_trait_call): use fnexpr
	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::resolve_fn_trait_call): likewise