### PR TITLE
gccrs: Track fn_once output lang item properly

### DIFF
--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -1137,5 +1137,18 @@ Mappings::lookup_builtin_marker ()
   return builtinMarker;
 }
 
+HIR::TraitItem *
+Mappings::lookup_trait_item_lang_item (Analysis::RustLangItem::ItemType item)
+{
+  DefId trait_item_id = UNKNOWN_DEFID;
+  bool trait_item_lang_item_defined = lookup_lang_item (item, &trait_item_id);
+
+  // FIXME
+  // make this an error? what does rustc do when a lang item is not defined?
+  rust_assert (trait_item_lang_item_defined);
+
+  return lookup_trait_item_defid (trait_item_id);
+}
+
 } // namespace Analysis
 } // namespace Rust

--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -321,6 +321,9 @@ public:
 
   HIR::ImplBlock *lookup_builtin_marker ();
 
+  HIR::TraitItem *
+  lookup_trait_item_lang_item (Analysis::RustLangItem::ItemType item);
+
 private:
   Mappings ();
 

--- a/gcc/testsuite/rust/compile/issue-2105.rs
+++ b/gcc/testsuite/rust/compile/issue-2105.rs
@@ -1,0 +1,23 @@
+pub enum Option<T> {
+    Some(T),
+    None,
+}
+
+pub use Option::{None, Some};
+
+#[lang = "fn_once"]
+pub trait FnOnce<Args> {
+    #[lang = "fn_once_output"]
+    type Output;
+
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+}
+
+impl<T> Option<T> {
+    pub fn map<R, F: FnOnce(T) -> R>(self, f: F) -> Option<R> {
+        match self {
+            Some(value) => Some(f(value)),
+            None => None,
+        }
+    }
+}


### PR DESCRIPTION
In order to setup the Output assoicated type we can rely on using generic argument bindings. So for example when we have the FnOnce trait:
```
  #[lang = "fn_once"]
  pub trait FnOnce<Args> {
      #[lang = "fn_once_output"]
      type Output;

      extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
  }
```
Thn we might have a function such as:

  ```pub fn map<R, F: FnOnce(T) -> R>(self, f: F) -> Option<R> { ... }```

This trait bound predicate of FnOnce(T) -> R we setup generics for the bound as:

  ```FnOnce<(T), Output=R>```

This means we can reuse our generic arguments handling to get this support.

Fixes #2105

gcc/rust/ChangeLog:

	* typecheck/rust-tyty-bounds.cc (TypeCheckBase::get_predicate_from_bound):
	* util/rust-hir-map.cc (Mappings::lookup_trait_item_lang_item):
	* util/rust-hir-map.h:

gcc/testsuite/ChangeLog:

	* rust/compile/issue-2105.rs: New test.
