### PR TITLE
gccrs: minor HIR interface cleanup

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -835,7 +835,7 @@ protected:
 
 // Base array initialisation internal element representation thing (abstract)
 // aka ArrayElements
-class ArrayElems
+class ArrayElems : public FullVisitable
 {
 public:
   enum ArrayExprType
@@ -1393,7 +1393,7 @@ public:
 
 /* Base HIR node for a single struct expression field (in struct instance
  * creation) - abstract */
-class StructExprField
+class StructExprField : public FullVisitable
 {
 public:
   enum StructExprFieldKind
@@ -2144,6 +2144,7 @@ protected:
 // A block HIR node
 class BlockExpr : public ExprWithBlock, public WithInnerAttrs
 {
+  // FIXME this should be private + get/set
 public:
   std::vector<std::unique_ptr<Stmt> > statements;
   std::unique_ptr<Expr> expr;

--- a/gcc/rust/hir/tree/rust-hir-pattern.h
+++ b/gcc/rust/hir/tree/rust-hir-pattern.h
@@ -781,7 +781,7 @@ protected:
 };
 
 // Base abstract class for patterns used in TupleStructPattern
-class TupleStructItems
+class TupleStructItems : public FullVisitable
 {
 public:
   enum ItemType
@@ -1014,7 +1014,7 @@ protected:
 };
 
 // Base abstract class representing TuplePattern patterns
-class TuplePatternItems
+class TuplePatternItems : public FullVisitable
 {
 public:
   enum TuplePatternItemType
@@ -1035,8 +1035,6 @@ public:
   }
 
   virtual std::string as_string () const = 0;
-
-  virtual void accept_vis (HIRFullVisitor &vis) = 0;
 
   virtual TuplePatternItemType get_pattern_type () const = 0;
 


### PR DESCRIPTION
Minor changes in HIR interface: add missing getters, make some classes
inherit from FullVisitable.

gcc/rust/ChangeLog:

	* hir/tree/rust-hir-expr.h (class ArrayElems): Inherit from FullVisitable.
	(class StructExprField): Likewise.
	* hir/tree/rust-hir-item.h (class WhereClauseItem): Likewise.
	(class UseTree): Likewise.
	(UseTreeRebind::get_path, UseTreeRebind::get_identifier)
	(UseTreeRebind::get_bind_type): New.
	(UseDeclaration::get_use_tree): New.
	(struct TraitFunctionDecl): Change struct to ...
	(class TraitFunctionDecl): ... class.
	(TraitFunctionDecl::get_where_clause): New.
	(StructField::get_outer_attrs): New.
	(struct TupleField): Change struct to ...
	(class TupleField): ... class.
	(TupleField::get_visibility, TupleField::get_outer_attrs): New.
	* hir/tree/rust-hir-pattern.h (class TupleStructItems): Inherit
	from FullVisitable.
	* hir/tree/rust-hir-pattern.h (class TuplePatternItems): Likewise

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>