### PR TITLE
Add location info to `Rust::Identifier`

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -35,8 +35,21 @@ struct MacroExpander;
 class Identifier
 {
 public:
-  Identifier (std::string ident = "")
-    : ident (ident), node_id (Analysis::Mappings::get ()->get_next_node_id ())
+  // Create dummy identifier
+  Identifier ()
+    : ident (""), node_id (Analysis::Mappings::get ()->get_next_node_id ()),
+      loc (Location ())
+  {}
+  // Create identifier with dummy location
+  Identifier (std::string ident, Location loc = Location ())
+    : ident (ident), node_id (Analysis::Mappings::get ()->get_next_node_id ()),
+      loc (loc)
+  {}
+  // Create identifier from token
+  Identifier (const_TokenPtr token)
+    : ident (token->get_str ()),
+      node_id (Analysis::Mappings::get ()->get_next_node_id ()),
+      loc (token->get_locus ())
   {}
 
   Identifier (const Identifier &) = default;
@@ -45,6 +58,7 @@ public:
   Identifier &operator= (Identifier &&) = default;
 
   NodeId get_node_id () const { return node_id; }
+  Location get_locus () const { return loc; }
   const std::string &as_string () const { return ident; }
 
   bool empty () const { return ident.empty (); }
@@ -52,6 +66,7 @@ public:
 private:
   std::string ident;
   NodeId node_id;
+  Location loc;
 };
 
 std::ostream &
@@ -1099,7 +1114,7 @@ public:
   }
 
   // "Error state" if ident is empty, so base stripping on this.
-  void mark_for_strip () override { ident = {}; }
+  void mark_for_strip () override { ident = {""}; }
   bool is_marked_for_strip () const override { return ident.empty (); }
 
   const std::vector<Attribute> &get_outer_attrs () const { return outer_attrs; }

--- a/gcc/rust/ast/rust-pattern.h
+++ b/gcc/rust/ast/rust-pattern.h
@@ -772,7 +772,7 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // based on idea of identifier no longer existing
-  void mark_for_strip () override { ident = {}; }
+  void mark_for_strip () override { ident = {""}; }
   bool is_marked_for_strip () const override { return ident.empty (); }
 
   const Identifier &get_identifier () const { return ident; }

--- a/gcc/rust/checks/lints/rust-lint-scan-deadcode.h
+++ b/gcc/rust/checks/lints/rust-lint-scan-deadcode.h
@@ -60,7 +60,7 @@ public:
 	    if (!implBlock->has_trait_ref ())
 	      {
 		rust_warning_at (
-		  function.get_locus (), 0,
+		  function.get_function_name ().get_locus (), 0,
 		  "associated function is never used: %<%s%>",
 		  function.get_function_name ().as_string ().c_str ());
 	      }
@@ -68,7 +68,8 @@ public:
 	else
 	  {
 	    rust_warning_at (
-	      function.get_locus (), 0, "function is never used: %<%s%>",
+	      function.get_function_name ().get_locus (), 0,
+	      "function is never used: %<%s%>",
 	      function.get_function_name ().as_string ().c_str ());
 	  }
       }

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -687,7 +687,7 @@ public:
 
   // Copy constructor with vector clone
   Module (Module const &other)
-    : VisItem (other), WithInnerAttrs (other.inner_attrs)
+    : VisItem (other), WithInnerAttrs (other.inner_attrs), module_name ("")
   {
     items.reserve (other.items.size ());
     for (const auto &e : other.items)

--- a/gcc/rust/resolve/rust-ast-resolve-item.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-item.cc
@@ -134,6 +134,7 @@ ResolveTraitItems::visit (AST::TraitItemMethod &func)
 
   // self turns into (self: Self) as a function param
   AST::SelfParam &self_param = function.get_self_param ();
+  // FIXME: which location should be used for Rust::Identifier `self`?
   AST::IdentifierPattern self_pattern (self_param.get_node_id (), {"self"},
 				       self_param.get_locus (),
 				       self_param.get_has_ref (),
@@ -648,6 +649,7 @@ ResolveItem::visit (AST::Method &method)
 
   // self turns into (self: Self) as a function param
   AST::SelfParam &self_param = method.get_self_param ();
+  // FIXME: which location should be used for Rust::Identifier `self`?
   AST::IdentifierPattern self_pattern (self_param.get_node_id (), {"self"},
 				       self_param.get_locus (),
 				       self_param.get_has_ref (),
@@ -824,6 +826,7 @@ ResolveItem::visit (AST::Trait &trait)
   resolver->push_new_type_rib (resolver->get_type_scope ().peek ());
 
   // we need to inject an implicit self TypeParam here
+  // FIXME: which location should be used for Rust::Identifier `Self`?
   AST::TypeParam *implicit_self
     = new AST::TypeParam ({"Self"}, trait.get_locus ());
   trait.insert_implict_self (

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.cc
@@ -225,6 +225,7 @@ TypeCheckImplItem::visit (HIR::Function &function)
       // compilation to know parameter names. The types are ignored but we
       // reuse the HIR identifier pattern which requires it
       HIR::SelfParam &self_param = function.get_self_param ();
+      // FIXME: which location should be used for Rust::Identifier for `self`?
       HIR::IdentifierPattern *self_pattern = new HIR::IdentifierPattern (
 	mapping, {"self"}, self_param.get_locus (), self_param.is_ref (),
 	self_param.get_mut (), std::unique_ptr<HIR::Pattern> (nullptr));


### PR DESCRIPTION
Fixes https://github.com/Rust-GCC/gccrs/issues/2333

```
gcc/rust/ChangeLog:

	* ast/rust-ast.h: Modify constructors of `Rust::Identifier`
	* ast/rust-pattern.h: Likewise.
	* hir/tree/rust-hir-item.h: Likewise.
	* parse/rust-parse-impl.h (Parser::parse_macro_rules_def): Likewise.
	(Parser::parse_decl_macro_def): Likewise.
	(Parser::parse_macro_match_fragment): Likewise.
	(Parser::parse_module): Likewise.
	(Parser::parse_use_tree): Likewise.
	(Parser::parse_function): Likewise.
	(Parser::parse_type_param): Likewise.
	(Parser::parse_type_alias): Likewise.
	(Parser::parse_struct): Likewise.
	(Parser::parse_struct_field): Likewise.
	(Parser::parse_enum): Likewise.
	(Parser::parse_enum_item): Likewise.
	(Parser::parse_union): Likewise.
	(Parser::parse_static_item): Likewise.
	(Parser::parse_trait): Likewise.
	(Parser::parse_trait_item): Likewise.
	(Parser::parse_trait_type): Likewise.
	(Parser::parse_trait_const): Likewise.
	(Parser::parse_external_item): Likewise.
	(Parser::parse_generic_args_binding): Likewise.
	(Parser::parse_method): Likewise.
	(Parser::parse_maybe_named_param): Likewise.
	(Parser::parse_identifier_pattern): Likewise.
	(Parser::parse_struct_expr_field): Likewise.
	(ResolveItem::visit): Likewise.
	* typecheck/rust-hir-type-check-implitem.cc (TypeCheckImplItem::visit):Add comments
	* resolve/rust-ast-resolve-item.cc (ResolveTraitItems::visit): Likewise.
	* checks/lints/rust-lint-scan-deadcode.h: Fix error location
```