### PR TITLE
[E0034] Ambiguous Method Call Error

### DIFF
--- a/gcc/rust/typecheck/rust-hir-path-probe.h
+++ b/gcc/rust/typecheck/rust-hir-path-probe.h
@@ -164,7 +164,8 @@ public:
     for (auto &c : candidates)
       r.add_range (c.locus);
 
-    rust_error_at (r, "multiple applicable items in scope for: %s",
+    rust_error_at (r, ErrorCode ("E0034"),
+		   "multiple applicable items in scope for: %s",
 		   query.as_string ().c_str ());
   }
 };


### PR DESCRIPTION
### Ambiguous Method Call Error - [E0034](https://doc.rust-lang.org/error_codes/E0034.html)
Ambiguous Method Call Error - more than one method has the same prototype.


### Code Tested from [E0034](https://doc.rust-lang.org/error_codes/E0034.html):
```rust
// https://doc.rust-lang.org/error_codes/E0034.html
struct Test;

trait Trait1 {
    fn foo();
}

trait Trait2 {
    fn foo();
}

impl Trait1 for Test { fn foo() {} }
impl Trait2 for Test { fn foo() {} }

fn main() {
    Test::foo() // { dg-error "multiple applicable items in scope for: test" } 
    // error, which foo() to call?
}
```
### Output:
```rust
mahad@linux:~/Desktop/mahad/gccrs-build$ gcc/crab1 ../mahad-testsuite/E0034.rs  -frust-incomplete-and-experimental-compiler-do-not-use
../mahad-testsuite/E0034.rs:16:11: error: multiple applicable items in scope for: foo [E0034]
   12 | impl Trait1 for Test { fn foo() {} }
      |                        ~~
   13 | impl Trait2 for Test { fn foo() {} }
      |                        ~~
......
   16 |     Test::foo() // { dg-error "multiple applicable items in scope for: test" }
      |           ^~~
../mahad-testsuite/E0034.rs:16:5: error: Failed to resolve expression of function call
   16 |     Test::foo() // { dg-error "multiple applicable items in scope for: test" }
      |     ^~~~

Analyzing compilation unit

Time variable                                   usr           sys          wall           GGC
 phase setup                        :   0.00 (  0%)   0.00 (  0%)   0.01 (100%)   138k ( 95%)
 TOTAL                              :   0.00          0.00          0.01          146k
Extra diagnostic checks enabled; compiler may run slowly.
Configure with --enable-checking=release to disable checks.
```
### Running TestCases:
- [`gcc/testsuite/rust/compile/generics6.rs`](https://github.com/MahadMuhammad/gccrs/blob/59504756f182bcbeae7c19406694d50c674d6d85/gcc/testsuite/rust/compile/generics6.rs)
```rust
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/generics6.rs:26:23: error: multiple applicable items in scope for: test [E0034]
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/generics6.rs:26:18: error: Failed to resolve expression of function call
compiler exited with status 1
```
---
**gcc/rust/ChangeLog**:

	* typecheck/rust-hir-path-probe.h: called error function

