### PR TITLE
[E0229] associated type bindings error

### DIFF
--- a/gcc/rust/typecheck/rust-tyty-subst.cc
+++ b/gcc/rust/typecheck/rust-tyty-subst.cc
@@ -606,7 +606,8 @@ SubstitutionRef::get_mappings_from_generic_args (HIR::GenericArgs &args)
 	  for (auto &binding : args.get_binding_args ())
 	    r.add_range (binding.get_locus ());
 
-	  rust_error_at (r, "associated type bindings are not allowed here");
+	  rust_error_at (r, ErrorCode ("E0229"),
+			 "associated type bindings are not allowed here");
 	  return SubstitutionArgumentMappings::error ();
 	}
     }


### PR DESCRIPTION
## Associated type binding Error - [E0229](https://doc.rust-lang.org/error_codes/E0229.html)  
Associated type binding outside of type
parameter Declaration and where Clause - [E0229](https://doc.rust-lang.org/error_codes/E0229.html) 

### Code Tested:
```rust
struct Foo<A, B>(A, B);

fn main() {
    let a;
    a = Foo::<A = i32, B = f32>(123f32);
    // { dg-error ErrorCode("E0229") "associated type bindings are not allowed here" "" { target *-*-* } .-1 }
    // { dg-error {Failed to resolve expression of function call} "" { target *-*-* } .-2 }
}
```
### Output:
```rust
mahad@linux:~/Desktop/mahad/gccrs-build$ gcc/crab1 /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/type-bindings1.rs -frust-incomplete-and-experimental-compiler-do-not-use
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/type-bindings1.rs:5:15: error: associated type bindings are not allowed here [E0229]
    5 |     a = Foo::<A = i32, B = f32>(123f32);
      |               ^        ~
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/type-bindings1.rs:5:9: error: Failed to resolve expression of function call
    5 |     a = Foo::<A = i32, B = f32>(123f32);
      |         ^~~

Analyzing compilation unit

Time variable                                   usr           sys          wall           GGC
 TOTAL                              :   0.00          0.00          0.00          146k
Extra diagnostic checks enabled; compiler may run slowly.
Configure with --enable-checking=release to disable checks.

```
**gcc/rust/ChangeLog:**

	* typecheck/rust-tyty-subst.cc (SubstitutionRef::get_mappings_from_generic_args): called error function


