### PR TITLE
gccrs: HIR cleanup

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -1633,7 +1633,7 @@ CompileExpr::visit (HIR::CallExpr &expr)
     return true;
   };
 
-  auto fn_address = CompileExpr::Compile (expr.get_fnexpr (), ctx);
+  auto fn_address = CompileExpr::Compile (expr.get_fnexpr ().get (), ctx);
 
   // is this a closure call?
   bool possible_trait_call
@@ -2227,7 +2227,8 @@ CompileExpr::array_copied_expr (Location expr_locus,
     }
 
   ctx->push_const_context ();
-  tree capacity_expr = CompileExpr::Compile (elems.get_num_copies_expr (), ctx);
+  tree capacity_expr
+    = CompileExpr::Compile (elems.get_num_copies_expr ().get (), ctx);
   ctx->pop_const_context ();
 
   if (!TREE_CONSTANT (capacity_expr))
@@ -2237,7 +2238,8 @@ CompileExpr::array_copied_expr (Location expr_locus,
     }
 
   // get the compiled value
-  tree translated_expr = CompileExpr::Compile (elems.get_elem_to_copy (), ctx);
+  tree translated_expr
+    = CompileExpr::Compile (elems.get_elem_to_copy ().get (), ctx);
 
   tree max_domain = TYPE_MAX_VALUE (domain);
   tree min_domain = TYPE_MIN_VALUE (domain);
@@ -2893,7 +2895,7 @@ CompileExpr::generate_possible_fn_trait_call (HIR::CallExpr &expr,
     }
 
   // need to apply any autoderef's to the self argument
-  HIR::Expr *fnexpr = expr.get_fnexpr ();
+  HIR::Expr *fnexpr = expr.get_fnexpr ().get ();
   HirId autoderef_mappings_id = fnexpr->get_mappings ().get_hirid ();
   std::vector<Resolver::Adjustment> *adjustments = nullptr;
   bool ok = ctx->get_tyctx ()->lookup_autoderef_mappings (autoderef_mappings_id,

--- a/gcc/rust/backend/rust-compile-stmt.cc
+++ b/gcc/rust/backend/rust-compile-stmt.cc
@@ -38,7 +38,7 @@ CompileStmt::Compile (HIR::Stmt *stmt, Context *ctx)
 void
 CompileStmt::visit (HIR::ExprStmt &stmt)
 {
-  translated = CompileExpr::Compile (stmt.get_expr (), ctx);
+  translated = CompileExpr::Compile (stmt.get_expr ().get (), ctx);
 }
 
 void
@@ -60,7 +60,7 @@ CompileStmt::visit (HIR::LetStmt &stmt)
       return;
     }
 
-  tree init = CompileExpr::Compile (stmt.get_init_expr (), ctx);
+  tree init = CompileExpr::Compile (stmt.get_init_expr ().get (), ctx);
   // FIXME use error_mark_node, check that CompileExpr returns error_mark_node
   // on failure and make this an assertion
   if (init == nullptr)

--- a/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
+++ b/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
@@ -493,9 +493,8 @@ PrivacyReporter::visit (HIR::RangeToInclExpr &)
 void
 PrivacyReporter::visit (HIR::ReturnExpr &expr)
 {
-  auto return_expr = expr.get_expr ();
-  if (return_expr)
-    return_expr->accept_vis (*this);
+  if (expr.get_expr ())
+    expr.get_expr ()->accept_vis (*this);
 }
 
 void
@@ -707,13 +706,11 @@ PrivacyReporter::visit (HIR::EmptyStmt &)
 void
 PrivacyReporter::visit (HIR::LetStmt &stmt)
 {
-  auto type = stmt.get_type ();
-  if (type)
-    check_type_privacy (type);
+  if (stmt.get_type ())
+    check_type_privacy (stmt.get_type ().get ());
 
-  auto init_expr = stmt.get_init_expr ();
-  if (init_expr)
-    init_expr->accept_vis (*this);
+  if (stmt.get_init_expr ())
+    stmt.get_init_expr ()->accept_vis (*this);
 }
 
 void

--- a/gcc/rust/checks/errors/rust-const-checker.cc
+++ b/gcc/rust/checks/errors/rust-const-checker.cc
@@ -346,11 +346,10 @@ ConstChecker::check_function_call (HirId fn_id, Location locus)
 void
 ConstChecker::visit (CallExpr &expr)
 {
-  auto fn = expr.get_fnexpr ();
-  if (!fn)
+  if (!expr.get_fnexpr ())
     return;
 
-  NodeId ast_node_id = fn->get_mappings ().get_nodeid ();
+  NodeId ast_node_id = expr.get_fnexpr ()->get_mappings ().get_nodeid ();
   NodeId ref_node_id;
   HirId definition_id;
 

--- a/gcc/rust/checks/errors/rust-unsafe-checker.cc
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.cc
@@ -407,11 +407,10 @@ UnsafeChecker::visit (StructExprStructBase &)
 void
 UnsafeChecker::visit (CallExpr &expr)
 {
-  auto fn = expr.get_fnexpr ();
-  if (!fn)
+  if (!expr.get_fnexpr ())
     return;
 
-  NodeId ast_node_id = fn->get_mappings ().get_nodeid ();
+  NodeId ast_node_id = expr.get_fnexpr ()->get_mappings ().get_nodeid ();
   NodeId ref_node_id;
   HirId definition_id;
 

--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -622,13 +622,11 @@ Dump::visit (LetStmt &let_stmt)
   indentation.increment ();
   stream << indentation;
 
-  auto var_pattern = let_stmt.get_pattern ();
-  stream << var_pattern->as_string ();
+  stream << let_stmt.get_pattern ()->as_string ();
   // return type
   if (let_stmt.has_type ())
     {
-      auto ret_type = let_stmt.get_type ();
-      stream << ": " << ret_type->as_string ();
+      stream << ": " << let_stmt.get_type ()->as_string ();
     }
 
   // init expr
@@ -637,8 +635,7 @@ Dump::visit (LetStmt &let_stmt)
       stream << " = Expr: {\n ";
       indentation.increment ();
       stream << indentation;
-      auto expr = let_stmt.get_init_expr ();
-      expr->accept_vis (*this);
+      let_stmt.get_init_expr ()->accept_vis (*this);
       stream << "\n";
       stream << indentation << "}\n";
       indentation.decrement ();
@@ -651,8 +648,7 @@ Dump::visit (LetStmt &let_stmt)
 void
 Dump::visit (ExprStmt &expr_stmt)
 {
-  auto expr = expr_stmt.get_expr ();
-  expr->accept_vis (*this);
+  expr_stmt.get_expr ()->accept_vis (*this);
 }
 
 void

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -715,6 +715,7 @@ public:
   void accept_vis (HIRStmtVisitor &vis) override;
   void accept_vis (HIRVisItemVisitor &vis) override;
 
+  Identifier get_module_name () const { return module_name; }
   std::vector<std::unique_ptr<Item>> &get_items () { return items; };
 
   /* Override that runs the function recursively on all items contained within
@@ -776,6 +777,8 @@ public:
   Location get_locus () const override final { return locus; }
 
   ItemKind get_item_kind () const override { return ItemKind::ExternCrate; }
+  std::string get_referenced_crate () { return referenced_crate; }
+  std::string get_as_clause_name () { return as_clause_name; }
 
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRStmtVisitor &vis) override;
@@ -859,6 +862,9 @@ public:
   /* Returns whether has path. Should be made redundant by PathType
    * PATH_PREFIXED. */
   bool has_path () const { return !path.is_empty (); }
+
+  PathType get_glob_type () { return glob_type; }
+  AST::SimplePath get_path () { return path; };
 
   std::string as_string () const override;
 
@@ -944,6 +950,10 @@ public:
   std::string as_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
+
+  PathType get_path_type () { return path_type; }
+  AST::SimplePath get_path () { return path; }
+  std::vector<std::unique_ptr<UseTree>> &get_trees () { return trees; }
 
   // TODO: find way to ensure only PATH_PREFIXED path_type has path - factory
   // methods?
@@ -2495,11 +2505,7 @@ public:
 
   std::unique_ptr<Type> &get_type () { return type; }
 
-  std::unique_ptr<Expr> &get_expr ()
-  {
-    rust_assert (has_expr ());
-    return expr;
-  }
+  std::unique_ptr<Expr> &get_expr () { return expr; }
 
   const std::string trait_identifier () const override final
   {

--- a/gcc/rust/hir/tree/rust-hir-pattern.h
+++ b/gcc/rust/hir/tree/rust-hir-pattern.h
@@ -131,6 +131,8 @@ public:
   Location get_locus () const override { return locus; }
 
   bool is_mut () const { return mut == Mutability::Mut; }
+  bool get_is_ref () const { return is_ref; }
+  std::unique_ptr<Pattern> &get_to_bind () { return to_bind; }
 
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRPatternVisitor &vis) override;
@@ -248,6 +250,7 @@ public:
   Location get_locus () const { return locus; }
 
   Literal get_literal () const { return literal; }
+  bool get_has_minus () const { return has_minus; }
 
   void accept_vis (HIRFullVisitor &vis) override;
 
@@ -390,6 +393,8 @@ public:
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRPatternVisitor &vis) override;
 
+  bool get_has_ellipsis_syntax () { return has_ellipsis_syntax; };
+
   Analysis::NodeMapping get_pattern_mappings () const override final
   {
     return mappings;
@@ -524,6 +529,7 @@ public:
 
   Location get_locus () const { return locus; }
   Analysis::NodeMapping get_mappings () const { return mappings; };
+  AST::AttrVec get_outer_attrs () { return outer_attrs; }
 
 protected:
   StructPatternField (Analysis::NodeMapping mappings,
@@ -576,6 +582,9 @@ public:
   std::string as_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
+
+  TupleIndex get_index () { return index; }
+  std::unique_ptr<Pattern> &get_tuple_pattern () { return tuple_pattern; }
 
   ItemType get_item_type () const override final { return ItemType::TUPLE_PAT; }
 
@@ -666,7 +675,7 @@ public:
   void accept_vis (HIRFullVisitor &vis) override;
 
   ItemType get_item_type () const override final { return ItemType::IDENT; }
-
+  bool get_has_ref () const { return has_ref; }
   Identifier get_identifier () const { return ident; };
 
 protected:

--- a/gcc/rust/hir/tree/rust-hir-stmt.h
+++ b/gcc/rust/hir/tree/rust-hir-stmt.h
@@ -138,11 +138,17 @@ public:
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRStmtVisitor &vis) override;
 
-  HIR::Type *get_type () { return type.get (); }
+  const std::vector<AST::Attribute> &get_outer_attrs () const
+  {
+    return outer_attrs;
+  }
+  std::vector<AST::Attribute> &get_outer_attrs () { return outer_attrs; }
 
-  HIR::Expr *get_init_expr () { return init_expr.get (); }
+  std::unique_ptr<HIR::Type> &get_type () { return type; }
 
-  HIR::Pattern *get_pattern () { return variables_pattern.get (); }
+  std::unique_ptr<HIR::Expr> &get_init_expr () { return init_expr; }
+
+  std::unique_ptr<HIR::Pattern> &get_pattern () { return variables_pattern; }
 
   bool is_item () const override final { return false; }
 
@@ -180,7 +186,7 @@ public:
 
   bool is_item () const override final { return false; }
 
-  Expr *get_expr () { return expr.get (); }
+  std::unique_ptr<Expr> &get_expr () { return expr; }
 
   // Copy constructor with clone
   ExprStmt (ExprStmt const &other)

--- a/gcc/rust/hir/tree/rust-hir-type.h
+++ b/gcc/rust/hir/tree/rust-hir-type.h
@@ -64,6 +64,10 @@ public:
     return mappings;
   }
 
+  std::vector<LifetimeParam> &get_for_lifetimes () { return for_lifetimes; }
+  bool get_in_parens () { return in_parens; }
+  bool get_opening_question_mark () { return opening_question_mark; }
+
   BoundType get_bound_type () const final override { return TRAITBOUND; }
 
   TypePath &get_path () { return type_path; }
@@ -131,7 +135,10 @@ public:
   ImplTraitType &operator= (ImplTraitType &&other) = default;
 
   std::string as_string () const override;
-
+  std::vector<std::unique_ptr<TypeParamBound>> &get_type_param_bounds ()
+  {
+    return type_param_bounds;
+  }
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRTypeVisitor &vis) override;
 };
@@ -186,7 +193,7 @@ public:
   TraitObjectType &operator= (TraitObjectType &&other) = default;
 
   std::string as_string () const override;
-
+  bool get_has_dyn () { return has_dyn; }
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRTypeVisitor &vis) override;
 
@@ -263,7 +270,7 @@ public:
      * parenthesised type, it must be in parentheses. */
     return type_in_parens->to_trait_bound (true);
   }
-
+  std::unique_ptr<Type> &get_type_in_parens () { return type_in_parens; }
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRTypeVisitor &vis) override;
 };
@@ -295,7 +302,7 @@ public:
   {}
 
   std::string as_string () const override;
-
+  TraitBound &get_trait_bound () { return trait_bound; }
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRTypeVisitor &vis) override;
 };
@@ -810,6 +817,10 @@ public:
 
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRTypeVisitor &vis) override;
+
+  std::vector<LifetimeParam> &get_for_lifetimes () { return for_lifetimes; }
+  bool get_is_variadic () { return is_variadic; }
+  FunctionQualifiers &get_function_qualifiers () { return function_qualifiers; }
 
   std::vector<MaybeNamedParam> &get_function_params () { return params; }
   const std::vector<MaybeNamedParam> &get_function_params () const

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -260,7 +260,7 @@ protected:
 class ExprWithoutBlock;
 
 // Base expression HIR node - abstract
-class Expr : public Node, public FullVisitable
+class Expr : public Node, virtual public FullVisitable
 {
 public:
   using FullVisitable::accept_vis;
@@ -383,7 +383,7 @@ public:
 };
 
 // Pattern base HIR node
-class Pattern : public Node, public FullVisitable
+class Pattern : public Node, virtual public FullVisitable
 {
 public:
   using FullVisitable::accept_vis;
@@ -750,6 +750,7 @@ public:
 
   bool has_default_expression () { return default_expression != nullptr; }
 
+  std::string get_name () { return name; }
   std::unique_ptr<Type> &get_type () { return type; }
   std::unique_ptr<Expr> &get_default_expression ()
   {

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.cc
@@ -38,7 +38,7 @@ TypeCheckStmt::Resolve (HIR::Stmt *stmt)
 void
 TypeCheckStmt::visit (HIR::ExprStmt &stmt)
 {
-  infered = TypeCheckExpr::Resolve (stmt.get_expr ());
+  infered = TypeCheckExpr::Resolve (stmt.get_expr ().get ());
 }
 
 void
@@ -82,7 +82,7 @@ TypeCheckStmt::visit (HIR::LetStmt &stmt)
   if (stmt.has_init_expr ())
     {
       init_expr_locus = stmt.get_init_expr ()->get_locus ();
-      init_expr_ty = TypeCheckExpr::Resolve (stmt.get_init_expr ());
+      init_expr_ty = TypeCheckExpr::Resolve (stmt.get_init_expr ().get ());
       if (init_expr_ty->get_kind () == TyTy::TypeKind::ERROR)
 	return;
 
@@ -94,7 +94,7 @@ TypeCheckStmt::visit (HIR::LetStmt &stmt)
   Location specified_ty_locus;
   if (stmt.has_type ())
     {
-      specified_ty = TypeCheckType::Resolve (stmt.get_type ());
+      specified_ty = TypeCheckType::Resolve (stmt.get_type ().get ());
       specified_ty_locus = stmt.get_type ()->get_locus ();
     }
 


### PR DESCRIPTION
Some more HIR cleanup.

gcc/rust/ChangeLog:

	* hir/tree/rust-hir-expr.h (BorrowExpr::is_double_borrow): New.
	(StructExprStructFields::get_struct_base): New.
	(MethodCallExpr::has_params): New.
	(ClosureExpr::has_params): New.
	(BlockExpr::get_inner_attrs): New.
	(WhileLoopExpr::get_patterns): New.
	(ForLoopExpr::get_pattern): New.
	(IfLetExpr::get_if_block): Return ref to unique_ptr.
	(IfLetExprConseqElse::get_else_block): Likewise.
	(MatchExpr::get_inner_attrs): New.
	* hir/tree/rust-hir-item.h (Module::get_module_name): New.
	(ExternCrate::get_referenced_crate)
	(ExternCrate::get_as_clause_name): New.
	(UseTreeGlob::get_glob_type, UseTreeGlob::get_path): New.
	(UseTreeList::get_path_type, UseTreeList::get_path)
	(UseTreeList::get_trees): New.
	* hir/tree/rust-hir-pattern.h (IdentifierPattern::get_is_ref)
	(IdentifierPattern::get_to_bind): New.
	(RangePatternBoundType::get_has_minus): New.
	(RangePattern::get_has_ellipsis_syntax): New.
	(StructPatternField::get_outer_attrs): New.
	(StructPatternFieldTuplePat::get_index)
	(StructPatternFieldTuplePat::get_tuple_pattern): New.
	(StructPatternFieldIdent::get_has_ref): New.
	* hir/tree/rust-hir-stmt.h (LetStmt::get_outer_attrs): New.
	* hir/tree/rust-hir-type.h (TraitBound::get_for_lifetimes): New.
	(TraitBound::get_in_params): New.
	(TraitBound::get_opening_question_mark): New.
	(ImplTraitType::get_type_param_bounds): New.
	(TraitObjectType::get_has_dyn): New.
	(TraitBound::get_type_in_parens): New.
	(ImplTraitTypeOneBound::get_trait_bound): New.
	(BareFunctionType::get_for_lifetimes)
	(BareFunctionType::get_is_variadic)
	(BareFunctionType::get_function_qualifiers): New.
	* hir/tree/rust-hir.h (class Expr): Virtual inherit from FullVisitable.
	(class Pattern): Likewise.
	(ConstGenericParam::get_name): New.
	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::visit): Adjust call.
	* backend/rust-compile-expr.cc (CompileExpr::visit): Adjust call.
	(CompileExpr::array_copied_expr): Likewise.
	(CompileExpr::generate_possible_fn_trait_call): Likewise.
	* backend/rust-compile-stmt.cc (CompileStmt::visit): Likewise.
	* checks/errors/privacy/rust-privacy-reporter.cc (PrivacyReporter::visit): Likewise.
	* checks/errors/rust-const-checker.cc (ConstChecker::visit): Likewise.
	* checks/errors/rust-unsafe-checker.cc (UnsafeChecker::visit): Likewise.
	* hir/rust-hir-dump.cc (Dump::visit): Likewise.
	* hir/tree/rust-hir-expr.h (ArrayElemsCopied::get_elem_to_copy)
	(ArrayElemsCopied::get_num_copies_expr): Return unique_ptr.
	(CallExpr::get_fnexpr): Likewise.
	(ReturnExpr::get_expr): Likewise.
	* hir/tree/rust-hir-item.h (TraitItemKind::get_expr): Remove
	assert. unique_ptr can be "empty". Must be checked in caller.
	* hir/tree/rust-hir-stmt.h (LetStmt::get_type)
	(LetStmt::get_init_expr, LetStmt::get_pattern): Return unique_ptr.
	(ExprStmt::get_expr): Likewise.
	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::visit): Adjust call.
	(TypeCheckExpr::resolve_fn_trait_call): Likewise.
	* typecheck/rust-hir-type-check-stmt.cc (TypeCheckStmt::visit): Likewise.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>