### PR TITLE
[E0061]  Refactored argument mismatch error function

### DIFF
--- a/gcc/testsuite/rust/compile/func2.rs
+++ b/gcc/testsuite/rust/compile/func2.rs
@@ -3,5 +3,5 @@ fn test(a: i32, b: i32) -> i32 {
 }
 
 fn main() {
-    let a = test(1); // { dg-error "unexpected number of arguments 1 expected 2" }
+    let a = test(1); // { dg-error "this function takes 2 arguments but 1 argument was supplied" }
 }

--- a/gcc/testsuite/rust/compile/tuple_struct2.rs
+++ b/gcc/testsuite/rust/compile/tuple_struct2.rs
@@ -1,5 +1,5 @@
 struct Bar(i32, i32, bool);
 
 fn main() {
-    let a = Bar(1, 2); // { dg-error "unexpected number of arguments 2 expected 3" }
+    let a = Bar(1, 2); // { dg-error "this function takes 3 arguments but 2 arguments were supplied" }
 }

--- a/gcc/testsuite/rust/compile/wrong_no_of_parameters.rs
+++ b/gcc/testsuite/rust/compile/wrong_no_of_parameters.rs
@@ -1,0 +1,9 @@
+// https://doc.rust-lang.org/error_codes/E0061.html
+fn main() {
+    fn f(u: i32) {}
+    fn T(u: i32, v: i32, w: i32, x: i32, y: i32, z: i32) {}
+
+    f(); // { dg-error "this function takes 1 argument but 0 arguments were supplied" }
+
+    T(1, 2, 3, 4, 5, 6, 7, 8, 9); // { dg-error "this function takes 6 arguments but 9 arguments were supplied" }
+}


### PR DESCRIPTION
## Argument Mismatch [Error-E0061](https://doc.rust-lang.org/error_codes/E0061.html) 
- Refactored argument mismatch error into one function `emit_unexpected_argument_error`.
- Changed unexpected argument message to similiar to rustc.
- You can view the same on [`compiler-explorer`](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DEArgoKkl9ZATwDKjdAGFUtEywYSAHKUcAZPAZMADl3ACNMYhAANlIAB1QFQjsGFzcPb3jE5IEAoNCWCKjYq0wbFKECJmICNPdPLh9S8oFK6oI8kPDImMsqmrqMxr72zoKimIBKS1QTYmR2DioGAGoCTHMIJhAVvABmACZSFbCd/YPJlYBaAFI97F3DlZuAdgAhG40AQRXflaZngc3idPl9XgARUGg5YrFhMQIQS6vD7fP4regEf7PPbgtYbAiIu7AgD0xOe7xW6GAV0ixBIgIOBAQeAUKyoJgYLVWVQA1hsVgd/sRgO5GARWWETJiuEKRWxBKyAO5MVkKExxOK0PCYdA3A6CiFQl6Q74caa0TgAVl4ng4WlIqE4ACUzJiFLN5phAXseKQCJozdMeSADpaAHTRLxeDQvPZ7ACckkkia40Ut%2Bk4khtAYdnF4ChAGj9AemcFgMEQKFQLDidEi5EoaBrdaiwGQyGICiuCmYcQUCFQFiwADc8AsAGraxUAeTijE4vpotHWncopztvDCgWqAE8F5vt8Qd9Owtoyv7uLwm/KCNOGLQ9xvSFhJcAnGJaAXL8/MHCjOIn3wYhzzwYcNhzTBVDKKVFl9QJ1gtJ8tTCYhdxcLAcwIYg8BYfdpioAxgAUSdMBnOdbUXWQRDEdgpBkQRFBUdQn10Lh9EMYxXX0PAwgLSBplQOJbAEL9eFQMDiGwrA%2BKgZg2BAHUcgYUhhzEExFgODQDh4SZpmaYTPAgRxBgaXwGHQMZuiiNiEiSAyTL0WylMswoejY/SKn6WpXHqPQPNaLyXImdyvIckLRkCLpXOsvSPQWCRzStbMn0dDgVlULxoiuaJJBWABxJwnCdIQVggAqipKuFzEiS4IFwQh6T1H1Jl4C8tF00hg0tItEKzUhcOTMMvEtaJtNTPZog0Yb41iW17VS/NC2LDdSwrCAkFmAg4ilBsICbWt6GIYJWEWUxzGQFYuAjLww3tRSiCkvR%2BEEajxDo575CUNQc1Y0hFVQuI8IzDhrVIOaxM4acpW2zFUCodLMuy3LyuK0qUcqlUV1qlxm0O70uBa5b2sSjg%2Btw7qwykPYXijCaEykDRpHB3MOEWos2sDTqQxurx43jKbQ0jaMaa4F5gb2ZL5rzImzVIMsoDWpB9pbXblcOkBiCkfmf1HCcp1nedvyXFcCwgdd7S3Zgj33UhLd3E8zxsG3rzFO8HxzF8TDfD8v19LA/2AAD7SAkCwK/O6oOQGCbfgzBEPtZDUKPdDFntLCcKBgimCIkiyMNyiXtEN7pA%2BxjvpYkN2KMDWuOQmSBKElJRIdCSpPA/jLDjkD7CM8ywrMizIvGNysjslJ%2B6cgygpH/yGDaAYfKGTvrAM%2BeOiHqy/NCxfTPMCL8k3gmZjmeKj8Q0HmdSlYzoIC6rsGjRSvqh78cJjmOoQTAmCwKJES5rgNA9UzLwcmRZL7SwLOzEsctFYgE2jDVW1YDqRGOvJDgGUso5XyoVVGZUcEY2qsQQm90SB4HQE9KiRdaIl1kGXZi9pdBHH%2BkwQGl4SYXxzKlKGW0pQrDhtfV0d8wwP1KjjZBxBvQXFaiWaYn9v49D/sGABQDSYgJAN1MGnCIFLXfkGEAkhwySC4AcLwSYNATWiPGaMjNxaSwhqzGWHVEIHDsSzaRK1pgSSSPYSQQA%3D%3D%3D):
```diff
- unexpected number of arguments x expected y [E0061]
+ this function takes y arguments but x arguments were supplied [E0061]
```
---
### Code Tested:
- [`rust/compile/func2.rs`](https://github.com/MahadMuhammad/gccrs/blob/3d3d4f7c54b24387e19548ab706ba401c2e073ff/gcc/testsuite/rust/compile/func2.rs)
- [`rust/compile/tuple_struct2.rs`](https://github.com/MahadMuhammad/gccrs/blob/3d3d4f7c54b24387e19548ab706ba401c2e073ff/gcc/testsuite/rust/compile/tuple_struct2.rs)
- [`rust/compile/unexpected_arguments.rs`](https://github.com/MahadMuhammad/gccrs/blob/3d3d4f7c54b24387e19548ab706ba401c2e073ff/gcc/testsuite/rust/compile/unexpected_arguments.rs)
```rust
// https://doc.rust-lang.org/error_codes/E0061.html
fn main() {
    fn f(u: i32) {}
    fn T(u: i32, v: i32, w: i32, x: i32, y: i32, z: i32) {}

    f(); // { dg-error "this function takes 1 argument but 0 arguments were supplied" }

    T(1, 2, 3, 4, 5, 6, 7, 8, 9); // { dg-error "this function takes 6 arguments but 9 arguments were supplied" }
}
```
---
## Output:
```rust
/gccrs/gcc/testsuite/rust/compile/func2.rs:6:13: error: this function takes 2 arguments but 1 arguments were supplied [E0061]
compiler exited with status 1

/gccrs/gcc/testsuite/rust/compile/tuple_struct2.rs:4:13: error: this function takes 3 arguments but 2 arguments were supplied [E0061]
compiler exited with status 1

/gccrs/gcc/testsuite/rust/compile/unexpected_arguments.rs:6:5: error: this function takes 1 arguments but 0 arguments were supplied [E0061]
/gccrs/gcc/testsuite/rust/compile/unexpected_arguments.rs:7:5: error: this function takes 6 arguments but 9 arguments were supplied [E0061]
compiler exited with status 1


```
---
**gcc/rust/ChangeLog:**

	* typecheck/rust-tyty-call.cc (emit_unexpected_argument_error): Refactored invalid number of argument into one function. (TypeCheckCallExpr::visit): called refactored function. (TypeCheckMethodCallExpr::check): called refactored function.

**gcc/testsuite/ChangeLog:**

	* rust/compile/func2.rs: updated comment to pass new test cases.
	* rust/compile/tuple_struct2.rs: updated comment.
	* rust/compile/unexpected_arguments.rs: Added new test.

---