### PR TITLE
Add utf-8 validation for input source

### DIFF
--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -167,6 +167,12 @@ Lexer::~Lexer ()
   // line_map->stop();
 }
 
+bool
+Lexer::input_source_is_valid_utf8 ()
+{
+  return raw_input_source->is_valid ();
+}
+
 /* TODO: need to optimise somehow to avoid the virtual function call in the
  * tight loop. Best idea at the moment is CRTP, but that might make lexer
  * implementation annoying when storing the "base class" (i.e. would need

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -497,6 +497,14 @@ Session::compile_crate (const char *filename)
 
   Lexer lex (filename, std::move (file_wrap), linemap, dump_lex_opt);
 
+  if (!lex.input_source_is_valid_utf8 ())
+    {
+      rust_error_at (Linemap::unknown_location (),
+		     "cannot read %s; stream did not contain valid UTF-8",
+		     filename);
+      return;
+    }
+
   Parser<Lexer> parser (lex);
 
   // generate crate from parser

--- a/gcc/testsuite/rust/compile/broken_utf8.rs
+++ b/gcc/testsuite/rust/compile/broken_utf8.rs
@@ -1,0 +1,2 @@
+// { dg-excess-errors "stream did not contain valid UTF-8" }
+ÿ


### PR DESCRIPTION
Addresses https://github.com/Rust-GCC/gccrs/issues/2287
```
gcc/rust/ChangeLog:

	* lex/rust-lex.cc (Lexer::input_source_is_valid_utf8): New method of `Lexer`.
	* lex/rust-lex.h: Likewise.
	* rust-session-manager.cc (Session::compile_crate): Add error.

gcc/testsuite/ChangeLog:

	* rust/compile/broken_utf8.rs: New test.
```