### PR TITLE
[E0046] Missing Items in Trait Implementation

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-item.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.cc
@@ -659,7 +659,8 @@ TypeCheckItem::validate_trait_impl_block (
 	      r.add_range (missing_trait_item.get_locus ());
 	    }
 
-	  rust_error_at (r, "missing %s in implementation of trait %<%s%>",
+	  rust_error_at (r, ErrorCode ("E0046"),
+			 "missing %s in implementation of trait %<%s%>",
 			 missing_items_buf.c_str (),
 			 trait_reference->get_name ().c_str ());
 	}


### PR DESCRIPTION
## Missing Items in Trait Implementation
missing foo in implementation of trait 'Foo'

### Code Tested from [`E0046`](https://doc.rust-lang.org/error_codes/E0046.html)
```rust
// https://doc.rust-lang.org/error_codes/E0046.html
trait Foo {
    fn foo();
}

struct Bar;

impl Foo for Bar {}
// error: not all trait items implemented, missing: `foo`
```
---
### Output:
```rust
➜  gccrs-build gcc/crab1 -frust-incomplete-and-experimental-compiler-do-not-use ../mahad-testsuite/E0046.rs
../mahad-testsuite/E0046.rs:9:1: error: missing foo in implementation of trait ‘Foo’ [E0046]
    4 |     fn foo();
      |     ~~
......
    9 | impl Foo for Bar {}
      | ^~~~

Analyzing compilation unit

Time variable                                   usr           sys          wall           GGC
 TOTAL                              :   0.00          0.00          0.00          146k
Extra diagnostic checks enabled; compiler may run slowly.
Configure with --enable-checking=release to disable checks.
```
---
### Running testcases:
- [`rust/compile/traits4.rs`](https://github.com/Rust-GCC/gccrs/blob/5406b633a1f5e6e3ae8da02589adf4ea003dec12/gcc/testsuite/rust/compile/traits4.rs)
- [`rust/compile/traits5.rs`](https://github.com/Rust-GCC/gccrs/blob/5406b633a1f5e6e3ae8da02589adf4ea003dec12/gcc/testsuite/rust/compile/traits5.rs)

```rust
/gccrs/gcc/testsuite/rust/compile/traits4.rs:8:1: error: missing A in implementation of trait 'Foo' [E0046]
compiler exited with status 1

/gccrs/gcc/testsuite/rust/compile/traits5.rs:8:1: error: missing A, test in implementation of trait 'Foo' [E0046]
compiler exited with status 1
```
---
gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-item.cc: called error function.
