### PR TITLE
[E0053] method 'x' has an incompatible type for trait 'y'

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.cc
@@ -528,7 +528,7 @@ TypeCheckImplItemWithTrait::visit (HIR::Function &function)
       RichLocation r (function.get_locus ());
       r.add_range (resolved_trait_item.get_locus ());
 
-      rust_error_at (r,
+      rust_error_at (r, ErrorCode ("E0053"),
 		     "method %<%s%> has an incompatible type for trait %<%s%>",
 		     function.get_function_name ().as_string ().c_str (),
 		     trait_reference.get_name ().c_str ());


### PR DESCRIPTION
The parameters of any trait method must match between a trait implementation and the trait definition

### Code tested from [`E0053`](https://doc.rust-lang.org/error_codes/E0053.html)
```rust
#![allow(unused)]
fn main() {
trait Foo {
    fn foo(x: u16);
    fn bar(&self);
}

struct Bar;

impl Foo for Bar {
    // error, expected u16, found i16
    fn foo(x: i16) { }

    // error, types differ in mutability
    fn bar(&mut self) { }
}
}
```
### Output:
```rust
➜  gccrs-build gcc/crab1 -frust-incomplete-and-experimental-compiler-do-not-use ../mahad-testsuite/E0053.rs
../mahad-testsuite/E0053.rs:12:5: error: expected ‘fn<Bar> (x u16,) -> ()’ got ‘fn (x i16,) -> ()’
    4 |     fn foo(x: u16);
      |     ~~
......
   12 |     fn foo(x: i16) { }
      |     ^~
../mahad-testsuite/E0053.rs:12:5: error: method ‘foo’ has an incompatible type for trait ‘Foo’ [E0053]
    4 |     fn foo(x: u16);
      |     ~~
......
   12 |     fn foo(x: i16) { }
      |     ^~

Analyzing compilation unit

Time variable                                   usr           sys          wall           GGC
 TOTAL                              :   0.00          0.00          0.00          146k
Extra diagnostic checks enabled; compiler may run slowly.
Configure with --enable-checking=release to disable checks.
```
---
### Running testcases:
- [`rust/compile/issue-2037.rs`](https://github.com/MahadMuhammad/gccrs/blob/E0053/gcc/testsuite/rust/compile/issue-2037.rs)
- [`rust/compile/traits2.rs`](https://github.com/MahadMuhammad/gccrs/blob/E0053/gcc/testsuite/rust/compile/traits2.rs)
- [`rust/compile/traits3.rs`](https://github.com/MahadMuhammad/gccrs/blob/E0053/gcc/testsuite/rust/compile/traits3.rs)
```rust
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/issue-2037.rs:8:5: error: expected 'fn<Baz> (ref mut self &mut Self=Baz{Baz {}},other &mut dyn [HIR Trait: Foo->[C: 0 Nid: 19 Hid: 30 Lid: 6] [(FN bar ), ]<Self>],) -> ()' got 'fn (ref mut self &mut Baz{Baz {}},other & dyn [HIR Trait: Foo->[C: 0 Nid: 19 Hid: 30 Lid: 6] [(FN bar ), ]<Self>],) -> ()'
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/issue-2037.rs:8:5: error: method 'bar' has an incompatible type for trait 'Foo' [E0053]
compiler exited with status 1

/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/traits2.rs:2:5: error: expected 'i32' got '()'
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/traits2.rs:9:5: error: expected 'fn<Baz> () -> i32' got 'fn () -> ()'
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/traits2.rs:9:5: error: method 'Bar' has an incompatible type for trait 'Foo' [E0053]
compiler exited with status 1

/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/traits3.rs:12:5: error: expected 'fn<Bar<T>> (a <placeholder:<Projection=<T>::i32>>,) -> <placeholder:<Projection=<T>::i32>>' got 'fn<T> (a f32,) -> f32'
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/traits3.rs:12:5: error: method 'baz' has an incompatible type for trait 'Foo' [E0053]
compiler exited with status 1
```
gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-implitem.cc (TypeCheckImplItemWithTrait::visit): called error function
