### PR TITLE
[E0425] Use of unresolved name

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-expr.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.cc
@@ -173,7 +173,8 @@ ResolveExpr::visit (AST::IdentifierExpr &expr)
     }
   else
     {
-      rust_error_at (expr.get_locus (), "failed to find name: %s",
+      rust_error_at (expr.get_locus (), ErrorCode ("E0425"),
+		     "cannot find value %qs in this scope",
 		     expr.as_string ().c_str ());
     }
 }

--- a/gcc/testsuite/rust/compile/break-rust2.rs
+++ b/gcc/testsuite/rust/compile/break-rust2.rs
@@ -1,4 +1,4 @@
 fn main() {
     break (rust);
-    // { dg-error "failed to find name: rust" "" { target *-*-* } .-1 }
+    // { dg-error "cannot find value .rust. in this scope" "" { target *-*-* } .-1 }
 }

--- a/gcc/testsuite/rust/compile/const_generics_3.rs
+++ b/gcc/testsuite/rust/compile/const_generics_3.rs
@@ -4,7 +4,7 @@ const M: usize = 4;
 
 struct Foo<T, const N: usize = 1> {
     // FIXME: This error is bogus. But having it means parsing is valid!
-    value: [i32; N], // { dg-error "failed to find name: N" }
+    value: [i32; N], // { dg-error "cannot find value .N. in this scope" }
 }
 
 fn main() {

--- a/gcc/testsuite/rust/compile/const_generics_4.rs
+++ b/gcc/testsuite/rust/compile/const_generics_4.rs
@@ -2,6 +2,6 @@
 
 const P: usize = 14;
 
-struct Foo<const N: usize = { M }>; // { dg-error "failed to find name: M" }
+struct Foo<const N: usize = { M }>; // { dg-error "cannot find value .M. in this scope" }
 struct Bar<const N: usize = { P }>;
 struct Baz<const N: NotAType = { P }>; // { dg-error "failed to resolve TypePath: NotAType in this scope" }

--- a/gcc/testsuite/rust/compile/not_find_value_in_scope.rs
+++ b/gcc/testsuite/rust/compile/not_find_value_in_scope.rs
@@ -1,0 +1,7 @@
+// https://doc.rust-lang.org/error_codes/E0425.html
+fn main() {
+    let f = x * x * 3; // { dg-error "cannot find value .x. in this scope" }
+    let a = f(); // invalid, too few parameters
+    let b = f(4); // this works!
+    let c = f(2, 3); // invalid, too many parameters
+}


### PR DESCRIPTION
## Use of unresolved name
- Refactored error message similiar to rustc [`E0425`](https://doc.rust-lang.org/error_codes/E0425.html)
---
### Code Tested & Running test cases:
- [`rust/compile/break-rust2.rs`](https://github.com/Rust-GCC/gccrs/blob/962364f07687e378abd892fdcc46b41ae725214e/gcc/testsuite/rust/compile/break-rust2.rs)
- [`rust/compile/const_generics_3.rs`](https://github.com/Rust-GCC/gccrs/blob/962364f07687e378abd892fdcc46b41ae725214e/gcc/testsuite/rust/compile/const_generics_3.rs)
- [`rust/compile/const_generics_4.rs`](https://github.com/Rust-GCC/gccrs/blob/962364f07687e378abd892fdcc46b41ae725214e/gcc/testsuite/rust/compile/const_generics_4.rs)
- [`rust/compile/unresolved_name.rs:`](https://github.com/Rust-GCC/gccrs/blob/962364f07687e378abd892fdcc46b41ae725214e/gcc/testsuite/rust/compile/unresolved_name.rs)
```rust
// https://doc.rust-lang.org/error_codes/E0057.html modified version of this code
fn main() {
    let f = x * x * 3; // { dg-error "cannot find value `x` in this scope" }
    let a = f(); // invalid, too few parameters
    let b = f(4); // this works!
    let c = f(2, 3); // invalid, too many parameters
}
```
---
### Output:
```rust
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/break-rust2.rs:2:12: error: cannot find value `rust` in this scope [E0425]
compiler exited with status 1

/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/const_generics_3.rs:7:18: error: cannot find value `N` in this scope [E0425]
compiler exited with status 1

/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/const_generics_4.rs:5:31: error: cannot find value `M` in this scope [E0425]
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/const_generics_4.rs:7:21: error: failed to resolve TypePath: NotAType in this scope
compiler exited with status 1

/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/unresolved_name.rs:3:13: error: cannot find value `x` in this scope [E0425]
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/unresolved_name.rs:3:17: error: cannot find value `x` in this scope [E0425]
compiler exited with status 1
```
---

**gcc/rust/ChangeLog**:

	* resolve/rust-ast-resolve-expr.cc (ResolveExpr::visit):
	called error function and changed error message
	similiar to rustc

**gcc/testsuite/ChangeLog**:

	* rust/compile/break-rust2.rs: Updated comment to pass testcase.
	* rust/compile/const_generics_3.rs: likewise.
	* rust/compile/const_generics_4.rs: likewise.
	* rust/compile/unresolved_name.rs: New test.
