### PR TITLE
[E0063] constructor is missing fields

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-struct.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-struct.cc
@@ -149,7 +149,7 @@ TypeCheckStructExpr::resolve (HIR::StructExprStructFields &struct_expr)
 	}
       else if (!struct_expr.has_struct_base ())
 	{
-	  rust_error_at (struct_expr.get_locus (),
+	  rust_error_at (struct_expr.get_locus (), ErrorCode ("E0063"),
 			 "constructor is missing fields");
 	  return;
 	}

--- a/gcc/testsuite/rust/compile/missing_constructor_fields.rs
+++ b/gcc/testsuite/rust/compile/missing_constructor_fields.rs
@@ -1,0 +1,10 @@
+// https://doc.rust-lang.org/error_codes/E0063.html
+struct Foo {
+    x: i32,
+    y: i32,
+    z: i32,
+}
+
+fn main() {
+    let x = Foo { x: 0 , y:1 }; // { dg-error "constructor is missing fields" }
+}


### PR DESCRIPTION
## Constructor is missing fields - [`E0063`](https://doc.rust-lang.org/error_codes/E0063.html)

Added error code for Missing Field in
struct or struct-like enum variant.

---
### Tested Code From [`E0063`](https://doc.rust-lang.org/error_codes/E0063.html)
```rust
// https://doc.rust-lang.org/error_codes/E0063.html
struct Foo {
    x: i32,
    y: i32,
    z: i32,
}

fn main() {
    let x = Foo { x: 0 , y:1 }; // { dg-error "constructor is missing fields" }
}
```
---
### Output:
```rust
➜  gccrs-build gcc/crab1 /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/missing_constructor_fields.rs
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/missing_constructor_fields.rs:9:13: error: constructor is missing fields [E0063]
    9 |     let x = Foo { x: 0 , y:1 }; // { dg-error "constructor is missing fields" }
      |             ^~~

Analyzing compilation unit

Time variable                                   usr           sys          wall           GGC
 TOTAL                              :   0.00          0.00          0.00          146k
Extra diagnostic checks enabled; compiler may run slowly.
Configure with --enable-checking=release to disable checks.
```

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-struct.cc (TypeCheckStructExpr::resolve): called error function.

gcc/testsuite/ChangeLog:

	* rust/compile/missing_constructor_fields.rs: New test.
