### PR TITLE
[E0070] invalid left-hand side of assignment

### DIFF
--- a/gcc/rust/resolve/rust-ast-verify-assignee.h
+++ b/gcc/rust/resolve/rust-ast-verify-assignee.h
@@ -35,7 +35,7 @@ public:
     VerifyAsignee checker;
     assignee->accept_vis (checker);
     if (!checker.ok)
-      rust_error_at (assignee->get_locus (),
+      rust_error_at (assignee->get_locus (), ErrorCode ("E0070"),
 		     "invalid left-hand side of assignment");
     return checker.ok;
   }

--- a/gcc/testsuite/rust/compile/wrong_lhs_assignment.rs
+++ b/gcc/testsuite/rust/compile/wrong_lhs_assignment.rs
@@ -1,0 +1,7 @@
+fn foo() {
+    1 = 3; // { dg-error "invalid left-hand side of assignment" }
+}
+
+fn main() {
+    foo();
+}


### PR DESCRIPTION
## [`E0070`](https://doc.rust-lang.org/error_codes/E0070.html) invalid left-hand side of assignment
-  Added error code support for an assignment operator which was used on a non-place expression.

---

### Code Tested:
```rust
fn foo() {
    1 = 3; // { dg-error "invalid left-hand side of assignment" }
}

fn main() {
    foo();
}
```

---

### Output:
```rust
gccrs/gcc/testsuite/rust/compile/wrong_lhs_assignment.rs:4:5: error: invalid left-hand side of assignment [E0070]
compiler exited with status 1
PASS: rust/compile/wrong_lhs_assignment.rs  (test for errors, line 4)
```


---

**gcc/rust/ChangeLog:**

	* resolve/rust-ast-verify-assignee.h: called error function.

**gcc/testsuite/ChangeLog:**

	* rust/compile/wrong_lhs_assignment.rs: New test.

---
