### PR TITLE
Add ```rust_error_at``` accepting ```location_t``` and ```ErrorCode```

### DIFF
--- a/gcc/rust/rust-diagnostics.cc
+++ b/gcc/rust/rust-diagnostics.cc
@@ -213,6 +213,28 @@ private:
 };
 
 void
+rust_be_error_at (const Location location, const ErrorCode code,
+		  const std::string &errmsg)
+{
+  rich_location gcc_loc (line_table, location);
+  diagnostic_metadata m;
+  rust_error_code_rule rule (code);
+  m.add_rule (rule);
+  error_meta (&gcc_loc, m, "%s", errmsg.c_str ());
+}
+
+void
+rust_error_at (const Location location, const ErrorCode code, const char *fmt,
+	       ...)
+{
+  va_list ap;
+
+  va_start (ap, fmt);
+  rust_be_error_at (location, code, expand_message (fmt, ap));
+  va_end (ap);
+}
+
+void
 rust_be_error_at (const RichLocation &location, const ErrorCode code,
 		  const std::string &errmsg)
 {

--- a/gcc/rust/rust-diagnostics.h
+++ b/gcc/rust/rust-diagnostics.h
@@ -70,6 +70,9 @@ extern void
 rust_error_at (const Location, const char *fmt, ...)
   RUST_ATTRIBUTE_GCC_DIAG (2, 3);
 extern void
+rust_error_at (const Location, const ErrorCode, const char *fmt, ...)
+  RUST_ATTRIBUTE_GCC_DIAG (3, 4);
+extern void
 rust_warning_at (const Location, int opt, const char *fmt, ...)
   RUST_ATTRIBUTE_GCC_DIAG (3, 4);
 extern void
@@ -109,6 +112,9 @@ rust_be_internal_error_at (const Location, const std::string &errmsg)
   RUST_ATTRIBUTE_NORETURN;
 extern void
 rust_be_error_at (const Location, const std::string &errmsg);
+extern void
+rust_be_error_at (const Location, const ErrorCode,
+		  const std::string &errmsg);
 extern void
 rust_be_error_at (const RichLocation &, const std::string &errmsg);
 extern void


### PR DESCRIPTION
Assuming we want to get rid of the ```RichLocation``` wrapper along with the ```Location``` wrapper, this removes a dependency on ```RichLocation```'s converting constructor (which allows ```Location``` to be implicitly cast to ```RichLocation```).