### PR TITLE
gccrs: minor HIR cleanup

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -597,15 +597,10 @@ public:
   void accept_vis (HIRExpressionVisitor &vis) override;
 
   // FIXME: isn't it the same as get_expr() from parent?
-  std::unique_ptr<Expr> &get_casted_expr ()
-  {
-    rust_assert (main_or_left_expr != nullptr);
-    return main_or_left_expr;
-  }
+  std::unique_ptr<Expr> &get_casted_expr () { return main_or_left_expr; }
 
   std::unique_ptr<Type> &get_type_to_convert_to ()
   {
-    rust_assert (type_to_convert_to != nullptr);
     return type_to_convert_to;
   }
 
@@ -739,17 +734,9 @@ public:
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRExpressionVisitor &vis) override;
 
-  std::unique_ptr<Expr> &get_left_expr ()
-  {
-    rust_assert (main_or_left_expr != nullptr);
-    return main_or_left_expr;
-  }
+  std::unique_ptr<Expr> &get_left_expr () { return main_or_left_expr; }
 
-  std::unique_ptr<Expr> &get_right_expr ()
-  {
-    rust_assert (right_expr != nullptr);
-    return right_expr;
-  }
+  std::unique_ptr<Expr> &get_right_expr () { return right_expr; }
 
   void visit_lhs (HIRFullVisitor &vis) { main_or_left_expr->accept_vis (vis); }
   void visit_rhs (HIRFullVisitor &vis) { right_expr->accept_vis (vis); }
@@ -809,11 +796,7 @@ public:
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRExpressionVisitor &vis) override;
 
-  std::unique_ptr<Expr> &get_expr_in_parens ()
-  {
-    rust_assert (expr_in_parens != nullptr);
-    return expr_in_parens;
-  }
+  std::unique_ptr<Expr> &get_expr_in_parens () { return expr_in_parens; }
 
   ExprType get_expression_type () const override final
   {
@@ -1258,11 +1241,7 @@ public:
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRExpressionVisitor &vis) override;
 
-  std::unique_ptr<Expr> &get_tuple_expr ()
-  {
-    rust_assert (tuple_expr != nullptr);
-    return tuple_expr;
-  }
+  std::unique_ptr<Expr> &get_tuple_expr () { return tuple_expr; }
 
   ExprType get_expression_type () const override final
   {
@@ -1947,11 +1926,7 @@ public:
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRExpressionVisitor &vis) override;
 
-  std::unique_ptr<Expr> &get_receiver_expr ()
-  {
-    rust_assert (receiver != nullptr);
-    return receiver;
-  }
+  std::unique_ptr<Expr> &get_receiver_expr () { return receiver; }
 
   Identifier get_field_name () const { return field; }
 
@@ -2041,17 +2016,9 @@ public:
   }
   std::vector<AST::Attribute> &get_outer_attrs () { return outer_attrs; }
 
-  std::unique_ptr<Pattern> &get_pattern ()
-  {
-    rust_assert (pattern != nullptr);
-    return pattern;
-  }
+  std::unique_ptr<Pattern> &get_pattern () { return pattern; }
 
-  std::unique_ptr<Type> &get_type ()
-  {
-    rust_assert (has_type_given ());
-    return type;
-  }
+  std::unique_ptr<Type> &get_type () { return type; }
 
   Location get_locus () const { return locus; }
 };
@@ -2119,11 +2086,7 @@ public:
 
   bool has_return_type () const { return return_type != nullptr; }
 
-  std::unique_ptr<Type> &get_return_type ()
-  {
-    rust_assert (has_return_type ());
-    return return_type;
-  };
+  std::unique_ptr<Type> &get_return_type () { return return_type; };
   std::unique_ptr<Expr> &get_expr () { return expr; }
 
   bool has_params () const { return !params.empty (); }
@@ -3409,11 +3372,7 @@ public:
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRExpressionVisitor &vis) override;
 
-  std::unique_ptr<Expr> &get_scrutinee_expr ()
-  {
-    rust_assert (value != nullptr);
-    return value;
-  }
+  std::unique_ptr<Expr> &get_scrutinee_expr () { return value; }
 
   std::vector<std::unique_ptr<Pattern> > &get_patterns ()
   {
@@ -3593,11 +3552,7 @@ public:
     return match_arm_patterns;
   }
 
-  std::unique_ptr<Expr> &get_guard_expr ()
-  {
-    rust_assert (has_match_arm_guard ());
-    return guard_expr;
-  }
+  std::unique_ptr<Expr> &get_guard_expr () { return guard_expr; }
 
   Location get_locus () const { return locus; }
 };
@@ -3702,11 +3657,7 @@ public:
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRExpressionVisitor &vis) override;
 
-  std::unique_ptr<Expr> &get_scrutinee_expr ()
-  {
-    rust_assert (branch_value != nullptr);
-    return branch_value;
-  }
+  std::unique_ptr<Expr> &get_scrutinee_expr () { return branch_value; }
   AST::AttrVec get_inner_attrs () const { return inner_attrs; }
   const std::vector<MatchCase> &get_match_cases () const { return match_arms; }
   std::vector<MatchCase> &get_match_cases () { return match_arms; }

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -119,11 +119,7 @@ public:
 
   Identifier get_type_representation () const { return type_representation; }
 
-  std::unique_ptr<Type> &get_type ()
-  {
-    rust_assert (type != nullptr);
-    return type;
-  }
+  std::unique_ptr<Type> &get_type () { return type; }
 
   Analysis::NodeMapping get_type_mappings () const
   {
@@ -455,11 +451,7 @@ public:
 
   ImplicitSelfKind get_self_kind () const { return self_kind; }
 
-  std::unique_ptr<Type> &get_type ()
-  {
-    rust_assert (has_type ());
-    return type;
-  }
+  std::unique_ptr<Type> &get_type () { return type; }
 
   Analysis::NodeMapping get_mappings () { return mappings; }
 
@@ -1213,11 +1205,7 @@ public:
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<BlockExpr> &get_definition ()
-  {
-    rust_assert (function_body != nullptr);
-    return function_body;
-  }
+  std::unique_ptr<BlockExpr> &get_definition () { return function_body; }
 
   const FunctionQualifiers &get_qualifiers () const { return qualifiers; }
 
@@ -1229,11 +1217,7 @@ public:
   bool has_return_type () const { return return_type != nullptr; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Type> &get_return_type ()
-  {
-    rust_assert (has_return_type ());
-    return return_type;
-  }
+  std::unique_ptr<Type> &get_return_type () { return return_type; }
 
   bool is_method () const { return !self.is_error (); }
 
@@ -1348,11 +1332,7 @@ public:
 
   WhereClause &get_where_clause () { return where_clause; }
 
-  std::unique_ptr<Type> &get_type_aliased ()
-  {
-    rust_assert (existing_type != nullptr);
-    return existing_type;
-  }
+  std::unique_ptr<Type> &get_type_aliased () { return existing_type; }
 
   Identifier get_new_type_name () const { return new_type_name; }
 
@@ -1518,11 +1498,7 @@ public:
 
   Identifier get_field_name () const { return field_name; }
 
-  std::unique_ptr<Type> &get_field_type ()
-  {
-    rust_assert (field_type != nullptr);
-    return field_type;
-  }
+  std::unique_ptr<Type> &get_field_type () { return field_type; }
 
   Analysis::NodeMapping get_mappings () const { return mappings; }
 
@@ -2343,11 +2319,7 @@ public:
     return generic_params;
   }
 
-  std::unique_ptr<Type> &get_return_type ()
-  {
-    rust_assert (has_return_type ());
-    return return_type;
-  }
+  std::unique_ptr<Type> &get_return_type () { return return_type; }
 
   std::vector<FunctionParam> &get_function_params () { return function_params; }
 
@@ -2414,11 +2386,7 @@ public:
 
   bool has_block_defined () const { return block_expr != nullptr; }
 
-  std::unique_ptr<BlockExpr> &get_block_expr ()
-  {
-    rust_assert (has_block_defined ());
-    return block_expr;
-  }
+  std::unique_ptr<BlockExpr> &get_block_expr () { return block_expr; }
 
   const std::string trait_identifier () const override final
   {
@@ -2860,11 +2828,7 @@ public:
 
   bool has_trait_ref () const { return trait_ref != nullptr; }
 
-  std::unique_ptr<TypePath> &get_trait_ref ()
-  {
-    rust_assert (has_trait_ref ());
-    return trait_ref;
-  }
+  std::unique_ptr<TypePath> &get_trait_ref () { return trait_ref; }
 
   WhereClause &get_where_clause () { return where_clause; }
 

--- a/gcc/rust/hir/tree/rust-hir-path.h
+++ b/gcc/rust/hir/tree/rust-hir-path.h
@@ -136,6 +136,8 @@ public:
     return *this;
   }
 
+  std::unique_ptr<Expr> &get_expression () { return expression; }
+
 private:
   std::unique_ptr<Expr> expression;
   Location locus;
@@ -604,16 +606,8 @@ public:
   };
   std::vector<std::unique_ptr<Type> > &get_params () { return inputs; };
 
-  const std::unique_ptr<Type> &get_return_type () const
-  {
-    rust_assert (has_return_type ());
-    return return_type;
-  };
-  std::unique_ptr<Type> &get_return_type ()
-  {
-    rust_assert (has_return_type ());
-    return return_type;
-  };
+  const std::unique_ptr<Type> &get_return_type () const { return return_type; };
+  std::unique_ptr<Type> &get_return_type () { return return_type; };
 };
 
 // Segment used in type path with a function argument
@@ -815,11 +809,7 @@ public:
 
   std::unique_ptr<Type> &get_type () { return type; }
 
-  std::unique_ptr<TypePath> &get_trait ()
-  {
-    rust_assert (has_as_clause ());
-    return trait;
-  }
+  std::unique_ptr<TypePath> &get_trait () { return trait; }
 
   bool trait_has_generic_args () const
   {

--- a/gcc/rust/hir/tree/rust-hir-pattern.h
+++ b/gcc/rust/hir/tree/rust-hir-pattern.h
@@ -405,17 +405,9 @@ public:
     return PatternType::RANGE;
   }
 
-  std::unique_ptr<RangePatternBound> &get_lower_bound ()
-  {
-    rust_assert (lower != nullptr);
-    return lower;
-  }
+  std::unique_ptr<RangePatternBound> &get_lower_bound () { return lower; }
 
-  std::unique_ptr<RangePatternBound> &get_upper_bound ()
-  {
-    rust_assert (upper != nullptr);
-    return upper;
-  }
+  std::unique_ptr<RangePatternBound> &get_upper_bound () { return upper; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather
@@ -484,11 +476,7 @@ public:
     return PatternType::REFERENCE;
   }
 
-  std::unique_ptr<Pattern> &get_referenced_pattern ()
-  {
-    rust_assert (pattern != nullptr);
-    return pattern;
-  }
+  std::unique_ptr<Pattern> &get_referenced_pattern () { return pattern; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -754,8 +754,6 @@ public:
   std::unique_ptr<Type> &get_type () { return type; }
   std::unique_ptr<Expr> &get_default_expression ()
   {
-    rust_assert (has_default_expression ());
-
     return default_expression;
   }
 


### PR DESCRIPTION
Add one more accessor and remove some rust_assert() in accessors for unique_ptr&.

gcc/rust/ChangeLog:

	* hir/tree/rust-hir-expr.h (TypeCastExpr::get_casted_expr): Remove
	assert in accessor.
	(TypeCastExpr::get_type_to_convert_to): Likewise.
	(CompoundAssignmentExpr::get_left_expr): Likewise.
	(CompoundAssignmentExpr::get_right_expr): Likewise.
	(GroupedExpr::get_expr_in_parens): Likewise.
	(TupleIndexExpr::get_tuple_expr): Likewise.
	(FieldAccessExpr::get_receiver_expr): Likewise.
	(ClosureParam::get_pattern): Likewise.
	(ClosureParam::get_type): Likewise.
	(ExprType::get_return_type): Likewise.
	(IfLetExpr::get_scrutinee_expr): Likewise.
	(MatchArm::get_guard_expr): Likewise.
	(MatchExpr::get_scrutinee_expr): Likewise.
	* hir/tree/rust-hir-item.h (TypeParam::get_type): Likewise.
	(SelfParam::get_type): Likewise.
	(Function::get_return_type): Likewise.
	(TypeAlias::get_type_aliased): Likewise.
	(StructField::get_field_type): Likewise.
	(TraitFunctionDecl::get_block_expr): Likewise.
	(ImplBlock::get_trait_ref): Likewise.
	* hir/tree/rust-hir-path.h (ConstGenericArg::get_expression): New.
	(TypePathFunction::get_return_type): Remove assert in accessor.
	(QualifiedPathType::get_trait): Likewise.
	* hir/tree/rust-hir-pattern.h (PatternType::get_lower_bound): Likewise.
	(PatternType::get_upper_bound): Likewise.
	(ReferencePattern::get_referenced_pattern): Likewise.
	* hir/tree/rust-hir.h (ConstGenericParam::get_default_expression): Likewise.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>