### PR TITLE
[E0093] Declaration of unknown intrinsic function

### DIFF
--- a/gcc/rust/backend/rust-compile-intrinsic.cc
+++ b/gcc/rust/backend/rust-compile-intrinsic.cc
@@ -228,7 +228,8 @@ Intrinsics::compile (TyTy::FnType *fntype)
     return it->second (ctx, fntype);
 
   Location locus = ctx->get_mappings ()->lookup_location (fntype->get_ref ());
-  rust_error_at (locus, "unknown builtin intrinsic: %s",
+  rust_error_at (locus, ErrorCode ("E0093"),
+		 "unrecognized intrinsic function: %<%s%>",
 		 fntype->get_identifier ().c_str ());
 
   return error_mark_node;

--- a/gcc/testsuite/rust/compile/torture/intrinsics-3.rs
+++ b/gcc/testsuite/rust/compile/torture/intrinsics-3.rs
@@ -5,5 +5,5 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    unsafe { not_an_intrinsic() }; // { dg-error "unknown builtin intrinsic: not_an_intrinsic" }
+    unsafe { not_an_intrinsic() }; // { dg-error "unrecognized intrinsic function: .not_an_intrinsic." }
 }


### PR DESCRIPTION
### [`E0093`](https://doc.rust-lang.org/error_codes/E0093.html) unknown builtin intrinsic: foo
- Refactored Error Message similiar to rustc.
- See on [godbolt](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DEArgoKkl9ZATwDKjdAGFUtEywYSupRwBk8DJgAcu4ARpjEIACcpAAOqAqEdgwubh5ecQlJAv6BISzhkTFWmDbJQgRMxASp7p5c3iVlAhVVBLnBYRHRlpXVtekNvW0d%2BYXRAJSWqCbEyOwcAKQATADMYGCLAKwAQlSYTASzmBABBMQBicgKE9sAIosaAIKPT5iqBBEMANQry6bmAC0ZwuDCuf1%2BAHYdq9vnDvlQfvxUBBbqsdt8APSY74RYgkEDfEwMYilVDABh4ABemHQ3xBlzwyARxOanl%2BADYNMjFlzXotIQ9nq9Ed8WEwAqioTDnvCiWCmPtpbC5fDkajFuiVXCBUKXoKOFNaJwtrxPBwtKRUJwAEpmAjfBQzOaYX5rHikAiaQ1TADWIGWAA4AHSQjmBjTLDRRDlRQNbLbSY0cSRm71Wzi8BQgDSe71TOCwGCIFCoFixOgRciUNDlyuRYDIZDEBSAhTMWIKBCoCxYABuTMwADU8JgAO4AeVijE4HpotE%2BLcooXToQCVQAnrPeGvmMQNxPQtpSl7uLxa2xBBOGLQtxbeFhQiZgE4xLRs2fSFhxUZxPev3gpJlH2mAfpa7ylCYnzbuQgiYMmlq0HgoTEJuLhYOm5x4Cw25TFQBjAAoI7jlOM6fvwggiGI7BSDIgiKCo6j/ro3gGEYIAAhYSGhNmkBTKgsS2AIH68KgIHEBcWC8VAzBsCAtLZAwpB9mIJgLFGyw8BMUxNEJngQI4Az1D4DDoKMXSRN48SJHpRl6NZinmQU3SNPBJ7lH0NSuHUei6R5IwBJ0zmWcM/TeYMoXtIFYwuTpzrzBIRommm/7Whw3yqIGHKAhykjfAA4k4Tg2kI3wQIVxWleK5gRBMZW4IQJBuqsXATLwp5aNppD%2BlsubJqmpA4ZIUTBvGHKaVwHKrFy8YxqQ5qWmlWY5nm94FsWEBIDMBCxFB1YQLWFb0MQQSsAsnHMlwwbhsG4H4EQkl6BRwiiOItHPQxajpixpBjqhsS4foyXzemaUTlBu0OqgVAZVlOV5RVJVlYjVVMDVxB1RALh1sdzWte1%2BZJSmvA4b1wZSKskKBoG02rFEUgaNIC2iZmlgrR1PrdQGI2BpNWxcJTHJSBykKSJIgZAxwqwpYtrMc%2Bt8CFiWh31vtKvHRxUhRLm/aDsRk7Tuac50Iu2YQCu/67puMFW/uh7HjYMEXowBDXre6aPs%2Br60O%2BMHfoYwB/pa%2BBAbYIFgbwEHIFBCwemc8HptxqH7uhCyWlhOFnnhBFEaOBtkXOshUW90gfUoX3MQG%2BgBxx9r6Mh0n8YJyQiVa4mSaB8A6W5bIOKZdneH40UWfZWS2eFxkOXpTnjK51h6a0YVpMZfktJ5M8uZFA%2BRRvllxbMCWtZLpog6lnDfBd3xXcNt31fdTUrC1bWrZ1UwIAcWCRKiXNcBofWcANUmuZmYZg4MtXM8tSBK02iAbakM1ZliOhEU6ckOCZWyrlAqRUkblWwajdGz8FIPTwOgJ6RdXo0VLrIT6TFLS6GWL9f6gNkwnxAWDCGUFvjQwvvaS6wYb4aDKtjJBxBmrLGfvLN%2BH9ujf39L/f%2BxNBogF6qfWWYC2YQMJlzSQ18uCJg5FsZY4YRaQgFpLaWqiWbqMkZLZYMsrEEzWlMcSiR7CSCAA%3D%3D)
---
### Running Testcases:
- [`rust/compile/torture/intrinsics-3.rs`](https://github.com/Rust-GCC/gccrs/blob/3016c44e535fe134d88c03ec3d61e3066e43180c/gcc/testsuite/rust/compile/torture/intrinsics-3.rs)
```rust
Executing on host: /home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../gccrs -B/home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../ /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/torture/intrinsics-3.rs   -fdiagnostics-plain-output   -frust-incomplete-and-experimental-compiler-do-not-use   -O0   -S -o intrinsics-3.s    (timeout = 300)
spawn -ignore SIGHUP /home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../gccrs -B/home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../ /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/torture/intrinsics-3.rs -fdiagnostics-plain-output -frust-incomplete-and-experimental-compiler-do-not-use -O0 -S -o intrinsics-3.s
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/torture/intrinsics-3.rs:8:14: error: unrecognized intrinsic function: 'not_an_intrinsic' [E0093]
compiler exited with status 1
PASS: rust/compile/torture/intrinsics-3.rs   -O0   (test for errors, line 8)
PASS: rust/compile/torture/intrinsics-3.rs   -O0  (test for excess errors)
Executing on host: /home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../gccrs -B/home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../ /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/torture/intrinsics-3.rs   -fdiagnostics-plain-output   -frust-incomplete-and-experimental-compiler-do-not-use   -O1   -S -o intrinsics-3.s    (timeout = 300)
spawn -ignore SIGHUP /home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../gccrs -B/home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../ /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/torture/intrinsics-3.rs -fdiagnostics-plain-output -frust-incomplete-and-experimental-compiler-do-not-use -O1 -S -o intrinsics-3.s
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/torture/intrinsics-3.rs:8:14: error: unrecognized intrinsic function: 'not_an_intrinsic' [E0093]
compiler exited with status 1
PASS: rust/compile/torture/intrinsics-3.rs   -O1   (test for errors, line 8)
PASS: rust/compile/torture/intrinsics-3.rs   -O1  (test for excess errors)
Executing on host: /home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../gccrs -B/home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../ /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/torture/intrinsics-3.rs   -fdiagnostics-plain-output   -frust-incomplete-and-experimental-compiler-do-not-use   -O2   -S -o intrinsics-3.s    (timeout = 300)
spawn -ignore SIGHUP /home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../gccrs -B/home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../ /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/torture/intrinsics-3.rs -fdiagnostics-plain-output -frust-incomplete-and-experimental-compiler-do-not-use -O2 -S -o intrinsics-3.s
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/torture/intrinsics-3.rs:8:14: error: unrecognized intrinsic function: 'not_an_intrinsic' [E0093]
compiler exited with status 1
PASS: rust/compile/torture/intrinsics-3.rs   -O2   (test for errors, line 8)
PASS: rust/compile/torture/intrinsics-3.rs   -O2  (test for excess errors)
Executing on host: /home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../gccrs -B/home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../ /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/torture/intrinsics-3.rs   -fdiagnostics-plain-output   -frust-incomplete-and-experimental-compiler-do-not-use   -O3 -g   -S -o intrinsics-3.s    (timeout = 300)
spawn -ignore SIGHUP /home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../gccrs -B/home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../ /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/torture/intrinsics-3.rs -fdiagnostics-plain-output -frust-incomplete-and-experimental-compiler-do-not-use -O3 -g -S -o intrinsics-3.s
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/torture/intrinsics-3.rs:8:14: error: unrecognized intrinsic function: 'not_an_intrinsic' [E0093]
compiler exited with status 1
PASS: rust/compile/torture/intrinsics-3.rs   -O3 -g   (test for errors, line 8)
PASS: rust/compile/torture/intrinsics-3.rs   -O3 -g  (test for excess errors)
Executing on host: /home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../gccrs -B/home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../ /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/torture/intrinsics-3.rs   -fdiagnostics-plain-output   -frust-incomplete-and-experimental-compiler-do-not-use   -Os   -S -o intrinsics-3.s    (timeout = 300)
spawn -ignore SIGHUP /home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../gccrs -B/home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../ /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/torture/intrinsics-3.rs -fdiagnostics-plain-output -frust-incomplete-and-experimental-compiler-do-not-use -Os -S -o intrinsics-3.s
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/torture/intrinsics-3.rs:8:14: error: unrecognized intrinsic function: 'not_an_intrinsic' [E0093]
compiler exited with status 1
PASS: rust/compile/torture/intrinsics-3.rs   -Os   (test for errors, line 8)
PASS: rust/compile/torture/intrinsics-3.rs   -Os  (test for excess errors)
Executing on host: /home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../gccrs -B/home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../ /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/torture/intrinsics-3.rs   -fdiagnostics-plain-output   -frust-incomplete-and-experimental-compiler-do-not-use   -O2 -flto -fno-use-linker-plugin -flto-partition=none   -S -o intrinsics-3.s    (timeout = 300)
spawn -ignore SIGHUP /home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../gccrs -B/home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../ /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/torture/intrinsics-3.rs -fdiagnostics-plain-output -frust-incomplete-and-experimental-compiler-do-not-use -O2 -flto -fno-use-linker-plugin -flto-partition=none -S -o intrinsics-3.s
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/torture/intrinsics-3.rs:8:14: error: unrecognized intrinsic function: 'not_an_intrinsic' [E0093]
compiler exited with status 1
PASS: rust/compile/torture/intrinsics-3.rs   -O2 -flto -fno-use-linker-plugin -flto-partition=none   (test for errors, line 8)
PASS: rust/compile/torture/intrinsics-3.rs   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
Executing on host: /home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../gccrs -B/home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../ /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/torture/intrinsics-3.rs   -fdiagnostics-plain-output   -frust-incomplete-and-experimental-compiler-do-not-use   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   -S -o intrinsics-3.s    (timeout = 300)
spawn -ignore SIGHUP /home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../gccrs -B/home/mahad/Desktop/mahad/gccrs-build/gcc/testsuite/rust/../../ /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/torture/intrinsics-3.rs -fdiagnostics-plain-output -frust-incomplete-and-experimental-compiler-do-not-use -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects -S -o intrinsics-3.s
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/torture/intrinsics-3.rs:8:14: error: unrecognized intrinsic function: 'not_an_intrinsic' [E0093]
compiler exited with status 1
PASS: rust/compile/torture/intrinsics-3.rs   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects   (test for errors, line 8)
PASS: rust/compile/torture/intrinsics-3.rs   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
```


---

gcc/rust/ChangeLog:

	* backend/rust-compile-intrinsic.cc (Intrinsics::compile): called error function.

gcc/testsuite/ChangeLog:

	* rust/compile/torture/intrinsics-3.rs: Updated comment to pass the test case.
---