### PR TITLE
[E0658] Use of unstable feature

### DIFF
--- a/gcc/rust/checks/errors/rust-feature-gate.cc
+++ b/gcc/rust/checks/errors/rust-feature-gate.cc
@@ -79,8 +79,8 @@ FeatureGate::gate (Feature::Name name, Location loc,
 	      "<https://github.com/rust-lang/rust/issues/%u> for more "
 	      "information. add `#![feature(%s)]` to the crate attributes to "
 	      "enable.";
-	  rust_error_at (loc, fmt_str, error_msg.c_str (), issue, issue,
-			 feature.as_string ().c_str ());
+	  rust_error_at (loc, ErrorCode ("E0658"), fmt_str, error_msg.c_str (),
+			 issue, issue, feature.as_string ().c_str ());
 	}
       else
 	{

--- a/gcc/testsuite/rust/compile/changed_intrinsics.rs
+++ b/gcc/testsuite/rust/compile/changed_intrinsics.rs
@@ -1,0 +1,9 @@
+extern "rust-intrinsic" { // { dg-error "intrinsics are subject to change." "" { target *-*-* }  }
+    fn foo(); 
+}
+
+fn main() {
+    unsafe {
+        foo();
+    }
+}


### PR DESCRIPTION
## [`E0658`](https://doc.rust-lang.org/error_codes/E0658.html) Use of Unstable feature
 - Added Errorcode Support for unstable features.

---
### Code Tested:
```rust
extern "rust-intrinsic" { // { dg-error "intrinsics are subject to change." "" { target *-*-* }  }
    fn foo(); // { dg-error "unrecognized intrinsic function: .foo." }
}

fn main() {
    unsafe {
        foo(); // { dg-error "unrecognized intrinsic function: .foo." }
    }
}
```

---

### Output:

```rust
/gccrs/gcc/testsuite/rust/compile/feature_extern_types.rs:2:5: error: extern types are experimental. see issue 43467 <https://github.com/rust-lang/rust/issues/43467> for more information. add `#![feature(extern_types)]` to the crate attributes to enable. [E0658]
compiler exited with status 1

```
---

gcc/rust/ChangeLog:

	* checks/errors/rust-feature-gate.cc (FeatureGate::gate): called error function.

gcc/testsuite/ChangeLog:

	* rust/compile/changed_intrinsics.rs: New test.

---
