### PR TITLE
proc_macro: Add from string implementation

### DIFF
--- a/gcc/rust/expand/rust-proc-macro.cc
+++ b/gcc/rust/expand/rust-proc-macro.cc
@@ -16,6 +16,8 @@
 
 #include "rust-diagnostics.h"
 #include "rust-proc-macro.h"
+#include "rust-lex.h"
+#include "rust-token-converter.h"
 #ifndef _WIN32
 #include <dlfcn.h>
 #endif
@@ -23,6 +25,60 @@
 namespace Rust {
 
 const std::string PROC_MACRO_DECL_PREFIX = "__gccrs_proc_macro_decls_";
+
+ProcMacro::TokenStream
+tokenstream_from_string (std::string &data, bool &lex_error)
+{
+  // FIXME: Insert location pointing to call site in tokens
+  Lexer lex (data);
+
+  std::vector<const_TokenPtr> tokens;
+  TokenPtr ptr;
+  for (ptr = lex.build_token ();
+       ptr != nullptr && ptr->get_id () != END_OF_FILE;
+       ptr = lex.build_token ())
+    {
+      tokens.emplace_back (ptr);
+    }
+
+  if (ptr == nullptr)
+    {
+      lex_error = true;
+      return ProcMacro::TokenStream::make_tokenstream ();
+    }
+
+  lex_error = false;
+  return convert (tokens);
+}
+
+static_assert (
+  std::is_same<decltype (tokenstream_from_string) *,
+	       ProcMacro::from_str_function_t>::value,
+  "Registration callback signature not synced, check proc macro internals.");
+
+template <typename Symbol, typename Callback>
+bool
+register_callback (void *handle, Symbol, std::string symbol_name,
+		   Callback callback)
+{
+  void *addr = dlsym (handle, symbol_name.c_str ());
+  if (addr == nullptr)
+    {
+      rust_error_at (Location (),
+		     "Callback registration symbol (%s) missing from "
+		     "proc macro, wrong version?",
+		     symbol_name.c_str ());
+      return false;
+    }
+
+  auto storage = reinterpret_cast<Symbol *> (addr);
+  *storage = callback;
+
+  return true;
+}
+
+#define REGISTER_CALLBACK(HANDLE, SYMBOL, CALLBACK)                            \
+  register_callback (HANDLE, SYMBOL, #SYMBOL, CALLBACK)
 
 const ProcMacro::ProcmacroArray *
 load_macros_array (std::string path)
@@ -36,6 +92,10 @@ load_macros_array (std::string path)
       return nullptr;
     }
 
+  if (!REGISTER_CALLBACK (handle, __gccrs_pm_callback_from_str_fn,
+			  tokenstream_from_string))
+    return nullptr;
+
   // FIXME: Add CrateStableId handling, right now all versions may be loaded,
   // even incompatible ones.
   return *reinterpret_cast<const ProcMacro::ProcmacroArray **> (
@@ -46,6 +106,8 @@ load_macros_array (std::string path)
   gcc_unreachable ();
 #endif
 }
+
+#undef REGISTER_CALLBACK
 
 const std::vector<ProcMacro::Procmacro>
 load_macros (std::string path)

--- a/libgrust/libproc_macro/proc_macro.cc
+++ b/libgrust/libproc_macro/proc_macro.cc
@@ -50,3 +50,5 @@ Procmacro::make_bang (const char *name, BangMacro macro)
 }
 
 } // namespace ProcMacro
+
+ProcMacro::from_str_function_t __gccrs_pm_callback_from_str_fn = nullptr;

--- a/libgrust/libproc_macro/proc_macro.h
+++ b/libgrust/libproc_macro/proc_macro.h
@@ -30,6 +30,7 @@
 #include "group.h"
 #include "punct.h"
 #include "ident.h"
+#include "registration.h"
 
 namespace ProcMacro {
 
@@ -61,6 +62,9 @@ struct Bang
   const char *name;
   BangMacro macro;
 };
+
+void
+proc_macro_register_from_str (ProcMacro::from_str_function_t fn);
 }
 
 enum ProcmacroTag

--- a/libgrust/libproc_macro/registration.h
+++ b/libgrust/libproc_macro/registration.h
@@ -20,54 +20,18 @@
 // see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef TOKENSTREAM_H
-#define TOKENSTREAM_H
+#ifndef REGISTRATION_H
+#define REGISTRATION_H
 
-#include <cstdint>
-#include <vector>
 #include <string>
+#include "tokenstream.h"
 
 namespace ProcMacro {
-struct TokenTree;
 
-struct TokenStream
-{
-  TokenTree *data;
-  std::uint64_t size;
-  std::uint64_t capacity;
-
-public:
-  void grow (std::uint64_t delta);
-  void push (TokenTree tree);
-
-  TokenStream clone () const;
-
-  static TokenStream make_tokenstream (std::vector<TokenTree> vec);
-  static TokenStream make_tokenstream (std::uint64_t capacity = 1);
-  static TokenStream make_tokenstream (std::string &str, bool &has_error);
-
-  static void drop (TokenStream *stream);
-};
-
-extern "C" TokenStream
-TokenStream__new ();
-
-extern "C" TokenStream
-TokenStream__with_capacity (std::uint64_t capacity);
-
-extern "C" void
-TokenSream__push (TokenStream *stream, TokenTree tree);
-
-extern "C" bool
-TokenStream__from_string (unsigned char *str, std::uint64_t len,
-			  TokenStream *ts);
-
-extern "C" TokenStream
-TokenStream__clone (const TokenStream *ts);
-
-extern "C" void
-TokenStream__drop (TokenStream *stream);
+using from_str_function_t = ProcMacro::TokenStream (*) (std::string &, bool &);
 
 } // namespace ProcMacro
 
-#endif /* ! TOKENSTREAM_H */
+extern "C" ProcMacro::from_str_function_t __gccrs_pm_callback_from_str_fn;
+
+#endif /* !REGISTRATION_H */

--- a/libgrust/libproc_macro/tokenstream.cc
+++ b/libgrust/libproc_macro/tokenstream.cc
@@ -22,6 +22,7 @@
 
 #include "tokenstream.h"
 #include "tokentree.h"
+#include "registration.h"
 
 #include <cstring>
 
@@ -43,6 +44,12 @@ TokenStream::make_tokenstream (std::uint64_t capacity)
 {
   auto *data = new TokenTree[capacity];
   return {data, 0, capacity};
+}
+
+TokenStream
+TokenStream::make_tokenstream (std::string &source, bool &has_error)
+{
+  return __gccrs_pm_callback_from_str_fn (source, has_error);
 }
 
 void
@@ -99,8 +106,11 @@ extern "C" bool
 TokenStream__from_string (unsigned char *str, std::uint64_t len,
 			  TokenStream *ts)
 {
-  // FIXME: Implement using parser ?
-  return false;
+  bool result;
+  auto source = std::string (reinterpret_cast<const char *> (str), len);
+
+  *ts = TokenStream::make_tokenstream (source, result);
+  return result;
 }
 
 extern "C" TokenStream


### PR DESCRIPTION
Add a callback registration symbol into the proc macro library so the compiler can register it's own lexing/parsing functions on load. Register a conversion from string callback in order to implement the `FromStr` trait on `TokenStream`.

Fixes #973 