### PR TITLE
Fix several warnings

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -90,6 +90,7 @@ enum class Kind
 class Visitable
 {
 public:
+  virtual ~Visitable () = default;
   virtual void accept_vis (ASTVisitor &vis) = 0;
 };
 

--- a/gcc/rust/backend/rust-compile-intrinsic.cc
+++ b/gcc/rust/backend/rust-compile-intrinsic.cc
@@ -371,7 +371,7 @@ offset_handler (Context *ctx, TyTy::FnType *fntype)
   tree pointer_offset_expr
     = pointer_offset_expression (dst, size, BUILTINS_LOCATION);
   auto return_statement
-    = ctx->get_backend ()->return_statement (fndecl, {pointer_offset_expr},
+    = ctx->get_backend ()->return_statement (fndecl, pointer_offset_expr,
 					     UNDEF_LOCATION);
   ctx->add_statement (return_statement);
   // BUILTIN offset FN BODY END
@@ -406,8 +406,7 @@ sizeof_handler (Context *ctx, TyTy::FnType *fntype)
   // BUILTIN size_of FN BODY BEGIN
   tree size_expr = TYPE_SIZE_UNIT (template_parameter_type);
   auto return_statement
-    = ctx->get_backend ()->return_statement (fndecl, {size_expr},
-					     UNDEF_LOCATION);
+    = ctx->get_backend ()->return_statement (fndecl, size_expr, UNDEF_LOCATION);
   ctx->add_statement (return_statement);
   // BUILTIN size_of FN BODY END
 
@@ -480,7 +479,7 @@ transmute_handler (Context *ctx, TyTy::FnType *fntype)
   tree result_expr = build_fold_indirect_ref_loc (UNKNOWN_LOCATION, t);
 
   auto return_statement
-    = ctx->get_backend ()->return_statement (fndecl, {result_expr},
+    = ctx->get_backend ()->return_statement (fndecl, result_expr,
 					     UNDEF_LOCATION);
   ctx->add_statement (return_statement);
   // BUILTIN transmute FN BODY END
@@ -520,7 +519,7 @@ rotate_handler (Context *ctx, TyTy::FnType *fntype, tree_code op)
   tree rotate_expr
     = fold_build2_loc (BUILTINS_LOCATION, op, TREE_TYPE (x), x, y);
   auto return_statement
-    = ctx->get_backend ()->return_statement (fndecl, {rotate_expr},
+    = ctx->get_backend ()->return_statement (fndecl, rotate_expr,
 					     UNDEF_LOCATION);
   ctx->add_statement (return_statement);
   // BUILTIN rotate FN BODY END
@@ -568,8 +567,7 @@ wrapping_op_handler_inner (Context *ctx, TyTy::FnType *fntype, tree_code op)
   auto wrap_expr = build2 (op, TREE_TYPE (lhs), lhs, rhs);
 
   auto return_statement
-    = ctx->get_backend ()->return_statement (fndecl, {wrap_expr},
-					     UNDEF_LOCATION);
+    = ctx->get_backend ()->return_statement (fndecl, wrap_expr, UNDEF_LOCATION);
   ctx->add_statement (return_statement);
   // BUILTIN wrapping_<op> FN BODY END
 
@@ -657,7 +655,7 @@ op_with_overflow_inner (Context *ctx, TyTy::FnType *fntype, tree_code op)
 						   UNDEF_LOCATION);
 
   auto return_statement
-    = ctx->get_backend ()->return_statement (fndecl, {result_expr},
+    = ctx->get_backend ()->return_statement (fndecl, result_expr,
 					     UNDEF_LOCATION);
   ctx->add_statement (return_statement);
 
@@ -940,8 +938,7 @@ atomic_load_handler_inner (Context *ctx, TyTy::FnType *fntype, int ordering)
     = ctx->get_backend ()->call_expression (atomic_load, {src, memorder},
 					    nullptr, UNDEF_LOCATION);
   auto return_statement
-    = ctx->get_backend ()->return_statement (fndecl, {load_call},
-					     UNDEF_LOCATION);
+    = ctx->get_backend ()->return_statement (fndecl, load_call, UNDEF_LOCATION);
 
   TREE_READONLY (load_call) = 0;
   TREE_SIDE_EFFECTS (load_call) = 1;
@@ -986,7 +983,7 @@ unchecked_op_inner (Context *ctx, TyTy::FnType *fntype, tree_code op)
 
   auto expr = build2 (op, TREE_TYPE (x), x, y);
   auto return_statement
-    = ctx->get_backend ()->return_statement (fndecl, {expr}, UNDEF_LOCATION);
+    = ctx->get_backend ()->return_statement (fndecl, expr, UNDEF_LOCATION);
 
   ctx->add_statement (return_statement);
 
@@ -1040,7 +1037,7 @@ uninit_handler (Context *ctx, TyTy::FnType *fntype)
   ctx->add_statement (memset_call);
 
   auto return_statement
-    = ctx->get_backend ()->return_statement (fndecl, {DECL_RESULT (fndecl)},
+    = ctx->get_backend ()->return_statement (fndecl, DECL_RESULT (fndecl),
 					     UNDEF_LOCATION);
   ctx->add_statement (return_statement);
   // BUILTIN size_of FN BODY END

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -90,6 +90,8 @@ public:
     Repetition,
   };
 
+  virtual ~MatchedFragmentContainer () = default;
+
   virtual Kind get_kind () const = 0;
 
   virtual std::string as_string () const = 0;

--- a/gcc/rust/hir/tree/rust-hir-full-decls.h
+++ b/gcc/rust/hir/tree/rust-hir-full-decls.h
@@ -37,7 +37,7 @@ class LifetimeParam;
 
 class TraitItem;
 class ImplItem;
-struct Crate;
+class Crate;
 class PathExpr;
 
 // rust-path.h
@@ -156,9 +156,9 @@ class UseDeclaration;
 class Function;
 class TypeAlias;
 class Struct;
-struct StructField;
+class StructField;
 class StructStruct;
-struct TupleField;
+class TupleField;
 class TupleStruct;
 class EnumItem;
 class EnumItemTuple;
@@ -168,7 +168,7 @@ class Enum;
 class Union;
 class ConstantItem;
 class StaticItem;
-struct TraitFunctionDecl;
+class TraitFunctionDecl;
 class TraitItemFunc;
 class TraitItemConst;
 class TraitItemType;

--- a/gcc/rust/rust-session-manager.h
+++ b/gcc/rust/rust-session-manager.h
@@ -42,7 +42,7 @@ struct Crate;
 }
 // crate forward decl
 namespace HIR {
-struct Crate;
+class Crate;
 }
 
 /* Data related to target, most useful for conditional compilation and


### PR DESCRIPTION
Several lines add some warning, it clutters the compiler output, makes error message harder to find/read when compiling with a high number of cores.