### PR TITLE
rust-unreachable: Add specific behavior for rust_unreachable

### DIFF
--- a/gcc/rust/ast/rust-ast-collector.cc
+++ b/gcc/rust/ast/rust-ast-collector.cc
@@ -208,7 +208,7 @@ TokenCollector::visit (Attribute &attrib)
 	    break;
 	  }
 	default:
-	  gcc_unreachable ();
+	  rust_unreachable ();
 	}
     }
   push (Rust::Token::make (RIGHT_SQUARE, UNDEF_LOCATION));
@@ -668,7 +668,7 @@ TokenCollector::visit (GenericArg &arg)
       }
       break;
     case GenericArg::Kind::Error:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 }
 
@@ -822,11 +822,11 @@ TokenCollector::visit (Literal &lit, Location locus)
 	else if (value == "true")
 	  push (Rust::Token::make (TRUE_LITERAL, locus));
 	else
-	  gcc_unreachable (); // Not a boolean
+	  rust_unreachable (); // Not a boolean
 	break;
       }
     case Literal::LitType::ERROR:
-      gcc_unreachable ();
+      rust_unreachable ();
       break;
     }
 }
@@ -1188,7 +1188,7 @@ void
 TokenCollector::visit (StructExprStructBase &)
 {
   // FIXME: Implement this node
-  gcc_unreachable ();
+  rust_unreachable ();
 }
 
 void
@@ -2252,7 +2252,7 @@ get_delimiters (DelimType delim)
     case CURLY:
       return {LEFT_CURLY, RIGHT_CURLY};
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 }
 

--- a/gcc/rust/ast/rust-ast-dump.h
+++ b/gcc/rust/ast/rust-ast-dump.h
@@ -71,7 +71,7 @@ public:
 	    previous = nullptr;
 	    break;
 	  default:
-	    gcc_unreachable ();
+	    rust_unreachable ();
 	  }
       }
   }

--- a/gcc/rust/ast/rust-ast-formatting.cc
+++ b/gcc/rust/ast/rust-ast-formatting.cc
@@ -51,7 +51,7 @@ get_string_in_delims (std::string str_input, DelimType delim_type)
     default:
       return "ERROR-MARK-STRING (delims)";
     }
-  gcc_unreachable ();
+  rust_unreachable ();
 }
 
 std::string
@@ -64,7 +64,7 @@ get_mode_dump_desc (AttrMode mode)
     case INNER:
       return "inner attributes";
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
       return "";
     }
 }

--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -225,7 +225,7 @@ Visibility::as_string () const
     case PUB_IN_PATH:
       return std::string ("pub(in ") + in_path.as_string () + std::string (")");
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 }
 
@@ -623,7 +623,7 @@ UseTreeGlob::as_string () const
       // some kind of error
       return "ERROR-PATH";
     }
-  gcc_unreachable ();
+  rust_unreachable ();
 }
 
 std::string

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -1887,7 +1887,7 @@ public:
 	return type == nullptr;
       }
 
-    gcc_unreachable ();
+    rust_unreachable ();
     return true;
   }
 
@@ -1913,7 +1913,7 @@ public:
 	return "Type: " + type->as_string ();
       }
 
-    gcc_unreachable ();
+    rust_unreachable ();
     return "";
   }
 };

--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -473,14 +473,14 @@ private:
 
   /**
    * Default function to use as an associated transcriber. This function should
-   * never be called, hence the gcc_unreachable().
+   * never be called, hence the rust_unreachable().
    * If this function is used, then the macro is not builtin and the compiler
    * should make use of the actual rules. If the macro is builtin, then another
    * associated transcriber should be used
    */
   static Fragment dummy_builtin (Location, MacroInvocData &)
   {
-    gcc_unreachable ();
+    rust_unreachable ();
     return Fragment::create_error ();
   }
 

--- a/gcc/rust/ast/rust-path.h
+++ b/gcc/rust/ast/rust-path.h
@@ -224,7 +224,7 @@ public:
       case Kind::Either:
 	break;
       case Kind::Error:
-	gcc_unreachable ();
+	rust_unreachable ();
       }
   }
 
@@ -254,7 +254,7 @@ public:
     switch (get_kind ())
       {
       case Kind::Error:
-	gcc_unreachable ();
+	rust_unreachable ();
       case Kind::Either:
 	return "Ambiguous: " + path.as_string ();
       case Kind::Const:

--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -1117,7 +1117,7 @@ sort_tuple_patterns (HIR::MatchExpr &expr)
       else /* TuplePatternItemType::RANGED */
 	{
 	  // FIXME
-	  gcc_unreachable ();
+	  rust_unreachable ();
 	}
     }
 
@@ -1430,25 +1430,25 @@ CompileExpr::visit (HIR::MatchExpr &expr)
 	    else
 	      {
 		// FIXME: There are other cases, but it better not be a Tuple
-		gcc_unreachable ();
+		rust_unreachable ();
 	      }
 	  }
 	  break;
 
 	  case HIR::Expr::ExprType::Path: {
 	    // FIXME
-	    gcc_unreachable ();
+	    rust_unreachable ();
 	  }
 	  break;
 
 	default:
-	  gcc_unreachable ();
+	  rust_unreachable ();
 	}
     }
   else
     {
       // FIXME: match on other types of expressions not yet implemented.
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 
   // setup the end label so the cases can exit properly
@@ -2856,7 +2856,7 @@ CompileExpr::generate_closure_fntype (HIR::ClosureExpr &expr,
   else
     {
       // FIXME error message?
-      gcc_unreachable ();
+      rust_unreachable ();
       return error_mark_node;
     }
 

--- a/gcc/rust/backend/rust-compile-intrinsic.cc
+++ b/gcc/rust/backend/rust-compile-intrinsic.cc
@@ -626,7 +626,7 @@ op_with_overflow_inner (Context *ctx, TyTy::FnType *fntype, tree_code op)
       break;
 
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
       break;
     }
   rust_assert (overflow_builtin != error_mark_node);

--- a/gcc/rust/backend/rust-compile-pattern.cc
+++ b/gcc/rust/backend/rust-compile-pattern.cc
@@ -199,7 +199,7 @@ CompilePatternBindings::visit (HIR::TupleStructPattern &pattern)
     {
       case HIR::TupleStructItems::RANGE: {
 	// TODO
-	gcc_unreachable ();
+	rust_unreachable ();
       }
       break;
 
@@ -284,13 +284,13 @@ CompilePatternBindings::visit (HIR::StructPattern &pattern)
 	{
 	  case HIR::StructPatternField::ItemType::TUPLE_PAT: {
 	    // TODO
-	    gcc_unreachable ();
+	    rust_unreachable ();
 	  }
 	  break;
 
 	  case HIR::StructPatternField::ItemType::IDENT_PAT: {
 	    // TODO
-	    gcc_unreachable ();
+	    rust_unreachable ();
 	  }
 	  break;
 
@@ -467,7 +467,7 @@ CompilePatternLet::visit (HIR::TuplePattern &pattern)
 	return;
       }
       default: {
-	gcc_unreachable ();
+	rust_unreachable ();
       }
     }
 }

--- a/gcc/rust/backend/rust-constexpr.cc
+++ b/gcc/rust/backend/rust-constexpr.cc
@@ -1132,7 +1132,7 @@ base_field_constructor_elt (vec<constructor_elt, va_gc> *v, tree ref)
     if (ce->index == field)
       return ce;
 
-  gcc_unreachable ();
+  rust_unreachable ();
   return NULL;
 }
 
@@ -1618,7 +1618,7 @@ eval_array_reference (const constexpr_ctx *ctx, tree t, bool lval,
       /* We can't do anything with other tree codes, so use
 	 VERIFY_CONSTANT to complain and fail.  */
       VERIFY_CONSTANT (ary);
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 
   bool found;
@@ -1855,7 +1855,7 @@ label_matches (const constexpr_ctx *ctx, tree *jump_target, tree stmt)
       break;
 
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
   return false;
 }
@@ -2695,7 +2695,7 @@ eval_store_expression (const constexpr_ctx *ctx, tree t, bool lval,
 	    if (TREE_CODE (probe) == ARRAY_REF)
 	      {
 		// TODO
-		gcc_unreachable ();
+		rust_unreachable ();
 		// elt = eval_and_check_array_index (ctx, probe, false,
 		// 				  non_constant_p, overflow_p);
 		if (*non_constant_p)
@@ -3372,7 +3372,7 @@ eval_call_expression (const constexpr_ctx *ctx, tree t, bool lval,
     {
       // return cxx_eval_internal_function (ctx, t, lval,
       //     			       non_constant_p, overflow_p);
-      gcc_unreachable ();
+      rust_unreachable ();
       return error_mark_node;
     }
 
@@ -3876,7 +3876,7 @@ build_data_member_initialization (tree t, vec<constructor_elt, va_gc> **vec)
 //	goto found;
 //
 //      default:
-//	gcc_unreachable ();
+//	rust_unreachable ();
 //      }
 // found:
 //
@@ -4143,7 +4143,7 @@ array_index_cmp (tree key, tree index)
 	  return 0;
       }
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 }
 
@@ -4435,7 +4435,7 @@ get_array_or_vector_nelts (const constexpr_ctx *ctx, tree type,
   else if (VECTOR_TYPE_P (type))
     nelts = size_int (TYPE_VECTOR_SUBPARTS (type));
   else
-    gcc_unreachable ();
+    rust_unreachable ();
 
   /* For VLAs, the number of elements won't be an integer constant.  */
   nelts
@@ -4787,7 +4787,7 @@ eval_bit_field_ref (const constexpr_ctx *ctx, tree t, bool lval,
     }
   if (fld_seen)
     return fold_convert (TREE_TYPE (t), retval);
-  gcc_unreachable ();
+  rust_unreachable ();
   return error_mark_node;
 }
 
@@ -4876,7 +4876,7 @@ eval_loop_expr (const constexpr_ctx *ctx, tree t, bool *non_constant_p,
       count = -1;
       break;
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
   auto_vec<tree, 10> save_exprs;
   new_ctx.save_exprs = &save_exprs;
@@ -6433,7 +6433,7 @@ potential_constant_expression_1 (tree t, bool want_rval, bool strict, bool now,
 
     default:
       sorry ("unexpected AST of kind %s", get_tree_code_name (TREE_CODE (t)));
-      gcc_unreachable ();
+      rust_unreachable ();
       return false;
     }
 #undef RECUR

--- a/gcc/rust/backend/rust-mangle.cc
+++ b/gcc/rust/backend/rust-mangle.cc
@@ -193,7 +193,7 @@ v0_simple_type_prefix (const TyTy::BaseType *ty)
       return "";
     }
 
-  gcc_unreachable ();
+  rust_unreachable ();
 }
 
 // Add an underscore-terminated base62 integer to the mangling string.
@@ -262,7 +262,7 @@ v0_type_prefix (const TyTy::BaseType *ty)
     return ty_prefix;
 
   // FIXME: We need to fetch more type prefixes
-  gcc_unreachable ();
+  rust_unreachable ();
 }
 
 static std::string
@@ -291,7 +291,7 @@ v0_mangle_item (const TyTy::BaseType *ty, const Resolver::CanonicalPath &path)
   v0_add_identifier (mangled, crate_name);
   v0_add_disambiguator (mangled, 62);
 
-  gcc_unreachable ();
+  rust_unreachable ();
 }
 
 std::string
@@ -305,7 +305,7 @@ Mangler::mangle_item (const TyTy::BaseType *ty,
     case Mangler::MangleVersion::V0:
       return v0_mangle_item (ty, path);
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 }
 

--- a/gcc/rust/backend/rust-tree.cc
+++ b/gcc/rust/backend/rust-tree.cc
@@ -384,7 +384,7 @@ convert_to_void (tree expr, impl_conv_void implicit)
 			    type);
 		break;
 	      default:
-		gcc_unreachable ();
+		rust_unreachable ();
 	      }
 	  }
 	/* Don't load the value if this is an implicit dereference, or if
@@ -440,7 +440,7 @@ convert_to_void (tree expr, impl_conv_void implicit)
 			    type);
 		break;
 	      default:
-		gcc_unreachable ();
+		rust_unreachable ();
 	      }
 	  }
 	else if (is_volatile && TREE_ADDRESSABLE (type))
@@ -495,7 +495,7 @@ convert_to_void (tree expr, impl_conv_void implicit)
 			    type);
 		break;
 	      default:
-		gcc_unreachable ();
+		rust_unreachable ();
 	      }
 	  }
 	if (is_reference || !is_volatile || !is_complete
@@ -573,7 +573,7 @@ convert_to_void (tree expr, impl_conv_void implicit)
 			  expr, type);
 	      break;
 	    default:
-	      gcc_unreachable ();
+	      rust_unreachable ();
 	    }
 
 	break;
@@ -1311,7 +1311,7 @@ type_memfn_quals (const_tree type)
   else if (TREE_CODE (type) == METHOD_TYPE)
     return rs_type_quals (class_of_this_parm (type));
   else
-    gcc_unreachable ();
+    rust_unreachable ();
 }
 
 // forked from gcc/cp/pt.cc find_parameter_pack_data
@@ -1882,7 +1882,7 @@ rs_tree_equal (tree t1, tree t2)
     case VOID_CST:
       /* There's only a single VOID_CST node, so we should never reach
 	 here.  */
-      gcc_unreachable ();
+      rust_unreachable ();
 
     case INTEGER_CST:
       return tree_int_cst_equal (t1, t2);
@@ -2049,7 +2049,7 @@ rs_tree_equal (tree t1, tree t2)
       return same_type_p (t1, t2);
 
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 
   /* We can get here with --disable-checking.  */
@@ -3645,7 +3645,7 @@ fold_offsetof (tree expr, tree type, enum tree_code ctx)
       return fold_offsetof (t, type);
 
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 
   if (!POINTER_TYPE_P (type))
@@ -3922,7 +3922,7 @@ retry:
       break;
 
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 }
 
@@ -4817,7 +4817,7 @@ fold_builtin_source_location (location_t loc)
 	  else if (strcmp (n, "_M_column") == 0)
 	    val = build_int_cst (TREE_TYPE (field), LOCATION_COLUMN (loc));
 	  else
-	    gcc_unreachable ();
+	    rust_unreachable ();
 	  CONSTRUCTOR_APPEND_ELT (v, field, val);
 	}
 
@@ -5943,7 +5943,7 @@ lvalue_error (location_t loc, enum lvalue_use use)
       error_at (loc, "lvalue required in %<asm%> statement");
       break;
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 }
 

--- a/gcc/rust/backend/rust-tree.h
+++ b/gcc/rust/backend/rust-tree.h
@@ -1958,7 +1958,7 @@ struct named_decl_hash : ggc_remove<tree>
 
   /* Nothing is deletable.  Everything is insertable.  */
   static bool is_deleted (value_type) { return false; }
-  static void mark_deleted (value_type) { gcc_unreachable (); }
+  static void mark_deleted (value_type) { rust_unreachable (); }
 };
 
 // forked from gcc/cp/cp-tree.h lang_decl_selector
@@ -2168,7 +2168,7 @@ struct named_label_hash : ggc_remove<named_label_entry *>
 
   /* Nothing is deletable.  Everything is insertable.  */
   inline static bool is_deleted (value_type) { return false; }
-  inline static void mark_deleted (value_type) { gcc_unreachable (); }
+  inline static void mark_deleted (value_type) { rust_unreachable (); }
 };
 
 // forked from gcc/cp/cp-tree.h

--- a/gcc/rust/checks/errors/privacy/rust-visibility-resolver.cc
+++ b/gcc/rust/checks/errors/privacy/rust-visibility-resolver.cc
@@ -117,7 +117,7 @@ VisibilityResolver::resolve_visibility (const HIR::Visibility &visibility,
 	return result;
       }
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
       return false;
     }
 }
@@ -240,7 +240,7 @@ VisibilityResolver::visit (HIR::ImplBlock &impl)
 	  vis_item = static_cast<HIR::ConstantItem *> (item.get ());
 	  break;
 	default:
-	  gcc_unreachable ();
+	  rust_unreachable ();
 	  return;
 	}
       vis_item->accept_vis (*this);

--- a/gcc/rust/checks/errors/rust-const-checker.cc
+++ b/gcc/rust/checks/errors/rust-const-checker.cc
@@ -72,7 +72,7 @@ ConstChecker::ctx_to_str (ConstGenericCtx ctx)
     case ConstGenericCtx::Impl:
       return "impl";
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 }
 

--- a/gcc/rust/checks/errors/rust-feature.cc
+++ b/gcc/rust/checks/errors/rust-feature.cc
@@ -43,7 +43,7 @@ Feature::create (Feature::Name name)
       return Feature (Feature::Name::EXTERN_TYPES, Feature::State::ACTIVE,
 		      "extern_types", "1.23.0", 43467, tl::nullopt, "");
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 }
 

--- a/gcc/rust/expand/rust-expand-visitor.cc
+++ b/gcc/rust/expand/rust-expand-visitor.cc
@@ -89,7 +89,7 @@ get_traits_to_derive (AST::Attribute &attr)
     case AST::AttrInput::LITERAL:
     case AST::AttrInput::META_ITEM:
     case AST::AttrInput::MACRO:
-      gcc_unreachable ();
+      rust_unreachable ();
       break;
     }
 
@@ -119,7 +119,7 @@ derive_item (AST::Item &item, const std::string &to_derive,
 	      result.push_back (node.take_item ());
 	      break;
 	    default:
-	      gcc_unreachable ();
+	      rust_unreachable ();
 	    }
 	}
     }
@@ -142,7 +142,7 @@ expand_item_attribute (AST::Item &item, AST::SimplePath &name,
 	      result.push_back (node.take_item ());
 	      break;
 	    default:
-	      gcc_unreachable ();
+	      rust_unreachable ();
 	    }
 	}
     }
@@ -171,7 +171,7 @@ expand_stmt_attribute (T &statement, AST::SimplePath &attribute,
 	      result.push_back (node.take_stmt ());
 	      break;
 	    default:
-	      gcc_unreachable ();
+	      rust_unreachable ();
 	    }
 	}
     }

--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -557,7 +557,7 @@ MacroExpander::match_matcher (Parser<MacroInvocLexer> &parser,
       }
       break;
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 
   return true;
@@ -750,7 +750,7 @@ MacroExpander::match_repetition (Parser<MacroInvocLexer> &parser,
       res = match_n_matches (parser, rep, match_amount, 0, 1);
       break;
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 
   rust_debug_loc (rep.get_match_locus (), "%s matched %lu times",
@@ -991,7 +991,7 @@ transcribe_context (MacroExpander::ContextType ctx,
     case MacroExpander::ContextType::EXPR:
       return transcribe_expression (parser);
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 }
 
@@ -1103,7 +1103,7 @@ MacroExpander::import_proc_macros (std::string extern_crate)
       // Extern crate path is not available.
       // FIXME: Emit error
       rust_error_at (UNDEF_LOCATION, "Cannot find requested proc macro crate");
-      gcc_unreachable ();
+      rust_unreachable ();
     }
   auto macros = load_macros (path->second);
 
@@ -1132,7 +1132,7 @@ MacroExpander::import_proc_macros (std::string extern_crate)
 	    macro.payload.bang);
 	  break;
 	default:
-	  gcc_unreachable ();
+	  rust_unreachable ();
 	}
     }
 }
@@ -1171,7 +1171,7 @@ MacroExpander::parse_proc_macro_output (ProcMacro::TokenStream ts)
     case ContextType::TYPE:
     case ContextType::EXPR:
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 
   if (parser.has_errors ())

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -220,7 +220,7 @@ public:
       current_map.emplace (fragment.fragment_ident,
 			   MatchedFragmentContainer::metavar (fragment));
     else
-      gcc_unreachable ();
+      rust_unreachable ();
   }
 
   /**

--- a/gcc/rust/expand/rust-macro-invoc-lexer.h
+++ b/gcc/rust/expand/rust-macro-invoc-lexer.h
@@ -38,7 +38,7 @@ public:
   std::string get_filename () const
   {
     // FIXME
-    gcc_unreachable ();
+    rust_unreachable ();
     return "FIXME";
   }
 
@@ -76,7 +76,7 @@ public:
   std::string get_filename () const
   {
     // FIXME
-    gcc_unreachable ();
+    rust_unreachable ();
     return "FIXME";
   }
 

--- a/gcc/rust/expand/rust-macro-substitute-ctx.cc
+++ b/gcc/rust/expand/rust-macro-substitute-ctx.cc
@@ -306,7 +306,7 @@ SubstituteCtx::substitute_token (size_t token_idx)
       }
     }
 
-  gcc_unreachable ();
+  rust_unreachable ();
 }
 
 std::vector<std::unique_ptr<AST::Token>>

--- a/gcc/rust/expand/rust-proc-macro-invoc-lexer.h
+++ b/gcc/rust/expand/rust-proc-macro-invoc-lexer.h
@@ -49,7 +49,7 @@ public:
   std::string get_filename () const
   {
     // FIXME
-    gcc_unreachable ();
+    rust_unreachable ();
     return "FIXME";
   }
 

--- a/gcc/rust/expand/rust-proc-macro.cc
+++ b/gcc/rust/expand/rust-proc-macro.cc
@@ -43,7 +43,7 @@ load_macros_array (std::string path)
 #else
   rust_sorry_at (UNDEF_LOCATION,
 		 "Procedural macros are not yet supported on windows host");
-  gcc_unreachable ();
+  rust_unreachable ();
 #endif
 }
 
@@ -53,7 +53,7 @@ load_macros (std::string path)
   const ProcMacro::ProcmacroArray *array = load_macros_array (path);
   // Did not load the proc macro
   if (array == nullptr)
-    gcc_unreachable ();
+    rust_unreachable ();
 
   rust_debug ("Found %lu procedural macros", array->length);
 

--- a/gcc/rust/hir/rust-ast-lower-base.cc
+++ b/gcc/rust/hir/rust-ast-lower-base.cc
@@ -621,7 +621,7 @@ ASTLoweringBase::lower_generic_args (AST::GenericArgs &args)
 	    break;
 	  }
 	default:
-	  gcc_unreachable ();
+	  rust_unreachable ();
 	}
     }
 
@@ -913,7 +913,7 @@ ASTLoweringBase::lower_literal (const AST::Literal &literal)
       type = HIR::Literal::LitType::BOOL;
       break;
     case AST::Literal::LitType::ERROR:
-      gcc_unreachable ();
+      rust_unreachable ();
       break;
     }
 

--- a/gcc/rust/hir/rust-ast-lower-expr.cc
+++ b/gcc/rust/hir/rust-ast-lower-expr.cc
@@ -461,7 +461,7 @@ ASTLoweringExpr::visit (AST::CompoundAssignmentExpr &expr)
       op = ArithmeticOrLogicalOperator::RIGHT_SHIFT;
       break;
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 
   HIR::Expr *asignee_expr

--- a/gcc/rust/hir/rust-ast-lower-pattern.cc
+++ b/gcc/rust/hir/rust-ast-lower-pattern.cc
@@ -76,7 +76,7 @@ ASTLoweringPattern::visit (AST::TupleStructPattern &pattern)
     {
       case AST::TupleStructItems::RANGE: {
 	// TODO
-	gcc_unreachable ();
+	rust_unreachable ();
       }
       break;
 
@@ -123,7 +123,7 @@ ASTLoweringPattern::visit (AST::StructPattern &pattern)
 	{
 	  case AST::StructPatternField::ItemType::TUPLE_PAT: {
 	    // TODO
-	    gcc_unreachable ();
+	    rust_unreachable ();
 	  }
 	  break;
 

--- a/gcc/rust/hir/rust-ast-lower-type.cc
+++ b/gcc/rust/hir/rust-ast-lower-type.cc
@@ -218,7 +218,7 @@ ASTLoweringType::visit (AST::BareFunctionType &fntype)
 	  kind = HIR::MaybeNamedParam::ParamKind::WILDCARD;
 	  break;
 	default:
-	  gcc_unreachable ();
+	  rust_unreachable ();
 	}
 
       HIR::Type *param_type

--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -184,7 +184,7 @@ Dump::visit (ArithmeticOrLogicalExpr &aole)
       operator_str = ">>";
       break;
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
       break;
     }
 

--- a/gcc/rust/hir/tree/rust-hir.cc
+++ b/gcc/rust/hir/tree/rust-hir.cc
@@ -66,7 +66,7 @@ get_string_in_delims (std::string str_input, AST::DelimType delim_type)
     default:
       return "ERROR-MARK-STRING (delims)";
     }
-  gcc_unreachable ();
+  rust_unreachable ();
 }
 
 std::string
@@ -128,7 +128,7 @@ Visibility::as_string () const
       return std::string ("pub(in ") + path.get_mappings ().as_string ()
 	     + std::string (")");
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 }
 
@@ -518,7 +518,7 @@ UseTreeGlob::as_string () const
       // some kind of error
       return "ERROR-PATH";
     }
-  gcc_unreachable ();
+  rust_unreachable ();
 }
 
 std::string
@@ -1342,7 +1342,7 @@ CompoundAssignmentExpr::as_string () const
       operator_str = ">>";
       break;
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
       break;
     }
 
@@ -1617,7 +1617,7 @@ ArithmeticOrLogicalExpr::as_string () const
       operator_str = ">>";
       break;
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
       break;
     }
 

--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -1829,7 +1829,7 @@ Lexer::parse_byte_string (Location loc)
     }
   else
     {
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 
   str.shrink_to_fit ();
@@ -2059,7 +2059,7 @@ Lexer::parse_string (Location loc)
     }
   else
     {
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 
   str.shrink_to_fit ();

--- a/gcc/rust/lex/rust-token.cc
+++ b/gcc/rust/lex/rust-token.cc
@@ -35,7 +35,7 @@ get_token_description (TokenId id)
 #undef RS_TOKEN_KEYWORD
 #undef RS_TOKEN
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 }
 
@@ -54,7 +54,7 @@ token_id_to_str (TokenId id)
 #undef RS_TOKEN_KEYWORD
 #undef RS_TOKEN
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 }
 
@@ -85,13 +85,13 @@ token_id_keyword_string (TokenId id)
       static const std::string str (str_ptr);                                  \
       return str;                                                              \
     }                                                                          \
-    gcc_unreachable ();
+    rust_unreachable ();
 #define RS_TOKEN(a, b)
       RS_TOKEN_LIST
 #undef RS_TOKEN_KEYWORD
 #undef RS_TOKEN
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 }
 

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -713,7 +713,7 @@ Parser<ManagedTokenSource>::parse_simple_path_segment ()
       // test prevent error
       return AST::SimplePathSegment::create_error ();
     }
-  gcc_unreachable ();
+  rust_unreachable ();
   /*rust_error_at(
     t->get_locus(), "invalid token '%s' in simple path segment",
     t->get_token_description());*/
@@ -765,7 +765,7 @@ Parser<ManagedTokenSource>::parse_path_ident_segment ()
       // test prevent error
       return AST::PathIdentSegment::create_error ();
     }
-  gcc_unreachable ();
+  rust_unreachable ();
   // not necessarily an error
 }
 
@@ -876,7 +876,7 @@ Parser<ManagedTokenSource>::parse_attr_input ()
       skip_after_end_attribute ();
       return nullptr;
     }
-  gcc_unreachable ();
+  rust_unreachable ();
   // TODO: find out how to stop gcc error on "no return value"
 }
 
@@ -5534,7 +5534,7 @@ Parser<ManagedTokenSource>::parse_inherent_impl_item ()
 	  lexer.skip_token (1); // TODO: is this right thing to do?
 	  return nullptr;
 	}
-      gcc_unreachable ();
+      rust_unreachable ();
     default:
       add_error (Error (t->get_locus (),
 			"unrecognised token %qs for item in inherent impl",
@@ -5718,7 +5718,7 @@ Parser<ManagedTokenSource>::parse_trait_impl_item ()
 	  lexer.skip_token (1); // TODO: is this right thing to do?
 	  return nullptr;
 	}
-      gcc_unreachable ();
+      rust_unreachable ();
     default:
       break;
     }
@@ -6703,7 +6703,7 @@ Parser<ManagedTokenSource>::parse_type_path_segment ()
 	new AST::TypePathSegment (std::move (ident_segment),
 				  has_separating_scope_resolution, locus));
     }
-  gcc_unreachable ();
+  rust_unreachable ();
 }
 
 // Parses a function call representation inside a type path.
@@ -9846,7 +9846,7 @@ Parser<ManagedTokenSource>::parse_reference_type ()
 	new AST::ReferenceType (false, parse_reference_type_inner (locus),
 				locus));
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 }
 
@@ -12337,7 +12337,7 @@ Parser<ManagedTokenSource>::null_denotation_path (
       return std::unique_ptr<AST::PathInExpression> (
 	new AST::PathInExpression (std::move (path)));
     }
-  gcc_unreachable ();
+  rust_unreachable ();
 }
 
 // Handling of expresions that do not start with a path for `null_denotation`.
@@ -12969,7 +12969,7 @@ get_lbp_for_arithmetic_or_logical_expr (
       return LBP_R_SHIFT;
     default:
       // WTF? should not happen, this is an error
-      gcc_unreachable ();
+      rust_unreachable ();
 
       return LBP_PLUS;
     }
@@ -13241,7 +13241,7 @@ get_lbp_for_comparison_expr (AST::ComparisonExpr::ExprType expr_type)
       return LBP_SMALLER_EQUAL;
     default:
       // WTF? should not happen, this is an error
-      gcc_unreachable ();
+      rust_unreachable ();
 
       return LBP_EQUAL;
     }
@@ -13512,7 +13512,7 @@ get_lbp_for_compound_assignment_expr (
       return LBP_R_SHIFT;
     default:
       // WTF? should not happen, this is an error
-      gcc_unreachable ();
+      rust_unreachable ();
 
       return LBP_PLUS;
     }

--- a/gcc/rust/parse/rust-parse.cc
+++ b/gcc/rust/parse/rust-parse.cc
@@ -278,7 +278,7 @@ peculiar_fragment_match_compatible (const AST::MacroMatchFragment &last_match,
 	    delim_id = LEFT_CURLY;
 	    break;
 	  default:
-	    gcc_unreachable ();
+	    rust_unreachable ();
 	    break;
 	  }
 	if (contains (allowed_toks, delim_id))

--- a/gcc/rust/resolve/rust-ast-resolve-path.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-path.cc
@@ -231,7 +231,7 @@ ResolvePath::resolve_path (AST::PathInExpression *expr)
 	}
       else
 	{
-	  gcc_unreachable ();
+	  rust_unreachable ();
 	}
     }
   return resolved_node_id;
@@ -407,7 +407,7 @@ ResolvePath::resolve_path (AST::SimplePath *expr)
 	}
       else
 	{
-	  gcc_unreachable ();
+	  rust_unreachable ();
 	}
     }
   return resolved_node_id;

--- a/gcc/rust/resolve/rust-ast-resolve-pattern.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-pattern.cc
@@ -96,7 +96,7 @@ PatternDeclaration::visit (AST::TupleStructPattern &pattern)
     {
       case AST::TupleStructItems::RANGE: {
 	// TODO
-	gcc_unreachable ();
+	rust_unreachable ();
       }
       break;
 
@@ -125,7 +125,7 @@ PatternDeclaration::visit (AST::StructPattern &pattern)
 	{
 	  case AST::StructPatternField::ItemType::TUPLE_PAT: {
 	    // TODO
-	    gcc_unreachable ();
+	    rust_unreachable ();
 	  }
 	  break;
 

--- a/gcc/rust/resolve/rust-ast-resolve-type.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-type.cc
@@ -264,7 +264,7 @@ ResolveRelativeTypePath::go (AST::TypePath &path, NodeId &resolved_node_id)
 	}
       else
 	{
-	  gcc_unreachable ();
+	  rust_unreachable ();
 	}
     }
 
@@ -396,7 +396,7 @@ ResolveTypeToCanonicalPath::visit (AST::TypePath &path)
 		    // constant or an ambiguous const generic?
 		    // TODO: At that point, will all generics have been
 		    // disambiguated? Can we thus canonical resolve types and
-		    // const and `gcc_unreachable` on ambiguous types?
+		    // const and `rust_unreachable` on ambiguous types?
 		    // This is probably fine as we just want to canonicalize
 		    // types, right?
 		    if (generic.get_kind () == AST::GenericArg::Kind::Type)
@@ -500,7 +500,7 @@ void
 ResolveTypeToCanonicalPath::visit (AST::TraitObjectType &)
 {
   // FIXME is this actually allowed? dyn A+B
-  gcc_unreachable ();
+  rust_unreachable ();
 }
 
 ResolveTypeToCanonicalPath::ResolveTypeToCanonicalPath ()
@@ -556,7 +556,7 @@ ResolveGenericArgs::resolve_disambiguated_generic (AST::GenericArg &arg)
       ResolveType::go (arg.get_type ().get ());
       break;
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 }
 void

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -1229,7 +1229,7 @@ operator_to_tree_code (NegationOperator op)
     case NegationOperator::NOT:
       return TRUTH_NOT_EXPR;
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 }
 
@@ -1266,7 +1266,7 @@ operator_to_tree_code (ArithmeticOrLogicalOperator op, bool floating_point)
     case ArithmeticOrLogicalOperator::RIGHT_SHIFT:
       return RSHIFT_EXPR;
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 }
 
@@ -1288,7 +1288,7 @@ operator_to_tree_code (ComparisonOperator op)
     case ComparisonOperator::LESS_OR_EQUAL:
       return LE_EXPR;
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 }
 
@@ -1302,7 +1302,7 @@ operator_to_tree_code (LazyBooleanOperator op)
     case LazyBooleanOperator::LOGICAL_AND:
       return TRUTH_ANDIF_EXPR;
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 }
 
@@ -1430,7 +1430,7 @@ fetch_overflow_builtins (ArithmeticOrLogicalOperator op)
       builtin_ctx.lookup_simple_builtin ("mul_overflow", &builtin);
       break;
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
       break;
     };
 
@@ -2191,10 +2191,10 @@ Gcc_backend::non_zero_size_type (tree type)
       }
 
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 
-  gcc_unreachable ();
+  rust_unreachable ();
 }
 
 // Convert EXPR_TREE to TYPE_TREE.  Sometimes the same unnamed Rust type
@@ -2227,7 +2227,7 @@ Gcc_backend::convert_tree (tree type_tree, tree expr_tree, Location location)
 			      expr_tree);
     }
 
-  gcc_unreachable ();
+  rust_unreachable ();
 }
 
 // Make a global variable.

--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -250,7 +250,7 @@ grs_langhook_type_for_mode (machine_mode mode, int unsignedp)
       return (unsignedp ? int_n_trees[i].unsigned_type
 			: int_n_trees[i].signed_type);
 
-  /* gcc_unreachable */
+  /* rust_unreachable */
   return NULL;
 }
 
@@ -267,7 +267,7 @@ static bool
 grs_langhook_global_bindings_p (void)
 {
   // return current_function_decl == NULL_TREE;
-  // gcc_unreachable();
+  // rust_unreachable();
   // return true;
   return false;
 }
@@ -281,7 +281,7 @@ grs_langhook_global_bindings_p (void)
 static tree
 grs_langhook_pushdecl (tree decl ATTRIBUTE_UNUSED)
 {
-  gcc_unreachable ();
+  rust_unreachable ();
   return NULL;
 }
 
@@ -291,7 +291,7 @@ grs_langhook_pushdecl (tree decl ATTRIBUTE_UNUSED)
 static tree
 grs_langhook_getdecls (void)
 {
-  // gcc_unreachable();
+  // rust_unreachable();
   return NULL;
 }
 
@@ -380,7 +380,7 @@ convert (tree type, tree expr)
       break;
     }
 
-  gcc_unreachable ();
+  rust_unreachable ();
 }
 
 /* FIXME: This is a hack to preserve trees that we create from the

--- a/gcc/rust/rust-system.h
+++ b/gcc/rust/rust-system.h
@@ -74,8 +74,12 @@ constexpr static const char *file_separator = "/";
 // When using gcc, rust_assert is just gcc_assert.
 #define rust_assert(EXPR) gcc_assert (EXPR)
 
-// When using gcc, rust_unreachable is just gcc_unreachable.
-#define rust_unreachable() gcc_unreachable ()
+/**
+ * rust_unreachable is just a fancy abort which causes an internal compiler
+ * error. This macro is not equivalent to `__builtin_unreachable` and does not
+ * indicate optimizations for the compiler
+ */
+#define rust_unreachable() (fancy_abort (__FILE__, __LINE__, __FUNCTION__))
 
 extern void
 rust_preserve_from_gc (tree t);

--- a/gcc/rust/typecheck/rust-autoderef.h
+++ b/gcc/rust/typecheck/rust-autoderef.h
@@ -83,7 +83,7 @@ public:
       case AdjustmentType::UNSIZE:
 	return "UNSIZE";
       }
-    gcc_unreachable ();
+    rust_unreachable ();
     return "";
   }
 

--- a/gcc/rust/typecheck/rust-hir-path-probe.cc
+++ b/gcc/rust/typecheck/rust-hir-path-probe.cc
@@ -339,7 +339,7 @@ PathProbeType::process_associated_trait_for_candidates (
 
     case TraitItemReference::TraitItemType::ERROR:
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
       break;
     }
 
@@ -389,7 +389,7 @@ PathProbeType::process_predicate_for_candidates (
 
     case TraitItemReference::TraitItemType::ERROR:
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
       break;
     }
 

--- a/gcc/rust/typecheck/rust-hir-trait-reference.cc
+++ b/gcc/rust/typecheck/rust-hir-trait-reference.cc
@@ -94,7 +94,7 @@ TraitItemReference::get_tyty () const
       return get_error ();
     }
 
-  gcc_unreachable ();
+  rust_unreachable ();
   return get_error ();
 }
 

--- a/gcc/rust/typecheck/rust-hir-type-check-base.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.cc
@@ -274,7 +274,7 @@ TypeCheckBase::resolve_literal (const Analysis::NodeMapping &expr_mappings,
       break;
 
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
       break;
     }
 

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -2046,7 +2046,7 @@ TypeCheckExpr::validate_arithmetic_type (
 		     == TyTy::InferType::INTEGRAL));
     }
 
-  gcc_unreachable ();
+  rust_unreachable ();
   return false;
 }
 

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -81,11 +81,17 @@ public:
   void visit (HIR::AsyncBlockExpr &) override {}
 
   // don't need to implement these see rust-hir-type-check-struct-field.h
-  void visit (HIR::StructExprFieldIdentifier &) override { gcc_unreachable (); }
-  void visit (HIR::StructExprFieldIndexValue &) override { gcc_unreachable (); }
+  void visit (HIR::StructExprFieldIdentifier &) override
+  {
+    rust_unreachable ();
+  }
+  void visit (HIR::StructExprFieldIndexValue &) override
+  {
+    rust_unreachable ();
+  }
   void visit (HIR::StructExprFieldIdentifierValue &) override
   {
-    gcc_unreachable ();
+    rust_unreachable ();
   }
 
 protected:

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.cc
@@ -259,7 +259,7 @@ TypeCheckImplItem::visit (HIR::Function &function)
 	      break;
 
 	    default:
-	      gcc_unreachable ();
+	      rust_unreachable ();
 	      return;
 	    }
 	}

--- a/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
@@ -101,7 +101,7 @@ TypeCheckPattern::visit (HIR::TupleStructPattern &pattern)
     {
       case HIR::TupleStructItems::RANGE: {
 	// TODO
-	gcc_unreachable ();
+	rust_unreachable ();
       }
       break;
 
@@ -201,7 +201,7 @@ TypeCheckPattern::visit (HIR::StructPattern &pattern)
 	{
 	  case HIR::StructPatternField::ItemType::TUPLE_PAT: {
 	    // TODO
-	    gcc_unreachable ();
+	    rust_unreachable ();
 	  }
 	  break;
 
@@ -334,7 +334,7 @@ TypeCheckPattern::visit (HIR::TuplePattern &pattern)
 	//   = *static_cast<HIR::TuplePatternItemsRanged *> (
 	//     pattern.get_items ().get ());
 	// TODO
-	gcc_unreachable ();
+	rust_unreachable ();
       }
       break;
     }

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.h
@@ -52,7 +52,7 @@ public:
   // this seems like it should not be part of this visitor
   void visit (HIR::TypePathSegmentFunction &segment) override
   {
-    gcc_unreachable ();
+    rust_unreachable ();
   }
 
   // nothing to do for these

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -246,7 +246,7 @@ TraitItemReference::get_type_from_fn (/*const*/ HIR::TraitItemFunc &fn) const
 	      break;
 
 	    default:
-	      gcc_unreachable ();
+	      rust_unreachable ();
 	      return nullptr;
 	    }
 	}

--- a/gcc/rust/typecheck/rust-substitution-mapper.h
+++ b/gcc/rust/typecheck/rust-substitution-mapper.h
@@ -41,26 +41,26 @@ public:
   void visit (TyTy::ProjectionType &type) override;
 
   // nothing to do for these
-  void visit (TyTy::InferType &) override { gcc_unreachable (); }
-  void visit (TyTy::TupleType &) override { gcc_unreachable (); }
-  void visit (TyTy::FnPtr &) override { gcc_unreachable (); }
-  void visit (TyTy::ArrayType &) override { gcc_unreachable (); }
-  void visit (TyTy::SliceType &) override { gcc_unreachable (); }
-  void visit (TyTy::BoolType &) override { gcc_unreachable (); }
-  void visit (TyTy::IntType &) override { gcc_unreachable (); }
-  void visit (TyTy::UintType &) override { gcc_unreachable (); }
-  void visit (TyTy::FloatType &) override { gcc_unreachable (); }
-  void visit (TyTy::USizeType &) override { gcc_unreachable (); }
-  void visit (TyTy::ISizeType &) override { gcc_unreachable (); }
-  void visit (TyTy::ErrorType &) override { gcc_unreachable (); }
-  void visit (TyTy::CharType &) override { gcc_unreachable (); }
-  void visit (TyTy::ReferenceType &) override { gcc_unreachable (); }
-  void visit (TyTy::PointerType &) override { gcc_unreachable (); }
-  void visit (TyTy::ParamType &) override { gcc_unreachable (); }
-  void visit (TyTy::StrType &) override { gcc_unreachable (); }
-  void visit (TyTy::NeverType &) override { gcc_unreachable (); }
-  void visit (TyTy::DynamicObjectType &) override { gcc_unreachable (); }
-  void visit (TyTy::ClosureType &) override { gcc_unreachable (); }
+  void visit (TyTy::InferType &) override { rust_unreachable (); }
+  void visit (TyTy::TupleType &) override { rust_unreachable (); }
+  void visit (TyTy::FnPtr &) override { rust_unreachable (); }
+  void visit (TyTy::ArrayType &) override { rust_unreachable (); }
+  void visit (TyTy::SliceType &) override { rust_unreachable (); }
+  void visit (TyTy::BoolType &) override { rust_unreachable (); }
+  void visit (TyTy::IntType &) override { rust_unreachable (); }
+  void visit (TyTy::UintType &) override { rust_unreachable (); }
+  void visit (TyTy::FloatType &) override { rust_unreachable (); }
+  void visit (TyTy::USizeType &) override { rust_unreachable (); }
+  void visit (TyTy::ISizeType &) override { rust_unreachable (); }
+  void visit (TyTy::ErrorType &) override { rust_unreachable (); }
+  void visit (TyTy::CharType &) override { rust_unreachable (); }
+  void visit (TyTy::ReferenceType &) override { rust_unreachable (); }
+  void visit (TyTy::PointerType &) override { rust_unreachable (); }
+  void visit (TyTy::ParamType &) override { rust_unreachable (); }
+  void visit (TyTy::StrType &) override { rust_unreachable (); }
+  void visit (TyTy::NeverType &) override { rust_unreachable (); }
+  void visit (TyTy::DynamicObjectType &) override { rust_unreachable (); }
+  void visit (TyTy::ClosureType &) override { rust_unreachable (); }
 
 private:
   SubstMapper (HirId ref, HIR::GenericArgs *generics, Location locus);
@@ -121,27 +121,27 @@ public:
   void visit (TyTy::ADTType &type) override;
   void visit (TyTy::ClosureType &type) override;
 
-  void visit (TyTy::InferType &) override { gcc_unreachable (); }
-  void visit (TyTy::TupleType &) override { gcc_unreachable (); }
-  void visit (TyTy::FnPtr &) override { gcc_unreachable (); }
-  void visit (TyTy::ArrayType &) override { gcc_unreachable (); }
-  void visit (TyTy::SliceType &) override { gcc_unreachable (); }
-  void visit (TyTy::BoolType &) override { gcc_unreachable (); }
-  void visit (TyTy::IntType &) override { gcc_unreachable (); }
-  void visit (TyTy::UintType &) override { gcc_unreachable (); }
-  void visit (TyTy::FloatType &) override { gcc_unreachable (); }
-  void visit (TyTy::USizeType &) override { gcc_unreachable (); }
-  void visit (TyTy::ISizeType &) override { gcc_unreachable (); }
-  void visit (TyTy::ErrorType &) override { gcc_unreachable (); }
-  void visit (TyTy::CharType &) override { gcc_unreachable (); }
-  void visit (TyTy::ReferenceType &) override { gcc_unreachable (); }
-  void visit (TyTy::PointerType &) override { gcc_unreachable (); }
-  void visit (TyTy::ParamType &) override { gcc_unreachable (); }
-  void visit (TyTy::StrType &) override { gcc_unreachable (); }
-  void visit (TyTy::NeverType &) override { gcc_unreachable (); }
-  void visit (TyTy::PlaceholderType &) override { gcc_unreachable (); }
-  void visit (TyTy::ProjectionType &) override { gcc_unreachable (); }
-  void visit (TyTy::DynamicObjectType &) override { gcc_unreachable (); }
+  void visit (TyTy::InferType &) override { rust_unreachable (); }
+  void visit (TyTy::TupleType &) override { rust_unreachable (); }
+  void visit (TyTy::FnPtr &) override { rust_unreachable (); }
+  void visit (TyTy::ArrayType &) override { rust_unreachable (); }
+  void visit (TyTy::SliceType &) override { rust_unreachable (); }
+  void visit (TyTy::BoolType &) override { rust_unreachable (); }
+  void visit (TyTy::IntType &) override { rust_unreachable (); }
+  void visit (TyTy::UintType &) override { rust_unreachable (); }
+  void visit (TyTy::FloatType &) override { rust_unreachable (); }
+  void visit (TyTy::USizeType &) override { rust_unreachable (); }
+  void visit (TyTy::ISizeType &) override { rust_unreachable (); }
+  void visit (TyTy::ErrorType &) override { rust_unreachable (); }
+  void visit (TyTy::CharType &) override { rust_unreachable (); }
+  void visit (TyTy::ReferenceType &) override { rust_unreachable (); }
+  void visit (TyTy::PointerType &) override { rust_unreachable (); }
+  void visit (TyTy::ParamType &) override { rust_unreachable (); }
+  void visit (TyTy::StrType &) override { rust_unreachable (); }
+  void visit (TyTy::NeverType &) override { rust_unreachable (); }
+  void visit (TyTy::PlaceholderType &) override { rust_unreachable (); }
+  void visit (TyTy::ProjectionType &) override { rust_unreachable (); }
+  void visit (TyTy::DynamicObjectType &) override { rust_unreachable (); }
 
 private:
   SubstMapperFromExisting (TyTy::BaseType *concrete, TyTy::BaseType *receiver);

--- a/gcc/rust/typecheck/rust-typecheck-context.cc
+++ b/gcc/rust/typecheck/rust-typecheck-context.cc
@@ -638,7 +638,7 @@ TypeCheckContextItem::get_context_type ()
       break;
 
     case ERROR:
-      gcc_unreachable ();
+      rust_unreachable ();
       return nullptr;
     }
 

--- a/gcc/rust/typecheck/rust-tyty-call.h
+++ b/gcc/rust/typecheck/rust-tyty-call.h
@@ -40,27 +40,27 @@ public:
     return checker.resolved;
   }
 
-  void visit (InferType &) override { gcc_unreachable (); }
-  void visit (TupleType &) override { gcc_unreachable (); }
-  void visit (ArrayType &) override { gcc_unreachable (); }
-  void visit (SliceType &) override { gcc_unreachable (); }
-  void visit (BoolType &) override { gcc_unreachable (); }
-  void visit (IntType &) override { gcc_unreachable (); }
-  void visit (UintType &) override { gcc_unreachable (); }
-  void visit (FloatType &) override { gcc_unreachable (); }
-  void visit (USizeType &) override { gcc_unreachable (); }
-  void visit (ISizeType &) override { gcc_unreachable (); }
-  void visit (ErrorType &) override { gcc_unreachable (); }
-  void visit (CharType &) override { gcc_unreachable (); }
-  void visit (ReferenceType &) override { gcc_unreachable (); }
-  void visit (PointerType &) override { gcc_unreachable (); }
-  void visit (ParamType &) override { gcc_unreachable (); }
-  void visit (StrType &) override { gcc_unreachable (); }
-  void visit (NeverType &) override { gcc_unreachable (); }
-  void visit (PlaceholderType &) override { gcc_unreachable (); }
-  void visit (ProjectionType &) override { gcc_unreachable (); }
-  void visit (DynamicObjectType &) override { gcc_unreachable (); }
-  void visit (ClosureType &type) override { gcc_unreachable (); }
+  void visit (InferType &) override { rust_unreachable (); }
+  void visit (TupleType &) override { rust_unreachable (); }
+  void visit (ArrayType &) override { rust_unreachable (); }
+  void visit (SliceType &) override { rust_unreachable (); }
+  void visit (BoolType &) override { rust_unreachable (); }
+  void visit (IntType &) override { rust_unreachable (); }
+  void visit (UintType &) override { rust_unreachable (); }
+  void visit (FloatType &) override { rust_unreachable (); }
+  void visit (USizeType &) override { rust_unreachable (); }
+  void visit (ISizeType &) override { rust_unreachable (); }
+  void visit (ErrorType &) override { rust_unreachable (); }
+  void visit (CharType &) override { rust_unreachable (); }
+  void visit (ReferenceType &) override { rust_unreachable (); }
+  void visit (PointerType &) override { rust_unreachable (); }
+  void visit (ParamType &) override { rust_unreachable (); }
+  void visit (StrType &) override { rust_unreachable (); }
+  void visit (NeverType &) override { rust_unreachable (); }
+  void visit (PlaceholderType &) override { rust_unreachable (); }
+  void visit (ProjectionType &) override { rust_unreachable (); }
+  void visit (DynamicObjectType &) override { rust_unreachable (); }
+  void visit (ClosureType &type) override { rust_unreachable (); }
 
   // tuple-structs
   void visit (ADTType &type) override;

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -112,7 +112,7 @@ TypeKindFormat::to_string (TypeKind kind)
     case TypeKind::ERROR:
       return "ERROR";
     }
-  gcc_unreachable ();
+  rust_unreachable ();
 }
 
 bool
@@ -671,7 +671,7 @@ BaseType::monomorphized_clone () const
       break;
     }
 
-  gcc_unreachable ();
+  rust_unreachable ();
   return nullptr;
 }
 
@@ -1405,7 +1405,7 @@ VariantDef::variant_type_string (VariantType type)
     case STRUCT:
       return "struct";
     }
-  gcc_unreachable ();
+  rust_unreachable ();
   return "";
 }
 
@@ -2278,7 +2278,7 @@ ClosureType::clone () const
 ClosureType *
 ClosureType::handle_substitions (SubstitutionArgumentMappings &mappings)
 {
-  gcc_unreachable ();
+  rust_unreachable ();
   return nullptr;
 }
 
@@ -2587,7 +2587,7 @@ IntType::as_string () const
     case I128:
       return "i128";
     }
-  gcc_unreachable ();
+  rust_unreachable ();
   return "__unknown_int_type";
 }
 
@@ -2674,7 +2674,7 @@ UintType::as_string () const
     case U128:
       return "u128";
     }
-  gcc_unreachable ();
+  rust_unreachable ();
   return "__unknown_uint_type";
 }
 
@@ -2755,7 +2755,7 @@ FloatType::as_string () const
     case F64:
       return "f64";
     }
-  gcc_unreachable ();
+  rust_unreachable ();
   return "__unknown_float_type";
 }
 

--- a/gcc/rust/typecheck/rust-unify.cc
+++ b/gcc/rust/typecheck/rust-unify.cc
@@ -1631,7 +1631,7 @@ UnifyRules::expect_projection (TyTy::ProjectionType *ltype,
 
       // FIXME
     case TyTy::PROJECTION:
-      gcc_unreachable ();
+      rust_unreachable ();
       break;
 
     case TyTy::DYNAMIC:

--- a/gcc/rust/util/rust-token-converter.cc
+++ b/gcc/rust/util/rust-token-converter.cc
@@ -250,7 +250,7 @@ convert (const std::vector<const_TokenPtr> &tokens)
 	  trees.push_back (ProcMacro::TokenStream::make_tokenstream ());
 	  break;
 	default:
-	  gcc_unreachable ();
+	  rust_unreachable ();
 	}
     }
   return trees.back ();
@@ -322,7 +322,7 @@ from_literal (const ProcMacro::Literal &literal,
     case ProcMacro::STR_RAW:
     case ProcMacro::BYTE_STR_RAW:
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 }
 
@@ -383,7 +383,7 @@ from_group (const ProcMacro::Group &g, std::vector<const_TokenPtr> &result)
       from_tokenstream (g.stream, result);
       break;
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 }
 
@@ -414,7 +414,7 @@ from_tokentree (const ProcMacro::TokenTree &tt,
       from_literal (tt.payload.literal, result);
       break;
     default:
-      gcc_unreachable ();
+      rust_unreachable ();
     }
 }
 


### PR DESCRIPTION
As discussed during the community call, rust_unreachable() should
always trigger an internal compiler error and should not offer
the behavior of __builtin_unreachable when asserts are disabled, unlike
gcc_unreachable().
