### PR TITLE
[E0133] Use of unsafe code outside of unsafe function or block

### DIFF
--- a/gcc/rust/checks/errors/rust-unsafe-checker.cc
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.cc
@@ -86,7 +86,8 @@ static void
 check_unsafe_call (HIR::Function *fn, Location locus, const std::string &kind)
 {
   if (fn->get_qualifiers ().is_unsafe ())
-    rust_error_at (locus, "call to unsafe %s requires unsafe function or block",
+    rust_error_at (locus, ErrorCode ("E0133"),
+		   "call to unsafe %s requires unsafe function or block",
 		   kind.c_str ());
 }
 


### PR DESCRIPTION
## [`E0133`](https://doc.rust-lang.org/error_codes/E0133.html)  Use of unsafe code outside of unsafe function or block

## Code tested from [`E0133`](https://doc.rust-lang.org/error_codes/E0133.html)
```rust
// https://doc.rust-lang.org/error_codes/E0133.html
unsafe fn f() { return; } // This is the unsafe code

fn main() {
    f(); // error: call to unsafe function requires unsafe function or block
}
```

---

### Output:
```rust
➜  gccrs-build gcc/crab1 ../mahad-testsuite/E0133.rs                                          
../mahad-testsuite/E0133.rs:4:5: error: call to unsafe function requires unsafe function or block [E0133]
    4 |     f(); // error: call to unsafe function requires unsafe function or block
      |     ^

Analyzing compilation unit

Time variable                                   usr           sys          wall           GGC
 TOTAL                              :   0.00          0.00          0.00          146k
Extra diagnostic checks enabled; compiler may run slowly.
Configure with --enable-checking=release to disable checks.
➜  gccrs-build 
```

---

### Running TestCases:
- These test cases are already added by Arthur.
- [`rust/compile/unsafe6.rs`](https://github.com/Rust-GCC/gccrs/blob/b75357f4a1835dcd288df67402340b4cb6b96c12/gcc/testsuite/rust/compile/unsafe6.rs)
- [`rust/compile/unsafe8.rs`](https://github.com/Rust-GCC/gccrs/blob/b75357f4a1835dcd288df67402340b4cb6b96c12/gcc/testsuite/rust/compile/unsafe8.rs)

```rust

➜  gccrs-build gcc/crab1 /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/unsafe6.rs
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/unsafe6.rs:7:5: error: call to unsafe function requires unsafe function or block [E0133]
    7 |     foo(); // { dg-error "call to unsafe function" }
      |     ^~~
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/unsafe6.rs:8:5: error: call to unsafe function requires unsafe function or block [E0133]
    8 |     bar(); // { dg-error "call to unsafe function" }
      |     ^~~

Analyzing compilation unit

Time variable                                   usr           sys          wall           GGC
 TOTAL                              :   0.00          0.00          0.00          146k
Extra diagnostic checks enabled; compiler may run slowly.
Configure with --enable-checking=release to disable checks.
```


```rust
➜  gccrs-build gcc/crab1 /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/unsafe8.rs                            
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/unsafe8.rs:9:5: error: call to unsafe method requires unsafe function or block [E0133]
    9 |     s.foo(); // { dg-error "call to unsafe method" }
      |     ^

Analyzing compilation unit

Time variable                                   usr           sys          wall           GGC
 TOTAL                              :   0.00          0.00          0.00          146k
Extra diagnostic checks enabled; compiler may run slowly.
Configure with --enable-checking=release to disable checks.

```

---


gcc/rust/ChangeLog:

	* checks/errors/rust-unsafe-checker.cc (check_unsafe_call): called error function.