### PR TITLE
[E0423] expected function, tuple struct or tuple variant, found struct

### DIFF
--- a/gcc/rust/typecheck/rust-tyty-call.cc
+++ b/gcc/rust/typecheck/rust-tyty-call.cc
@@ -59,7 +59,7 @@ TypeCheckCallExpr::visit (ADTType &type)
   if (variant.get_variant_type () != TyTy::VariantDef::VariantType::TUPLE)
     {
       rust_error_at (
-	call.get_locus (),
+	call.get_locus (), ErrorCode ("E0423"),
 	"expected function, tuple struct or tuple variant, found struct %<%s%>",
 	type.get_name ().c_str ());
       return;

--- a/gcc/testsuite/rust/compile/found_struct.rs
+++ b/gcc/testsuite/rust/compile/found_struct.rs
@@ -1,0 +1,11 @@
+// https://doc.rust-lang.org/error_codes/E0423.html
+#![allow(unused)]
+fn main() {
+    struct Foo {
+        a: bool,
+    };
+
+    let f = Foo(); // { dg-error "expected function, tuple struct or tuple variant, found struct .Foo." }
+                   // error: expected function, tuple struct or tuple variant, found `Foo`
+                   // `Foo` is a struct name, but this expression uses it like a function name
+}


### PR DESCRIPTION
---
### Expected function, tuple struct or tuple variant, found struct - [`E0423`](https://doc.rust-lang.org/error_codes/E0423.html)

Give error when an identifier was used like a function name or a value was expected and the identifier exists but it belongs to a different namespace.



---

### Code tested from [`E0423`](https://doc.rust-lang.org/error_codes/E0423.html):
```rust
// https://doc.rust-lang.org/error_codes/E0423.html
#![allow(unused)]
fn main() {
    struct Foo {
        a: bool,
    };

    let f = Foo(); // { dg-error "expected function, tuple struct or tuple variant, found struct .Foo." }
                   // error: expected function, tuple struct or tuple variant, found `Foo`
                   // `Foo` is a struct name, but this expression uses it like a function name
}
```
### Output:
```rust
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/found_struct.rs:8:13: error: expected function, tuple struct or tuple variant, found struct 'Foo' [E0423]
compiler exited with status 1
PASS: rust/compile/found_struct.rs  (test for errors, line 8)
PASS: rust/compile/found_struct.rs (test for excess errors)
```


---

### Running Test Cases:
- [`rust/compile/tuple_struct1.rs`](https://github.com/Rust-GCC/gccrs/blob/866512cbc09bc883ef844b2b6cb70a72335756a7/gcc/testsuite/rust/compile/tuple_struct1.rs)

### Output:
```rust
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/tuple_struct1.rs:7:13: error: expected function, tuple struct or tuple variant, found struct 'Foo' [E0423]
compiler exited with status 1
PASS: rust/compile/tuple_struct1.rs  (test for errors, line 7)
PASS: rust/compile/tuple_struct1.rs (test for excess errors)
```

---

**gcc/rust/ChangeLog:**

	* typecheck/rust-tyty-call.cc (TypeCheckCallExpr::visit): called error function.

**gcc/testsuite/ChangeLog:**

	* rust/compile/found_struct.rs: New test.

---
