### PR TITLE
cli: Add frust-type option

### DIFF
--- a/gcc/rust/lang.opt
+++ b/gcc/rust/lang.opt
@@ -82,6 +82,34 @@ frust-max-recursion-depth=
 Rust RejectNegative Type(int) Var(rust_max_recursion_depth) Init(64)
 -frust-max-recursion-depth=<integer>
 
+frust-crate-type=
+Rust Joined RejectNegative Enum(frust_crate_type) Var(flag_rust_crate_type)
+-frust-crate-type=[bin|lib|rlib|dylib|cdylib|staticlib|proc-macro]     Crate type to emit
+
+Enum
+Name(frust_crate_type) Type(int) UnknownError(unknown crate type: '%qs')
+
+EnumValue
+Enum(frust_crate_type) String(bin) Value(0)
+
+EnumValue
+Enum(frust_crate_type) String(lib) Value(1)
+
+EnumValue
+Enum(frust_crate_type) String(rlib) Value(2)
+
+EnumValue
+Enum(frust_crate_type) String(dylib) Value(3)
+
+EnumValue
+Enum(frust_crate_type) String(cdylib) Value(4)
+
+EnumValue
+Enum(frust_crate_type) String(staticlib) Value(5)
+
+EnumValue
+Enum(frust_crate_type) String(proc-macro) Value(6)
+
 frust-mangling=
 Rust Joined RejectNegative Enum(frust_mangling) Var(flag_rust_mangling)
 -frust-mangling=[legacy|v0]     Version to use for name mangling

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -234,7 +234,9 @@ Session::handle_option (
 	ret = handle_cfg_option (string_arg);
 	break;
       }
-
+    case OPT_frust_crate_type_:
+      options.set_crate_type (flag_rust_crate_type);
+      break;
     case OPT_frust_edition_:
       options.set_edition (flag_rust_edition);
       break;

--- a/gcc/rust/rust-session-manager.h
+++ b/gcc/rust/rust-session-manager.h
@@ -54,7 +54,26 @@ struct TargetOptions
   std::unordered_map<std::string, std::unordered_set<tl::optional<std::string>>>
     features;
 
+  enum class CrateType
+  {
+    BIN = 0,
+    LIB,
+    RLIB,
+    DYLIB,
+    CDYLIB,
+    STATICLIB,
+    PROC_MACRO
+  } crate_type
+    = CrateType::BIN;
+
 public:
+  void set_crate_type (int raw_type)
+  {
+    crate_type = static_cast<CrateType> (raw_type);
+  }
+
+  const CrateType &get_crate_type () const { return crate_type; }
+
   // Returns whether a key is defined in the feature set.
   bool has_key (std::string key) const
   {
@@ -214,7 +233,6 @@ struct CompileOptions
   bool crate_name_set_manually = false;
   bool enable_test = false;
   bool debug_assertions = false;
-  bool proc_macro = false;
   std::string metadata_output_path;
 
   enum class Edition
@@ -280,6 +298,14 @@ struct CompileOptions
   }
 
   const Edition &get_edition () const { return edition; }
+
+  void set_crate_type (int raw_type) { target_data.set_crate_type (raw_type); }
+
+  bool is_proc_macro () const
+  {
+    return target_data.get_crate_type ()
+	   == TargetOptions::CrateType::PROC_MACRO;
+  }
 
   void set_compile_step (int raw_step)
   {


### PR DESCRIPTION
Add a new option to crab1 cli to accept crate type. This version of the argument only accept a single crate type. Rustc accepts a comma separated list of crate types but this might require a litle more work for gcc.