### PR TITLE
Proc macro attribute check

### DIFF
--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -561,6 +561,11 @@ AttributeChecker::visit (AST::Function &fun)
 
       if (result.name == "proc_macro_derive")
 	{
+	  if (!attribute.has_attr_input ())
+	    {
+	      rust_error_at (attribute.get_locus (),
+			     "malformed %<%s%> attribute input", name);
+	    }
 	  check_crate_type (name, attribute);
 	}
       else if (result.name == "proc_macro"

--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -565,6 +565,10 @@ AttributeChecker::visit (AST::Function &fun)
 	    {
 	      rust_error_at (attribute.get_locus (),
 			     "malformed %<%s%> attribute input", name);
+	      rust_inform (
+		attribute.get_locus (),
+		"must be of the form: %<#[proc_macro_derive(TraitName, "
+		"/*opt*/ attributes(name1, name2, ...))]%>");
 	    }
 	  check_crate_type (name, attribute);
 	}

--- a/gcc/testsuite/rust/compile/proc_macro_attribute_crate_type.rs
+++ b/gcc/testsuite/rust/compile/proc_macro_attribute_crate_type.rs
@@ -1,0 +1,4 @@
+// { dg-additional-options "-frust-crate-type=lib" }
+
+#[proc_macro_attribute] // { dg-excess-errors "the '#\[proc_macro_attribute\]' attribute is only usable with crates of the 'proc-macro' crate type" }
+pub fn my_invalid_macro() {}

--- a/gcc/testsuite/rust/compile/proc_macro_crate_type.rs
+++ b/gcc/testsuite/rust/compile/proc_macro_crate_type.rs
@@ -1,0 +1,4 @@
+// { dg-additional-options "-frust-crate-type=lib" }
+
+#[proc_macro] // { dg-excess-errors "the '#\[proc_macro\]' attribute is only usable with crates of the 'proc-macro' crate type" }
+pub fn my_invalid_macro() {}

--- a/gcc/testsuite/rust/compile/proc_macro_derive_crate_type.rs
+++ b/gcc/testsuite/rust/compile/proc_macro_derive_crate_type.rs
@@ -1,0 +1,6 @@
+// { dg-additional-options "-frust-crate-type=lib" }
+
+trait Dungeness {}
+
+#[proc_macro_derive(Dungeness)] // { dg-excess-errors "the '#\[proc_macro_derive\]' attribute is only usable with crates of the 'proc-macro' crate type" }
+pub fn my_invalid_macro() {}

--- a/gcc/testsuite/rust/compile/proc_macro_derive_malformed.rs
+++ b/gcc/testsuite/rust/compile/proc_macro_derive_malformed.rs
@@ -1,0 +1,4 @@
+// { dg-additional-options "-frust-crate-type=proc-macro" }
+
+#[proc_macro_derive] // { dg-excess-errors "malformed 'proc_macro_derive' attribute input" }
+pub fn my_invalid_macro() {}


### PR DESCRIPTION
Add attribute check for proc macros declarations.

Requires #2435 

Fixes #2437 