### PR TITLE
[E0323] Implemented associated const, expected another trait

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.cc
@@ -389,12 +389,14 @@ TypeCheckImplItemWithTrait::visit (HIR::ConstantItem &constant)
 				       TraitItemReference::TraitItemType::CONST,
 				       &raw_trait_item);
 
-  // unknown trait item
+  // unknown trait item - https://doc.rust-lang.org/error_codes/E0323.html
   if (!found || raw_trait_item->is_error ())
     {
       rich_location r (line_table, constant.get_locus ());
       r.add_range (trait_reference.get_locus ());
-      rust_error_at (r, "constant %<%s%> is not a member of trait %<%s%>",
+      rust_error_at (r, ErrorCode ("E0323"),
+		     "item %qs is an associated const, which does not match "
+		     "its trait %qs",
 		     constant.get_identifier ().as_string ().c_str (),
 		     trait_reference.get_name ().c_str ());
       return;

--- a/gcc/testsuite/rust/compile/non_member_const.rs
+++ b/gcc/testsuite/rust/compile/non_member_const.rs
@@ -1,0 +1,15 @@
+// https://doc.rust-lang.org/error_codes/E0323.html
+#![allow(unused)]
+fn main() {
+trait Foo {
+    type N;
+}
+
+struct Bar;
+
+impl Foo for Bar {
+    const N : u32 = 0; // { dg-error "item .N. is an associated const, which does not match its trait .Foo." }
+    // error: item `N` is an associated const, which doesn't match its
+    //        trait `<Bar as Foo>`
+}
+}


### PR DESCRIPTION
### Const is not member of trait [`E0323`](https://doc.rust-lang.org/error_codes/E0323.html) 

- Refactored Error message similiar to rustc.

---

### Code tested from [`E0323`](https://doc.rust-lang.org/error_codes/E0323.html):

```rust
// https://doc.rust-lang.org/error_codes/E0323.html
#![allow(unused)]
fn main() {
trait Foo {
    type N;
}

struct Bar;

impl Foo for Bar {
    const N : u32 = 0; // { dg-error "item .N. is an associated const, which does not match its trait .Foo." }
    // error: item `N` is an associated const, which doesn't match its
    //        trait `<Bar as Foo>`
}
}
```

---

### Output:

```rust
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/non_member_const.rs:11:5: error: item 'N' is an associated const, which does not match its trait 'Foo' [E0323]
compiler exited with status 1
PASS: rust/compile/non_member_const.rs  (test for errors, line 11)
PASS: rust/compile/non_member_const.rs (test for excess errors)
```

---

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-implitem.cc (TypeCheckImplItemWithTrait::visit): called error function.

gcc/testsuite/ChangeLog:

	* rust/compile/non_member_const.rs: New test.
