### PR TITLE
Add privacy check to `proc_macro`, `proc_macro_derive` and `proc_macro_attribute` attributes.

### DIFF
--- a/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
+++ b/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
@@ -37,8 +37,6 @@ PrivacyReporter::PrivacyReporter (
 static tl::optional<std::string>
 find_proc_macro_attribute (const AST::AttrVec &outer_attrs)
 {
-  tl::optional<std::string> result;
-
   for (auto &a : outer_attrs)
     {
       auto &segments = a.get_path ().get_segments ();
@@ -47,10 +45,10 @@ find_proc_macro_attribute (const AST::AttrVec &outer_attrs)
       auto name = segments.at (0).get_segment_name ();
       if (name == "proc_macro" || name == "proc_macro_attribute"
 	  || name == "proc_macro_derive")
-	result = {name};
+	return name;
     }
 
-  return result;
+  return tl::nullopt;
 }
 
 // Common check on crate items when dealing with 'proc-macro' crate type.

--- a/gcc/testsuite/rust/compile/proc_macro_attribute_crate_type.rs
+++ b/gcc/testsuite/rust/compile/proc_macro_attribute_crate_type.rs
@@ -1,4 +1,4 @@
 // { dg-additional-options "-frust-crate-type=lib" }
 
-#[proc_macro_attribute] // { dg-excess-errors "the '#\[proc_macro_attribute\]' attribute is only usable with crates of the 'proc-macro' crate type" }
+#[proc_macro_attribute] // { dg-error "the .#.proc_macro_attribute.. attribute is only usable with crates of the .proc-macro. crate type" }
 pub fn my_invalid_macro() {}

--- a/gcc/testsuite/rust/compile/proc_macro_attribute_private.rs
+++ b/gcc/testsuite/rust/compile/proc_macro_attribute_private.rs
@@ -1,0 +1,4 @@
+// { dg-additional-options "-frust-crate-type=proc-macro" }
+
+#[proc_macro_attribute]
+fn my_macro() {} // { dg-error "functions tagged with .#.proc_macro_attribute.. must be .pub." }

--- a/gcc/testsuite/rust/compile/proc_macro_crate_type.rs
+++ b/gcc/testsuite/rust/compile/proc_macro_crate_type.rs
@@ -1,4 +1,4 @@
 // { dg-additional-options "-frust-crate-type=lib" }
 
-#[proc_macro] // { dg-excess-errors "the '#\[proc_macro\]' attribute is only usable with crates of the 'proc-macro' crate type" }
+#[proc_macro] // { dg-error "the .#.proc_macro.. attribute is only usable with crates of the .proc-macro. crate type" }
 pub fn my_invalid_macro() {}

--- a/gcc/testsuite/rust/compile/proc_macro_derive_crate_type.rs
+++ b/gcc/testsuite/rust/compile/proc_macro_derive_crate_type.rs
@@ -2,5 +2,5 @@
 
 trait Dungeness {}
 
-#[proc_macro_derive(Dungeness)] // { dg-excess-errors "the '#\[proc_macro_derive\]' attribute is only usable with crates of the 'proc-macro' crate type" }
+#[proc_macro_derive(Dungeness)] // { dg-error "the .#.proc_macro_derive.. attribute is only usable with crates of the .proc-macro. crate type" }
 pub fn my_invalid_macro() {}

--- a/gcc/testsuite/rust/compile/proc_macro_derive_private.rs
+++ b/gcc/testsuite/rust/compile/proc_macro_derive_private.rs
@@ -1,0 +1,6 @@
+// { dg-additional-options "-frust-crate-type=proc-macro" }
+
+trait Chesapeake {}
+
+#[proc_macro_derive(Chesapeake)]
+fn my_macro() {} // { dg-error "functions tagged with .#.proc_macro_derive.. must be .pub." }

--- a/gcc/testsuite/rust/compile/proc_macro_private.rs
+++ b/gcc/testsuite/rust/compile/proc_macro_private.rs
@@ -1,0 +1,4 @@
+// { dg-additional-options "-frust-crate-type=proc-macro" }
+
+#[proc_macro]
+fn my_macro() {} // { dg-error "functions tagged with .#.proc_macro.. must be .pub." }

--- a/gcc/testsuite/rust/compile/proc_macro_pub_function.rs
+++ b/gcc/testsuite/rust/compile/proc_macro_pub_function.rs
@@ -1,0 +1,3 @@
+// { dg-additional-options "-frust-crate-type=proc-macro" }
+
+pub fn wild_pub_function() {} // { dg-error ".proc-macro. crate types currently cannot export any items other than functions tagged with .#.proc_macro.., .#.proc_macro_derive.. or .#.proc_macro_attribute.." }

--- a/gcc/testsuite/rust/compile/proc_macro_pub_module.rs
+++ b/gcc/testsuite/rust/compile/proc_macro_pub_module.rs
@@ -1,0 +1,3 @@
+// { dg-additional-options "-frust-crate-type=proc-macro" }
+
+pub fn wild_pub_module() {} // { dg-error ".proc-macro. crate types currently cannot export any items other than functions tagged with .#.proc_macro.., .#.proc_macro_derive.. or .#.proc_macro_attribute.." }


### PR DESCRIPTION
Proc macro crates cannot have any public function but proc macros. Proc macros should be public.

Requires #2435 

Fixes #2442 