### PR TITLE
Change Ident structure

### DIFF
--- a/gcc/rust/util/rust-token-converter.cc
+++ b/gcc/rust/util/rust-token-converter.cc
@@ -269,7 +269,7 @@ from_tokenstream (const ProcMacro::TokenStream &ts,
 static void
 from_ident (const ProcMacro::Ident &ident, std::vector<const_TokenPtr> &result)
 {
-  std::string value (reinterpret_cast<const char *> (ident.val), ident.len);
+  std::string value (ident.value.to_string ());
   if (ident.is_raw)
     value = "r#" + value;
 

--- a/libgrust/libproc_macro/ident.cc
+++ b/libgrust/libproc_macro/ident.cc
@@ -28,15 +28,15 @@ namespace ProcMacro {
 extern "C" {
 
 Ident
-Ident__new (unsigned char *str, std::uint64_t len, Span span)
+Ident__new (FFIString str, Span span)
 {
-  return Ident::make_ident (str, len, span);
+  return Ident::make_ident (str, span);
 }
 
 Ident
-Ident__new_raw (unsigned char *str, std::uint64_t len, Span span)
+Ident__new_raw (FFIString str, Span span)
 {
-  return Ident::make_ident (str, len, span, true);
+  return Ident::make_ident (str, span, true);
 }
 
 void
@@ -55,35 +55,25 @@ Ident__clone (const Ident *ident)
 Ident
 Ident::clone () const
 {
-  unsigned char *val = new unsigned char[this->len];
-  // FIXME: UTF-8 Update this with sizeof codepoint instead
-  std::memcpy (val, this->val, this->len * sizeof (char));
-  return {this->is_raw, val, this->len};
+  return {this->is_raw, value.clone (), this->span};
 }
 
 Ident
 Ident::make_ident (std::string str, Span span, bool raw)
 {
-  return Ident::make_ident (reinterpret_cast<const unsigned char *> (
-			      str.c_str ()),
-			    str.length (), span, raw);
+  return Ident::make_ident (FFIString::make_ffistring (str), span, raw);
 }
 
 Ident
-Ident::make_ident (const unsigned char *str, std::uint64_t len, Span span,
-		   bool raw)
+Ident::make_ident (FFIString str, Span span, bool raw)
 {
-  unsigned char *val = new unsigned char[len];
-  // FIXME: UTF-8 Update this with sizeof codepoint instead
-  std::memcpy (val, str, len * sizeof (char));
-  return {raw, val, len};
+  return {raw, str, span};
 }
 
 void
 Ident::drop (Ident *ident)
 {
-  delete[] ident->val;
-  ident->len = 0;
+  FFIString::drop (&ident->value);
 }
 
 } // namespace ProcMacro

--- a/libgrust/libproc_macro/ident.h
+++ b/libgrust/libproc_macro/ident.h
@@ -27,23 +27,20 @@
 #include <string>
 
 #include "span.h"
+#include "ffistring.h"
 
 namespace ProcMacro {
 
 struct Ident
 {
   bool is_raw;
-  // TODO: Adapt this to UTF-8
-  unsigned char *val;
-  // Length in bytes
-  std::uint64_t len;
+  FFIString value;
   Span span;
 
 public:
   Ident clone () const;
   static Ident make_ident (std::string str, Span span, bool raw = false);
-  static Ident make_ident (const unsigned char *str, std::uint64_t len,
-			   Span span, bool raw = false);
+  static Ident make_ident (FFIString str, Span span, bool raw = false);
 
   static void drop (Ident *ident);
 };
@@ -51,10 +48,10 @@ public:
 extern "C" {
 
 Ident
-Ident__new (unsigned char *str, std::uint64_t len, Span span);
+Ident__new (FFIString str, Span span);
 
 Ident
-Ident__new_raw (unsigned char *str, std::uint64_t len, Span span);
+Ident__new_raw (FFIString str, Span span);
 
 void
 Ident__drop (Ident *ident);


### PR DESCRIPTION
Use FFIString in Ident structure rather that a raw pointer and a length, this will reduce the size of the code dealing with raw pointers. Which should prevent some error.

Fixes #2246 