### PR TITLE
[E0045] Variadic Parameters Used on Non-C ABI Function

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.cc
@@ -138,7 +138,15 @@ TypeCheckTopLevelExternItem::visit (HIR::ExternalFunctionItem &function)
 
   uint8_t flags = TyTy::FnType::FNTYPE_IS_EXTERN_FLAG;
   if (function.is_variadic ())
-    flags |= TyTy::FnType::FNTYPE_IS_VARADIC_FLAG;
+    {
+      flags |= TyTy::FnType::FNTYPE_IS_VARADIC_FLAG;
+      if (parent.get_abi () != Rust::ABI::C)
+	{
+	  rust_error_at (
+	    function.get_locus (), ErrorCode ("E0045"),
+	    "C-variadic function must have C or cdecl calling convention");
+	}
+    }
 
   RustIdent ident{
     CanonicalPath::new_seg (function.get_mappings ().get_nodeid (),

--- a/gcc/testsuite/rust/compile/abi-vardaic.rs
+++ b/gcc/testsuite/rust/compile/abi-vardaic.rs
@@ -1,0 +1,7 @@
+// https://doc.rust-lang.org/error_codes/E0045.html
+#![allow(unused)]
+fn main() {
+    extern "Rust" {
+        fn foo(x: u8, ...); // { dg-error "C-variadic function must have C or cdecl calling convention" }
+    }
+}


### PR DESCRIPTION
# Variadic Parameters Used on Non-C ABI Function - [`E0045`](https://doc.rust-lang.org/error_codes/E0045.html)
- Added error code support for using variadic parameters used on Non-C ABI function.
- Fixes #2382

---


### Code tested from [`E0045`](https://doc.rust-lang.org/error_codes/E0045.html)
```rust
// https://doc.rust-lang.org/error_codes/E0045.html
#![allow(unused)]
fn main() {
    extern "Rust" {
        fn foo(x: u8, ...); // { dg-error "C-variadic function must have C or cdecl calling convention" }
    }
}
```

---

### Output:
```rust
➜  gccrs-build gcc/crab1 /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/abi-vardaic.rs                           
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/abi-vardaic.rs:5:9: error: C-variadic function must have C or cdecl calling convention [E0045]
    5 |         fn foo(x: u8, ...); // { dg-error "C-variadic function must have C or cdecl calling convention" }
      |         ^~

Analyzing compilation unit

Time variable                                   usr           sys          wall           GGC
 TOTAL                              :   0.00          0.00          0.00          146k
Extra diagnostic checks enabled; compiler may run slowly.
Configure with --enable-checking=release to disable checks.
```

---


**gcc/rust/ChangeLog:**

	* typecheck/rust-hir-type-check-implitem.cc (TypeCheckTopLevelExternItem::visit): Added check for error code support.

**gcc/testsuite/ChangeLog:**

	* rust/compile/abi-vardaic.rs: New test.

---