### PR TITLE
[E0268] break or continue used outside of loop

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -1277,7 +1277,8 @@ TypeCheckExpr::visit (HIR::BreakExpr &expr)
 {
   if (!context->have_loop_context ())
     {
-      rust_error_at (expr.get_locus (), "cannot %<break%> outside of a loop");
+      rust_error_at (expr.get_locus (), ErrorCode ("E0268"),
+		     "%<break%> outside of a loop or labeled block");
       return;
     }
 
@@ -1311,8 +1312,8 @@ TypeCheckExpr::visit (HIR::ContinueExpr &expr)
 {
   if (!context->have_loop_context ())
     {
-      rust_error_at (expr.get_locus (),
-		     "cannot %<continue%> outside of a loop");
+      rust_error_at (expr.get_locus (), ErrorCode ("E0268"),
+		     "%<continue%> outside of a loop");
       return;
     }
 

--- a/gcc/testsuite/rust/compile/break1.rs
+++ b/gcc/testsuite/rust/compile/break1.rs
@@ -1,5 +1,5 @@
 fn main() {
     let a;
     a = 1;
-    break a; // { dg-error "cannot 'break' outside of a loop" }
+    break a; // { dg-error ".break. outside of a loop or labeled block" }
 }

--- a/gcc/testsuite/rust/compile/break_continue_outside_loop.rs
+++ b/gcc/testsuite/rust/compile/break_continue_outside_loop.rs
@@ -1,0 +1,10 @@
+// https://doc.rust-lang.org/error_codes/E0268.html
+#![allow(unused)]
+fn boo() {
+    continue; // { dg-error ".continue. outside of a loop" }
+    break; // { dg-error ".break. outside of a loop or labeled block" }
+}
+
+fn main() {
+    boo()
+}

--- a/gcc/testsuite/rust/compile/continue1.rs
+++ b/gcc/testsuite/rust/compile/continue1.rs
@@ -3,7 +3,7 @@ fn main() {
     let mut b = 1;
 
     let _fib = {
-        continue; // { dg-error "cannot 'continue' outside of a loop" }
+        continue;   // { dg-error ".continue. outside of a loop" }
         123
     };
 }


### PR DESCRIPTION
# Loop Keyword used outside of loop - [`E0268`](https://doc.rust-lang.org/error_codes/E0268.html)

- A loop keyword (break or continue) was used outside of a loop.
- Refactored error description similiar to rustc.
---

### Code tested from [`E0268`](https://doc.rust-lang.org/error_codes/E0268.html)

```rust
// https://doc.rust-lang.org/error_codes/E0268.html
#![allow(unused)]
fn boo() {
    continue; // { dg-error ".continue. outside of a loop" }
    break; // { dg-error ".break. outside of a loop or labeled block" }
}

fn main() {
    boo()
}
```

---

### Output:

```rust
➜  gccrs-build gcc/crab1 /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/break_continue_outside_loop.rs
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/break_continue_outside_loop.rs:4:5: error: ‘continue’ outside of a loop [E0268]
    4 |     continue;       // { dg-error ".continue. outside of a loop"}
      |     ^~~~~~~~
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/break_continue_outside_loop.rs:5:5: error: ‘break’ outside of a loop or labeled block [E0268]
    5 |     break;          // { dg-error ".break. outside of a loop or labeled block"}
      |     ^~~~~

Analyzing compilation unit

Time variable                                   usr           sys          wall           GGC
 phase parsing                      :   0.00 (  0%)   0.01 (100%)   0.00 (  0%)  8192  (  5%)
 parser (global)                    :   0.00 (  0%)   0.01 (100%)   0.00 (  0%)  8192  (  5%)
 TOTAL                              :   0.00          0.01          0.00          146k
Extra diagnostic checks enabled; compiler may run slowly.
Configure with --enable-checking=release to disable checks.
```

---

### Running testcases:
- [`gcc/testsuite/rust/compile/break1.rs`](https://github.com/Rust-GCC/gccrs/blob/b8268b6b7bb7c0353bfda2c88889b0f0ec71e7c8/gcc/testsuite/rust/compile/break1.rs)
- [`gcc/testsuite/rust/compile/continue1.rs`](https://github.com/Rust-GCC/gccrs/blob/b8268b6b7bb7c0353bfda2c88889b0f0ec71e7c8/gcc/testsuite/rust/compile/continue1.rs)

```rust
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/break1.rs:4:5: error: 'break' outside of a loop or labeled block [E0268]
compiler exited with status 1
PASS: rust/compile/break1.rs  (test for errors, line 4)
PASS: rust/compile/break1.rs (test for excess errors)

/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/continue1.rs:6:9: error: 'continue' outside of a loop [E0268]
compiler exited with status 1
PASS: rust/compile/continue1.rs  (test for errors, line 6)
PASS: rust/compile/continue1.rs (test for excess errors)
```
---

**gcc/rust/ChangeLog:**

	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::visit): refactored and call error function.

**gcc/testsuite/ChangeLog:**

	* rust/compile/break1.rs: Modified to pass test case.
	* rust/compile/continue1.rs: likewise.
	* rust/compile/break_continue_outside_loop.rs: New test.

---