### PR TITLE
Prevent multiple bootstrap builds from running at once

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -1,9 +1,8 @@
 name: GCC Bootstrap Build
 
 on:
-  push:
-    branches: [ master ]
-  merge_group:
+  schedule:
+  - cron: '0 0 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
This should prevent the github-provided runners from spending all their time on bootstrap builds