### PR TITLE
Proc macro non function errors

### DIFF
--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -198,6 +198,33 @@ check_doc_attribute (const AST::Attribute &attribute)
     }
 }
 
+static bool
+is_proc_macro_type (const AST::Attribute &attribute)
+{
+  BuiltinAttrDefinition result;
+  if (!is_builtin (attribute, result))
+    return false;
+
+  auto name = result.name;
+  return name == "proc_macro" || name == "proc_macro_derive"
+	 || name == "proc_macro_attribute";
+}
+
+// Emit an error when one encountered attribute is either #[proc_macro],
+// #[proc_macro_attribute] or #[proc_macro_derive]
+static void
+check_proc_macro_non_function (const AST::AttrVec &attributes)
+{
+  for (auto &attr : attributes)
+    {
+      if (is_proc_macro_type (attr))
+	rust_error_at (
+	  attr.get_locus (),
+	  "the %<#[%s]%> attribute may only be used on bare functions",
+	  attr.get_path ().get_segments ()[0].as_string ().c_str ());
+    }
+}
+
 void
 AttributeChecker::check_attribute (const AST::Attribute &attribute)
 {
@@ -517,12 +544,16 @@ AttributeChecker::visit (AST::Method &)
 {}
 
 void
-AttributeChecker::visit (AST::Module &)
-{}
+AttributeChecker::visit (AST::Module &module)
+{
+  check_proc_macro_non_function (module.get_outer_attrs ());
+}
 
 void
-AttributeChecker::visit (AST::ExternCrate &)
-{}
+AttributeChecker::visit (AST::ExternCrate &crate)
+{
+  check_proc_macro_non_function (crate.get_outer_attrs ());
+}
 
 void
 AttributeChecker::visit (AST::UseTreeGlob &)
@@ -537,8 +568,10 @@ AttributeChecker::visit (AST::UseTreeRebind &)
 {}
 
 void
-AttributeChecker::visit (AST::UseDeclaration &)
-{}
+AttributeChecker::visit (AST::UseDeclaration &declaration)
+{
+  check_proc_macro_non_function (declaration.get_outer_attrs ());
+}
 
 void
 AttributeChecker::visit (AST::Function &fun)
@@ -581,18 +614,23 @@ AttributeChecker::visit (AST::Function &fun)
 }
 
 void
-AttributeChecker::visit (AST::TypeAlias &)
-{}
+AttributeChecker::visit (AST::TypeAlias &alias)
+{
+  check_proc_macro_non_function (alias.get_outer_attrs ());
+}
 
 void
 AttributeChecker::visit (AST::StructStruct &struct_item)
 {
   check_attributes (struct_item.get_outer_attrs ());
+  check_proc_macro_non_function (struct_item.get_outer_attrs ());
 }
 
 void
-AttributeChecker::visit (AST::TupleStruct &)
-{}
+AttributeChecker::visit (AST::TupleStruct &tuplestruct)
+{
+  check_proc_macro_non_function (tuplestruct.get_outer_attrs ());
+}
 
 void
 AttributeChecker::visit (AST::EnumItem &)
@@ -611,20 +649,28 @@ AttributeChecker::visit (AST::EnumItemDiscriminant &)
 {}
 
 void
-AttributeChecker::visit (AST::Enum &)
-{}
+AttributeChecker::visit (AST::Enum &enumeration)
+{
+  check_proc_macro_non_function (enumeration.get_outer_attrs ());
+}
 
 void
-AttributeChecker::visit (AST::Union &)
-{}
+AttributeChecker::visit (AST::Union &u)
+{
+  check_proc_macro_non_function (u.get_outer_attrs ());
+}
 
 void
-AttributeChecker::visit (AST::ConstantItem &)
-{}
+AttributeChecker::visit (AST::ConstantItem &item)
+{
+  check_proc_macro_non_function (item.get_outer_attrs ());
+}
 
 void
-AttributeChecker::visit (AST::StaticItem &)
-{}
+AttributeChecker::visit (AST::StaticItem &item)
+{
+  check_proc_macro_non_function (item.get_outer_attrs ());
+}
 
 void
 AttributeChecker::visit (AST::TraitItemFunc &)
@@ -643,16 +689,22 @@ AttributeChecker::visit (AST::TraitItemType &)
 {}
 
 void
-AttributeChecker::visit (AST::Trait &)
-{}
+AttributeChecker::visit (AST::Trait &trait)
+{
+  check_proc_macro_non_function (trait.get_outer_attrs ());
+}
 
 void
-AttributeChecker::visit (AST::InherentImpl &)
-{}
+AttributeChecker::visit (AST::InherentImpl &impl)
+{
+  check_proc_macro_non_function (impl.get_outer_attrs ());
+}
 
 void
-AttributeChecker::visit (AST::TraitImpl &)
-{}
+AttributeChecker::visit (AST::TraitImpl &impl)
+{
+  check_proc_macro_non_function (impl.get_outer_attrs ());
+}
 
 void
 AttributeChecker::visit (AST::ExternalTypeItem &)
@@ -667,8 +719,10 @@ AttributeChecker::visit (AST::ExternalFunctionItem &)
 {}
 
 void
-AttributeChecker::visit (AST::ExternBlock &)
-{}
+AttributeChecker::visit (AST::ExternBlock &block)
+{
+  check_proc_macro_non_function (block.get_outer_attrs ());
+}
 
 // rust-macro.h
 void

--- a/gcc/testsuite/rust/compile/proc_macro_attribute_non_function.rs
+++ b/gcc/testsuite/rust/compile/proc_macro_attribute_non_function.rs
@@ -1,0 +1,58 @@
+// { dg-additional-options "-frust-crate-type=proc-macro" }
+
+mod inner {
+    struct InnerStruct;
+}
+
+#[proc_macro_attribute] // { dg-error "the .#.proc_macro_attribute.. attribute may only be used on bare functions" }
+type AliasedType = inner::InnerStruct;
+
+// { dg-error "the .#.proc_macro_attribute.. attribute may only be used on bare functions" "" { target *-*-* } .+1 }
+#[proc_macro_attribute]
+use inner::InnerStruct;
+
+#[proc_macro_attribute] // { dg-error "the .#.proc_macro_attribute.. attribute may only be used on bare functions" }
+struct MyStruct;
+
+#[proc_macro_attribute] // { dg-error "the .#.proc_macro_attribute.. attribute may only be used on bare functions" }
+struct MyCurlyStruct {
+    member: usize,
+}
+
+#[proc_macro_attribute] // { dg-error "the .#.proc_macro_attribute.. attribute may only be used on bare functions" }
+struct MyTupleStruct(usize);
+
+#[proc_macro_attribute]
+// { dg-error "the .#.proc_macro_attribute.. attribute may only be used on bare functions" "" { target *-*-* } .-1 }
+extern crate my_extern_crate; // { dg-error "unknown crate .my_extern_crate." }
+                              // { dg-error "failed to locate crate .my_extern_crate." "" { target *-*-* } .-1 }
+
+#[proc_macro_attribute] // { dg-error "the .#.proc_macro_attribute.. attribute may only be used on bare functions" }
+mod my_module {}
+
+#[proc_macro_attribute] // { dg-error "the .#.proc_macro_attribute.. attribute may only be used on bare functions" }
+enum MyEnum {}
+
+#[proc_macro_attribute] // { dg-error "the .#.proc_macro_attribute.. attribute may only be used on bare functions" }
+union MyUnion {
+    f1: u32,
+    f2: f32,
+}
+
+#[proc_macro_attribute] // { dg-error "the .#.proc_macro_attribute.. attribute may only be used on bare functions" }
+const MY_CONST_STR: &str = "my_string";
+
+#[proc_macro_attribute] // { dg-error "the .#.proc_macro_attribute.. attribute may only be used on bare functions" }
+static MY_STATIC_USIZE: usize = 10;
+
+#[proc_macro_attribute] // { dg-error "the .#.proc_macro_attribute.. attribute may only be used on bare functions" }
+trait MyTrait {}
+
+#[proc_macro_attribute] // { dg-error "the .#.proc_macro_attribute.. attribute may only be used on bare functions" }
+impl MyStruct {}
+
+#[proc_macro_attribute] // { dg-error "the .#.proc_macro_attribute.. attribute may only be used on bare functions" }
+impl MyTrait for MyStruct {}
+
+#[proc_macro_attribute] // { dg-error "the .#.proc_macro_attribute.. attribute may only be used on bare functions" }
+extern "C" {}

--- a/gcc/testsuite/rust/compile/proc_macro_derive_non_function.rs
+++ b/gcc/testsuite/rust/compile/proc_macro_derive_non_function.rs
@@ -1,0 +1,60 @@
+// { dg-additional-options "-frust-crate-type=proc-macro" }
+
+trait ToDerive {}
+
+mod inner {
+    struct InnerStruct;
+}
+
+#[proc_macro_derive(ToDerive)] // { dg-error "the .#.proc_macro_derive.. attribute may only be used on bare functions" }
+type AliasedType = inner::InnerStruct;
+
+// { dg-error "the .#.proc_macro_derive.. attribute may only be used on bare functions" "" { target *-*-* } .+1 }
+#[proc_macro_derive(ToDerive)]
+use inner::InnerStruct;
+
+#[proc_macro_derive(ToDerive)] // { dg-error "the .#.proc_macro_derive.. attribute may only be used on bare functions" }
+struct MyStruct;
+
+#[proc_macro_derive(ToDerive)] // { dg-error "the .#.proc_macro_derive.. attribute may only be used on bare functions" }
+struct MyCurlyStruct {
+    member: usize,
+}
+
+#[proc_macro_derive(ToDerive)] // { dg-error "the .#.proc_macro_derive.. attribute may only be used on bare functions" }
+struct MyTupleStruct(usize);
+
+#[proc_macro_derive(ToDerive)]
+// { dg-error "the .#.proc_macro_derive.. attribute may only be used on bare functions" "" { target *-*-* } .-1 }
+extern crate my_extern_crate; // { dg-error "unknown crate .my_extern_crate." }
+                              // { dg-error "failed to locate crate .my_extern_crate." "" { target *-*-* } .-1 }
+
+#[proc_macro_derive(ToDerive)] // { dg-error "the .#.proc_macro_derive.. attribute may only be used on bare functions" }
+mod my_module {}
+
+#[proc_macro_derive(ToDerive)] // { dg-error "the .#.proc_macro_derive.. attribute may only be used on bare functions" }
+enum MyEnum {}
+
+#[proc_macro_derive(ToDerive)] // { dg-error "the .#.proc_macro_derive.. attribute may only be used on bare functions" }
+union MyUnion {
+    f1: u32,
+    f2: f32,
+}
+
+#[proc_macro_derive(ToDerive)] // { dg-error "the .#.proc_macro_derive.. attribute may only be used on bare functions" }
+const MY_CONST_STR: &str = "my_string";
+
+#[proc_macro_derive(ToDerive)] // { dg-error "the .#.proc_macro_derive.. attribute may only be used on bare functions" }
+static MY_STATIC_USIZE: usize = 10;
+
+#[proc_macro_derive(ToDerive)] // { dg-error "the .#.proc_macro_derive.. attribute may only be used on bare functions" }
+trait MyTrait {}
+
+#[proc_macro_derive(ToDerive)] // { dg-error "the .#.proc_macro_derive.. attribute may only be used on bare functions" }
+impl MyStruct {}
+
+#[proc_macro_derive(ToDerive)] // { dg-error "the .#.proc_macro_derive.. attribute may only be used on bare functions" }
+impl MyTrait for MyStruct {}
+
+#[proc_macro_derive(ToDerive)] // { dg-error "the .#.proc_macro_derive.. attribute may only be used on bare functions" }
+extern "C" {}

--- a/gcc/testsuite/rust/compile/proc_macro_non_function.rs
+++ b/gcc/testsuite/rust/compile/proc_macro_non_function.rs
@@ -1,0 +1,57 @@
+// { dg-additional-options "-frust-crate-type=proc-macro" }
+
+mod inner {
+    struct InnerStruct;
+}
+
+#[proc_macro] // { dg-error "the .#.proc_macro.. attribute may only be used on bare functions" }
+type AliasedType = inner::InnerStruct;
+
+// { dg-error "the .#.proc_macro.. attribute may only be used on bare functions" "" { target *-*-* } .+1 }
+#[proc_macro]
+use inner::InnerStruct;
+
+#[proc_macro] // { dg-error "the .#.proc_macro.. attribute may only be used on bare functions" }
+struct MyStruct;
+
+#[proc_macro] // { dg-error "the .#.proc_macro.. attribute may only be used on bare functions" }
+struct MyCurlyStruct {
+    member: usize,
+}
+
+#[proc_macro] // { dg-error "the .#.proc_macro.. attribute may only be used on bare functions" }
+struct MyTupleStruct(usize);
+
+#[proc_macro] // { dg-error "the .#.proc_macro.. attribute may only be used on bare functions" }
+extern crate my_extern_crate; // { dg-error "unknown crate .my_extern_crate." }
+                              // { dg-error "failed to locate crate .my_extern_crate." "" { target *-*-* } .-1 }
+
+#[proc_macro] // { dg-error "the .#.proc_macro.. attribute may only be used on bare functions" }
+mod my_module {}
+
+#[proc_macro] // { dg-error "the .#.proc_macro.. attribute may only be used on bare functions" }
+enum MyEnum {}
+
+#[proc_macro] // { dg-error "the .#.proc_macro.. attribute may only be used on bare functions" }
+union MyUnion {
+    f1: u32,
+    f2: f32,
+}
+
+#[proc_macro] // { dg-error "the .#.proc_macro.. attribute may only be used on bare functions" }
+const MY_CONST_STR: &str = "my_string";
+
+#[proc_macro] // { dg-error "the .#.proc_macro.. attribute may only be used on bare functions" }
+static MY_STATIC_USIZE: usize = 10;
+
+#[proc_macro] // { dg-error "the .#.proc_macro.. attribute may only be used on bare functions" }
+trait MyTrait {}
+
+#[proc_macro] // { dg-error "the .#.proc_macro.. attribute may only be used on bare functions" }
+impl MyStruct {}
+
+#[proc_macro] // { dg-error "the .#.proc_macro.. attribute may only be used on bare functions" }
+impl MyTrait for MyStruct {}
+
+#[proc_macro] // { dg-error "the .#.proc_macro.. attribute may only be used on bare functions" }
+extern "C" {}


### PR DESCRIPTION
Emit an error when a procedural macro attribute is placed on a non function item.

Fixes #2459 