### PR TITLE
nr2.0: Add base for Early name resolution

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -113,6 +113,7 @@ GRS_OBJS = \
 	rust/rust-name-resolution-context.o \
 	rust/rust-default-resolver.o \
     rust/rust-toplevel-name-resolver-2.0.o \
+	rust/rust-early-name-resolver-2.0.o \
     rust/rust-early-name-resolver.o \
     rust/rust-name-resolver.o \
     rust/rust-ast-resolve.o \

--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -576,6 +576,8 @@ public:
     return AST::Kind::MACRO_RULES_DEFINITION;
   }
 
+  MacroKind get_kind () const { return kind; }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */

--- a/gcc/rust/resolve/rust-default-resolver.cc
+++ b/gcc/rust/resolve/rust-default-resolver.cc
@@ -303,15 +303,25 @@ DefaultResolver::visit (AST::StructExprFieldIndexValue &)
 
 void
 DefaultResolver::visit (AST::CallExpr &expr)
-{}
+{
+  expr.get_function_expr ()->accept_vis (*this);
+  for (auto &param : expr.get_params ())
+    param->accept_vis (*this);
+}
 
 void
 DefaultResolver::visit (AST::MethodCallExpr &expr)
-{}
+{
+  expr.get_receiver_expr ()->accept_vis (*this);
+  for (auto &param : expr.get_params ())
+    param->accept_vis (*this);
+}
 
 void
 DefaultResolver::visit (AST::FieldAccessExpr &expr)
-{}
+{
+  expr.get_receiver_expr ()->accept_vis (*this);
+}
 
 void
 DefaultResolver::visit (AST::ClosureExprInner &)

--- a/gcc/rust/resolve/rust-default-resolver.h
+++ b/gcc/rust/resolve/rust-default-resolver.h
@@ -56,7 +56,7 @@ public:
   void visit (AST::Union &);
   void visit (AST::Enum &);
 
-  // Visitors that visit their expression node
+  // Visitors that visit their expression node(s)
   void visit (AST::BorrowExpr &);
   void visit (AST::DereferenceExpr &);
   void visit (AST::ErrorPropagationExpr &);

--- a/gcc/rust/resolve/rust-early-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver-2.0.cc
@@ -1,0 +1,164 @@
+// Copyright (C) 2020-2023 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-early-name-resolver-2.0.h"
+#include "rust-ast-full.h"
+#include "rust-toplevel-name-resolver-2.0.h"
+
+namespace Rust {
+namespace Resolver2_0 {
+
+Early::Early (NameResolutionContext &ctx) : DefaultResolver (ctx) {}
+
+void
+Early::go (AST::Crate &crate)
+{
+  // First we go through TopLevel resolution to get all our declared items
+  auto toplevel = TopLevel (ctx);
+  toplevel.go (crate);
+
+  textual_scope.push ();
+
+  // Then we proceed to the proper "early" name resolution: Import and macro
+  // name resolution
+  for (auto &item : crate.items)
+    item->accept_vis (*this);
+
+  textual_scope.pop ();
+}
+
+void
+Early::TextualScope::push ()
+{
+  // push a new empty scope
+  scopes.emplace_back ();
+}
+
+void
+Early::TextualScope::pop ()
+{
+  rust_assert (!scopes.empty ());
+
+  scopes.pop_back ();
+}
+
+void
+Early::TextualScope::insert (std::string name, NodeId id)
+{
+  rust_assert (!scopes.empty ());
+
+  // we can ignore the return value as we always want the latest defined macro
+  // to shadow a previous one - so if two macros have the same name and get
+  // inserted with the same key, it's not a bug
+  scopes.back ().insert ({name, id});
+}
+
+tl::optional<NodeId>
+Early::TextualScope::get (const std::string &name)
+{
+  for (auto iterator = scopes.rbegin (); iterator != scopes.rend (); iterator++)
+    {
+      auto scope = *iterator;
+      auto found = scope.find (name);
+      if (found != scope.end ())
+	return found->second;
+    }
+
+  return tl::nullopt;
+}
+
+void
+Early::visit (AST::MacroRulesDefinition &def)
+{
+  DefaultResolver::visit (def);
+
+  textual_scope.insert (def.get_rule_name ().as_string (), def.get_node_id ());
+}
+
+void
+Early::visit (AST::BlockExpr &block)
+{
+  textual_scope.push ();
+
+  DefaultResolver::visit (block);
+
+  textual_scope.pop ();
+}
+
+void
+Early::visit (AST::Module &module)
+{
+  textual_scope.push ();
+
+  DefaultResolver::visit (module);
+
+  textual_scope.pop ();
+}
+
+void
+Early::visit (AST::MacroInvocation &invoc)
+{
+  auto path = invoc.get_invoc_data ().get_path ();
+
+  // When a macro is invoked by an unqualified identifier (not part of a
+  // multi-part path), it is first looked up in textual scoping. If this does
+  // not yield any results, then it is looked up in path-based scoping. If the
+  // macro's name is qualified with a path, then it is only looked up in
+  // path-based scoping.
+
+  // https://doc.rust-lang.org/reference/macros-by-example.html#path-based-scope
+
+  tl::optional<NodeId> definition = tl::nullopt;
+  if (path.get_segments ().size () == 1)
+    definition = textual_scope.get (path.get_final_segment ().as_string ());
+
+  // we won't have changed `definition` from `nullopt` if there are more
+  // than one segments in our path
+  if (!definition.has_value ())
+    definition = ctx.macros.resolve_path (path);
+
+  // if the definition still does not have a value, then it's an error
+  if (!definition.has_value ())
+    {
+      rust_error_at (invoc.get_locus (), ErrorCode::E0433,
+		     "could not resolve macro invocation");
+      return;
+    }
+
+  // now do we need to keep mappings or something? or insert "uses" into our
+  // ForeverStack? can we do that? are mappings simpler?
+}
+
+void
+Early::visit (AST::UseDeclaration &use)
+{}
+
+void
+Early::visit (AST::UseTreeRebind &use)
+{}
+
+void
+Early::visit (AST::UseTreeList &use)
+{}
+
+void
+Early::visit (AST::UseTreeGlob &use)
+{}
+
+} // namespace Resolver2_0
+} // namespace Rust

--- a/gcc/rust/resolve/rust-early-name-resolver-2.0.h
+++ b/gcc/rust/resolve/rust-early-name-resolver-2.0.h
@@ -1,0 +1,84 @@
+// Copyright (C) 2020-2023 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_EARLY_NAME_RESOLVER_2_0_H
+#define RUST_EARLY_NAME_RESOLVER_2_0_H
+
+#include "optional.h"
+#include "rust-ast.h"
+#include "rust-ast-visitor.h"
+#include "rust-name-resolution-context.h"
+#include "rust-default-resolver.h"
+
+namespace Rust {
+namespace Resolver2_0 {
+
+class Early : public DefaultResolver
+{
+  using DefaultResolver::visit;
+
+public:
+  Early (NameResolutionContext &ctx);
+
+  void go (AST::Crate &crate);
+
+  // we need to handle definitions for textual scoping
+  void visit (AST::MacroRulesDefinition &) override;
+
+  // as well as lexical scopes
+  void visit (AST::BlockExpr &) override;
+  void visit (AST::Module &) override;
+
+  void visit (AST::MacroInvocation &) override;
+  void visit (AST::UseDeclaration &) override;
+  void visit (AST::UseTreeRebind &) override;
+  void visit (AST::UseTreeList &) override;
+  void visit (AST::UseTreeGlob &) override;
+
+private:
+  /**
+   * Macros can either be resolved through textual scoping or regular path
+   * scoping - which this class represents. Textual scoping works similarly to a
+   * "simple" name resolution algorith, with the addition of "shadowing". Each
+   * time a new lexical scope is entered, we push a new map onto the stack, in
+   * which newly defined macros are added. The latest defined macro is the one
+   * that takes precedence. When resolving a macro invocation to its definition,
+   * we walk up the stack and look for a definition in each of the map until we
+   * find one. Otherwise, the macro invocation is unresolved, and goes through
+   * regular path resolution.
+   */
+  class TextualScope
+  {
+  public:
+    void push ();
+    void pop ();
+
+    void insert (std::string name, NodeId id);
+    tl::optional<NodeId> get (const std::string &name);
+
+  private:
+    std::vector<std::unordered_map<std::string, NodeId>> scopes;
+  };
+
+  TextualScope textual_scope;
+};
+
+} // namespace Resolver2_0
+} // namespace Rust
+
+#endif // ! RUST_EARLY_NAME_RESOLVER_2_0_H

--- a/gcc/rust/resolve/rust-name-resolution-context.cc
+++ b/gcc/rust/resolve/rust-name-resolution-context.cc
@@ -30,9 +30,11 @@ NameResolutionContext::insert (Identifier name, NodeId id, Namespace ns)
       return values.insert (name, id);
     case Namespace::Types:
       return types.insert (name, id);
-    case Namespace::Labels:
     case Namespace::Macros:
+      return macros.insert (name, id);
+    case Namespace::Labels:
     default:
+      // return labels.insert (name, id);
       rust_unreachable ();
     }
 }

--- a/gcc/rust/resolve/rust-rib.cc
+++ b/gcc/rust/resolve/rust-rib.cc
@@ -36,13 +36,15 @@ Rib::Rib (Kind kind, std::unordered_map<std::string, NodeId> values)
 {}
 
 tl::expected<NodeId, DuplicateNameError>
-Rib::insert (std::string name, NodeId id)
+Rib::insert (std::string name, NodeId id, bool can_shadow)
 {
   auto res = values.insert ({name, id});
   auto inserted_id = res.first->second;
+  auto existed = !res.second;
 
-  // if we couldn't insert, the element already exists - exit with an error
-  if (!res.second)
+  // if we couldn't insert, the element already exists - exit with an error,
+  // unless shadowing is allowed
+  if (existed && !can_shadow)
     return tl::make_unexpected (DuplicateNameError (name, inserted_id));
 
   // return the NodeId

--- a/gcc/rust/resolve/rust-rib.h
+++ b/gcc/rust/resolve/rust-rib.h
@@ -93,7 +93,7 @@ public:
     ForwardTypeParamBan,
     /* Const generic, as in the following example: fn foo<T, const X: T>() {} */
     ConstParamType,
-  };
+  } kind;
 
   Rib (Kind kind);
   Rib (Kind kind, std::string identifier, NodeId id);
@@ -107,12 +107,14 @@ public:
    *
    * @param name The name associated with the AST node
    * @param id Its NodeId
+   * @param can_shadow If the newly inserted value can shadow an existing one
    *
    * @return `DuplicateNameError` if the node is already present in the rib. The
    *         `DuplicateNameError` class contains the NodeId of the existing
    * node. Returns the new NodeId on success.
    */
-  tl::expected<NodeId, DuplicateNameError> insert (std::string name, NodeId id);
+  tl::expected<NodeId, DuplicateNameError> insert (std::string name, NodeId id,
+						   bool can_shadow = false);
 
   /**
    * Access an inserted NodeId.
@@ -125,7 +127,6 @@ public:
   const std::unordered_map<std::string, NodeId> &get_values () const;
 
 private:
-  Kind kind;
   std::unordered_map<std::string, NodeId> values;
 };
 

--- a/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
@@ -86,7 +86,8 @@ TopLevel::visit (AST::MacroRulesDefinition &macro)
 {
   // we do not insert macros in the current rib as that needs to be done in the
   // textual scope of the Early pass. we only insert them in the root of the
-  // crate if they are marked with #[macro_export]
+  // crate if they are marked with #[macro_export]. The execption to this is
+  // macros 2.0, which get resolved and inserted like regular items.
 
   if (is_macro_export (macro))
     {
@@ -103,6 +104,9 @@ TopLevel::visit (AST::MacroRulesDefinition &macro)
 			 macro.get_rule_name ().as_string ().c_str ());
 	}
     }
+
+  if (macro.get_kind () == AST::MacroRulesDefinition::MacroKind::DeclMacro)
+    insert_or_error_out (macro.get_rule_name (), macro, Namespace::Macros);
 }
 
 void

--- a/gcc/testsuite/rust/compile/name_resolution10.rs
+++ b/gcc/testsuite/rust/compile/name_resolution10.rs
@@ -1,0 +1,19 @@
+// { dg-options "-frust-name-resolution-2.0 -frust-compile-until=lowering" }
+
+#![feature(decl_macro)]
+
+pub mod foo {
+    pub mod bar {
+        pub mod baz {
+            // macros 2.0 get inserted in Ribs like items
+            pub macro boof() {}
+        }
+    }
+}
+
+#[macro_export]
+fn main() {
+    foo::bar::baz::boof!();
+    crate::foo::bar::baz::boof!();
+    self::foo::bar::baz::boof!();
+}

--- a/gcc/testsuite/rust/compile/name_resolution6.rs
+++ b/gcc/testsuite/rust/compile/name_resolution6.rs
@@ -1,0 +1,28 @@
+// { dg-options "-frust-name-resolution-2.0 -frust-compile-until=lowering" }
+
+pub mod foo {
+    pub mod bar {
+        pub mod baz {
+            pub mod qux {
+                #[macro_export]
+                macro_rules! foo {
+                    (one) => {};
+                }
+
+                pub fn foo() {}
+            }
+        }
+
+        fn f() {
+            fn inner() {
+                macro_rules! foo {
+                    (two) => {};
+                }
+
+                foo!(two); // ok, textual scope
+                crate::foo!(one); // ok, path res
+                super::super::foo!(one); // ok, path res
+            }
+        }
+    }
+}

--- a/gcc/testsuite/rust/compile/name_resolution7.rs
+++ b/gcc/testsuite/rust/compile/name_resolution7.rs
@@ -1,0 +1,17 @@
+// { dg-options "-frust-name-resolution-2.0" }
+
+// check that macros by example do not get inserted in ribs like regular items
+pub mod foo {
+    pub mod bar {
+        pub mod baz {
+            pub mod qux {
+                macro_rules! foo {
+                    (one) => {};
+                }
+            }
+        }
+    }
+}
+
+crate::foo::bar::baz::qux::foo!(); // { dg-error "could not resolve macro invocation" }
+foo::bar::baz::qux::foo!(); // { dg-error "could not resolve macro invocation" }

--- a/gcc/testsuite/rust/compile/name_resolution8.rs
+++ b/gcc/testsuite/rust/compile/name_resolution8.rs
@@ -1,0 +1,26 @@
+// { dg-options "-frust-name-resolution-2.0" }
+
+// check that macros by example get exported to the crate's root with #[macro_export]
+pub mod foo {
+    pub mod bar {
+        pub mod baz {
+            pub mod qux {
+				#[macro_export]
+                macro_rules! foo {
+                    (one) => {};
+                }
+            }
+        }
+    }
+}
+
+crate::foo!(one); // ok
+foo!(one); // ok
+
+mod a {
+	mod b {
+		mod c {
+			super::super::super::foo!(one); // ok
+		}
+	}
+}

--- a/gcc/testsuite/rust/compile/name_resolution9.rs
+++ b/gcc/testsuite/rust/compile/name_resolution9.rs
@@ -1,0 +1,17 @@
+// { dg-options "-frust-name-resolution-2.0" }
+
+pub mod foo {
+    pub mod bar {
+        fn f() {
+            super::super::super::foo!(); // { dg-error "too many leading .super. keywords" }
+                                         // { dg-error "could not resolve macro invocation" "" { target *-*-* } .-1 }
+
+            super::crate::foo!(); // { dg-error "leading path segment .crate. can only be used" }
+                                  // { dg-error "could not resolve macro invocation" "" { target *-*-* } .-1 }
+
+			
+            crate::foo::bar::super::foo!(); // { dg-error "leading path segment .super. can only be used" }
+		                                    // { dg-error "could not resolve macro invocation" "" { target *-*-* } .-1 }
+        }
+    }
+}


### PR DESCRIPTION
This adds a base visitor for resolving macro invocations in the new name resolution 2.0 algorithm. Needs #2469 and #2456