### PR TITLE
Increase FFIString usage

### DIFF
--- a/libgrust/libproc_macro/literal.cc
+++ b/libgrust/libproc_macro/literal.cc
@@ -28,7 +28,7 @@ namespace ProcMacro {
 
 extern "C" {
 bool
-Literal__from_string (const unsigned char *str, std::uint64_t len, Literal *lit)
+Literal__from_string (FFIString str, Literal *lit)
 {
   // FIXME: implement this function with lexer
   std::abort ();

--- a/libgrust/libproc_macro/literal.h
+++ b/libgrust/libproc_macro/literal.h
@@ -105,8 +105,7 @@ public:
 
 extern "C" {
 bool
-Literal__from_string (const unsigned char *str, std::uint64_t len,
-		      Literal *lit);
+Literal__from_string (FFIString str, Literal *lit);
 }
 } // namespace ProcMacro
 

--- a/libgrust/libproc_macro/rust/bridge/literal.rs
+++ b/libgrust/libproc_macro/rust/bridge/literal.rs
@@ -1,12 +1,10 @@
 use bridge::{ffistring::FFIString, span::Span};
-use std::convert::TryInto;
-use std::ffi::c_uchar;
 use std::fmt;
 use std::str::FromStr;
 use LexError;
 
 extern "C" {
-    fn Literal__from_string(str: *const c_uchar, len: u64, lit: *mut Literal) -> bool;
+    fn Literal__from_string(str: FFIString, lit: *mut Literal) -> bool;
 }
 
 #[repr(C)]
@@ -234,13 +232,7 @@ impl FromStr for Literal {
         };
         // TODO: We might want to pass a LexError by reference to retrieve
         // error information
-        if unsafe {
-            Literal__from_string(
-                string.as_ptr(),
-                string.len().try_into().unwrap(),
-                &mut lit as *mut Literal,
-            )
-        } {
+        if unsafe { Literal__from_string(string.into(), &mut lit as *mut Literal) } {
             Err(LexError)
         } else {
             Ok(lit)

--- a/libgrust/libproc_macro/tokenstream.cc
+++ b/libgrust/libproc_macro/tokenstream.cc
@@ -103,11 +103,10 @@ TokenSream__push (TokenStream *stream, TokenTree tree)
 }
 
 extern "C" bool
-TokenStream__from_string (unsigned char *str, std::uint64_t len,
-			  TokenStream *ts)
+TokenStream__from_string (FFIString str, TokenStream *ts)
 {
   bool result;
-  auto source = std::string (reinterpret_cast<const char *> (str), len);
+  auto source = str.to_string ();
 
   *ts = TokenStream::make_tokenstream (source, result);
   return result;

--- a/libgrust/libproc_macro/tokenstream.h
+++ b/libgrust/libproc_macro/tokenstream.h
@@ -27,6 +27,8 @@
 #include <vector>
 #include <string>
 
+#include "ffistring.h"
+
 namespace ProcMacro {
 struct TokenTree;
 
@@ -59,8 +61,7 @@ extern "C" void
 TokenSream__push (TokenStream *stream, TokenTree tree);
 
 extern "C" bool
-TokenStream__from_string (unsigned char *str, std::uint64_t len,
-			  TokenStream *ts);
+TokenStream__from_string (FFIString str, TokenStream *ts);
 
 extern "C" TokenStream
 TokenStream__clone (const TokenStream *ts);


### PR DESCRIPTION
Two remaining structures in the rust interface were still using raw string pointer and length to communicate with the C++ library throught extern C functions. Using FFIString instead allow us to reduce the scope of potential errors using those raw pointers.