### PR TITLE
gccrs: fix ICE when we have unimplemented/invalid trait items

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-item.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.cc
@@ -615,7 +615,8 @@ TypeCheckItem::validate_trait_impl_block (
 						   impl_item.get (), self,
 						   specified_bound,
 						   substitutions);
-	  trait_item_refs.push_back (trait_item_ref.get_raw_item ());
+	  if (!trait_item_ref.is_error ())
+	    trait_item_refs.push_back (trait_item_ref.get_raw_item ());
 	}
     }
 

--- a/gcc/testsuite/rust/compile/issue-2478.rs
+++ b/gcc/testsuite/rust/compile/issue-2478.rs
@@ -1,0 +1,16 @@
+#[lang = "sized"]
+pub trait Sized {}
+
+struct Bar;
+
+trait Foo {
+    const N: u32;
+
+    fn M();
+}
+
+impl Foo for Bar {
+    // { dg-error "missing N, M in implementation of trait .Foo." "" { target *-*-* } .-1 }
+    fn N() {}
+    // { dg-error "method .N. is not a member of trait .Foo." "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/compile/non_member_const.rs
+++ b/gcc/testsuite/rust/compile/non_member_const.rs
@@ -7,9 +7,7 @@ trait Foo {
 
 struct Bar;
 
-impl Foo for Bar {
+impl Foo for Bar {// { dg-error "missing N in implementation of trait .Foo." }
     const N : u32 = 0; // { dg-error "item .N. is an associated const, which does not match its trait .Foo." }
-    // error: item `N` is an associated const, which doesn't match its
-    //        trait `<Bar as Foo>`
 }
 }


### PR DESCRIPTION
When the resulting trait item is in an error state this means the underlying fields will be null.

Fixes #2478
