### PR TITLE
gccrs: Fix ICE by adding check for enum candidate's

### DIFF
--- a/gcc/rust/typecheck/rust-hir-trait-resolve.cc
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.cc
@@ -339,11 +339,11 @@ TraitItemReference::resolve_item (HIR::TraitItemConst &constant)
 void
 TraitItemReference::resolve_item (HIR::TraitItemFunc &func)
 {
-  if (!is_optional ())
-    return;
-
   TyTy::BaseType *item_tyty = get_tyty ();
   if (item_tyty->get_kind () == TyTy::TypeKind::ERROR)
+    return;
+
+  if (!is_optional ())
     return;
 
   // check the block and return types

--- a/gcc/testsuite/rust/compile/issue-2479.rs
+++ b/gcc/testsuite/rust/compile/issue-2479.rs
@@ -1,0 +1,22 @@
+#![allow(unused)]
+fn main() {
+enum Dragon {
+    Born,
+}
+
+fn oblivion() -> Dragon::Born {
+// { dg-error "expected type, found variant of Dragon" "" { target *-*-* } .-1 }
+// { dg-error "failed to resolve return type" "" { target *-*-* } .-2 }
+    Dragon::Born
+}
+
+enum Wizard {
+    Gandalf,
+    Saruman,
+}
+
+trait Isengard {
+    fn wizard(_: Wizard::Saruman);
+    // { dg-error "expected type, found variant of Wizard" "" { target *-*-* } .-1 }
+}
+}


### PR DESCRIPTION
Fixes #2479