### PR TITLE
[E0572] return is outside of function context

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -152,7 +152,7 @@ TypeCheckExpr::visit (HIR::ReturnExpr &expr)
 {
   if (!context->have_function_context ())
     {
-      rust_error_at (expr.get_locus (),
+      rust_error_at (expr.get_locus (), ErrorCode::E0572,
 		     "return statement outside of function body");
       infered = new TyTy::ErrorType (expr.get_mappings ().get_hirid ());
       return;


### PR DESCRIPTION
### [`E0572`](https://doc.rust-lang.org/error_codes/E0572.html) -  return statement was found outside of a function body:


---

### I tried this code from [`E0572`](https://doc.rust-lang.org/error_codes/E0572.html)

```rust
const FOO: u32 = return 0; // error: return statement outside of function body

fn main() {}
```


---

### Output:

```rust
➜  gccrs-build gcc/crab1  ../mahad-testsuite/E0572.rs
../mahad-testsuite/E0572.rs:1:18: error: return statement outside of function body [E0572]
    1 | const FOO: u32 = return 0; // error: return statement outside of function body
      |                  ^~~~~~
../mahad-testsuite/E0572.rs:1:1: error: expected ‘u32’ got ‘<tyty::error>’
    1 | const FOO: u32 = return 0; // error: return statement outside of function body
      | ^~~~~      ~~~   ~~~~~~

Analyzing compilation unit

Time variable                                   usr           sys          wall           GGC
 TOTAL                              :   0.00          0.00          0.00          146k
Extra diagnostic checks enabled; compiler may run slowly.
Configure with --enable-checking=release to disable checks.
```
---

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::visit): called error function.

