### PR TITLE
[E0308] mismatch types on both sides of assignment Operator

### DIFF
--- a/gcc/rust/typecheck/rust-unify.cc
+++ b/gcc/rust/typecheck/rust-unify.cc
@@ -122,7 +122,8 @@ UnifyRules::emit_type_mismatch () const
   rich_location r (line_table, locus);
   r.add_range (lhs.get_locus ());
   r.add_range (rhs.get_locus ());
-  rust_error_at (r, "expected %<%s%> got %<%s%>",
+  rust_error_at (r, ErrorCode::E0308,
+		 "mismatched types, expected %qs but got %qs",
 		 expected->get_name ().c_str (), expr->get_name ().c_str ());
 }
 

--- a/gcc/testsuite/rust/compile/arrays1.rs
+++ b/gcc/testsuite/rust/compile/arrays1.rs
@@ -1,4 +1,4 @@
 fn main() {
     let xs: [i32; 5] = [1, 2, 3, 4, 5];
-    let a: bool = xs[0]; // { dg-error "expected .bool. got .i32." }
+    let a: bool = xs[0]; // { dg-error "mismatched types, expected .bool. but got .i32." }
 }

--- a/gcc/testsuite/rust/compile/bad_type1.rs
+++ b/gcc/testsuite/rust/compile/bad_type1.rs
@@ -1,3 +1,3 @@
 fn main() {
-    let logical: bool = 123; // { dg-error "expected .bool. got .<integer>." }
+    let logical: bool = 123; // { dg-error "mismatched types, expected .bool. but got .<integer>." }
 }

--- a/gcc/testsuite/rust/compile/bad_type2.rs
+++ b/gcc/testsuite/rust/compile/bad_type2.rs
@@ -8,7 +8,7 @@ fn main() {
 
     let mut x;
     x = 1;
-    x = true; // { dg-error "expected .<integer>. got .bool." }
+    x = true; // { dg-error "mismatched types, expected .<integer>. but got .bool." }
 
     let call_test = test(1);
 }

--- a/gcc/testsuite/rust/compile/const_generics_6.rs
+++ b/gcc/testsuite/rust/compile/const_generics_6.rs
@@ -1,2 +1,2 @@
 struct Foo<const N: usize>;
-struct Bar<const N: usize = { 15i32 }>; // { dg-error "expected .usize. got .i32." }
+struct Bar<const N: usize = { 15i32 }>; // { dg-error "mismatched types, expected .usize. but got .i32." }

--- a/gcc/testsuite/rust/compile/deadcode_err1.rs
+++ b/gcc/testsuite/rust/compile/deadcode_err1.rs
@@ -3,7 +3,7 @@ fn foo() -> i32 {
 
     let mut a = 1; // { dg-warning "unreachable statement" }
     a = 1.1; // { dg-warning "unreachable statement" }
-    // { dg-error "expected .<integer>. got .<float>." "" { target *-*-* } .-1 }
+    // { dg-error "mismatched types, expected .<integer>. but got .<float>." "" { target *-*-* } .-1 }
 }
 
 fn main() {

--- a/gcc/testsuite/rust/compile/deadcode_err2.rs
+++ b/gcc/testsuite/rust/compile/deadcode_err2.rs
@@ -1,11 +1,11 @@
 fn foo() -> i32 {
     return 1;
-    return 1.5; // { dg-error "expected .i32. got .<float>." }
+    return 1.5; // { dg-error "mismatched types, expected .i32. but got .<float>." }
     // { dg-warning "unreachable statement" "" { target *-*-* } .-1 } 
 }
 
 fn bar() -> i32 {
-    return 1.5; // { dg-error "expected .i32. got .<float>." }
+    return 1.5; // { dg-error "mismatched types, expected .i32. but got .<float>." }
     return 1;
     // { dg-warning "unreachable statement" "" { target *-*-* } .-1 } 
 }

--- a/gcc/testsuite/rust/compile/func1.rs
+++ b/gcc/testsuite/rust/compile/func1.rs
@@ -1,5 +1,5 @@
 fn test(x: i32) -> bool {
-    return x + 1; // { dg-error "expected .bool. got .i32." }
+    return x + 1; // { dg-error "mismatched types, expected .bool. but got .i32." }
 }
 
 fn main() {

--- a/gcc/testsuite/rust/compile/func3.rs
+++ b/gcc/testsuite/rust/compile/func3.rs
@@ -4,5 +4,5 @@ fn test(a: i32, b: i32) -> i32 {
 
 fn main() {
     let a = test(1, true);
-    // { dg-error "expected .i32. got .bool." "" { target *-*-* } .-1 }
+    // { dg-error "mismatched types, expected .i32. but got .bool." "" { target *-*-* } .-1 }
 }

--- a/gcc/testsuite/rust/compile/func4.rs
+++ b/gcc/testsuite/rust/compile/func4.rs
@@ -1,4 +1,4 @@
-fn func() -> i32 { // { dg-error "expected .i32. got ...." }
+fn func() -> i32 { // { dg-error "mismatched types, expected .i32. but got ...." }
 }
 
 fn main() {

--- a/gcc/testsuite/rust/compile/func5.rs
+++ b/gcc/testsuite/rust/compile/func5.rs
@@ -1,5 +1,5 @@
 fn func() -> i32 {
-    return; // { dg-error "expected .i32. got ...." }
+    return; // { dg-error "mismatched types, expected .i32. but got ...." }
 }
 
 fn main() {

--- a/gcc/testsuite/rust/compile/generics1.rs
+++ b/gcc/testsuite/rust/compile/generics1.rs
@@ -1,4 +1,4 @@
-// { dg-error "expected .i32. got .i8." "" { target *-*-* } 0 }
+// { dg-error "mismatched types, expected .i32. but got .i8." "" { target *-*-* } 0 }
 
 #[lang = "sized"]
 pub trait Sized {}

--- a/gcc/testsuite/rust/compile/generics2.rs
+++ b/gcc/testsuite/rust/compile/generics2.rs
@@ -1,4 +1,4 @@
-// { dg-error "expected .i32. got .i8." "" { target *-*-* } 0 }
+// { dg-error "mismatched types, expected .i32. but got .i8." "" { target *-*-* } 0 }
 
 #[lang = "sized"]
 pub trait Sized {}

--- a/gcc/testsuite/rust/compile/generics3.rs
+++ b/gcc/testsuite/rust/compile/generics3.rs
@@ -1,4 +1,4 @@
-// { dg-error "expected .i32. got .i8." "" { target *-*-* } 0 }
+// { dg-error "mismatched types, expected .i32. but got .i8." "" { target *-*-* } 0 }
 #[lang = "sized"]
 pub trait Sized {}
 

--- a/gcc/testsuite/rust/compile/implicit_returns_err1.rs
+++ b/gcc/testsuite/rust/compile/implicit_returns_err1.rs
@@ -1,5 +1,5 @@
 fn test(x: i32) -> i32 {
-    if x > 1 { // { dg-error "expected .... got .<integer>." }
+    if x > 1 { // { dg-error "mismatched types, expected .... but got .<integer>." }
         1
     } else {
         2

--- a/gcc/testsuite/rust/compile/implicit_returns_err2.rs
+++ b/gcc/testsuite/rust/compile/implicit_returns_err2.rs
@@ -1,5 +1,5 @@
 fn test(x: i32) -> i32 {
-    // { dg-error "expected .i32. got .bool." "" { target *-*-* } .-1 }
+    // { dg-error "mismatched types, expected .i32. but got .bool." "" { target *-*-* } .-1 }
     return 1;
     // { dg-warning "unreachable expression" "" { target *-*-* } .+1 }
     true

--- a/gcc/testsuite/rust/compile/implicit_returns_err3.rs
+++ b/gcc/testsuite/rust/compile/implicit_returns_err3.rs
@@ -1,4 +1,4 @@
-fn test(x: i32) -> i32 { // { dg-error "expected .i32. got ...." }
+fn test(x: i32) -> i32 { // { dg-error "mismatched types, expected .i32. but got ...." }
     if x > 1 {
         1
     }

--- a/gcc/testsuite/rust/compile/implicit_returns_err4.rs
+++ b/gcc/testsuite/rust/compile/implicit_returns_err4.rs
@@ -1,5 +1,5 @@
 fn test(x: bool) -> bool {
-    // { dg-error "expected .bool. got ...." "" { target *-*-*} .-1 }
+    // { dg-error "mismatched types, expected .bool. but got ...." "" { target *-*-*} .-1 }
     return x;
     // { dg-warning "unreachable expression" "" { target *-*-* } .+1 }
     ()

--- a/gcc/testsuite/rust/compile/issue-1152.rs
+++ b/gcc/testsuite/rust/compile/issue-1152.rs
@@ -1,6 +1,6 @@
 fn test() {
     let f = [0; -4_isize];
-    // { dg-error "expected .usize. got .isize." "" { target *-*-* } .-1 }
+    // { dg-error "mismatched types, expected .usize. but got .isize." "" { target *-*-* } .-1 }
     let f = [0_usize; -1_isize];
-    // { dg-error "expected .usize. got .isize." "" { target *-*-* } .-1 }
+    // { dg-error "mismatched types, expected .usize. but got .isize." "" { target *-*-* } .-1 }
 }

--- a/gcc/testsuite/rust/compile/issue-2477.rs
+++ b/gcc/testsuite/rust/compile/issue-2477.rs
@@ -1,3 +1,3 @@
 const FOO: u32 = return 0;
 // { dg-error "return statement outside of function body" "" { target *-*-* } .-1 }
-// { dg-error "expected .u32. got" "" { target *-*-* } .-2 }
+// { dg-error "mismatched types, expected .u32. but got" "" { target *-*-* } .-2 }

--- a/gcc/testsuite/rust/compile/mismatched-types.rs
+++ b/gcc/testsuite/rust/compile/mismatched-types.rs
@@ -1,0 +1,9 @@
+// ErrorCode::E0308
+#![allow(unused)]
+fn main() {
+    fn plus_one(x: i32) -> i32 { 
+        x + 1 
+    }
+    plus_one("Not a number");       // { dg-error "mismatched types, expected .i32. but got .& str." }
+    let x: f32 = "Not a float";     // { dg-error "mismatched types, expected .f32. but got .& str." }
+}

--- a/gcc/testsuite/rust/compile/reference1.rs
+++ b/gcc/testsuite/rust/compile/reference1.rs
@@ -2,5 +2,5 @@ fn main() {
     let a = &123;
     let b: &mut i32 = a;
     // { dg-error "mismatched mutability" "" { target *-*-* } .-1 }
-    // { dg-error "expected .&mut i32. got .& i32." "" { target *-*-* } .-2 }
+    // { dg-error "mismatched types, expected .&mut i32. but got .& i32." "" { target *-*-* } .-2 }
 }

--- a/gcc/testsuite/rust/compile/stmt_with_block_err1.rs
+++ b/gcc/testsuite/rust/compile/stmt_with_block_err1.rs
@@ -1,11 +1,11 @@
 fn test(x: i32) -> i32 {
-    if x > 1 { // { dg-error "expected .... got .<integer>." }
+    if x > 1 { // { dg-error "mismatched types, expected .... but got .<integer>." }
         1
     } else {
         2
     }
 
-    { // { dg-error "expected .... got .<integer>." }
+    { // { dg-error "mismatched types, expected .... but got .<integer>." }
         3
     }
 

--- a/gcc/testsuite/rust/compile/traits1.rs
+++ b/gcc/testsuite/rust/compile/traits1.rs
@@ -3,7 +3,7 @@ pub trait Sized {}
 
 trait Foo {
     fn Bar() -> i32 {}
-    // { dg-error "expected .i32. got .()." "" { target *-*-* } .-1 }
+    // { dg-error "mismatched types, expected .i32. but got .()." "" { target *-*-* } .-1 }
 }
 
 struct Baz;

--- a/gcc/testsuite/rust/compile/traits2.rs
+++ b/gcc/testsuite/rust/compile/traits2.rs
@@ -3,14 +3,14 @@ pub trait Sized {}
 
 trait Foo {
     fn Bar() -> i32 {}
-    // { dg-error "expected .i32. got .()." "" { target *-*-* } .-1 }
+    // { dg-error "mismatched types, expected .i32. but got .()." "" { target *-*-* } .-1 }
 }
 
 struct Baz;
 
 impl Foo for Baz {
     fn Bar() {}
-    // { dg-error "expected" "" { target *-*-* } .-1 }
+    // { dg-error "mismatched types, expected" "" { target *-*-* } .-1 }
     // { dg-error "method .Bar. has an incompatible type for trait .Foo." "" { target *-*-* } .-2 }
 }
 

--- a/gcc/testsuite/rust/compile/tuple_mismatch.rs
+++ b/gcc/testsuite/rust/compile/tuple_mismatch.rs
@@ -7,7 +7,7 @@ fn main() {
 
 // The lhs and rhs sizes don't match, but we still resolve 'a' to be bool, we don't
 // error out immediately once we notice the size mismatch.
-fn foo() -> i32 { // { dg-error "expected .i32. got .bool." }
+fn foo() -> i32 { // { dg-error "mismatched types, expected .i32. but got .bool." }
     let (a, _) = (true, 2, 3); // { dg-error "expected a tuple with 3 elements, found one with 2 elements" }
     a
 }

--- a/gcc/testsuite/rust/compile/tuple_struct3.rs
+++ b/gcc/testsuite/rust/compile/tuple_struct3.rs
@@ -2,5 +2,5 @@ struct Foo(i32, i32, bool);
 
 fn main() {
     let c = Foo(1, 2f32, true);
-    // { dg-error "expected .i32. got .f32." "" { target *-*-* } .-1 }
+    // { dg-error "mismatched types, expected .i32. but got .f32." "" { target *-*-* } .-1 }
 }


### PR DESCRIPTION
## Mismatch types - [`E0308`](https://doc.rust-lang.org/error_codes/E0308.html) 
- This errorcode emits when there are mismatch types between lhs & rhs of assignment operator & refactored message.

---

### Code Tested from  [`E0308`](https://doc.rust-lang.org/error_codes/E0308.html) 

```rust
// ErrorCode::E0308
#![allow(unused)]
fn main() {
    fn plus_one(x: i32) -> i32 { 
        x + 1 
    }
    plus_one("Not a number");       // { dg-error "mismatched types, expected .i32. got .& str." }
    let x: f32 = "Not a float";     // { dg-error "mismatched types, expected .f32. got .& str." }
}

```

---

### Output:

```rust
➜  gccrs-build gcc/crab1 /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/mismatched-types.rs
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/mismatched-types.rs:7:14: error: mismatched types, expected ‘i32’ got ‘& str’ [E0308]
    4 |     fn plus_one(x: i32) -> i32 {
      |                 ~
......
    7 |     plus_one("Not a number");       // { dg-error "mismatched types, expected .i32. got .& str." }
      |              ^~~~~~~~~~~~~
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/mismatched-types.rs:8:5: error: mismatched types, expected ‘f32’ got ‘& str’ [E0308]
    8 |     let x: f32 = "Not a float";     // { dg-error "mismatched types, expected .f32. got .& str." }
      |     ^~~    ~~~   ~~~~~~~~~~~~

Analyzing compilation unit

Time variable                                   usr           sys          wall           GGC
 phase setup                        :   0.00 (  0%)   0.00 (  0%)   0.01 (100%)   138k ( 95%)
 TOTAL                              :   0.00          0.00          0.01          146k
Extra diagnostic checks enabled; compiler may run slowly.
Configure with --enable-checking=release to disable checks.

```

---


> There are no previous running test cases for this.

---

gcc/rust/ChangeLog:

	* typecheck/rust-unify.cc (UnifyRules::emit_type_mismatch): refactored & called error function.

gcc/testsuite/ChangeLog:

	* rust/compile/mismatched-types.rs: New test from rustc.

