### PR TITLE
[E0426] Use of undeclared label

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-expr.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.cc
@@ -451,8 +451,9 @@ ResolveExpr::visit (AST::BreakExpr &expr)
 				    label.get_lifetime_name ()),
 	    &resolved_node))
 	{
-	  rust_error_at (expr.get_label ().get_locus (),
-			 "failed to resolve label");
+	  rust_error_at (expr.get_label ().get_locus (), ErrorCode::E0426,
+			 "use of undeclared label %qs in %<break%>",
+			 label.get_lifetime_name ().c_str ());
 	  return;
 	}
       resolver->insert_resolved_label (label.get_node_id (), resolved_node);
@@ -572,8 +573,9 @@ ResolveExpr::visit (AST::ContinueExpr &expr)
 				    label.get_lifetime_name ()),
 	    &resolved_node))
 	{
-	  rust_error_at (expr.get_label ().get_locus (),
-			 "failed to resolve label");
+	  rust_error_at (expr.get_label ().get_locus (), ErrorCode::E0426,
+			 "use of undeclared label %qs in %<continue%>",
+			 label.get_lifetime_name ().c_str ());
 	  return;
 	}
       resolver->insert_resolved_label (label.get_node_id (), resolved_node);

--- a/gcc/testsuite/rust/compile/undeclared_label.rs
+++ b/gcc/testsuite/rust/compile/undeclared_label.rs
@@ -1,0 +1,16 @@
+// ErrorCode::E0426
+#![allow(unused)]
+fn resolve_label_continue() -> () {
+    loop {
+        continue 'a; // { dg-error "use of undeclared label .a. in .continue." }
+    }
+}
+fn resolve_label_break() -> () {
+    loop {
+        break 'crabby; // { dg-error "use of undeclared label .crabby. in .break." }
+    }
+}
+fn main() {
+    resolve_label_continue();
+    resolve_label_break();
+}


### PR DESCRIPTION
## Use of undeclared `label` in `break` or `continue` statement - [`E0426`](https://doc.rust-lang.org/error_codes/E0426.html)
 - Refactored error message to print more userfriendly message and added error code.

---

### Code Tested

```rust
// ErrorCode::E0426
#![allow(unused)]
fn resolve_label_continue() -> () {
    loop {
        continue 'a; // { dg-error "use of undeclared label .a. in .continue." }
    }
}
fn resolve_label_break() -> () {
    loop {
        break 'crabby; // { dg-error "use of undeclared label .crabby. in .break." }
    }
}
fn main() {
    resolve_label_continue();
    resolve_label_break();
}
```


---

### Output:

```rust
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/undeclared_label.rs:5:18: error: use of undeclared label ‘a’ in ‘continue’ [E0426]
    5 |         continue 'a; // { dg-error "use of undeclared label .a. in .continue." }
      |                  ^~
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/undeclared_label.rs:10:15: error: use of undeclared label ‘crabby’ in ‘break’ [E0426]
   10 |         break 'crabby; // { dg-error "use of undeclared label .crabby. in .break." }

```

---

gcc/rust/ChangeLog:

	* resolve/rust-ast-resolve-expr.cc (ResolveExpr::visit): refactored message and called error function.

gcc/testsuite/ChangeLog:

	* rust/compile/undeclared_label.rs: New test for E0426.

---