### PR TITLE
mklog: handle Signed-Off-By, minor cleanup

### DIFF
--- a/contrib/mklog.py
+++ b/contrib/mklog.py
@@ -68,7 +68,7 @@ TAB_WIDTH = 8
 #   +--------------------------------------------------+
 
 # this regex matches the first line of the "end" in the initial commit message
-FIRST_LINE_OF_END_RE = re.compile('(?i)^(signed-off-by|co-authored-by|#): ')
+FIRST_LINE_OF_END_RE = re.compile('(?i)^(signed-off-by:|co-authored-by:|#) ')
 
 pr_regex = re.compile(r'(\/(\/|\*)|[Cc*!])\s+(?P<pr>PR [a-z+-]+\/[0-9]+)')
 prnum_regex = re.compile(r'PR (?P<comp>[a-z+-]+)/(?P<num>[0-9]+)')


### PR DESCRIPTION
fixup for:

commit 1531c699220160e21655fac29b693a436f564188
Author:     Marc Poulhiès <dkm@kataplop.net>
AuthorDate: Thu Jul 6 22:40:57 2023 +0200
Commit:     CohenArthur <arthur.cohen@embecosm.com>
CommitDate: Wed Jul 12 11:41:31 2023 +0000

    mklog: handle Signed-Off-By, minor cleanup

The regex was not matching the # comments.

contrib/ChangeLog:

	* mklog.py (FIRST_LINE_OF_END_RE): Correctly match comments.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>