### PR TITLE
[E0635] Use of Unknown feature.

### DIFF
--- a/gcc/rust/checks/errors/rust-feature-gate.cc
+++ b/gcc/rust/checks/errors/rust-feature-gate.cc
@@ -49,8 +49,8 @@ FeatureGate::check (AST::Crate &crate)
 		    }
 
 		  else
-		    rust_error_at (item->get_locus (), "unknown feature '%s'",
-				   name_str.c_str ());
+		    rust_error_at (item->get_locus (), ErrorCode::E0635,
+				   "unknown feature %qs", name_str.c_str ());
 		}
 	    }
 	}

--- a/gcc/testsuite/rust/compile/feature.rs
+++ b/gcc/testsuite/rust/compile/feature.rs
@@ -1,4 +1,6 @@
-#![feature(AA)] //{ dg-error "unknown feature 'AA'" }
-                   
+// ErrorCode - E0635
+#![feature(AA)] //{ dg-error "unknown feature .AA." }
+#![feature(iamcrabby)] // { dg-error "unknown feature .iamcrabby." }
+#![feature(nonexistent_gccrs_feature)] // { dg-error "unknown feature .nonexistent_gccrs_feature." }
 
-fn main(){}
+fn main() {}


### PR DESCRIPTION
## Use of Unknown feature - [`E0635`](https://doc.rust-lang.org/error_codes/E0635.html)
Added ErrorCode support for use of unknown
feature.

---

### Code Tested:

```rust
// ErrorCode - E0635
#![feature(AA)] //{ dg-error "unknown feature .AA." }
#![feature(iamcrabby)] // { dg-error "unknown feature .iamcrabby." }
#![feature(nonexistent_gccrs_feature)] // { dg-error "unknown feature .nonexistent_gccrs_feature." }

fn main() {}
```

---

### Output:

```rust
➜  gccrs-build gcc/crab1 /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/feature.rs
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/feature.rs:1:12: error: unknown feature ‘AA’ [E0635]
    1 | #![feature(AA)] //{ dg-error "unknown feature .AA." }
      |            ^~
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/feature.rs:2:12: error: unknown feature ‘iamcrabby’ [E0635]
    2 | #![feature(iamcrabby)] // { dg-error "unknown feature .iamcrabby." }
      |            ^~~~~~~~~
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/feature.rs:3:12: error: unknown feature ‘asm’ [E0635]
    3 | #![feature(asm)] // { dg-error "unknown feature .asm." }
      |            ^~~

Analyzing compilation unit

Time variable                                   usr           sys          wall           GGC
 TOTAL                              :   0.00          0.00          0.00          146k
Extra diagnostic checks enabled; compiler may run slowly.
Configure with --enable-checking=release to disable checks.
```

---

gcc/rust/ChangeLog:

	* checks/errors/rust-feature-gate.cc (FeatureGate::check): errorcode support for unknown feature.

gcc/testsuite/ChangeLog:

	* rust/compile/feature.rs: Added new unknown feature.

---