### PR TITLE
[E0703] Use of Invalid ABI

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-base.cc
+++ b/gcc/rust/hir/rust-ast-lower-base.cc
@@ -702,7 +702,8 @@ ASTLoweringBase::lower_qualifiers (const AST::FunctionQualifiers &qualifiers)
       const std::string &extern_abi = qualifiers.get_extern_abi ();
       abi = get_abi_from_string (extern_abi);
       if (has_extern && abi == ABI::UNKNOWN)
-	rust_error_at (qualifiers.get_locus (), "unknown ABI option");
+	rust_error_at (qualifiers.get_locus (), ErrorCode::E0703,
+		       "invalid ABI: found %qs", extern_abi.c_str ());
     }
 
   return HIR::FunctionQualifiers (qualifiers.get_const_status (), unsafety,
@@ -946,7 +947,8 @@ ASTLoweringBase::lower_extern_block (AST::ExternBlock &extern_block)
       const std::string &extern_abi = extern_block.get_abi ();
       abi = get_abi_from_string (extern_abi);
       if (abi == ABI::UNKNOWN)
-	rust_error_at (extern_block.get_locus (), "unknown ABI option");
+	rust_error_at (extern_block.get_locus (), ErrorCode::E0703,
+		       "invalid ABI: found %qs", extern_abi.c_str ());
     }
 
   HIR::ExternBlock *hir_extern_block

--- a/gcc/testsuite/rust/compile/abi-options1.rs
+++ b/gcc/testsuite/rust/compile/abi-options1.rs
@@ -1,7 +1,9 @@
 extern "foobar" {
-    // { dg-error "unknown ABI option" "" { target *-*-* } .-1 }
+    // { dg-error "invalid ABI: found .foobar." "" { target *-*-* } .-1 }
     fn printf(s: *const i8, ...);
 }
 
 pub extern "baz" fn test() {}
-// { dg-error "unknown ABI option" "" { target *-*-* } .-1 }
+// { dg-error "invalid ABI: found .baz." "" { target *-*-* } .-1 }
+
+// extern "Rust" fn foo() {} // OK!


### PR DESCRIPTION
## Added error code support for invalid ABI -  [`E0703`](https://doc.rust-lang.org/error_codes/E0703.html)

### Code tested:

```rust
extern "foobar" {
    // { dg-error "invalid ABI: found .foobar." "" { target *-*-* } .-1 }
    fn printf(s: *const i8, ...);
}

pub extern "baz" fn test() {}
// { dg-error "invalid ABI: found .baz." "" { target *-*-* } .-1 }

// extern "Rust" fn foo() {} // OK!
```

---

### Output:

```bash
➜  gccrs-build gcc/crab1 /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/abi-options1.rs     
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/abi-options1.rs:1:1: error: invalid ABI: found ‘foobar’ [E0703]
    1 | extern "foobar" {
      | ^~~~~~
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/abi-options1.rs:6:5: error: invalid ABI: found ‘baz’ [E0703]
    6 | pub extern "baz" fn test() {}
      |     ^~~~~~

Analyzing compilation unit

Time variable                                   usr           sys          wall           GGC
 TOTAL                              :   0.00          0.00          0.00          146k
Extra diagnostic checks enabled; compiler may run slowly.
Configure with --enable-checking=release to disable checks.
```

---

gcc/rust/ChangeLog:

	* hir/rust-ast-lower-base.cc (ASTLoweringBase::lower_qualifiers): called error function. (ASTLoweringBase::lower_extern_block): likewise.

gcc/testsuite/ChangeLog:

	* rust/compile/abi-options1.rs: updated comment for testcase.

