### PR TITLE
[E0282] type annotations needed

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -57,7 +57,7 @@ TypeResolution::Resolve (HIR::Crate &crate)
     bool ok = infer_var->default_type (&default_type);
     if (!ok)
       {
-	rust_error_at (mappings->lookup_location (id),
+	rust_error_at (mappings->lookup_location (id), ErrorCode::E0282,
 		       "type annotations needed");
 	return true;
       }


### PR DESCRIPTION
## Compiler failed to infer type & asked for type annotation [`E0282`](https://doc.rust-lang.org/error_codes/E0282.html)

---

### Code Tested:

```rust
fn main() {
    let arr = [];
    // { dg-error "type annotations needed" "" { target *-*-* } .-1 }
}
```


---

### Output:

```bash
➜  gccrs-build gcc/crab1 /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/array_empty_list.rs
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/array_empty_list.rs:2:15: error: type annotations needed [E0282]
    2 |     let arr = [];
      |               ^

Analyzing compilation unit

Time variable                                   usr           sys          wall           GGC
 TOTAL                              :   0.00          0.00          0.00          146k
Extra diagnostic checks enabled; compiler may run slowly.
Configure with --enable-checking=release to disable checks.
```

---

### Running testcase:

- [`gcc/testsuite/rust/compile/array_empty_list.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/array_empty_list.rs)
- [`gcc/testsuite/rust/compile/closure_no_type_anno.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/closure_no_type_anno.rs)
- [`gcc/testsuite/rust/compile/generics11.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/generics11.rs)
- [`gcc/testsuite/rust/compile/generics12.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/generics12.rs)
- [`gcc/testsuite/rust/compile/issue-2036.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/issue-2036.rs)


---


gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check.cc (TypeResolution::Resolve): added errorcode.

