### PR TITLE
[E0308] array misamatch types

### DIFF
--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -401,11 +401,12 @@ HIRCompileBase::verify_array_capacities (tree ltype, tree rtype,
 
   if (ltype_length != rtype_length)
     {
-      rust_error_at (
-	rvalue_locus,
-	"expected an array with a fixed size of " HOST_WIDE_INT_PRINT_UNSIGNED
-	" elements, found one with " HOST_WIDE_INT_PRINT_UNSIGNED " elements",
-	ltype_length, rtype_length);
+      rust_error_at (rvalue_locus, ErrorCode::E0308,
+		     "mismatched types, expected an array with a fixed size "
+		     "of " HOST_WIDE_INT_PRINT_UNSIGNED
+		     " elements, found one with " HOST_WIDE_INT_PRINT_UNSIGNED
+		     " elements",
+		     ltype_length, rtype_length);
       return false;
     }
 

--- a/gcc/testsuite/rust/compile/arrays2.rs
+++ b/gcc/testsuite/rust/compile/arrays2.rs
@@ -1,5 +1,5 @@
 // { dg-additional-options "-w" }
 fn main() {
     let array: [i32; 5] = [1, 2, 3];
-    // { dg-error "expected an array with a fixed size of 5 elements, found one with 3 elements" "" { target *-*-* } .-1 }
+    // { dg-error "mismatched types, expected an array with a fixed size of 5 elements, found one with 3 elements" "" { target *-*-* } .-1 }
 }


### PR DESCRIPTION
 ## Array mismatch types - [`E0308`](https://doc.rust-lang.org/error_codes/E0308.html)  

- This error code was already added in this PR https://github.com/Rust-GCC/gccrs/pull/2494. But this error code is also valid for this mismatch array case.

---

### Code tested:

```rust
// { dg-additional-options "-w" }
fn main() {
    let array: [i32; 5] = [1, 2, 3];
    // { dg-error "mismatched types, expected an array with a fixed size of 5 elements, found one with 3 elements" "" { target *-*-* } .-1 }
}
```

### Output:

```bash
➜  gccrs-build gcc/crab1 /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/arrays2.rs
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/arrays2.rs:3:27: error: mismatched types, expected an array with a fixed size of 5 elements, found one with 3 elements [E0308]
    3 |     let array: [i32; 5] = [1, 2, 3];
      |                           ^

Analyzing compilation unit

Time variable                                   usr           sys          wall           GGC
 phase parsing                      :   0.00 (  0%)   0.00 (  0%)   0.01 (100%)    33k ( 18%)
 parser (global)                    :   0.00 (  0%)   0.00 (  0%)   0.01 (100%)    33k ( 18%)
 TOTAL                              :   0.00          0.00          0.01          179k
Extra diagnostic checks enabled; compiler may run slowly.
Configure with --enable-checking=release to disable checks.

```

---

gcc/rust/ChangeLog:

	* backend/rust-compile.cc (HIRCompileBase::verify_array_capacities): Added ErrorCode.

gcc/testsuite/ChangeLog:

	* rust/compile/arrays2.rs: 