### PR TITLE
[E0541] Use of unknown meta item

### DIFF
--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -212,7 +212,8 @@ HIRCompileBase::handle_deprecated_attribute_on_fndecl (
 	    }
 	  else
 	    {
-	      rust_error_at (attr.get_locus (), "unknown meta item %qs",
+	      rust_error_at (attr.get_locus (), ErrorCode::E0541,
+			     "unknown meta item %qs",
 			     key_value.first.as_string ().c_str ());
 	    }
 	}

--- a/gcc/testsuite/rust/compile/attr_deprecated_2.rs
+++ b/gcc/testsuite/rust/compile/attr_deprecated_2.rs
@@ -1,7 +1,7 @@
 #[deprecated(since="1.0")]
 fn test1() {}
 
-// { dg-excess-errors "unknown meta item ...." }
+// { dg-excess-errors "unknown meta item .invalid." }
 #[deprecated(invalid="invalid")]
 fn test2() {}
 


### PR DESCRIPTION
## Use of unknown meta item [`E0541`](https://doc.rust-lang.org/error_codes/E0541.html)



---

### Code Tested:

- [`gcc/testsuite/rust/compile/attr_deprecated_2.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/attr_deprecated_2.rs)



---


gcc/rust/ChangeLog:

	* backend/rust-compile-base.cc: Added ErrorCode.

gcc/testsuite/ChangeLog:

	* rust/compile/attr_deprecated_2.rs: Updated comment to pass the testcase.

