### PR TITLE
[E0380] Use of auto trait with method or associated item

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -4922,8 +4922,8 @@ Parser<ManagedTokenSource>::parse_trait (AST::Visibility vis,
 
   if (is_auto_trait && !trait_items.empty ())
     {
-      add_error (
-	Error (locus, "associated items are forbidden within auto traits"));
+      add_error (Error (locus, ErrorCode::E0380,
+			"auto traits cannot have associated items"));
 
       // FIXME: unsure if this should be done at parsing time or not
       for (const auto &item : trait_items)

--- a/gcc/testsuite/rust/compile/auto_trait_invalid.rs
+++ b/gcc/testsuite/rust/compile/auto_trait_invalid.rs
@@ -2,7 +2,7 @@
 
 #![feature(optin_builtin_traits)]
 
-unsafe auto trait Invalid { // { dg-error "associated items are forbidden within auto traits" }
+unsafe auto trait Invalid { // { dg-error "auto traits cannot have associated items" }
     fn foo(); // { dg-message "remove this item" }
 
     fn bar() {} // { dg-message "remove this item" }


### PR DESCRIPTION
## Use of auto trait with a method or an associated item - [`E0380`](https://doc.rust-lang.org/error_codes/E0380.html)

 - Updated `add_error` to `rust_error_at`

---

### Running testcase:
- [`gcc/testsuite/rust/compile/auto_trait_invalid.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/auto_trait_invalid.rs)
---

gcc/rust/ChangeLog:

	* parse/rust-parse-impl.h (Parser::parse_trait): added errorcode.

gcc/testsuite/ChangeLog:

	* rust/compile/auto_trait_invalid.rs: New comment.

---