### PR TITLE
`[E0054-E0604-E0620-E0606]` TypeCasting ErrorCodes

### DIFF
--- a/gcc/testsuite/rust/compile/all-cast.rs
+++ b/gcc/testsuite/rust/compile/all-cast.rs
@@ -1,0 +1,11 @@
+fn main() {
+    let x = 5;
+    let x_is_nonzero = x as bool; // { dg-error "cannot cast .<integer>. as .bool." }
+
+    0u32 as char; // { dg-error "cannot cast .u32. as .char., only .u8. can be cast as .char." }
+
+    let x = &[1_usize, 2] as [usize]; // { dg-error "cast to unsized type: .& .usize:CAPACITY.. as ..usize.." }
+
+    let a = &0u8; // Here, `x` is a `&u8`.
+    let y: u32 = a as u32; // { dg-error "casting .& u8. as .u32. is invalid" }
+}

--- a/gcc/testsuite/rust/compile/bad_as_bool_char.rs
+++ b/gcc/testsuite/rust/compile/bad_as_bool_char.rs
@@ -2,17 +2,17 @@ pub fn main ()
 {
   let t = true;
   let f = false;
-  let fone = t as f32;   // { dg-error "invalid cast" }
-  let fzero = f as f64;  // { dg-error "invalid cast" }
+  let fone = t as f32;   // { dg-error "casting .bool. as .f32. is invalid" }
+  let fzero = f as f64;  // { dg-error "casting .bool. as .f64. is invalid" }
 
-  let nb = 0u8 as bool;  // { dg-error "invalid cast .u8. to .bool. \\\[E0054\\\]" }
-  let nc = true as char; // { dg-error "invalid cast" }
+  let nb = 0u8 as bool;  // { dg-error "cannot cast .u8. as .bool." }
+  let nc = true as char; // { dg-error "cannot cast .bool. as .char., only .u8. can be cast as .char." }
 
   let a = 'a';
   let b = 'b';
-  let fa = a as f32;     // { dg-error "invalid cast" }
-  let bb = b as bool;    // { dg-error "invalid cast .char. to .bool. \\\[E0054\\\]" }
+  let fa = a as f32;     // { dg-error "casting .char. as .f32. is invalid" }
+  let bb = b as bool;    // { dg-error "cannot cast .char. as .bool." }
 
   let t32: u32 = 33;
-  let ab = t32 as char;  // { dg-error "invalid cast" }
+  let ab = t32 as char;  // { dg-error "cannot cast .u32. as .char., only .u8. can be cast as .char." }
 }

--- a/gcc/testsuite/rust/compile/cast1.rs
+++ b/gcc/testsuite/rust/compile/cast1.rs
@@ -1,5 +1,5 @@
 fn main() {
     let a: i32 = 123;
     let b = a as char;
-    // { dg-error "invalid cast .i32. to .char." "" { target *-*-* } .-1 }
+    // { dg-error "cannot cast .i32. as .char., only .u8. can be cast as .char." "" { target *-*-* } .-1 }
 }

--- a/gcc/testsuite/rust/compile/cast4.rs
+++ b/gcc/testsuite/rust/compile/cast4.rs
@@ -1,5 +1,5 @@
 fn main() {
     let a: i32 = 123;
     let u = a as bool;
-    // { dg-error "invalid cast .i32. to .bool." "" { target *-*-* } .-1 }
+    // { dg-error "cannot cast .i32. as .bool." "" { target *-*-* } .-1 }
 }

--- a/gcc/testsuite/rust/compile/cast5.rs
+++ b/gcc/testsuite/rust/compile/cast5.rs
@@ -1,11 +1,11 @@
 fn main() {
     const A: char = 0x1F888 as char;
-    // { dg-error "invalid cast .<integer>. to .char." "" { target *-*-* } .-1 }
+    // { dg-error "cannot cast .<integer>. as .char., only .u8. can be cast as .char." "" { target *-*-* } .-1 }
     const B: char = 129160 as char;
-    // { dg-error "invalid cast .<integer>. to .char." "" { target *-*-* } .-1 }
+    // { dg-error "cannot cast .<integer>. as .char., only .u8. can be cast as .char." "" { target *-*-* } .-1 }
     const C: i32 = 42;
     const D: char = C as char;
-    // { dg-error "invalid cast .i32. to .char." "" { target *-*-* } .-1 }
+    // { dg-error "cannot cast .i32. as .char., only .u8. can be cast as .char." "" { target *-*-* } .-1 }
     const E: char = '\u{01F888}';
     const F: u8 = 42; 
     const G: char= F as char;


### PR DESCRIPTION
## Added All Casting ErrorCodes & Updated error message accordingly: 

- Added errorcodes according to different conditions and updated error message according to type casting type.

These are all the error codes related to casting in rustc.

- [`E0054`](https://doc.rust-lang.org/error_codes/E0054.html) to `bool`
- [`E0604`](https://doc.rust-lang.org/error_codes/E0604.html) to `char` other than `u8`
- [`E0605`](https://doc.rust-lang.org/error_codes/E0605.html) Invalid cast between standard data structures, needs rust `standard` library.
- [`E0606`](https://doc.rust-lang.org/error_codes/E0606.html)  incompatible cast - only `primitive` casts.
- [`E0607`](https://doc.rust-lang.org/error_codes/E0607.html) cast of `thin` & `fat pointers` - not supported in gccrs.
- [`E0620`](https://doc.rust-lang.org/error_codes/E0620.html) cast to `unsized` type.
- [`E0623`](https://doc.rust-lang.org/error_codes/E0623.html) A `lifetime` didn't match what was expected - not supported by gccrs.
- [`E0641`](https://doc.rust-lang.org/error_codes/E0641.html)  cast to/from a `pointer` with an `unknown kind` -  `gccrs` emits wrong error here. We need to improve this PR https://github.com/Rust-GCC/gccrs/pull/2490 to fix this issue. See https://godbolt.org/z/xzovd3P36
- [`E0781`](https://doc.rust-lang.org/error_codes/E0781.html) Use of `ABI` with `non-function pointers`.

---


### Added ErrorCodes:
- [`E0054`](https://doc.rust-lang.org/error_codes/E0054.html)
- [`E0604`](https://doc.rust-lang.org/error_codes/E0604.html)
- [`E0620`](https://doc.rust-lang.org/error_codes/E0620.html)
- [`E0606`](https://doc.rust-lang.org/error_codes/E0606.html)








---

### Code Tested:

```rust
fn main() {
    let x = 5;
    let x_is_nonzero = x as bool; // { dg-error "cannot cast .<integer>. as .bool." }

    0u32 as char; // { dg-error "cannot cast .u32. as .char., only .u8. can be cast as .char." }

    let x = &[1_usize, 2] as [usize]; // { dg-error "cast to unsized type: .& .usize:CAPACITY.. as ..usize.." }

    let a = &0u8; // Here, `x` is a `&u8`.
    let y: u32 = a as u32; // { dg-error "casting .& u8. as .u32. is invalid" }
}
```

---

### Output:

```bash
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/all-cast.rs:3:24: error: cannot cast ‘<integer>’ as ‘bool’ [E0054]
    3 |     let x_is_nonzero = x as bool; // { dg-error "cannot cast .<integer>. as .bool." }
      |                        ^    ~~~~
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/all-cast.rs:5:5: error: cannot cast ‘u32’ as ‘char’, only ‘u8’ can be cast as ‘char’ [E0604]
    5 |     0u32 as char; // { dg-error "cannot cast .u32. as .char., only .u8. can be cast as .char." }
      |     ^~~~    ~~~~
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/all-cast.rs:7:13: error: cast to unsized type: ‘& [usize:CAPACITY]’ as ‘[usize]’ [E0620]
    7 |     let x = &[1_usize, 2] as [usize]; // { dg-error "cast to unsized type: .& .usize:CAPACITY.. as ..usize.." }
      |             ^                ~
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/all-cast.rs:10:18: error: casting ‘& u8’ as ‘u32’ is invalid [E0606]
   10 |     let y: u32 = a as u32; // { dg-error "casting .& u8. as .u32. is invalid" }
      |                  ^    ~~~
```



---

gcc/rust/ChangeLog:

	* typecheck/rust-casts.cc (TypeCastRules::emit_cast_error): Refactored ErrorCodes & error messages.

gcc/testsuite/ChangeLog:

	* rust/compile/bad_as_bool_char.rs: Updated comment to pass test case.
	* rust/compile/cast1.rs: likewise.
	* rust/compile/cast4.rs: likewise.
	* rust/compile/cast5.rs: likewise.
	* rust/compile/all-cast.rs: New test for all error codes.

