### PR TITLE
[E0753] Use of inner doc comment in invalid context

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -1218,8 +1218,9 @@ Parser<ManagedTokenSource>::parse_outer_attribute ()
   if (lexer.peek_token ()->get_id () == INNER_DOC_COMMENT)
     {
       Error error (
-	lexer.peek_token ()->get_locus (),
-	"inner doc (%<//!%> or %</*!%>) only allowed at start of item "
+	lexer.peek_token ()->get_locus (), ErrorCode::E0753,
+	"expected outer doc comment, inner doc (%<//!%> or %</*!%>) only "
+	"allowed at start of item "
 	"and before any outer attribute or doc (%<#[%>, %<///%> or %</**%>)");
       add_error (std::move (error));
       lexer.skip_token ();

--- a/gcc/testsuite/rust/compile/bad_inner_doc.rs
+++ b/gcc/testsuite/rust/compile/bad_inner_doc.rs
@@ -2,13 +2,13 @@ pub fn main ()
 {
   //! inner doc allowed
   let _x = 42;
-  // { dg-error "inner doc" "" { target *-*-* } .+1 }
+  // { dg-error "expected outer doc comment, inner doc" "" { target *-*-* } .+1 }
   //! inner doc disallowed
   mod module
   {
     /*! inner doc allowed */
     /// outer doc allowed
-    // { dg-error "inner doc" "" { target *-*-* } .+1 }
+    // { dg-error "expected outer doc comment, inner doc" "" { target *-*-* } .+1 }
     /*! but inner doc not here */
     mod x { }
   }


### PR DESCRIPTION
##  Use of inner doc comment in invalid context - [`E0753`](https://doc.rust-lang.org/error_codes/E0753.html)



---

### Code Tested:
- [`gcc/testsuite/rust/compile/bad_inner_doc.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/bad_inner_doc.rs)

```rust
// ErrorCode - E0753
pub fn main ()
{
  //! inner doc allowed
  let _x = 42;
  // { dg-error "expected outer doc comment, inner doc" "" { target *-*-* } .+1 }
  //! inner doc disallowed
  mod module
  {
    /*! inner doc allowed */
    /// outer doc allowed
    // { dg-error "expected outer doc comment, inner doc" "" { target *-*-* } .+1 }
    /*! but inner doc not here */
    mod x { }
  }
}
```


### Output:

```bash
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/bad_inner_doc.rs:6:3: error: expected outer doc comment, inner doc ('//!' or '/*!') only allowed at start of item and before any outer attribute or doc ('#[', '///' or '/**') [E0753]
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/bad_inner_doc.rs:12:5: error: expected outer doc comment, inner doc ('//!' or '/*!') only allowed at start of item and before any outer attribute or doc ('#[', '///' or '/**') [E0753]
compiler exited with status 1
PASS: rust/compile/bad_inner_doc.rs  at line 5 (test for errors, line 6)
PASS: rust/compile/bad_inner_doc.rs  at line 11 (test for errors, line 12)
PASS: rust/compile/bad_inner_doc.rs (test for excess errors)
```


---

gcc/rust/ChangeLog:

	* parse/rust-parse-impl.h (Parser::parse_outer_attribute): Added errorcode & updated error function.

gcc/testsuite/ChangeLog:

	* rust/compile/bad_inner_doc.rs: 