### PR TITLE
Fix a warning about extra semicolon

### DIFF
--- a/gcc/rust/util/rust-common.h
+++ b/gcc/rust/util/rust-common.h
@@ -63,7 +63,7 @@ enum_to_str (Mutability mut)
       return "Mut";
     }
   gcc_unreachable ();
-};
+}
 
 } // namespace Rust
 


### PR DESCRIPTION
This semicolon produces several warning in each TU the header file is included in.