### PR TITLE
[E0412] used type name not in scope

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-type.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-type.cc
@@ -240,7 +240,7 @@ ResolveRelativeTypePath::go (AST::TypePath &path, NodeId &resolved_node_id)
 	}
       else if (is_first_segment)
 	{
-	  rust_error_at (segment->get_locus (),
+	  rust_error_at (segment->get_locus (), ErrorCode::E0412,
 			 "failed to resolve TypePath: %s in this scope",
 			 segment->as_string ().c_str ());
 	  return false;


### PR DESCRIPTION
### used type name not in scope - [`E0412`](https://doc.rust-lang.org/error_codes/E0412.html) 


### Code:

```rust
struct S<const N: usize>;

pub fn foo<const N: FooBar>() {} // { dg-error "failed to resolve" }
type Foo<const N: FooBar> = S<N>; // { dg-error "failed to resolve" }
struct Foo2<const N: FooBar>; // { dg-error "failed to resolve" }
enum Foo3<const N: FooBar> { // { dg-error "failed to resolve" }
    Foo,
    Bar,
}
union Foo4<const N: FooBar> { // { dg-error "failed to resolve" }
    a: usize,
    b: i32,
}
trait Fooable<const N: FooBar> {} // { dg-error "failed to resolve" }

trait Traitable {}
impl<const N: FooBar> Traitable for Foo2<N> {} // { dg-error "failed to resolve" }

```




### Output:

```bash
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/const_generics_7.rs:3:21: error: failed to resolve TypePath: FooBar in this scope [E0412]
    3 | pub fn foo<const N: FooBar>() {} // { dg-error "failed to resolve" }
      |                     ^~~~~~
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/const_generics_7.rs:4:19: error: failed to resolve TypePath: FooBar in this scope [E0412]
    4 | type Foo<const N: FooBar> = S<N>; // { dg-error "failed to resolve" }
      |                   ^~~~~~
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/const_generics_7.rs:4:31: error: failed to resolve TypePath: N in this scope [E0412]
    4 | type Foo<const N: FooBar> = S<N>; // { dg-error "failed to resolve" }
      |                               ^
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/const_generics_7.rs:5:22: error: failed to resolve TypePath: FooBar in this scope [E0412]
    5 | struct Foo2<const N: FooBar>; // { dg-error "failed to resolve" }
      |                      ^~~~~~
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/const_generics_7.rs:6:20: error: failed to resolve TypePath: FooBar in this scope [E0412]
    6 | enum Foo3<const N: FooBar> { // { dg-error "failed to resolve" }
      |                    ^~~~~~
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/const_generics_7.rs:10:21: error: failed to resolve TypePath: FooBar in this scope [E0412]
   10 | union Foo4<const N: FooBar> { // { dg-error "failed to resolve" }
      |                     ^~~~~~
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/const_generics_7.rs:14:24: error: failed to resolve TypePath: FooBar in this scope [E0412]
   14 | trait Fooable<const N: FooBar> {} // { dg-error "failed to resolve" }
      |                        ^~~~~~
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/const_generics_7.rs:17:15: error: failed to resolve TypePath: FooBar in this scope [E0412]
   17 | impl<const N: FooBar> Traitable for Foo2<N> {} // { dg-error "failed to resolve" }
      |               ^~~~~~
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/const_generics_7.rs:17:42: error: failed to resolve TypePath: N in this scope [E0412]
   17 | impl<const N: FooBar> Traitable for Foo2<N> {} // { dg-error "failed to resolve" }
      |                                          ^
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/const_generics_7.rs:17:42: error: failed to resolve TypePath: N in this scope [E0412]

```
gcc/rust/ChangeLog:

	* resolve/rust-ast-resolve-type.cc (ResolveRelativeTypePath::go): Added ErrorCode.

