### PR TITLE
Add punycode encoding to v0 mangling

### DIFF
--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -2533,8 +2533,9 @@ Lexer::start_line (int current_line, int current_column)
 namespace selftest {
 
 // Checks if `src` has the same contents as the given characters
-void
-assert_source_content (Rust::InputSource &src, std::vector<uint32_t> expected)
+static void
+assert_source_content (Rust::InputSource &src,
+		       const std::vector<uint32_t> &expected)
 {
   Rust::Codepoint src_char = src.next ();
   for (auto expected_char : expected)
@@ -2549,15 +2550,16 @@ assert_source_content (Rust::InputSource &src, std::vector<uint32_t> expected)
   ASSERT_TRUE (src_char.is_eof ());
 }
 
-void
-test_buffer_input_source (std::string str, std::vector<uint32_t> expected)
+static void
+test_buffer_input_source (std::string str,
+			  const std::vector<uint32_t> &expected)
 {
   Rust::BufferInputSource source (str, 0);
   assert_source_content (source, expected);
 }
 
-void
-test_file_input_source (std::string str, std::vector<uint32_t> expected)
+static void
+test_file_input_source (std::string str, const std::vector<uint32_t> &expected)
 {
   FILE *tmpf = tmpfile ();
   // Moves to the first character

--- a/gcc/rust/resolve/rust-ast-resolve-toplevel.h
+++ b/gcc/rust/resolve/rust-ast-resolve-toplevel.h
@@ -430,7 +430,7 @@ public:
       }
     else
       {
-	CrateNum found_crate_num = UNKNOWN_CREATENUM;
+	CrateNum found_crate_num = UNKNOWN_CRATENUM;
 	bool found
 	  = mappings->lookup_crate_name (extern_crate.get_referenced_crate (),
 					 found_crate_num);

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -979,7 +979,7 @@ NodeId
 Session::load_extern_crate (const std::string &crate_name, location_t locus)
 {
   // has it already been loaded?
-  CrateNum found_crate_num = UNKNOWN_CREATENUM;
+  CrateNum found_crate_num = UNKNOWN_CRATENUM;
   bool found = mappings->lookup_crate_name (crate_name, found_crate_num);
   if (found)
     {

--- a/gcc/rust/util/rust-canonical-path.h
+++ b/gcc/rust/util/rust-canonical-path.h
@@ -58,7 +58,7 @@ public:
   {
     rust_assert (!path.empty ());
     return CanonicalPath ({std::pair<NodeId, std::string> (id, path)},
-			  UNKNOWN_CREATENUM);
+			  UNKNOWN_CRATENUM);
   }
 
   static CanonicalPath
@@ -88,7 +88,7 @@ public:
 
   static CanonicalPath create_empty ()
   {
-    return CanonicalPath ({}, UNKNOWN_CREATENUM);
+    return CanonicalPath ({}, UNKNOWN_CRATENUM);
   }
 
   bool is_empty () const { return segs.size () == 0; }
@@ -171,7 +171,7 @@ public:
 
   CrateNum get_crate_num () const
   {
-    rust_assert (crate_num != UNKNOWN_CREATENUM);
+    rust_assert (crate_num != UNKNOWN_CRATENUM);
     return crate_num;
   }
 

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -29,7 +29,7 @@ namespace Analysis {
 NodeMapping
 NodeMapping::get_error ()
 {
-  return NodeMapping (UNKNOWN_CREATENUM, UNKNOWN_NODEID, UNKNOWN_HIRID,
+  return NodeMapping (UNKNOWN_CRATENUM, UNKNOWN_NODEID, UNKNOWN_HIRID,
 		      UNKNOWN_LOCAL_DEFID);
 }
 
@@ -94,7 +94,7 @@ static const HirId kDefaultHirIdBegin = 1;
 static const HirId kDefaultCrateNumBegin = 0;
 
 Mappings::Mappings ()
-  : crateNumItr (kDefaultCrateNumBegin), currentCrateNum (UNKNOWN_CREATENUM),
+  : crateNumItr (kDefaultCrateNumBegin), currentCrateNum (UNKNOWN_CRATENUM),
     hirIdIter (kDefaultHirIdBegin), nodeIdIter (kDefaultNodeIdBegin)
 {
   Analysis::NodeMapping node (0, 0, 0, 0);

--- a/gcc/rust/util/rust-mapping-common.h
+++ b/gcc/rust/util/rust-mapping-common.h
@@ -61,7 +61,7 @@ struct DefId
   }
 };
 
-#define UNKNOWN_CREATENUM ((uint32_t) (0))
+#define UNKNOWN_CRATENUM ((uint32_t) (UINT32_MAX))
 #define UNKNOWN_NODEID ((uint32_t) (0))
 #define UNKNOWN_HIRID ((uint32_t) (0))
 #define UNKNOWN_LOCAL_DEFID ((uint32_t) (0))


### PR DESCRIPTION
~~Depends on https://github.com/Rust-GCC/gccrs/pull/2533~~
Please review the last commit

```
gcc/rust/ChangeLog:

	* backend/rust-mangle.cc (v0_add_identifier): Added punycode encoding
	(v0_mangle_item): Likewise.
	* resolve/rust-ast-resolve-toplevel.h: fix typo
	* rust-session-manager.cc (Session::load_extern_crate): fix typo
	* util/rust-canonical-path.h: fix typo
	* util/rust-hir-map.cc (NodeMapping::get_error): fix typo
	(Mappings::Mappings): fix typo
	* util/rust-mapping-common.h (UNKNOWN_CREATENUM): fix typo
	(UNKNOWN_CRATENUM): Change 0 to UINT32_MAX
```

I manually checked the following cases for `add_v0_identifier`:
```
_あ to u5___x7t
my_crate__ to 10my_crate__
6foobar
foobar to 6foobar
あ to u3l8j
_あいう to u7___x7tgi
ああああ to u6l8jaaa
```