### PR TITLE
[E0658] Use of mutable reference in constant functions.

### DIFF
--- a/gcc/rust/checks/errors/rust-const-checker.cc
+++ b/gcc/rust/checks/errors/rust-const-checker.cc
@@ -861,7 +861,7 @@ void
 ConstChecker::visit (ReferenceType &type)
 {
   if (const_context.is_in_context () && type.is_mut ())
-    rust_error_at (type.get_locus (),
+    rust_error_at (type.get_locus (), ErrorCode::E0658,
 		   "mutable references are not allowed in constant functions");
 }
 

--- a/gcc/rust/checks/errors/rust-feature-gate.cc
+++ b/gcc/rust/checks/errors/rust-feature-gate.cc
@@ -86,7 +86,7 @@ FeatureGate::gate (Feature::Name name, location_t loc,
 	{
 	  const char *fmt_str
 	    = "%s. add `#![feature(%s)]` to the crate attributes to enable.";
-	  rust_error_at (loc, fmt_str, error_msg.c_str (),
+	  rust_error_at (loc, ErrorCode::E0658, fmt_str, error_msg.c_str (),
 			 feature.as_string ().c_str ());
 	}
     }


### PR DESCRIPTION
## Use of mutable reference in constant functions. [`E0658`](https://doc.rust-lang.org/error_codes/E0658.html)


### Running cases:

- [`gcc/testsuite/rust/compile/const10.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/const10.rs)

#### For changed_intrinsics:

- [`gcc/testsuite/rust/compile/changed_intrinsics.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/changed_intrinsics.rs)
- [`gcc/testsuite/rust/compile/feature_intrinsics.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/feature_intrinsics.rs)




### For internal implementation detail:
- [`gcc/testsuite/rust/compile/feature_rust_attri1.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/feature_rust_attri1.rs)
- [`gcc/testsuite/rust/compile/feature_rust_attri0.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/feature_rust_attri0.rs)

```bash
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/const10.rs:1:18: error: mutable references are not allowed in constant functions [E0658]
    1 | const fn foo (a: &mut i32) { // { dg-error "mutable references are not allowed in constant functions" }
      |                  ^


```
gcc/rust/ChangeLog:

	* checks/errors/rust-const-checker.cc (ConstChecker::visit): added error code.

