### PR TITLE
Handle nested macro definition (resolver)

### DIFF
--- a/gcc/rust/resolve/rust-early-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver-2.0.cc
@@ -135,8 +135,10 @@ Early::visit (AST::MacroInvocation &invoc)
   // if the definition still does not have a value, then it's an error
   if (!definition.has_value ())
     {
-      rust_error_at (invoc.get_locus (), ErrorCode::E0433,
-		     "could not resolve macro invocation");
+      collect_error ([&] () {
+	rust_error_at (invoc.get_locus (), ErrorCode::E0433,
+		       "could not resolve macro invocation");
+      });
       return;
     }
 

--- a/gcc/rust/resolve/rust-early-name-resolver-2.0.h
+++ b/gcc/rust/resolve/rust-early-name-resolver-2.0.h
@@ -28,6 +28,8 @@
 namespace Rust {
 namespace Resolver2_0 {
 
+using ResolveError = std::function<void ()>;
+
 class Early : public DefaultResolver
 {
   using DefaultResolver::visit;
@@ -36,6 +38,11 @@ public:
   Early (NameResolutionContext &ctx);
 
   void go (AST::Crate &crate);
+
+  const std::vector<ResolveError> &get_macro_resolve_errors () const
+  {
+    return macro_resolve_errors;
+  }
 
   // we need to handle definitions for textual scoping
   void visit (AST::MacroRulesDefinition &) override;
@@ -76,6 +83,9 @@ private:
   };
 
   TextualScope textual_scope;
+  std::vector<ResolveError> macro_resolve_errors;
+
+  void collect_error (ResolveError e) { macro_resolve_errors.push_back (e); }
 };
 
 } // namespace Resolver2_0

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -875,6 +875,7 @@ Session::expansion (AST::Crate &crate)
   /* expand by calling cxtctxt object's monotonic_expander's expand_crate
    * method. */
   MacroExpander expander (crate, cfg, *this);
+  std::vector<Resolver2_0::ResolveError> macro_errors;
 
   while (!fixed_point_reached && iterations < cfg.recursion_limit)
     {
@@ -883,7 +884,11 @@ Session::expansion (AST::Crate &crate)
       auto ctx = Resolver2_0::NameResolutionContext ();
 
       if (flag_name_resolution_2_0)
-	Resolver2_0::Early (ctx).go (crate);
+	{
+	  Resolver2_0::Early early (ctx);
+	  early.go (crate);
+	  macro_errors = early.get_macro_resolve_errors ();
+	}
       else
 	Resolver::EarlyNameResolver ().go (crate);
 
@@ -895,6 +900,11 @@ Session::expansion (AST::Crate &crate)
 
       if (saw_errors ())
 	break;
+    }
+
+  for (auto &error : macro_errors)
+    {
+      error ();
     }
 
   if (iterations == cfg.recursion_limit)


### PR DESCRIPTION
Fixes #2516 

This PR clashes with #2541  we need to decide which one get merged. Per

> // now do we need to keep mappings or something? or insert "uses" into our
> // ForeverStack? can we do that? are mappings simpler?

This is still an early draft, I don't really know where I am going with this one. @CohenArthur could you give me more details about what you had in mind with this comment ?