### PR TITLE
[E0015] Use of non-const inside const

### DIFF
--- a/gcc/rust/checks/errors/rust-const-checker.cc
+++ b/gcc/rust/checks/errors/rust-const-checker.cc
@@ -339,8 +339,9 @@ ConstChecker::check_function_call (HirId fn_id, location_t locus)
     }
 
   if (is_error)
-    rust_error_at (locus, "only functions marked as %<const%> are allowed to "
-			  "be called from constant contexts");
+    rust_error_at (locus, ErrorCode::E0015,
+		   "only functions marked as %<const%> are allowed to be "
+		   "called from constant contexts");
 }
 
 void


### PR DESCRIPTION
## Use of `non-const` inside `const` - [`E0015`](https://doc.rust-lang.org/error_codes/E0015.html)

### Code tested:
- [`gcc/testsuite/rust/compile/diagnostic_underline.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/diagnostic_underline.rs)
- [`gcc/testsuite/rust/compile/const-issue1440.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/const-issue1440.rs)
- [`gcc/testsuite/rust/compile/const1.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/const1.rs)
- [`gcc/testsuite/rust/compile/const3.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/const3.rs)





---


gcc/rust/ChangeLog:

	* checks/errors/rust-const-checker.cc (ConstChecker::check_function_call): Added errorcode.

