### PR TITLE
[E0107] Wrong number of generic argument

### DIFF
--- a/gcc/rust/typecheck/rust-tyty-subst.cc
+++ b/gcc/rust/typecheck/rust-tyty-subst.cc
@@ -633,7 +633,7 @@ SubstitutionRef::get_mappings_from_generic_args (HIR::GenericArgs &args)
       r.add_range (substitutions.front ().get_param_locus ());
 
       rust_error_at (
-	r,
+	r, ErrorCode::E0107,
 	"generic item takes at least %lu type arguments but %lu were supplied",
 	(unsigned long) (min_required_substitutions () - offs),
 	(unsigned long) args.get_type_args ().size ());


### PR DESCRIPTION
## Wrong number of generic argument [`E0107`](https://doc.rust-lang.org/error_codes/E0107.html)

- [`gcc/testsuite/rust/compile/expected_type_args2.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/expected_type_args2.rs)
- [`gcc/testsuite/rust/compile/expected_type_args3.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/expected_type_args3.rs)
- [`gcc/testsuite/rust/compile/traits12.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/traits12.rs)


gcc/rust/ChangeLog:

	* typecheck/rust-tyty-subst.cc (SubstitutionRef::get_mappings_from_generic_args): Added errorcode.

