### PR TITLE
gccrs: Adjust HIR dump for IfExpr and IfExprConseqElse

### DIFF
--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -323,6 +323,14 @@ Dump::do_structexprstruct (StructExprStruct &e)
 }
 
 void
+Dump::do_ifexpr (IfExpr &e)
+{
+  do_expr (e);
+  visit_field ("condition", e.get_if_condition ());
+  visit_field ("if_block", e.get_if_block ());
+}
+
+void
 Dump::do_expr (Expr &e)
 {
   do_mappings (e.get_mappings ());
@@ -1404,18 +1412,10 @@ Dump::visit (ForLoopExpr &e)
 }
 
 void
-Dump::visit (IfExpr &if_expr)
+Dump::visit (IfExpr &e)
 {
   begin ("IfExpr");
-  begin ("condition");
-
-  if_expr.vis_if_condition (*this);
-  end ("condition");
-
-  begin ("if_block");
-  if_expr.vis_if_block (*this);
-  end ("if_block");
-
+  do_ifexpr (e);
   end ("IfExpr");
 }
 
@@ -1423,18 +1423,8 @@ void
 Dump::visit (IfExprConseqElse &e)
 {
   begin ("IfExprConseqElse");
-
-  begin ("condition");
-  e.vis_if_condition (*this);
-  end ("condition");
-
-  begin ("if_block");
-  e.vis_if_block (*this);
-  end ("if_block");
-
-  begin ("else_block");
-  e.vis_else_block (*this);
-  end ("else_block");
+  do_ifexpr (e);
+  visit_field ("else_block", e.get_else_block ());
 
   end ("IfExprConseqElse");
 }

--- a/gcc/rust/hir/rust-hir-dump.h
+++ b/gcc/rust/hir/rust-hir-dump.h
@@ -77,6 +77,7 @@ private:
   void do_item (Item &);
   void do_type (Type &);
   void do_expr (Expr &);
+  void do_ifexpr (IfExpr &);
   void do_ifletexpr (IfLetExpr &);
   void do_pathexpr (PathExpr &);
   void do_pathpattern (PathPattern &);


### PR DESCRIPTION
Adjust the HIR dump for IfExpr and IfExprConseqElse
to use visit_field() and factor common part.

gcc/rust/ChangeLog:

	* hir/rust-hir-dump.h (do_ifexpr): New.
	* hir/rust-hir-dump.cc (Dump::do_ifexpr): New.
	(Dump::visit): Use do_ifexpr and visit_field

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>