### PR TITLE
gccrs: simplify matching possible candidates

### DIFF
--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -843,6 +843,12 @@ HIRCompileBase::resolve_method_address (TyTy::FnType *fntype,
   // look for the exact fntype
   for (auto &candidate : filteredFunctionCandidates)
     {
+      if (filteredFunctionCandidates.size () == 1)
+	{
+	  selectedCandidate = &candidate;
+	  break;
+	}
+
       bool compatable
 	= Resolver::types_compatable (TyTy::TyWithLocation (candidate.ty),
 				      TyTy::TyWithLocation (fntype), expr_locus,


### PR DESCRIPTION
We do extra checking after the fact here to ensure its a valid candidate and in the case there is only one candidate lets just go for it.

Addresses #1895

gcc/rust/ChangeLog:

	* backend/rust-compile-base.cc (HIRCompileBase::resolve_method_address): use the single candidate
