### PR TITLE
gccrs: improve name mangling hash

### DIFF
--- a/gcc/rust/backend/rust-compile-intrinsic.cc
+++ b/gcc/rust/backend/rust-compile-intrinsic.cc
@@ -242,17 +242,12 @@ Intrinsics::compile (TyTy::FnType *fntype)
 static bool
 check_for_cached_intrinsic (Context *ctx, TyTy::FnType *fntype, tree *lookup)
 {
+  const Resolver::CanonicalPath &canonical_path = fntype->get_ident ().path;
+  std::string asm_name = ctx->mangle_item (fntype, canonical_path);
   if (ctx->lookup_function_decl (fntype->get_ty_ref (), lookup,
-				 fntype->get_id (), fntype))
+				 fntype->get_id (), fntype, asm_name))
     {
-      // Has this been added to the list? Then it must be finished
-      if (ctx->function_completed (*lookup))
-	{
-	  tree dummy = NULL_TREE;
-	  if (!ctx->lookup_function_decl (fntype->get_ty_ref (), &dummy))
-	    ctx->insert_function_decl (fntype, *lookup);
-	  return true;
-	}
+      return true;
     }
 
   return false;

--- a/gcc/rust/backend/rust-mangle.cc
+++ b/gcc/rust/backend/rust-mangle.cc
@@ -269,7 +269,7 @@ static std::string
 legacy_mangle_item (const TyTy::BaseType *ty,
 		    const Resolver::CanonicalPath &path)
 {
-  const std::string hash = legacy_hash (ty->as_string ());
+  const std::string hash = legacy_hash (ty->mangle_string ());
   const std::string hash_sig = legacy_mangle_name (hash);
 
   return kMangledSymbolPrefix + legacy_mangle_canonical_path (path) + hash_sig

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -158,6 +158,12 @@ public:
   bool has_subsititions_defined () const;
   bool needs_generic_substitutions () const;
 
+  std::string mangle_string () const
+  {
+    return TypeKindFormat::to_string (get_kind ()) + ":" + as_string () + ":"
+	   + mappings_str () + ":" + bounds_as_string ();
+  }
+
   /* Returns a pointer to a clone of this. The caller is responsible for
    * releasing the memory of the returned ty. */
   virtual BaseType *clone () const = 0;


### PR DESCRIPTION
We can endup with duplicate symbol names for different intrinsics with our current hash setup. This adds in the mappings and extra info to improve hash uniqueness.

Addresses #1895

gcc/rust/ChangeLog:

	* backend/rust-compile-intrinsic.cc (check_for_cached_intrinsic): simplify this cached intrinsic check
	* backend/rust-mangle.cc (legacy_mangle_item): use new interface
	* typecheck/rust-tyty.h: new managle helper
