### PR TITLE
`#[no_mangle]` should not be applied to non-ASCII items

### DIFF
--- a/gcc/rust/backend/rust-mangle.cc
+++ b/gcc/rust/backend/rust-mangle.cc
@@ -87,7 +87,7 @@ legacy_mangle_name (const std::string &name)
 	  i++;
 	  m = "..";
 	}
-      else if (c.value < 0x80)
+      else if (c.is_ascii ())
 	// ASCII
 	m.push_back (c.value);
       else

--- a/gcc/rust/lex/rust-input-source.h
+++ b/gcc/rust/lex/rust-input-source.h
@@ -28,9 +28,6 @@ constexpr uint8_t UTF8_BOM1 = 0xEF;
 constexpr uint8_t UTF8_BOM2 = 0xBB;
 constexpr uint8_t UTF8_BOM3 = 0xBF;
 
-constexpr uint32_t MAX_ASCII_CODEPOINT = 0x7F;
-constexpr uint32_t CODEPOINT_INVALID = 0xFFFE;
-
 // Input source wrapper thing.
 class InputSource
 {

--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -1734,7 +1734,7 @@ Lexer::parse_byte_char (location_t loc)
       // otherwise, get character from direct input character
       byte_char = current_char;
 
-      if (byte_char.value > 0x7f)
+      if (!byte_char.is_ascii ())
 	{
 	  rust_error_at (get_current_location (),
 			 "non-ASCII character in %<byte char%>");

--- a/gcc/rust/util/rust-codepoint.h
+++ b/gcc/rust/util/rust-codepoint.h
@@ -23,6 +23,9 @@
 
 namespace Rust {
 
+constexpr uint32_t MAX_ASCII_CODEPOINT = 0x7F;
+constexpr uint32_t CODEPOINT_INVALID = 0xFFFE;
+
 // FIXME: move this to rust-unicode.h?
 struct Codepoint
 {
@@ -36,6 +39,7 @@ struct Codepoint
 
   static Codepoint eof () { return Codepoint (UINT32_MAX); }
   bool is_eof () const { return value == UINT32_MAX; }
+  bool is_ascii () const { return value <= MAX_ASCII_CODEPOINT; }
 
   // Returns a C++ string containing string value of codepoint.
   std::string as_string ();

--- a/gcc/rust/util/rust-punycode.cc
+++ b/gcc/rust/util/rust-punycode.cc
@@ -42,7 +42,7 @@ extract_basic_string (const std::vector<Codepoint> &src)
   std::string basic_string;
   for (auto c : src)
     {
-      if (c.value <= 0x7F)
+      if (c.is_ascii ())
 	basic_string += c.as_string ();
     }
   return basic_string;

--- a/gcc/rust/util/rust-unicode.cc
+++ b/gcc/rust/util/rust-unicode.cc
@@ -16,6 +16,7 @@
 // along with GCC; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
+#include "rust-input-source.h"
 #include "rust-system.h"
 #include "optional.h"
 #include "selftest.h"
@@ -326,6 +327,15 @@ is_numeric (uint32_t codepoint)
     return false;
   else
     return true;
+}
+
+bool
+is_ascii_only (const std::string &str)
+{
+  for (char c : str)
+    if (static_cast<uint32_t> (c) > MAX_ASCII_CODEPOINT)
+      return false;
+  return true;
 }
 
 } // namespace Rust

--- a/gcc/rust/util/rust-unicode.h
+++ b/gcc/rust/util/rust-unicode.h
@@ -63,6 +63,9 @@ bool
 is_alphabetic (uint32_t codepoint);
 
 bool
+is_ascii_only (const std::string &str);
+
+bool
 is_numeric (uint32_t codepoint);
 
 } // namespace Rust


### PR DESCRIPTION
Fixes https://github.com/Rust-GCC/gccrs/issues/2548

```
gccrs: Check function names with no_mangle.
gcc/rust/ChangeLog:

	* backend/rust-compile-base.cc (HIRCompileBase::setup_fndecl): Add parameter.
	* backend/rust-compile-base.h: Likewise.
	* backend/rust-compile-implitem.cc (CompileTraitItem::visit): Change type of parameter.
	* backend/rust-compile-item.cc (CompileItem::visit): Likewise.
	* lex/rust-input-source.h: Move constants to rust-codepoint.h
	* util/rust-codepoint.h (struct Codepoint): Add is_ascii method.
	* util/rust-punycode.cc (extract_basic_string): Use it.
	* lex/rust-lex.cc (Lexer::parse_byte_char): Likewise.
	* backend/rust-mangle.cc (legacy_mangle_name): Likewise.
	* util/rust-unicode.cc (is_ascii_only): New function.
	* util/rust-unicode.h (is_ascii_only): Likewise.
```

Error diagnostics looks like this:
```rust
#[no_mangle]
pub fn ascii() {}

#[no_mangle]
pub fn notーascii() {}
```

```bash
./gccrs-build/gcc/crab1 a.rs -frust-incomplete-and-experimental-compiler-do-not-use -fdump-tree-gimple
a.rs:5:8: error: attribute ‘no_mangle’ requires ASCII identifier [E0754]
    5 | pub fn notーascii() {}
      |        ^~~~~~~~

```