### PR TITLE
[E0592] method or associated functions already defined with same names

### DIFF
--- a/gcc/rust/typecheck/rust-hir-inherent-impl-overlap.h
+++ b/gcc/rust/typecheck/rust-hir-inherent-impl-overlap.h
@@ -129,8 +129,11 @@ public:
 			   const std::string &name)
   {
     rich_location r (line_table, dup->get_locus ());
+    std::string msg = "duplicate definitions for " + name;
+    r.add_fixit_replace (query->get_locus (), msg.c_str ());
     r.add_range (query->get_locus ());
-    rust_error_at (r, "duplicate definitions with name %s", name.c_str ());
+    rust_error_at (r, ErrorCode::E0592, "duplicate definitions with name %qs",
+		   name.c_str ());
   }
 
 private:

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -1097,8 +1097,7 @@ TypeCheckExpr::visit (HIR::MethodCallExpr &expr)
       r.add_fixit_replace (rich_msg.c_str ());
 
       rust_error_at (
-	r, ErrorCode::E0034,
-	"multiple applicable items in scope for method %qs",
+	r, ErrorCode::E0592, "duplicate definitions with name %qs",
 	expr.get_method_name ().get_segment ().as_string ().c_str ());
       return;
     }

--- a/gcc/testsuite/rust/compile/generics7.rs
+++ b/gcc/testsuite/rust/compile/generics7.rs
@@ -22,9 +22,9 @@ impl<T> Foo<T> {
         self.a
     }
 }
-
+// E0592
 fn main() {
     let a = Foo { a: 123 };
     a.bar();
-    // { dg-error "multiple applicable items in scope for method .bar." "" { target *-*-* } .-1 }
+    // { dg-error "duplicate definitions with name .bar." "" { target *-*-* } .-1 }
 }

--- a/gcc/testsuite/rust/compile/generics8.rs
+++ b/gcc/testsuite/rust/compile/generics8.rs
@@ -10,7 +10,7 @@ impl<T> Foo<i32, T> {
 }
 
 impl Foo<i32, f32> {
-    fn test() -> f32 { // { dg-error "duplicate definitions with name test" }
+    fn test() -> f32 { // { dg-error "duplicate definitions with name .test." }
         123f32
     }
 }

--- a/gcc/testsuite/rust/compile/issue-925.rs
+++ b/gcc/testsuite/rust/compile/issue-925.rs
@@ -17,9 +17,9 @@ impl A for S {
 impl B for S {
     fn foo(&self) {}
 }
-
+// E0592
 fn test() {
     let a = S;
     a.foo();
-    // { dg-error "multiple applicable items in scope for method .foo." "" { target *-*-* } .-1 }
+    // { dg-error "duplicate definitions with name .foo." "" { target *-*-* } .-1 }
 }


### PR DESCRIPTION
## Multiple candidated for `method` or `function` - [`E0592`](https://doc.rust-lang.org/error_codes/E0592.html)

- Added errorcode & rich location.

### Running testcases:
- [`gcc/testsuite/rust/compile/generics7.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/generics7.rs)
- [`gcc/testsuite/rust/compile/issue-925.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/issue-925.rs)


### Output:

```rust
../mahad-testsuite/E0592.rs:28:7: error: duplicate definitions with name ‘bar’ [E0592]
    9 |     fn bar(self) -> isize {
      |     ~~ 
      |     duplicate definitions for bar
......
   21 |     fn bar(self) -> T {
      |     ~~ 
      |     duplicate definitions for bar
......
   28 |     a.bar();
      |       ^~~

```

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::visit): Added rich location and errorcode.

gcc/testsuite/ChangeLog:

	* rust/compile/generics7.rs: Updated comment.
	* rust/compile/issue-925.rs: likewise.
