### PR TITLE
Invalid order of generic parameters

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -3142,9 +3142,12 @@ Parser<ManagedTokenSource>::parse_generic_params (EndTokenPred is_end_token)
 
   // FIXME: Add reordering hint
   if (order_error)
-    rust_error_at (generic_params.front ()->get_locus (),
-		   "invalid order for generic parameters: lifetimes should "
-		   "always come before types");
+    {
+      Error error (generic_params.front ()->get_locus (),
+		   "invalid order for generic parameters: lifetime parameters "
+		   "must be declared prior to type and const parameters");
+      add_error (std::move (error));
+    }
 
   generic_params.shrink_to_fit ();
   return generic_params;

--- a/gcc/testsuite/rust/compile/generics13.rs
+++ b/gcc/testsuite/rust/compile/generics13.rs
@@ -1,1 +1,1 @@
-struct Foo<A, 'a>; // { dg-error "invalid order for generic parameters: lifetimes should always come before types" }
+struct Foo<A, 'a>; // { dg-error "invalid order for generic parameters: lifetime parameters must be declared prior to type and const parameters" }


### PR DESCRIPTION
### Invalid order of generic parameters

- Added more user-friendly message & hint for fixing ordering


### Output:
- [`gcc/testsuite/rust/compile/generics13.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/generics13.rs)
```rust
➜  gccrs-build gcc/crab1 /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/generics13.rs
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/generics13.rs:1:12: error: invalid order for generic parameters: lifetime parameters must be declared prior to type and const parameters
    1 | struct Foo<A, 'a>; // { dg-error "invalid order for generic parameters: lifetimes should always come before types" }
      |            ^
      |            reorder the parameters: lifetimes, then consts and types

Analyzing compilation unit

Time variable                                   usr           sys          wall           GGC
 TOTAL                              :   0.00          0.00          0.00          146k
Extra diagnostic checks enabled; compiler may run slowly.
Configure with --enable-checking=release to disable checks.

```
gcc/rust/ChangeLog:

	* parse/rust-parse-impl.h (Parser::parse_generic_params): Added fixit_hint and more user friendly message.

gcc/testsuite/ChangeLog:

	* rust/compile/generics13.rs: for dejagnu,

