### PR TITLE
[E0534] inline attribute was malformed

### DIFF
--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -247,7 +247,10 @@ HIRCompileBase::handle_inline_attribute_on_fndecl (tree fndecl,
   AST::AttrInputMetaItemContainer *meta_item = option.parse_to_meta_item ();
   if (meta_item->get_items ().size () != 1)
     {
-      rust_error_at (attr.get_locus (), "invalid number of arguments");
+      rich_location rich_locus (line_table, attr.get_locus ());
+      rich_locus.add_fixit_replace ("expected one argument");
+      rust_error_at (rich_locus, ErrorCode::E0534,
+		     "invalid number of arguments");
       return;
     }
 

--- a/gcc/testsuite/rust/compile/inline_2.rs
+++ b/gcc/testsuite/rust/compile/inline_2.rs
@@ -4,3 +4,6 @@ fn test_a() {}
 
 #[inline(A, B)] // { dg-error "invalid number of arguments" }
 fn test_b() {}
+
+#[inline()] // { dg-error "invalid number of arguments" }
+fn test_c() {}


### PR DESCRIPTION
## Invalid number of `inline` attributes - [`E0534`](https://doc.rust-lang.org/error_codes/E0534.html)

Inline attribute takes one argument, but
more than one argument was found.


### Running Testcases:
- [`gcc/testsuite/rust/compile/inline_2.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/inline_2.rs)

```rust
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/inline_2.rs:2:3: error: unknown inline option
    2 | #[inline(A)] // { dg-error "unknown inline option" }
      |   ^~~~~~
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/inline_2.rs:5:3: error: invalid number of arguments [E0534]
    5 | #[inline(A, B)] // { dg-error "invalid number of arguments" }
      |   ^~~~~~
      |   expected one argument
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/inline_2.rs:8:3: error: invalid number of arguments [E0534]
    8 | #[inline()] // { dg-error "invalid number of arguments" }
      |   ^~~~~~
      |   expected one argument


```


---

**gcc/rust/ChangeLog:**

	* backend/rust-compile-base.cc (HIRCompileBase::handle_inline_attribute_on_fndecl): Added rich_location & error code.

**gcc/testsuite/ChangeLog:**

	* rust/compile/inline_2.rs: Added new case.
