### PR TITLE
[E0535] Unknown argument given to inline attribute

### DIFF
--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -272,7 +272,11 @@ HIRCompileBase::handle_inline_attribute_on_fndecl (tree fndecl,
     }
   else
     {
-      rust_error_at (attr.get_locus (), "unknown inline option");
+      rich_location rich_locus (line_table, attr.get_locus ());
+      rich_locus.add_fixit_replace ("unknown inline option");
+      rust_error_at (rich_locus, ErrorCode::E0535,
+		     "invalid argument, %<inline%> attribute only accepts "
+		     "%<always%> or %<never%>");
     }
 }
 

--- a/gcc/testsuite/rust/compile/inline_2.rs
+++ b/gcc/testsuite/rust/compile/inline_2.rs
@@ -1,5 +1,5 @@
 // { dg-additional-options "-w" }
-#[inline(A)] // { dg-error "unknown inline option" }
+#[inline(A)] // { dg-error "invalid argument, .inline. attribute only accepts .always. or .never." }
 fn test_a() {}
 
 #[inline(A, B)] // { dg-error "invalid number of arguments" }


### PR DESCRIPTION
## Unknown argument given to `inline` attribute. [`E0535`](https://doc.rust-lang.org/error_codes/E0535.html) 


The inline attribute only supports two arguments:
 - `always`
 - `never`
 
  All other arguments given to the inline attribute will always return this error.


### Running testcases:
- [`gcc/testsuite/rust/compile/inline_2.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/inline_2.rs)

```rust
➜  gccrs-build gcc/crab1 /home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/inline_2.rs
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/inline_2.rs:2:3: error: invalid argument, ‘inline’ attribute only accepts ‘always’ or ‘never’ [E0535]
    2 | #[inline(A)] // { dg-error "unknown inline option" }
      |   ^~~~~~
      |   unknown inline option
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/inline_2.rs:5:3: error: invalid number of arguments
    5 | #[inline(A, B)] // { dg-error "invalid number of arguments" }
      |   ^~~~~~
```


---

**gcc/rust/ChangeLog:**

	* backend/rust-compile-base.cc (HIRCompileBase::handle_inline_attribute_on_fndecl): Added rich_location & error code.

**gcc/testsuite/ChangeLog:**

	* rust/compile/inline_2.rs: Added new message.
