### PR TITLE
[E0034] found more than one items for method

### DIFF
--- a/gcc/rust/typecheck/rust-hir-path-probe.h
+++ b/gcc/rust/typecheck/rust-hir-path-probe.h
@@ -165,8 +165,11 @@ public:
     for (auto &c : candidates)
       r.add_range (c.locus);
 
+    std::string rich_msg = "multiple " + query.as_string () + " found";
+    r.add_fixit_replace (rich_msg.c_str ());
+
     rust_error_at (r, ErrorCode::E0034,
-		   "multiple applicable items in scope for: %s",
+		   "multiple applicable items in scope for: %qs",
 		   query.as_string ().c_str ());
   }
 };

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -1065,11 +1065,18 @@ TypeCheckExpr::visit (HIR::MethodCallExpr &expr)
   if (candidates.size () > 1)
     {
       rich_location r (line_table, expr.get_method_name ().get_locus ());
+      std::string rich_msg
+	= "multiple " + expr.get_method_name ().get_segment ().as_string ()
+	  + " found";
+
       for (auto &c : candidates)
 	r.add_range (c.candidate.locus);
 
+      r.add_fixit_replace (rich_msg.c_str ());
+
       rust_error_at (
-	r, "multiple candidates found for method %<%s%>",
+	r, ErrorCode::E0034,
+	"multiple applicable items in scope for method %qs",
 	expr.get_method_name ().get_segment ().as_string ().c_str ());
       return;
     }

--- a/gcc/testsuite/rust/compile/generics6.rs
+++ b/gcc/testsuite/rust/compile/generics6.rs
@@ -26,7 +26,7 @@ impl Foo<f32> {
 }
 
 fn main() {
-    let a: i32 = Foo::test(); // { dg-error "multiple applicable items in scope for: test" }
+    let a: i32 = Foo::test(); // { dg-error "multiple applicable items in scope for: .test." }
     // { dg-error {Failed to resolve expression of function call} "" { target *-*-* } .-1 }
 }
 

--- a/gcc/testsuite/rust/compile/generics7.rs
+++ b/gcc/testsuite/rust/compile/generics7.rs
@@ -26,5 +26,5 @@ impl<T> Foo<T> {
 fn main() {
     let a = Foo { a: 123 };
     a.bar();
-    // { dg-error "multiple candidates found for method .bar." "" { target *-*-* } .-1 }
+    // { dg-error "multiple applicable items in scope for method .bar." "" { target *-*-* } .-1 }
 }

--- a/gcc/testsuite/rust/compile/issue-925.rs
+++ b/gcc/testsuite/rust/compile/issue-925.rs
@@ -21,5 +21,5 @@ impl B for S {
 fn test() {
     let a = S;
     a.foo();
-    // { dg-error "multiple candidates found for method .foo." "" { target *-*-* } .-1 }
+    // { dg-error "multiple applicable items in scope for method .foo." "" { target *-*-* } .-1 }
 }


### PR DESCRIPTION
### Multiple Applicable items found for method `foo` - [`E0034`](https://doc.rust-lang.org/error_codes/E0034.html) 


Added rich location and error code for [`E0034`](https://doc.rust-lang.org/error_codes/E0034.html) 


Also, Fixes https://github.com/Rust-GCC/gccrs/issues/2366



### Code tested:
- [`gcc/testsuite/rust/compile/generics6.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/generics6.rs)

```rust
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/generics6.rs:29:23: error: multiple applicable items in scope for: ‘test’ [E0034]
    9 |     fn test() -> i32 { // { dg-error "possible candidate" "TODO" { xfail *-*-* } }
      |     ~~                 
......
   19 |     fn test() -> i32 { // { dg-error "possible candidate" "TODO" { xfail *-*-* } }
      |     ~~                 
......
   29 |     let a: i32 = Foo::test(); // { dg-error "multiple applicable items in scope for: test" }
      |                       ^~~~
      |                       multiple test found
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/generics6.rs:29:18: error: Failed to resolve expression of function call
   29 |     let a: i32 = Foo::test(); // { dg-error "multiple applicable items in scope for: test" }
      |                  ^~~


```




























---

**gcc/rust/ChangeLog:**

	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::visit): Added rich location and error code.

**gcc/testsuite/ChangeLog:**

	* rust/compile/generics7.rs: Updated dejagnu comment.
	* rust/compile/issue-925.rs: likewise.

