### PR TITLE
[E0391] Detected type dependency cycle

### DIFF
--- a/gcc/rust/typecheck/rust-hir-trait-resolve.cc
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.cc
@@ -156,7 +156,10 @@ TraitResolver::resolve_trait (HIR::Trait *trait_reference)
   DefId trait_id = trait_reference->get_mappings ().get_defid ();
   if (context->trait_query_in_progress (trait_id))
     {
-      rust_error_at (trait_reference->get_locus (), "trait cycle detected");
+      rust_error_at (
+	trait_reference->get_locus (), ErrorCode::E0391,
+	"cycle detected when computing the super predicates of %qs",
+	trait_reference->get_name ().as_string ().c_str ());
       return &TraitReference::error_node ();
     }
 

--- a/gcc/testsuite/rust/compile/issue-1589.rs
+++ b/gcc/testsuite/rust/compile/issue-1589.rs
@@ -2,7 +2,7 @@
 pub trait Sized {}
 
 pub trait A: B {}
-// { dg-error "trait cycle detected" "" { target *-*-* } .-1 }
+// { dg-error "cycle detected when computing the super predicates of .A." "" { target *-*-* } .-1 }
 
 pub trait B: A {}
-// { dg-error "trait cycle detected" "" { target *-*-* } .-1 }
+// { dg-error "cycle detected when computing the super predicates of .B." "" { target *-*-* } .-1 }

--- a/gcc/testsuite/rust/compile/trait-cycle.rs
+++ b/gcc/testsuite/rust/compile/trait-cycle.rs
@@ -1,0 +1,4 @@
+pub trait FirstTrait: SecondTrait {}
+// { dg-error "cycle detected when computing the super predicates of .FirstTrait." "" { target *-*-* } .-1 }
+pub trait SecondTrait: FirstTrait {}
+// { dg-error "cycle detected when computing the super predicates of .SecondTrait." "" { target *-*-* } .-1 }


### PR DESCRIPTION
## `trait` cycle detected - [`E0391`](https://doc.rust-lang.org/error_codes/E0391.html) 

This errorcode & message emits when cycle
detected when computing the super predicates
of `x` which requires computing the super
predicates of `y`, which again requires
computing the super predicates of `x`,
completing the cycle.


### Code Tested:
- [`gcc/testsuite/rust/compile/issue-1589.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/issue-1589.rs)

```rust
~/gccrs/gcc/testsuite/rust/compile/trait-cycle.rs:1:5: error: cycle detected when computing the super predicates of ‘FirstTrait’ [E0391]
    1 | pub trait FirstTrait: SecondTrait {}
      |     ^~~~~
~/gccrs/gcc/testsuite/rust/compile/trait-cycle.rs:3:5: error: cycle detected when computing the super predicates of ‘SecondTrait’ [E0391]
    3 | pub trait SecondTrait: FirstTrait {}
      |     ^~~~~



```
























---
**gcc/rust/ChangeLog:**

	* typecheck/rust-hir-trait-resolve.cc (TraitResolver::resolve_trait): Updated errorcode & more userfriendly message.

**gcc/testsuite/ChangeLog:**

	* rust/compile/issue-1589.rs: Updated comment for dejagnu.
	* rust/compile/trait-cycle.rs: New relevant test.
