### PR TITLE
[E0271] Type mismatch between associated type trait.

### DIFF
--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -351,8 +351,15 @@ BaseType::satisfies_bound (const TypeBoundPredicate &predicate,
 		      r.add_range (predicate.get_locus ());
 		      r.add_range (mappings->lookup_location (i.get_hirid ()));
 
+		      std::string rich_msg
+			= "expected " + bound_ty->destructure ()->get_name ()
+			  + ", found "
+			  + impl_item_ty->destructure ()->get_name ();
+		      r.add_fixit_replace (rich_msg.c_str ());
+
 		      rust_error_at (
-			r, "expected %<%s%> got %<%s%>",
+			r, ErrorCode::E0271,
+			"type mismatch, expected %qs but got %qs",
 			bound_ty->destructure ()->get_name ().c_str (),
 			impl_item_ty->destructure ()->get_name ().c_str ());
 		    }

--- a/gcc/testsuite/rust/compile/issue-1725-2.rs
+++ b/gcc/testsuite/rust/compile/issue-1725-2.rs
@@ -26,6 +26,6 @@ pub fn foo<T: core::ops::Add<Output = i32>>(a: T) -> i32 {
 
 pub fn main() {
     foo(123f32);
-    // { dg-error "expected .i32. got .f32." "" { target *-*-* } .-1 }
+    // { dg-error "type mismatch, expected .i32. but got .f32." "" { target *-*-* } .-1 }
     // { dg-error "bounds not satisfied for f32 .Add. is not satisfied" "" { target *-*-* } .-2 }
 }


### PR DESCRIPTION
## Mismatch types between associated `traits` - [`E0271`](https://doc.rust-lang.org/error_codes/E0271.html)

Added rich location and error code.

### Running testcases:
- [`gcc/testsuite/rust/compile/issue-1725-2.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/issue-1725-2.rs)

```rust
~/gccrs/gcc/testsuite/rust/compile/issue-1725-2.rs:28:9: error: type mismatch, expected ‘i32’ but got ‘f32’ [E0271]
   16 |     type Output = f32;
      |     ~~~~ 
......
   23 | pub fn foo<T: core::ops::Add<Output = i32>>(a: T) -> i32 {
      |               ~~~~
......
   28 |     foo(123f32);
      |         ^~~~~~
      |         expected i32, found f32
~/gccrs/gcc/testsuite/rust/compile/issue-1725-2.rs:28:9: error: bounds not satisfied for f32 ‘Add’ is not satisfied [E0277]
   23 | pub fn foo<T: core::ops::Add<Output = i32>>(a: T) -> i32 {
      |               ~~~~
......
   28 |     foo(123f32);
      |         ^~~~~~


```

















---
**gcc/rust/ChangeLog:**

	* typecheck/rust-tyty.cc (BaseType::satisfies_bound): Added errorcode and user-friendly error message.

**gcc/testsuite/ChangeLog:**

	* rust/compile/issue-1725-2.rs: Updated dejagnu message.

