### PR TITLE
[E0532] Pattern arm did not match expected kind.

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
@@ -53,9 +53,10 @@ TypeCheckPattern::visit (HIR::TupleStructPattern &pattern)
   TyTy::BaseType *pattern_ty = TypeCheckExpr::Resolve (&pattern.get_path ());
   if (pattern_ty->get_kind () != TyTy::TypeKind::ADT)
     {
-      rust_error_at (pattern.get_locus (),
-		     "expected tuple struct/variant, found: %s",
-		     pattern_ty->get_name ().c_str ());
+      rust_error_at (
+	pattern.get_locus (), ErrorCode::E0532,
+	"expected tuple struct or tuple variant, found function %qs",
+	pattern_ty->get_name ().c_str ());
       return;
     }
 

--- a/gcc/testsuite/rust/compile/issue-2029.rs
+++ b/gcc/testsuite/rust/compile/issue-2029.rs
@@ -6,7 +6,7 @@ fn foo(_: usize) -> Foo {
 fn main() {
     match Foo(true) {
         foo(x)
-        // { dg-error "expected tuple struct/variant, found" "" { target *-*-* } .-1 }
+        // { dg-error "expected tuple struct or tuple variant, found function " "" { target *-*-* } .-1 }
         => ()
     }
 }


### PR DESCRIPTION
## Expected `tuple` or `struct` variant found `function` - [`E0532`](https://doc.rust-lang.org/error_codes/E0532.html)



### Code Tested:

- [`gcc/testsuite/rust/compile/issue-2029.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/issue-2029.rs)

```rust
~/gccrs/gcc/testsuite/rust/compile/issue-2029.rs:8:9: error: expected tuple struct or tuple variant, found function ‘fn (_ usize,) -> Foo{Foo (0:bool)}’ [E0532]
    8 |         foo(x)
      |         ^~~
      |         a tuple struct with a similar name exists

```

---

**gcc/rust/ChangeLog:**

	* typecheck/rust-hir-type-check-pattern.cc (TypeCheckPattern::visit): Added rich location & error code.

**gcc/testsuite/ChangeLog:**

	* rust/compile/issue-2029.rs: Updated for dejagnu testcase.

---