### PR TITLE
[E0769] Use of struct or tuple variant in struct or struct variant

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
@@ -182,8 +182,14 @@ TypeCheckPattern::visit (HIR::StructPattern &pattern)
     {
       std::string variant_type
 	= TyTy::VariantDef::variant_type_string (variant->get_variant_type ());
-      rust_error_at (pattern.get_locus (),
-		     "expected struct variant, found %s variant %s",
+
+      rich_location rich_locus (line_table, pattern.get_locus ());
+      std::string rich_msg = "use the tuple variant pattern syntax instead "
+			     + variant->get_identifier () + "(_)";
+      rich_locus.add_fixit_replace (rich_msg.c_str ());
+
+      rust_error_at (rich_locus, ErrorCode::E0769,
+		     "%s variant %qs written as struct variant",
 		     variant_type.c_str (),
 		     variant->get_identifier ().c_str ());
       return;

--- a/gcc/testsuite/rust/compile/match4.rs
+++ b/gcc/testsuite/rust/compile/match4.rs
@@ -10,7 +10,7 @@ fn inspect(f: Foo) {
         Foo::A => {}
         Foo::B => {}
         Foo::C { a } => {}
-        // { dg-error "expected struct variant, found tuple variant C" "" { target *-*-* } .-1 }
+        // { dg-error "tuple variant .C. written as struct variant" "" { target *-*-* } .-1 }
         Foo::D { x, y } => {}
     }
 }


### PR DESCRIPTION
## Expected struct variant, found tuple struct/variant - [`E0769`](https://doc.rust-lang.org/error_codes/E0769.html)


A tuple struct or tuple variant was used in a pattern as if it were a struct or struct variant.


### Code tested:
- [`gcc/testsuite/rust/compile/match4.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/match4.rs)

```rust
/home/mahad/Desktop/mahad/gccrs/gcc/testsuite/rust/compile/match4.rs:12:9: error: tuple variant ‘C’ written as struct variant [E0769]
   12 |         Foo::C { a } => {}
      |         ^~~
      |         use the tuple variant pattern syntax instead C(_)
```














---

**gcc/rust/ChangeLog:**

	* typecheck/rust-hir-type-check-pattern.cc (TypeCheckPattern::visit): Added error code and rich location.

**gcc/testsuite/ChangeLog:**

	* rust/compile/match4.rs: Updated new error commment.
