### PR TITLE
[E0573] Something other than type was used

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -510,9 +510,17 @@ TypeCheckType::resolve_segments (
 
       if (candidate.is_enum_candidate ())
 	{
-	  rust_error_at (seg->get_locus (),
-			 "expected type, found variant of %s",
-			 tyseg->get_name ().c_str ());
+	  TyTy::ADTType *adt = static_cast<TyTy::ADTType *> (tyseg);
+	  auto last_variant = adt->get_variants ();
+	  TyTy::VariantDef *variant = last_variant.back ();
+
+	  rich_location richloc (line_table, seg->get_locus ());
+	  richloc.add_fixit_replace ("not a type");
+
+	  rust_error_at (richloc, ErrorCode::E0573,
+			 "expected type, found variant of %<%s::%s%>",
+			 adt->get_name ().c_str (),
+			 variant->get_identifier ().c_str ());
 	  return new TyTy::ErrorType (expr_id);
 	}
 

--- a/gcc/testsuite/rust/compile/issue-2479.rs
+++ b/gcc/testsuite/rust/compile/issue-2479.rs
@@ -5,7 +5,7 @@ enum Dragon {
 }
 
 fn oblivion() -> Dragon::Born {
-// { dg-error "expected type, found variant of Dragon" "" { target *-*-* } .-1 }
+// { dg-error "expected type, found variant of .Dragon::Born." "" { target *-*-* } .-1 }
 // { dg-error "failed to resolve return type" "" { target *-*-* } .-2 }
     Dragon::Born
 }
@@ -17,6 +17,6 @@ enum Wizard {
 
 trait Isengard {
     fn wizard(_: Wizard::Saruman);
-    // { dg-error "expected type, found variant of Wizard" "" { target *-*-* } .-1 }
+    // { dg-error "expected type, found variant of .Wizard::Saruman." "" { target *-*-* } .-1 }
 }
 }


### PR DESCRIPTION
## Expected `Type` got something else - [`E0573`](https://doc.rust-lang.org/error_codes/E0573.html) 

- Added last variant name, errorcode & rich location. for enum candidates.
- Improved by this issue https://github.com/Rust-GCC/gccrs/issues/2479

---


### Testcases:
- [`gcc/testsuite/rust/compile/issue-2479.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/issue-2479.rs)


```rust
test.rs:7:26: error: expected type, found variant of ‘Dragon::Born’ [E0573]
    7 | fn oblivion() -> Dragon::Born { // error!
      |                          ^~~~
      |                          not a type
test.rs:7:1: error: failed to resolve return type
    7 | fn oblivion() -> Dragon::Born { // error!
      | ^~
test.rs:20:26: error: expected type, found variant of ‘Wizard::Saruman’ [E0573]
   20 |     fn wizard(_: Wizard::Saruman); // error!
      |                          ^~~~~~~
      |                          not a type

```

---

**gcc/rust/ChangeLog:**

	* typecheck/rust-hir-type-check-type.cc: Added last variant name, errorcode & rich location.

**gcc/testsuite/ChangeLog:**

	* rust/compile/issue-2479.rs: Updated comment.

---