### PR TITLE
Top level or-patterns are not allowed let binding

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-pattern.cc
+++ b/gcc/rust/hir/rust-ast-lower-pattern.cc
@@ -333,9 +333,12 @@ ASTLoweringPattern::visit (AST::AltPattern &pattern)
     = new HIR::AltPattern (mapping, std::move (alts), pattern.get_locus ());
 
   if (is_let_top_level)
-    rust_error_at (pattern.get_locus (),
-		   "top level alternate patterns are not allowed for %<let%> "
-		   "bindings - use an outer grouped pattern");
+    {
+      rich_location richloc (line_table, pattern.get_locus ());
+      richloc.add_fixit_replace ("use an outer grouped pattern");
+      rust_error_at (
+	richloc, "top level or-patterns are not allowed for %<let%> bindings");
+    }
 }
 
 } // namespace HIR

--- a/gcc/testsuite/rust/compile/let_alt.rs
+++ b/gcc/testsuite/rust/compile/let_alt.rs
@@ -1,4 +1,4 @@
 fn main() {
     let _a | _a = 12;
-    // { dg-error "top level alternate patterns are not allowed" "" { target *-*-* } .-1 }
+    // { dg-error "top level or-patterns are not allowed for .let. bindings" "" { target *-*-* } .-1 }
 }


### PR DESCRIPTION
## Top level or-patterns are not allowed let binding - [`E0658`](https://doc.rust-lang.org/error_codes/E0658.html)

- This error code is emitted by `rustc 1.49.0`, but not emitted by `rustc -nightly`.
- I have updated according to `rustc 1.49.0`, as we are targeting `rustc 1.49.0` testsuite.
- See the difference here [`godbolt`](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DEArgoKkl9ZATwDKjdAGFUtEywYSAzKUcAZPAZMADl3ACNMYhAAJlIAB1QFQjsGFzcPb3jE5IEAoNCWCKjYq0wbFKECJmICNPdPLh9S8oFK6oI8kPDImMsqmrqMxr72zoKimIBKS1QTYmR2DioGAGoWJkCISZWAUgB2ACEdjQBBFfOV%2BgIVgH0mXb2nW/udrwARFa5o16PTi5WAPQAh4HFboYAAWkixBIu2i0SIcUumAAbphaCsxARIsxsSs4kwCNjiAwFJjiJgVgxUNcxLRUAB3TDoHbwuHfNn7UH9YCYa4AKghgv5Dw%2BADoIVxRccTvs3jKONNaJwAKy8TwcLSkVCcABKZmuClm80prK8PFIBE0iumAGsJNExZIAJxcPYADjd8JVKo00Xd7v0nEk6ut2s4vAUIA0lut0zgsBgiBQqBYcTokXIlDQaYzUWAyGQxAUEIUzDiCgQNNIWBReAWADU8JgGQB5OKMTgWmi0YlRiBhMNhQLVACeXd4w%2BYxFHrbC2jKVu4vBzbEErYYtHHmt4WDCJmATjpUeXNcw6yM4h3NbwFPKaJPWswqjKJmxE/IgnRYdoeDCxDHFwsDDAhiDwFgJ2mKgDGABQmxbdtO1PfhBBEMR2CkGRBEUFR1GvXQuH0QxjANfQ/yjSBplQOJbAEE9eFQNFiDArAKKgZg2BAZkcgYUgUTEExFmiP0eEmaZmlozwIEcQYGl8Bh0DGbookIhIkkk2S9DUnilMKHpCIkip%2BlqVx6j0QzWmM3SJgM4zNNs0ZAi6PSVPE40FgkJVVVDa8dQ4FZVHdAA2CEgskFYAHEnCcXUhBWCAopiuL1nMSJtggXBCFhM0uEmXgly0MTSHtX0gw4ENSAgl0xXdFUguiLguCCrwgo0WrnSC0gNS1PzI2jWMd3jJMICQWYCDiN8swgHN03oYhglYRZTHMZBPjFIL3TFJ98CIFi9BQ4RRHETCDpwtQwwI0gGQAuJILKtUurDPzWzfCbrlQKgAuC0LwsS2L4r%2B5KmFS4h0pcXM5rhc08oGwqvPK3gIN9MUpC8D13RarxXUkDRpG6hiI0sfqCptYqJD2LbnRxt0NCpjQmq4QNlQ4LwfJ6wmSaG%2BAE2TGa8ymvm5pAYgpGdGNa3rTB4LbDsNW7Og%2B0oQdrynMcP1Vmc5wXGwP1XRgCA3Lcwz3A8j1oWgTwtLAL2AK8tXwO9bAfMNn1fd9T0CbFma1X9/0AjBFi1UDwLu6CmFg6XELl3gDrQ47pFOpRzvw3oDCMYXSN9tiqJolITwhCEi0JTAIQIUcO1eN4pwYpiWMwbPLHRRcUgcBT7PkxSnPGfSsnUlJ2%2B0yTrJ7iyGDaAZTKGRvrEk8eOi75TzLsye5PMRz8kX3KZjmDyt%2BZh78fDfzloIVauCdZ0tvizLdqh3L8rjaYEEwJgsCiLYya4DQY2ZiqkZjQ%2BvUiYxk5qQHmI0QBjTegLVMs1IgLU4hwQKIUwqRWiv9BK6CgYgxhtxXaeB0D7VkHHDCCdZBnTwlqXQsRrpMFusueGB8nqcBeuNN8KwPorBPmfC%2BV8IDgzgcQKG0QYacyfi/N%2BlA7QSG/mVP%2BIBSqAMJlGEBj8yZeEkGKFUTU9hBRVP6FUzoqbRBVGVVmj1fIczjGA4aw0kCC0zBQaasC8wgAYHgYACACBbjPHWRszYZZIXlr2SI/ZlZag1tuC0kStaLl1qmNcBtNzbntpgfch5jwfmtsRO2u5bzN2dteV2yA3yLAtJ7b815fYARnEBQO%2BUwIQQYXwGCcEAlRw/LHI6pCsLyCTpQnQIAfBpxIuYMiYQG7UUkvRbUtcCH13gOJJuLQpIyRXnofwC8XJaWyBpdZqldkpGHipaezdLLtHbqPOexyl4XP2SMGoNyt5Gh3hhRhbMCbHwNKtdxnjvGjmvjtbK0RoYP0GuI1%2BPQP72miJon0kgsYaDql4Oqkh3TOiZsGRGCiAHMI4H1VRg0bHc1Gq9SaTiHHzUWpwbha1qrbSyntQiXT0ISDIdhfpF0hlXRundfeHyj6sLehwz6tLfleK3PFAReYoZeFEWo5%2BkL37w3kYovFBLYak3tCimqzo9gIpVOi/VWNojOjMQKoBYiyrRAtVY8FfFQkt0kEAA)



---


**gcc/rust/ChangeLog:**

	* hir/rust-ast-lower-pattern.cc (ASTLoweringPattern::visit): Added richlocation & error code.

**gcc/testsuite/ChangeLog:**

	* rust/compile/let_alt.rs: Updated comment.


---