### PR TITLE
[E0599] Failed to resovle method implementation

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -1055,9 +1055,11 @@ TypeCheckExpr::visit (HIR::MethodCallExpr &expr)
 			     expr.get_method_name ().get_segment ());
   if (candidates.empty ())
     {
+      rich_location richloc (line_table, expr.get_method_name ().get_locus ());
+      richloc.add_fixit_replace ("method not found");
       rust_error_at (
-	expr.get_method_name ().get_locus (),
-	"failed to resolve method for %<%s%>",
+	richloc, ErrorCode::E0599,
+	"no method named %qs found in the current scope",
 	expr.get_method_name ().get_segment ().as_string ().c_str ());
       return;
     }

--- a/gcc/testsuite/rust/compile/cfg2.rs
+++ b/gcc/testsuite/rust/compile/cfg2.rs
@@ -8,5 +8,5 @@ impl Foo {
 fn main() {
     let a = Foo;
     a.test();
-    // { dg-error "failed to resolve method for .test." "" { target *-*-* } .-1 }
+    // { dg-error "no method named .test. found in the current scope" "" { target *-*-* } .-1 }
 }

--- a/gcc/testsuite/rust/compile/issue-2139.rs
+++ b/gcc/testsuite/rust/compile/issue-2139.rs
@@ -14,5 +14,5 @@ impl Foo for u16 {
 fn main() {
     let a: u16 = 123;
     a.foo();
-    // { dg-error "failed to resolve method for .foo." "" { target *-*-* } .-1 }
+    // { dg-error "no method named .foo. found in the current scope" "" { target *-*-* } .-1 }
 }

--- a/gcc/testsuite/rust/compile/issue-2190-1.rs
+++ b/gcc/testsuite/rust/compile/issue-2190-1.rs
@@ -9,5 +9,5 @@ trait Deref {
 
 fn foo<T: Deref<Target = i32>>(t: &T) -> i32 {
     t.max(2)
-    // { dg-error "failed to resolve method for .max." "" { target *-*-* } .-1 }
+    // { dg-error "no method named .max. found in the current scope" "" { target *-*-* } .-1 }
 }

--- a/gcc/testsuite/rust/compile/method1.rs
+++ b/gcc/testsuite/rust/compile/method1.rs
@@ -8,5 +8,5 @@ pub fn main() {
     a = Foo(123);
 
     a.test();
-    // { dg-error "failed to resolve method for .test." "" { target *-*-* } .-1 }
+    // { dg-error "no method named .test. found in the current scope" "" { target *-*-* } .-1 }
 }


### PR DESCRIPTION
## Use of unresolved method on type - [`E0599`](https://doc.rust-lang.org/error_codes/E0599.html)

Added new error message, rich location and error code.

### Testcases:
- [`gcc/testsuite/rust/compile/cfg2.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/cfg2.rs)
- [`gcc/testsuite/rust/compile/issue-2139.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/issue-2139.rs)
- [`gcc/testsuite/rust/compile/issue-2190-1.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/issue-2190-1.rs)
- [`gcc/testsuite/rust/compile/method1.rs`](https://github.com/Rust-GCC/gccrs/blob/master/gcc/testsuite/rust/compile/method1.rs)


---

**gcc/rust/ChangeLog:**

	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::visit): Added new error message, rich location and error code.

**gcc/testsuite/ChangeLog:**

	* rust/compile/cfg2.rs: Updated according to new message.
	* rust/compile/issue-2139.rs: likewise.
	* rust/compile/issue-2190-1.rs: likewise
	* rust/compile/method1.rs: likewise
---