### PR TITLE
diagnostics: Added non-const `rich_location *` function

### DIFF
--- a/gcc/rust/rust-diagnostics.cc
+++ b/gcc/rust/rust-diagnostics.cc
@@ -278,6 +278,28 @@ rust_error_at (const rich_location &location, const ErrorCode code,
 }
 
 void
+rust_be_error_at (rich_location *richloc, const ErrorCode code,
+		  const std::string &errmsg)
+{
+  diagnostic_metadata m;
+  rust_error_code_rule rule (code);
+  m.add_rule (rule);
+  error_meta (richloc, m, "%s", errmsg.c_str ());
+}
+
+void
+rust_error_at (rich_location *richloc, const ErrorCode code, const char *fmt,
+	       ...)
+{
+  /* TODO: Refactoring diagnostics to this overload */
+  va_list ap;
+
+  va_start (ap, fmt);
+  rust_be_error_at (richloc, code, expand_message (fmt, ap));
+  va_end (ap);
+}
+
+void
 rust_be_warning_at (const location_t location, int opt,
 		    const std::string &warningmsg)
 {
@@ -342,6 +364,23 @@ rust_error_at (const rich_location &location, const char *fmt, ...)
 
   va_start (ap, fmt);
   rust_be_error_at (location, expand_message (fmt, ap));
+  va_end (ap);
+}
+
+void
+rust_be_error_at (rich_location *richloc, const std::string &errmsg)
+{
+  error_at (richloc, "%s", errmsg.c_str ());
+}
+
+void
+rust_error_at (rich_location *richloc, const char *fmt, ...)
+{
+  /* TODO: Refactoring diagnostics to this overload */
+  va_list ap;
+
+  va_start (ap, fmt);
+  rust_be_error_at (richloc, expand_message (fmt, ap));
   va_end (ap);
 }
 

--- a/gcc/rust/rust-diagnostics.h
+++ b/gcc/rust/rust-diagnostics.h
@@ -107,6 +107,12 @@ rust_error_at (const rich_location &, const char *fmt, ...)
 extern void
 rust_error_at (const rich_location &, const ErrorCode, const char *fmt, ...)
   RUST_ATTRIBUTE_GCC_DIAG (3, 4);
+extern void /* similiar to other frontends */
+rust_error_at(rich_location *richloc,const char *fmt, ...)
+  RUST_ATTRIBUTE_GCC_DIAG (2, 3);
+extern void /* similiar to other frontends */
+rust_error_at(rich_location *richloc, const ErrorCode, const char *fmt, ...)
+  RUST_ATTRIBUTE_GCC_DIAG (3, 4);
 // clang-format on
 
 // These interfaces provide a way for the front end to ask for
@@ -137,6 +143,11 @@ rust_be_error_at (const rich_location &, const std::string &errmsg);
 extern void
 rust_be_error_at (const rich_location &, const ErrorCode,
 		  const std::string &errmsg);
+extern void /* similiar to other frontends */
+rust_be_error_at (rich_location *richloc, const std::string &errmsg);
+extern void /* similiar to other frontends */
+rust_be_error_at (rich_location *richloc, const ErrorCode,
+      const std::string &errmsg);
 extern void
 rust_be_warning_at (const location_t, int opt, const std::string &warningmsg);
 extern void

--- a/gcc/rust/rust_error_codes.def
+++ b/gcc/rust/rust_error_codes.def
@@ -1,3 +1,21 @@
+// Copyright (C) 2020-2023 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
 ERROR(0001), // this error code is no longer emitted by the compiler
 ERROR(0002), // this error code is no longer emitted by the compiler
 ERROR(0004),


### PR DESCRIPTION
Currently, gccrs using the const `rich_location &`, and then using the cast to convert it to the functions which was used to emit the errors, having the overloaded is good, similiar to other frontends.




---

**gcc/rust/ChangeLog:**

	* rust-diagnostics.cc (rust_be_error_at): Added overload function. (rust_error_at): non-const `rich_location *` function.
	* rust-diagnostics.h (rust_error_at): Implementation of overloaded function. (rust_be_error_at): likewise.
	* rust_error_codes.def: Added GNU license.

---