### PR TITLE
Fix invalid call to ```vector::front``` in ```TypeBoundPredicate``` constructors

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -1826,6 +1826,7 @@ TypeCheckExpr::resolve_fn_trait_call (HIR::CallExpr &expr,
 				      TyTy::BaseType **result)
 {
   // we turn this into a method call expr
+  // TODO: add implicit self argument (?)
   auto associated_predicate = TyTy::TypeBoundPredicate::error ();
   HIR::PathIdentSegment method_name
     = resolve_possible_fn_trait_call_method_name (*receiver_tyty,

--- a/gcc/rust/typecheck/rust-tyty-bounds.cc
+++ b/gcc/rust/typecheck/rust-tyty-bounds.cc
@@ -310,6 +310,8 @@ TypeBoundPredicate::TypeBoundPredicate (
     reference (trait_reference.get_mappings ().get_defid ()), locus (locus),
     error_flag (false), polarity (polarity)
 {
+  rust_assert (!trait_reference.get_trait_substs ().empty ());
+
   substitutions.clear ();
   for (const auto &p : trait_reference.get_trait_substs ())
     substitutions.push_back (p.clone ());
@@ -326,6 +328,8 @@ TypeBoundPredicate::TypeBoundPredicate (
     reference (reference), locus (locus), error_flag (false),
     polarity (polarity)
 {
+  rust_assert (!subst.empty ());
+
   substitutions.clear ();
   for (const auto &p : subst)
     substitutions.push_back (p.clone ());
@@ -334,6 +338,12 @@ TypeBoundPredicate::TypeBoundPredicate (
   SubstitutionArg placeholder_self (&get_substs ().front (), nullptr);
   used_arguments.get_mappings ().push_back (placeholder_self);
 }
+
+TypeBoundPredicate::TypeBoundPredicate (mark_is_error)
+  : SubstitutionRef ({}, SubstitutionArgumentMappings::empty ()),
+    reference (UNKNOWN_DEFID), locus (UNDEF_LOCATION), error_flag (true),
+    polarity (BoundPolarity::RegularBound)
+{}
 
 TypeBoundPredicate::TypeBoundPredicate (const TypeBoundPredicate &other)
   : SubstitutionRef ({}, SubstitutionArgumentMappings::empty ()),
@@ -413,10 +423,7 @@ TypeBoundPredicate::operator= (const TypeBoundPredicate &other)
 TypeBoundPredicate
 TypeBoundPredicate::error ()
 {
-  auto p = TypeBoundPredicate (UNKNOWN_DEFID, {}, BoundPolarity::RegularBound,
-			       UNDEF_LOCATION);
-  p.error_flag = true;
-  return p;
+  return TypeBoundPredicate (mark_is_error ());
 }
 
 std::string

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -450,6 +450,12 @@ public:
   bool is_equal (const TypeBoundPredicate &other) const;
 
 private:
+  struct mark_is_error
+  {
+  };
+
+  TypeBoundPredicate (mark_is_error);
+
   DefId reference;
   location_t locus;
   bool error_flag;


### PR DESCRIPTION
I included a ```TODO```, since I'm pretty sure ```TypeCheckExpr::resolve_fn_trait_call``` should be providing an implicit self argument.