### PR TITLE
Retrieve proc macro definition

### DIFF
--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -410,8 +410,9 @@ struct MacroExpander
   template <typename T>
   AST::Fragment expand_derive_proc_macro (T &item, AST::SimplePath &path)
   {
-    CustomDeriveProcMacro macro;
-    if (!mappings->lookup_derive_proc_macro_invocation (path, macro))
+    tl::optional<CustomDeriveProcMacro &> macro
+      = mappings->lookup_derive_proc_macro_invocation (path);
+    if (!macro.has_value ())
       {
 	rust_error_at (path.get_locus (), "Macro not found");
 	return AST::Fragment::create_error ();
@@ -424,15 +425,17 @@ struct MacroExpander
     auto c = collector.collect_tokens ();
     std::vector<const_TokenPtr> vec (c.cbegin (), c.cend ());
 
-    return parse_proc_macro_output (macro.get_handle () (convert (vec)));
+    return parse_proc_macro_output (
+      macro.value ().get_handle () (convert (vec)));
   }
 
   template <typename T>
   AST::Fragment expand_bang_proc_macro (T &item,
 					AST::MacroInvocation &invocation)
   {
-    BangProcMacro macro;
-    if (!mappings->lookup_bang_proc_macro_invocation (invocation, macro))
+    tl::optional<BangProcMacro &> macro
+      = mappings->lookup_bang_proc_macro_invocation (invocation);
+    if (!macro.has_value ())
       {
 	rust_error_at (invocation.get_locus (), "Macro not found");
 	return AST::Fragment::create_error ();
@@ -445,14 +448,16 @@ struct MacroExpander
     auto c = collector.collect_tokens ();
     std::vector<const_TokenPtr> vec (c.cbegin (), c.cend ());
 
-    return parse_proc_macro_output (macro.get_handle () (convert (vec)));
+    return parse_proc_macro_output (
+      macro.value ().get_handle () (convert (vec)));
   }
 
   template <typename T>
   AST::Fragment expand_attribute_proc_macro (T &item, AST::SimplePath &path)
   {
-    AttributeProcMacro macro;
-    if (!mappings->lookup_attribute_proc_macro_invocation (path, macro))
+    tl::optional<AttributeProcMacro &> macro
+      = mappings->lookup_attribute_proc_macro_invocation (path);
+    if (!macro.has_value ())
       {
 	rust_error_at (path.get_locus (), "Macro not found");
 	return AST::Fragment::create_error ();
@@ -467,8 +472,8 @@ struct MacroExpander
 
     // FIXME: Handle attributes
     return parse_proc_macro_output (
-      macro.get_handle () (ProcMacro::TokenStream::make_tokenstream (),
-			   convert (vec)));
+      macro.value ().get_handle () (ProcMacro::TokenStream::make_tokenstream (),
+				    convert (vec)));
   }
 
   /**

--- a/gcc/rust/expand/rust-proc-macro.cc
+++ b/gcc/rust/expand/rust-proc-macro.cc
@@ -16,6 +16,7 @@
 
 #include "rust-diagnostics.h"
 #include "rust-proc-macro.h"
+#include "rust-session-manager.h"
 #include "rust-lex.h"
 #include "rust-token-converter.h"
 #include "rust-attributes.h"
@@ -68,7 +69,7 @@ ProcMacro::TokenStream
 tokenstream_from_string (std::string &data, bool &lex_error)
 {
   // FIXME: Insert location pointing to call site in tokens
-  Lexer lex (data, nullptr);
+  Lexer lex (data, Session::get_instance ().linemap);
 
   std::vector<const_TokenPtr> tokens;
   TokenPtr ptr;

--- a/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
@@ -104,12 +104,25 @@ TopLevel::visit (AST::ExternCrate &crate)
     = Analysis::Mappings::get ()->lookup_derive_proc_macros (num);
 
   auto sub_visitor = [&] () {
+    // TODO: Find a way to keep this part clean without the double dispatch.
     if (derive_macros.has_value ())
-      insert_macros (derive_macros.value (), ctx);
+      {
+	insert_macros (derive_macros.value (), ctx);
+	for (auto &macro : derive_macros.value ())
+	  Analysis::Mappings::get ()->insert_derive_proc_macro_def (macro);
+      }
     if (attribute_macros.has_value ())
-      insert_macros (attribute_macros.value (), ctx);
+      {
+	insert_macros (attribute_macros.value (), ctx);
+	for (auto &macro : attribute_macros.value ())
+	  Analysis::Mappings::get ()->insert_attribute_proc_macro_def (macro);
+      }
     if (bang_macros.has_value ())
-      insert_macros (bang_macros.value (), ctx);
+      {
+	insert_macros (bang_macros.value (), ctx);
+	for (auto &macro : bang_macros.value ())
+	  Analysis::Mappings::get ()->insert_bang_proc_macro_def (macro);
+      }
   };
 
   if (crate.has_as_clause ())

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -1072,16 +1072,14 @@ Mappings::insert_derive_proc_macro_invocation (AST::SimplePath &invoc,
   procmacroDeriveInvocations[invoc.get_node_id ()] = def;
 }
 
-bool
-Mappings::lookup_derive_proc_macro_invocation (AST::SimplePath &invoc,
-					       CustomDeriveProcMacro &def)
+tl::optional<CustomDeriveProcMacro &>
+Mappings::lookup_derive_proc_macro_invocation (AST::SimplePath &invoc)
 {
   auto it = procmacroDeriveInvocations.find (invoc.get_node_id ());
   if (it == procmacroDeriveInvocations.end ())
-    return false;
+    return tl::nullopt;
 
-  def = it->second;
-  return true;
+  return it->second;
 }
 
 void
@@ -1094,16 +1092,14 @@ Mappings::insert_bang_proc_macro_invocation (AST::MacroInvocation &invoc,
   procmacroBangInvocations[invoc.get_macro_node_id ()] = def;
 }
 
-bool
-Mappings::lookup_bang_proc_macro_invocation (AST::MacroInvocation &invoc,
-					     BangProcMacro &def)
+tl::optional<BangProcMacro &>
+Mappings::lookup_bang_proc_macro_invocation (AST::MacroInvocation &invoc)
 {
   auto it = procmacroBangInvocations.find (invoc.get_macro_node_id ());
   if (it == procmacroBangInvocations.end ())
-    return false;
+    return tl::nullopt;
 
-  def = it->second;
-  return true;
+  return it->second;
 }
 
 void
@@ -1116,16 +1112,14 @@ Mappings::insert_attribute_proc_macro_invocation (AST::SimplePath &invoc,
   procmacroAttributeInvocations[invoc.get_node_id ()] = def;
 }
 
-bool
-Mappings::lookup_attribute_proc_macro_invocation (AST::SimplePath &invoc,
-						  AttributeProcMacro &def)
+tl::optional<AttributeProcMacro &>
+Mappings::lookup_attribute_proc_macro_invocation (AST::SimplePath &invoc)
 {
   auto it = procmacroAttributeInvocations.find (invoc.get_node_id ());
   if (it == procmacroAttributeInvocations.end ())
-    return false;
+    return tl::nullopt;
 
-  def = it->second;
-  return true;
+  return it->second;
 }
 
 void

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -1029,37 +1029,34 @@ Mappings::insert_attribute_proc_macro_def (NodeId id, AttributeProcMacro macro)
   procmacroAttributeMappings[id] = macro;
 }
 
-bool
-Mappings::lookup_derive_proc_macro_def (NodeId id, CustomDeriveProcMacro &macro)
+tl::optional<CustomDeriveProcMacro &>
+Mappings::lookup_derive_proc_macro_def (NodeId id)
 {
   auto it = procmacroDeriveMappings.find (id);
   if (it == procmacroDeriveMappings.end ())
-    return false;
+    return tl::nullopt;
 
-  macro = it->second;
-  return true;
+  return it->second;
 }
 
-bool
-Mappings::lookup_bang_proc_macro_def (NodeId id, BangProcMacro &macro)
+tl::optional<BangProcMacro &>
+Mappings::lookup_bang_proc_macro_def (NodeId id)
 {
   auto it = procmacroBangMappings.find (id);
   if (it == procmacroBangMappings.end ())
-    return false;
+    return tl::nullopt;
 
-  macro = it->second;
-  return true;
+  return it->second;
 }
 
-bool
-Mappings::lookup_attribute_proc_macro_def (NodeId id, AttributeProcMacro &macro)
+tl::optional<AttributeProcMacro &>
+Mappings::lookup_attribute_proc_macro_def (NodeId id)
 {
   auto it = procmacroAttributeMappings.find (id);
   if (it == procmacroAttributeMappings.end ())
-    return false;
+    return tl::nullopt;
 
-  macro = it->second;
-  return true;
+  return it->second;
 }
 
 void

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -1003,30 +1003,30 @@ Mappings::lookup_attribute_proc_macros (CrateNum num)
 }
 
 void
-Mappings::insert_derive_proc_macro_def (NodeId id, CustomDeriveProcMacro macro)
+Mappings::insert_derive_proc_macro_def (CustomDeriveProcMacro macro)
 {
-  auto it = procmacroDeriveMappings.find (id);
+  auto it = procmacroDeriveMappings.find (macro.get_node_id ());
   rust_assert (it == procmacroDeriveMappings.end ());
 
-  procmacroDeriveMappings[id] = macro;
+  procmacroDeriveMappings[macro.get_node_id ()] = macro;
 }
 
 void
-Mappings::insert_bang_proc_macro_def (NodeId id, BangProcMacro macro)
+Mappings::insert_bang_proc_macro_def (BangProcMacro macro)
 {
-  auto it = procmacroBangMappings.find (id);
+  auto it = procmacroBangMappings.find (macro.get_node_id ());
   rust_assert (it == procmacroBangMappings.end ());
 
-  procmacroBangMappings[id] = macro;
+  procmacroBangMappings[macro.get_node_id ()] = macro;
 }
 
 void
-Mappings::insert_attribute_proc_macro_def (NodeId id, AttributeProcMacro macro)
+Mappings::insert_attribute_proc_macro_def (AttributeProcMacro macro)
 {
-  auto it = procmacroAttributeMappings.find (id);
+  auto it = procmacroAttributeMappings.find (macro.get_node_id ());
   rust_assert (it == procmacroAttributeMappings.end ());
 
-  procmacroAttributeMappings[id] = macro;
+  procmacroAttributeMappings[macro.get_node_id ()] = macro;
 }
 
 tl::optional<CustomDeriveProcMacro &>

--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -306,9 +306,11 @@ public:
   void insert_bang_proc_macro_def (NodeId id, BangProcMacro macro);
   void insert_attribute_proc_macro_def (NodeId id, AttributeProcMacro macro);
 
-  bool lookup_derive_proc_macro_def (NodeId id, CustomDeriveProcMacro &macro);
-  bool lookup_bang_proc_macro_def (NodeId id, BangProcMacro &macro);
-  bool lookup_attribute_proc_macro_def (NodeId id, AttributeProcMacro &macro);
+  tl::optional<CustomDeriveProcMacro &>
+  lookup_derive_proc_macro_def (NodeId id);
+  tl::optional<BangProcMacro &> lookup_bang_proc_macro_def (NodeId id);
+  tl::optional<AttributeProcMacro &>
+  lookup_attribute_proc_macro_def (NodeId id);
 
   tl::optional<CustomDeriveProcMacro &>
   lookup_derive_proc_macro_invocation (AST::SimplePath &invoc);

--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -302,9 +302,9 @@ public:
   tl::optional<std::vector<AttributeProcMacro> &>
   lookup_attribute_proc_macros (CrateNum num);
 
-  void insert_derive_proc_macro_def (NodeId id, CustomDeriveProcMacro macro);
-  void insert_bang_proc_macro_def (NodeId id, BangProcMacro macro);
-  void insert_attribute_proc_macro_def (NodeId id, AttributeProcMacro macro);
+  void insert_derive_proc_macro_def (CustomDeriveProcMacro macro);
+  void insert_bang_proc_macro_def (BangProcMacro macro);
+  void insert_attribute_proc_macro_def (AttributeProcMacro macro);
 
   tl::optional<CustomDeriveProcMacro &>
   lookup_derive_proc_macro_def (NodeId id);

--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -310,19 +310,18 @@ public:
   bool lookup_bang_proc_macro_def (NodeId id, BangProcMacro &macro);
   bool lookup_attribute_proc_macro_def (NodeId id, AttributeProcMacro &macro);
 
+  tl::optional<CustomDeriveProcMacro &>
+  lookup_derive_proc_macro_invocation (AST::SimplePath &invoc);
+  tl::optional<BangProcMacro &>
+  lookup_bang_proc_macro_invocation (AST::MacroInvocation &invoc_id);
+  tl::optional<AttributeProcMacro &>
+  lookup_attribute_proc_macro_invocation (AST::SimplePath &invoc);
   void insert_derive_proc_macro_invocation (AST::SimplePath &invoc,
 					    CustomDeriveProcMacro def);
-
-  bool lookup_derive_proc_macro_invocation (AST::SimplePath &invoc,
-					    CustomDeriveProcMacro &def);
   void insert_bang_proc_macro_invocation (AST::MacroInvocation &invoc,
 					  BangProcMacro def);
-  bool lookup_bang_proc_macro_invocation (AST::MacroInvocation &invoc_id,
-					  BangProcMacro &def);
   void insert_attribute_proc_macro_invocation (AST::SimplePath &invoc,
 					       AttributeProcMacro def);
-  bool lookup_attribute_proc_macro_invocation (AST::SimplePath &invoc,
-					       AttributeProcMacro &def);
 
   void insert_visibility (NodeId id, Privacy::ModuleVisibility visibility);
   bool lookup_visibility (NodeId id, Privacy::ModuleVisibility &def);


### PR DESCRIPTION
Proc macro are resolved but not expanded. This PR allows the code to properly retrieve the macro definition in order for it to be expanded.

Requires #2496