### PR TITLE
Bump ```docker/build-push-action``` to v4

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: ${{ github.repository == 'Rust-GCC/gccrs' }}


### PR DESCRIPTION
This should get rid of some [docker build warnings](https://github.com/powerboat9/gccrs/actions/runs/6044879809)