### PR TITLE
Unify raw attribute values

### DIFF
--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -27,6 +27,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "rust-parse.h"
 #include "rust-operators.h"
 #include "rust-dir-owner.h"
+#include "rust-attribute-values.h"
 
 /* Compilation unit used for various AST-related functions that would make
  * the headers too long if they were defined inline and don't receive any
@@ -4190,7 +4191,8 @@ Attribute::check_cfg_predicate (const Session &session) const
   /* assume that cfg predicate actually can exist, i.e. attribute has cfg or
    * cfg_attr path */
   if (!has_attr_input ()
-      || (path.as_string () != "cfg" && path.as_string () != "cfg_attr"))
+      || (path.as_string () != Values::Attributes::CFG
+	  && path.as_string () != Values::Attributes::CFG_ATTR))
     {
       // DEBUG message
       rust_debug (
@@ -4212,7 +4214,7 @@ Attribute::check_cfg_predicate (const Session &session) const
 std::vector<Attribute>
 Attribute::separate_cfg_attrs () const
 {
-  if (!has_attr_input () || path.as_string () != "cfg_attr")
+  if (!has_attr_input () || path.as_string () != Values::Attributes::CFG_ATTR)
     return {};
 
   // assume that it has already been parsed

--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -30,6 +30,7 @@
 #include "rust-hir-path-probe.h"
 #include "rust-type-util.h"
 #include "rust-compile-implitem.h"
+#include "rust-attribute-values.h"
 
 #include "fold-const.h"
 #include "stringpool.h"
@@ -42,7 +43,9 @@ namespace Compile {
 
 bool inline should_mangle_item (const tree fndecl)
 {
-  return lookup_attribute ("no_mangle", DECL_ATTRIBUTES (fndecl)) == NULL_TREE;
+  return lookup_attribute (Values::Attributes::NO_MANGLE,
+			   DECL_ATTRIBUTES (fndecl))
+	 == NULL_TREE;
 }
 
 void
@@ -69,15 +72,17 @@ HIRCompileBase::setup_fndecl (tree fndecl, bool is_main_entry_point,
   // is it inline?
   for (const auto &attr : attrs)
     {
-      bool is_inline = attr.get_path ().as_string ().compare ("inline") == 0;
+      bool is_inline
+	= attr.get_path ().as_string () == Values::Attributes::INLINE;
       bool is_must_use
-	= attr.get_path ().as_string ().compare ("must_use") == 0;
-      bool is_cold = attr.get_path ().as_string ().compare ("cold") == 0;
+	= attr.get_path ().as_string () == Values::Attributes::MUST_USE;
+      bool is_cold = attr.get_path ().as_string () == Values::Attributes::COLD;
       bool is_link_section
-	= attr.get_path ().as_string ().compare ("link_section") == 0;
-      bool no_mangle = attr.get_path ().as_string ().compare ("no_mangle") == 0;
+	= attr.get_path ().as_string () == Values::Attributes::LINK_SECTION;
+      bool no_mangle
+	= attr.get_path ().as_string () == Values::Attributes::NO_MANGLE;
       bool is_deprecated
-	= attr.get_path ().as_string ().compare ("deprecated") == 0;
+	= attr.get_path ().as_string () == Values::Attributes::DEPRECATED;
 
       if (is_inline)
 	{
@@ -113,7 +118,7 @@ HIRCompileBase::handle_cold_attribute_on_fndecl (tree fndecl,
   // simple #[cold]
   if (!attr.has_attr_input ())
     {
-      tree cold = get_identifier ("cold");
+      tree cold = get_identifier (Values::Attributes::COLD);
       // this will get handled by the GCC backend later
       DECL_ATTRIBUTES (fndecl)
 	= tree_cons (cold, NULL_TREE, DECL_ATTRIBUTES (fndecl));
@@ -160,8 +165,9 @@ HIRCompileBase::handle_no_mangle_attribute_on_fndecl (
       return;
     }
 
-  DECL_ATTRIBUTES (fndecl) = tree_cons (get_identifier ("no_mangle"), NULL_TREE,
-					DECL_ATTRIBUTES (fndecl));
+  DECL_ATTRIBUTES (fndecl)
+    = tree_cons (get_identifier (Values::Attributes::NO_MANGLE), NULL_TREE,
+		 DECL_ATTRIBUTES (fndecl));
 }
 
 void
@@ -223,7 +229,7 @@ HIRCompileBase::handle_deprecated_attribute_on_fndecl (
     {
       tree attr_list = build_tree_list (NULL_TREE, value);
       DECL_ATTRIBUTES (fndecl)
-	= tree_cons (get_identifier ("deprecated"), attr_list,
+	= tree_cons (get_identifier (Values::Attributes::DEPRECATED), attr_list,
 		     DECL_ATTRIBUTES (fndecl));
     }
 }

--- a/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
+++ b/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
@@ -21,6 +21,7 @@
 #include "rust-hir-expr.h"
 #include "rust-hir-stmt.h"
 #include "rust-hir-item.h"
+#include "rust-attribute-values.h"
 
 namespace Rust {
 namespace Privacy {
@@ -43,8 +44,9 @@ find_proc_macro_attribute (const AST::AttrVec &outer_attrs)
       if (segments.size () != 1)
 	continue;
       auto name = segments.at (0).get_segment_name ();
-      if (name == "proc_macro" || name == "proc_macro_attribute"
-	  || name == "proc_macro_derive")
+      if (name == Values::Attributes::PROC_MACRO
+	  || name == Values::Attributes::PROC_MACRO_ATTRIBUTE
+	  || name == Values::Attributes::PROC_MACRO_DERIVE)
 	return name;
     }
 

--- a/gcc/rust/checks/errors/rust-unsafe-checker.cc
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.cc
@@ -21,6 +21,7 @@
 #include "rust-hir-expr.h"
 #include "rust-hir-stmt.h"
 #include "rust-hir-item.h"
+#include "rust-attribute-values.h"
 
 namespace Rust {
 namespace HIR {
@@ -186,7 +187,8 @@ check_target_attr (HIR::Function *fn, location_t locus)
   if (std::any_of (fn->get_outer_attrs ().begin (),
 		   fn->get_outer_attrs ().end (),
 		   [] (const AST::Attribute &attr) {
-		     return attr.get_path ().as_string () == "target_feature";
+		     return attr.get_path ().as_string ()
+			    == Values::Attributes::TARGET_FEATURE;
 		   }))
     rust_error_at (locus,
 		   "call to function with %<#[target_feature]%> requires "

--- a/gcc/rust/expand/rust-cfg-strip.cc
+++ b/gcc/rust/expand/rust-cfg-strip.cc
@@ -19,6 +19,7 @@
 #include "rust-cfg-strip.h"
 #include "rust-ast-full.h"
 #include "rust-session-manager.h"
+#include "rust-attribute-values.h"
 
 namespace Rust {
 
@@ -33,7 +34,8 @@ fails_cfg (const AST::AttrVec &attrs)
 
   for (const auto &attr : attrs)
     {
-      if (attr.get_path () == "cfg" && !attr.check_cfg_predicate (session))
+      if (attr.get_path () == Values::Attributes::CFG
+	  && !attr.check_cfg_predicate (session))
 	return true;
     }
   return false;
@@ -51,7 +53,7 @@ fails_cfg_with_expand (AST::AttrVec &attrs)
   // TODO: maybe have something that strips cfg attributes that evaluate true?
   for (auto &attr : attrs)
     {
-      if (attr.get_path () == "cfg")
+      if (attr.get_path () == Values::Attributes::CFG)
 	{
 	  if (!attr.is_parsed_to_meta_item ())
 	    attr.parse_attr_to_meta_item ();
@@ -96,7 +98,7 @@ expand_cfg_attrs (AST::AttrVec &attrs)
   for (std::size_t i = 0; i < attrs.size (); i++)
     {
       auto &attr = attrs[i];
-      if (attr.get_path () == "cfg_attr")
+      if (attr.get_path () == Values::Attributes::CFG_ATTR)
 	{
 	  if (!attr.is_parsed_to_meta_item ())
 	    attr.parse_attr_to_meta_item ();

--- a/gcc/rust/expand/rust-macro-builtins.cc
+++ b/gcc/rust/expand/rust-macro-builtins.cc
@@ -29,6 +29,7 @@
 #include "rust-macro.h"
 #include "rust-parse.h"
 #include "rust-session-manager.h"
+#include "rust-attribute-values.h"
 
 namespace Rust {
 

--- a/gcc/rust/hir/rust-ast-lower-base.cc
+++ b/gcc/rust/hir/rust-ast-lower-base.cc
@@ -20,6 +20,7 @@
 #include "rust-ast-lower-type.h"
 #include "rust-ast-lower-pattern.h"
 #include "rust-ast-lower-extern.h"
+#include "rust-attribute-values.h"
 
 namespace Rust {
 namespace HIR {
@@ -722,12 +723,12 @@ ASTLoweringBase::handle_outer_attributes (const ItemWrapper &item)
 	  continue;
 	}
 
-      bool is_lang_item = str_path.compare ("lang") == 0
+      bool is_lang_item = str_path == Values::Attributes::LANG
 			  && attr.has_attr_input ()
 			  && attr.get_attr_input ().get_attr_input_type ()
 			       == AST::AttrInput::AttrInputType::LITERAL;
 
-      bool is_doc_item = str_path.compare ("doc") == 0;
+      bool is_doc_item = str_path == Values::Attributes::DOC;
 
       if (is_doc_item)
 	handle_doc_item_attribute (item, attr);
@@ -967,7 +968,7 @@ ASTLoweringBase::lower_macro_definition (AST::MacroRulesDefinition &def)
 {
   auto is_export = false;
   for (const auto &attr : def.get_outer_attrs ())
-    if (attr.get_path ().as_string () == "macro_export")
+    if (attr.get_path ().as_string () == Values::Attributes::MACRO_EXPORT)
       is_export = true;
 
   if (is_export)

--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -23,6 +23,7 @@
 #include "rust-hir-type.h"
 #include "rust-hir.h"
 #include <string>
+#include "rust-attribute-values.h"
 
 namespace Rust {
 namespace HIR {
@@ -633,7 +634,7 @@ void
 Dump::visit (AST::Attribute &attribute)
 {
   // Special, no begin/end as this is called by do_inner_attrs.
-  put_field ("path", attribute.get_path ().as_string ());
+  put_field (Values::Attributes::PATH, attribute.get_path ().as_string ());
 
   std::string str = "none";
   if (attribute.has_attr_input ())

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -26,6 +26,7 @@
 #include "rust-diagnostics.h"
 #include "rust-make-unique.h"
 #include "rust-dir-owner.h"
+#include "rust-attribute-values.h"
 
 namespace Rust {
 // Left binding powers of operations.
@@ -490,7 +491,7 @@ Parser<ManagedTokenSource>::parse_doc_comment ()
 {
   const_TokenPtr token = lexer.peek_token ();
   location_t locus = token->get_locus ();
-  AST::SimplePathSegment segment ("doc", locus);
+  AST::SimplePathSegment segment (Values::Attributes::DOC, locus);
   std::vector<AST::SimplePathSegment> segments;
   segments.push_back (std::move (segment));
   AST::SimplePath attr_path (std::move (segments), false, locus);

--- a/gcc/rust/parse/rust-parse.cc
+++ b/gcc/rust/parse/rust-parse.cc
@@ -18,6 +18,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "rust-linemap.h"
 #include "rust-diagnostics.h"
 #include "rust-token.h"
+#include "rust-attribute-values.h"
 
 namespace Rust {
 
@@ -28,7 +29,7 @@ extract_module_path (const AST::AttrVec &inner_attrs,
   AST::Attribute path_attr = AST::Attribute::create_empty ();
   for (const auto &attr : inner_attrs)
     {
-      if (attr.get_path ().as_string () == "path")
+      if (attr.get_path ().as_string () == Values::Attributes::PATH)
 	{
 	  path_attr = attr;
 	  break;
@@ -48,7 +49,7 @@ extract_module_path (const AST::AttrVec &inner_attrs,
 
   for (const auto &attr : outer_attrs)
     {
-      if (attr.get_path ().as_string () == "path")
+      if (attr.get_path ().as_string () == Values::Attributes::PATH)
 	{
 	  path_attr = attr;
 	  break;

--- a/gcc/rust/resolve/rust-early-name-resolver.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver.cc
@@ -20,6 +20,7 @@
 #include "rust-ast-full.h"
 #include "rust-name-resolver.h"
 #include "rust-macro-builtins.h"
+#include "rust-attribute-values.h"
 
 namespace Rust {
 namespace Resolver {
@@ -29,7 +30,7 @@ static bool
 is_macro_use_module (const AST::Module &mod)
 {
   for (const auto &attr : mod.get_outer_attrs ())
-    if (attr.get_path ().as_string () == "macro_use")
+    if (attr.get_path ().as_string () == Values::Attributes::MACRO_USE)
       return true;
 
   return false;
@@ -973,7 +974,8 @@ EarlyNameResolver::visit (AST::MacroInvocation &invoc)
   bool is_builtin
     = std::any_of (outer_attrs.begin (), outer_attrs.end (),
 		   [] (AST::Attribute attr) {
-		     return attr.get_path () == "rustc_builtin_macro";
+		     return attr.get_path ()
+			    == Values::Attributes::RUSTC_BUILTIN_MACRO;
 		   });
 
   if (is_builtin)

--- a/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
@@ -19,6 +19,7 @@
 #include "rust-toplevel-name-resolver-2.0.h"
 #include "rust-ast-full.h"
 #include "rust-hir-map.h"
+#include "rust-attribute-values.h"
 
 namespace Rust {
 namespace Resolver2_0 {
@@ -75,7 +76,7 @@ static bool
 is_macro_export (AST::MacroRulesDefinition &def)
 {
   for (const auto &attr : def.get_outer_attrs ())
-    if (attr.get_path ().as_string () == "macro_export")
+    if (attr.get_path ().as_string () == Values::Attributes::MACRO_EXPORT)
       return true;
 
   return false;

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -45,6 +45,7 @@
 #include "rust-cfg-strip.h"
 #include "rust-expand-visitor.h"
 #include "rust-unicode.h"
+#include "rust-attribute-values.h"
 
 #include "diagnostic.h"
 #include "input.h"
@@ -807,8 +808,8 @@ Session::injection (AST::Crate &crate)
     {
       // create "macro use" attribute for use on extern crate item to enable
       // loading macros from it
-      AST::Attribute attr (AST::SimplePath::from_str ("macro_use",
-						      UNDEF_LOCATION),
+      AST::Attribute attr (AST::SimplePath::from_str (
+			     Values::Attributes::MACRO_USE, UNDEF_LOCATION),
 			   nullptr);
 
       // create "extern crate" item with the name

--- a/gcc/rust/typecheck/rust-hir-type-check-base.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.cc
@@ -21,6 +21,7 @@
 #include "rust-hir-type-check-type.h"
 #include "rust-hir-trait-resolve.h"
 #include "rust-type-util.h"
+#include "rust-attribute-values.h"
 
 namespace Rust {
 namespace Resolver {
@@ -291,7 +292,7 @@ TypeCheckBase::parse_repr_options (const AST::AttrVec &attrs, location_t locus)
 
   for (const auto &attr : attrs)
     {
-      bool is_repr = attr.get_path ().as_string ().compare ("repr") == 0;
+      bool is_repr = attr.get_path ().as_string () == Values::Attributes::REPR;
       if (is_repr)
 	{
 	  const AST::AttrInput &input = attr.get_attr_input ();

--- a/gcc/rust/util/rust-attribute-values.h
+++ b/gcc/rust/util/rust-attribute-values.h
@@ -1,0 +1,40 @@
+#ifndef RUST_ATTRIBUTES_VALUE_H
+#define RUST_ATTRIBUTES_VALUE_H
+
+namespace Rust {
+namespace Values {
+// TODO: Change this to a namespace + inline constexpr in the future
+class Attributes
+{
+public:
+  static constexpr auto &INLINE = "inline";
+  static constexpr auto &COLD = "cold";
+  static constexpr auto &CFG = "cfg";
+  static constexpr auto &CFG_ATTR = "cfg_attr";
+  static constexpr auto &DEPRECATED = "deprecated";
+  static constexpr auto &ALLOW = "allow";
+  static constexpr auto &ALLOW_INTERNAL_UNSTABLE = "allow_internal_unstable";
+  static constexpr auto &DOC = "doc";
+  static constexpr auto &MUST_USE = "must_use";
+  static constexpr auto &LANG = "lang";
+  static constexpr auto &LINK_SECTION = "link_section";
+  static constexpr auto &NO_MANGLE = "no_mangle";
+  static constexpr auto &REPR = "repr";
+  static constexpr auto &RUSTC_BUILTIN_MACRO = "rustc_builtin_macro";
+  static constexpr auto &PATH = "path";
+  static constexpr auto &MACRO_USE = "macro_use";
+  static constexpr auto &MACRO_EXPORT = "macro_export";
+  static constexpr auto &PROC_MACRO = "proc_macro";
+  static constexpr auto &PROC_MACRO_DERIVE = "proc_macro_derive";
+  static constexpr auto &PROC_MACRO_ATTRIBUTE = "proc_macro_attribute";
+  static constexpr auto &TARGET_FEATURE = "target_feature";
+  // From now on, these are reserved by the compiler and gated through
+  // #![feature(rustc_attrs)]
+  static constexpr auto &RUSTC_INHERIT_OVERFLOW_CHECKS
+    = "rustc_inherit_overflow_checks";
+  static constexpr auto &STABLE = "stable";
+};
+} // namespace Values
+} // namespace Rust
+
+#endif /* !RUST_ATTRIBUTES_VALUE_H */

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -22,6 +22,7 @@
 #include "rust-hir-full.h"
 #include "rust-macro-builtins.h"
 #include "rust-mapping-common.h"
+#include "rust-attribute-values.h"
 
 namespace Rust {
 namespace Analysis {
@@ -872,7 +873,8 @@ Mappings::insert_macro_def (AST::MacroRulesDefinition *macro)
   bool should_be_builtin
     = std::any_of (outer_attrs.begin (), outer_attrs.end (),
 		   [] (AST::Attribute attr) {
-		     return attr.get_path () == "rustc_builtin_macro";
+		     return attr.get_path ()
+			    == Values::Attributes::RUSTC_BUILTIN_MACRO;
 		   });
   if (should_be_builtin)
     {


### PR DESCRIPTION
Maybe controversial changes, review carefully and consider all implications, this is meant to remove raw attribute values. Hopefully this will make the code less prone to typos.