### PR TITLE
Bump our docker build's debian base image version to match ```rust:latest```'s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11 AS gcc-builder
+FROM debian:12 AS gcc-builder
 
 RUN apt-get update; \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \


### PR DESCRIPTION
This *should* fix our docker builds. It looks like ```rust:latest``` [upgraded](https://github.com/docker-library/official-images/commit/10f7c0abd9f0f04360d30a83344ae7d8ea03bb86#diff-6591a398dd9843ff51ada710b7ff40291be32d8edd66a833f1a5de00d24d7640L16-R26) from debian 10 to debian 12 shortly before our docker builds started failing with ```cannot replace to directory /var/lib/buildkit/runc-overlayfs/cachemounts/buildkit596534011/usr/share/doc/libcrypt-dev with file```.