### PR TITLE
[E0603] Use of private item outside scope

### DIFF
--- a/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
+++ b/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
@@ -166,7 +166,12 @@ PrivacyReporter::check_for_privacy_violation (const NodeId &use_id,
     }
 
   if (!valid)
-    rust_error_at (locus, "definition is private in this context");
+    {
+      rich_location richloc (line_table, locus);
+      richloc.add_fixit_replace ("item is private");
+      rust_error_at (richloc, ErrorCode::E0603,
+		     "definition is private in this context");
+    }
 }
 
 void

--- a/gcc/testsuite/rust/compile/privacy1.rs
+++ b/gcc/testsuite/rust/compile/privacy1.rs
@@ -4,7 +4,7 @@ mod orange {
         pub fn doux() {}
     }
 
-    fn brown() {
+    fn brown() {// E0603
         green::sain(); // { dg-error "definition is private in this context" }
         green::doux();
     }

--- a/gcc/testsuite/rust/compile/privacy3.rs
+++ b/gcc/testsuite/rust/compile/privacy3.rs
@@ -8,7 +8,7 @@ mod orange {
     }
 
     fn brown() {
-        if green::sain() {
+        if green::sain() {// E0603
             // { dg-error "definition is private in this context" "" { target *-*-* } .-1 }
             green::doux();
         }

--- a/gcc/testsuite/rust/compile/privacy4.rs
+++ b/gcc/testsuite/rust/compile/privacy4.rs
@@ -8,7 +8,7 @@ mod orange {
         }
     }
 
-    fn brown() {
+    fn brown() {// E0603
         green::bean::<bool>(false);
         // { dg-error "definition is private in this context" "" { target *-*-* } .-1 }
         let a = green::bean::<i32>(15);

--- a/gcc/testsuite/rust/compile/privacy5.rs
+++ b/gcc/testsuite/rust/compile/privacy5.rs
@@ -5,7 +5,7 @@ mod orange {
         pub struct Baz;
     }
 
-    fn brown() {
+    fn brown() {// E0603
         let _ = green::Foo; // { dg-error "definition is private in this context" }
         let _ = green::Bar;
         let _ = green::Baz;


### PR DESCRIPTION
## Use of private item outside scope - [`E0603`](https://doc.rust-lang.org/error_codes/E0603.html) 
- Use of private item outside scope
- Updated error message.
















gcc/rust/ChangeLog:

	* checks/errors/privacy/rust-privacy-reporter.cc (PrivacyReporter::check_for_privacy_violation): Added errorcode & richlocation.

gcc/testsuite/ChangeLog:

	* rust/compile/privacy1.rs: Updated comment for dejagnu.
	* rust/compile/privacy3.rs: likewise.
	* rust/compile/privacy4.rs: likewise.
	* rust/compile/privacy5.rs: likewise.
