### PR TITLE
Add `try` intrinsics

### DIFF
--- a/gcc/rust/lang.opt
+++ b/gcc/rust/lang.opt
@@ -212,4 +212,17 @@ frust-borrowcheck
 Rust Var(flag_borrowcheck)
 Use the WIP borrow checker.
 
+frust-panic=
+Rust Joined RejectNegative Enum(frust_panic) Var(flag_rust_panic)
+-frust-edition=[unwind|abort]             Panic strategy to compile crate with
+
+Enum
+Name(frust_panic) Type(int) UnknownError(unknown panic strategy %qs)
+
+EnumValue
+Enum(frust_panic) String(unwind) Value(0)
+
+EnumValue
+Enum(frust_panic) String(abort) Value(1)
+
 ; This comment is to ensure we retain the blank line above.

--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -146,6 +146,8 @@ grs_langhook_init_options_struct (struct gcc_options *opts)
   opts->x_warn_unused_result = 1;
   /* lets warn for infinite recursion*/
   opts->x_warn_infinite_recursion = 1;
+  /* Enable exception handling (aka `panic!` in Rust) */
+  opts->x_flag_exceptions = 1;
 
   // nothing yet - used by frontends to change specific options for the language
   Rust::Session::get_instance ().init_options ();

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -266,6 +266,9 @@ Session::handle_option (
     case OPT_frust_metadata_output_:
       options.set_metadata_output (arg);
       break;
+    case OPT_frust_panic_:
+      options.set_panic_strategy (flag_rust_panic);
+      break;
 
     default:
       break;

--- a/gcc/rust/rust-session-manager.h
+++ b/gcc/rust/rust-session-manager.h
@@ -264,6 +264,13 @@ struct CompileOptions
   } compile_until
     = CompileStep::End;
 
+  enum class PanicStrategy
+  {
+    Unwind,
+    Abort,
+  } panic_strategy
+    = PanicStrategy::Unwind;
+
   bool dump_option_enabled (DumpOption option) const
   {
     return dump_options.find (option) != dump_options.end ();
@@ -319,6 +326,13 @@ struct CompileOptions
   }
 
   const CompileStep &get_compile_until () const { return compile_until; }
+
+  void set_panic_strategy (int strategy)
+  {
+    panic_strategy = static_cast<PanicStrategy> (strategy);
+  }
+
+  const PanicStrategy &get_panic_strategy () const { return panic_strategy; }
 
   void set_metadata_output (const std::string &path)
   {

--- a/gcc/testsuite/rust/compile/try-catch-unwind-new.rs
+++ b/gcc/testsuite/rust/compile/try-catch-unwind-new.rs
@@ -1,0 +1,20 @@
+// { dg-options "-O2 -w -fdump-tree-optimized" }
+#![feature(intrinsics)]
+
+extern "rust-intrinsic" {
+    // { dg-final { scan-tree-dump-times "__builtin_eh_pointer" 1 "optimized" } }
+    fn catch_unwind(try_fn: fn(_: *mut u8), data: *mut u8, catch_fn: fn(_: *mut u8, _: *mut u8));
+}
+
+extern "C" {
+    fn try_fn(data: *mut u8);
+    fn catch_fn(data: *mut u8, ex: *mut u8);
+}
+
+pub fn not_main(d: &mut u8) {
+    unsafe {
+        // { dg-final { scan-tree-dump-times "try_fn" 1 "optimized" } }
+        catch_unwind(try_fn, d, catch_fn);
+        // { dg-final { scan-tree-dump-times "catch_fn" 1 "optimized" } }
+    }
+}

--- a/gcc/testsuite/rust/compile/try-catch-unwind-old.rs
+++ b/gcc/testsuite/rust/compile/try-catch-unwind-old.rs
@@ -1,0 +1,21 @@
+// { dg-options "-O2 -w -fdump-tree-optimized" }
+#![feature(intrinsics)]
+
+extern "rust-intrinsic" {
+    // { dg-final { scan-tree-dump-times "__builtin_eh_pointer" 1 "optimized" } }
+    fn r#try(try_fn: fn(_: *mut u8), data: *mut u8, catch_fn: fn(_: *mut u8, _: *mut u8)) -> i32;
+}
+
+extern "C" {
+    fn try_fn(data: *mut u8);
+    fn catch_fn(data: *mut u8, ex: *mut u8);
+}
+
+pub fn not_main(d: &mut u8) -> i32 {
+    unsafe {
+        // { dg-final { scan-tree-dump-times "try_fn" 1 "optimized" } }
+        let _: i32 = r#try(try_fn, d, catch_fn);
+        // { dg-final { scan-tree-dump-times "catch_fn" 1 "optimized" } }
+    }
+    42
+}


### PR DESCRIPTION
This pull request adds the `try` intrinsic, making it possible to handle `panic`s.

A new option, `-frust-panic` is added to specify the panic handling strategy.

Note that currently, only `try`-`catch` mechanism is added in this pull request.
To correctly handle the `panic` structures, an unwinder must also be implemented (in the runtime library).