### PR TITLE
Add ```assume``` intrinsic

### DIFF
--- a/gcc/testsuite/rust/compile/assume.rs
+++ b/gcc/testsuite/rust/compile/assume.rs
@@ -1,0 +1,13 @@
+mod intrinsics {
+    extern "rust-intrinsic" {
+        pub fn assume(value: bool);
+    }
+}
+
+pub fn foo(v: i32) -> i32 {
+    unsafe { intrinsics::assume (v == 12); }
+    v
+}
+
+pub fn main() {
+}


### PR DESCRIPTION
I've been having trouble getting this to work so far, optimizations don't seem to be taking the assumption into account. This *might* change after gcc upstream is merged in, but there's probably something off with my code.