### PR TITLE
gccrs: trivial typo fix.

### DIFF
--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -564,7 +564,7 @@ HIRCompileBase::compile_function (
   tree fndecl = Backend::function (compiled_fn_type, ir_symbol_name,
 				   "" /* asm_name */, flags, locus);
 
-  setup_fndecl (fndecl, is_main_fn, fntype->has_subsititions_defined (),
+  setup_fndecl (fndecl, is_main_fn, fntype->has_substitutions_defined (),
 		visibility, qualifiers, outer_attrs);
   setup_abi_options (fndecl, qualifiers.get_abi ());
 
@@ -792,7 +792,7 @@ HIRCompileBase::resolve_method_address (TyTy::FnType *fntype,
   HIR::Item *resolved_item = ctx->get_mappings ()->lookup_defid (id);
   if (resolved_item != nullptr)
     {
-      if (!fntype->has_subsititions_defined ())
+      if (!fntype->has_substitutions_defined ())
 	return CompileItem::compile (resolved_item, ctx);
 
       return CompileItem::compile (resolved_item, ctx, fntype);

--- a/gcc/rust/backend/rust-compile-extern.h
+++ b/gcc/rust/backend/rust-compile-extern.h
@@ -91,7 +91,7 @@ public:
 
     rust_assert (fntype_tyty->get_kind () == TyTy::TypeKind::FNDEF);
     TyTy::FnType *fntype = static_cast<TyTy::FnType *> (fntype_tyty);
-    if (fntype->has_subsititions_defined ())
+    if (fntype->has_substitutions_defined ())
       {
 	// we cant do anything for this only when it is used and a concrete type
 	// is given
@@ -114,7 +114,7 @@ public:
 	return;
       }
 
-    if (fntype->has_subsititions_defined ())
+    if (fntype->has_substitutions_defined ())
       {
 	// override the Hir Lookups for the substituions in this context
 	fntype->override_context ();

--- a/gcc/rust/backend/rust-compile-implitem.cc
+++ b/gcc/rust/backend/rust-compile-implitem.cc
@@ -71,7 +71,7 @@ CompileTraitItem::visit (HIR::TraitItemFunc &func)
 	}
     }
 
-  if (fntype->has_subsititions_defined ())
+  if (fntype->has_substitutions_defined ())
     {
       // override the Hir Lookups for the substituions in this context
       fntype->override_context ();

--- a/gcc/rust/backend/rust-compile-intrinsic.cc
+++ b/gcc/rust/backend/rust-compile-intrinsic.cc
@@ -282,7 +282,7 @@ check_for_cached_intrinsic (Context *ctx, TyTy::FnType *fntype, tree *lookup)
 static void
 maybe_override_ctx (TyTy::FnType *fntype)
 {
-  if (fntype->has_subsititions_defined ())
+  if (fntype->has_substitutions_defined ())
     fntype->override_context ();
 }
 

--- a/gcc/rust/backend/rust-compile-item.cc
+++ b/gcc/rust/backend/rust-compile-item.cc
@@ -118,7 +118,7 @@ CompileItem::visit (HIR::Function &function)
 
   rust_assert (fntype_tyty->get_kind () == TyTy::TypeKind::FNDEF);
   TyTy::FnType *fntype = static_cast<TyTy::FnType *> (fntype_tyty);
-  if (fntype->has_subsititions_defined ())
+  if (fntype->has_substitutions_defined ())
     {
       // we cant do anything for this only when it is used and a concrete type
       // is given
@@ -166,7 +166,7 @@ CompileItem::visit (HIR::Function &function)
       return;
     }
 
-  if (fntype->has_subsititions_defined ())
+  if (fntype->has_substitutions_defined ())
     {
       // override the Hir Lookups for the substituions in this context
       fntype->override_context ();

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -184,7 +184,7 @@ HIRCompileBase::query_compile (HirId ref, TyTy::BaseType *lookup,
   bool is_fn = lookup->get_kind () == TyTy::TypeKind::FNDEF;
   if (is_hir_item)
     {
-      if (!lookup->has_subsititions_defined ())
+      if (!lookup->has_substitutions_defined ())
 	return CompileItem::compile (resolved_item, ctx, nullptr, true,
 				     expr_locus);
       else
@@ -193,7 +193,7 @@ HIRCompileBase::query_compile (HirId ref, TyTy::BaseType *lookup,
     }
   else if (is_hir_extern_item)
     {
-      if (!lookup->has_subsititions_defined ())
+      if (!lookup->has_substitutions_defined ())
 	return CompileExternItem::compile (resolved_extern_item, ctx, nullptr,
 					   true, expr_locus);
       else
@@ -222,7 +222,7 @@ HIRCompileBase::query_compile (HirId ref, TyTy::BaseType *lookup,
       bool is_impl_item = resolved_item != nullptr;
       if (is_impl_item)
 	{
-	  if (!lookup->has_subsititions_defined ())
+	  if (!lookup->has_substitutions_defined ())
 	    return CompileInherentImplItem::Compile (resolved_item, ctx,
 						     nullptr, true, expr_locus);
 	  else
@@ -285,7 +285,7 @@ HIRCompileBase::query_compile (HirId ref, TyTy::BaseType *lookup,
 		impl->get_type ()->get_mappings ().get_hirid (), &self);
 	      rust_assert (ok);
 
-	      if (!lookup->has_subsititions_defined ())
+	      if (!lookup->has_substitutions_defined ())
 		return CompileInherentImplItem::Compile (impl_item, ctx,
 							 nullptr, true,
 							 expr_locus);

--- a/gcc/rust/typecheck/rust-coercion.cc
+++ b/gcc/rust/typecheck/rust-coercion.cc
@@ -72,7 +72,7 @@ TypeCoercionRules::do_coercion (TyTy::BaseType *receiver)
       //     let _: Option<?T> = Some({ return; });
       //
       // here, we would coerce from `!` to `?T`.
-      if (expected->has_subsititions_defined () && !expected->is_concrete ())
+      if (expected->has_substitutions_defined () && !expected->is_concrete ())
 	{
 	  location_t locus = mappings->lookup_location (receiver->get_ref ());
 	  TyTy::TyVar implicit_var

--- a/gcc/rust/typecheck/rust-hir-type-check-item.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.cc
@@ -120,7 +120,7 @@ TypeCheckItem::ResolveImplBlockSelfWithInference (
 
   // we only need to apply to the bounds manually on types which dont bind
   // generics
-  if (!infer->has_subsititions_defined ())
+  if (!infer->has_substitutions_defined ())
     {
       for (auto &bound : infer->get_specified_bounds ())
 	bound.handle_substitions (*infer_arguments);

--- a/gcc/rust/typecheck/rust-hir-type-check-path.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-path.cc
@@ -133,7 +133,7 @@ TypeCheckExpr::visit (HIR::QualifiedPathInExpression &expr)
   // turbo-fish segment path::<ty>
   if (item_seg.has_generic_args ())
     {
-      if (!infered->has_subsititions_defined ())
+      if (!infered->has_substitutions_defined ())
 	{
 	  rust_error_at (item_seg.get_locus (),
 			 "substitutions not supported for %s",

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -283,7 +283,7 @@ TypeCheckType::visit (HIR::QualifiedPathInType &path)
       // turbo-fish segment path::<ty>
       if (generic_seg.has_generic_args ())
 	{
-	  if (!translated->has_subsititions_defined ())
+	  if (!translated->has_substitutions_defined ())
 	    {
 	      rust_error_at (item_seg->get_locus (),
 			     "substitutions not supported for %s",

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -837,7 +837,7 @@ BaseType::is_concrete () const
 }
 
 bool
-BaseType::has_subsititions_defined () const
+BaseType::has_substitutions_defined () const
 {
   const TyTy::BaseType *x = destructure ();
   switch (x->get_kind ())
@@ -1680,10 +1680,10 @@ ADTType::is_equal (const BaseType &other) const
   if (number_of_variants () != other2.number_of_variants ())
     return false;
 
-  if (has_subsititions_defined () != other2.has_subsititions_defined ())
+  if (has_substitutions_defined () != other2.has_substitutions_defined ())
     return false;
 
-  if (has_subsititions_defined ())
+  if (has_substitutions_defined ())
     {
       if (get_num_substitutions () != other2.get_num_substitutions ())
 	return false;
@@ -1757,7 +1757,7 @@ handle_substitions (SubstitutionArgumentMappings &subst_mappings,
 	    }
 	}
     }
-  else if (fty->has_subsititions_defined () || !fty->is_concrete ())
+  else if (fty->has_substitutions_defined () || !fty->is_concrete ())
     {
       BaseType *concrete
 	= Resolver::SubstMapperInternal::Resolve (fty, subst_mappings);
@@ -2001,10 +2001,10 @@ FnType::is_equal (const BaseType &other) const
   if (!get_return_type ()->is_equal (*other2.get_return_type ()))
     return false;
 
-  if (has_subsititions_defined () != other2.has_subsititions_defined ())
+  if (has_substitutions_defined () != other2.has_substitutions_defined ())
     return false;
 
-  if (has_subsititions_defined ())
+  if (has_substitutions_defined ())
     {
       if (get_num_substitutions () != other2.get_num_substitutions ())
 	return false;
@@ -2141,7 +2141,7 @@ FnType::handle_substitions (SubstitutionArgumentMappings &subst_mappings)
 		}
 	    }
 	}
-      else if (fty->has_subsititions_defined () || !fty->is_concrete ())
+      else if (fty->has_substitutions_defined () || !fty->is_concrete ())
 	{
 	  BaseType *concrete
 	    = Resolver::SubstMapperInternal::Resolve (fty, subst_mappings);

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -155,7 +155,7 @@ public:
   const RustIdent &get_ident () const;
   location_t get_locus () const;
 
-  bool has_subsititions_defined () const;
+  bool has_substitutions_defined () const;
   bool needs_generic_substitutions () const;
 
   std::string mangle_string () const


### PR DESCRIPTION
Fix subsititions -> substitutions

gcc/rust/ChangeLog:

	* backend/rust-compile-base.cc (HIRCompileBase::compile_function):
	Fix typo in substitutions.
	(HIRCompileBase::resolve_method_address): Likewise.
	* backend/rust-compile-extern.h (CompileExternItem::visit):
	Likewise.
	* backend/rust-compile-implitem.cc (CompileTraitItem::visit):
	Likewise.
	* backend/rust-compile-intrinsic.cc (maybe_override_ctx):
	Likewise.
	* backend/rust-compile-item.cc (CompileItem::visit): Likewise.
	* backend/rust-compile-resolve-path.cc
	(HIRCompileBase::query_compile): Likewise.
	* typecheck/rust-coercion.cc (TypeCoercionRules::do_coercion):
	Likewise.
	* typecheck/rust-hir-type-check-item.cc
	(TypeCheckItem::ResolveImplBlockSelfWithInference): Likewise.
	* typecheck/rust-hir-type-check-path.cc (TypeCheckExpr::visit):
	Likewise.
	* typecheck/rust-hir-type-check-type.cc (TypeCheckType::visit):
	Likewise.
	* typecheck/rust-tyty.cc (BaseType::has_subsititions_defined):
	Renamed into ...
	(BaseType::has_substitutions_defined): ... this.
	(ADTType::is_equal): Fix typo in substitutions.
	(handle_substitions): Likewise.
	(FnType::is_equal): Likewise.
	(FnType::handle_substitions): Likewise.
	* typecheck/rust-tyty.h (has_subsititions_defined): Renamed into
	...
	(has_substitutions_defined): ... this.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>