### PR TITLE
gccrs: Minor typo fix

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -1634,11 +1634,11 @@ CompileExpr::visit (HIR::CallExpr &expr)
   if (possible_trait_call)
     return;
 
-  bool is_varadic = false;
+  bool is_variadic = false;
   if (tyty->get_kind () == TyTy::TypeKind::FNDEF)
     {
       const TyTy::FnType *fn = static_cast<const TyTy::FnType *> (tyty);
-      is_varadic = fn->is_varadic ();
+      is_variadic = fn->is_variadic ();
     }
 
   size_t required_num_args = expr.get_arguments ().size ();
@@ -1659,7 +1659,7 @@ CompileExpr::visit (HIR::CallExpr &expr)
       auto &argument = expr.get_arguments ().at (i);
       auto rvalue = CompileExpr::Compile (argument.get (), ctx);
 
-      if (is_varadic && i >= required_num_args)
+      if (is_variadic && i >= required_num_args)
 	{
 	  args.push_back (rvalue);
 	  continue;

--- a/gcc/rust/backend/rust-compile-type.cc
+++ b/gcc/rust/backend/rust-compile-type.cc
@@ -218,12 +218,13 @@ TyTyResolveCompile::visit (const TyTy::FnType &type)
       parameters.push_back (compiled_param);
     }
 
-  if (!type.is_varadic ())
+  if (!type.is_variadic ())
     translated = Backend::function_type (receiver, parameters, results, NULL,
 					 type.get_ident ().locus);
   else
-    translated = Backend::function_type_varadic (receiver, parameters, results,
-						 NULL, type.get_ident ().locus);
+    translated
+      = Backend::function_type_variadic (receiver, parameters, results, NULL,
+					 type.get_ident ().locus);
 }
 
 void

--- a/gcc/rust/rust-backend.h
+++ b/gcc/rust/rust-backend.h
@@ -126,10 +126,10 @@ function_type (const typed_identifier &receiver,
 	       location_t location);
 
 tree
-function_type_varadic (const typed_identifier &receiver,
-		       const std::vector<typed_identifier> &parameters,
-		       const std::vector<typed_identifier> &results,
-		       tree result_struct, location_t location);
+function_type_variadic (const typed_identifier &receiver,
+			const std::vector<typed_identifier> &parameters,
+			const std::vector<typed_identifier> &results,
+			tree result_struct, location_t location);
 
 tree
 function_ptr_type (tree result, const std::vector<tree> &praameters,

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -529,10 +529,10 @@ function_type (const typed_identifier &receiver,
 }
 
 tree
-function_type_varadic (const typed_identifier &receiver,
-		       const std::vector<typed_identifier> &parameters,
-		       const std::vector<typed_identifier> &results,
-		       tree result_struct, location_t)
+function_type_variadic (const typed_identifier &receiver,
+			const std::vector<typed_identifier> &parameters,
+			const std::vector<typed_identifier> &results,
+			tree result_struct, location_t)
 {
   size_t n = parameters.size () + (receiver.type != NULL_TREE ? 1 : 0);
   tree *args = XALLOCAVEC (tree, n);

--- a/gcc/rust/typecheck/rust-tyty-call.cc
+++ b/gcc/rust/typecheck/rust-tyty-call.cc
@@ -116,7 +116,7 @@ TypeCheckCallExpr::visit (FnType &type)
 {
   if (call.num_params () != type.num_params ())
     {
-      if (type.is_varadic ())
+      if (type.is_variadic ())
 	{
 	  if (call.num_params () < type.num_params ())
 	    {

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -723,7 +723,7 @@ public:
 
   bool is_extern () const { return (flags & FNTYPE_IS_EXTERN_FLAG) != 0; }
 
-  bool is_varadic () const { return (flags & FNTYPE_IS_VARADIC_FLAG) != 0; }
+  bool is_variadic () const { return (flags & FNTYPE_IS_VARADIC_FLAG) != 0; }
 
   DefId get_id () const { return id; }
 


### PR DESCRIPTION
Fix varadic -> variadic

gcc/rust/ChangeLog:

            * backend/rust-compile-expr.cc (CompileExpr::visit): Fix typo in varIadic.
            * backend/rust-compile-type.cc (TyTyResolveCompile::visit): Likewise.
            * rust-backend.h (function_type_varadic): Rename into ...
            (function_type_variadic): ... this.
            * rust-gcc.cc (function_type_varadic): Rename into ...
            (function_type_variadic): ... this.
            * typecheck/rust-tyty-call.cc (TypeCheckCallExpr::visit): Likewise.
            * typecheck/rust-tyty.h (is_varadic): Renamed into ...
            (is_variadic): ... this.
