### PR TITLE
[E0617] Attempt for invalid type variable in `variadic` function

### DIFF
--- a/gcc/rust/typecheck/rust-tyty-call.cc
+++ b/gcc/rust/typecheck/rust-tyty-call.cc
@@ -184,7 +184,10 @@ TypeCheckCallExpr::visit (FnType &type)
 		if ((int_ty.get_int_kind () == TyTy::IntType::IntKind::I8)
 		    || (int_ty.get_int_kind () == TyTy::IntType::IntKind::I16))
 		  {
-		    rust_error_at (arg_locus,
+		    rich_location richloc (line_table, arg_locus);
+		    richloc.add_fixit_replace (
+		      "cast the value to c_int: as c_int");
+		    rust_error_at (richloc, ErrorCode::E0617,
 				   "expected %<c_int%> variadic argument");
 		    return;
 		  }
@@ -197,7 +200,10 @@ TypeCheckCallExpr::visit (FnType &type)
 		    || (uint_ty.get_uint_kind ()
 			== TyTy::UintType::UintKind::U16))
 		  {
-		    rust_error_at (arg_locus,
+		    rich_location richloc (line_table, arg_locus);
+		    richloc.add_fixit_replace (
+		      "cast the value to c_uint: as c_uint");
+		    rust_error_at (richloc, ErrorCode::E0617,
 				   "expected %<c_uint%> variadic argument");
 		    return;
 		  }
@@ -208,19 +214,28 @@ TypeCheckCallExpr::visit (FnType &type)
 		      .get_float_kind ()
 		    == TyTy::FloatType::FloatKind::F32)
 		  {
-		    rust_error_at (arg_locus,
+		    rich_location richloc (line_table, arg_locus);
+		    richloc.add_fixit_replace (
+		      "cast the value to c_double: as c_double");
+		    rust_error_at (richloc, ErrorCode::E0617,
 				   "expected %<c_double%> variadic argument");
 		    return;
 		  }
 		break;
 	      }
-	    case TyTy::TypeKind::BOOL:
-	      rust_error_at (arg_locus, "expected %<c_int%> variadic argument");
-	      return;
-	    case TyTy::TypeKind::FNDEF:
-	      rust_error_at (arg_locus,
-			     "unexpected function definition type as variadic "
-			     "argument - cast to function pointer");
+	      case TyTy::TypeKind::BOOL: {
+		rich_location richloc (line_table, arg_locus);
+		richloc.add_fixit_replace ("cast the value to c_int: as c_int");
+		rust_error_at (arg_locus, ErrorCode::E0617,
+			       "expected %<c_int%> variadic argument");
+		return;
+	      }
+	      case TyTy::TypeKind::FNDEF: {
+		rust_error_at (
+		  arg_locus, ErrorCode::E0617,
+		  "unexpected function definition type as variadic "
+		  "argument - cast to function pointer");
+	      }
 	      return;
 	    default:
 	      break;

--- a/gcc/testsuite/rust/compile/variadic.rs
+++ b/gcc/testsuite/rust/compile/variadic.rs
@@ -4,5 +4,11 @@ extern "C" {
 
 fn main() {
     // { dg-error "expected .c_int. variadic argument" "" { target *-*-* } .+1 }
-    printf("%d\n" as *const str as *const i8, 1i8);
+    printf("%d\n" as *const str as *const i8, 1i8); 
+
+    // { dg-error "expected .c_uint. variadic argument" "" { target *-*-* } .+1 }
+    printf("%d\n" as *const str as *const i8, 1u8); 
+
+     // { dg-error "expected .c_double. variadic argument" "" { target *-*-* } .+1 }
+    printf("%d\n" as *const str as *const i8, 1f32);
 }


### PR DESCRIPTION
## Attempt to pass `invalid type` variable into a `variadic` function - [`E0617`](https://doc.rust-lang.org/error_codes/E0617.html)

There are some certain rust types must be cast before passing them to a variadic function, because of arcane ABI rules dictated by the C standard. To fix the error, cast the value to the type specified by the error message.



---



gcc/rust/ChangeLog:

	* typecheck/rust-tyty-call.cc (TypeCheckCallExpr::visit): Added ErrorCode & more fixit hints.

gcc/testsuite/ChangeLog:

	* rust/compile/variadic.rs: Added new checks.


---
