### PR TITLE
gccrs: Add debug helper to dump HIR

### DIFF
--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -68,6 +68,18 @@ BoundPolarityString (BoundPolarity polarity)
   return "unknown";
 }
 
+/**
+ * Static member used to dump HIR from the debugger to stderr.
+ *
+ * @param v The HIR node to dump
+ */
+void
+Dump::debug (FullVisitable &v)
+{
+  Dump dump (std::cerr);
+  v.accept_vis (dump);
+}
+
 void
 Dump::go (HIR::Crate &e)
 {
@@ -2390,3 +2402,10 @@ Dump::visit (BareFunctionType &e)
 
 } // namespace HIR
 } // namespace Rust
+
+// In the global namespace to make it easier to call from debugger
+void
+debug (Rust::HIR::FullVisitable &v)
+{
+  Rust::HIR::Dump::debug (v);
+}

--- a/gcc/rust/hir/rust-hir-dump.h
+++ b/gcc/rust/hir/rust-hir-dump.h
@@ -32,6 +32,8 @@ namespace HIR {
 class Dump : public HIRFullVisitor
 {
 public:
+  static void debug (FullVisitable &v);
+
   Dump (std::ostream &stream);
   void go (HIR::Crate &crate);
 
@@ -247,5 +249,9 @@ private:
 
 } // namespace HIR
 } // namespace Rust
+
+// In the global namespace to make it easier to call from debugger
+void
+debug (Rust::HIR::FullVisitable &v);
 
 #endif // !RUST_HIR_DUMP_H


### PR DESCRIPTION
Add simple debug wrapper to dump HIR nodes on stderr.
Similar to what we already have for AST.

gcc/rust/ChangeLog:

	* hir/rust-hir-dump.cc (Dump::debug): New.
	(debug): New.
	* hir/rust-hir-dump.h (debug): New.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>