### PR TITLE
Fix spelling

### DIFF
--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -4594,14 +4594,14 @@ struct InlineAsmTemplatePiece
 
 struct TupleClobber
 {
-  // as gccrs still doesen't contain a symbol class I have put them as strings
+  // as gccrs still doesn't contain a symbol class I have put them as strings
   std::string symbol;
   location_t loc;
 };
 
 struct TupleTemplateStr
 {
-  // as gccrs still doesen't contain a symbol class I have put them as strings
+  // as gccrs still doesn't contain a symbol class I have put them as strings
   std::string symbol;
   std::string optional_symbol;
   location_t loc;

--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -473,7 +473,7 @@ CompileExpr::visit (HIR::StructExprStructFields &struct_expr)
   else
     {
       // this assumes all fields are in order from type resolution and if a
-      // base struct was specified those fields are filed via accesors
+      // base struct was specified those fields are filed via accessors
       for (size_t i = 0; i < struct_expr.get_fields ().size (); i++)
 	{
 	  // assignments are coercion sites so lets convert the rvalue if
@@ -1552,7 +1552,7 @@ CompileExpr::visit (HIR::CallExpr &expr)
 	}
 
       // this assumes all fields are in order from type resolution and if a
-      // base struct was specified those fields are filed via accesors
+      // base struct was specified those fields are filed via accessors
       std::vector<tree> arguments;
       for (size_t i = 0; i < expr.get_arguments ().size (); i++)
 	{

--- a/gcc/rust/backend/rust-compile-implitem.h
+++ b/gcc/rust/backend/rust-compile-implitem.h
@@ -24,7 +24,7 @@
 namespace Rust {
 namespace Compile {
 
-// this is a proxy for HIR::ImplItem's back to use the normel HIR::Item path
+// this is a proxy for HIR::ImplItem's back to use the normal HIR::Item path
 class CompileInherentImplItem : public CompileItem
 {
 public:

--- a/gcc/rust/backend/rust-constexpr.cc
+++ b/gcc/rust/backend/rust-constexpr.cc
@@ -141,7 +141,7 @@ struct GTY ((for_user)) rust_constexpr_call
   /* Result of the call.
        NULL means the call is being evaluated.
        error_mark_node means that the evaluation was erroneous;
-       otherwise, the actuall value of the call.  */
+       otherwise, the actual value of the call.  */
   tree result;
   /* The hash of this call; we remember it here to avoid having to
      recalculate it when expanding the hash table.  */


### PR DESCRIPTION
I wrote a small script to scan for spelling mistakes
```sh
#!/bin/sh

grep -rohP '[^[:space:]();<>]*' | \
sort -u | \
grep -v -e '^https://' -e '^http://' -e '^0x[a-f0-9]+$' | \
aspell list | \
sort -fu | \
less
```
There are a lot of false positives, but I found a few true positives