### PR TITLE
Fix CanonicalPath for impl

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-item.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-item.cc
@@ -565,6 +565,7 @@ ResolveItem::visit (AST::InherentImpl &impl_block)
 
   // FIXME this needs to be protected behind nominal type-checks see:
   // rustc --explain E0118
+  // issue #2634
   ResolveType::go (impl_block.get_type ().get ());
 
   // Setup paths
@@ -576,13 +577,15 @@ ResolveItem::visit (AST::InherentImpl &impl_block)
 	      self_cpath.get ().c_str ());
 
   CanonicalPath impl_type = self_cpath;
-  CanonicalPath impl_prefix = prefix.append (impl_type);
+  CanonicalPath impl_type_seg
+    = CanonicalPath::inherent_impl_seg (impl_block.get_node_id (), impl_type);
+  CanonicalPath impl_prefix = prefix.append (impl_type_seg);
 
   // see https://godbolt.org/z/a3vMbsT6W
   CanonicalPath cpath = CanonicalPath::create_empty ();
   if (canonical_prefix.size () <= 1)
     {
-      cpath = self_cpath;
+      cpath = impl_prefix;
     }
   else
     {

--- a/gcc/rust/resolve/rust-ast-resolve-toplevel.h
+++ b/gcc/rust/resolve/rust-ast-resolve-toplevel.h
@@ -344,10 +344,14 @@ public:
   void visit (AST::InherentImpl &impl_block) override
   {
     std::string raw_impl_type_path = impl_block.get_type ()->as_string ();
-    CanonicalPath impl_type
+    CanonicalPath impl_type_seg
       = CanonicalPath::new_seg (impl_block.get_type ()->get_node_id (),
 				raw_impl_type_path);
-    CanonicalPath impl_prefix = prefix.append (impl_type);
+
+    CanonicalPath impl_type
+      = CanonicalPath::inherent_impl_seg (impl_block.get_node_id (),
+					  impl_type_seg);
+    CanonicalPath impl_prefix = prefix.append (impl_type_seg);
 
     for (auto &impl_item : impl_block.get_impl_items ())
       ResolveToplevelImplItem::go (impl_item.get (), impl_prefix);

--- a/gcc/rust/util/rust-canonical-path.h
+++ b/gcc/rust/util/rust-canonical-path.h
@@ -69,6 +69,12 @@ public:
 					 + trait_seg.get () + ">");
   }
 
+  static CanonicalPath inherent_impl_seg (NodeId id,
+					  const CanonicalPath &impl_type_seg)
+  {
+    return CanonicalPath::new_seg (id, "<" + impl_type_seg.get () + ">");
+  }
+
   std::string get () const
   {
     std::string buf;


### PR DESCRIPTION
Fix #2631 

```
gcc/rust/ChangeLog:

	* util/rust-canonical-path.h: Add new segment kind for inherent impl.
	* resolve/rust-ast-resolve-item.cc (ResolveItem::visit): Use it.
	* resolve/rust-ast-resolve-toplevel.h: Use it.
```