### PR TITLE
Fix ICE when emitting an error during cfg strip

### DIFF
--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -877,6 +877,9 @@ Session::expansion (AST::Crate &crate)
   while (!fixed_point_reached && iterations < cfg.recursion_limit)
     {
       CfgStrip ().go (crate);
+      // Errors might happen during cfg strip pass
+      if (saw_errors ())
+	break;
 
       auto ctx = Resolver2_0::NameResolutionContext ();
 


### PR DESCRIPTION
When an error was emitted during the cfg strip pass by the crate loader, it was ignored and the error state propagated until another pass (name resolver).

Fixes #2638 