### PR TITLE
Fix type confusion in coercion

### DIFF
--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -115,8 +115,8 @@ HIRCompileBase::coercion_site1 (tree rvalue, TyTy::BaseType *rval,
       if (!valid_coercion)
 	return error_mark_node;
 
-      const TyTy::ReferenceType *exp
-	= static_cast<const TyTy::ReferenceType *> (expected);
+      const TyTy::PointerType *exp
+	= static_cast<const TyTy::PointerType *> (expected);
 
       TyTy::BaseType *actual_base = nullptr;
       if (actual->get_kind () == TyTy::TypeKind::REF)


### PR DESCRIPTION
Fixes #2641

There was a mismatch between a manual discriminant test and the static cast.

gcc/rust/ChangeLog:

	* backend/rust-compile.cc (HIRCompileBase::coercion_site1): Fix wrong cast

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[x] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`