### PR TITLE
Remove unnecessary "empty vector" comments

### DIFF
--- a/gcc/rust/expand/rust-macro-builtins.cc
+++ b/gcc/rust/expand/rust-macro-builtins.cc
@@ -583,7 +583,6 @@ MacroBuiltin::include_str_handler (location_t invoc_locus,
   auto node = AST::SingleASTNode (make_string (invoc_locus, str));
   auto str_tok = make_token (Token::make_string (invoc_locus, std::move (str)));
 
-  // FIXME: Do not return an empty token vector here
   return AST::Fragment ({node}, std::move (str_tok));
 }
 
@@ -785,7 +784,6 @@ MacroBuiltin::env_handler (location_t invoc_locus, AST::MacroInvocData &invoc)
   auto tok
     = make_token (Token::make_string (invoc_locus, std::move (env_value)));
 
-  // FIXME: Do not return an empty token vector here
   return AST::Fragment ({node}, std::move (tok));
 }
 
@@ -824,7 +822,6 @@ MacroBuiltin::cfg_handler (location_t invoc_locus, AST::MacroInvocData &invoc)
   auto tok = make_token (
     Token::make (result ? TRUE_LITERAL : FALSE_LITERAL, invoc_locus));
 
-  // FIXME: Do not return an empty token vector here
   return AST::Fragment ({literal_exp}, std::move (tok));
 }
 
@@ -912,7 +909,6 @@ MacroBuiltin::line_handler (location_t invoc_locus, AST::MacroInvocData &)
   auto tok
     = make_token (Token::make_int (invoc_locus, std::to_string (current_line)));
 
-  // FIXME: Do not return an empty token vector here
   return AST::Fragment ({line_no}, std::move (tok));
 }
 


### PR DESCRIPTION
Addresses #2358

gcc/rust/ChangeLog:

	* expand/rust-macro-builtins.cc (MacroBuiltin::include_str_handler): Comment removed
	(MacroBuiltin::env_handler): Comment removed
	(MacroBuiltin::cfg_handler): Comment removed
	(MacroBuiltin::line_handler): Comment removed

- \[X] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[X] Read contributing guidlines
- \[X] `make check-rust` passes locally
- \[ ] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Removed unnecessary "empty vector" comments