### PR TITLE
Fix parser bug on tupplestruct pattern

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -11452,6 +11452,8 @@ Parser<ManagedTokenSource>::parse_struct_pattern_field_partial (
 	std::string index_str = t->get_str ();
 	int index = atoi (index_str.c_str ());
 
+	lexer.skip_token ();
+
 	if (!skip_token (COLON))
 	  {
 	    return nullptr;


### PR DESCRIPTION
Fixes #2645

gcc/rust/ChangeLog:

	* parse/rust-parse-impl.h: Add missing token consumption