### PR TITLE
Fix expression segment parsing

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -6804,11 +6804,13 @@ Parser<ManagedTokenSource>::parse_path_expr_segment ()
   /* use lookahead to determine if they actually exist (don't want to
    * accidently parse over next ident segment) */
   if (lexer.peek_token ()->get_id () == SCOPE_RESOLUTION
-      && lexer.peek_token (1)->get_id () == LEFT_ANGLE)
+      && (lexer.peek_token (1)->get_id () == LEFT_ANGLE
+	  || lexer.peek_token (1)->get_id () == LEFT_SHIFT))
     {
       // skip scope resolution
       lexer.skip_token ();
 
+      // Let parse_path_generic_args split "<<" tokens
       AST::GenericArgs generic_args = parse_path_generic_args ();
 
       return AST::PathExprSegment (std::move (ident), locus,

--- a/gcc/testsuite/rust/compile/parse_generic_path_expr.rs
+++ b/gcc/testsuite/rust/compile/parse_generic_path_expr.rs
@@ -1,0 +1,4 @@
+// { dg-additional-options "-frust-compile-until=ast" }
+fn main() {
+    only_foo::<<i32 as Bar>::Item>();
+}


### PR DESCRIPTION
Fixes #2652 

- [x] Fix issue
- [x] Add test

Generic parsing failed due to some token that had not been split yet.