### PR TITLE
Fix RangeFromExpr parsing in for loop

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -22,6 +22,7 @@
 /* DO NOT INCLUDE ANYWHERE - this is automatically included with rust-parse.h
  * This is also the reason why there are no include guards. */
 
+#include "rust-token.h"
 #define INCLUDE_ALGORITHM
 #include "rust-diagnostics.h"
 #include "rust-make-unique.h"
@@ -12086,7 +12087,7 @@ Parser<ManagedTokenSource>::parse_expr (int right_binding_power,
     {
       TokenId id = current_token->get_id ();
       if (id == SEMICOLON || id == RIGHT_PAREN || id == RIGHT_CURLY
-	  || id == RIGHT_SQUARE || id == COMMA)
+	  || id == RIGHT_SQUARE || id == COMMA || id == LEFT_CURLY)
 	return nullptr;
     }
 

--- a/gcc/testsuite/rust/compile/range_from_expr_for_loop.rs
+++ b/gcc/testsuite/rust/compile/range_from_expr_for_loop.rs
@@ -1,0 +1,7 @@
+// { dg-additional-options "-frust-compile-until=ast" }
+fn main() {
+    for _ in 1.. {
+        break;
+    }
+    let i = 2;
+}

--- a/gcc/testsuite/rust/compile/while_break_expr.rs
+++ b/gcc/testsuite/rust/compile/while_break_expr.rs
@@ -1,0 +1,3 @@
+fn main() {
+    let _ = 'l: while break 'l {};
+}


### PR DESCRIPTION
`RangeFromExpr` were not parsed correctly in for loop.

Fixes #2660
Fixes #2658