### PR TITLE
Fix closure in closure parsing

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -14445,11 +14445,16 @@ Parser<ManagedTokenSource>::parse_closure_expr_pratt (const_TokenPtr tok,
 
 	    if (lexer.peek_token ()->get_id () != COMMA)
 	      {
+		if (lexer.peek_token ()->get_id () == OR)
+		  lexer.split_current_token (PIPE, PIPE);
 		// not an error but means param list is done
 		break;
 	      }
 	    // skip comma
 	    lexer.skip_token ();
+
+	    if (lexer.peek_token ()->get_id () == OR)
+	      lexer.split_current_token (PIPE, PIPE);
 
 	    t = lexer.peek_token ();
 	  }

--- a/gcc/testsuite/rust/compile/closure_in_closure.rs
+++ b/gcc/testsuite/rust/compile/closure_in_closure.rs
@@ -1,0 +1,8 @@
+// { dg-additional-options "-frust-compile-until=ast" }
+//
+// Do not reformat this test! The default rust format settings will insert a
+// space between closure parameter lists.
+fn main() {
+    let f = |_||x, y| x+y;
+    assert_eq!(f(())(1, 2), 3);
+}


### PR DESCRIPTION
Fix a the parsing of a closure in another closure without a space lead to the lexer creating an OR token.

Fixes #2656 