### PR TITLE
Fix macro "default" call at item level

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -1133,7 +1133,8 @@ Parser<ManagedTokenSource>::parse_item (bool called_from_statement)
 	  return parse_vis_item (std::move (outer_attrs));
 	  // or should this go straight to parsing union?
 	}
-      else if (t->get_str () == "default")
+      else if (t->get_str () == "default"
+	       && lexer.peek_token (1)->get_id () != EXCLAM)
 	{
 	  add_error (Error (t->get_locus (),
 			    "%qs is only allowed on items within %qs blocks",

--- a/gcc/testsuite/rust/compile/parse_item_default_macro.rs
+++ b/gcc/testsuite/rust/compile/parse_item_default_macro.rs
@@ -1,0 +1,8 @@
+// { dg-additional-options "-frust-compile-until=ast" }
+macro_rules! default {
+    ($($x:tt)*) => { $($x)* }
+}
+
+default! {
+    struct A;
+}


### PR DESCRIPTION
A macro `default` called at item level was previously rejected.

Fixes #2655 