### PR TITLE
Accept `macro_rules` name for a macro rule.

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -1070,6 +1070,18 @@ Parser<ManagedTokenSource>::parse_token_tree ()
     }
 }
 
+template <typename ManagedTokenSource>
+bool
+Parser<ManagedTokenSource>::is_macro_rules_def (const_TokenPtr t)
+{
+  auto macro_name = lexer.peek_token (2)->get_id ();
+
+  bool allowed_macro_name = (macro_name == IDENTIFIER || macro_name == TRY);
+
+  return t->get_str () == "macro_rules"
+	 && lexer.peek_token (1)->get_id () == EXCLAM && allowed_macro_name;
+}
+
 // Parses a single item
 template <typename ManagedTokenSource>
 std::unique_ptr<AST::Item>
@@ -1140,7 +1152,7 @@ Parser<ManagedTokenSource>::parse_item (bool called_from_statement)
 			    "default", "impl"));
 	  return nullptr;
 	}
-      else if (t->get_str () == "macro_rules")
+      else if (is_macro_rules_def (t))
 	{
 	  // macro_rules! macro item
 	  return parse_macro_rules_def (std::move (outer_attrs));
@@ -6227,8 +6239,7 @@ Parser<ManagedTokenSource>::parse_stmt (ParseRestrictions restrictions)
 	  return parse_vis_item (std::move (outer_attrs));
 	  // or should this go straight to parsing union?
 	}
-      else if (t->get_str () == "macro_rules"
-	       && lexer.peek_token (1)->get_id () == EXCLAM)
+      else if (is_macro_rules_def (t))
 	{
 	  // macro_rules! macro item
 	  return parse_macro_rules_def (std::move (outer_attrs));

--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -141,6 +141,7 @@ public:
   parse_block_expr (AST::AttrVec outer_attrs = AST::AttrVec (),
 		    location_t pratt_parsed_loc = UNKNOWN_LOCATION);
 
+  bool is_macro_rules_def (const_TokenPtr t);
   std::unique_ptr<AST::Item> parse_item (bool called_from_statement);
   std::unique_ptr<AST::Pattern> parse_pattern ();
   std::unique_ptr<AST::Pattern> parse_pattern_no_alt ();

--- a/gcc/testsuite/rust/compile/macro57.rs
+++ b/gcc/testsuite/rust/compile/macro57.rs
@@ -1,0 +1,13 @@
+macro_rules! macro_rules {
+    () => {};
+}
+
+macro_rules! foo {
+    () => {};
+}
+
+foo!();
+
+fn main() {}
+
+macro_rules!();

--- a/gcc/testsuite/rust/compile/macro_rules_macro_rules.rs
+++ b/gcc/testsuite/rust/compile/macro_rules_macro_rules.rs
@@ -1,0 +1,10 @@
+macro_rules! macro_rules {
+    () => {
+        struct S;
+    };
+}
+macro_rules! {} // calls the macro defined above
+
+fn main() {
+    let _s = S;
+}


### PR DESCRIPTION
This fix allows the user to use the name `macro_rules` for it's macros.

Fixes #2651 