### PR TITLE
Quick fix for ```MacroRuleDefinition``` use-after-free

### DIFF
--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -578,6 +578,11 @@ public:
 
   MacroKind get_kind () const { return kind; }
 
+  std::unique_ptr<MacroRulesDefinition> clone_macro_rules_def () const
+  {
+    return std::unique_ptr<MacroRulesDefinition> (clone_item_impl ());
+  }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -917,7 +917,8 @@ Mappings::insert_macro_invocation (AST::MacroInvocation &invoc,
   auto it = macroInvocations.find (invoc.get_macro_node_id ());
   rust_assert (it == macroInvocations.end ());
 
-  macroInvocations[invoc.get_macro_node_id ()] = def;
+  // TODO: remove hack that converts use-after-free into memory leak
+  macroInvocations[invoc.get_macro_node_id ()] = def->clone_macro_rules_def ().release ();
 }
 
 bool


### PR DESCRIPTION
Macro expansion seems to destruct instances of MacroRulesDefinition in modules. This patch should prevent a use-after-free by cloning and then leaking MacroRulesDefinition instances.