### PR TITLE
Fix parse mut ref

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -12082,7 +12082,7 @@ Parser<ManagedTokenSource>::parse_expr (int right_binding_power,
     {
       TokenId id = current_token->get_id ();
       if (id == SEMICOLON || id == RIGHT_PAREN || id == RIGHT_CURLY
-	  || id == RIGHT_SQUARE)
+	  || id == RIGHT_SQUARE || id == COMMA)
 	return nullptr;
     }
 

--- a/gcc/testsuite/rust/compile/match_break.rs
+++ b/gcc/testsuite/rust/compile/match_break.rs
@@ -1,0 +1,14 @@
+// { dg-additional-options "-frust-compile-until=ast" }
+enum Nat {
+    S(Box<Nat>),
+    Z,
+}
+fn test(x: &mut Nat) {
+    let mut p = &mut *x;
+    loop {
+        match p {
+            &mut Nat::Z => break,
+            &mut Nat::S(ref mut n) => p = &mut *n,
+        }
+    }
+}


### PR DESCRIPTION
Stop nullable expr parsing when there is a comma.

Fixes #2657