### PR TITLE
gccrs: minor changes (typo and minor refactor)

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -1635,17 +1635,13 @@ CompileExpr::visit (HIR::CallExpr &expr)
     return;
 
   bool is_variadic = false;
-  if (tyty->get_kind () == TyTy::TypeKind::FNDEF)
-    {
-      const TyTy::FnType *fn = static_cast<const TyTy::FnType *> (tyty);
-      is_variadic = fn->is_variadic ();
-    }
-
   size_t required_num_args = expr.get_arguments ().size ();
+
   if (tyty->get_kind () == TyTy::TypeKind::FNDEF)
     {
       const TyTy::FnType *fn = static_cast<const TyTy::FnType *> (tyty);
       required_num_args = fn->num_params ();
+      is_variadic = fn->is_variadic ();
     }
   else if (tyty->get_kind () == TyTy::TypeKind::FNPTR)
     {

--- a/gcc/rust/backend/rust-compile-extern.h
+++ b/gcc/rust/backend/rust-compile-extern.h
@@ -115,10 +115,8 @@ public:
       }
 
     if (fntype->has_substitutions_defined ())
-      {
-	// override the Hir Lookups for the substituions in this context
-	fntype->override_context ();
-      }
+      // override the HIR lookups for the substitutions in this context
+      fntype->override_context ();
 
     if (fntype->get_abi () == ABI::INTRINSIC)
       {


### PR DESCRIPTION
Fix a typo and merge 2 if clauses using the same condition.

gcc/rust/ChangeLog:

	* backend/rust-compile-expr.cc (CompileExpr::visit): Merge 2 if clauses.
	* backend/rust-compile-extern.h: Fix typo in comment.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>