### PR TITLE
Handle newlines during string parsing while lexing

### DIFF
--- a/gcc/testsuite/rust/compile/issue-2187.rs
+++ b/gcc/testsuite/rust/compile/issue-2187.rs
@@ -1,0 +1,11 @@
+const A: &'static u8 = b"
+";
+const B: &'static str = b"
+";
+const C: &'static u8 = "
+";
+const D: &'static str = "
+";
+ERROR_TIME
+// { dg-error "unrecognised token" "" { target *-*-* } .-1 }
+// { dg-error "failed to parse item in crate" "" { target *-*-* } .-2 }

--- a/gcc/testsuite/rust/execute/torture/issue-2187.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-2187.rs
@@ -1,0 +1,23 @@
+/* { dg-output "L1\n\L2\nL3\nL4" } */
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+fn main() -> i32 {
+    let A = b"L1
+L2\0";
+    let B = "L3
+L4\0";
+
+    unsafe {
+        let a = "%s\n\0";
+        let b = a as *const str;
+        let c = b as *const i8;
+
+        printf(c, A);
+        printf(c, B);
+    }
+
+    0
+}
+


### PR DESCRIPTION
If newline strings are encountered while lexing, the lexer now handles newline characters by incrementing current line number. This provides correct line number when displaying errors. If the lexer encounters end of file before string end, then it will use the start of the string as the location to an report error.

Fixes #2187
