### PR TITLE
Fix macro fragment follow set

### DIFF
--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -149,6 +149,7 @@ public:
   {
     switch (kind)
       {
+      case PATH:
       case PAT:
       case TY:
       case VIS:

--- a/gcc/testsuite/rust/compile/macro-issue2653.rs
+++ b/gcc/testsuite/rust/compile/macro-issue2653.rs
@@ -1,0 +1,5 @@
+macro_rules! foo {
+    ($p:path $b:block) => {};
+}
+
+fn main() {}


### PR DESCRIPTION
A recent issue highlighted a bad behavior with macro match follow set rules, this PR fixes it.

Fixes #2653 