### PR TITLE
Fix pub unit type parsing

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -2296,8 +2296,11 @@ Parser<ManagedTokenSource>::parse_visibility ()
   auto vis_loc = lexer.peek_token ()->get_locus ();
   lexer.skip_token ();
 
-  // create simple pub visibility if no parentheses
-  if (lexer.peek_token ()->get_id () != LEFT_PAREN)
+  // create simple pub visibility if
+  // - found no parentheses
+  // - found unit type `()`
+  if (lexer.peek_token ()->get_id () != LEFT_PAREN
+      || lexer.peek_token (1)->get_id () == RIGHT_PAREN)
     {
       return AST::Visibility::create_public (vis_loc);
       // or whatever

--- a/gcc/testsuite/rust/compile/parse_pub_unit_type.rs
+++ b/gcc/testsuite/rust/compile/parse_pub_unit_type.rs
@@ -1,0 +1,1 @@
+pub struct Foo(pub ());


### PR DESCRIPTION
Unit types could not be parsed correctly when made public.

Fixes #2648 