### PR TITLE
libgrust: Add changelog, maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -181,6 +181,7 @@ libgo			Ian Lance Taylor	<ian@airs.com>
 libgomp			Jakub Jelinek		<jakub@redhat.com>
 libgomp			Tobias Burnus		<tobias@codesourcery.com>
 libgomp (OpenACC)	Thomas Schwinge		<thomas@codesourcery.com>
+libgrust		All Rust front end maintainers
 libiberty		Ian Lance Taylor	<ian@airs.com>
 libitm			Torvald Riegel		<triegel@redhat.com>
 libobjc			Nicola Pero		<nicola.pero@meta-innovation.com>

--- a/contrib/gcc-changelog/git_commit.py
+++ b/contrib/gcc-changelog/git_commit.py
@@ -69,6 +69,7 @@ default_changelog_locations = {
     'libgfortran',
     'libgm2',
     'libgomp',
+    'libgrust',
     'libhsail-rt',
     'libiberty',
     'libitm',

--- a/contrib/gcc_update
+++ b/contrib/gcc_update
@@ -153,6 +153,10 @@ libgomp/testsuite/Makefile.in: libgomp/testsuite/Makefile.am libgomp/aclocal.m4
 libgomp/configure.ac: libgomp/plugin/configfrag.ac
 libgomp/configure: libgomp/configure.ac libgomp/aclocal.m4
 libgomp/config.h.in: libgomp/configure.ac libgomp/aclocal.m4
+libgrust/Makefile.in: libgrust/Makefile.am libgrust/aclocal.m4
+libgrust/aclocal.m4: libgrust/configure.ac
+libgrust/configure: libgrust/configure.ac libgrust/aclocal.m4
+libgrust/libproc_macro_internal/Makefile.in: libgrust/libproc_macro_internal/Makefile.am libgrust/aclocal.m4
 libitm/aclocal.m4: libitm/configure.ac libitm/acinclude.m4
 libitm/Makefile.in: libitm/Makefile.am libitm/aclocal.m4
 libitm/testsuite/Makefile.in: libitm/testsuite/Makefile.am libitm/aclocal.m4

--- a/libgrust/ChangeLog
+++ b/libgrust/ChangeLog
@@ -1,0 +1,6 @@
+
+Copyright (C) 2023 Free Software Foundation, Inc.
+
+Copying and distribution of this file, with or without modification,
+are permitted in any medium without royalty provided the copyright
+notice and this notice are preserved.


### PR DESCRIPTION
Asking for a review of the patch itself, but I will be sending it upstream in a later version of [this patchset](https://gcc.gnu.org/pipermail/gcc-rust/2023-September/001222.html)