### PR TITLE
Parse variadic functions

### DIFF
--- a/gcc/rust/ast/rust-ast-visitor.cc
+++ b/gcc/rust/ast/rust-ast-visitor.cc
@@ -721,8 +721,11 @@ void
 DefaultASTVisitor::visit (AST::FunctionParam &param)
 {
   visit_outer_attrs (param);
-  visit (param.get_pattern ());
-  visit (param.get_type ());
+  if (param.has_name ())
+    visit (param.get_pattern ());
+
+  if (!param.is_variadic ())
+    visit (param.get_type ());
 }
 
 void
@@ -1054,7 +1057,8 @@ void
 DefaultASTVisitor::visit (AST::NamedFunctionParam &param)
 {
   visit_outer_attrs (param);
-  visit (param.get_type ());
+  if (!param.is_variadic ())
+    visit (param.get_type ());
 }
 
 void

--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -3036,7 +3036,7 @@ ExternalFunctionItem::as_string () const
 
   // function params
   str += "\n Function params: ";
-  if (function_params.empty () && !has_variadics)
+  if (function_params.empty ())
     {
       str += "none";
     }
@@ -3044,21 +3044,6 @@ ExternalFunctionItem::as_string () const
     {
       for (const auto &param : function_params)
 	str += "\n  " + param.as_string ();
-
-      if (has_variadics)
-	{
-	  str += "\n  variadic outer attrs: ";
-	  if (has_variadic_outer_attrs ())
-	    {
-	      for (const auto &attr : variadic_outer_attrs)
-		str += "\n   " + attr.as_string ();
-	    }
-	  else
-	    {
-	      str += "none";
-	    }
-	  str += "\n  ... (variadic)";
-	}
     }
 
   // add type on new line
@@ -3080,9 +3065,13 @@ NamedFunctionParam::as_string () const
 {
   std::string str = append_attributes (outer_attrs, OUTER);
 
-  str += "\n" + name;
+  if (has_name ())
+    str += "\n" + name;
 
-  str += "\n Type: " + param_type->as_string ();
+  if (is_variadic ())
+    str += "...";
+  else
+    str += "\n Type: " + param_type->as_string ();
 
   return str;
 }

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -4166,6 +4166,7 @@ class NamedFunctionParam
 
   NodeId node_id;
   location_t locus;
+  bool variadic;
 
 public:
   /* Returns whether the named function parameter has a name (i.e. name is not
@@ -4178,7 +4179,7 @@ public:
   bool is_error () const
   {
     // also if identifier is "" but that is probably more costly to compute
-    return param_type == nullptr;
+    return param_type == nullptr && !variadic;
   }
 
   std::string get_name () const { return name; }
@@ -4195,17 +4196,35 @@ public:
 		      std::vector<Attribute> outer_attrs, location_t locus)
     : name (std::move (name)), param_type (std::move (param_type)),
       outer_attrs (std::move (outer_attrs)),
-      node_id (Analysis::Mappings::get ()->get_next_node_id ()), locus (locus)
+      node_id (Analysis::Mappings::get ()->get_next_node_id ()), locus (locus),
+      variadic (false)
+  {}
+
+  NamedFunctionParam (std::string name, std::vector<Attribute> outer_attrs,
+		      location_t locus)
+    : name (std::move (name)), param_type (nullptr),
+      outer_attrs (std::move (outer_attrs)),
+      node_id (Analysis::Mappings::get ()->get_next_node_id ()), locus (locus),
+      variadic (true)
+  {}
+
+  NamedFunctionParam (std::vector<Attribute> outer_attrs, location_t locus)
+    : name (""), param_type (nullptr), outer_attrs (std::move (outer_attrs)),
+      node_id (Analysis::Mappings::get ()->get_next_node_id ()), locus (locus),
+      variadic (true)
   {}
 
   // Copy constructor
   NamedFunctionParam (NamedFunctionParam const &other)
-    : name (other.name), outer_attrs (other.outer_attrs)
+    : name (other.name), outer_attrs (other.outer_attrs),
+      variadic (other.variadic)
   {
     node_id = other.node_id;
     // guard to prevent null dereference (only required if error state)
     if (other.param_type != nullptr)
       param_type = other.param_type->clone_type ();
+    else
+      param_type = nullptr;
   }
 
   ~NamedFunctionParam () = default;

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -1682,6 +1682,12 @@ public:
 
   void accept_vis (ASTVisitor &vis) override;
 
+  bool is_variadic () const
+  {
+    return function_params.size () != 0
+	   && function_params.back ().is_variadic ();
+  }
+
   // Invalid if block is null, so base stripping on that.
   void mark_for_strip () override { function_body = nullptr; }
   bool is_marked_for_strip () const override

--- a/gcc/rust/expand/rust-cfg-strip.cc
+++ b/gcc/rust/expand/rust-cfg-strip.cc
@@ -2603,12 +2603,15 @@ CfgStrip::visit (AST::ExternalFunctionItem &item)
 	  continue;
 	}
 
-      auto &type = param.get_type ();
-      type->accept_vis (*this);
+      if (!param.is_variadic ())
+	{
+	  auto &type = param.get_type ();
+	  param.get_type ()->accept_vis (*this);
 
-      if (type->is_marked_for_strip ())
-	rust_error_at (type->get_locus (),
-		       "cannot strip type in this position");
+	  if (type->is_marked_for_strip ())
+	    rust_error_at (type->get_locus (),
+			   "cannot strip type in this position");
+	}
 
       // increment if nothing else happens
       ++it;

--- a/gcc/rust/expand/rust-expand-visitor.cc
+++ b/gcc/rust/expand/rust-expand-visitor.cc
@@ -1265,12 +1265,9 @@ ExpandVisitor::visit (AST::ExternalFunctionItem &item)
   for (auto &param : item.get_generic_params ())
     visit (param);
 
-  // FIXME: Should this work? What is the difference between NamedFunctionParam
-  // and FunctionParam?
-  // expand_function_params (item.get_function_params ());
-
   for (auto &param : item.get_function_params ())
-    maybe_expand_type (param.get_type ());
+    if (!param.is_variadic ())
+      maybe_expand_type (param.get_type ());
 
   if (item.has_return_type ())
     maybe_expand_type (item.get_return_type ());

--- a/gcc/rust/hir/rust-ast-lower-extern.h
+++ b/gcc/rust/hir/rust-ast-lower-extern.h
@@ -110,7 +110,7 @@ public:
     translated = new HIR::ExternalFunctionItem (
       mapping, function.get_identifier (), std::move (generic_params),
       std::unique_ptr<HIR::Type> (return_type), std::move (where_clause),
-      std::move (function_params), function.is_variadic (), std::move (vis),
+      std::move (function_params), is_variadic, std::move (vis),
       function.get_outer_attrs (), function.get_locus ());
   }
 

--- a/gcc/rust/hir/rust-ast-lower-extern.h
+++ b/gcc/rust/hir/rust-ast-lower-extern.h
@@ -79,15 +79,20 @@ public:
 	  ? ASTLoweringType::translate (function.get_return_type ().get ())
 	  : nullptr;
 
+    bool is_variadic = function.is_variadic ();
+    auto begin = function.get_function_params ().begin ();
+    auto end = is_variadic ? function.get_function_params ().end () - 1
+			   : function.get_function_params ().end ();
+
     std::vector<HIR::NamedFunctionParam> function_params;
-    for (auto &param : function.get_function_params ())
+    for (auto it = begin; it != end; it++)
       {
 	HIR::Type *param_type
-	  = ASTLoweringType::translate (param.get_type ().get ());
-	Identifier param_name = param.get_name ();
+	  = ASTLoweringType::translate (it->get_type ().get ());
+	Identifier param_name = it->get_name ();
 
 	auto crate_num = mappings->get_current_crate ();
-	Analysis::NodeMapping mapping (crate_num, param.get_node_id (),
+	Analysis::NodeMapping mapping (crate_num, it->get_node_id (),
 				       mappings->get_next_hir_id (crate_num),
 				       mappings->get_next_localdef_id (
 					 crate_num));

--- a/gcc/rust/metadata/rust-export-metadata.cc
+++ b/gcc/rust/metadata/rust-export-metadata.cc
@@ -118,11 +118,12 @@ ExportContext::emit_function (const HIR::Function &fn)
 	  function_params.push_back (std::move (p));
 	}
 
-      AST::ExternalItem *external_item = new AST::ExternalFunctionItem (
-	item_name, {} /* generic_params */, std::move (return_type),
-	where_clause, std::move (function_params), false /* has_variadics */,
-	{} /* variadic_outer_attrs */, vis, function.get_outer_attrs (),
-	function.get_locus ());
+      AST::ExternalItem *external_item
+	= new AST::ExternalFunctionItem (item_name, {} /* generic_params */,
+					 std::move (return_type), where_clause,
+					 std::move (function_params), vis,
+					 function.get_outer_attrs (),
+					 function.get_locus ());
 
       std::vector<std::unique_ptr<AST::ExternalItem>> external_items;
       external_items.push_back (

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -5970,7 +5970,7 @@ Parser<ManagedTokenSource>::parse_named_function_param ()
   AST::AttrVec outer_attrs = parse_outer_attributes ();
   location_t locus = lexer.peek_token ()->get_locus ();
 
-  if (lexer.peek_token ()->get_id () == ELLIPSIS)
+  if (lexer.peek_token ()->get_id () == ELLIPSIS) // Unnamed variadic
     {
       lexer.skip_token (); // Skip ellipsis
       return AST::NamedFunctionParam (std::move (outer_attrs), locus);
@@ -6000,6 +6000,13 @@ Parser<ManagedTokenSource>::parse_named_function_param ()
     {
       // skip after somewhere?
       return AST::NamedFunctionParam::create_error ();
+    }
+
+  if (lexer.peek_token ()->get_id () == ELLIPSIS) // Named variadic
+    {
+      lexer.skip_token (); // Skip ellipsis
+      return AST::NamedFunctionParam (std::move (name), std::move (outer_attrs),
+				      locus);
     }
 
   // parse (required) type

--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -298,6 +298,13 @@ private:
   AST::Lifetime lifetime_from_token (const_TokenPtr tok);
   std::unique_ptr<AST::ExternalTypeItem>
   parse_external_type_item (AST::Visibility vis, AST::AttrVec outer_attrs);
+  std::unique_ptr<AST::ExternalFunctionItem>
+  parse_external_function_item (AST::Visibility vis, AST::AttrVec outer_attrs);
+  AST::NamedFunctionParam parse_named_function_param ();
+  template <typename EndTokenPred>
+  std::vector<AST::NamedFunctionParam>
+  parse_named_function_params (EndTokenPred is_end_token);
+
   std::unique_ptr<AST::TypeAlias> parse_type_alias (AST::Visibility vis,
 						    AST::AttrVec outer_attrs);
   std::unique_ptr<AST::Struct> parse_struct (AST::Visibility vis,
@@ -338,8 +345,6 @@ private:
 				       AST::AttrVec outer_attrs);
   std::unique_ptr<AST::ExternBlock>
   parse_extern_block (AST::Visibility vis, AST::AttrVec outer_attrs);
-  AST::NamedFunctionParam parse_named_function_param (AST::AttrVec outer_attrs
-						      = AST::AttrVec ());
   AST::Method parse_method ();
 
   // Expression-related (Pratt parsed)

--- a/gcc/rust/resolve/rust-ast-resolve-item.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-item.cc
@@ -1115,9 +1115,8 @@ ResolveExternItem::visit (AST::ExternalFunctionItem &function)
   // we make a new scope so the names of parameters are resolved and shadowed
   // correctly
   for (auto &param : function.get_function_params ())
-    {
+    if (!param.is_variadic ())
       ResolveType::go (param.get_type ().get ());
-    }
 
   // done
   resolver->get_name_scope ().pop ();

--- a/gcc/rust/resolve/rust-early-name-resolver.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver.cc
@@ -872,7 +872,8 @@ EarlyNameResolver::visit (AST::ExternalFunctionItem &item)
     generic->accept_vis (*this);
 
   for (auto &param : item.get_function_params ())
-    param.get_type ()->accept_vis (*this);
+    if (!param.is_variadic ())
+      param.get_type ()->accept_vis (*this);
 
   if (item.has_return_type ())
     item.get_return_type ()->accept_vis (*this);

--- a/gcc/testsuite/rust/compile/extern_c_named_variadic.rs
+++ b/gcc/testsuite/rust/compile/extern_c_named_variadic.rs
@@ -1,0 +1,5 @@
+extern "C" {
+    fn variadic(x: isize, args: ...);
+}
+
+fn main() {}

--- a/gcc/testsuite/rust/compile/parse_variadic_function.rs
+++ b/gcc/testsuite/rust/compile/parse_variadic_function.rs
@@ -1,0 +1,4 @@
+fn main() {}
+
+#[cfg(FALSE)]
+fn variadic(x: isize, ...) {}

--- a/gcc/testsuite/rust/compile/pattern_variadic.rs
+++ b/gcc/testsuite/rust/compile/pattern_variadic.rs
@@ -1,0 +1,14 @@
+extern "C" {
+    fn printf(fmt: *const i8, _: ...);
+}
+
+fn main() -> i32 {
+    unsafe {
+        printf(
+            "%s" as *const str as *const i8,
+            "Message" as *const str as *const i8,
+        );
+    }
+
+    0
+}

--- a/gcc/testsuite/rust/execute/torture/named_variadic.rs
+++ b/gcc/testsuite/rust/execute/torture/named_variadic.rs
@@ -1,0 +1,20 @@
+// { dg-output "Named variadic" }
+
+extern "C" {
+    fn printf(fmt: *const i8, variadic: ...);
+}
+
+fn print(s: &str) {
+    unsafe {
+        printf(
+            "%s" as *const str as *const i8,
+            s as *const str as *const i8,
+        );
+    }
+}
+
+fn main() -> i32 {
+    print("Named variadic");
+
+    0
+}


### PR DESCRIPTION
Parse variadic functions.

This version of the PR modifies the way variadic are stored in the ast. Variadic were previously handled at function level, but this makes the parser a bit ugly. This PR suggest keeping variadic informations as a special parameter instead. It requires a lot of work to reflect this change at all level of the compiler. Many passes consider the number of arguments without checking for variadicity, therefore, this PR creates a big pile of ICE as of [c6d9843](https://github.com/Rust-GCC/gccrs/pull/2701/commits/c6d984301f88b315137b61cb91a0053d5e3e0f46).

Alternative to #2704

Fixes #2664 
Fixes #2700 