### PR TITLE
Fix more tuple indices

### DIFF
--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -2358,9 +2358,6 @@ Lexer::parse_decimal_int_or_float (location_t loc)
       current_char = peek_input ();
       length++;
 
-      // add a '0' after the . to prevent ambiguity
-      str += '0';
-
       // type hint not allowed
 
       current_column += length;

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -12907,12 +12907,18 @@ Parser<ManagedTokenSource>::left_denotation (const_TokenPtr tok,
 	    auto dot_pos = str.find (".");
 	    auto prefix = str.substr (0, dot_pos);
 	    auto suffix = str.substr (dot_pos + 1);
-	    lexer.split_current_token (
-	      {Token::make_int (current_loc, std::move (prefix),
-				CORETYPE_PURE_DECIMAL),
-	       Token::make (DOT, current_loc + 1),
-	       Token::make_int (current_loc + 2, std::move (suffix),
-				CORETYPE_PURE_DECIMAL)});
+	    if (dot_pos == str.size () - 1)
+	      lexer.split_current_token (
+		{Token::make_int (current_loc, std::move (prefix),
+				  CORETYPE_PURE_DECIMAL),
+		 Token::make (DOT, current_loc + 1)});
+	    else
+	      lexer.split_current_token (
+		{Token::make_int (current_loc, std::move (prefix),
+				  CORETYPE_PURE_DECIMAL),
+		 Token::make (DOT, current_loc + 1),
+		 Token::make_int (current_loc + 2, std::move (suffix),
+				  CORETYPE_PURE_DECIMAL)});
 	    return parse_tuple_index_expr (tok, std::move (left),
 					   std::move (outer_attrs),
 					   restrictions);

--- a/gcc/testsuite/rust/compile/tuple_float_index.rs
+++ b/gcc/testsuite/rust/compile/tuple_float_index.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let tuple = (((),()),);
+
+    // Do not reformat, the space after the second dot is required
+    let _ = tuple.0. 1;
+}


### PR DESCRIPTION
Fix a tricky case with lexer floating point disambiguation.

Requires #2694 

Fixes #2663 