### PR TITLE
Remove obsolete HIR::BorrowExpr::double_borrow

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-expr.cc
+++ b/gcc/rust/hir/rust-ast-lower-expr.cc
@@ -632,7 +632,7 @@ ASTLoweringExpr::visit (AST::BorrowExpr &expr)
 				 mappings->get_next_hir_id (crate_num),
 				 UNKNOWN_LOCAL_DEFID);
 
-  HIR::BorrowExpr *borrow_expr
+  auto *borrow_expr
     = new HIR::BorrowExpr (mapping, std::unique_ptr<HIR::Expr> (borrow_lvalue),
 			   expr.get_is_mut () ? Mutability::Mut
 					      : Mutability::Imm,
@@ -640,8 +640,8 @@ ASTLoweringExpr::visit (AST::BorrowExpr &expr)
 
   if (expr.get_is_double_borrow ())
     {
-      NodeId artifical_bouble_borrow_id = mappings->get_next_node_id ();
-      Analysis::NodeMapping mapping (crate_num, artifical_bouble_borrow_id,
+      NodeId artificial_double_borrow_id = mappings->get_next_node_id ();
+      Analysis::NodeMapping mapping (crate_num, artificial_double_borrow_id,
 				     mappings->get_next_hir_id (crate_num),
 				     UNKNOWN_LOCAL_DEFID);
 

--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -808,7 +808,6 @@ Dump::visit (BorrowExpr &e)
   begin ("BorrowExpr");
   do_operatorexpr (e);
 
-  put_field ("double_borrow", std::to_string (e.is_double_borrow ()));
   put_field ("mut", enum_to_str (e.get_mut ()));
 
   end ("BorrowExpr");

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -213,7 +213,6 @@ public:
 class BorrowExpr : public OperatorExpr
 {
   Mutability mut;
-  bool double_borrow;
 
 public:
   std::string as_string () const override;
@@ -231,8 +230,6 @@ public:
 
   Mutability get_mut () const { return mut; }
   bool is_mut () const { return mut == Mutability::Mut; }
-
-  bool is_double_borrow () const { return double_borrow; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather

--- a/gcc/rust/hir/tree/rust-hir.cc
+++ b/gcc/rust/hir/tree/rust-hir.cc
@@ -1182,11 +1182,6 @@ BorrowExpr::as_string () const
 {
   std::string str ("&");
 
-  if (double_borrow)
-    {
-      str += "&";
-    }
-
   if (is_mut ())
     {
       str += "mut ";


### PR DESCRIPTION
Fixes #2718 

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`
- \[x] Added any relevant test cases to `gcc/testsuite/rust/`