### PR TITLE
v0-mangle closures

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -2219,8 +2219,12 @@ CompileExpr::generate_closure_function (HIR::ClosureExpr &expr,
 
   const Resolver::CanonicalPath &parent_canonical_path
     = closure_tyty.get_ident ().path;
+  NodeId node_id;
+  bool ok = ctx->get_mappings ()->lookup_hir_to_node (
+    expr.get_mappings ().get_hirid (), &node_id);
+  rust_assert (ok);
   Resolver::CanonicalPath path = parent_canonical_path.append (
-    Resolver::CanonicalPath::new_seg (UNKNOWN_NODEID, "{{closure}}"));
+    Resolver::CanonicalPath::new_seg (node_id, "{{closure}}"));
 
   std::string ir_symbol_name = path.get ();
   std::string asm_name = ctx->mangle_item (&closure_tyty, path);

--- a/gcc/rust/util/rust-mapping-common.h
+++ b/gcc/rust/util/rust-mapping-common.h
@@ -62,8 +62,8 @@ struct DefId
 };
 
 #define UNKNOWN_CRATENUM ((uint32_t) (UINT32_MAX))
-#define UNKNOWN_NODEID ((uint32_t) (0))
-#define UNKNOWN_HIRID ((uint32_t) (0))
+#define UNKNOWN_NODEID ((uint32_t) (UINT32_MAX))
+#define UNKNOWN_HIRID ((uint32_t) (UINT32_MAX))
 #define UNKNOWN_LOCAL_DEFID ((uint32_t) (0))
 #define UNKNOWN_DEFID (DefId{0, 0})
 

--- a/gcc/testsuite/rust/compile/v0-mangle2.rs
+++ b/gcc/testsuite/rust/compile/v0-mangle2.rs
@@ -1,0 +1,17 @@
+// { dg-additional-options -frust-mangling=v0 }
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "fn_once"]
+pub trait FnOnce<Args> {
+    #[lang = "fn_once_output"]
+    type Output;
+
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+}
+
+fn main() {
+    // { dg-final { scan-assembler "_R.*NC.*NvC.*10v0_mangle24main.*0" } }
+    let closure_annotated = |i: i32| -> i32 { i + 1 };
+    let _ = closure_annotated(0) - 1;
+}


### PR DESCRIPTION
Addresses https://github.com/Rust-GCC/gccrs/issues/2635

Implement v0-mangling for closures with reference to RFC.
https://rust-lang.github.io/rfcs/2603-rust-symbol-name-mangling-v0.html#closures-and-closure-environments

After this PR is merged, I will work on mangling generic functions.
To do so, I will refactor `CanonicalPath`s to extract type info from them.

gcc/rust/ChangeLog:

	* backend/rust-compile-expr.cc (CompileExpr::generate_closure_function): Fix reference to node.
	* backend/rust-mangle.cc (struct V0Path): Modified to accept closures.
	(v0_crate_path): Modified to accept closures.
	(v0_closure): New function to mangle closures.
	(v0_path): Modified to accept closures
	* util/rust-mapping-common.h (UNKNOWN_NODEID): Change to UINT32_MAX.
	(UNKNOWN_HIRID): Change to UINT32_MAX.

gcc/testsuite/ChangeLog:

	* rust/compile/v0-mangle2.rs: New test.
