### PR TITLE
Further ast validation

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -100,6 +100,7 @@ GRS_OBJS = \
     rust/rust-hir.o \
     rust/rust-hir-map.o \
     rust/rust-attributes.o \
+    rust/rust-keyword-values.o \
     rust/rust-abi.o \
     rust/rust-token-converter.o \
     rust/rust-macro.o \

--- a/gcc/rust/ast/rust-ast-collector.cc
+++ b/gcc/rust/ast/rust-ast-collector.cc
@@ -16,6 +16,7 @@
 // along with GCC; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 #include "rust-ast-collector.h"
+#include "rust-item.h"
 
 namespace Rust {
 namespace AST {
@@ -188,6 +189,17 @@ TokenCollector::visit (FunctionParam &param)
 	}
       push (Rust::Token::make (ELLIPSIS, UNDEF_LOCATION));
     }
+}
+
+void
+TokenCollector::visit (VariadicParam &param)
+{
+  if (param.has_pattern ())
+    {
+      visit (param.get_pattern ());
+      push (Rust::Token::make (COLON, UNDEF_LOCATION));
+    }
+  push (Rust::Token::make (ELLIPSIS, UNDEF_LOCATION));
 }
 
 void
@@ -1783,13 +1795,6 @@ TokenCollector::visit (Function &function)
 
   push (Rust::Token::make (LEFT_PAREN, UNDEF_LOCATION));
 
-  if (function.has_self_param ())
-    {
-      visit (function.get_self_param ());
-      if (!function.get_function_params ().empty ())
-	push (Rust::Token::make (COMMA, UNDEF_LOCATION));
-    }
-
   visit_items_joined_by_separator (function.get_function_params ());
   push (Rust::Token::make (RIGHT_PAREN, UNDEF_LOCATION));
 
@@ -2069,13 +2074,7 @@ TokenCollector::visit (TraitItemMethod &item)
   push (Rust::Token::make_identifier (UNDEF_LOCATION, std::move (id)));
   push (Rust::Token::make (LEFT_PAREN, UNDEF_LOCATION));
 
-  visit (method.get_self_param ());
-
-  if (!method.get_function_params ().empty ())
-    {
-      push (Rust::Token::make (COMMA, UNDEF_LOCATION));
-      visit_items_joined_by_separator (method.get_function_params (), COMMA);
-    }
+  visit_items_joined_by_separator (method.get_function_params (), COMMA);
 
   push (Rust::Token::make (RIGHT_PAREN, UNDEF_LOCATION));
 

--- a/gcc/rust/ast/rust-ast-collector.h
+++ b/gcc/rust/ast/rust-ast-collector.h
@@ -163,6 +163,7 @@ public:
   void visit (Literal &lit, location_t locus = UNDEF_LOCATION);
 
   void visit (FunctionParam &param);
+  void visit (VariadicParam &param);
   void visit (Attribute &attrib);
   void visit (Visibility &vis);
   void visit (std::vector<std::unique_ptr<GenericParam>> &params);

--- a/gcc/rust/ast/rust-ast-visitor.cc
+++ b/gcc/rust/ast/rust-ast-visitor.cc
@@ -1462,5 +1462,13 @@ ContextualASTVisitor::visit (AST::TraitImpl &impl)
   pop_context ();
 }
 
+void
+ContextualASTVisitor::visit (AST::Trait &trait)
+{
+  push_context (Context::TRAIT);
+  DefaultASTVisitor::visit (trait);
+  pop_context ();
+}
+
 } // namespace AST
 } // namespace Rust

--- a/gcc/rust/ast/rust-ast-visitor.cc
+++ b/gcc/rust/ast/rust-ast-visitor.cc
@@ -708,12 +708,6 @@ DefaultASTVisitor::visit (AST::FunctionQualifiers &qualifiers)
 {}
 
 void
-DefaultASTVisitor::visit (AST::SelfParam &self)
-{
-  visit (self.get_lifetime ());
-}
-
-void
 DefaultASTVisitor::visit (AST::WhereClause &where)
 {
   for (auto &item : where.get_items ())
@@ -726,7 +720,18 @@ DefaultASTVisitor::visit (AST::FunctionParam &param)
   if (param.has_name ())
     visit (param.get_pattern ());
 
-  if (!param.is_variadic ())
+  visit (param.get_type ());
+}
+
+void
+DefaultASTVisitor::visit (AST::SelfParam &param)
+{
+  visit_outer_attrs (param);
+
+  if (param.has_lifetime ())
+    visit (param.get_lifetime ());
+
+  if (param.has_type ())
     visit (param.get_type ());
 }
 
@@ -1436,6 +1441,13 @@ DefaultASTVisitor::visit (AST::BareFunctionType &type)
       visit (attr);
   if (type.has_return_type ())
     visit (type.get_return_type ());
+}
+
+void
+DefaultASTVisitor::visit (AST::VariadicParam &param)
+{
+  if (param.has_pattern ())
+    visit (param.get_pattern ());
 }
 
 void

--- a/gcc/rust/ast/rust-ast-visitor.cc
+++ b/gcc/rust/ast/rust-ast-visitor.cc
@@ -494,7 +494,9 @@ void
 DefaultASTVisitor::visit (AST::BreakExpr &expr)
 {
   visit_outer_attrs (expr);
-  visit (expr.get_label ());
+  if (expr.has_label ())
+    visit (expr.get_label ());
+
   if (expr.has_break_expr ())
     visit (expr.get_break_expr ());
 }

--- a/gcc/rust/ast/rust-ast-visitor.h
+++ b/gcc/rust/ast/rust-ast-visitor.h
@@ -23,6 +23,7 @@
 // full include not required - only forward decls
 #include "rust-ast-full-decls.h"
 #include "rust-ast.h"
+#include "rust-item.h"
 #include "rust-system.h"
 
 namespace Rust {
@@ -129,6 +130,10 @@ public:
 
   // rust-item.h
   virtual void visit (TypeParam &param) = 0;
+  virtual void visit (SelfParam &param) = 0;
+  virtual void visit (FunctionParam &param) = 0;
+  virtual void visit (VariadicParam &param) = 0;
+
   // virtual void visit(WhereClauseItem& item) = 0;
   virtual void visit (LifetimeWhereClauseItem &item) = 0;
   virtual void visit (TypeBoundWhereClauseItem &item) = 0;
@@ -386,6 +391,9 @@ protected:
   virtual void visit (AST::SliceType &type) override;
   virtual void visit (AST::InferredType &type) override;
   virtual void visit (AST::BareFunctionType &type) override;
+  virtual void visit (AST::SelfParam &self) override;
+  virtual void visit (AST::FunctionParam &param) override;
+  virtual void visit (AST::VariadicParam &param) override;
 
   template <typename T> void visit (T &node);
 
@@ -406,9 +414,7 @@ protected:
   virtual void visit (AST::MatchArm &arm);
   virtual void visit (AST::Visibility &vis);
   virtual void visit (AST::FunctionQualifiers &qualifiers);
-  virtual void visit (AST::SelfParam &self);
   virtual void visit (AST::WhereClause &where);
-  virtual void visit (AST::FunctionParam &param);
   virtual void visit (AST::StructField &field);
   virtual void visit (AST::TupleField &field);
   virtual void visit (AST::TraitFunctionDecl &decl);

--- a/gcc/rust/ast/rust-ast-visitor.h
+++ b/gcc/rust/ast/rust-ast-visitor.h
@@ -442,6 +442,7 @@ protected:
     FUNCTION,
     INHERENT_IMPL,
     TRAIT_IMPL,
+    TRAIT,
     MODULE,
     CRATE,
   };
@@ -452,6 +453,8 @@ protected:
   virtual void visit (AST::InherentImpl &impl) override;
 
   virtual void visit (AST::TraitImpl &impl) override;
+
+  virtual void visit (AST::Trait &trait) override;
 
   template <typename T> void visit (T &item)
   {

--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -1090,6 +1090,62 @@ Union::as_string () const
   return str;
 }
 
+Function::Function (Function const &other)
+  : VisItem (other), qualifiers (other.qualifiers),
+    function_name (other.function_name), where_clause (other.where_clause),
+    locus (other.locus), is_default (other.is_default)
+{
+  // guard to prevent null dereference (always required)
+  if (other.return_type != nullptr)
+    return_type = other.return_type->clone_type ();
+
+  // guard to prevent null dereference (only required if error state)
+  if (other.function_body != nullptr)
+    function_body = other.function_body->clone_block_expr ();
+
+  generic_params.reserve (other.generic_params.size ());
+  for (const auto &e : other.generic_params)
+    generic_params.push_back (e->clone_generic_param ());
+
+  function_params.reserve (other.function_params.size ());
+  for (const auto &e : other.function_params)
+    function_params.push_back (e->clone_param ());
+}
+
+Function &
+Function::operator= (Function const &other)
+{
+  VisItem::operator= (other);
+  function_name = other.function_name;
+  qualifiers = other.qualifiers;
+  where_clause = other.where_clause;
+  // visibility = other.visibility->clone_visibility();
+  // outer_attrs = other.outer_attrs;
+  locus = other.locus;
+  is_default = other.is_default;
+
+  // guard to prevent null dereference (always required)
+  if (other.return_type != nullptr)
+    return_type = other.return_type->clone_type ();
+  else
+    return_type = nullptr;
+
+  // guard to prevent null dereference (only required if error state)
+  if (other.function_body != nullptr)
+    function_body = other.function_body->clone_block_expr ();
+  else
+    function_body = nullptr;
+
+  generic_params.reserve (other.generic_params.size ());
+  for (const auto &e : other.generic_params)
+    generic_params.push_back (e->clone_generic_param ());
+
+  function_params.reserve (other.function_params.size ());
+  for (const auto &e : other.function_params)
+    function_params.push_back (e->clone_param ());
+
+  return *this;
+}
 std::string
 Function::as_string () const
 {
@@ -1149,7 +1205,7 @@ Function::as_string () const
       str += "(";
       for (; i != e; i++)
 	{
-	  str += (*i).as_string ();
+	  str += (*i)->as_string ();
 	  if (e != i + 1)
 	    str += ", ";
 	}
@@ -2245,6 +2301,33 @@ FunctionParam::as_string () const
   return param_name->as_string () + " : " + type->as_string ();
 }
 
+void
+FunctionParam::accept_vis (ASTVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+void
+SelfParam::accept_vis (ASTVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+void
+VariadicParam::accept_vis (ASTVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+std::string
+VariadicParam::as_string () const
+{
+  if (has_pattern ())
+    return get_pattern ()->as_string () + " : ...";
+  else
+    return "...";
+}
+
 std::string
 FunctionQualifiers::as_string () const
 {
@@ -3013,6 +3096,33 @@ NamedFunctionParam::as_string () const
   return str;
 }
 
+TraitItemFunc::TraitItemFunc (TraitItemFunc const &other)
+  : TraitItem (other.locus), outer_attrs (other.outer_attrs), decl (other.decl)
+{
+  node_id = other.node_id;
+
+  // guard to prevent null dereference
+  if (other.block_expr != nullptr)
+    block_expr = other.block_expr->clone_block_expr ();
+}
+
+TraitItemFunc &
+TraitItemFunc::operator= (TraitItemFunc const &other)
+{
+  TraitItem::operator= (other);
+  outer_attrs = other.outer_attrs;
+  decl = other.decl;
+  locus = other.locus;
+  node_id = other.node_id;
+
+  // guard to prevent null dereference
+  if (other.block_expr != nullptr)
+    block_expr = other.block_expr->clone_block_expr ();
+  else
+    block_expr = nullptr;
+
+  return *this;
+}
 std::string
 TraitItemFunc::as_string () const
 {
@@ -3062,7 +3172,7 @@ TraitFunctionDecl::as_string () const
   if (has_params ())
     {
       for (const auto &param : function_params)
-	str += "\n  " + param.as_string ();
+	str += "\n  " + param->as_string ();
     }
   else
     {
@@ -3082,6 +3192,34 @@ TraitFunctionDecl::as_string () const
     str += "none";
 
   return str;
+}
+
+TraitItemMethod::TraitItemMethod (TraitItemMethod const &other)
+  : TraitItem (other.locus), outer_attrs (other.outer_attrs), decl (other.decl)
+{
+  node_id = other.node_id;
+
+  // guard to prevent null dereference
+  if (other.block_expr != nullptr)
+    block_expr = other.block_expr->clone_block_expr ();
+}
+
+TraitItemMethod &
+TraitItemMethod::operator= (TraitItemMethod const &other)
+{
+  TraitItem::operator= (other);
+  outer_attrs = other.outer_attrs;
+  decl = other.decl;
+  locus = other.locus;
+  node_id = other.node_id;
+
+  // guard to prevent null dereference
+  if (other.block_expr != nullptr)
+    block_expr = other.block_expr->clone_block_expr ();
+  else
+    block_expr = nullptr;
+
+  return *this;
 }
 
 std::string
@@ -3129,13 +3267,11 @@ TraitMethodDecl::as_string () const
 	}
     }
 
-  str += "\n Self param: " + self_param.as_string ();
-
   str += "\n Function params: ";
   if (has_params ())
     {
       for (const auto &param : function_params)
-	str += "\n  " + param.as_string ();
+	str += "\n  " + param->as_string ();
     }
   else
     {

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -1042,6 +1042,173 @@ protected:
   Item *clone_stmt_impl () const final override { return clone_item_impl (); }
 };
 
+// Visibility of item - if the item has it, then it is some form of public
+struct Visibility
+{
+public:
+  enum VisType
+  {
+    PRIV,
+    PUB,
+    PUB_CRATE,
+    PUB_SELF,
+    PUB_SUPER,
+    PUB_IN_PATH
+  };
+
+private:
+  VisType vis_type;
+  // Only assigned if vis_type is IN_PATH
+  SimplePath in_path;
+  location_t locus;
+
+  // should this store location info?
+
+public:
+  // Creates a Visibility - TODO make constructor protected or private?
+  Visibility (VisType vis_type, SimplePath in_path, location_t locus)
+    : vis_type (vis_type), in_path (std::move (in_path)), locus (locus)
+  {}
+
+  VisType get_vis_type () const { return vis_type; }
+
+  // Returns whether visibility is in an error state.
+  bool is_error () const
+  {
+    return vis_type == PUB_IN_PATH && in_path.is_empty ();
+  }
+
+  // Returns whether a visibility has a path
+  bool has_path () const { return !is_error () && vis_type >= PUB_CRATE; }
+
+  // Returns whether visibility is public or not.
+  bool is_public () const { return vis_type != PRIV && !is_error (); }
+
+  location_t get_locus () const { return locus; }
+
+  // empty?
+  // Creates an error visibility.
+  static Visibility create_error ()
+  {
+    return Visibility (PUB_IN_PATH, SimplePath::create_empty (),
+		       UNDEF_LOCATION);
+  }
+
+  // Unique pointer custom clone function
+  /*std::unique_ptr<Visibility> clone_visibility() const {
+      return std::unique_ptr<Visibility>(clone_visibility_impl());
+  }*/
+
+  /* TODO: think of a way to only allow valid Visibility states - polymorphism
+   * is one idea but may be too resource-intensive. */
+
+  // Creates a public visibility with no further features/arguments.
+  // empty?
+  static Visibility create_public (location_t pub_vis_location)
+  {
+    return Visibility (PUB, SimplePath::create_empty (), pub_vis_location);
+  }
+
+  // Creates a public visibility with crate-relative paths
+  static Visibility create_crate (location_t crate_tok_location,
+				  location_t crate_vis_location)
+  {
+    return Visibility (PUB_CRATE,
+		       SimplePath::from_str ("crate", crate_tok_location),
+		       crate_vis_location);
+  }
+
+  // Creates a public visibility with self-relative paths
+  static Visibility create_self (location_t self_tok_location,
+				 location_t self_vis_location)
+  {
+    return Visibility (PUB_SELF,
+		       SimplePath::from_str ("self", self_tok_location),
+		       self_vis_location);
+  }
+
+  // Creates a public visibility with parent module-relative paths
+  static Visibility create_super (location_t super_tok_location,
+				  location_t super_vis_location)
+  {
+    return Visibility (PUB_SUPER,
+		       SimplePath::from_str ("super", super_tok_location),
+		       super_vis_location);
+  }
+
+  // Creates a private visibility
+  static Visibility create_private ()
+  {
+    return Visibility (PRIV, SimplePath::create_empty (), UNDEF_LOCATION);
+  }
+
+  // Creates a public visibility with a given path or whatever.
+  static Visibility create_in_path (SimplePath in_path,
+				    location_t in_path_vis_location)
+  {
+    return Visibility (PUB_IN_PATH, std::move (in_path), in_path_vis_location);
+  }
+
+  std::string as_string () const;
+  const SimplePath &get_path () const { return in_path; }
+  SimplePath &get_path () { return in_path; }
+
+protected:
+  // Clone function implementation - not currently virtual but may be if
+  // polymorphism used
+  /*virtual*/ Visibility *clone_visibility_impl () const
+  {
+    return new Visibility (*this);
+  }
+};
+// Item that supports visibility - abstract base class
+class VisItem : public Item
+{
+  Visibility visibility;
+  std::vector<Attribute> outer_attrs;
+
+protected:
+  // Visibility constructor
+  VisItem (Visibility visibility,
+	   std::vector<Attribute> outer_attrs = std::vector<Attribute> ())
+    : visibility (std::move (visibility)), outer_attrs (std::move (outer_attrs))
+  {}
+
+  // Visibility copy constructor
+  VisItem (VisItem const &other)
+    : visibility (other.visibility), outer_attrs (other.outer_attrs)
+  {}
+
+  // Overload assignment operator to clone
+  VisItem &operator= (VisItem const &other)
+  {
+    visibility = other.visibility;
+    outer_attrs = other.outer_attrs;
+
+    return *this;
+  }
+
+  // move constructors
+  VisItem (VisItem &&other) = default;
+  VisItem &operator= (VisItem &&other) = default;
+
+public:
+  /* Does the item have some kind of public visibility (non-default
+   * visibility)? */
+  bool has_visibility () const { return visibility.is_public (); }
+
+  std::string as_string () const override;
+
+  // TODO: this mutable getter seems really dodgy. Think up better way.
+  Visibility &get_visibility () { return visibility; }
+  const Visibility &get_visibility () const { return visibility; }
+
+  std::vector<Attribute> &get_outer_attrs () override { return outer_attrs; }
+  const std::vector<Attribute> &get_outer_attrs () const override
+  {
+    return outer_attrs;
+  }
+};
 // forward decl of ExprWithoutBlock
 class ExprWithoutBlock;
 

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -3,6 +3,7 @@
 
 #include "rust-ast.h"
 #include "rust-path.h"
+#include "rust-macro.h"
 #include "rust-operators.h"
 
 namespace Rust {

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -2727,7 +2727,7 @@ protected:
 class BreakExpr : public ExprWithoutBlock
 {
   std::vector<Attribute> outer_attrs;
-  Lifetime label;
+  LoopLabel label;
   std::unique_ptr<Expr> break_expr;
   location_t locus;
 
@@ -2745,7 +2745,7 @@ public:
   bool has_break_expr () const { return break_expr != nullptr; }
 
   // Constructor for a break expression
-  BreakExpr (Lifetime break_label, std::unique_ptr<Expr> expr_in_break,
+  BreakExpr (LoopLabel break_label, std::unique_ptr<Expr> expr_in_break,
 	     std::vector<Attribute> outer_attribs, location_t locus)
     : outer_attrs (std::move (outer_attribs)), label (std::move (break_label)),
       break_expr (std::move (expr_in_break)), locus (locus)
@@ -2807,7 +2807,7 @@ public:
     outer_attrs = std::move (new_attrs);
   }
 
-  Lifetime &get_label () { return label; }
+  LoopLabel &get_label () { return label; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather

--- a/gcc/rust/checks/errors/rust-ast-validation.cc
+++ b/gcc/rust/checks/errors/rust-ast-validation.cc
@@ -37,6 +37,21 @@ ASTValidation::visit (AST::Lifetime &lifetime)
 }
 
 void
+ASTValidation::visit (AST::LoopLabel &label)
+{
+  auto name = label.get_lifetime ().get_lifetime_name ();
+  auto lifetime_name = '\'' + name;
+  auto &keywords = Values::Keywords::keywords;
+  if (keywords.find (name) != keywords.end ())
+    rust_error_at (label.get_locus (), "invalid label name %qs",
+		   lifetime_name.c_str ());
+
+  // WARNING: Do not call ContextualASTVisitor, we don't want to visit the
+  // lifetime
+  // Maybe we should refactor LoopLabel instead ?
+}
+
+void
 ASTValidation::visit (AST::ConstantItem &const_item)
 {
   if (!const_item.has_expr () && context.back () != Context::TRAIT_IMPL)

--- a/gcc/rust/checks/errors/rust-ast-validation.cc
+++ b/gcc/rust/checks/errors/rust-ast-validation.cc
@@ -43,7 +43,7 @@ ASTValidation::visit (AST::LoopLabel &label)
   auto lifetime_name = '\'' + name;
   auto &keywords = Values::Keywords::keywords;
   if (keywords.find (name) != keywords.end ())
-    rust_error_at (label.get_locus (), "invalid label name %qs",
+    rust_error_at (label.get_lifetime ().get_locus (), "invalid label name %qs",
 		   lifetime_name.c_str ());
 
   // WARNING: Do not call ContextualASTVisitor, we don't want to visit the

--- a/gcc/rust/checks/errors/rust-ast-validation.cc
+++ b/gcc/rust/checks/errors/rust-ast-validation.cc
@@ -21,6 +21,29 @@
 
 namespace Rust {
 
+namespace {
+// TODO: make constexpr when update to c++20
+const std::map<std::string, TokenId> keywords = {
+#define RS_TOKEN(x, y)
+#define RS_TOKEN_KEYWORD(tok, key) {key, tok},
+  RS_TOKEN_LIST
+#undef RS_TOKEN_KEYWORD
+#undef RS_TOKEN
+};
+} // namespace
+
+void
+ASTValidation::visit (AST::Lifetime &lifetime)
+{
+  auto name = lifetime.get_lifetime_name ();
+  auto valid = std::set<std::string>{"static", "_"};
+  if (valid.find (name) == valid.end ()
+      && keywords.find (name) != keywords.end ())
+    rust_error_at (lifetime.get_locus (), "lifetimes cannot use keyword names");
+
+  AST::ContextualASTVisitor::visit (lifetime);
+}
+
 void
 ASTValidation::visit (AST::ConstantItem &const_item)
 {

--- a/gcc/rust/checks/errors/rust-ast-validation.cc
+++ b/gcc/rust/checks/errors/rust-ast-validation.cc
@@ -81,4 +81,19 @@ ASTValidation::visit (AST::ExternalFunctionItem &item)
   AST::ContextualASTVisitor::visit (item);
 }
 
+void
+ASTValidation::visit (AST::Function &function)
+{
+  std::set<Context> valid_context
+    = {Context::INHERENT_IMPL, Context::TRAIT_IMPL};
+
+  if (valid_context.find (context.back ()) == valid_context.end ()
+      && function.has_self_param ())
+    rust_error_at (
+      function.get_self_param ()->get_locus (),
+      "%<self%> parameter is only allowed in associated functions");
+
+  AST::ContextualASTVisitor::visit (function);
+}
+
 } // namespace Rust

--- a/gcc/rust/checks/errors/rust-ast-validation.cc
+++ b/gcc/rust/checks/errors/rust-ast-validation.cc
@@ -18,25 +18,17 @@
 
 #include "rust-ast-validation.h"
 #include "rust-diagnostics.h"
+#include "rust-keyword-values.h"
 
 namespace Rust {
-
-namespace {
-// TODO: make constexpr when update to c++20
-const std::map<std::string, TokenId> keywords = {
-#define RS_TOKEN(x, y)
-#define RS_TOKEN_KEYWORD(tok, key) {key, tok},
-  RS_TOKEN_LIST
-#undef RS_TOKEN_KEYWORD
-#undef RS_TOKEN
-};
-} // namespace
 
 void
 ASTValidation::visit (AST::Lifetime &lifetime)
 {
   auto name = lifetime.get_lifetime_name ();
   auto valid = std::set<std::string>{"static", "_"};
+  auto &keywords = Values::Keywords::keywords;
+
   if (valid.find (name) == valid.end ()
       && keywords.find (name) != keywords.end ())
     rust_error_at (lifetime.get_locus (), "lifetimes cannot use keyword names");

--- a/gcc/rust/checks/errors/rust-ast-validation.cc
+++ b/gcc/rust/checks/errors/rust-ast-validation.cc
@@ -62,4 +62,23 @@ ASTValidation::visit (AST::ConstantItem &const_item)
   AST::ContextualASTVisitor::visit (const_item);
 }
 
+void
+ASTValidation::visit (AST::ExternalFunctionItem &item)
+{
+  auto &params = item.get_function_params ();
+
+  if (params.size () == 1 && params[0].is_variadic ())
+    rust_error_at (
+      params[0].get_locus (),
+      "C-variadic function must be declared with at least one named argument");
+
+  for (auto it = params.begin (); it != params.end (); it++)
+    if (it->is_variadic () && it + 1 != params.end ())
+      rust_error_at (
+	it->get_locus (),
+	"%<...%> must be the last argument of a C-variadic function");
+
+  AST::ContextualASTVisitor::visit (item);
+}
+
 } // namespace Rust

--- a/gcc/rust/checks/errors/rust-ast-validation.h
+++ b/gcc/rust/checks/errors/rust-ast-validation.h
@@ -37,6 +37,7 @@ public:
   virtual void visit (AST::Lifetime &lifetime);
   virtual void visit (AST::LoopLabel &label);
   virtual void visit (AST::ExternalFunctionItem &item);
+  virtual void visit (AST::Function &function);
 };
 
 } // namespace Rust

--- a/gcc/rust/checks/errors/rust-ast-validation.h
+++ b/gcc/rust/checks/errors/rust-ast-validation.h
@@ -35,6 +35,7 @@ public:
 
   virtual void visit (AST::ConstantItem &const_item);
   virtual void visit (AST::Lifetime &lifetime);
+  virtual void visit (AST::LoopLabel &label);
 };
 
 } // namespace Rust

--- a/gcc/rust/checks/errors/rust-ast-validation.h
+++ b/gcc/rust/checks/errors/rust-ast-validation.h
@@ -34,6 +34,7 @@ public:
   void check (AST::Crate &crate) { AST::ContextualASTVisitor::visit (crate); }
 
   virtual void visit (AST::ConstantItem &const_item);
+  virtual void visit (AST::Lifetime &lifetime);
 };
 
 } // namespace Rust

--- a/gcc/rust/checks/errors/rust-ast-validation.h
+++ b/gcc/rust/checks/errors/rust-ast-validation.h
@@ -36,6 +36,7 @@ public:
   virtual void visit (AST::ConstantItem &const_item);
   virtual void visit (AST::Lifetime &lifetime);
   virtual void visit (AST::LoopLabel &label);
+  virtual void visit (AST::ExternalFunctionItem &item);
 };
 
 } // namespace Rust

--- a/gcc/rust/checks/errors/rust-feature-gate.h
+++ b/gcc/rust/checks/errors/rust-feature-gate.h
@@ -183,6 +183,9 @@ public:
   void visit (AST::SliceType &type) override {}
   void visit (AST::InferredType &type) override {}
   void visit (AST::BareFunctionType &type) override {}
+  void visit (AST::FunctionParam &param) override {}
+  void visit (AST::VariadicParam &param) override {}
+  void visit (AST::SelfParam &param) override {}
 
 private:
   void gate (Feature::Name name, location_t loc, const std::string &error_msg);

--- a/gcc/rust/expand/rust-cfg-strip.h
+++ b/gcc/rust/expand/rust-cfg-strip.h
@@ -18,6 +18,7 @@
 
 #include "rust-ast-visitor.h"
 #include "rust-ast.h"
+#include "rust-item.h"
 
 namespace Rust {
 // Visitor used to maybe_strip attributes.
@@ -32,7 +33,8 @@ public:
 
   void maybe_strip_struct_fields (std::vector<AST::StructField> &fields);
   void maybe_strip_tuple_fields (std::vector<AST::TupleField> &fields);
-  void maybe_strip_function_params (std::vector<AST::FunctionParam> &params);
+  void maybe_strip_function_params (
+    std::vector<std::unique_ptr<AST::Param>> &params);
   void maybe_strip_generic_args (AST::GenericArgs &args);
   void maybe_strip_qualified_path_type (AST::QualifiedPathType &path_type);
   void maybe_strip_closure_params (std::vector<AST::ClosureParam> &params);
@@ -222,5 +224,8 @@ public:
   void visit (AST::SliceType &type) override;
   void visit (AST::InferredType &) override;
   void visit (AST::BareFunctionType &type) override;
+  void visit (AST::VariadicParam &type) override;
+  void visit (AST::FunctionParam &type) override;
+  void visit (AST::SelfParam &type) override;
 };
 } // namespace Rust

--- a/gcc/rust/expand/rust-derive-clone.cc
+++ b/gcc/rust/expand/rust-derive-clone.cc
@@ -17,6 +17,7 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-derive-clone.h"
+#include "rust-item.h"
 
 namespace Rust {
 namespace AST {
@@ -50,13 +51,17 @@ DeriveClone::clone_fn (std::unique_ptr<Expr> &&clone_expr)
 		   loc, loc));
   auto big_self_type = builder.single_type_path ("Self");
 
+  std::unique_ptr<SelfParam> self (new SelfParam (Lifetime::error (),
+						  /* is_mut */ false, loc));
+
+  std::vector<std::unique_ptr<Param>> params;
+  params.push_back (std::move (self));
+
   return std::unique_ptr<TraitImplItem> (
     new Function ({"clone"}, builder.fn_qualifiers (), /* generics */ {},
-		  tl::optional<SelfParam> (tl::in_place, Lifetime::error (),
-					   /* is_mut */ false, loc),
-		  /* function params */ {}, std::move (big_self_type),
-		  WhereClause::create_empty (), std::move (block),
-		  Visibility::create_private (), {}, loc));
+		  /* function params */ std::move (params),
+		  std::move (big_self_type), WhereClause::create_empty (),
+		  std::move (block), Visibility::create_private (), {}, loc));
 }
 
 /**

--- a/gcc/rust/expand/rust-derive.h
+++ b/gcc/rust/expand/rust-derive.h
@@ -220,6 +220,9 @@ private:
   virtual void visit (SliceType &type) override final{};
   virtual void visit (InferredType &type) override final{};
   virtual void visit (BareFunctionType &type) override final{};
+  virtual void visit (SelfParam &param) override final{};
+  virtual void visit (FunctionParam &param) override final{};
+  virtual void visit (VariadicParam &param) override final{};
 };
 
 } // namespace AST

--- a/gcc/rust/expand/rust-expand-visitor.h
+++ b/gcc/rust/expand/rust-expand-visitor.h
@@ -67,7 +67,8 @@ public:
    * Expand all macro invocations in lieu of types within a list of function
    * parameters
    */
-  void expand_function_params (std::vector<AST::FunctionParam> &params);
+  void
+  expand_function_params (std::vector<std::unique_ptr<AST::Param>> &params);
 
   /**
    * Expand all macro invocations in lieu of types within a list of generic
@@ -82,7 +83,6 @@ public:
 
   // FIXME: Add documentation
   void expand_closure_params (std::vector<AST::ClosureParam> &params);
-  void expand_self_param (AST::SelfParam &self_param);
   void expand_where_clause (AST::WhereClause &where_clause);
   void expand_trait_function_decl (AST::TraitFunctionDecl &decl);
   void expand_trait_method_decl (AST::TraitMethodDecl &decl);
@@ -347,6 +347,9 @@ public:
   void visit (AST::SliceType &type) override;
   void visit (AST::InferredType &) override;
   void visit (AST::BareFunctionType &type) override;
+  void visit (AST::VariadicParam &type) override;
+  void visit (AST::FunctionParam &type) override;
+  void visit (AST::SelfParam &type) override;
 
   template <typename T>
   void expand_inner_attribute (T &item, AST::SimplePath &Path);

--- a/gcc/rust/hir/rust-ast-lower-base.cc
+++ b/gcc/rust/hir/rust-ast-lower-base.cc
@@ -21,6 +21,8 @@
 #include "rust-ast-lower-pattern.h"
 #include "rust-ast-lower-extern.h"
 #include "rust-attribute-values.h"
+#include "rust-item.h"
+#include "rust-system.h"
 
 namespace Rust {
 namespace HIR {
@@ -515,6 +517,18 @@ void
 ASTLoweringBase::visit (AST::BareFunctionType &)
 {}
 
+void
+ASTLoweringBase::visit (AST::FunctionParam &param)
+{}
+
+void
+ASTLoweringBase::visit (AST::VariadicParam &param)
+{}
+
+void
+ASTLoweringBase::visit (AST::SelfParam &param)
+{}
+
 HIR::Lifetime
 ASTLoweringBase::lower_lifetime (AST::Lifetime &lifetime)
 {
@@ -629,28 +643,31 @@ ASTLoweringBase::lower_generic_args (AST::GenericArgs &args)
 }
 
 HIR::SelfParam
-ASTLoweringBase::lower_self (AST::SelfParam &self)
+ASTLoweringBase::lower_self (std::unique_ptr<AST::Param> &param)
 {
+  rust_assert (param->is_self ());
+
+  auto self = static_cast<AST::SelfParam *> (param.get ());
   auto crate_num = mappings->get_current_crate ();
-  Analysis::NodeMapping mapping (crate_num, self.get_node_id (),
+  Analysis::NodeMapping mapping (crate_num, self->get_node_id (),
 				 mappings->get_next_hir_id (crate_num),
 				 mappings->get_next_localdef_id (crate_num));
 
-  if (self.has_type ())
+  if (self->has_type ())
     {
-      HIR::Type *type = ASTLoweringType::translate (self.get_type ().get ());
+      HIR::Type *type = ASTLoweringType::translate (self->get_type ().get ());
       return HIR::SelfParam (mapping, std::unique_ptr<HIR::Type> (type),
-			     self.get_is_mut (), self.get_locus ());
+			     self->get_is_mut (), self->get_locus ());
     }
-  else if (!self.get_has_ref ())
+  else if (!self->get_has_ref ())
     {
       return HIR::SelfParam (mapping, std::unique_ptr<HIR::Type> (nullptr),
-			     self.get_is_mut (), self.get_locus ());
+			     self->get_is_mut (), self->get_locus ());
     }
 
-  AST::Lifetime l = self.get_lifetime ();
-  return HIR::SelfParam (mapping, lower_lifetime (l), self.get_is_mut (),
-			 self.get_locus ());
+  AST::Lifetime l = self->get_lifetime ();
+  return HIR::SelfParam (mapping, lower_lifetime (l), self->get_is_mut (),
+			 self->get_locus ());
 }
 
 HIR::Type *

--- a/gcc/rust/hir/rust-ast-lower-base.h
+++ b/gcc/rust/hir/rust-ast-lower-base.h
@@ -251,6 +251,9 @@ public:
   virtual void visit (AST::SliceType &type);
   virtual void visit (AST::InferredType &type);
   virtual void visit (AST::BareFunctionType &type);
+  virtual void visit (AST::FunctionParam &param);
+  virtual void visit (AST::VariadicParam &param);
+  virtual void visit (AST::SelfParam &param);
 
 protected:
   ASTLoweringBase ()
@@ -274,7 +277,7 @@ protected:
 
   HIR::GenericArgsBinding lower_binding (AST::GenericArgsBinding &binding);
 
-  HIR::SelfParam lower_self (AST::SelfParam &self);
+  HIR::SelfParam lower_self (std::unique_ptr<AST::Param> &self);
 
   HIR::Type *lower_type_no_bounds (AST::TypeNoBounds *type);
 

--- a/gcc/rust/hir/rust-ast-lower-expr.cc
+++ b/gcc/rust/hir/rust-ast-lower-expr.cc
@@ -589,7 +589,8 @@ ASTLoweringExpr::visit (AST::ForLoopExpr &expr)
 void
 ASTLoweringExpr::visit (AST::BreakExpr &expr)
 {
-  HIR::Lifetime break_label = lower_lifetime (expr.get_label ());
+  HIR::Lifetime break_label
+    = lower_lifetime (expr.get_label ().get_lifetime ());
   HIR::Expr *break_expr
     = expr.has_break_expr ()
 	? ASTLoweringExpr::translate (expr.get_break_expr ().get ())

--- a/gcc/rust/hir/rust-ast-lower-implitem.h
+++ b/gcc/rust/hir/rust-ast-lower-implitem.h
@@ -23,6 +23,7 @@
 #include "rust-ast-lower-expr.h"
 #include "rust-ast-lower-pattern.h"
 #include "rust-ast-lower-block.h"
+#include "rust-item.h"
 
 namespace Rust {
 namespace HIR {
@@ -141,22 +142,26 @@ public:
 				    : nullptr;
 
     std::vector<HIR::FunctionParam> function_params;
-    for (auto &param : function.get_function_params ())
+    for (auto &p : function.get_function_params ())
       {
+	if (p->is_self () || p->is_variadic ())
+	  continue;
+	auto param = static_cast<AST::FunctionParam *> (p.get ());
+
 	auto translated_pattern = std::unique_ptr<HIR::Pattern> (
-	  ASTLoweringPattern::translate (param.get_pattern ().get ()));
+	  ASTLoweringPattern::translate (param->get_pattern ().get ()));
 	auto translated_type = std::unique_ptr<HIR::Type> (
-	  ASTLoweringType::translate (param.get_type ().get ()));
+	  ASTLoweringType::translate (param->get_type ().get ()));
 
 	auto crate_num = mappings->get_current_crate ();
-	Analysis::NodeMapping mapping (crate_num, param.get_node_id (),
+	Analysis::NodeMapping mapping (crate_num, param->get_node_id (),
 				       mappings->get_next_hir_id (crate_num),
 				       UNKNOWN_LOCAL_DEFID);
 
 	auto hir_param
 	  = HIR::FunctionParam (mapping, std::move (translated_pattern),
 				std::move (translated_type),
-				param.get_locus ());
+				param->get_locus ());
 	function_params.push_back (std::move (hir_param));
       }
 
@@ -255,22 +260,27 @@ public:
 			       : nullptr;
 
     std::vector<HIR::FunctionParam> function_params;
-    for (auto &param : ref.get_function_params ())
+    for (auto &p : ref.get_function_params ())
       {
+	if (p->is_variadic () || p->is_self ())
+	  continue;
+
+	auto param = static_cast<AST::FunctionParam *> (p.get ());
+
 	auto translated_pattern = std::unique_ptr<HIR::Pattern> (
-	  ASTLoweringPattern::translate (param.get_pattern ().get ()));
+	  ASTLoweringPattern::translate (param->get_pattern ().get ()));
 	auto translated_type = std::unique_ptr<HIR::Type> (
-	  ASTLoweringType::translate (param.get_type ().get ()));
+	  ASTLoweringType::translate (param->get_type ().get ()));
 
 	auto crate_num = mappings->get_current_crate ();
-	Analysis::NodeMapping mapping (crate_num, param.get_node_id (),
+	Analysis::NodeMapping mapping (crate_num, param->get_node_id (),
 				       mappings->get_next_hir_id (crate_num),
 				       UNKNOWN_LOCAL_DEFID);
 
 	auto hir_param
 	  = HIR::FunctionParam (mapping, std::move (translated_pattern),
 				std::move (translated_type),
-				param.get_locus ());
+				param->get_locus ());
 	function_params.push_back (std::move (hir_param));
       }
 
@@ -329,22 +339,27 @@ public:
     HIR::SelfParam self_param = lower_self (ref.get_self_param ());
 
     std::vector<HIR::FunctionParam> function_params;
-    for (auto &param : ref.get_function_params ())
+    for (auto &p : ref.get_function_params ())
       {
+	if (p->is_variadic () || p->is_self ())
+	  continue;
+
+	auto param = static_cast<AST::FunctionParam *> (p.get ());
+
 	auto translated_pattern = std::unique_ptr<HIR::Pattern> (
-	  ASTLoweringPattern::translate (param.get_pattern ().get ()));
+	  ASTLoweringPattern::translate (param->get_pattern ().get ()));
 	auto translated_type = std::unique_ptr<HIR::Type> (
-	  ASTLoweringType::translate (param.get_type ().get ()));
+	  ASTLoweringType::translate (param->get_type ().get ()));
 
 	auto crate_num = mappings->get_current_crate ();
-	Analysis::NodeMapping mapping (crate_num, param.get_node_id (),
+	Analysis::NodeMapping mapping (crate_num, param->get_node_id (),
 				       mappings->get_next_hir_id (crate_num),
 				       UNKNOWN_LOCAL_DEFID);
 
 	auto hir_param
 	  = HIR::FunctionParam (mapping, std::move (translated_pattern),
 				std::move (translated_type),
-				param.get_locus ());
+				param->get_locus ());
 	function_params.push_back (hir_param);
       }
 

--- a/gcc/rust/hir/rust-ast-lower-item.cc
+++ b/gcc/rust/hir/rust-ast-lower-item.cc
@@ -26,6 +26,7 @@
 #include "rust-ast-lower-expr.h"
 #include "rust-ast-lower-pattern.h"
 #include "rust-ast-lower-block.h"
+#include "rust-item.h"
 
 namespace Rust {
 namespace HIR {
@@ -420,21 +421,25 @@ ASTLoweringItem::visit (AST::Function &function)
 				  : nullptr;
 
   std::vector<HIR::FunctionParam> function_params;
-  for (auto &param : function.get_function_params ())
+  for (auto &p : function.get_function_params ())
     {
+      if (p->is_variadic () || p->is_self ())
+	continue;
+      auto param = static_cast<AST::FunctionParam *> (p.get ());
+
       auto translated_pattern = std::unique_ptr<HIR::Pattern> (
-	ASTLoweringPattern::translate (param.get_pattern ().get ()));
+	ASTLoweringPattern::translate (param->get_pattern ().get ()));
       auto translated_type = std::unique_ptr<HIR::Type> (
-	ASTLoweringType::translate (param.get_type ().get ()));
+	ASTLoweringType::translate (param->get_type ().get ()));
 
       auto crate_num = mappings->get_current_crate ();
-      Analysis::NodeMapping mapping (crate_num, param.get_node_id (),
+      Analysis::NodeMapping mapping (crate_num, param->get_node_id (),
 				     mappings->get_next_hir_id (crate_num),
 				     UNKNOWN_LOCAL_DEFID);
 
       auto hir_param
 	= HIR::FunctionParam (mapping, std::move (translated_pattern),
-			      std::move (translated_type), param.get_locus ());
+			      std::move (translated_type), param->get_locus ());
       function_params.push_back (std::move (hir_param));
     }
 

--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -24,6 +24,7 @@
 #include "rust-session-manager.h"
 #include "safe-ctype.h"
 #include "cpplib.h"
+#include "rust-keyword-values.h"
 
 namespace Rust {
 // TODO: move to separate compilation unit?
@@ -254,25 +255,12 @@ Lexer::replace_current_token (TokenPtr replacement)
   rust_debug ("called 'replace_current_token' - this is deprecated");
 }
 
-/* shitty anonymous namespace that can only be accessed inside the compilation
- * unit - used for classify_keyword binary search in sorted array of keywords
- * created with x-macros. */
-namespace {
-// TODO: make constexpr when update to c++20
-const std::map<std::string, TokenId> keywords = {
-#define RS_TOKEN(x, y)
-#define RS_TOKEN_KEYWORD(tok, key) {key, tok},
-  RS_TOKEN_LIST
-#undef RS_TOKEN_KEYWORD
-#undef RS_TOKEN
-};
-} // namespace
-
 /* Determines whether the string passed in is a keyword or not. If it is, it
  * returns the keyword name.  */
 TokenId
 Lexer::classify_keyword (const std::string &str)
 {
+  auto &keywords = Rust::Values::Keywords::keywords;
   auto keyword = keywords.find (str);
 
   if (keyword == keywords.end ())

--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -1938,8 +1938,13 @@ Lexer::parse_raw_identifier (location_t loc)
     rust_error_at (get_current_location (),
 		   "%<_%> is not a valid raw identifier");
 
-  if (str == "crate" || str == "extern" || str == "self" || str == "super"
-      || str == "Self")
+  using namespace Rust::Values;
+  std::set<std::string> invalid{
+    Keywords::CRATE, Keywords::EXTERN_TOK, Keywords::SELF,
+    Keywords::SUPER, Keywords::SELF_ALIAS,
+  };
+
+  if (invalid.find (str) != invalid.end ())
     {
       rust_error_at (get_current_location (),
 		     "%qs is a forbidden raw identifier", str.c_str ());

--- a/gcc/rust/metadata/rust-export-metadata.cc
+++ b/gcc/rust/metadata/rust-export-metadata.cc
@@ -22,9 +22,11 @@
 #include "rust-hir-map.h"
 #include "rust-ast-dump.h"
 #include "rust-abi.h"
+#include "rust-item.h"
 #include "rust-object-export.h"
 
 #include "md5.h"
+#include "rust-system.h"
 
 namespace Rust {
 namespace Metadata {
@@ -107,15 +109,18 @@ ExportContext::emit_function (const HIR::Function &fn)
 	}
 
       std::vector<AST::NamedFunctionParam> function_params;
-      for (AST::FunctionParam &param : function.get_function_params ())
+      for (auto &p : function.get_function_params ())
 	{
-	  std::string name = param.get_pattern ()->as_string ();
+	  if (p->is_variadic () || p->is_self ())
+	    rust_unreachable ();
+	  auto param = static_cast<AST::FunctionParam *> (p.get ());
+	  std::string name = param->get_pattern ()->as_string ();
 	  std::unique_ptr<AST::Type> param_type
-	    = param.get_type ()->clone_type ();
+	    = param->get_type ()->clone_type ();
 
-	  AST::NamedFunctionParam p (name, std::move (param_type), {},
-				     param.get_locus ());
-	  function_params.push_back (std::move (p));
+	  AST::NamedFunctionParam np (name, std::move (param_type), {},
+				      param->get_locus ());
+	  function_params.push_back (std::move (np));
 	}
 
       AST::ExternalItem *external_item

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -28,6 +28,7 @@
 #include "rust-make-unique.h"
 #include "rust-dir-owner.h"
 #include "rust-attribute-values.h"
+#include "rust-keyword-values.h"
 
 #include "optional.h"
 
@@ -682,6 +683,7 @@ template <typename ManagedTokenSource>
 AST::SimplePathSegment
 Parser<ManagedTokenSource>::parse_simple_path_segment ()
 {
+  using namespace Values;
   const_TokenPtr t = lexer.peek_token ();
   switch (t->get_id ())
     {
@@ -692,15 +694,15 @@ Parser<ManagedTokenSource>::parse_simple_path_segment ()
     case SUPER:
       lexer.skip_token ();
 
-      return AST::SimplePathSegment ("super", t->get_locus ());
+      return AST::SimplePathSegment (Keywords::SUPER, t->get_locus ());
     case SELF:
       lexer.skip_token ();
 
-      return AST::SimplePathSegment ("self", t->get_locus ());
+      return AST::SimplePathSegment (Keywords::SELF, t->get_locus ());
     case CRATE:
       lexer.skip_token ();
 
-      return AST::SimplePathSegment ("crate", t->get_locus ());
+      return AST::SimplePathSegment (Keywords::CRATE, t->get_locus ());
     case DOLLAR_SIGN:
       if (lexer.peek_token (1)->get_id () == CRATE)
 	{

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -2879,11 +2879,20 @@ Parser<ManagedTokenSource>::parse_function (AST::Visibility vis,
       return nullptr;
     }
 
+  std::unique_ptr<AST::Param> initial_param = parse_self_param ();
+  if (initial_param != nullptr)
+    skip_token (COMMA);
+
   // parse function parameters (only if next token isn't right paren)
-  std::vector<AST::FunctionParam> function_params;
+  std::vector<std::unique_ptr<AST::Param>> function_params;
+
   if (lexer.peek_token ()->get_id () != RIGHT_PAREN)
     function_params
       = parse_function_params ([] (TokenId id) { return id == RIGHT_PAREN; });
+
+  if (initial_param != nullptr)
+    function_params.insert (function_params.begin (),
+			    std::move (initial_param));
 
   if (!skip_token (RIGHT_PAREN))
     {
@@ -2907,11 +2916,10 @@ Parser<ManagedTokenSource>::parse_function (AST::Visibility vis,
 
   return std::unique_ptr<AST::Function> (
     new AST::Function (std::move (function_name), std::move (qualifiers),
-		       std::move (generic_params),
-		       tl::optional<AST::SelfParam> (),
-		       std::move (function_params), std::move (return_type),
-		       std::move (where_clause), std::move (block_expr),
-		       std::move (vis), std::move (outer_attrs), locus));
+		       std::move (generic_params), std::move (function_params),
+		       std::move (return_type), std::move (where_clause),
+		       std::move (block_expr), std::move (vis),
+		       std::move (outer_attrs), locus));
 }
 
 // Parses function or method qualifiers (i.e. const, unsafe, and extern).
@@ -3525,18 +3533,18 @@ Parser<ManagedTokenSource>::parse_type_param ()
  * has end token handling. */
 template <typename ManagedTokenSource>
 template <typename EndTokenPred>
-std::vector<AST::FunctionParam>
+std::vector<std::unique_ptr<AST::Param>>
 Parser<ManagedTokenSource>::parse_function_params (EndTokenPred is_end_token)
 {
-  std::vector<AST::FunctionParam> params;
+  std::vector<std::unique_ptr<AST::Param>> params;
 
   if (is_end_token (lexer.peek_token ()->get_id ()))
     return params;
 
-  AST::FunctionParam initial_param = parse_function_param ();
+  auto initial_param = parse_function_param ();
 
   // Return empty parameter list if no parameter there
-  if (initial_param.is_error ())
+  if (initial_param == nullptr)
     {
       // TODO: is this an error?
       return params;
@@ -3558,15 +3566,15 @@ Parser<ManagedTokenSource>::parse_function_params (EndTokenPred is_end_token)
 	break;
 
       // now, as right paren would break, function param is required
-      AST::FunctionParam param = parse_function_param ();
-      if (param.is_error ())
+      auto param = parse_function_param ();
+      if (param == nullptr)
 	{
 	  Error error (lexer.peek_token ()->get_locus (),
 		       "failed to parse function param (in function params)");
 	  add_error (std::move (error));
 
 	  // skip somewhere?
-	  return std::vector<AST::FunctionParam> ();
+	  return std::vector<std::unique_ptr<AST::Param>> ();
 	}
 
       params.push_back (std::move (param));
@@ -3581,7 +3589,7 @@ Parser<ManagedTokenSource>::parse_function_params (EndTokenPred is_end_token)
 /* Parses a single regular (i.e. non-generic) parameter in a function or
  * method, i.e. the "name: type" bit. Also handles it not existing. */
 template <typename ManagedTokenSource>
-AST::FunctionParam
+std::unique_ptr<AST::Param>
 Parser<ManagedTokenSource>::parse_function_param ()
 {
   // parse outer attributes if they exist
@@ -3593,7 +3601,8 @@ Parser<ManagedTokenSource>::parse_function_param ()
   if (lexer.peek_token ()->get_id () == ELLIPSIS) // Unnamed variadic
     {
       lexer.skip_token (); // Skip ellipsis
-      return AST::FunctionParam (std::move (outer_attrs), locus);
+      return Rust::make_unique<AST::VariadicParam> (
+	AST::VariadicParam (std::move (outer_attrs), locus));
     }
 
   std::unique_ptr<AST::Pattern> param_pattern = parse_pattern ();
@@ -3602,32 +3611,32 @@ Parser<ManagedTokenSource>::parse_function_param ()
   if (param_pattern == nullptr)
     {
       // skip after something
-      return AST::FunctionParam::create_error ();
+      return nullptr;
     }
 
   if (!skip_token (COLON))
     {
       // skip after something
-      return AST::FunctionParam::create_error ();
+      return nullptr;
     }
 
   if (lexer.peek_token ()->get_id () == ELLIPSIS) // Named variadic
     {
       lexer.skip_token (); // Skip ellipsis
-      return AST::FunctionParam (std::move (param_pattern),
-				 std::move (outer_attrs), locus);
+      return Rust::make_unique<AST::VariadicParam> (
+	AST::VariadicParam (std::move (param_pattern), std::move (outer_attrs),
+			    locus));
     }
   else
     {
       std::unique_ptr<AST::Type> param_type = parse_type ();
       if (param_type == nullptr)
 	{
-	  // skip?
-	  return AST::FunctionParam::create_error ();
+	  return nullptr;
 	}
-      return AST::FunctionParam (std::move (param_pattern),
-				 std::move (param_type),
-				 std::move (outer_attrs), locus);
+      return Rust::make_unique<AST::FunctionParam> (
+	AST::FunctionParam (std::move (param_pattern), std::move (param_type),
+			    std::move (outer_attrs), locus));
     }
 }
 
@@ -5051,13 +5060,14 @@ Parser<ManagedTokenSource>::parse_trait_item ()
 
 	/* now for function vs method disambiguation - method has opening
 	 * "self" param */
-	AST::SelfParam self_param = parse_self_param ();
+	std::unique_ptr<AST::Param> initial_param = parse_self_param ();
 	/* FIXME: ensure that self param doesn't accidently consume tokens for
 	 * a function */
 	bool is_method = false;
-	if (!self_param.is_error ())
+	if (initial_param != nullptr)
 	  {
-	    is_method = true;
+	    if (initial_param->is_self ())
+	      is_method = true;
 
 	    /* skip comma so function and method regular params can be parsed
 	     * in same way */
@@ -5066,7 +5076,7 @@ Parser<ManagedTokenSource>::parse_trait_item ()
 	  }
 
 	// parse trait function params
-	std::vector<AST::FunctionParam> function_params
+	std::vector<std::unique_ptr<AST::Param>> function_params
 	  = parse_function_params (
 	    [] (TokenId id) { return id == RIGHT_PAREN; });
 
@@ -5075,6 +5085,10 @@ Parser<ManagedTokenSource>::parse_trait_item ()
 	    // skip after somewhere?
 	    return nullptr;
 	  }
+
+	if (initial_param != nullptr)
+	  function_params.insert (function_params.begin (),
+				  std::move (initial_param));
 
 	// parse return type (optional)
 	std::unique_ptr<AST::Type> return_type = parse_function_return_type ();
@@ -5114,7 +5128,6 @@ Parser<ManagedTokenSource>::parse_trait_item ()
 	    AST::TraitMethodDecl method_decl (std::move (ident),
 					      std::move (qualifiers),
 					      std::move (generic_params),
-					      std::move (self_param),
 					      std::move (function_params),
 					      std::move (return_type),
 					      std::move (where_clause));
@@ -5592,14 +5605,15 @@ Parser<ManagedTokenSource>::parse_inherent_impl_function_or_method (
 
   // now for function vs method disambiguation - method has opening "self"
   // param
-  AST::SelfParam self_param = parse_self_param ();
+  std::unique_ptr<AST::Param> initial_param = parse_self_param ();
   /* FIXME: ensure that self param doesn't accidently consume tokens for a
    * function one idea is to lookahead up to 4 tokens to see whether self is
    * one of them */
   bool is_method = false;
-  if (!self_param.is_error ())
+  if (initial_param != nullptr)
     {
-      is_method = true;
+      if (initial_param->is_self ())
+	is_method = true;
 
       /* skip comma so function and method regular params can be parsed in
        * same way */
@@ -5608,8 +5622,12 @@ Parser<ManagedTokenSource>::parse_inherent_impl_function_or_method (
     }
 
   // parse trait function params
-  std::vector<AST::FunctionParam> function_params
+  std::vector<std::unique_ptr<AST::Param>> function_params
     = parse_function_params ([] (TokenId id) { return id == RIGHT_PAREN; });
+
+  if (initial_param != nullptr)
+    function_params.insert (function_params.begin (),
+			    std::move (initial_param));
 
   if (!skip_token (RIGHT_PAREN))
     {
@@ -5650,18 +5668,18 @@ Parser<ManagedTokenSource>::parse_inherent_impl_function_or_method (
   // do actual if instead of ternary for return value optimisation
   if (is_method)
     {
-      return std::unique_ptr<AST::Function> (new AST::Function (
-	std::move (ident), std::move (qualifiers), std::move (generic_params),
-	tl::optional<AST::SelfParam> (tl::in_place, std::move (self_param)),
-	std::move (function_params), std::move (return_type),
-	std::move (where_clause), std::move (body), std::move (vis),
-	std::move (outer_attrs), locus));
+      return std::unique_ptr<AST::Function> (
+	new AST::Function (std::move (ident), std::move (qualifiers),
+			   std::move (generic_params),
+			   std::move (function_params), std::move (return_type),
+			   std::move (where_clause), std::move (body),
+			   std::move (vis), std::move (outer_attrs), locus));
     }
   else
     {
       return std::unique_ptr<AST::Function> (
 	new AST::Function (std::move (ident), std::move (qualifiers),
-			   std::move (generic_params), tl::nullopt,
+			   std::move (generic_params),
 			   std::move (function_params), std::move (return_type),
 			   std::move (where_clause), std::move (body),
 			   std::move (vis), std::move (outer_attrs), locus));
@@ -5795,13 +5813,14 @@ Parser<ManagedTokenSource>::parse_trait_impl_function_or_method (
 
   // now for function vs method disambiguation - method has opening "self"
   // param
-  AST::SelfParam self_param = parse_self_param ();
+  std::unique_ptr<AST::Param> initial_param = parse_self_param ();
   // FIXME: ensure that self param doesn't accidently consume tokens for a
   // function
   bool is_method = false;
-  if (!self_param.is_error ())
+  if (initial_param != nullptr)
     {
-      is_method = true;
+      if (initial_param->is_self ())
+	is_method = true;
 
       // skip comma so function and method regular params can be parsed in
       // same way
@@ -5819,7 +5838,7 @@ Parser<ManagedTokenSource>::parse_trait_impl_function_or_method (
     "started to parse function params in function or method trait impl item");
 
   // parse trait function params (only if next token isn't right paren)
-  std::vector<AST::FunctionParam> function_params;
+  std::vector<std::unique_ptr<AST::Param>> function_params;
   if (lexer.peek_token ()->get_id () != RIGHT_PAREN)
     {
       function_params
@@ -5837,6 +5856,10 @@ Parser<ManagedTokenSource>::parse_trait_impl_function_or_method (
 	  return nullptr;
 	}
     }
+
+  if (initial_param != nullptr)
+    function_params.insert (function_params.begin (),
+			    std::move (initial_param));
 
   // DEBUG
   rust_debug ("successfully parsed function params in function or method "
@@ -5886,24 +5909,12 @@ Parser<ManagedTokenSource>::parse_trait_impl_function_or_method (
       return nullptr;
     }
 
-  // do actual if instead of ternary for return value optimisation
-  if (is_method)
-    {
-      return std::unique_ptr<AST::Function> (new AST::Function (
-	std::move (ident), std::move (qualifiers), std::move (generic_params),
-	tl::optional<AST::SelfParam> (tl::in_place, std::move (self_param)),
-	std::move (function_params), std::move (return_type),
-	std::move (where_clause), std::move (body), std::move (vis),
-	std::move (outer_attrs), locus, is_default));
-    }
-  else
-    {
-      return std::unique_ptr<AST::Function> (new AST::Function (
-	std::move (ident), std::move (qualifiers), std::move (generic_params),
-	tl::nullopt, std::move (function_params), std::move (return_type),
-	std::move (where_clause), std::move (body), std::move (vis),
-	std::move (outer_attrs), locus, is_default));
-    }
+  return std::unique_ptr<AST::Function> (
+    new AST::Function (std::move (ident), std::move (qualifiers),
+		       std::move (generic_params), std::move (function_params),
+		       std::move (return_type), std::move (where_clause),
+		       std::move (body), std::move (vis),
+		       std::move (outer_attrs), locus, is_default));
 }
 
 // Parses an extern block of declarations.
@@ -7097,13 +7108,49 @@ Parser<ManagedTokenSource>::parse_qualified_path_in_type ()
 
 // Parses a self param. Also handles self param not existing.
 template <typename ManagedTokenSource>
-AST::SelfParam
+std::unique_ptr<AST::Param>
 Parser<ManagedTokenSource>::parse_self_param ()
 {
   bool has_reference = false;
   AST::Lifetime lifetime = AST::Lifetime::error ();
 
   location_t locus = lexer.peek_token ()->get_locus ();
+
+  // TODO: Feels off, find a better way to clearly express this
+  std::vector<std::vector<TokenId>> ptrs
+    = {{ASTERISK, SELF} /* *self */,
+       {ASTERISK, CONST, SELF} /* *const self */,
+       {ASTERISK, MUT, SELF} /* *mut self */};
+
+  for (auto &s : ptrs)
+    {
+      size_t i = 0;
+      for (i = 0; i > s.size (); i++)
+	if (lexer.peek_token (i)->get_id () != s[i])
+	  break;
+      if (i == s.size ())
+	rust_error_at (lexer.peek_token ()->get_locus (),
+		       "cannot pass %<self%> by raw pointer");
+    }
+
+  // Trying to find those patterns:
+  //
+  // &'lifetime mut self
+  // &'lifetime self
+  // & mut self
+  // & self
+  // mut self
+  // self
+  //
+  // If not found, it is probably a function, exit and let function parsing
+  // handle it.
+  bool is_self = false;
+  for (size_t i = 0; i < 5; i++)
+    if (lexer.peek_token (i)->get_id () == SELF)
+      is_self = true;
+
+  if (!is_self)
+    return nullptr;
 
   // test if self is a reference parameter
   if (lexer.peek_token ()->get_id () == AMP)
@@ -7124,7 +7171,7 @@ Parser<ManagedTokenSource>::parse_self_param ()
 	      add_error (std::move (error));
 
 	      // skip after somewhere?
-	      return AST::SelfParam::create_error ();
+	      return nullptr;
 	    }
 	}
     }
@@ -7142,7 +7189,7 @@ Parser<ManagedTokenSource>::parse_self_param ()
   if (self_tok->get_id () != SELF)
     {
       // skip after somewhere?
-      return AST::SelfParam::create_error ();
+      return nullptr;
     }
   lexer.skip_token ();
 
@@ -7161,7 +7208,7 @@ Parser<ManagedTokenSource>::parse_self_param ()
 	  add_error (std::move (error));
 
 	  // skip after somewhere?
-	  return AST::SelfParam::create_error ();
+	  return nullptr;
 	}
     }
 
@@ -7174,114 +7221,20 @@ Parser<ManagedTokenSource>::parse_self_param ()
       add_error (std::move (error));
 
       // skip after somewhere?
-      return AST::SelfParam::create_error ();
+      return nullptr;
     }
 
   if (has_reference)
     {
-      return AST::SelfParam (std::move (lifetime), has_mut, locus);
+      return Rust::make_unique<AST::SelfParam> (std::move (lifetime), has_mut,
+						locus);
     }
   else
     {
       // note that type may be nullptr here and that's fine
-      return AST::SelfParam (std::move (type), has_mut, locus);
+      return Rust::make_unique<AST::SelfParam> (std::move (type), has_mut,
+						locus);
     }
-}
-
-/* Parses a method. Note that this function is probably useless because using
- * lookahead to determine whether a function is a method is a PITA (maybe not
- * even doable), so most places probably parse a "function or method" and then
- * resolve it into whatever it is afterward. As such, this is only here for
- * algorithmically defining the grammar rule. */
-template <typename ManagedTokenSource>
-std::unique_ptr<AST::Function>
-Parser<ManagedTokenSource>::parse_method ()
-{
-  location_t locus = lexer.peek_token ()->get_locus ();
-  /* Note: as a result of the above, this will not attempt to disambiguate a
-   * function parse qualifiers */
-  AST::FunctionQualifiers qualifiers = parse_function_qualifiers ();
-
-  skip_token (FN_TOK);
-
-  const_TokenPtr ident_tok = expect_token (IDENTIFIER);
-  if (ident_tok == nullptr)
-    {
-      skip_after_next_block ();
-      return nullptr;
-    }
-  Identifier method_name{ident_tok};
-
-  // parse generic params - if exist
-  std::vector<std::unique_ptr<AST::GenericParam>> generic_params
-    = parse_generic_params_in_angles ();
-
-  if (!skip_token (LEFT_PAREN))
-    {
-      Error error (lexer.peek_token ()->get_locus (),
-		   "method missing opening parentheses before parameter list");
-      add_error (std::move (error));
-
-      skip_after_next_block ();
-      return nullptr;
-    }
-
-  // parse self param
-  AST::SelfParam self_param = parse_self_param ();
-  if (self_param.is_error ())
-    {
-      Error error (lexer.peek_token ()->get_locus (),
-		   "could not parse self param in method");
-      add_error (std::move (error));
-
-      skip_after_next_block ();
-      return nullptr;
-    }
-
-  // skip comma if it exists
-  if (lexer.peek_token ()->get_id () == COMMA)
-    lexer.skip_token ();
-
-  // parse function parameters
-  std::vector<AST::FunctionParam> function_params
-    = parse_function_params ([] (TokenId id) { return id == RIGHT_PAREN; });
-
-  if (!skip_token (RIGHT_PAREN))
-    {
-      Error error (lexer.peek_token ()->get_locus (),
-		   "method declaration missing closing parentheses after "
-		   "parameter list");
-      add_error (std::move (error));
-
-      skip_after_next_block ();
-      return nullptr;
-    }
-
-  // parse function return type - if exists
-  std::unique_ptr<AST::Type> return_type = parse_function_return_type ();
-
-  // parse where clause - if exists
-  AST::WhereClause where_clause = parse_where_clause ();
-
-  // parse block expression
-  std::unique_ptr<AST::BlockExpr> block_expr = parse_block_expr ();
-  if (block_expr == nullptr)
-    {
-      Error error (lexer.peek_token ()->get_locus (),
-		   "method declaration missing block expression");
-      add_error (std::move (error));
-
-      skip_after_end_block ();
-      return nullptr;
-    }
-
-  // does not parse visibility, but this method isn't used, so doesn't matter
-  return std::unique_ptr<AST::Function> (new AST::Function (
-    std::move (method_name), std::move (qualifiers), std::move (generic_params),
-    tl::optional<AST::SelfParam> (tl::in_place, std::move (self_param)),
-    std::move (function_params), std::move (return_type),
-    std::move (where_clause), std::move (block_expr),
-    AST::Visibility::create_error (), AST::AttrVec (), locus));
 }
 
 /* Parses an expression or macro statement. */

--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -164,7 +164,7 @@ public:
   std::unique_ptr<AST::InherentImplItem> parse_inherent_impl_item ();
   std::unique_ptr<AST::TraitImplItem> parse_trait_impl_item ();
   AST::PathInExpression parse_path_in_expression ();
-  std::vector<std::unique_ptr<AST::LifetimeParam> > parse_lifetime_params ();
+  std::vector<std::unique_ptr<AST::LifetimeParam>> parse_lifetime_params ();
   AST::Visibility parse_visibility ();
   std::unique_ptr<AST::IdentifierPattern> parse_identifier_pattern ();
   std::unique_ptr<AST::Token> parse_identifier_or_keyword_token ();
@@ -246,17 +246,17 @@ private:
   std::unique_ptr<AST::Function> parse_function (AST::Visibility vis,
 						 AST::AttrVec outer_attrs);
   AST::FunctionQualifiers parse_function_qualifiers ();
-  std::vector<std::unique_ptr<AST::GenericParam> >
+  std::vector<std::unique_ptr<AST::GenericParam>>
   parse_generic_params_in_angles ();
   template <typename EndTokenPred>
-  std::vector<std::unique_ptr<AST::GenericParam> >
+  std::vector<std::unique_ptr<AST::GenericParam>>
   parse_generic_params (EndTokenPred is_end_token);
   template <typename EndTokenPred>
   std::unique_ptr<AST::GenericParam>
   parse_generic_param (EndTokenPred is_end_token);
 
   template <typename EndTokenPred>
-  std::vector<std::unique_ptr<AST::LifetimeParam> >
+  std::vector<std::unique_ptr<AST::LifetimeParam>>
   parse_lifetime_params (EndTokenPred is_end_token);
   std::vector<AST::LifetimeParam> parse_lifetime_params_objs ();
   template <typename EndTokenPred>
@@ -268,15 +268,15 @@ private:
     std::string error_msg = "failed to parse generic param in generic params")
     -> std::vector<decltype (parsing_function ())>;
   AST::LifetimeParam parse_lifetime_param ();
-  std::vector<std::unique_ptr<AST::TypeParam> > parse_type_params ();
+  std::vector<std::unique_ptr<AST::TypeParam>> parse_type_params ();
   template <typename EndTokenPred>
-  std::vector<std::unique_ptr<AST::TypeParam> >
+  std::vector<std::unique_ptr<AST::TypeParam>>
   parse_type_params (EndTokenPred is_end_token);
   std::unique_ptr<AST::TypeParam> parse_type_param ();
   template <typename EndTokenPred>
-  std::vector<AST::FunctionParam>
+  std::vector<std::unique_ptr<AST::Param>>
   parse_function_params (EndTokenPred is_end_token);
-  AST::FunctionParam parse_function_param ();
+  std::unique_ptr<AST::Param> parse_function_param ();
   std::unique_ptr<AST::Type> parse_function_return_type ();
   AST::WhereClause parse_where_clause ();
   std::unique_ptr<AST::WhereClauseItem> parse_where_clause_item ();
@@ -286,9 +286,9 @@ private:
   parse_type_bound_where_clause_item ();
   std::vector<AST::LifetimeParam> parse_for_lifetimes ();
   template <typename EndTokenPred>
-  std::vector<std::unique_ptr<AST::TypeParamBound> >
+  std::vector<std::unique_ptr<AST::TypeParamBound>>
   parse_type_param_bounds (EndTokenPred is_end_token);
-  std::vector<std::unique_ptr<AST::TypeParamBound> > parse_type_param_bounds ();
+  std::vector<std::unique_ptr<AST::TypeParamBound>> parse_type_param_bounds ();
   std::unique_ptr<AST::TypeParamBound> parse_type_param_bound ();
   std::unique_ptr<AST::TraitBound> parse_trait_bound ();
   std::vector<AST::Lifetime> parse_lifetime_bounds ();
@@ -317,9 +317,9 @@ private:
   AST::TupleField parse_tuple_field ();
   std::unique_ptr<AST::Enum> parse_enum (AST::Visibility vis,
 					 AST::AttrVec outer_attrs);
-  std::vector<std::unique_ptr<AST::EnumItem> > parse_enum_items ();
+  std::vector<std::unique_ptr<AST::EnumItem>> parse_enum_items ();
   template <typename EndTokenPred>
-  std::vector<std::unique_ptr<AST::EnumItem> >
+  std::vector<std::unique_ptr<AST::EnumItem>>
   parse_enum_items (EndTokenPred is_end_token);
   std::unique_ptr<AST::EnumItem> parse_enum_item ();
   std::unique_ptr<AST::Union> parse_union (AST::Visibility vis,
@@ -334,7 +334,7 @@ private:
   parse_trait_type (AST::AttrVec outer_attrs);
   std::unique_ptr<AST::TraitItemConst>
   parse_trait_const (AST::AttrVec outer_attrs);
-  AST::SelfParam parse_self_param ();
+  std::unique_ptr<AST::Param> parse_self_param ();
   std::unique_ptr<AST::Impl> parse_impl (AST::Visibility vis,
 					 AST::AttrVec outer_attrs);
   std::unique_ptr<AST::InherentImplItem>
@@ -594,7 +594,7 @@ private:
   parse_match_expr (AST::AttrVec outer_attrs = AST::AttrVec (),
 		    location_t pratt_parsed_loc = UNKNOWN_LOCATION);
   AST::MatchArm parse_match_arm ();
-  std::vector<std::unique_ptr<AST::Pattern> >
+  std::vector<std::unique_ptr<AST::Pattern>>
   parse_match_arm_patterns (TokenId end_token_id);
   std::unique_ptr<AST::Expr> parse_labelled_loop_expr (const_TokenPtr tok,
 						       AST::AttrVec outer_attrs
@@ -692,7 +692,7 @@ public:
 
   // Parse items without parsing an entire crate. This function is the main
   // parsing loop of AST::Crate::parse_crate().
-  std::vector<std::unique_ptr<AST::Item> > parse_items ();
+  std::vector<std::unique_ptr<AST::Item>> parse_items ();
 
   // Main entry point for parser.
   std::unique_ptr<AST::Crate> parse_crate ();

--- a/gcc/rust/resolve/rust-ast-resolve-base.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-base.cc
@@ -646,5 +646,17 @@ void
 ResolverBase::visit (AST::BareFunctionType &)
 {}
 
+void
+ResolverBase::visit (AST::SelfParam &)
+{}
+
+void
+ResolverBase::visit (AST::VariadicParam &)
+{}
+
+void
+ResolverBase::visit (AST::FunctionParam &)
+{}
+
 } // namespace Resolver
 } // namespace Rust

--- a/gcc/rust/resolve/rust-ast-resolve-base.h
+++ b/gcc/rust/resolve/rust-ast-resolve-base.h
@@ -196,6 +196,9 @@ public:
   void visit (AST::SliceType &);
   void visit (AST::InferredType &);
   void visit (AST::BareFunctionType &);
+  void visit (AST::FunctionParam &param);
+  void visit (AST::VariadicParam &param);
+  void visit (AST::SelfParam &param);
 
 protected:
   ResolverBase ()

--- a/gcc/rust/resolve/rust-ast-resolve-expr.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.cc
@@ -452,7 +452,7 @@ ResolveExpr::visit (AST::BreakExpr &expr)
 {
   if (expr.has_label ())
     {
-      auto label = expr.get_label ();
+      auto label = expr.get_label ().get_lifetime ();
       if (label.get_lifetime_type () != AST::Lifetime::LifetimeType::NAMED)
 	{
 	  rust_error_at (label.get_locus (),
@@ -466,7 +466,7 @@ ResolveExpr::visit (AST::BreakExpr &expr)
 				    label.get_lifetime_name ()),
 	    &resolved_node))
 	{
-	  rust_error_at (expr.get_label ().get_locus (), ErrorCode::E0426,
+	  rust_error_at (label.get_locus (), ErrorCode::E0426,
 			 "use of undeclared label %qs in %<break%>",
 			 label.get_lifetime_name ().c_str ());
 	  return;

--- a/gcc/rust/resolve/rust-ast-resolve-item.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-item.cc
@@ -17,11 +17,13 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-ast-resolve-item.h"
+#include "rust-ast-full-decls.h"
 #include "rust-ast-resolve-toplevel.h"
 #include "rust-ast-resolve-type.h"
 #include "rust-ast-resolve-pattern.h"
 #include "rust-ast-resolve-path.h"
 
+#include "rust-item.h"
 #include "selftest.h"
 
 namespace Rust {
@@ -87,11 +89,26 @@ ResolveTraitItems::visit (AST::TraitItemFunc &func)
 
   // we make a new scope so the names of parameters are resolved and shadowed
   // correctly
-  for (auto &param : function.get_function_params ())
+  for (auto &p : function.get_function_params ())
     {
-      ResolveType::go (param.get_type ().get ());
-      PatternDeclaration::go (param.get_pattern ().get (), Rib::ItemType::Param,
-			      bindings);
+      if (p->is_variadic ())
+	{
+	  auto param = static_cast<AST::VariadicParam *> (p.get ());
+	  PatternDeclaration::go (param->get_pattern ().get (),
+				  Rib::ItemType::Param, bindings);
+	}
+      else if (p->is_self ())
+	{
+	  auto param = static_cast<AST::SelfParam *> (p.get ());
+	  ResolveType::go (param->get_type ().get ());
+	}
+      else
+	{
+	  auto param = static_cast<AST::FunctionParam *> (p.get ());
+	  ResolveType::go (param->get_type ().get ());
+	  PatternDeclaration::go (param->get_pattern ().get (),
+				  Rib::ItemType::Param, bindings);
+	}
     }
 
   if (function.has_where_clause ())
@@ -133,43 +150,55 @@ ResolveTraitItems::visit (AST::TraitItemMethod &func)
     ResolveType::go (function.get_return_type ().get ());
 
   // self turns into (self: Self) as a function param
-  AST::SelfParam &self_param = function.get_self_param ();
-  // FIXME: which location should be used for Rust::Identifier `self`?
-  AST::IdentifierPattern self_pattern (self_param.get_node_id (), {"self"},
-				       self_param.get_locus (),
-				       self_param.get_has_ref (),
-				       self_param.get_is_mut (),
-				       std::unique_ptr<AST::Pattern> (nullptr));
-  PatternDeclaration::go (&self_pattern, Rib::ItemType::Param);
-
-  if (self_param.has_type ())
-    {
-      // This shouldn't happen the parser should already error for this
-      rust_assert (!self_param.get_has_ref ());
-      ResolveType::go (self_param.get_type ().get ());
-    }
-  else
-    {
-      // here we implicitly make self have a type path of Self
-      std::vector<std::unique_ptr<AST::TypePathSegment>> segments;
-      segments.push_back (std::unique_ptr<AST::TypePathSegment> (
-	new AST::TypePathSegment ("Self", false, self_param.get_locus ())));
-
-      AST::TypePath self_type_path (std::move (segments),
-				    self_param.get_locus ());
-      ResolveType::go (&self_type_path);
-    }
-
   std::vector<PatternBinding> bindings
     = {PatternBinding (PatternBoundCtx::Product, std::set<Identifier> ())};
 
   // we make a new scope so the names of parameters are resolved and shadowed
   // correctly
-  for (auto &param : function.get_function_params ())
+  for (auto &p : function.get_function_params ())
     {
-      ResolveType::go (param.get_type ().get ());
-      PatternDeclaration::go (param.get_pattern ().get (), Rib::ItemType::Param,
-			      bindings);
+      if (p->is_variadic ())
+	{
+	  auto param = static_cast<AST::VariadicParam *> (p.get ());
+	  PatternDeclaration::go (param->get_pattern ().get (),
+				  Rib::ItemType::Param, bindings);
+	}
+      else if (p->is_self ())
+	{
+	  auto param = static_cast<AST::SelfParam *> (p.get ());
+	  // FIXME: which location should be used for Rust::Identifier `self`?
+	  AST::IdentifierPattern self_pattern (
+	    param->get_node_id (), {"self"}, param->get_locus (),
+	    param->get_has_ref (), param->get_is_mut (),
+	    std::unique_ptr<AST::Pattern> (nullptr));
+
+	  PatternDeclaration::go (&self_pattern, Rib::ItemType::Param);
+
+	  if (param->has_type ())
+	    {
+	      // This shouldn't happen the parser should already error for this
+	      rust_assert (!param->get_has_ref ());
+	      ResolveType::go (param->get_type ().get ());
+	    }
+	  else
+	    {
+	      // here we implicitly make self have a type path of Self
+	      std::vector<std::unique_ptr<AST::TypePathSegment>> segments;
+	      segments.push_back (std::unique_ptr<AST::TypePathSegment> (
+		new AST::TypePathSegment ("Self", false, param->get_locus ())));
+
+	      AST::TypePath self_type_path (std::move (segments),
+					    param->get_locus ());
+	      ResolveType::go (&self_type_path);
+	    }
+	}
+      else
+	{
+	  auto param = static_cast<AST::FunctionParam *> (p.get ());
+	  ResolveType::go (param->get_type ().get ());
+	  PatternDeclaration::go (param->get_pattern ().get (),
+				  Rib::ItemType::Param, bindings);
+	}
     }
 
   if (function.has_where_clause ())
@@ -527,29 +556,32 @@ ResolveItem::visit (AST::Function &function)
   if (function.has_self_param ())
     {
       // self turns into (self: Self) as a function param
-      AST::SelfParam &self_param = function.get_self_param ();
+      std::unique_ptr<AST::Param> &s_param = function.get_self_param ();
+      auto self_param = static_cast<AST::SelfParam *> (s_param.get ());
+
       // FIXME: which location should be used for Rust::Identifier `self`?
       AST::IdentifierPattern self_pattern (
-	self_param.get_node_id (), {"self"}, self_param.get_locus (),
-	self_param.get_has_ref (), self_param.get_is_mut (),
+	self_param->get_node_id (), {"self"}, self_param->get_locus (),
+	self_param->get_has_ref (), self_param->get_is_mut (),
 	std::unique_ptr<AST::Pattern> (nullptr));
       PatternDeclaration::go (&self_pattern, Rib::ItemType::Param);
 
-      if (self_param.has_type ())
+      if (self_param->has_type ())
 	{
 	  // This shouldn't happen the parser should already error for this
-	  rust_assert (!self_param.get_has_ref ());
-	  ResolveType::go (self_param.get_type ().get ());
+	  rust_assert (!self_param->get_has_ref ());
+	  ResolveType::go (self_param->get_type ().get ());
 	}
       else
 	{
 	  // here we implicitly make self have a type path of Self
 	  std::vector<std::unique_ptr<AST::TypePathSegment>> segments;
 	  segments.push_back (std::unique_ptr<AST::TypePathSegment> (
-	    new AST::TypePathSegment ("Self", false, self_param.get_locus ())));
+	    new AST::TypePathSegment ("Self", false,
+				      self_param->get_locus ())));
 
 	  AST::TypePath self_type_path (std::move (segments),
-					self_param.get_locus ());
+					self_param->get_locus ());
 	  ResolveType::go (&self_type_path);
 	}
     }
@@ -559,11 +591,28 @@ ResolveItem::visit (AST::Function &function)
 
   // we make a new scope so the names of parameters are resolved and shadowed
   // correctly
-  for (auto &param : function.get_function_params ())
+  for (auto &p : function.get_function_params ())
     {
-      ResolveType::go (param.get_type ().get ());
-      PatternDeclaration::go (param.get_pattern ().get (), Rib::ItemType::Param,
-			      bindings);
+      if (p->is_variadic ())
+	{
+	  auto param = static_cast<AST::VariadicParam *> (p.get ());
+	  if (param->has_pattern ())
+	    PatternDeclaration::go (param->get_pattern ().get (),
+				    Rib::ItemType::Param, bindings);
+	}
+      else if (p->is_self ())
+	{
+	  auto param = static_cast<AST::SelfParam *> (p.get ());
+	  if (param->has_type ())
+	    ResolveType::go (param->get_type ().get ());
+	}
+      else
+	{
+	  auto param = static_cast<AST::FunctionParam *> (p.get ());
+	  ResolveType::go (param->get_type ().get ());
+	  PatternDeclaration::go (param->get_pattern ().get (),
+				  Rib::ItemType::Param, bindings);
+	}
     }
 
   // resolve the function body

--- a/gcc/rust/resolve/rust-default-resolver.h
+++ b/gcc/rust/resolve/rust-default-resolver.h
@@ -197,6 +197,9 @@ public:
   void visit (AST::SliceType &);
   void visit (AST::InferredType &);
   void visit (AST::BareFunctionType &);
+  void visit (AST::FunctionParam &);
+  void visit (AST::VariadicParam &);
+  void visit (AST::SelfParam &);
 
 protected:
   DefaultResolver (NameResolutionContext &ctx) : ctx (ctx) {}

--- a/gcc/rust/resolve/rust-early-name-resolver.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver.cc
@@ -662,11 +662,8 @@ EarlyNameResolver::visit (AST::Function &function)
     for (auto &generic : function.get_generic_params ())
       generic->accept_vis (*this);
 
-  if (function.has_self_param () && function.get_self_param ().has_type ())
-    function.get_self_param ().get_type ()->accept_vis (*this);
-
-  for (auto &param : function.get_function_params ())
-    param.get_type ()->accept_vis (*this);
+  for (auto &p : function.get_function_params ())
+    p->accept_vis (*this);
 
   if (function.has_return_type ())
     function.get_return_type ()->accept_vis (*this);
@@ -758,8 +755,8 @@ EarlyNameResolver::visit (AST::TraitItemFunc &item)
   for (auto &generic : decl.get_generic_params ())
     generic->accept_vis (*this);
 
-  for (auto &param : decl.get_function_params ())
-    param.get_type ()->accept_vis (*this);
+  for (auto &p : decl.get_function_params ())
+    p->accept_vis (*this);
 
   if (item.has_definition ())
     item.get_definition ()->accept_vis (*this);
@@ -777,8 +774,8 @@ EarlyNameResolver::visit (AST::TraitItemMethod &item)
   for (auto &generic : decl.get_generic_params ())
     generic->accept_vis (*this);
 
-  for (auto &param : decl.get_function_params ())
-    param.get_type ()->accept_vis (*this);
+  for (auto &p : decl.get_function_params ())
+    p->accept_vis (*this);
 
   if (item.has_definition ())
     item.get_definition ()->accept_vis (*this);
@@ -1230,6 +1227,29 @@ EarlyNameResolver::visit (AST::BareFunctionType &type)
 
   if (type.has_return_type ())
     type.get_return_type ()->accept_vis (*this);
+}
+
+void
+EarlyNameResolver::visit (AST::VariadicParam &param)
+{
+  if (param.has_pattern ())
+    param.get_pattern ()->accept_vis (*this);
+}
+
+void
+EarlyNameResolver::visit (AST::FunctionParam &param)
+{
+  param.get_pattern ()->accept_vis (*this);
+  param.get_type ()->accept_vis (*this);
+}
+
+void
+EarlyNameResolver::visit (AST::SelfParam &param)
+{
+  if (param.has_type ())
+    param.get_type ()->accept_vis (*this);
+  if (param.has_lifetime ())
+    param.get_lifetime ().accept_vis (*this);
 }
 
 } // namespace Resolver

--- a/gcc/rust/resolve/rust-early-name-resolver.h
+++ b/gcc/rust/resolve/rust-early-name-resolver.h
@@ -277,6 +277,10 @@ private:
   virtual void visit (AST::SliceType &type);
   virtual void visit (AST::InferredType &type);
   virtual void visit (AST::BareFunctionType &type);
+
+  virtual void visit (AST::VariadicParam &type);
+  virtual void visit (AST::FunctionParam &type);
+  virtual void visit (AST::SelfParam &type);
 };
 
 } // namespace Resolver

--- a/gcc/rust/util/rust-attribute-values.h
+++ b/gcc/rust/util/rust-attribute-values.h
@@ -1,5 +1,23 @@
-#ifndef RUST_ATTRIBUTES_VALUE_H
-#define RUST_ATTRIBUTES_VALUE_H
+// Copyright (C) 2020-2023 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_ATTRIBUTE_VALUES_H
+#define RUST_ATTRIBUTE_VALUES_H
 
 namespace Rust {
 namespace Values {
@@ -37,4 +55,4 @@ public:
 } // namespace Values
 } // namespace Rust
 
-#endif /* !RUST_ATTRIBUTES_VALUE_H */
+#endif /* !RUST_ATTRIBUTE_VALUES_H */

--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -996,5 +996,17 @@ void
 AttributeChecker::visit (AST::BareFunctionType &)
 {}
 
+void
+AttributeChecker::visit (AST::SelfParam &)
+{}
+
+void
+AttributeChecker::visit (AST::VariadicParam &)
+{}
+
+void
+AttributeChecker::visit (AST::FunctionParam &)
+{}
+
 } // namespace Analysis
 } // namespace Rust

--- a/gcc/rust/util/rust-attributes.h
+++ b/gcc/rust/util/rust-attributes.h
@@ -264,6 +264,9 @@ private:
   void visit (AST::SliceType &type);
   void visit (AST::InferredType &type);
   void visit (AST::BareFunctionType &type);
+  void visit (AST::FunctionParam &param);
+  void visit (AST::VariadicParam &param);
+  void visit (AST::SelfParam &param);
 };
 
 } // namespace Analysis

--- a/gcc/rust/util/rust-keyword-values.cc
+++ b/gcc/rust/util/rust-keyword-values.cc
@@ -1,0 +1,33 @@
+// Copyright (C) 2020-2023 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-keyword-values.h"
+
+namespace Rust {
+namespace Values {
+
+const std::set<std::string> Keywords::keywords = {
+#define RS_TOKEN(x, y)
+#define RS_TOKEN_KEYWORD(tok, key) key,
+  RS_TOKEN_LIST
+#undef RS_TOKEN_KEYWORD
+#undef RS_TOKEN
+};
+
+} // namespace Values
+} // namespace Rust

--- a/gcc/rust/util/rust-keyword-values.cc
+++ b/gcc/rust/util/rust-keyword-values.cc
@@ -17,17 +17,26 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-keyword-values.h"
+#include "rust-token.h"
 
 namespace Rust {
 namespace Values {
 
-const std::set<std::string> Keywords::keywords = {
+// TODO: Can't we do this inline ?
+static std::map<std::string, TokenId>
+get_keywords ()
+{
+  std::map<std::string, TokenId> m = {
 #define RS_TOKEN(x, y)
-#define RS_TOKEN_KEYWORD(tok, key) key,
-  RS_TOKEN_LIST
+#define RS_TOKEN_KEYWORD(tok, key) {key, tok},
+    RS_TOKEN_LIST
 #undef RS_TOKEN_KEYWORD
 #undef RS_TOKEN
-};
+  };
+  return m;
+}
+
+const std::map<std::string, TokenId> Keywords::keywords = get_keywords ();
 
 } // namespace Values
 } // namespace Rust

--- a/gcc/rust/util/rust-keyword-values.h
+++ b/gcc/rust/util/rust-keyword-values.h
@@ -1,0 +1,45 @@
+// Copyright (C) 2020-2023 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_KEYWORD_VALUES_H
+#define RUST_KEYWORD_VALUES_H
+
+#include "rust-token.h"
+
+namespace Rust {
+namespace Values {
+
+// TODO: Change this to a namespace + inline constexpr in the future
+class Keywords
+{
+public:
+  const static std::set<std::string> keywords;
+
+  // Rust keyword values
+public:
+#define RS_TOKEN(x, y)
+#define RS_TOKEN_KEYWORD(tok, key) static constexpr auto &tok = key;
+  RS_TOKEN_LIST
+#undef RS_TOKEN_KEYWORD
+#undef RS_TOKEN
+};
+
+} // namespace Values
+} // namespace Rust
+
+#endif /* !RUST_KEYWORD_VALUES_H */

--- a/gcc/rust/util/rust-keyword-values.h
+++ b/gcc/rust/util/rust-keyword-values.h
@@ -28,7 +28,7 @@ namespace Values {
 class Keywords
 {
 public:
-  const static std::set<std::string> keywords;
+  const static std::map<std::string, TokenId> keywords;
 
   // Rust keyword values
 public:

--- a/gcc/testsuite/rust/compile/invalid_label_name.rs
+++ b/gcc/testsuite/rust/compile/invalid_label_name.rs
@@ -1,0 +1,23 @@
+pub fn function() {
+    'continue: loop {
+        // { dg-error "invalid label name .'continue." "" { target *-*-* } .-1 }
+        break 'extern;
+        // { dg-error "invalid label name .'extern." "" { target *-*-* } .-1 }
+    }
+
+    'break: loop {
+        // { dg-error "invalid label name .'break." "" { target *-*-* } .-1 }
+        break 'for;
+        // { dg-error "invalid label name .'for." "" { target *-*-* } .-1 }
+    }
+
+    'crate: loop {
+        // { dg-error "invalid label name .'crate." "" { target *-*-* } .-1 }
+        break 'loop;
+        // { dg-error "invalid label name .'loop." "" { target *-*-* } .-1 }
+    }
+
+    'a: loop {
+        break 'a;
+    }
+}

--- a/gcc/testsuite/rust/compile/invalid_variadics.rs
+++ b/gcc/testsuite/rust/compile/invalid_variadics.rs
@@ -1,0 +1,6 @@
+extern "C" {
+    pub fn dog(b: i32, a: ..., c: i32);
+    // { dg-error "..... must be the last argument of a C-variadic function" "" { target *-*-* } .-1 }
+    pub fn cat(a: ...);
+    // { dg-error "C-variadic function must be declared with at least one named argument" "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/compile/lifetime_name_validation.rs
+++ b/gcc/testsuite/rust/compile/lifetime_name_validation.rs
@@ -1,0 +1,6 @@
+pub fn one<'continue>() {} // { dg-error "lifetimes cannot use keyword names" }
+pub fn two<'_>() {}
+
+pub fn three<'static>() {}
+
+pub fn four<'loop>() {} // { dg-error "lifetimes cannot use keyword names" }


### PR DESCRIPTION
The grammar let slip some invalid rust code (on purpose). We need to reject this invalid code in a later pass.

Fixes #2710 
Fixes #2711 