### PR TITLE
Added support to Parse ASYNC function

### DIFF
--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -357,6 +357,8 @@ private:
   std::unique_ptr<AST::ExternBlock>
   parse_extern_block (AST::Visibility vis, AST::AttrVec outer_attrs);
   std::unique_ptr<AST::Function> parse_method ();
+  std::unique_ptr<AST::Function> parse_async_item (AST::Visibility vis,
+						   AST::AttrVec outer_attrs);
 
   // Expression-related (Pratt parsed)
   std::unique_ptr<AST::Expr>

--- a/gcc/testsuite/rust/compile/issue-2650-1.rs
+++ b/gcc/testsuite/rust/compile/issue-2650-1.rs
@@ -1,0 +1,5 @@
+// { dg-additional-options "-frust-edition=2018" }
+
+pub async fn a() -> u32 {
+    1
+}

--- a/gcc/testsuite/rust/compile/issue-2650-2.rs
+++ b/gcc/testsuite/rust/compile/issue-2650-2.rs
@@ -1,0 +1,5 @@
+// { dg-additional-options "-frust-edition=2015" }
+
+pub async fn a() -> u32 { // { dg-error "'async fn' is not permitted in Rust 2015" }
+    1
+}


### PR DESCRIPTION
Fixes issue #2650 
The parser now parses ASYNC functions.
gcc/rust/ChangeLog:

	* parse/rust-parse-impl.h (Parser::parse_item):Added ASYNC case.
	(Parser::parse_vis_item):Added a switch case to handle ASYNC.

gcc/testsuite/ChangeLog:

	* rust/compile/issue-2650.rs: New test.

Signed-off-by : M V V S Manoj Kumar <mvvsmanojkumar@gmail.com>