### PR TITLE
Add ForeverStack APIs for Name Resolution 2.0

### DIFF
--- a/gcc/rust/ast/rust-ast-collector.cc
+++ b/gcc/rust/ast/rust-ast-collector.cc
@@ -191,7 +191,7 @@ TokenCollector::visit (SimplePathSegment &segment)
     {
       push (Rust::Token::make (SUPER, segment.get_locus ()));
     }
-  else if (segment.is_lower_self ())
+  else if (segment.is_lower_self_seg ())
     {
       push (Rust::Token::make (SELF, segment.get_locus ()));
     }

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -399,7 +399,7 @@ public:
   {
     return as_string ().compare ("crate") == 0;
   }
-  bool is_lower_self () const { return as_string ().compare ("self") == 0; }
+  bool is_lower_self_seg () const { return as_string ().compare ("self") == 0; }
   bool is_big_self () const { return as_string ().compare ("Self") == 0; }
 };
 

--- a/gcc/rust/ast/rust-path.h
+++ b/gcc/rust/ast/rust-path.h
@@ -536,6 +536,7 @@ public:
   {
     return !has_generic_args () && get_ident_segment ().is_crate_segment ();
   }
+
   bool is_lower_self_seg () const
   {
     return !has_generic_args () && get_ident_segment ().is_lower_self ();
@@ -644,6 +645,14 @@ public:
   void set_outer_attrs (std::vector<Attribute> new_attrs) override
   {
     outer_attrs = std::move (new_attrs);
+  }
+
+  NodeId get_pattern_node_id () const { return get_node_id (); }
+
+  PathExprSegment &get_final_segment () { return get_segments ().back (); }
+  const PathExprSegment &get_final_segment () const
+  {
+    return get_segments ().back ();
   }
 
 protected:

--- a/gcc/rust/resolve/rust-ast-resolve-item.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-item.cc
@@ -1031,7 +1031,7 @@ ResolveItem::visit (AST::UseDeclaration &use_item)
       if (!ok)
 	continue;
 
-      const AST::SimplePathSegment &final_seg = path.get_final_segment ();
+      const AST::SimplePathSegment &final_seg = path.get_segments ().back ();
 
       auto decl
 	= CanonicalPath::new_seg (resolved_node_id, final_seg.as_string ());

--- a/gcc/rust/resolve/rust-ast-resolve-path.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-path.cc
@@ -367,7 +367,7 @@ ResolvePath::resolve_path (AST::SimplePath *expr)
       //   	      is_first_segment ? "true" : "false",
       //   	      is_final_segment ? "true" : "false");
       if (resolved_node_id == UNKNOWN_NODEID && !is_first_segment
-	  && is_final_segment && segment.is_lower_self ())
+	  && is_final_segment && segment.is_lower_self_seg ())
 	{
 	  resolved_node_id = previous_resolved_node_id;
 	}

--- a/gcc/rust/resolve/rust-ast-resolve-path.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-path.cc
@@ -368,9 +368,7 @@ ResolvePath::resolve_path (AST::SimplePath *expr)
       //   	      is_final_segment ? "true" : "false");
       if (resolved_node_id == UNKNOWN_NODEID && !is_first_segment
 	  && is_final_segment && segment.is_lower_self_seg ())
-	{
-	  resolved_node_id = previous_resolved_node_id;
-	}
+	resolved_node_id = previous_resolved_node_id;
 
       // final check
       if (resolved_node_id == UNKNOWN_NODEID)

--- a/gcc/rust/resolve/rust-early-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver-2.0.cc
@@ -131,7 +131,7 @@ Early::visit (AST::MacroInvocation &invoc)
   // we won't have changed `definition` from `nullopt` if there are more
   // than one segments in our path
   if (!definition.has_value ())
-    definition = ctx.macros.resolve_path (path);
+    definition = ctx.macros.resolve_path (path.get_segments ());
 
   // if the definition still does not have a value, then it's an error
   if (!definition.has_value ())
@@ -188,7 +188,8 @@ Early::visit_attributes (std::vector<AST::Attribute> &attrs)
 	  auto traits = attr.get_traits_to_derive ();
 	  for (auto &trait : traits)
 	    {
-	      auto definition = ctx.macros.resolve_path (trait.get ());
+	      auto definition
+		= ctx.macros.resolve_path (trait.get ().get_segments ());
 	      if (!definition.has_value ())
 		{
 		  // FIXME: Change to proper error message
@@ -210,7 +211,8 @@ Early::visit_attributes (std::vector<AST::Attribute> &attrs)
 		 ->lookup_builtin (name)
 		 .is_error ()) // Do not resolve builtins
 	{
-	  auto definition = ctx.macros.resolve_path (attr.get_path ());
+	  auto definition
+	    = ctx.macros.resolve_path (attr.get_path ().get_segments ());
 	  if (!definition.has_value ())
 	    {
 	      // FIXME: Change to proper error message

--- a/gcc/rust/resolve/rust-forever-stack.h
+++ b/gcc/rust/resolve/rust-forever-stack.h
@@ -470,10 +470,13 @@ public:
   /**
    * Resolve a path to its definition in the current `ForeverStack`
    *
+   * // TODO: Add documentation for `segments`
+   *
    * @return a valid option with the NodeId if the path is present in the
    *         current map, an empty one otherwise.
    */
-  template <typename P> tl::optional<NodeId> resolve_path (const P &path);
+  template <typename S>
+  tl::optional<NodeId> resolve_path (const std::vector<S> &segments);
 
   std::string as_debug_string ();
 

--- a/gcc/rust/resolve/rust-forever-stack.h
+++ b/gcc/rust/resolve/rust-forever-stack.h
@@ -473,7 +473,7 @@ public:
    * @return a valid option with the NodeId if the path is present in the
    *         current map, an empty one otherwise.
    */
-  tl::optional<NodeId> resolve_path (const AST::SimplePath &path);
+  template <typename P> tl::optional<NodeId> resolve_path (const P &path);
 
   std::string as_debug_string ();
 
@@ -550,18 +550,19 @@ private:
 
   /* Helper types and functions for `resolve_path` */
 
-  using SegIterator = std::vector<AST::SimplePathSegment>::const_iterator;
+  template <typename S>
+  using SegIterator = typename std::vector<S>::const_iterator;
 
   Node &find_closest_module (Node &starting_point);
 
-  tl::optional<SegIterator>
-  find_starting_point (const std::vector<AST::SimplePathSegment> &segments,
-		       Node &starting_point);
+  template <typename S>
+  tl::optional<SegIterator<S>>
+  find_starting_point (const std::vector<S> &segments, Node &starting_point);
 
-  tl::optional<Node &>
-  resolve_segments (Node &starting_point,
-		    const std::vector<AST::SimplePathSegment> &segments,
-		    SegIterator iterator);
+  template <typename S>
+  tl::optional<Node &> resolve_segments (Node &starting_point,
+					 const std::vector<S> &segments,
+					 SegIterator<S> iterator);
 };
 
 } // namespace Resolver2_0

--- a/gcc/rust/resolve/rust-forever-stack.h
+++ b/gcc/rust/resolve/rust-forever-stack.h
@@ -396,7 +396,10 @@ template <Namespace N> class ForeverStack
 {
 public:
   ForeverStack ()
-    : root (Node (Rib (Rib::Kind::Normal))), cursor_reference (root)
+    // FIXME: Is that valid? Do we use the root? If yes, we should give the
+    // crate's node id to ForeverStack's constructor
+    : root (Node (Rib (Rib::Kind::Normal), UNKNOWN_NODEID)),
+      cursor_reference (root)
   {
     rust_assert (root.is_root ());
     rust_assert (root.is_leaf ());
@@ -478,6 +481,12 @@ public:
   template <typename S>
   tl::optional<NodeId> resolve_path (const std::vector<S> &segments);
 
+  // FIXME: Documentation
+  tl::optional<Resolver::CanonicalPath> to_canonical_path (NodeId id);
+
+  // FIXME: Documentation
+  tl::optional<Rib &> to_rib (NodeId rib_id);
+
   std::string as_debug_string ();
 
 private:
@@ -509,8 +518,10 @@ private:
   class Node
   {
   public:
-    Node (Rib rib) : rib (rib) {}
-    Node (Rib rib, Node &parent) : rib (rib), parent (parent) {}
+    Node (Rib rib, NodeId id) : rib (rib), id (id) {}
+    Node (Rib rib, NodeId id, Node &parent)
+      : rib (rib), id (id), parent (parent)
+    {}
 
     bool is_root () const;
     bool is_leaf () const;
@@ -519,6 +530,8 @@ private:
 
     Rib rib; // this is the "value" of the node - the data it keeps.
     std::map<Link, Node, LinkCmp> children; // all the other nodes it links to
+
+    NodeId id; // The node id of the Node's scope
 
     tl::optional<Node &> parent; // `None` only if the node is a root
   };
@@ -566,6 +579,12 @@ private:
   tl::optional<Node &> resolve_segments (Node &starting_point,
 					 const std::vector<S> &segments,
 					 SegIterator<S> iterator);
+
+  /* Helper functions for forward resolution (to_canonical_path, to_rib...) */
+
+  // FIXME: Documentation
+  tl::optional<std::pair<Node &, std::string>> dfs (Node &starting_point,
+						    NodeId to_find);
 };
 
 } // namespace Resolver2_0

--- a/gcc/rust/resolve/rust-forever-stack.h
+++ b/gcc/rust/resolve/rust-forever-stack.h
@@ -585,6 +585,8 @@ private:
   // FIXME: Documentation
   tl::optional<std::pair<Node &, std::string>> dfs (Node &starting_point,
 						    NodeId to_find);
+  // FIXME: Documentation
+  tl::optional<Rib &> dfs_rib (Node &starting_point, NodeId to_find);
 };
 
 } // namespace Resolver2_0

--- a/gcc/rust/resolve/rust-forever-stack.hxx
+++ b/gcc/rust/resolve/rust-forever-stack.hxx
@@ -429,24 +429,25 @@ ForeverStack<N>::resolve_segments (
 }
 
 template <Namespace N>
-template <typename P>
+template <typename S>
 tl::optional<NodeId>
-ForeverStack<N>::resolve_path (const P &path)
+ForeverStack<N>::resolve_path (const std::vector<S> &segments)
 {
+  // TODO: What to do if segments.empty() ?
+
   // if there's only one segment, we just use `get`
-  if (path.get_segments ().size () == 1)
-    return get (path.get_final_segment ().as_string ());
+  if (segments.size () == 1)
+    return get (segments.back ().as_string ());
 
   auto starting_point = cursor ();
-  auto &segments = path.get_segments ();
 
   return find_starting_point (segments, starting_point)
     .and_then ([this, &segments, &starting_point] (
-		 std::vector<AST::SimplePathSegment>::const_iterator iterator) {
+		 typename std::vector<S>::const_iterator iterator) {
       return resolve_segments (starting_point, segments, iterator);
     })
-    .and_then ([&path] (Node final_node) {
-      return final_node.rib.get (path.get_final_segment ().as_string ());
+    .and_then ([&segments] (Node final_node) {
+      return final_node.rib.get (segments.back ().as_string ());
     });
 }
 

--- a/gcc/rust/resolve/rust-forever-stack.hxx
+++ b/gcc/rust/resolve/rust-forever-stack.hxx
@@ -333,7 +333,7 @@ ForeverStack<N>::find_starting_point (const std::vector<S> &segments,
 
   for (; !is_last (iterator, segments); iterator++)
     {
-      auto seg = *iterator;
+      auto &seg = *iterator;
       auto is_self_or_crate
 	= seg.is_crate_path_seg () || seg.is_lower_self_seg ();
 

--- a/gcc/rust/resolve/rust-forever-stack.hxx
+++ b/gcc/rust/resolve/rust-forever-stack.hxx
@@ -532,9 +532,27 @@ ForeverStack<N>::to_canonical_path (NodeId id)
 
 template <Namespace N>
 tl::optional<Rib &>
+ForeverStack<N>::dfs_rib (ForeverStack<N>::Node &starting_point, NodeId to_find)
+{
+  if (starting_point.id == to_find)
+    return starting_point.rib;
+
+  for (auto &child : starting_point.children)
+    {
+      auto candidate = dfs_rib (child.second, to_find);
+
+      if (candidate.has_value ())
+	return candidate;
+    }
+
+  return tl::nullopt;
+}
+
+template <Namespace N>
+tl::optional<Rib &>
 ForeverStack<N>::to_rib (NodeId rib_id)
 {
-  return tl::nullopt;
+  return dfs_rib (root, rib_id);
 }
 
 template <Namespace N>

--- a/gcc/rust/resolve/rust-forever-stack.hxx
+++ b/gcc/rust/resolve/rust-forever-stack.hxx
@@ -523,8 +523,6 @@ ForeverStack<N>::to_canonical_path (NodeId id)
 
     // Finally, append the name
     path = path.append (Resolver::CanonicalPath::new_seg (id, name));
-    rust_debug ("[ARTHUR] found path: %s. Size: %lu", path.get ().c_str (),
-		segments.size ());
 
     return path;
   });

--- a/gcc/rust/resolve/rust-forever-stack.hxx
+++ b/gcc/rust/resolve/rust-forever-stack.hxx
@@ -313,7 +313,8 @@ ForeverStack<N>::find_starting_point (
   for (; !is_last (iterator, segments); iterator++)
     {
       auto seg = *iterator;
-      auto is_self_or_crate = seg.is_crate_path_seg () || seg.is_lower_self ();
+      auto is_self_or_crate
+	= seg.is_crate_path_seg () || seg.is_lower_self_seg ();
 
       // if we're after the first path segment and meet `self` or `crate`, it's
       // an error - we should only be seeing `super` keywords at this point
@@ -327,7 +328,7 @@ ForeverStack<N>::find_starting_point (
 	  iterator++;
 	  break;
 	}
-      if (seg.is_lower_self ())
+      if (seg.is_lower_self_seg ())
 	{
 	  // do nothing and exit
 	  iterator++;
@@ -371,7 +372,7 @@ ForeverStack<N>::resolve_segments (
       // check that we don't encounter *any* leading keywords afterwards
       if (check_leading_kw_at_start (seg, seg.is_crate_path_seg ()
 					    || seg.is_super_path_seg ()
-					    || seg.is_lower_self ()))
+					    || seg.is_lower_self_seg ()))
 	return tl::nullopt;
 
       tl::optional<typename ForeverStack<N>::Node &> child = tl::nullopt;

--- a/gcc/rust/resolve/rust-rib.h
+++ b/gcc/rust/resolve/rust-rib.h
@@ -28,6 +28,31 @@ namespace Rust {
 namespace Resolver2_0 {
 
 /**
+
+pub enum Namespace {
+   /// The type namespace includes `struct`s, `enum`s, `union`s, `trait`s, and
+`mod`s
+   /// (and, by extension, crates).
+   ///
+   /// Note that the type namespace includes other items; this is not an
+   /// exhaustive list.
+   TypeNS,
+   /// The value namespace includes `fn`s, `const`s, `static`s, and local
+variables (including function arguments). ValueNS,
+   /// The macro namespace includes `macro_rules!` macros, declarative `macro`s,
+   /// procedural macros, attribute macros, `derive` macros, and non-macro
+attributes
+   /// like `#[inline]` and `#[rustfmt::skip]`.
+   MacroNS,
+}
+
+*/
+
+// FIXME: There's no `labels` namespace, not sure if we need one or how to keep
+// one
+// FIXME: And where are things like loop labels kept?
+
+/**
  * All namespaces that Rust's name resolution needs to handle
  */
 // TODO: Move to `rust-forever-stack.h`?


### PR DESCRIPTION
- ast: Change *Path nodes API
- rib: Add Namespace enum
- forever-stack: Fix basic get logic
- foreverstack: Specialize `get` for Namespace::Labels
- forever stack: Fix resolve_path signature
- forever stack: Improve resolve_path implementation
- foreverstack: Add `to_canonical_path` method
- foreverstack: Add `to_rib` method

This PR introduces the necessary changes from #2620 in order to make late name resolution possible. Cherry-picked, cleaned up and all changelog'ed up.