### PR TITLE
Add base for late name resolution 2.0

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -116,6 +116,7 @@ GRS_OBJS = \
     rust/rust-default-resolver.o \
     rust/rust-toplevel-name-resolver-2.0.o \
     rust/rust-early-name-resolver-2.0.o \
+    rust/rust-late-name-resolver-2.0.o \
     rust/rust-early-name-resolver.o \
     rust/rust-name-resolver.o \
     rust/rust-ast-resolve.o \

--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
@@ -1,0 +1,105 @@
+// Copyright (C) 2020-2023 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-ast-full.h"
+#include "rust-late-name-resolver-2.0.h"
+#include "rust-default-resolver.h"
+
+namespace Rust {
+namespace Resolver2_0 {
+
+Late::Late (NameResolutionContext &ctx) : DefaultResolver (ctx) {}
+
+void
+Late::go (AST::Crate &crate)
+{
+  for (auto &item : crate.items)
+    item->accept_vis (*this);
+}
+
+void
+Late::new_label (Identifier name, NodeId id)
+{
+  // labels can always shadow, so `insert` should never fail. if it does, we're
+  // in big trouble!
+  auto ok = ctx.labels.insert (name, id);
+
+  rust_assert (ok);
+}
+
+void
+Late::visit (AST::LetStmt &let)
+{
+  // so we don't need that method
+  DefaultResolver::visit (let);
+
+  // how do we deal with the fact that `let a = blipbloup` should look for a
+  // label and cannot go through function ribs, but `let a = blipbloup()` can?
+
+  // how do we insert ribs here, and only pop them when we exit the current
+  // function?
+  // keep a list of ribs to pop when a scope exits? so only for blocks?
+  // how do we pop ribs that need to be popped not in order?
+  // I think it's not important if we have shadowing, correct?
+
+  // if we have shadowing, it should work! we'll see
+
+  // ctx.insert(Identifier name, NodeId id, Namespace ns)
+  // ctx.scoped (Rib::Kind::Normal /* FIXME: Is that valid? */,
+  // Namespace::Labels,
+  //      let.get_node_id (), [] () {});
+}
+
+void
+Late::visit (AST::IdentifierPattern &identifier)
+{
+  // do we insert in labels or in values
+  // but values does not allow shadowing... since functions cannot shadow
+  // do we insert functions in labels as well?
+  new_label (identifier.get_ident (), identifier.get_node_id ());
+}
+
+void
+Late::visit (AST::IdentifierExpr &expr)
+{
+  // TODO: same thing as visit(PathInExpression) here?
+
+  auto label = ctx.labels.get (expr.get_ident ());
+  auto value = ctx.values.get (expr.get_ident ());
+
+  rust_debug ("[ARTHUR] label: %d", label ? *label : -1);
+  rust_debug ("[ARTHUR] value: %d", value ? *value : -1);
+}
+
+void
+Late::visit (AST::PathInExpression &expr)
+{
+  // TODO: How do we have a nice error with `can't capture dynamic environment
+  // in a function item` error here?
+  // do we emit it in `get<Namespace::Labels>`?
+
+  auto label = ctx.labels.resolve_path (expr.get_segments ());
+
+  auto value = ctx.values.resolve_path (expr.get_segments ());
+
+  rust_debug ("[ARTHUR] label: %d", label ? *label : -1);
+  rust_debug ("[ARTHUR] value: %d", value ? *value : -1);
+}
+
+} // namespace Resolver2_0
+} // namespace Rust

--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.h
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.h
@@ -1,0 +1,57 @@
+// Copyright (C) 2020-2023 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_LATE_NAME_RESOLVER_2_0_H
+#define RUST_LATE_NAME_RESOLVER_2_0_H
+
+#include "rust-ast-full.h"
+#include "rust-default-resolver.h"
+
+namespace Rust {
+namespace Resolver2_0 {
+
+class Late : public DefaultResolver
+{
+  using DefaultResolver::visit;
+
+public:
+  Late (NameResolutionContext &ctx);
+
+  void go (AST::Crate &crate);
+
+  void new_label (Identifier name, NodeId id);
+
+  // some more label declarations
+  void visit (AST::LetStmt &) override;
+  // TODO: Do we need this?
+  // void visit (AST::Method &) override;
+  void visit (AST::IdentifierPattern &) override;
+
+  // resolutions
+  void visit (AST::IdentifierExpr &) override;
+  void visit (AST::PathInExpression &) override;
+
+private:
+};
+
+// TODO: Add missing mappings and data structures
+
+} // namespace Resolver2_0
+} // namespace Rust
+
+#endif // ! RUST_LATE_NAME_RESOLVER_2_0_H

--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.h
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.h
@@ -47,6 +47,8 @@ public:
   void visit (AST::PathInExpression &) override;
 
 private:
+  /* Setup Rust's builtin types (u8, i32, !...) in the resolver */
+  void setup_builtin_types ();
 };
 
 // TODO: Add missing mappings and data structures

--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.h
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.h
@@ -45,6 +45,7 @@ public:
   // resolutions
   void visit (AST::IdentifierExpr &) override;
   void visit (AST::PathInExpression &) override;
+  void visit (AST::TypePath &) override;
 
 private:
   /* Setup Rust's builtin types (u8, i32, !...) in the resolver */

--- a/gcc/rust/resolve/rust-name-resolution-context.cc
+++ b/gcc/rust/resolve/rust-name-resolution-context.cc
@@ -44,6 +44,15 @@ NameResolutionContext::insert (Identifier name, NodeId id, Namespace ns)
 }
 
 void
+NameResolutionContext::map_usage (NodeId usage, NodeId definition)
+{
+  auto inserted = resolved_nodes.emplace (usage, definition).second;
+
+  // is that valid?
+  rust_assert (inserted);
+}
+
+void
 NameResolutionContext::scoped (Rib rib, NodeId id,
 			       std::function<void (void)> lambda,
 			       tl::optional<Identifier> path)

--- a/gcc/rust/resolve/rust-name-resolution-context.cc
+++ b/gcc/rust/resolve/rust-name-resolution-context.cc
@@ -21,6 +21,10 @@
 namespace Rust {
 namespace Resolver2_0 {
 
+NameResolutionContext::NameResolutionContext ()
+  : mappings (*Analysis::Mappings::get ())
+{}
+
 tl::expected<NodeId, DuplicateNameError>
 NameResolutionContext::insert (Identifier name, NodeId id, Namespace ns)
 {

--- a/gcc/rust/resolve/rust-name-resolution-context.h
+++ b/gcc/rust/resolve/rust-name-resolution-context.h
@@ -21,6 +21,7 @@
 
 #include "optional.h"
 #include "rust-forever-stack.h"
+#include "rust-hir-map.h"
 
 namespace Rust {
 namespace Resolver2_0 {
@@ -136,6 +137,8 @@ correct
 class NameResolutionContext
 {
 public:
+  NameResolutionContext ();
+
   /**
    * Insert a new value in the current rib.
    *
@@ -174,6 +177,8 @@ public:
   ForeverStack<Namespace::Types> types;
   ForeverStack<Namespace::Macros> macros;
   ForeverStack<Namespace::Labels> labels;
+
+  Analysis::Mappings &mappings;
 };
 
 } // namespace Resolver2_0

--- a/gcc/rust/resolve/rust-name-resolution-context.h
+++ b/gcc/rust/resolve/rust-name-resolution-context.h
@@ -19,7 +19,6 @@
 #ifndef RUST_NAME_RESOLVER_2_0_H
 #define RUST_NAME_RESOLVER_2_0_H
 
-#include "optional.h"
 #include "rust-forever-stack.h"
 #include "rust-hir-map.h"
 
@@ -179,6 +178,13 @@ public:
   ForeverStack<Namespace::Labels> labels;
 
   Analysis::Mappings &mappings;
+
+  // TODO: Rename
+  void map_usage (NodeId usage, NodeId definition);
+
+private:
+  /* Map of "usage" nodes which have been resolved to a "definition" node */
+  std::map<NodeId, NodeId> resolved_nodes;
 };
 
 } // namespace Resolver2_0

--- a/gcc/rust/resolve/rust-name-resolution-context.h
+++ b/gcc/rust/resolve/rust-name-resolution-context.h
@@ -173,6 +173,7 @@ public:
   ForeverStack<Namespace::Values> values;
   ForeverStack<Namespace::Types> types;
   ForeverStack<Namespace::Macros> macros;
+  ForeverStack<Namespace::Labels> labels;
 };
 
 } // namespace Resolver2_0

--- a/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
@@ -185,10 +185,7 @@ TopLevel::visit (AST::Function &function)
   insert_or_error_out (function.get_function_name (), function,
 		       Namespace::Values);
 
-  auto def_fn
-    = [this, &function] () { function.get_definition ()->accept_vis (*this); };
-
-  ctx.scoped (Rib::Kind::Function, function.get_node_id (), def_fn);
+  DefaultResolver::visit (function);
 }
 
 void


### PR DESCRIPTION
- ctx: Add Labels ForeverStack to the resolver.
- nr2.0: Add base for late name resolution
- toplevel: Use DefaultResolver for Function
- nr2.0: Store mappings in NameResolutionContext
- late: Start setting up builtin types
- late: Start storing mappings properly in the resolver

Needs #2739 
