### PR TITLE
Add `use` declaration resolution

### DIFF
--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -940,6 +940,7 @@ protected:
 class UseTree
 {
   location_t locus;
+  NodeId node_id;
 
 public:
   enum Kind
@@ -975,6 +976,7 @@ public:
   virtual Kind get_kind () const = 0;
 
   location_t get_locus () const { return locus; }
+  NodeId get_node_id () const { return node_id; }
 
   virtual void accept_vis (ASTVisitor &vis) = 0;
 
@@ -982,7 +984,9 @@ protected:
   // Clone function implementation as pure virtual method
   virtual UseTree *clone_use_tree_impl () const = 0;
 
-  UseTree (location_t locus) : locus (locus) {}
+  UseTree (location_t locus)
+    : locus (locus), node_id (Analysis::Mappings::get ()->get_next_node_id ())
+  {}
 };
 
 // Use tree with a glob (wildcard) operator
@@ -1182,7 +1186,7 @@ public:
 
   Kind get_kind () const override { return Rebind; }
 
-  SimplePath get_path () const
+  const SimplePath &get_path () const
   {
     rust_assert (has_path ());
     return path;

--- a/gcc/rust/resolve/rust-early-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver-2.0.cc
@@ -189,22 +189,6 @@ Early::visit (AST::MacroInvocation &invoc)
 }
 
 void
-Early::visit (AST::UseDeclaration &use)
-{}
-
-void
-Early::visit (AST::UseTreeRebind &use)
-{}
-
-void
-Early::visit (AST::UseTreeList &use)
-{}
-
-void
-Early::visit (AST::UseTreeGlob &use)
-{}
-
-void
 Early::visit_attributes (std::vector<AST::Attribute> &attrs)
 {
   auto mappings = Analysis::Mappings::get ();

--- a/gcc/rust/resolve/rust-early-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver-2.0.cc
@@ -27,6 +27,33 @@ namespace Resolver2_0 {
 Early::Early (NameResolutionContext &ctx) : DefaultResolver (ctx) {}
 
 void
+Early::insert_once (AST::MacroInvocation &invocation, NodeId resolved)
+{
+  // TODO: Should we use `ctx.mark_resolved()`?
+  AST::MacroRulesDefinition *definition;
+  auto ok = ctx.mappings.lookup_macro_def (resolved, &definition);
+
+  rust_assert (ok);
+
+  AST::MacroRulesDefinition *existing;
+  auto exists = ctx.mappings.lookup_macro_invocation (invocation, &existing);
+
+  if (!exists)
+    ctx.mappings.insert_macro_invocation (invocation, definition);
+}
+
+void
+Early::insert_once (AST::MacroRulesDefinition &def)
+{
+  // TODO: Should we use `ctx.mark_resolved()`?
+  AST::MacroRulesDefinition *definition;
+  auto exists = ctx.mappings.lookup_macro_def (def.get_node_id (), &definition);
+
+  if (!exists)
+    ctx.mappings.insert_macro_def (&def);
+}
+
+void
 Early::go (AST::Crate &crate)
 {
   // First we go through TopLevel resolution to get all our declared items
@@ -89,6 +116,7 @@ Early::visit (AST::MacroRulesDefinition &def)
   DefaultResolver::visit (def);
 
   textual_scope.insert (def.get_rule_name ().as_string (), def.get_node_id ());
+  insert_once (def);
 }
 
 void
@@ -140,6 +168,8 @@ Early::visit (AST::MacroInvocation &invoc)
 			    "could not resolve macro invocation"));
       return;
     }
+
+  insert_once (invoc, *definition);
 
   // now do we need to keep mappings or something? or insert "uses" into our
   // ForeverStack? can we do that? are mappings simpler?

--- a/gcc/rust/resolve/rust-early-name-resolver-2.0.h
+++ b/gcc/rust/resolve/rust-early-name-resolver-2.0.h
@@ -50,10 +50,7 @@ public:
   void visit (AST::Module &) override;
 
   void visit (AST::MacroInvocation &) override;
-  void visit (AST::UseDeclaration &) override;
-  void visit (AST::UseTreeRebind &) override;
-  void visit (AST::UseTreeList &) override;
-  void visit (AST::UseTreeGlob &) override;
+
   void visit (AST::Function &) override;
   void visit (AST::StructStruct &) override;
 

--- a/gcc/rust/resolve/rust-early-name-resolver-2.0.h
+++ b/gcc/rust/resolve/rust-early-name-resolver-2.0.h
@@ -61,6 +61,16 @@ private:
   void visit_attributes (std::vector<AST::Attribute> &attrs);
 
   /**
+   * Insert a resolved macro invocation into the mappings once, meaning that we
+   * can call this function each time the early name resolution pass is underway
+   * and it will not trigger assertions for already resolved invocations.
+   */
+  // TODO: Rename
+  void insert_once (AST::MacroInvocation &invocation, NodeId resolved);
+  // TODO: Rename
+  void insert_once (AST::MacroRulesDefinition &definition);
+
+  /**
    * Macros can either be resolved through textual scoping or regular path
    * scoping - which this class represents. Textual scoping works similarly to a
    * "simple" name resolution algorith, with the addition of "shadowing". Each

--- a/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
@@ -43,6 +43,9 @@ TopLevel::insert_or_error_out (const Identifier &identifier, const T &node,
 
   if (!result)
     {
+      // can we do something like check if the node id is the same? if it is the
+      // same, it's not an error, just the resolver running multiple times?
+
       rich_location rich_loc (line_table, loc);
       rich_loc.add_range (node_locations[result.error ().existing]);
 
@@ -54,6 +57,11 @@ TopLevel::insert_or_error_out (const Identifier &identifier, const T &node,
 void
 TopLevel::go (AST::Crate &crate)
 {
+  // we do not include builtin types in the top-level definition collector, as
+  // they are not used until `Late`. furthermore, we run this visitor multiple
+  // times in a row in a fixed-point fashion, so it would make the code
+  // responsible for this ugly and perfom a lot of error checking.
+
   for (auto &item : crate.items)
     item->accept_vis (*this);
 }

--- a/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.h
+++ b/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.h
@@ -53,6 +53,9 @@ private:
   template <typename T>
   void insert_or_error_out (const Identifier &identifier, const T &node,
 			    Namespace ns);
+  void insert_or_error_out (const Identifier &identifier,
+			    const location_t &locus, const NodeId &id,
+			    Namespace ns);
 
   // FIXME: Do we move these to our mappings?
   std::unordered_map<NodeId, location_t> node_locations;
@@ -73,6 +76,14 @@ private:
   void visit (AST::Union &union_item) override;
   void visit (AST::ConstantItem &const_item) override;
   void visit (AST::ExternCrate &crate) override;
+
+  // FIXME: Documentation
+  // Call this on all the paths of a UseDec - so each flattened path in a
+  // UseTreeList for example
+  // FIXME: Should that return `found`?
+  bool handle_use_dec (AST::SimplePath path);
+
+  void visit (AST::UseDeclaration &use) override;
 };
 
 } // namespace Resolver2_0


### PR DESCRIPTION
- early: Resolve paths properly
- toplevel: Add comment about running the collector twice
- ast: Add NodeId to UseTree base class
- early: Move `use` declaration resolving to TopLevel
- toplevel: Resolve `use` declarations

Needs #2740
Needs #2739 