### PR TITLE
fixup: Ensure buffer allocation for bootstrap

### DIFF
--- a/gcc/rust/expand/rust-proc-macro.cc
+++ b/gcc/rust/expand/rust-proc-macro.cc
@@ -183,7 +183,8 @@ generate_proc_macro_decls_symbol (std::uint32_t stable_crate_id)
   // Size could be hardcoded since we know the input size but I elected to
   // calculate it everytime so we won't have any desync between code and data.
   int size = std::snprintf (nullptr, 0, PROC_MACRO_DECLS_FMT_ARGS);
-  std::vector<char> buf (size + 1);
+  std::vector<char> buf;
+  buf.resize (size + 1, '\0');
   std::sprintf (buf.data (), PROC_MACRO_DECLS_FMT_ARGS);
 #undef PROC_MACRO_DECLS_FMT_ARGS
 


### PR DESCRIPTION
Bootstrap was failing because the vector did not allocate the internal buffer and was holding a null pointer.

Commit to fixup is b71fd2afa831

gcc/rust/ChangeLog:

	* expand/rust-proc-macro.cc (generate_proc_macro_decls_symbol): Resize the vector and initialize it with dummy data before changing it.
