### PR TITLE
Reject regular variadic functions

### DIFF
--- a/gcc/rust/checks/errors/rust-ast-validation.cc
+++ b/gcc/rust/checks/errors/rust-ast-validation.cc
@@ -93,6 +93,11 @@ ASTValidation::visit (AST::Function &function)
       function.get_self_param ()->get_locus (),
       "%<self%> parameter is only allowed in associated functions");
 
+  if (function.is_variadic ())
+    rust_error_at (
+      function.get_function_params ().back ()->get_locus (),
+      "only foreign or %<unsafe extern \"C\"%> functions may be C-variadic");
+
   AST::ContextualASTVisitor::visit (function);
 }
 

--- a/gcc/testsuite/rust/compile/non_foreign_variadic_function.rs
+++ b/gcc/testsuite/rust/compile/non_foreign_variadic_function.rs
@@ -1,0 +1,4 @@
+pub fn toto(a: i32, ...) {}
+// { dg-error "only foreign or .unsafe extern .C.. functions may be C-variadic" "" { target *-*-* } .-1 }
+
+fn main() {}


### PR DESCRIPTION
Variadic regular functions were recently added in the parser as they should be rejected in the ast validation pass. Those are now rejected in the ast validation pass.

Fixes #2712 