### PR TITLE
Auto trait AST validation

### DIFF
--- a/gcc/rust/checks/errors/rust-ast-validation.cc
+++ b/gcc/rust/checks/errors/rust-ast-validation.cc
@@ -96,4 +96,18 @@ ASTValidation::visit (AST::Function &function)
   AST::ContextualASTVisitor::visit (function);
 }
 
+void
+ASTValidation::visit (AST::Trait &trait)
+{
+  if (trait.is_auto ())
+    {
+      if (trait.has_generics ())
+	rust_error_at (trait.get_generic_params ()[0]->get_locus (),
+		       ErrorCode::E0567,
+		       "auto traits cannot have generic parameters");
+    }
+
+  AST::ContextualASTVisitor::visit (trait);
+}
+
 } // namespace Rust

--- a/gcc/rust/checks/errors/rust-ast-validation.cc
+++ b/gcc/rust/checks/errors/rust-ast-validation.cc
@@ -109,6 +109,13 @@ ASTValidation::visit (AST::Trait &trait)
 	rust_error_at (trait.get_type_param_bounds ()[0]->get_locus (),
 		       ErrorCode::E0568,
 		       "auto traits cannot have super traits");
+      if (trait.has_trait_items ())
+	{
+	  rust_error_at (trait.get_identifier ().get_locus (), ErrorCode::E0380,
+			 "auto traits cannot have methods or associated items");
+	  for (const auto &item : trait.get_trait_items ())
+	    Error::Hint (item->get_locus (), "remove this item").emit ();
+	}
     }
 
   AST::ContextualASTVisitor::visit (trait);

--- a/gcc/rust/checks/errors/rust-ast-validation.cc
+++ b/gcc/rust/checks/errors/rust-ast-validation.cc
@@ -105,6 +105,10 @@ ASTValidation::visit (AST::Trait &trait)
 	rust_error_at (trait.get_generic_params ()[0]->get_locus (),
 		       ErrorCode::E0567,
 		       "auto traits cannot have generic parameters");
+      if (trait.has_type_param_bounds ())
+	rust_error_at (trait.get_type_param_bounds ()[0]->get_locus (),
+		       ErrorCode::E0568,
+		       "auto traits cannot have super traits");
     }
 
   AST::ContextualASTVisitor::visit (trait);

--- a/gcc/rust/checks/errors/rust-ast-validation.h
+++ b/gcc/rust/checks/errors/rust-ast-validation.h
@@ -38,6 +38,7 @@ public:
   virtual void visit (AST::LoopLabel &label);
   virtual void visit (AST::ExternalFunctionItem &item);
   virtual void visit (AST::Function &function);
+  virtual void visit (AST::Trait &trait);
 };
 
 } // namespace Rust

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -4983,18 +4983,6 @@ Parser<ManagedTokenSource>::parse_trait (AST::Visibility vis,
       return nullptr;
     }
 
-  if (is_auto_trait && !trait_items.empty ())
-    {
-      add_error (Error (locus, ErrorCode::E0380,
-			"auto traits cannot have associated items"));
-
-      // FIXME: unsure if this should be done at parsing time or not
-      for (const auto &item : trait_items)
-	add_error (Error::Hint (item->get_locus (), "remove this item"));
-
-      return nullptr;
-    }
-
   trait_items.shrink_to_fit ();
   return std::unique_ptr<AST::Trait> (
     new AST::Trait (std::move (ident), is_unsafe, is_auto_trait,

--- a/gcc/testsuite/rust/compile/auto_trait_invalid.rs
+++ b/gcc/testsuite/rust/compile/auto_trait_invalid.rs
@@ -2,7 +2,9 @@
 
 #![feature(optin_builtin_traits)]
 
-unsafe auto trait Invalid { // { dg-error "auto traits cannot have associated items" }
+auto trait Invalid {
+    // { dg-error "auto traits cannot have methods or associated items" "" { target *-*-* } .-1 }
+
     fn foo(); // { dg-message "remove this item" }
 
     fn bar() {} // { dg-message "remove this item" }
@@ -13,4 +15,3 @@ unsafe auto trait Invalid { // { dg-error "auto traits cannot have associated it
 
     const BAR: i32 = 15; // { dg-message "remove this item" }
 }
-// { dg-error "failed to parse item in crate" "" {target *-*-* } .+1 }

--- a/gcc/testsuite/rust/compile/auto_trait_super_trait.rs
+++ b/gcc/testsuite/rust/compile/auto_trait_super_trait.rs
@@ -1,0 +1,4 @@
+trait Cold {}
+
+auto trait IsCool: Cold {}
+// { dg-error "auto traits cannot have super traits .E0568." "" { target *-*-* } .-1 }

--- a/gcc/testsuite/rust/compile/generic_auto_trait.rs
+++ b/gcc/testsuite/rust/compile/generic_auto_trait.rs
@@ -1,0 +1,2 @@
+auto trait IsCooler<G> {}
+// { dg-error "auto traits cannot have generic parameters .E0567." "" { target *-*-* } .-1 }


### PR DESCRIPTION
Some constructs are forbidden in rust with auto traits such as generic arguments and super traits. Rust code containing such construct should be rejected and the compiler should emit an error.