### PR TITLE
Make early name resolver inherit from default one

### DIFF
--- a/gcc/rust/resolve/rust-early-name-resolver.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver.cc
@@ -80,6 +80,31 @@ EarlyNameResolver::EarlyNameResolver ()
 void
 EarlyNameResolver::go (AST::Crate &crate)
 {
+  visit (crate);
+}
+
+void
+EarlyNameResolver::resolve_generic_args (AST::GenericArgs &generic_args)
+{
+  for (auto &arg : generic_args.get_generic_args ())
+    arg.accept_vis (*this);
+
+  for (auto &arg : generic_args.get_binding_args ())
+    arg.get_type ()->accept_vis (*this);
+}
+
+void
+EarlyNameResolver::resolve_qualified_path_type (AST::QualifiedPathType &path)
+{
+  path.get_type ()->accept_vis (*this);
+
+  if (path.has_as_clause ())
+    path.get_as_type_path ().accept_vis (*this);
+}
+
+void
+EarlyNameResolver::visit (AST::Crate &crate)
+{
   std::vector<std::unique_ptr<AST::Item>> new_items;
   auto items = crate.take_items ();
 
@@ -107,29 +132,6 @@ EarlyNameResolver::go (AST::Crate &crate)
 }
 
 void
-EarlyNameResolver::resolve_generic_args (AST::GenericArgs &generic_args)
-{
-  for (auto &arg : generic_args.get_generic_args ())
-    arg.accept_vis (*this);
-
-  for (auto &arg : generic_args.get_binding_args ())
-    arg.get_type ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::resolve_qualified_path_type (AST::QualifiedPathType &path)
-{
-  path.get_type ()->accept_vis (*this);
-
-  if (path.has_as_clause ())
-    path.get_as_type_path ().accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::Token &)
-{}
-
-void
 EarlyNameResolver::visit (AST::DelimTokenTree &)
 {}
 
@@ -139,10 +141,6 @@ EarlyNameResolver::visit (AST::AttrInputMetaItemContainer &)
 
 void
 EarlyNameResolver::visit (AST::IdentifierExpr &)
-{}
-
-void
-EarlyNameResolver::visit (AST::Lifetime &)
 {}
 
 void
@@ -164,30 +162,10 @@ EarlyNameResolver::visit (AST::PathInExpression &path)
 }
 
 void
-EarlyNameResolver::visit (AST::TypePathSegment &)
-{}
-
-void
 EarlyNameResolver::visit (AST::TypePathSegmentGeneric &segment)
 {
   if (segment.has_generic_args ())
     resolve_generic_args (segment.get_generic_args ());
-}
-
-void
-EarlyNameResolver::visit (AST::TypePathSegmentFunction &segment)
-{
-  for (auto &type : segment.get_type_path_function ().get_params ())
-    type->accept_vis (*this);
-
-  segment.get_type_path_function ().get_return_type ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::TypePath &path)
-{
-  for (auto &seg : path.get_segments ())
-    seg->accept_vis (*this);
 }
 
 void
@@ -230,117 +208,6 @@ EarlyNameResolver::visit (AST::MetaItemPathLit &)
 {}
 
 void
-EarlyNameResolver::visit (AST::BorrowExpr &expr)
-{
-  expr.get_borrowed_expr ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::DereferenceExpr &expr)
-{
-  expr.get_dereferenced_expr ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::ErrorPropagationExpr &expr)
-{
-  expr.get_propagating_expr ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::NegationExpr &expr)
-{
-  expr.get_negated_expr ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::ArithmeticOrLogicalExpr &expr)
-{
-  expr.get_left_expr ()->accept_vis (*this);
-  expr.get_right_expr ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::ComparisonExpr &expr)
-{
-  expr.get_left_expr ()->accept_vis (*this);
-  expr.get_right_expr ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::LazyBooleanExpr &expr)
-{
-  expr.get_left_expr ()->accept_vis (*this);
-  expr.get_right_expr ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::TypeCastExpr &expr)
-{
-  expr.get_casted_expr ()->accept_vis (*this);
-  expr.get_type_to_cast_to ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::AssignmentExpr &expr)
-{
-  expr.get_left_expr ()->accept_vis (*this);
-  expr.get_right_expr ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::CompoundAssignmentExpr &expr)
-{
-  expr.get_left_expr ()->accept_vis (*this);
-  expr.get_right_expr ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::GroupedExpr &expr)
-{
-  expr.get_expr_in_parens ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::ArrayElemsValues &elems)
-{
-  for (auto &expr : elems.get_values ())
-    expr->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::ArrayElemsCopied &elems)
-{
-  elems.get_elem_to_copy ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::ArrayExpr &expr)
-{
-  expr.get_array_elems ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::ArrayIndexExpr &expr)
-{
-  expr.get_array_expr ()->accept_vis (*this);
-  expr.get_index_expr ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::TupleExpr &expr)
-{
-  for (auto &elem : expr.get_tuple_elems ())
-    elem->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::TupleIndexExpr &expr)
-{
-  expr.get_tuple_expr ()->accept_vis (*this);
-}
-
-void
 EarlyNameResolver::visit (AST::StructExprStruct &)
 {}
 
@@ -349,59 +216,8 @@ EarlyNameResolver::visit (AST::StructExprFieldIdentifier &)
 {}
 
 void
-EarlyNameResolver::visit (AST::StructExprFieldIdentifierValue &field)
-{
-  field.get_value ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::StructExprFieldIndexValue &field)
-{
-  field.get_value ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::StructExprStructFields &expr)
-{
-  for (auto &field : expr.get_fields ())
-    field->accept_vis (*this);
-}
-
-void
 EarlyNameResolver::visit (AST::StructExprStructBase &)
 {}
-
-void
-EarlyNameResolver::visit (AST::CallExpr &expr)
-{
-  expr.get_function_expr ()->accept_vis (*this);
-  for (auto &param : expr.get_params ())
-    param->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::MethodCallExpr &expr)
-{
-  expr.get_receiver_expr ()->accept_vis (*this);
-  for (auto &param : expr.get_params ())
-    param->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::FieldAccessExpr &expr)
-{
-  expr.get_receiver_expr ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::ClosureExprInner &expr)
-{
-  expr.get_definition_expr ()->accept_vis (*this);
-
-  for (auto &param : expr.get_params ())
-    if (param.has_type_given ())
-      param.get_type ()->accept_vis (*this);
-}
 
 void
 EarlyNameResolver::visit (AST::BlockExpr &expr)
@@ -416,93 +232,12 @@ EarlyNameResolver::visit (AST::BlockExpr &expr)
 }
 
 void
-EarlyNameResolver::visit (AST::ClosureExprInnerTyped &expr)
-{
-  expr.get_definition_block ()->accept_vis (*this);
-
-  for (auto &param : expr.get_params ())
-    param.get_type ()->accept_vis (*this);
-}
-
-void
 EarlyNameResolver::visit (AST::ContinueExpr &)
 {}
 
 void
-EarlyNameResolver::visit (AST::BreakExpr &expr)
-{
-  if (expr.has_break_expr ())
-    expr.get_break_expr ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::RangeFromToExpr &expr)
-{
-  expr.get_from_expr ()->accept_vis (*this);
-  expr.get_to_expr ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::RangeFromExpr &expr)
-{
-  expr.get_from_expr ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::RangeToExpr &expr)
-{
-  expr.get_to_expr ()->accept_vis (*this);
-}
-
-void
 EarlyNameResolver::visit (AST::RangeFullExpr &)
 {}
-
-void
-EarlyNameResolver::visit (AST::RangeFromToInclExpr &expr)
-{
-  expr.get_from_expr ()->accept_vis (*this);
-  expr.get_to_expr ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::RangeToInclExpr &expr)
-{
-  expr.get_to_expr ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::ReturnExpr &expr)
-{
-  if (expr.has_returned_expr ())
-    expr.get_returned_expr ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::UnsafeBlockExpr &expr)
-{
-  expr.get_block_expr ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::LoopExpr &expr)
-{
-  expr.get_loop_block ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::WhileLoopExpr &expr)
-{
-  expr.get_predicate_expr ()->accept_vis (*this);
-  expr.get_loop_block ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::WhileLetLoopExpr &expr)
-{
-  expr.get_scrutinee_expr ()->accept_vis (*this);
-  expr.get_loop_block ()->accept_vis (*this);
-}
 
 void
 EarlyNameResolver::visit (AST::ForLoopExpr &expr)
@@ -515,35 +250,12 @@ EarlyNameResolver::visit (AST::ForLoopExpr &expr)
 }
 
 void
-EarlyNameResolver::visit (AST::IfExpr &expr)
-{
-  expr.get_condition_expr ()->accept_vis (*this);
-  expr.get_if_block ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::IfExprConseqElse &expr)
-{
-  expr.get_condition_expr ()->accept_vis (*this);
-  expr.get_if_block ()->accept_vis (*this);
-  expr.get_else_block ()->accept_vis (*this);
-}
-
-void
 EarlyNameResolver::visit (AST::IfLetExpr &expr)
 {
   expr.get_value_expr ()->accept_vis (*this);
 
   scoped (expr.get_node_id (),
 	  [&expr, this] () { expr.get_if_block ()->accept_vis (*this); });
-}
-
-void
-EarlyNameResolver::visit (AST::IfLetExprConseqElse &expr)
-{
-  expr.get_value_expr ()->accept_vis (*this);
-  expr.get_if_block ()->accept_vis (*this);
-  expr.get_else_block ()->accept_vis (*this);
 }
 
 void
@@ -568,37 +280,8 @@ EarlyNameResolver::visit (AST::MatchExpr &expr)
 }
 
 void
-EarlyNameResolver::visit (AST::AwaitExpr &expr)
-{
-  expr.get_awaited_expr ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::AsyncBlockExpr &expr)
-{
-  expr.get_block_expr ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::TypeParam &param)
-{
-  for (auto &bound : param.get_type_param_bounds ())
-    bound->accept_vis (*this);
-
-  if (param.has_type ())
-    param.get_type ()->accept_vis (*this);
-}
-
-void
 EarlyNameResolver::visit (AST::LifetimeWhereClauseItem &)
 {}
-
-void
-EarlyNameResolver::visit (AST::TypeBoundWhereClauseItem &item)
-{
-  for (auto &bound : item.get_type_param_bounds ())
-    bound->accept_vis (*this);
-}
 
 void
 EarlyNameResolver::visit (AST::Module &module)
@@ -656,139 +339,12 @@ EarlyNameResolver::visit (AST::UseDeclaration &)
 {}
 
 void
-EarlyNameResolver::visit (AST::Function &function)
-{
-  if (function.has_generics ())
-    for (auto &generic : function.get_generic_params ())
-      generic->accept_vis (*this);
-
-  for (auto &p : function.get_function_params ())
-    p->accept_vis (*this);
-
-  if (function.has_return_type ())
-    function.get_return_type ()->accept_vis (*this);
-
-  function.get_definition ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::TypeAlias &type_alias)
-{
-  type_alias.get_type_aliased ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::StructStruct &struct_item)
-{
-  for (auto &field : struct_item.get_fields ())
-    field.get_field_type ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::TupleStruct &tuple_struct)
-{
-  for (auto &field : tuple_struct.get_fields ())
-    field.get_field_type ()->accept_vis (*this);
-}
-
-void
 EarlyNameResolver::visit (AST::EnumItem &)
 {}
 
 void
-EarlyNameResolver::visit (AST::EnumItemTuple &item)
-{
-  for (auto &field : item.get_tuple_fields ())
-    field.get_field_type ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::EnumItemStruct &item)
-{
-  for (auto &field : item.get_struct_fields ())
-    field.get_field_type ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::EnumItemDiscriminant &item)
-{
-  item.get_expr ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::Enum &enum_item)
-{
-  for (auto &generic : enum_item.get_generic_params ())
-    generic->accept_vis (*this);
-
-  for (auto &variant : enum_item.get_variants ())
-    variant->accept_vis (*this);
-}
-
-void
 EarlyNameResolver::visit (AST::Union &)
 {}
-
-void
-EarlyNameResolver::visit (AST::ConstantItem &const_item)
-{
-  const_item.get_type ()->accept_vis (*this);
-  if (const_item.has_expr ())
-    const_item.get_expr ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::StaticItem &static_item)
-{
-  static_item.get_type ()->accept_vis (*this);
-  static_item.get_expr ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::TraitItemFunc &item)
-{
-  auto &decl = item.get_trait_function_decl ();
-
-  if (decl.has_return_type ())
-    decl.get_return_type ()->accept_vis (*this);
-
-  for (auto &generic : decl.get_generic_params ())
-    generic->accept_vis (*this);
-
-  for (auto &p : decl.get_function_params ())
-    p->accept_vis (*this);
-
-  if (item.has_definition ())
-    item.get_definition ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::TraitItemMethod &item)
-{
-  // FIXME: Can we factor this with the above function?
-  auto &decl = item.get_trait_method_decl ();
-
-  if (decl.has_return_type ())
-    decl.get_return_type ()->accept_vis (*this);
-
-  for (auto &generic : decl.get_generic_params ())
-    generic->accept_vis (*this);
-
-  for (auto &p : decl.get_function_params ())
-    p->accept_vis (*this);
-
-  if (item.has_definition ())
-    item.get_definition ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::TraitItemConst &item)
-{
-  item.get_type ()->accept_vis (*this);
-
-  if (item.has_expr ())
-    item.get_expr ()->accept_vis (*this);
-}
 
 void
 EarlyNameResolver::visit (AST::TraitItemType &)
@@ -841,26 +397,6 @@ EarlyNameResolver::visit (AST::ExternalTypeItem &item)
 }
 
 void
-EarlyNameResolver::visit (AST::ExternalStaticItem &item)
-{
-  item.get_type ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::ExternalFunctionItem &item)
-{
-  for (auto &generic : item.get_generic_params ())
-    generic->accept_vis (*this);
-
-  for (auto &param : item.get_function_params ())
-    if (!param.is_variadic ())
-      param.get_type ()->accept_vis (*this);
-
-  if (item.has_return_type ())
-    item.get_return_type ()->accept_vis (*this);
-}
-
-void
 EarlyNameResolver::visit (AST::ExternBlock &block)
 {
   scoped (block.get_node_id (), [&block, this] () {
@@ -868,10 +404,6 @@ EarlyNameResolver::visit (AST::ExternBlock &block)
       item->accept_vis (*this);
   });
 }
-
-void
-EarlyNameResolver::visit (AST::MacroMatchFragment &)
-{}
 
 void
 EarlyNameResolver::visit (AST::MacroMatchRepetition &)
@@ -992,10 +524,6 @@ EarlyNameResolver::visit (AST::MetaItemSeq &)
 {}
 
 void
-EarlyNameResolver::visit (AST::MetaWord &)
-{}
-
-void
 EarlyNameResolver::visit (AST::MetaNameValueStr &)
 {}
 
@@ -1005,25 +533,6 @@ EarlyNameResolver::visit (AST::MetaListPaths &)
 
 void
 EarlyNameResolver::visit (AST::MetaListNameValueStr &)
-{}
-
-void
-EarlyNameResolver::visit (AST::LiteralPattern &)
-{}
-
-void
-EarlyNameResolver::visit (AST::IdentifierPattern &pattern)
-{
-  if (pattern.has_pattern_to_bind ())
-    pattern.get_pattern_to_bind ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::WildcardPattern &)
-{}
-
-void
-EarlyNameResolver::visit (AST::RestPattern &)
 {}
 
 void
@@ -1039,53 +548,12 @@ EarlyNameResolver::visit (AST::RangePatternBoundQualPath &)
 {}
 
 void
-EarlyNameResolver::visit (AST::RangePattern &pattern)
-{
-  pattern.get_lower_bound ()->accept_vis (*this);
-  pattern.get_upper_bound ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::ReferencePattern &pattern)
-{
-  pattern.get_referenced_pattern ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::StructPatternFieldTuplePat &field)
-{
-  field.get_index_pattern ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::StructPatternFieldIdentPat &field)
-{
-  field.get_ident_pattern ()->accept_vis (*this);
-}
-
-void
 EarlyNameResolver::visit (AST::StructPatternFieldIdent &)
 {}
 
 void
 EarlyNameResolver::visit (AST::StructPattern &)
 {}
-
-void
-EarlyNameResolver::visit (AST::TupleStructItemsNoRange &tuple_items)
-{
-  for (auto &pattern : tuple_items.get_patterns ())
-    pattern->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::TupleStructItemsRange &tuple_items)
-{
-  for (auto &pattern : tuple_items.get_lower_patterns ())
-    pattern->accept_vis (*this);
-  for (auto &pattern : tuple_items.get_upper_patterns ())
-    pattern->accept_vis (*this);
-}
 
 void
 EarlyNameResolver::visit (AST::TupleStructPattern &pattern)
@@ -1101,70 +569,6 @@ EarlyNameResolver::visit (AST::TupleStructPattern &pattern)
       return;
     }
   pattern.get_items ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::TuplePatternItemsMultiple &tuple_items)
-{
-  for (auto &pattern : tuple_items.get_patterns ())
-    pattern->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::TuplePatternItemsRanged &tuple_items)
-{
-  for (auto &pattern : tuple_items.get_lower_patterns ())
-    pattern->accept_vis (*this);
-  for (auto &pattern : tuple_items.get_upper_patterns ())
-    pattern->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::TuplePattern &pattern)
-{
-  pattern.get_items ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::GroupedPattern &pattern)
-{
-  pattern.get_pattern_in_parens ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::SlicePattern &pattern)
-{
-  for (auto &item : pattern.get_items ())
-    item->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::AltPattern &pattern)
-{
-  for (auto &alt : pattern.get_alts ())
-    alt->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::EmptyStmt &)
-{}
-
-void
-EarlyNameResolver::visit (AST::LetStmt &stmt)
-{
-  if (stmt.has_type ())
-    stmt.get_type ()->accept_vis (*this);
-
-  if (stmt.has_init_expr ())
-    stmt.get_init_expr ()->accept_vis (*this);
-
-  stmt.get_pattern ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::ExprStmt &stmt)
-{
-  stmt.get_expr ()->accept_vis (*this);
 }
 
 void
@@ -1196,10 +600,6 @@ EarlyNameResolver::visit (AST::TupleType &)
 {}
 
 void
-EarlyNameResolver::visit (AST::NeverType &)
-{}
-
-void
 EarlyNameResolver::visit (AST::RawPointerType &)
 {}
 
@@ -1218,39 +618,6 @@ EarlyNameResolver::visit (AST::SliceType &)
 void
 EarlyNameResolver::visit (AST::InferredType &)
 {}
-
-void
-EarlyNameResolver::visit (AST::BareFunctionType &type)
-{
-  for (auto &param : type.get_function_params ())
-    param.get_type ()->accept_vis (*this);
-
-  if (type.has_return_type ())
-    type.get_return_type ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::VariadicParam &param)
-{
-  if (param.has_pattern ())
-    param.get_pattern ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::FunctionParam &param)
-{
-  param.get_pattern ()->accept_vis (*this);
-  param.get_type ()->accept_vis (*this);
-}
-
-void
-EarlyNameResolver::visit (AST::SelfParam &param)
-{
-  if (param.has_type ())
-    param.get_type ()->accept_vis (*this);
-  if (param.has_lifetime ())
-    param.get_lifetime ().accept_vis (*this);
-}
 
 } // namespace Resolver
 } // namespace Rust

--- a/gcc/rust/resolve/rust-early-name-resolver.h
+++ b/gcc/rust/resolve/rust-early-name-resolver.h
@@ -27,7 +27,7 @@
 namespace Rust {
 namespace Resolver {
 
-class EarlyNameResolver : public AST::ASTVisitor
+class EarlyNameResolver : public AST::DefaultASTVisitor
 {
 public:
   EarlyNameResolver ();
@@ -35,6 +35,7 @@ public:
   void go (AST::Crate &crate);
 
 private:
+  using AST::DefaultASTVisitor::visit;
   /**
    * Execute a lambda within a scope. This is equivalent to calling
    * `enter_scope` before your code and `exit_scope` after. This ensures
@@ -126,18 +127,14 @@ private:
    */
   void resolve_qualified_path_type (AST::QualifiedPathType &path);
 
-  virtual void visit (AST::Token &tok);
+  virtual void visit (AST::Crate &crate);
   virtual void visit (AST::DelimTokenTree &delim_tok_tree);
   virtual void visit (AST::AttrInputMetaItemContainer &input);
   virtual void visit (AST::IdentifierExpr &ident_expr);
-  virtual void visit (AST::Lifetime &lifetime);
   virtual void visit (AST::LifetimeParam &lifetime_param);
   virtual void visit (AST::ConstGenericParam &const_param);
   virtual void visit (AST::PathInExpression &path);
-  virtual void visit (AST::TypePathSegment &segment);
   virtual void visit (AST::TypePathSegmentGeneric &segment);
-  virtual void visit (AST::TypePathSegmentFunction &segment);
-  virtual void visit (AST::TypePath &path);
   virtual void visit (AST::QualifiedPathInExpression &path);
   virtual void visit (AST::QualifiedPathInType &path);
   virtual void visit (AST::LiteralExpr &expr);
@@ -145,124 +142,45 @@ private:
   virtual void visit (AST::AttrInputMacro &attr_input);
   virtual void visit (AST::MetaItemLitExpr &meta_item);
   virtual void visit (AST::MetaItemPathLit &meta_item);
-  virtual void visit (AST::BorrowExpr &expr);
-  virtual void visit (AST::DereferenceExpr &expr);
-  virtual void visit (AST::ErrorPropagationExpr &expr);
-  virtual void visit (AST::NegationExpr &expr);
-  virtual void visit (AST::ArithmeticOrLogicalExpr &expr);
-  virtual void visit (AST::ComparisonExpr &expr);
-  virtual void visit (AST::LazyBooleanExpr &expr);
-  virtual void visit (AST::TypeCastExpr &expr);
-  virtual void visit (AST::AssignmentExpr &expr);
-  virtual void visit (AST::CompoundAssignmentExpr &expr);
-  virtual void visit (AST::GroupedExpr &expr);
-  virtual void visit (AST::ArrayElemsValues &elems);
-  virtual void visit (AST::ArrayElemsCopied &elems);
-  virtual void visit (AST::ArrayExpr &expr);
-  virtual void visit (AST::ArrayIndexExpr &expr);
-  virtual void visit (AST::TupleExpr &expr);
-  virtual void visit (AST::TupleIndexExpr &expr);
   virtual void visit (AST::StructExprStruct &expr);
   virtual void visit (AST::StructExprFieldIdentifier &field);
-  virtual void visit (AST::StructExprFieldIdentifierValue &field);
-  virtual void visit (AST::StructExprFieldIndexValue &field);
-  virtual void visit (AST::StructExprStructFields &expr);
   virtual void visit (AST::StructExprStructBase &expr);
-  virtual void visit (AST::CallExpr &expr);
-  virtual void visit (AST::MethodCallExpr &expr);
-  virtual void visit (AST::FieldAccessExpr &expr);
-  virtual void visit (AST::ClosureExprInner &expr);
   virtual void visit (AST::BlockExpr &expr);
-  virtual void visit (AST::ClosureExprInnerTyped &expr);
   virtual void visit (AST::ContinueExpr &expr);
-  virtual void visit (AST::BreakExpr &expr);
-  virtual void visit (AST::RangeFromToExpr &expr);
-  virtual void visit (AST::RangeFromExpr &expr);
-  virtual void visit (AST::RangeToExpr &expr);
   virtual void visit (AST::RangeFullExpr &expr);
-  virtual void visit (AST::RangeFromToInclExpr &expr);
-  virtual void visit (AST::RangeToInclExpr &expr);
-  virtual void visit (AST::ReturnExpr &expr);
-  virtual void visit (AST::UnsafeBlockExpr &expr);
-  virtual void visit (AST::LoopExpr &expr);
-  virtual void visit (AST::WhileLoopExpr &expr);
-  virtual void visit (AST::WhileLetLoopExpr &expr);
   virtual void visit (AST::ForLoopExpr &expr);
-  virtual void visit (AST::IfExpr &expr);
-  virtual void visit (AST::IfExprConseqElse &expr);
   virtual void visit (AST::IfLetExpr &expr);
-  virtual void visit (AST::IfLetExprConseqElse &expr);
   virtual void visit (AST::MatchExpr &expr);
-  virtual void visit (AST::AwaitExpr &expr);
-  virtual void visit (AST::AsyncBlockExpr &expr);
-  virtual void visit (AST::TypeParam &param);
   virtual void visit (AST::LifetimeWhereClauseItem &item);
-  virtual void visit (AST::TypeBoundWhereClauseItem &item);
   virtual void visit (AST::Module &module);
   virtual void visit (AST::ExternCrate &crate);
   virtual void visit (AST::UseTreeGlob &use_tree);
   virtual void visit (AST::UseTreeList &use_tree);
   virtual void visit (AST::UseTreeRebind &use_tree);
   virtual void visit (AST::UseDeclaration &use_decl);
-  virtual void visit (AST::Function &function);
-  virtual void visit (AST::TypeAlias &type_alias);
-  virtual void visit (AST::StructStruct &struct_item);
-  virtual void visit (AST::TupleStruct &tuple_struct);
   virtual void visit (AST::EnumItem &item);
-  virtual void visit (AST::EnumItemTuple &item);
-  virtual void visit (AST::EnumItemStruct &item);
-  virtual void visit (AST::EnumItemDiscriminant &item);
-  virtual void visit (AST::Enum &enum_item);
   virtual void visit (AST::Union &union_item);
-  virtual void visit (AST::ConstantItem &const_item);
-  virtual void visit (AST::StaticItem &static_item);
-  virtual void visit (AST::TraitItemFunc &item);
-  virtual void visit (AST::TraitItemMethod &item);
-  virtual void visit (AST::TraitItemConst &item);
   virtual void visit (AST::TraitItemType &item);
   virtual void visit (AST::Trait &trait);
   virtual void visit (AST::InherentImpl &impl);
   virtual void visit (AST::TraitImpl &impl);
   virtual void visit (AST::ExternalTypeItem &item);
-  virtual void visit (AST::ExternalStaticItem &item);
-  virtual void visit (AST::ExternalFunctionItem &item);
   virtual void visit (AST::ExternBlock &block);
-  virtual void visit (AST::MacroMatchFragment &match);
   virtual void visit (AST::MacroMatchRepetition &match);
   virtual void visit (AST::MacroMatcher &matcher);
   virtual void visit (AST::MacroRulesDefinition &rules_def);
   virtual void visit (AST::MacroInvocation &macro_invoc);
   virtual void visit (AST::MetaItemPath &meta_item);
   virtual void visit (AST::MetaItemSeq &meta_item);
-  virtual void visit (AST::MetaWord &meta_item);
   virtual void visit (AST::MetaNameValueStr &meta_item);
   virtual void visit (AST::MetaListPaths &meta_item);
   virtual void visit (AST::MetaListNameValueStr &meta_item);
-  virtual void visit (AST::LiteralPattern &pattern);
-  virtual void visit (AST::IdentifierPattern &pattern);
-  virtual void visit (AST::WildcardPattern &pattern);
-  virtual void visit (AST::RestPattern &pattern);
   virtual void visit (AST::RangePatternBoundLiteral &bound);
   virtual void visit (AST::RangePatternBoundPath &bound);
   virtual void visit (AST::RangePatternBoundQualPath &bound);
-  virtual void visit (AST::RangePattern &pattern);
-  virtual void visit (AST::ReferencePattern &pattern);
-  virtual void visit (AST::StructPatternFieldTuplePat &field);
-  virtual void visit (AST::StructPatternFieldIdentPat &field);
   virtual void visit (AST::StructPatternFieldIdent &field);
   virtual void visit (AST::StructPattern &pattern);
-  virtual void visit (AST::TupleStructItemsNoRange &tuple_items);
-  virtual void visit (AST::TupleStructItemsRange &tuple_items);
   virtual void visit (AST::TupleStructPattern &pattern);
-  virtual void visit (AST::TuplePatternItemsMultiple &tuple_items);
-  virtual void visit (AST::TuplePatternItemsRanged &tuple_items);
-  virtual void visit (AST::TuplePattern &pattern);
-  virtual void visit (AST::GroupedPattern &pattern);
-  virtual void visit (AST::SlicePattern &pattern);
-  virtual void visit (AST::AltPattern &pattern);
-  virtual void visit (AST::EmptyStmt &stmt);
-  virtual void visit (AST::LetStmt &stmt);
-  virtual void visit (AST::ExprStmt &stmt);
   virtual void visit (AST::TraitBound &bound);
   virtual void visit (AST::ImplTraitType &type);
   virtual void visit (AST::TraitObjectType &type);
@@ -270,17 +188,11 @@ private:
   virtual void visit (AST::ImplTraitTypeOneBound &type);
   virtual void visit (AST::TraitObjectTypeOneBound &type);
   virtual void visit (AST::TupleType &type);
-  virtual void visit (AST::NeverType &type);
   virtual void visit (AST::RawPointerType &type);
   virtual void visit (AST::ReferenceType &type);
   virtual void visit (AST::ArrayType &type);
   virtual void visit (AST::SliceType &type);
   virtual void visit (AST::InferredType &type);
-  virtual void visit (AST::BareFunctionType &type);
-
-  virtual void visit (AST::VariadicParam &type);
-  virtual void visit (AST::FunctionParam &type);
-  virtual void visit (AST::SelfParam &type);
 };
 
 } // namespace Resolver


### PR DESCRIPTION
Many visit functions in the early name resolver are just plain old traversal visit functions like the ones from the default visitor. Makes early name visitor inherit from the default visitor in order to avoid traversal duplication.