### PR TITLE
Make default resolver inherit from default visitor

### DIFF
--- a/gcc/rust/resolve/rust-default-resolver.cc
+++ b/gcc/rust/resolve/rust-default-resolver.cc
@@ -18,6 +18,7 @@
 
 #include "rust-default-resolver.h"
 #include "rust-ast-full.h"
+#include "rust-ast-visitor.h"
 #include "rust-item.h"
 
 namespace Rust {
@@ -147,24 +148,9 @@ DefaultResolver::visit (AST::StructStruct &type)
   // we also can't visit `StructField`s by default, so there's nothing to do -
   // correct? or should we do something like
 
-  for (auto &field : type.get_fields ())
-    field.get_field_type ()->accept_vis (*this);
+  AST::DefaultASTVisitor::visit (type);
 
   // FIXME: ???
-}
-
-void
-DefaultResolver::visit (AST::TupleStruct &type)
-{
-  for (auto &field : type.get_fields ())
-    field.get_field_type ()->accept_vis (*this);
-}
-
-void
-DefaultResolver::visit (AST::Union &type)
-{
-  for (auto &field : type.get_variants ())
-    field.get_field_type ()->accept_vis (*this);
 }
 
 void
@@ -182,146 +168,12 @@ DefaultResolver::visit (AST::Enum &type)
 }
 
 void
-DefaultResolver::visit (AST::BorrowExpr &expr)
-{
-  expr.get_borrowed_expr ()->accept_vis (*this);
-}
-
-void
-DefaultResolver::visit (AST::DereferenceExpr &expr)
-{
-  expr.get_dereferenced_expr ()->accept_vis (*this);
-}
-
-void
-DefaultResolver::visit (AST::ErrorPropagationExpr &expr)
-{
-  expr.get_propagating_expr ()->accept_vis (*this);
-}
-
-void
-DefaultResolver::visit (AST::NegationExpr &expr)
-{
-  expr.get_negated_expr ()->accept_vis (*this);
-}
-
-void
-DefaultResolver::visit (AST::ArithmeticOrLogicalExpr &expr)
-{
-  expr.get_left_expr ()->accept_vis (*this);
-  expr.get_right_expr ()->accept_vis (*this);
-}
-
-void
-DefaultResolver::visit (AST::ComparisonExpr &expr)
-{
-  expr.get_left_expr ()->accept_vis (*this);
-  expr.get_right_expr ()->accept_vis (*this);
-}
-
-void
-DefaultResolver::visit (AST::LazyBooleanExpr &expr)
-{
-  expr.get_left_expr ()->accept_vis (*this);
-  expr.get_right_expr ()->accept_vis (*this);
-}
-
-void
-DefaultResolver::visit (AST::TypeCastExpr &expr)
-{
-  expr.get_type_to_cast_to ()->accept_vis (*this);
-  expr.get_casted_expr ()->accept_vis (*this);
-}
-
-void
-DefaultResolver::visit (AST::AssignmentExpr &expr)
-{
-  expr.get_left_expr ()->accept_vis (*this);
-  expr.get_right_expr ()->accept_vis (*this);
-}
-
-void
-DefaultResolver::visit (AST::CompoundAssignmentExpr &expr)
-{
-  expr.get_left_expr ()->accept_vis (*this);
-  expr.get_right_expr ()->accept_vis (*this);
-}
-
-void
-DefaultResolver::visit (AST::GroupedExpr &expr)
-{
-  expr.get_expr_in_parens ()->accept_vis (*this);
-}
-
-void
-DefaultResolver::visit (AST::ArrayElemsValues &array)
-{
-  for (auto &value : array.get_values ())
-    value->accept_vis (*this);
-}
-
-void
-DefaultResolver::visit (AST::ArrayElemsCopied &array)
-{
-  array.get_elem_to_copy ()->accept_vis (*this);
-  array.get_num_copies ()->accept_vis (*this);
-}
-
-void
-DefaultResolver::visit (AST::ArrayExpr &expr)
-{
-  expr.get_array_elems ()->accept_vis (*this);
-}
-
-void
-DefaultResolver::visit (AST::ArrayIndexExpr &expr)
-{
-  expr.get_array_expr ()->accept_vis (*this);
-  expr.get_index_expr ()->accept_vis (*this);
-}
-
-void
-DefaultResolver::visit (AST::TupleExpr &expr)
-{
-  for (auto &element : expr.get_tuple_elems ())
-    element->accept_vis (*this);
-}
-
-void
-DefaultResolver::visit (AST::TupleIndexExpr &expr)
-{
-  expr.get_tuple_expr ()->accept_vis (*this);
-}
-
-void
 DefaultResolver::visit (AST::StructExprFieldIdentifierValue &)
 {}
 
 void
 DefaultResolver::visit (AST::StructExprFieldIndexValue &)
 {}
-
-void
-DefaultResolver::visit (AST::CallExpr &expr)
-{
-  expr.get_function_expr ()->accept_vis (*this);
-  for (auto &param : expr.get_params ())
-    param->accept_vis (*this);
-}
-
-void
-DefaultResolver::visit (AST::MethodCallExpr &expr)
-{
-  expr.get_receiver_expr ()->accept_vis (*this);
-  for (auto &param : expr.get_params ())
-    param->accept_vis (*this);
-}
-
-void
-DefaultResolver::visit (AST::FieldAccessExpr &expr)
-{
-  expr.get_receiver_expr ()->accept_vis (*this);
-}
 
 void
 DefaultResolver::visit (AST::ClosureExprInner &)
@@ -336,13 +188,6 @@ DefaultResolver::visit (AST::ContinueExpr &expr)
 {}
 
 void
-DefaultResolver::visit (AST::BreakExpr &expr)
-{
-  if (expr.has_break_expr ())
-    expr.get_break_expr ()->accept_vis (*this);
-}
-
-void
 DefaultResolver::visit (AST::RangeFromToExpr &expr)
 {}
 
@@ -352,10 +197,6 @@ DefaultResolver::visit (AST::RangeFromExpr &expr)
 
 void
 DefaultResolver::visit (AST::RangeToExpr &expr)
-{}
-
-void
-DefaultResolver::visit (AST::RangeFullExpr &expr)
 {}
 
 void
@@ -415,28 +256,6 @@ DefaultResolver::visit (AST::AsyncBlockExpr &expr)
 {}
 
 void
-DefaultResolver::visit (AST::LetStmt &let_stmt)
-{
-  let_stmt.get_pattern ()->accept_vis (*this);
-
-  if (let_stmt.has_type ())
-    let_stmt.get_type ()->accept_vis (*this);
-
-  if (let_stmt.has_init_expr ())
-    let_stmt.get_init_expr ()->accept_vis (*this);
-}
-
-void
-DefaultResolver::visit (AST::ExprStmt &stmt)
-{
-  stmt.get_expr ()->accept_vis (*this);
-}
-
-void
-DefaultResolver::visit (AST::Token &)
-{}
-
-void
 DefaultResolver::visit (AST::DelimTokenTree &)
 {}
 
@@ -449,10 +268,6 @@ DefaultResolver::visit (AST::IdentifierExpr &expr)
 {}
 
 void
-DefaultResolver::visit (AST::Lifetime &)
-{}
-
-void
 DefaultResolver::visit (AST::LifetimeParam &)
 {}
 
@@ -462,10 +277,6 @@ DefaultResolver::visit (AST::ConstGenericParam &)
 
 void
 DefaultResolver::visit (AST::PathInExpression &)
-{}
-
-void
-DefaultResolver::visit (AST::TypePathSegment &)
 {}
 
 void
@@ -510,10 +321,6 @@ DefaultResolver::visit (AST::MetaItemPathLit &)
 
 void
 DefaultResolver::visit (AST::StructExprStruct &)
-{}
-
-void
-DefaultResolver::visit (AST::StructExprFieldIdentifier &)
 {}
 
 void
@@ -623,10 +430,6 @@ DefaultResolver::visit (AST::ExternalFunctionItem &)
 {}
 
 void
-DefaultResolver::visit (AST::MacroMatchFragment &)
-{}
-
-void
 DefaultResolver::visit (AST::MacroMatchRepetition &)
 {}
 
@@ -651,42 +454,11 @@ DefaultResolver::visit (AST::MetaItemSeq &)
 {}
 
 void
-DefaultResolver::visit (AST::MetaWord &)
-{}
-
-void
-DefaultResolver::visit (AST::MetaNameValueStr &)
-{}
-
-void
 DefaultResolver::visit (AST::MetaListPaths &)
 {}
 
 void
 DefaultResolver::visit (AST::MetaListNameValueStr &)
-{}
-
-void
-DefaultResolver::visit (AST::LiteralPattern &)
-{}
-
-void
-DefaultResolver::visit (AST::IdentifierPattern &pattern)
-{
-  if (pattern.has_pattern_to_bind ())
-    pattern.get_pattern_to_bind ()->accept_vis (*this);
-}
-
-void
-DefaultResolver::visit (AST::WildcardPattern &)
-{}
-
-void
-DefaultResolver::visit (AST::RestPattern &)
-{}
-
-void
-DefaultResolver::visit (AST::RangePatternBoundLiteral &)
 {}
 
 void
@@ -790,10 +562,6 @@ DefaultResolver::visit (AST::TupleType &)
 {}
 
 void
-DefaultResolver::visit (AST::NeverType &)
-{}
-
-void
 DefaultResolver::visit (AST::RawPointerType &)
 {}
 
@@ -807,10 +575,6 @@ DefaultResolver::visit (AST::ArrayType &)
 
 void
 DefaultResolver::visit (AST::SliceType &)
-{}
-
-void
-DefaultResolver::visit (AST::InferredType &)
 {}
 
 void

--- a/gcc/rust/resolve/rust-default-resolver.h
+++ b/gcc/rust/resolve/rust-default-resolver.h
@@ -32,9 +32,11 @@ namespace Resolver2_0 {
  * visiting each node's subnodes - a block's statements, a function call's
  * arguments...
  */
-class DefaultResolver : public AST::ASTVisitor
+class DefaultResolver : public AST::DefaultASTVisitor
 {
 public:
+  using AST::DefaultASTVisitor::visit;
+
   virtual ~DefaultResolver () {}
 
   // First, our lexical scope expressions - these visit their sub nodes, always
@@ -51,41 +53,17 @@ public:
 
   // type dec nodes, which visit their fields or variants by default
   void visit (AST::StructStruct &);
-  void visit (AST::TupleStruct &);
-  void visit (AST::Union &);
   void visit (AST::Enum &);
 
   // Visitors that visit their expression node(s)
-  void visit (AST::BorrowExpr &);
-  void visit (AST::DereferenceExpr &);
-  void visit (AST::ErrorPropagationExpr &);
-  void visit (AST::NegationExpr &);
-  void visit (AST::ArithmeticOrLogicalExpr &);
-  void visit (AST::ComparisonExpr &);
-  void visit (AST::LazyBooleanExpr &);
-  void visit (AST::TypeCastExpr &);
-  void visit (AST::AssignmentExpr &);
-  void visit (AST::CompoundAssignmentExpr &);
-  void visit (AST::GroupedExpr &);
-  void visit (AST::ArrayElemsValues &);
-  void visit (AST::ArrayElemsCopied &);
-  void visit (AST::ArrayExpr &);
-  void visit (AST::ArrayIndexExpr &);
-  void visit (AST::TupleExpr &);
-  void visit (AST::TupleIndexExpr &);
   void visit (AST::StructExprFieldIdentifierValue &);
   void visit (AST::StructExprFieldIndexValue &);
-  void visit (AST::CallExpr &);
-  void visit (AST::MethodCallExpr &);
-  void visit (AST::FieldAccessExpr &);
   void visit (AST::ClosureExprInner &);
   void visit (AST::ClosureExprInnerTyped &);
   void visit (AST::ContinueExpr &);
-  void visit (AST::BreakExpr &);
   void visit (AST::RangeFromToExpr &);
   void visit (AST::RangeFromExpr &);
   void visit (AST::RangeToExpr &);
-  void visit (AST::RangeFullExpr &);
   void visit (AST::RangeFromToInclExpr &);
   void visit (AST::RangeToInclExpr &);
   void visit (AST::ReturnExpr &);
@@ -100,19 +78,14 @@ public:
   void visit (AST::MatchExpr &);
   void visit (AST::AwaitExpr &);
   void visit (AST::AsyncBlockExpr &);
-  void visit (AST::LetStmt &);
-  void visit (AST::ExprStmt &);
 
   // Leaf visitors, which do nothing by default
-  void visit (AST::Token &);
   void visit (AST::DelimTokenTree &);
   void visit (AST::AttrInputMetaItemContainer &);
   void visit (AST::IdentifierExpr &);
-  void visit (AST::Lifetime &);
   void visit (AST::LifetimeParam &);
   void visit (AST::ConstGenericParam &);
   void visit (AST::PathInExpression &);
-  void visit (AST::TypePathSegment &);
   void visit (AST::TypePathSegmentGeneric &);
   void visit (AST::TypePathSegmentFunction &);
   void visit (AST::TypePath &);
@@ -124,7 +97,6 @@ public:
   void visit (AST::MetaItemLitExpr &);
   void visit (AST::MetaItemPathLit &);
   void visit (AST::StructExprStruct &);
-  void visit (AST::StructExprFieldIdentifier &);
   void visit (AST::StructExprStructFields &);
   void visit (AST::StructExprStructBase &);
   void visit (AST::TypeParam &);
@@ -149,22 +121,14 @@ public:
   void visit (AST::ExternalTypeItem &);
   void visit (AST::ExternalStaticItem &);
   void visit (AST::ExternalFunctionItem &);
-  void visit (AST::MacroMatchFragment &);
   void visit (AST::MacroMatchRepetition &);
   void visit (AST::MacroMatcher &);
   void visit (AST::MacroRulesDefinition &);
   void visit (AST::MacroInvocation &);
   void visit (AST::MetaItemPath &);
   void visit (AST::MetaItemSeq &);
-  void visit (AST::MetaWord &);
-  void visit (AST::MetaNameValueStr &);
   void visit (AST::MetaListPaths &);
   void visit (AST::MetaListNameValueStr &);
-  void visit (AST::LiteralPattern &);
-  void visit (AST::IdentifierPattern &);
-  void visit (AST::WildcardPattern &);
-  void visit (AST::RestPattern &);
-  void visit (AST::RangePatternBoundLiteral &);
   void visit (AST::RangePatternBoundPath &);
   void visit (AST::RangePatternBoundQualPath &);
   void visit (AST::RangePattern &);
@@ -190,12 +154,10 @@ public:
   void visit (AST::ImplTraitTypeOneBound &);
   void visit (AST::TraitObjectTypeOneBound &);
   void visit (AST::TupleType &);
-  void visit (AST::NeverType &);
   void visit (AST::RawPointerType &);
   void visit (AST::ReferenceType &);
   void visit (AST::ArrayType &);
   void visit (AST::SliceType &);
-  void visit (AST::InferredType &);
   void visit (AST::BareFunctionType &);
   void visit (AST::FunctionParam &);
   void visit (AST::VariadicParam &);


### PR DESCRIPTION
The default resolver put some scope in place but mostly has traversal functions similar to the default ast visitor, making it inherit from the default visitor allows us to avoid code duplication.