### PR TITLE
gccrs: Remove backend dependancy on resolution rib information

### DIFF
--- a/gcc/rust/backend/rust-compile-base.h
+++ b/gcc/rust/backend/rust-compile-base.h
@@ -145,9 +145,6 @@ protected:
 
   static bool mark_addressable (tree, location_t);
 
-  static std::vector<Bvariable *>
-  compile_locals_for_block (Context *ctx, Resolver::Rib &rib, tree fndecl);
-
   static tree named_constant_expression (tree type_tree,
 					 const std::string &name,
 					 tree const_val, location_t location);

--- a/gcc/rust/backend/rust-compile-block.cc
+++ b/gcc/rust/backend/rust-compile-block.cc
@@ -42,20 +42,9 @@ CompileBlock::visit (HIR::BlockExpr &expr)
   tree fndecl = fnctx.fndecl;
   location_t start_location = expr.get_locus ();
   location_t end_location = expr.get_end_locus ();
-  auto body_mappings = expr.get_mappings ();
-
-  Resolver::Rib *rib = nullptr;
-  if (!ctx->get_resolver ()->find_name_rib (body_mappings.get_nodeid (), &rib))
-    {
-      rust_fatal_error (expr.get_locus (), "failed to setup locals per block");
-      return;
-    }
-
-  std::vector<Bvariable *> locals
-    = compile_locals_for_block (ctx, *rib, fndecl);
 
   tree enclosing_scope = ctx->peek_enclosing_scope ();
-  tree new_block = Backend::block (fndecl, enclosing_scope, locals,
+  tree new_block = Backend::block (fndecl, enclosing_scope, {} /*locals*/,
 				   start_location, end_location);
   ctx->push_block (new_block);
 

--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -2310,7 +2310,6 @@ CompileExpr::generate_closure_function (HIR::ClosureExpr &expr,
   bool is_block_expr
     = function_body->get_expression_type () == HIR::Expr::ExprType::Block;
 
-  std::vector<Bvariable *> locals = {};
   if (is_block_expr)
     {
       auto body_mappings = function_body->get_mappings ();
@@ -2319,8 +2318,6 @@ CompileExpr::generate_closure_function (HIR::ClosureExpr &expr,
 	= ctx->get_resolver ()->find_name_rib (body_mappings.get_nodeid (),
 					       &rib);
       rust_assert (ok);
-
-      locals = compile_locals_for_block (ctx, *rib, fndecl);
     }
 
   tree enclosing_scope = NULL_TREE;
@@ -2333,7 +2330,7 @@ CompileExpr::generate_closure_function (HIR::ClosureExpr &expr,
       end_location = body->get_end_locus ();
     }
 
-  tree code_block = Backend::block (fndecl, enclosing_scope, locals,
+  tree code_block = Backend::block (fndecl, enclosing_scope, {} /*locals*/,
 				    start_location, end_location);
   ctx->push_block (code_block);
 

--- a/gcc/rust/backend/rust-compile-var-decl.h
+++ b/gcc/rust/backend/rust-compile-var-decl.h
@@ -30,11 +30,12 @@ class CompileVarDecl : public HIRCompileBase, public HIR::HIRPatternVisitor
   using HIR::HIRPatternVisitor::visit;
 
 public:
-  static void compile (tree fndecl, tree translated_type, HIR::Pattern *pattern,
-		       std::vector<Bvariable *> &locals, Context *ctx)
+  static std::vector<Bvariable *> compile (tree fndecl, tree translated_type,
+					   HIR::Pattern *pattern, Context *ctx)
   {
-    CompileVarDecl compiler (ctx, fndecl, translated_type, locals);
+    CompileVarDecl compiler (ctx, fndecl, translated_type);
     pattern->accept_vis (compiler);
+    return compiler.vars;
   }
 
   void visit (HIR::IdentifierPattern &pattern) override
@@ -42,15 +43,58 @@ public:
     if (!pattern.is_mut ())
       translated_type = Backend::immutable_type (translated_type);
 
-    Bvariable *var
-      = Backend::local_variable (fndecl, pattern.get_identifier ().as_string (),
-				 translated_type, NULL /*decl_var*/,
-				 pattern.get_locus ());
+    tree bind_tree = ctx->peek_enclosing_scope ();
+    std::string identifier = pattern.get_identifier ().as_string ();
+    tree decl
+      = build_decl (pattern.get_locus (), VAR_DECL,
+		    Backend::get_identifier_node (identifier), translated_type);
+    DECL_CONTEXT (decl) = fndecl;
+
+    gcc_assert (TREE_CODE (bind_tree) == BIND_EXPR);
+    tree block_tree = BIND_EXPR_BLOCK (bind_tree);
+    gcc_assert (TREE_CODE (block_tree) == BLOCK);
+    DECL_CHAIN (decl) = BLOCK_VARS (block_tree);
+    BLOCK_VARS (block_tree) = decl;
+    BIND_EXPR_VARS (bind_tree) = BLOCK_VARS (block_tree);
+
+    rust_preserve_from_gc (decl);
+    Bvariable *var = new Bvariable (decl);
 
     HirId stmt_id = pattern.get_mappings ().get_hirid ();
     ctx->insert_var_decl (stmt_id, var);
 
-    locals.push_back (var);
+    vars.push_back (var);
+  }
+
+  void visit (HIR::TuplePattern &pattern) override
+  {
+    switch (pattern.get_items ()->get_item_type ())
+      {
+	case HIR::TuplePatternItems::ItemType::MULTIPLE: {
+	  rust_assert (TREE_CODE (translated_type) == RECORD_TYPE);
+	  auto &items = static_cast<HIR::TuplePatternItemsMultiple &> (
+	    *pattern.get_items ());
+
+	  size_t offs = 0;
+	  for (auto &sub : items.get_patterns ())
+	    {
+	      tree sub_ty = error_mark_node;
+	      tree field = TYPE_FIELDS (translated_type);
+	      for (size_t i = 0; i < offs; i++)
+		{
+		  field = DECL_CHAIN (field);
+		  gcc_assert (field != NULL_TREE);
+		}
+	      sub_ty = TREE_TYPE (field);
+	      CompileVarDecl::compile (fndecl, sub_ty, sub.get (), ctx);
+	      offs++;
+	    }
+	}
+	break;
+
+      default:
+	break;
+      }
   }
 
   // Empty visit for unused Pattern HIR nodes.
@@ -62,21 +106,18 @@ public:
   void visit (HIR::ReferencePattern &) override {}
   void visit (HIR::SlicePattern &) override {}
   void visit (HIR::StructPattern &) override {}
-  void visit (HIR::TuplePattern &) override {}
   void visit (HIR::TupleStructPattern &) override {}
   void visit (HIR::WildcardPattern &) override {}
 
 private:
-  CompileVarDecl (Context *ctx, tree fndecl, tree translated_type,
-		  std::vector<Bvariable *> &locals)
-    : HIRCompileBase (ctx), fndecl (fndecl), translated_type (translated_type),
-      locals (locals)
+  CompileVarDecl (Context *ctx, tree fndecl, tree translated_type)
+    : HIRCompileBase (ctx), fndecl (fndecl), translated_type (translated_type)
   {}
 
   tree fndecl;
   tree translated_type;
 
-  std::vector<Bvariable *> &locals;
+  std::vector<Bvariable *> vars;
 };
 
 } // namespace Compile


### PR DESCRIPTION
When making more desugaring for the HIR we can need to add new Let bindings which will require namesolution information but also rib information for which block the let binding is associated which was very unnessecary. This patch simply updates the BLOCK_CONTEXT of the current scope as we are compiling and encounter HIR::LetStmts instead of trying to do it all upfront which lots of wierd checks

gcc/rust/ChangeLog:

	* backend/rust-compile-base.cc (HIRCompileBase::compile_locals_for_block): removed
	* backend/rust-compile-base.h: update header
	* backend/rust-compile-block.cc (CompileBlock::visit): remove old logic
	* backend/rust-compile-expr.cc (CompileExpr::generate_closure_function): likewise
	* backend/rust-compile-stmt.cc (CompileStmt::visit): likewise
	* backend/rust-compile-var-decl.h: ensure we setup tuple bindings correctly