### PR TITLE
Add test for binding name resolution scope

### DIFF
--- a/gcc/testsuite/rust/compile/name_resolution11.rs
+++ b/gcc/testsuite/rust/compile/name_resolution11.rs
@@ -1,0 +1,7 @@
+// { dg-additional-options "-frust-name-resolution-2.0 -frust-compile-until=lowering" }
+fn foo() {
+    let b = 10;
+    fn bar() {
+        let a = foo;
+    }
+}

--- a/gcc/testsuite/rust/compile/name_resolution12.rs
+++ b/gcc/testsuite/rust/compile/name_resolution12.rs
@@ -1,0 +1,10 @@
+// { dg-additional-options "-frust-name-resolution-2.0 -frust-compile-until=lowering" }
+
+const TOTO: i32 = 10;
+
+fn foo() {
+    let b = 10;
+    fn bar() {
+        let e = TOTO;
+    }
+}

--- a/gcc/testsuite/rust/compile/name_resolution13.rs
+++ b/gcc/testsuite/rust/compile/name_resolution13.rs
@@ -1,0 +1,9 @@
+// { dg-additional-options "-frust-name-resolution-2.0 -frust-compile-until=lowering" }
+
+fn foo() {
+    let b = 10;
+    fn bar() {
+        let c = b;
+        // { dg-error "cannot find value .b. in this scope .E0425." "" { target *-*-* } .-1 }
+    }
+}

--- a/gcc/testsuite/rust/execute/torture/name_resolution.rs
+++ b/gcc/testsuite/rust/execute/torture/name_resolution.rs
@@ -1,0 +1,24 @@
+// { dg-additional-options "-frust-name-resolution-2.0" }
+// { dg-output "Value is 10\r*\n" }
+
+const BAZ: i32 = 10;
+
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+fn foo() {
+    fn bar() {
+        let e = BAZ;
+        unsafe {
+            printf("Value is %i\n" as *const str as *const i8, e);
+        }
+    }
+
+    bar();
+}
+
+fn main() -> i32 {
+    foo();
+    0
+}


### PR DESCRIPTION
Local variables and functions or global variables have different resolution when binded to a variable. This was not covered before, even though it was handled by the new name resolution. This commit highlight this behavior from the new name resolution mechanism.

Fixes #2730 