### PR TITLE
Allow enabling ```lang_items``` and ```no_core``` features

### DIFF
--- a/gcc/rust/checks/errors/rust-feature.cc
+++ b/gcc/rust/checks/errors/rust-feature.cc
@@ -56,6 +56,8 @@ const std::map<std::string, Feature::Name> Feature::name_hash_map = {
   // later Rust versions
   {"optin_builtin_traits", Feature::Name::AUTO_TRAITS},
   {"extern_types", Feature::Name::EXTERN_TYPES},
+  {"lang_items", Feature::Name::LANG_ITEMS},
+  {"no_core", Feature::Name::NO_CORE},
 }; // namespace Rust
 
 tl::optional<Feature::Name>

--- a/gcc/rust/checks/errors/rust-feature.h
+++ b/gcc/rust/checks/errors/rust-feature.h
@@ -43,6 +43,8 @@ public:
     DECL_MACRO,
     AUTO_TRAITS,
     EXTERN_TYPES,
+    LANG_ITEMS,
+    NO_CORE,
   };
 
   const std::string &as_string () { return m_name_str; }

--- a/gcc/testsuite/rust/compile/sized-stub.rs
+++ b/gcc/testsuite/rust/compile/sized-stub.rs
@@ -1,0 +1,6 @@
+#![feature(lang_items)]
+#![feature(no_core)]
+#![no_core]
+
+#[lang = "sized"]
+trait Sized {}


### PR DESCRIPTION
This should allow code such as

```rust
#![feature(lang_items)]
#![feature(no_core)]
#![no_core]

#[lang = "sized"]
trait Sized {}
```

to compile.