### PR TITLE
Renamed `WIN64` to `WIN_64`

### DIFF
--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -463,7 +463,7 @@ HIRCompileBase::setup_abi_options (tree fndecl, ABI abi)
 
       break;
 
-    case Rust::ABI::WIN64:
+    case Rust::ABI::WIN_64:
       abi_tree = get_identifier ("ms_abi");
 
       break;

--- a/gcc/rust/util/rust-abi.cc
+++ b/gcc/rust/util/rust-abi.cc
@@ -40,7 +40,7 @@ get_abi_from_string (const std::string &abi)
   else if (abi.compare ("sysv64") == 0)
     return Rust::ABI::SYSV64;
   else if (abi.compare ("win64") == 0)
-    return Rust::ABI::WIN64;
+    return Rust::ABI::WIN_64;
 
   return Rust::ABI::UNKNOWN;
 }
@@ -64,7 +64,7 @@ get_string_from_abi (Rust::ABI abi)
       return "fastcall";
     case Rust::ABI::SYSV64:
       return "sysv64";
-    case Rust::ABI::WIN64:
+    case Rust::ABI::WIN_64:
       return "win64";
 
     case Rust::ABI::UNKNOWN:

--- a/gcc/rust/util/rust-abi.h
+++ b/gcc/rust/util/rust-abi.h
@@ -30,7 +30,7 @@ enum ABI
   CDECL,
   STDCALL,
   FASTCALL,
-  WIN64,
+  WIN_64,
   SYSV64
 };
 


### PR DESCRIPTION
Fixes issue #2768

gcc/rust/ChangeLog:

	* backend/rust-compile-base.cc (HIRCompileBase::setup_abi_options): Renamed `WIN64` to `WIN_64`
	* util/rust-abi.cc (get_abi_from_string): Likewise
	(get_string_from_abi): Likewise
	* util/rust-abi.h (enum ABI): Likewise

Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---

*Please write a comment explaining your change. This is the message
that will be part of the merge commit.
