### PR TITLE
Handle `async` qualifier inside trait

### DIFF
--- a/gcc/rust/checks/errors/rust-ast-validation.cc
+++ b/gcc/rust/checks/errors/rust-ast-validation.cc
@@ -107,6 +107,11 @@ ASTValidation::visit (AST::Function &function)
     rust_error_at (function.get_locus (), ErrorCode::E0379,
 		   "functions in traits cannot be declared const");
 
+  // may change soon
+  if (qualifiers.is_async () && context.back () == Context::TRAIT_IMPL)
+    rust_error_at (function.get_locus (), ErrorCode::E0706,
+		   "functions in traits cannot be declared %<async%>");
+
   if (valid_context.find (context.back ()) == valid_context.end ()
       && function.has_self_param ())
     rust_error_at (

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -5784,6 +5784,8 @@ Parser<ManagedTokenSource>::parse_trait_impl_item ()
       // function or method
       return parse_trait_impl_function_or_method (visibility,
 						  std::move (outer_attrs));
+    case ASYNC:
+      return parse_async_item (visibility, std::move (outer_attrs));
     case CONST:
       // lookahead to resolve production - could be function/method or const
       // item

--- a/gcc/testsuite/rust/compile/issue-2767.rs
+++ b/gcc/testsuite/rust/compile/issue-2767.rs
@@ -1,0 +1,13 @@
+// { dg-additional-options "-frust-edition=2018" }
+trait Foo {
+    fn f() -> u32;
+}
+
+impl Foo for u32 {
+    async fn f() -> u32 {
+        // { dg-error "functions in traits cannot be declared .async." "" { target *-*-* } .-1 }
+        22
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #2778

gcc/rust/ChangeLog:

	* parse/rust-parse-impl.h (Parser::parse_trait_impl_item): Handled `async` similar to `const` (Parser::parse_pattern): clang-format.

Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`
- \[x] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---

*Please write a comment explaining your change. This is the message
that will be part of the merge commit.
