### PR TITLE
Unify storage of associated items in ```SingleASTNode```

### DIFF
--- a/gcc/rust/ast/rust-ast-fragment.cc
+++ b/gcc/rust/ast/rust-ast-fragment.cc
@@ -153,14 +153,12 @@ void
 Fragment::assert_single_fragment (SingleASTNode::NodeType expected) const
 {
   static const std::map<SingleASTNode::NodeType, const char *> str_map = {
-    {SingleASTNode::NodeType::IMPL, "impl"},
+    {SingleASTNode::NodeType::ASSOC_ITEM, "associated item"},
     {SingleASTNode::NodeType::ITEM, "item"},
     {SingleASTNode::NodeType::TYPE, "type"},
     {SingleASTNode::NodeType::EXPRESSION, "expr"},
     {SingleASTNode::NodeType::STMT, "stmt"},
     {SingleASTNode::NodeType::EXTERN, "extern"},
-    {SingleASTNode::NodeType::TRAIT, "trait"},
-    {SingleASTNode::NodeType::TRAIT_IMPL, "trait impl"},
   };
 
   auto actual = nodes[0].get_kind ();

--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -60,16 +60,8 @@ SingleASTNode::SingleASTNode (SingleASTNode const &other)
       external_item = other.external_item->clone_external_item ();
       break;
 
-    case TRAIT:
-      trait_item = other.trait_item->clone_trait_item ();
-      break;
-
-    case IMPL:
-      impl_item = other.impl_item->clone_associated_item ();
-      break;
-
-    case TRAIT_IMPL:
-      trait_impl_item = other.trait_impl_item->clone_trait_impl_item ();
+    case ASSOC_ITEM:
+      assoc_item = other.assoc_item->clone_associated_item ();
       break;
 
     case TYPE:
@@ -100,16 +92,8 @@ SingleASTNode::operator= (SingleASTNode const &other)
       external_item = other.external_item->clone_external_item ();
       break;
 
-    case TRAIT:
-      trait_item = other.trait_item->clone_trait_item ();
-      break;
-
-    case IMPL:
-      impl_item = other.impl_item->clone_associated_item ();
-      break;
-
-    case TRAIT_IMPL:
-      trait_impl_item = other.trait_impl_item->clone_trait_impl_item ();
+    case ASSOC_ITEM:
+      assoc_item = other.assoc_item->clone_associated_item ();
       break;
 
     case TYPE:
@@ -140,16 +124,8 @@ SingleASTNode::accept_vis (ASTVisitor &vis)
       external_item->accept_vis (vis);
       break;
 
-    case TRAIT:
-      trait_item->accept_vis (vis);
-      break;
-
-    case IMPL:
-      impl_item->accept_vis (vis);
-      break;
-
-    case TRAIT_IMPL:
-      trait_impl_item->accept_vis (vis);
+    case ASSOC_ITEM:
+      assoc_item->accept_vis (vis);
       break;
 
     case TYPE:
@@ -171,12 +147,8 @@ SingleASTNode::is_error ()
       return stmt == nullptr;
     case EXTERN:
       return external_item == nullptr;
-    case TRAIT:
-      return trait_item == nullptr;
-    case IMPL:
-      return impl_item == nullptr;
-    case TRAIT_IMPL:
-      return trait_impl_item == nullptr;
+    case ASSOC_ITEM:
+      return assoc_item == nullptr;
     case TYPE:
       return type == nullptr;
     }
@@ -198,12 +170,8 @@ SingleASTNode::as_string () const
       return "Stmt: " + stmt->as_string ();
     case EXTERN:
       return "External Item: " + external_item->as_string ();
-    case TRAIT:
-      return "Trait Item: " + trait_item->as_string ();
-    case IMPL:
-      return "Impl Item: " + impl_item->as_string ();
-    case TRAIT_IMPL:
-      return "Trait Impl Item: " + trait_impl_item->as_string ();
+    case ASSOC_ITEM:
+      return "Associated Item: " + assoc_item->as_string ();
     case TYPE:
       return "Type: " + type->as_string ();
     }

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -1655,8 +1655,22 @@ public:
   virtual location_t get_locus () const = 0;
 };
 
+// Abstract base class for items used in a trait impl
+class TraitImplItem : public AssociatedItem
+{
+protected:
+  virtual TraitImplItem *clone_associated_item_impl () const override = 0;
+
+public:
+  // Unique pointer custom clone function
+  std::unique_ptr<TraitImplItem> clone_trait_impl_item () const
+  {
+    return std::unique_ptr<TraitImplItem> (clone_associated_item_impl ());
+  }
+};
+
 // Item used in trait declarations - abstract base class
-class TraitItem : virtual public AssociatedItem
+class TraitItem : public TraitImplItem
 {
 protected:
   TraitItem (location_t locus)
@@ -1685,20 +1699,6 @@ public:
 
   NodeId get_node_id () const { return node_id; }
   location_t get_locus () const override { return locus; }
-};
-
-// Abstract base class for items used in a trait impl
-class TraitImplItem : virtual public AssociatedItem
-{
-protected:
-  virtual TraitImplItem *clone_associated_item_impl () const override = 0;
-
-public:
-  // Unique pointer custom clone function
-  std::unique_ptr<TraitImplItem> clone_trait_impl_item () const
-  {
-    return std::unique_ptr<TraitImplItem> (clone_associated_item_impl ());
-  }
 };
 
 // Abstract base class for an item used inside an extern block
@@ -1829,9 +1829,7 @@ public:
     ITEM,
     STMT,
     EXTERN,
-    TRAIT,
-    IMPL,
-    TRAIT_IMPL,
+    ASSOC_ITEM,
     TYPE,
   };
 
@@ -1843,9 +1841,7 @@ private:
   std::unique_ptr<Item> item;
   std::unique_ptr<Stmt> stmt;
   std::unique_ptr<ExternalItem> external_item;
-  std::unique_ptr<TraitItem> trait_item;
-  std::unique_ptr<AssociatedItem> impl_item;
-  std::unique_ptr<TraitImplItem> trait_impl_item;
+  std::unique_ptr<AssociatedItem> assoc_item;
   std::unique_ptr<Type> type;
 
 public:
@@ -1865,16 +1861,8 @@ public:
     : kind (EXTERN), external_item (std::move (item))
   {}
 
-  SingleASTNode (std::unique_ptr<TraitItem> item)
-    : kind (TRAIT), trait_item (std::move (item))
-  {}
-
   SingleASTNode (std::unique_ptr<AssociatedItem> item)
-    : kind (IMPL), impl_item (std::move (item))
-  {}
-
-  SingleASTNode (std::unique_ptr<TraitImplItem> trait_impl_item)
-    : kind (TRAIT_IMPL), trait_impl_item (std::move (trait_impl_item))
+    : kind (ASSOC_ITEM), assoc_item (std::move (item))
   {}
 
   SingleASTNode (std::unique_ptr<Type> type)
@@ -1934,7 +1922,8 @@ public:
   std::unique_ptr<TraitItem> take_trait_item ()
   {
     rust_assert (!is_error ());
-    return std::move (trait_item);
+    return std::unique_ptr<TraitItem> (
+      static_cast<TraitItem *> (assoc_item.release ()));
   }
 
   std::unique_ptr<ExternalItem> take_external_item ()
@@ -1943,16 +1932,22 @@ public:
     return std::move (external_item);
   }
 
-  std::unique_ptr<AssociatedItem> take_impl_item ()
+  std::unique_ptr<AssociatedItem> take_assoc_item ()
   {
     rust_assert (!is_error ());
-    return std::move (impl_item);
+    return std::move (assoc_item);
+  }
+
+  std::unique_ptr<AssociatedItem> take_impl_item ()
+  {
+    return take_assoc_item ();
   }
 
   std::unique_ptr<TraitImplItem> take_trait_impl_item ()
   {
     rust_assert (!is_error ());
-    return std::move (trait_impl_item);
+    return std::unique_ptr<TraitImplItem> (
+      static_cast<TraitImplItem *> (assoc_item.release ()));
   }
 
   std::unique_ptr<Type> take_type ()

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -1289,9 +1289,7 @@ protected:
 class LetStmt;
 
 // Rust function declaration AST node
-class Function : public VisItem,
-		 virtual public AssociatedItem,
-		 public TraitImplItem
+class Function : public VisItem, public TraitImplItem
 {
   FunctionQualifiers qualifiers;
   Identifier function_name;
@@ -2314,9 +2312,7 @@ protected:
 
 /* "Constant item" AST node - used for constant, compile-time expressions
  * within module scope (like constexpr) */
-class ConstantItem : public VisItem,
-		     virtual public AssociatedItem,
-		     public TraitImplItem
+class ConstantItem : public VisItem, public TraitImplItem
 {
   // either has an identifier or "_" - maybe handle in identifier?
   // bool identifier_is_underscore;

--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -598,8 +598,6 @@ class MacroInvocation : public TypeNoBounds,
 			public Pattern,
 			public Item,
 			public TraitItem,
-			public TraitImplItem,
-			virtual public AssociatedItem,
 			public ExternalItem,
 			public ExprWithoutBlock
 {


### PR DESCRIPTION
This is a bit clunky but gets us closer to unifying handling of associated items in the AST and should be a minimal change.