### PR TITLE
Added newline to get more readable lexdump

### DIFF
--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -240,7 +240,7 @@ Lexer::dump_and_skip (int n)
 				     + std::string (tok->get_type_hint_str ()))
 				  : "")
 	      << " ";
-	  out << Linemap::location_to_string (loc) << " ";
+	  out << Linemap::location_to_string (loc) << '\n';
 	}
 
       token_queue.skip (0);


### PR DESCRIPTION
Fixes #2783

The line giving information about token now ends with '\n' rather than " " to make the gccrs.lex.dump file more readable. This file is generated using flag -frust-dump-lex 
