### PR TITLE
Handle `async` functions in traits

### DIFF
--- a/gcc/rust/checks/errors/rust-ast-validation.cc
+++ b/gcc/rust/checks/errors/rust-ast-validation.cc
@@ -149,7 +149,7 @@ ASTValidation::visit (AST::TraitFunctionDecl &decl)
 		       "functions in traits cannot be declared %<async%>");
       if (qualifiers.is_const ())
 	rust_error_at (decl.get_identifier ().get_locus (), ErrorCode::E0379,
-		       "functions in traits cannot be declared const");
+		       "functions in traits cannot be declared %<const%>");
     }
 }
 

--- a/gcc/rust/checks/errors/rust-ast-validation.cc
+++ b/gcc/rust/checks/errors/rust-ast-validation.cc
@@ -141,9 +141,16 @@ ASTValidation::visit (AST::TraitFunctionDecl &decl)
 {
   const auto &qualifiers = decl.get_qualifiers ();
 
-  if (context.back () == Context::TRAIT && qualifiers.is_const ())
-    rust_error_at (decl.get_identifier ().get_locus (), ErrorCode::E0379,
-		   "functions in traits cannot be declared const");
+  if (context.back () == Context::TRAIT)
+    {
+      // may change soon
+      if (qualifiers.is_async ())
+	rust_error_at (decl.get_identifier ().get_locus (), ErrorCode::E0706,
+		       "functions in traits cannot be declared %<async%>");
+      if (qualifiers.is_const ())
+	rust_error_at (decl.get_identifier ().get_locus (), ErrorCode::E0379,
+		       "functions in traits cannot be declared const");
+    }
 }
 
 void

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -5096,6 +5096,7 @@ Parser<ManagedTokenSource>::parse_trait_item ()
       // else, fallthrough to function
       // TODO: find out how to disable gcc "implicit fallthrough" error
       gcc_fallthrough ();
+    case ASYNC:
     case UNSAFE:
     case EXTERN_KW:
       case FN_KW: {

--- a/gcc/testsuite/rust/compile/const_trait_fn.rs
+++ b/gcc/testsuite/rust/compile/const_trait_fn.rs
@@ -1,4 +1,4 @@
 trait Osterkz {
     const fn x();
-    // { dg-error "functions in traits cannot be declared const .E0379." "" { target *-*-* } .-1 }
+    // { dg-error "functions in traits cannot be declared .const." "" { target *-*-* } .-1 }
 }

--- a/gcc/testsuite/rust/compile/issue-2785.rs
+++ b/gcc/testsuite/rust/compile/issue-2785.rs
@@ -1,0 +1,9 @@
+// { dg-additional-options "-frust-edition=2018" }
+trait Foo {
+    async fn foo(){}
+    // { dg-error "functions in traits cannot be declared .async." "" { target *-*-* } .-1 }
+    async fn bar();
+    // { dg-error "functions in traits cannot be declared .async." "" { target *-*-* } .-1 }
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #2785 
I opened this pull request because I have some doubts.
So I created a switch-case for `async` keyword when reading trait items. I generate an error (I know its not the right way) and return nullptr.
The returning nullptr generates additional errors that results in the test case failing.
The correct way to generate error would be to add check in `ASTValidation::visit (AST::TraitFunctionDecl &decl)` function but it won't work right now because we never made the AST node.
To solve this problem I think we need to implement `parse_trait_async()` and to implement this function we need to make an AST node `AST::TraitItemAsync`.
But this node will be pretty much useless as `async` isn't allowed inside traits so I don't know if this is the right way to approach this problem
@CohenArthur Is there any other way to solve this problem, I am sorry if I failed to reach an obvious solution, lemme know.