### PR TITLE
Handle `async` keyword for regular implementations

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -5600,6 +5600,7 @@ Parser<ManagedTokenSource>::parse_inherent_impl_item ()
 	    return nullptr;
 	  }
       }
+    case ASYNC:
     case EXTERN_KW:
     case UNSAFE:
     case FN_KW:

--- a/gcc/testsuite/rust/compile/issue-2788.rs
+++ b/gcc/testsuite/rust/compile/issue-2788.rs
@@ -1,0 +1,10 @@
+// { dg-additional-options "-frust-compile-until=lowering" }
+struct Foo {
+    arg_1: u32,
+    arg_2: i32,
+}
+
+impl Foo {
+    async fn asynchronous_function_1(&self) {}
+    async fn asynchronous_function_2() {}
+}


### PR DESCRIPTION
Fixes #2788 
I am not sure how to test this as we don't have to check for error. I was reading up on `async` functions usage and I think Tokio is required to write small code snippets, which isn't supported by gccrs yet.