### PR TITLE
Add test for inherent implementation of crate

### DIFF
--- a/gcc/testsuite/rust/link/crate_import_0.rs
+++ b/gcc/testsuite/rust/link/crate_import_0.rs
@@ -1,0 +1,6 @@
+extern crate crate_import_1;
+use crate_import_1::Foo;
+
+impl Foo { } // error
+
+fn main() { }

--- a/gcc/testsuite/rust/link/crate_import_1.rs
+++ b/gcc/testsuite/rust/link/crate_import_1.rs
@@ -1,0 +1,5 @@
+pub struct Foo {
+    pub value: i32,
+}
+
+impl Foo { }


### PR DESCRIPTION
If we try to provide an implementation of a struct outside of the crate where it is implemented, the compiler crashes. This commit tries to demonstrate it.