### PR TITLE
Add improved error when no fields in initializer

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -1017,6 +1017,24 @@ TypeCheckExpr::visit (HIR::StructExprStruct &struct_expr)
       return;
     }
 
+  TyTy::ADTType *adt = static_cast<TyTy::ADTType *> (struct_path_ty);
+  for (auto variant : adt->get_variants ())
+    {
+      if (!variant->get_fields ().empty ())
+	{
+	  std::vector<std::string> field_names;
+	  for (auto &field : variant->get_fields ())
+	    field_names.push_back (field->get_name ());
+	  Error missing_fields_error
+	    = TypeCheckStructExpr::make_missing_field_error (
+	      struct_expr.get_locus (), field_names,
+	      struct_path_ty->get_name ());
+	  // We might want to return or handle these in the future emit for now.
+	  missing_fields_error.emit ();
+	  return;
+	}
+    }
+
   infered = struct_path_ty;
 }
 

--- a/gcc/rust/typecheck/rust-hir-type-check-struct-field.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-struct-field.h
@@ -25,12 +25,21 @@
 #include "rust-tyty.h"
 
 namespace Rust {
+
+struct Error;
+
 namespace Resolver {
 
 class TypeCheckStructExpr : public TypeCheckBase
 {
 public:
   static TyTy::BaseType *Resolve (HIR::StructExprStructFields *expr);
+
+  // Helper for making any errors
+  static Error
+  make_missing_field_error (location_t locus,
+			    const std::vector<std::string> &missing_field_names,
+			    const std::string &struct_name);
 
 protected:
   void resolve (HIR::StructExprStructFields &struct_expr);

--- a/gcc/testsuite/rust/compile/missing_constructor_fields.rs
+++ b/gcc/testsuite/rust/compile/missing_constructor_fields.rs
@@ -6,5 +6,7 @@ struct Foo {
 }
 
 fn main() {
-    let x = Foo { x: 0 , y:1 }; // { dg-error "constructor is missing fields" }
+    let z = Foo { x: 0 , y:1 }; // { dg-error "missing field z in initializer of 'Foo'" }
+    let xz = Foo { y:1 }; // { dg-error "missing fields x, z in initializer of 'Foo'" }
+    let xyz = Foo { }; // { dg-error "missing fields x, y, z in initializer of 'Foo'" }
 }


### PR DESCRIPTION
Fixes #2389 

If a struct type with a variant that has fields is initialized with some fields the expression  HIR StructExprStructFields is checked that all the fields are assigned. However, if no fields are initialized the HIR StructExprStruct is generated. This doesn't check if the struct is a unit during typechekc and only fails at the compile stage with a ICE.

Add a check at the typecheck stage that makes sure the struct does not have a variant with fields and give an error message based on the rustc one.

We have also updated the message given in the case where one field was present to list the missing fields and match more closely the new message.

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::visit) Add additional check
	* typecheck/rust-hir-type-check-struct-field.h: A helper method to make error added
	* typecheck/rust-hir-type-check-expr-struct.cc (TypeCheckStructExpr::resolve) Update message

gcc/testsuite/ChangeLog:

	* rust/compile/missing_constructor_fields.rs: Added case with no initializers

Signed-off-by: Robert Goss <goss.robert@gmail.com>
