### PR TITLE
Emit error when range pattern is empty

### DIFF
--- a/gcc/rust/checks/errors/rust-ast-validation.h
+++ b/gcc/rust/checks/errors/rust-ast-validation.h
@@ -43,6 +43,7 @@ public:
   virtual void visit (AST::Function &function);
   virtual void visit (AST::Trait &trait);
   virtual void visit (AST::TraitFunctionDecl &decl);
+  virtual void visit (AST::RangePattern &pattern);
 };
 
 } // namespace Rust

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -10435,7 +10435,7 @@ Parser<ManagedTokenSource>::parse_literal_or_range_pattern ()
 
       return std::unique_ptr<AST::RangePattern> (
 	new AST::RangePattern (std::move (lower), std::move (upper),
-			       range_lower->get_locus ()));
+			       range_lower->get_locus (), next->get_id () == ELLIPSIS));
     }
   else
     {

--- a/gcc/testsuite/rust/compile/issue-2794.rs
+++ b/gcc/testsuite/rust/compile/issue-2794.rs
@@ -1,0 +1,15 @@
+fn main() {
+    let mut x = 11;
+    match x {
+        2..=1 => x = 6,
+        // { dg-error "lower range bound must be less than or equal to upper" "" { target *-*-* } .-1 }
+        _ => x = 7,
+    }
+
+    let mut y = 'a';
+    match y {
+        'z'..='y' => y = 'b',
+        // { dg-error "lower range bound must be less than or equal to upper" "" { target *-*-* } .-1 }
+        _ => y = 'c',
+    }
+}


### PR DESCRIPTION
I couldn't find a cleaner way to get values of upper and lower bound. Tell me if there is a better way to get those values.
@CohenArthur @P-E-P 