### PR TITLE
Add improved error when a field is redefined in a struct constructor

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-struct-field.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-struct-field.h
@@ -35,9 +35,9 @@ public:
 protected:
   void resolve (HIR::StructExprStructFields &struct_expr);
 
-  void visit (HIR::StructExprFieldIdentifierValue &field);
-  void visit (HIR::StructExprFieldIndexValue &field);
-  void visit (HIR::StructExprFieldIdentifier &field);
+  bool visit (HIR::StructExprFieldIdentifierValue &field);
+  bool visit (HIR::StructExprFieldIndexValue &field);
+  bool visit (HIR::StructExprFieldIdentifier &field);
 
 private:
   TypeCheckStructExpr (HIR::Expr *e);

--- a/gcc/testsuite/rust/compile/repeated_constructor_fields.rs
+++ b/gcc/testsuite/rust/compile/repeated_constructor_fields.rs
@@ -1,0 +1,10 @@
+struct Foo {
+    x: i32,
+}
+
+fn main() {
+    let x = Foo {
+        x: 0,
+        x: 0, // { dg-error "field 'x' specified more than once" }
+    };
+}


### PR DESCRIPTION
Fixes #2381

If a struct type is initialized with one of it's fields repeated it will currently issue an error at the use site. However we would like to give the rust error code and (like rustc) show both the specifications for the field to help the user diagnose the issue.

We move the check after the index for the field has been established so we can look up if the field has already been defined and get it's location.

We update the visit method to return if it has handled an error otherwise we then output a second fatal error as not all the field in the specification have been processed.

gcc/rust/ChangeLog:

    * gcc/rust/typecheck/rust-hir-type-check-struct-field.h: Allow visit to return a bool
    * gcc/rust/typecheck/rust-hir-type-check-struct-field.cc: Improve check of respecification of fields

gcc/testsuite/ChangeLog:

    * rust/compile/repeated_constructor_fields.rs: Added case with fields in constructor repeated

I have read and accept the developers certificate of origin  at https://gcc.gnu.org/dco.html