### PR TITLE
rust_debug: Cast size_t values to unsigned long before printing.

### DIFF
--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -918,7 +918,8 @@ HIRCompileBase::resolve_method_address (TyTy::FnType *fntype,
     }
 
   const Resolver::PathProbeCandidate *selectedCandidate = nullptr;
-  rust_debug_loc (expr_locus, "resolved to %lu candidates", candidates.size ());
+  rust_debug_loc (expr_locus, "resolved to %lu candidates",
+		  (unsigned long) candidates.size ());
 
   // filter for the possible case of non fn type items
   std::set<Resolver::PathProbeCandidate> filteredFunctionCandidates;

--- a/gcc/rust/expand/rust-proc-macro.cc
+++ b/gcc/rust/expand/rust-proc-macro.cc
@@ -171,7 +171,7 @@ load_macros (std::string path)
   if (array == nullptr)
     return {};
 
-  rust_debug ("Found %lu procedural macros", array->length);
+  rust_debug ("Found %lu procedural macros", (unsigned long) array->length);
 
   return std::vector<ProcMacro::Procmacro> (array->macros,
 					    array->macros + array->length);

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -1122,10 +1122,10 @@ TypeCheckExpr::visit (HIR::MethodCallExpr &expr)
 
   auto candidate = *candidates.begin ();
   rust_debug_loc (expr.get_method_name ().get_locus (),
-		  "resolved method to: {%u} {%s} with [%zu] adjustments",
+		  "resolved method to: {%u} {%s} with [%lu] adjustments",
 		  candidate.candidate.ty->get_ref (),
 		  candidate.candidate.ty->debug_str ().c_str (),
-		  candidate.adjustments.size ());
+		  (unsigned long) candidate.adjustments.size ());
 
   // Get the adjusted self
   Adjuster adj (receiver_tyty);


### PR DESCRIPTION
Using %lu to format size_t values breaks 32 bit targets, and %zu is not
supported by one of the hosts GCC aims to support - HPUX

gcc/rust/ChangeLog:

	* backend/rust-compile-base.cc (HIRCompileBase::resolve_method_address):
	Cast size_t value to unsigned long.
	* expand/rust-proc-macro.cc (load_macros): Likewise.
	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::visit): Likewise.

Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[ ] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[ ] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[ ] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---

*Please write a comment explaining your change. This is the message
that will be part of the merge commit.
