### PR TITLE
testsuite: Fix missing handling of little endian.

### DIFF
--- a/gcc/testsuite/rust/compile/issue-1446.rs
+++ b/gcc/testsuite/rust/compile/issue-1446.rs
@@ -1,3 +1,11 @@
+// fake function
+pub fn swap_bytes(this: u32) -> u32 {
+    (((this) & 0xff000000) >> 24)
+        | (((this) & 0x00ff0000) >> 8)
+        | (((this) & 0x0000ff00) << 8)
+        | (((this) & 0x000000ff) << 24)
+}
+
 pub fn to_le(this: u32) -> u32 {
     #[cfg(target_endian = "little")]
     {
@@ -5,6 +13,6 @@ pub fn to_le(this: u32) -> u32 {
     }
     #[cfg(not(target_endian = "little"))]
     {
-        this.swap_bytes()
+        swap_bytes(this)
     }
 }

--- a/gcc/testsuite/rust/compile/iterators1.rs
+++ b/gcc/testsuite/rust/compile/iterators1.rs
@@ -232,24 +232,6 @@ macro_rules! impl_uint {
                     }
                 }
 
-                pub fn to_le(self) -> Self {
-                    #[cfg(target_endian = "little")]
-                    {
-                        self
-                    }
-                }
-
-                pub const fn from_le_bytes(bytes: [u8; mem::size_of::<Self>()]) -> Self {
-                    Self::from_le(Self::from_ne_bytes(bytes))
-                }
-
-                pub const fn from_le(x: Self) -> Self {
-                    #[cfg(target_endian = "little")]
-                    {
-                        x
-                    }
-                }
-
                 pub const fn from_ne_bytes(bytes: [u8; mem::size_of::<Self>()]) -> Self {
                     unsafe { mem::transmute(bytes) }
                 }

--- a/gcc/testsuite/rust/compile/macros/builtin/eager1.rs
+++ b/gcc/testsuite/rust/compile/macros/builtin/eager1.rs
@@ -15,7 +15,7 @@ macro_rules! b {
 }
 
 fn main() {
-    // { dg-final { scan-tree-dump-times {"test1canary"} 1 gimple } }
+    // { dg-final { scan-assembler {"test1canary"} } }
     let _ = concat!(a!(), 1, b!());
     // should not error
     concat!(a!(), true, b!(),);

--- a/gcc/testsuite/rust/compile/macros/builtin/recurse2.rs
+++ b/gcc/testsuite/rust/compile/macros/builtin/recurse2.rs
@@ -15,7 +15,29 @@ macro_rules! a {
     };
 }
 
+extern "C" {
+    fn printf(fmt: *const i8, ...);
+}
+
+fn print_ptr(s: &str) {
+    unsafe {
+        printf("%p\n\0" as *const str as *const i8, s as *const str);
+    }
+}
+
+fn print_str(s: &str) {
+    unsafe {
+        printf(
+            "%s\n\0" as *const str as *const i8,
+            s as *const str as *const i8,
+        );
+    }
+}
+
+// { dg-final { scan-assembler {"abheyho"} } }
+static S: &str = concat!("a", 'b', a!(), a!(b c d e f a!()), '\0');
+
 fn main() {
-    // { dg-final { scan-tree-dump-times {"abheyho"} 1 gimple } }
-    let _ = concat!("a", 'b', a!(), a!(b c d e f a!()), '\0');
+    print_ptr(S);
+    print_str(S);
 }


### PR DESCRIPTION
Some failures occur in the testsuite because we
did not account for the big-endian case.

gcc/testsuite/ChangeLog:

	* rust/compile/issue-1446.rs: Add swap_bytes function.
	* rust/compile/iterators1.rs: Remove unused {to, from}_le functions.

Before merging this I would like to run our testsuite on the compile farm on a SPARC machine to see that they're really fixed. Will report here once it's done.
