### PR TITLE
Set the default ABI to C for extern blocks and extern functions

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-base.cc
+++ b/gcc/rust/hir/rust-ast-lower-base.cc
@@ -718,8 +718,8 @@ ASTLoweringBase::lower_qualifiers (const AST::FunctionQualifiers &qualifiers)
   Unsafety unsafety
     = qualifiers.is_unsafe () ? Unsafety::Unsafe : Unsafety::Normal;
   bool has_extern = qualifiers.is_extern ();
+  ABI abi = has_extern ? ABI::C : ABI::RUST;
 
-  ABI abi = ABI::RUST;
   if (qualifiers.has_abi ())
     {
       const std::string &extern_abi = qualifiers.get_extern_abi ();
@@ -965,7 +965,7 @@ ASTLoweringBase::lower_extern_block (AST::ExternBlock &extern_block)
       extern_items.push_back (std::unique_ptr<HIR::ExternalItem> (lowered));
     }
 
-  ABI abi = ABI::RUST;
+  ABI abi = ABI::C;
   if (extern_block.has_abi ())
     {
       const std::string &extern_abi = extern_block.get_abi ();


### PR DESCRIPTION
Previously, the default ABI was set to Rust, which is incorrect for extern blocks and extern functions. This patch changes the default ABI to C for these cases.

Reference: https://doc.rust-lang.org/reference/items/functions.html#extern-function-qualifier
Zulip discussion:  https://gcc-rust.zulipchat.com/#narrow/stream/266897-general/topic/extern.20blocks/near/346429045

gcc/rust/ChangeLog:

	* hir/rust-ast-lower-base.cc (ASTLoweringBase::lower_qualifiers): (ASTLoweringBase::lower_extern_block): Change ABI to C for extern

