### PR TITLE
gccrs: Fix output line ending patterns for Windows platforms.

### DIFF
--- a/gcc/testsuite/rust/execute/torture/builtin_macros1.rs
+++ b/gcc/testsuite/rust/execute/torture/builtin_macros1.rs
@@ -1,4 +1,4 @@
-// { dg-output "rust/execute/torture/builtin_macros1.rs\r*" }
+// { dg-output "rust/execute/torture/builtin_macros1.rs\r*\n" }
 #![feature(rustc_attrs)]
 
 #[rustc_builtin_macro]

--- a/gcc/testsuite/rust/execute/torture/coercion3.rs
+++ b/gcc/testsuite/rust/execute/torture/coercion3.rs
@@ -1,4 +1,4 @@
-// { dg-output "123\n" }
+// { dg-output "123\r*\n" }
 #[lang = "sized"]
 pub trait Sized {}
 

--- a/gcc/testsuite/rust/execute/torture/issue-2080.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-2080.rs
@@ -1,4 +1,4 @@
-// { dg-output "hello world: gccrs\n" }
+// { dg-output "hello world: gccrs\r*\n" }
 // { dg-additional-options "-w" }
 static TEST_1: &str = "gccrs";
 static TEST_2: i32 = 123;

--- a/gcc/testsuite/rust/execute/torture/issue-2179.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-2179.rs
@@ -1,4 +1,4 @@
-// { dg-output "123\n" }
+// { dg-output "123\r*\n" }
 #[lang = "sized"]
 pub trait Sized {}
 

--- a/gcc/testsuite/rust/execute/torture/issue-2180.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-2180.rs
@@ -1,4 +1,4 @@
-// { dg-output "123\n" }
+// { dg-output "123\r*\n" }
 #[lang = "sized"]
 pub trait Sized {}
 

--- a/gcc/testsuite/rust/execute/torture/iter1.rs
+++ b/gcc/testsuite/rust/execute/torture/iter1.rs
@@ -1,4 +1,4 @@
-// { dg-output "1\n2\n" }
+// { dg-output "1\r*\n2\r*\n" }
 #![feature(intrinsics)]
 
 pub use option::Option::{self, None, Some};


### PR DESCRIPTION
gcc/testsuite/ChangeLog:

	* rust/execute/torture/builtin_macros1.rs: Fix output pattern.
	* rust/execute/torture/coercion3.rs: Likewise.
	* rust/execute/torture/issue-2080.rs: Likewise.
	* rust/execute/torture/issue-2179.rs: Likewise.
	* rust/execute/torture/issue-2180.rs: Likewise.
	* rust/execute/torture/iter1.rs: Likewise.

