### PR TITLE
Parse normal functions with `self` parameter correctly

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -2946,8 +2946,8 @@ Parser<ManagedTokenSource>::parse_function (AST::Visibility vis,
       && initial_param.error () != ParseSelfError::NOT_SELF)
     return nullptr;
 
-  if (initial_param.has_value ())
-    skip_token (COMMA);
+  if (initial_param.has_value () && lexer.peek_token ()->get_id () == COMMA)
+    skip_token ();
 
   // parse function parameters (only if next token isn't right paren)
   std::vector<std::unique_ptr<AST::Param>> function_params;

--- a/gcc/testsuite/rust/compile/issue-2812.rs
+++ b/gcc/testsuite/rust/compile/issue-2812.rs
@@ -1,0 +1,4 @@
+// { dg-additional-options "-frust-compile-until=astvalidation" }
+fn foo_1(&self);
+fn foo_1(&mut self);
+fn foo_1(self);


### PR DESCRIPTION
Fixes #2812 
Might use same function to parse normal function and trait functions so should be a useful fix.