### PR TITLE
gccrs: add test cases to prove type inference is working

### DIFF
--- a/gcc/testsuite/rust/compile/issue-2772-1.rs
+++ b/gcc/testsuite/rust/compile/issue-2772-1.rs
@@ -1,0 +1,20 @@
+// { dg-options "-w" }
+#[lang = "sized"]
+pub trait Sized {}
+
+struct Pair<'a, T, U>
+where
+    T: 'a,
+    U: 'a,
+{
+    left: T,
+    right: U,
+}
+
+pub fn test<'a>() {
+    let a: i32 = 50;
+    let x = Pair {
+        left: &&a,
+        right: &a,
+    };
+}

--- a/gcc/testsuite/rust/compile/issue-2772-2.rs
+++ b/gcc/testsuite/rust/compile/issue-2772-2.rs
@@ -1,0 +1,20 @@
+// { dg-options "-w" }
+#[lang = "sized"]
+pub trait Sized {}
+
+struct Pair<'a, T, U>
+where
+    T: 'a,
+    U: 'a,
+{
+    left: T,
+    right: U,
+}
+
+pub fn test<'a>() {
+    let a: i32 = 50;
+    let x = Pair::<&'_ _, &'_ _> {
+        left: &&a,
+        right: &a,
+    };
+}


### PR DESCRIPTION
Fixes #2772

gcc/testsuite/ChangeLog:

	* rust/compile/issue-2772-1.rs: New test.
	* rust/compile/issue-2772-2.rs: New test.