### PR TITLE
gccrs: Fix ICE accessing empty vector without check

### DIFF
--- a/gcc/rust/typecheck/rust-tyty-subst.cc
+++ b/gcc/rust/typecheck/rust-tyty-subst.cc
@@ -617,7 +617,8 @@ SubstitutionRef::get_mappings_from_generic_args (HIR::GenericArgs &args)
   if (args.get_type_args ().size () + offs > substitutions.size ())
     {
       rich_location r (line_table, args.get_locus ());
-      r.add_range (substitutions.front ().get_param_locus ());
+      if (!substitutions.empty ())
+	r.add_range (substitutions.front ().get_param_locus ());
 
       rust_error_at (
 	r,

--- a/gcc/testsuite/rust/compile/issue-2747.rs
+++ b/gcc/testsuite/rust/compile/issue-2747.rs
@@ -1,0 +1,31 @@
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "fn_once"]
+pub trait FnOnce<Args> {
+    #[lang = "fn_once_output"]
+    type Output;
+
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+}
+
+struct Foo<'a, 'b: 'a> {
+    x: &'a i32,
+    y: &'a i32,
+    a: &'b i32,
+    q: &'a [&'b i32],
+}
+
+pub fn test<'x, 'y>(f: Foo<'x, 'y, ()>) {
+    // { dg-error "generic item takes at most 0 type arguments but 1 were supplied" "" { target *-*-* } .-1 }
+    let x = 5;
+    let y = 6;
+    let z = 7;
+    type F<'a, 'b> = fn(&'a i32, &'b i32) -> i32;
+    let f = Foo {
+        x: &x,
+        y: &y,
+        a: &z,
+        q: &[&x, &y],
+    };
+}


### PR DESCRIPTION
Fixes #2747

gcc/rust/ChangeLog:

	* typecheck/rust-tyty-subst.cc (SubstitutionRef::get_mappings_from_generic_args): fix

gcc/testsuite/ChangeLog:

	* rust/compile/issue-2747.rs: New test.