### PR TITLE
gccrs: Add testcase to show issue is already fixed

### DIFF
--- a/gcc/testsuite/rust/compile/issue-2782.rs
+++ b/gcc/testsuite/rust/compile/issue-2782.rs
@@ -1,0 +1,12 @@
+#[lang = "sized"]
+pub trait Sized {}
+
+struct S<T>(T);
+
+impl S<u8> {
+    fn foo<U>() {}
+}
+
+fn main() {
+    S::foo::<i32>();
+}


### PR DESCRIPTION
Fixes #2782

gcc/testsuite/ChangeLog:

	* rust/compile/issue-2782.rs: New test.