### PR TITLE
gccrs: fix bug in pattern check for tuples

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
@@ -302,7 +302,8 @@ TypeCheckPattern::visit (HIR::TuplePattern &pattern)
 	  = *static_cast<HIR::TuplePatternItemsMultiple *> (
 	    pattern.get_items ().get ());
 
-	if (parent->get_kind () != TyTy::TUPLE)
+	auto resolved_parent = parent->destructure ();
+	if (resolved_parent->get_kind () != TyTy::TUPLE)
 	  {
 	    rust_error_at (pattern.get_locus (), "expected %s, found tuple",
 			   parent->as_string ().c_str ());
@@ -312,7 +313,8 @@ TypeCheckPattern::visit (HIR::TuplePattern &pattern)
 	const auto &patterns = ref.get_patterns ();
 	size_t nitems_to_resolve = patterns.size ();
 
-	TyTy::TupleType &par = *static_cast<TyTy::TupleType *> (parent);
+	TyTy::TupleType &par
+	  = *static_cast<TyTy::TupleType *> (resolved_parent);
 	if (patterns.size () != par.get_fields ().size ())
 	  {
 	    emit_pattern_size_error (pattern, par.get_fields ().size (),

--- a/gcc/testsuite/rust/compile/issue-2775.rs
+++ b/gcc/testsuite/rust/compile/issue-2775.rs
@@ -1,0 +1,11 @@
+// { dg-options "-w" }
+#[lang = "sized"]
+pub trait Sized {}
+
+struct Ref<'a, T> {
+    x: &'a T,
+}
+
+pub fn test<'a, 'b, 'c>() {
+    let (_, &&Ref::<(&'_ i32, i32)> { x: &(a, b) }): (i32, &'_ &'b Ref<'b, (&'c i32, i32)>);
+}


### PR DESCRIPTION
We can point to generic parent types which means we need to do the shallow resolve thing that rustc does. We have destructure which is similar to get what the parameter type points to.

Fixes #2775

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-pattern.cc (TypeCheckPattern::visit): use destructure

gcc/testsuite/ChangeLog:

	* rust/compile/issue-2775.rs: New test.