### PR TITLE
gccrs: Add testcase for matches!() macro

### DIFF
--- a/gcc/testsuite/rust/execute/torture/matches_macro.rs
+++ b/gcc/testsuite/rust/execute/torture/matches_macro.rs
@@ -1,0 +1,30 @@
+macro_rules! matches {
+    ($expression:expr, $($pattern:pat)|+ $( if $guard:expr ),*) => {
+        match $expression {
+            $($pattern)|+ => true,
+            _ => false,
+        }
+    }
+}
+
+pub fn should_match() -> bool {
+    matches!(1, 1)
+}
+
+pub fn shouldnt() -> bool {
+    matches!(1, 2)
+}
+
+fn main() -> i32 {
+    let mut retval = 2;
+
+    if should_match() {
+        retval -= 1;
+    }
+
+    if !shouldnt() {
+        retval -= 1;
+    }
+
+    retval
+}


### PR DESCRIPTION
This adds a testcase for issue #2129.

gcc/testsuite/ChangeLog:

	* rust/execute/torture/matches_macro.rs: New test.

Fixes #2129