### PR TITLE
Add testcase for #2314, fix formatting in macro error

### DIFF
--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -414,7 +414,7 @@ struct MacroExpander
       = mappings->lookup_derive_proc_macro_invocation (path);
     if (!macro.has_value ())
       {
-	rust_error_at (path.get_locus (), "Macro not found");
+	rust_error_at (path.get_locus (), "macro not found");
 	return AST::Fragment::create_error ();
       }
 
@@ -437,7 +437,7 @@ struct MacroExpander
       = mappings->lookup_bang_proc_macro_invocation (invocation);
     if (!macro.has_value ())
       {
-	rust_error_at (invocation.get_locus (), "Macro not found");
+	rust_error_at (invocation.get_locus (), "macro not found");
 	return AST::Fragment::create_error ();
       }
 
@@ -459,7 +459,7 @@ struct MacroExpander
       = mappings->lookup_attribute_proc_macro_invocation (path);
     if (!macro.has_value ())
       {
-	rust_error_at (path.get_locus (), "Macro not found");
+	rust_error_at (path.get_locus (), "macro not found");
 	return AST::Fragment::create_error ();
       }
 

--- a/gcc/testsuite/rust/compile/rustc_const_stable.rs
+++ b/gcc/testsuite/rust/compile/rustc_const_stable.rs
@@ -1,0 +1,2 @@
+#[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
+pub fn foo() {} // { dg-error "macro not found" "" { target *-*-* } .-1 }


### PR DESCRIPTION
- expand: Fix formatting for "macro not found" error
- gccrs: Add testcase for #[rustc_const_stable]
