### PR TITLE
gccrs: Fix typo in RegionConstraints instance

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -97,7 +97,7 @@ private:
   HIR::ImplBlock *parent;
   TyTy::BaseType *self;
   std::vector<TyTy::SubstitutionParamMapping> substitutions;
-  TyTy::RegionConstraints region_costraints;
+  TyTy::RegionConstraints region_constraints;
 };
 
 } // namespace Resolver


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-implitem.h: Fix typo in field
	(region_costraints -> region_constraints).

@jdupak is that okay to merge or should it wait? I can also close the PR and you can integrate the commit to your dev branch if it helps