### PR TITLE
gccrs: add powi intrinsics

### DIFF
--- a/gcc/rust/backend/rust-builtins.cc
+++ b/gcc/rust/backend/rust-builtins.cc
@@ -285,46 +285,70 @@ void
 BuiltinsContext::register_rust_mappings ()
 {
   rust_intrinsic_to_gcc_builtin = {
-    {"sinf32", "__builtin_sinf"},
-    {"sqrtf32", "__builtin_sqrtf"},
-    {"sqrtf64", "__builtin_sqrt"},
     {"unreachable", "__builtin_unreachable"},
     {"abort", "__builtin_abort"},
+
+    // Math intrinsics
+    {"sqrtf32", "__builtin_sqrtf"},
+    {"sqrtf64", "__builtin_sqrt"},
+
+    {"sinf32", "__builtin_sinf"},
     {"sinf64", "__builtin_sin"},
+
     {"cosf32", "__builtin_cosf"},
     {"cosf64", "__builtin_cos"},
+
     {"powf32", "__builtin_powf"},
     {"powf64", "__builtin_pow"},
+
+    {"powif32", "__builtin_powif"},
+    {"powif64", "__builtin_powi"},
+
     {"expf32", "__builtin_expf"},
     {"expf64", "__builtin_exp"},
+
     {"exp2f32", "__builtin_exp2f"},
     {"exp2f64", "__builtin_exp2"},
+
     {"logf32", "__builtin_logf"},
     {"logf64", "__builtin_log"},
+
     {"log10f32", "__builtin_log10f"},
     {"log10f64", "__builtin_log10"},
+
     {"log2f32", "__builtin_log2f"},
     {"log2f64", "__builtin_log2"},
+
     {"fmaf32", "__builtin_fmaf"},
     {"fmaf64", "__builtin_fma"},
+
     {"fabsf32", "__builtin_fabsf"},
     {"fabsf64", "__builtin_fabs"},
+
     {"minnumf32", "__builtin_fminf"},
     {"minnumf64", "__builtin_fmin"},
+
     {"maxnumf32", "__builtin_fmaxf"},
     {"maxnumf64", "__builtin_fmax"},
+
     {"copysignf32", "__builtin_copysignf"},
     {"copysignf64", "__builtin_copysign"},
+
     {"floorf32", "__builtin_floorf"},
     {"floorf64", "__builtin_floor"},
+
     {"ceilf32", "__builtin_ceilf"},
     {"ceilf64", "__builtin_ceil"},
+
     {"truncf32", "__builtin_truncf"},
     {"truncf64", "__builtin_trunc"},
+
     {"rintf32", "__builtin_rintf"},
     {"rintf64", "__builtin_rint"},
+
     {"nearbyintf32", "__builtin_nearbyintf"},
     {"nearbyintf64", "__builtin_nearbyint"},
+
     {"roundf32", "__builtin_roundf"},
     {"roundf64", "__builtin_round"},
   };

--- a/gcc/rust/backend/rust-builtins.h
+++ b/gcc/rust/backend/rust-builtins.h
@@ -1,3 +1,5 @@
+// Copyright (C) 2020-2024 Free Software Foundation, Inc.
+
 // This file is part of GCC.
 
 // GCC is free software; you can redistribute it and/or modify it under

--- a/gcc/testsuite/rust/compile/torture/intrinsics-math.rs
+++ b/gcc/testsuite/rust/compile/torture/intrinsics-math.rs
@@ -14,6 +14,9 @@ extern "rust-intrinsic" {
     pub fn powf32(a: f32, x: f32) -> f32;
     pub fn powf64(a: f64, x: f64) -> f64;
 
+    pub fn powif32(a: f32, x: i32) -> f32;
+    pub fn powif64(a: f64, x: i64) -> f64;
+
     pub fn expf32(x: f32) -> f32;
     pub fn expf64(x: f64) -> f64;
 
@@ -84,9 +87,14 @@ fn main() {
         // { dg-final { scan-tree-dump-times {(?n)f64 .* __builtin_cos.? \(.*6\.0e\+0\);$} 1 original } }
 
         f32 = powf32(7f32, 8f32);
-        // { dg-final { scan-tree-dump-times {(?n)f32 .* __builtin_pow. \(.*7\.0e\+0, .*8\.0e\+0\);$} 1 original } }
+        // { dg-final { scan-tree-dump-times {(?n)f32 .* __builtin_pow[^i] \(.*7\.0e\+0, .*8\.0e\+0\);$} 1 original } }
         f64 = powf64(9f64, 10f64);
-        // { dg-final { scan-tree-dump-times {(?n)f64 .* __builtin_pow.? \(.*9\.0e\+0, .*1\.0e\+1\);$} 1 original } }
+        // { dg-final { scan-tree-dump-times {(?n)f64 .* __builtin_pow[^i]? \(.*9\.0e\+0, .*1\.0e\+1\);$} 1 original } }
+
+        f32 = powif32(7f32, 8i32);
+        // { dg-final { scan-tree-dump-times {(?n)f32 .* __builtin_powi. \(.*7\.0e\+0, .*8\);$} 1 original } }
+        f64 = powif64(9f64, 10i64);
+        // { dg-final { scan-tree-dump-times {(?n)f64 .* __builtin_powi.? \(.*9\.0e\+0, .*10\);$} 1 original } }
 
         f32 = expf32(11f32);
         // { dg-final { scan-tree-dump-times {(?n)f32 .* __builtin_exp. \(.*1\.1e\+1\);$} 1 original } }


### PR DESCRIPTION
```
gcc/rust/ChangeLog:

	* backend/rust-builtins.cc (BuiltinsContext::register_rust_mappings): Add powi and reformat.
	* backend/rust-builtins.h: Add missing copyright header.

gcc/testsuite/ChangeLog:

	* rust/compile/torture/intrinsics-math.rs: Adjust pow test, add test for powi.
```