### PR TITLE
Unify `AST::ExternalFunctionItem` with `AST::Function`

### DIFF
--- a/gcc/rust/ast/rust-ast-collector.cc
+++ b/gcc/rust/ast/rust-ast-collector.cc
@@ -2085,31 +2085,6 @@ TokenCollector::visit (ExternalStaticItem &item)
 }
 
 void
-TokenCollector::visit (ExternalFunctionItem &function)
-{
-  visit_items_as_lines (function.get_outer_attrs ());
-  visit (function.get_visibility ());
-
-  auto id = function.get_identifier ().as_string ();
-
-  push (Rust::Token::make (FN_KW, function.get_locus ()));
-  push (Rust::Token::make_identifier (UNDEF_LOCATION, std::move (id)));
-  if (function.has_generics ())
-    visit (function.get_generic_params ());
-  push (Rust::Token::make (LEFT_PAREN, UNDEF_LOCATION));
-
-  visit_items_joined_by_separator (function.get_function_params ());
-
-  push (Rust::Token::make (RIGHT_PAREN, UNDEF_LOCATION));
-  if (function.has_return_type ())
-    {
-      push (Rust::Token::make (RETURN_TYPE, UNDEF_LOCATION));
-      visit (function.get_return_type ());
-    }
-  push (Rust::Token::make (SEMICOLON, UNDEF_LOCATION));
-}
-
-void
 TokenCollector::visit (ExternBlock &block)
 {
   visit_items_as_lines (block.get_outer_attrs ());

--- a/gcc/rust/ast/rust-ast-collector.h
+++ b/gcc/rust/ast/rust-ast-collector.h
@@ -333,7 +333,6 @@ public:
   void visit (TraitImpl &impl);
   void visit (ExternalTypeItem &item);
   void visit (ExternalStaticItem &item);
-  void visit (ExternalFunctionItem &item);
   void visit (ExternBlock &block);
 
   // rust-macro.h

--- a/gcc/rust/ast/rust-ast-full-decls.h
+++ b/gcc/rust/ast/rust-ast-full-decls.h
@@ -203,7 +203,6 @@ class ExternalItem;
 class ExternalTypeItem;
 class ExternalStaticItem;
 class NamedFunctionParam;
-class ExternalFunctionItem;
 class ExternBlock;
 
 // rust-macro.h

--- a/gcc/rust/ast/rust-ast-visitor.cc
+++ b/gcc/rust/ast/rust-ast-visitor.cc
@@ -1005,24 +1005,6 @@ DefaultASTVisitor::visit (AST::NamedFunctionParam &param)
 }
 
 void
-DefaultASTVisitor::visit (AST::ExternalFunctionItem &item)
-{
-  visit_outer_attrs (item);
-  visit (item.get_visibility ());
-  for (auto &generic : item.get_generic_params ())
-    visit (generic);
-
-  if (item.has_where_clause ())
-    visit (item.get_where_clause ());
-
-  for (auto &param : item.get_function_params ())
-    visit (param);
-
-  if (item.has_return_type ())
-    visit (item.get_return_type ());
-}
-
-void
 DefaultASTVisitor::visit (AST::ExternBlock &block)
 {
   visit_outer_attrs (block);

--- a/gcc/rust/ast/rust-ast-visitor.h
+++ b/gcc/rust/ast/rust-ast-visitor.h
@@ -164,7 +164,6 @@ public:
   // virtual void visit(ExternalItem& item) = 0;
   virtual void visit (ExternalTypeItem &type) = 0;
   virtual void visit (ExternalStaticItem &item) = 0;
-  virtual void visit (ExternalFunctionItem &item) = 0;
   virtual void visit (ExternBlock &block) = 0;
 
   // rust-macro.h
@@ -338,7 +337,6 @@ protected:
   virtual void visit (AST::TraitImpl &impl) override;
   virtual void visit (AST::ExternalTypeItem &item) override;
   virtual void visit (AST::ExternalStaticItem &item) override;
-  virtual void visit (AST::ExternalFunctionItem &item) override;
   virtual void visit (AST::ExternBlock &block) override;
   virtual void visit (AST::MacroMatchFragment &match) override;
   virtual void visit (AST::MacroMatchRepetition &match) override;

--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -2975,69 +2975,6 @@ ExternalStaticItem::as_string () const
 }
 
 std::string
-ExternalFunctionItem::as_string () const
-{
-  // outer attributes
-  std::string str = append_attributes (outer_attrs, OUTER);
-
-  // start visibility on new line and with a space
-  str += "\n" + visibility.as_string () + " ";
-
-  str += "fn ";
-
-  // add name
-  str += item_name.as_string ();
-
-  // generic params
-  str += "\n Generic params: ";
-  if (generic_params.empty ())
-    {
-      str += "none";
-    }
-  else
-    {
-      for (const auto &param : generic_params)
-	{
-	  // DEBUG: null pointer check
-	  if (param == nullptr)
-	    {
-	      rust_debug (
-		"something really terrible has gone wrong - null pointer "
-		"generic param in external function item.");
-	      return "NULL_POINTER_MARK";
-	    }
-
-	  str += "\n  " + param->as_string ();
-	}
-    }
-
-  // function params
-  str += "\n Function params: ";
-  if (function_params.empty ())
-    {
-      str += "none";
-    }
-  else
-    {
-      for (const auto &param : function_params)
-	str += "\n  " + param.as_string ();
-    }
-
-  // add type on new line
-  str += "\n (return) Type: "
-	 + (has_return_type () ? return_type->as_string () : "()");
-
-  // where clause
-  str += "\n Where clause: ";
-  if (has_where_clause ())
-    str += where_clause.as_string ();
-  else
-    str += "none";
-
-  return str;
-}
-
-std::string
 NamedFunctionParam::as_string () const
 {
   std::string str = append_attributes (outer_attrs, OUTER);
@@ -4862,12 +4799,6 @@ ExternalTypeItem::accept_vis (ASTVisitor &vis)
 
 void
 ExternalStaticItem::accept_vis (ASTVisitor &vis)
-{
-  vis.visit (*this);
-}
-
-void
-ExternalFunctionItem::accept_vis (ASTVisitor &vis)
 {
   vis.visit (*this);
 }

--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -1061,9 +1061,11 @@ Union::as_string () const
 }
 
 Function::Function (Function const &other)
-  : VisItem (other), qualifiers (other.qualifiers),
-    function_name (other.function_name), where_clause (other.where_clause),
-    locus (other.locus), is_default (other.is_default)
+  : VisItem (other), ExternalItem (other.get_node_id ()),
+    qualifiers (other.qualifiers), function_name (other.function_name),
+    where_clause (other.where_clause), locus (other.locus),
+    is_default (other.is_default),
+    is_external_function (other.is_external_function)
 {
   // guard to prevent null dereference (always required)
   if (other.return_type != nullptr)
@@ -1095,6 +1097,7 @@ Function::operator= (Function const &other)
   // outer_attrs = other.outer_attrs;
   locus = other.locus;
   is_default = other.is_default;
+  is_external_function = other.is_external_function;
 
   // guard to prevent null dereference (always required)
   if (other.return_type != nullptr)

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -1360,11 +1360,31 @@ protected:
 class Pattern : public Visitable
 {
 public:
+  enum class Kind
+  {
+    Literal,
+    Identifier,
+    Wildcard,
+    Rest,
+    Range,
+    Reference,
+    Struct,
+    TupleStruct,
+    Tuple,
+    Grouped,
+    Slice,
+    Alt,
+    Path,
+    MacroInvocation,
+  };
+
   // Unique pointer custom clone function
   std::unique_ptr<Pattern> clone_pattern () const
   {
     return std::unique_ptr<Pattern> (clone_pattern_impl ());
   }
+
+  virtual Kind get_pattern_kind () = 0;
 
   // possible virtual methods: is_refutable()
 

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -1695,6 +1695,8 @@ class ExternalItem : public Visitable
 public:
   ExternalItem () : node_id (Analysis::Mappings::get ()->get_next_node_id ()) {}
 
+  ExternalItem (NodeId node_id) : node_id (node_id) {}
+
   virtual ~ExternalItem () {}
 
   // Unique pointer custom clone function
@@ -1708,7 +1710,7 @@ public:
   virtual void mark_for_strip () = 0;
   virtual bool is_marked_for_strip () const = 0;
 
-  NodeId get_node_id () const { return node_id; }
+  virtual NodeId get_node_id () const { return node_id; }
 
 protected:
   // Clone function implementation as pure virtual method

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -1289,7 +1289,7 @@ protected:
 class LetStmt;
 
 // Rust function declaration AST node
-class Function : public VisItem, public AssociatedItem
+class Function : public VisItem, public AssociatedItem, public ExternalItem
 {
   FunctionQualifiers qualifiers;
   Identifier function_name;
@@ -1300,6 +1300,7 @@ class Function : public VisItem, public AssociatedItem
   tl::optional<std::unique_ptr<BlockExpr>> function_body;
   location_t locus;
   bool is_default;
+  bool is_external_function;
 
 public:
   std::string as_string () const override;
@@ -1330,16 +1331,17 @@ public:
 	    std::unique_ptr<Type> return_type, WhereClause where_clause,
 	    tl::optional<std::unique_ptr<BlockExpr>> function_body,
 	    Visibility vis, std::vector<Attribute> outer_attrs,
-	    location_t locus, bool is_default = false)
+	    location_t locus, bool is_default = false,
+	    bool is_external_function = false)
     : VisItem (std::move (vis), std::move (outer_attrs)),
-      qualifiers (std::move (qualifiers)),
+      ExternalItem (Stmt::node_id), qualifiers (std::move (qualifiers)),
       function_name (std::move (function_name)),
       generic_params (std::move (generic_params)),
       function_params (std::move (function_params)),
       return_type (std::move (return_type)),
       where_clause (std::move (where_clause)),
       function_body (std::move (function_body)), locus (locus),
-      is_default (is_default)
+      is_default (is_default), is_external_function (is_external_function)
   {}
 
   // TODO: add constructor with less fields
@@ -1363,6 +1365,8 @@ public:
     return function_params.size () != 0
 	   && function_params.back ()->is_variadic ();
   }
+
+  bool is_external () const { return is_external_function; }
 
   // Invalid if block is null, so base stripping on that.
   void mark_for_strip () override { function_body = nullptr; }
@@ -1422,6 +1426,9 @@ public:
     return function_params[0];
   }
 
+  // ExternalItem::node_id is same as Stmt::node_id
+  NodeId get_node_id () const override { return Stmt::node_id; }
+
 protected:
   /* Use covariance to implement clone function as returning this object
    * rather than base */
@@ -1430,6 +1437,13 @@ protected:
   /* Use covariance to implement clone function as returning this object
    * rather than base */
   Function *clone_associated_item_impl () const override
+  {
+    return new Function (*this);
+  }
+
+  /* Use covariance to implement clone function as returning this object
+   * rather than base */
+  Function *clone_external_item_impl () const override
   {
     return new Function (*this);
   }
@@ -3257,10 +3271,11 @@ public:
       item_name (std::move (item_name)), locus (locus), marked_for_strip (false)
   {}
 
+  // copy constructor
   ExternalTypeItem (ExternalTypeItem const &other)
-    : outer_attrs (other.outer_attrs), visibility (other.visibility),
-      item_name (other.item_name), locus (other.locus),
-      marked_for_strip (other.marked_for_strip)
+    : ExternalItem (other.get_node_id ()), outer_attrs (other.outer_attrs),
+      visibility (other.visibility), item_name (other.item_name),
+      locus (other.locus), marked_for_strip (other.marked_for_strip)
   {
     node_id = other.node_id;
   }
@@ -3340,8 +3355,9 @@ public:
 
   // Copy constructor
   ExternalStaticItem (ExternalStaticItem const &other)
-    : outer_attrs (other.outer_attrs), visibility (other.visibility),
-      item_name (other.item_name), locus (other.locus), has_mut (other.has_mut)
+    : ExternalItem (other.get_node_id ()), outer_attrs (other.outer_attrs),
+      visibility (other.visibility), item_name (other.item_name),
+      locus (other.locus), has_mut (other.has_mut)
   {
     node_id = other.node_id;
     // guard to prevent null dereference (only required if error state)
@@ -3607,9 +3623,10 @@ public:
 
   // Copy constructor with clone
   ExternalFunctionItem (ExternalFunctionItem const &other)
-    : outer_attrs (other.outer_attrs), visibility (other.visibility),
-      item_name (other.item_name), locus (other.locus),
-      where_clause (other.where_clause), function_params (other.function_params)
+    : ExternalItem (other.get_node_id ()), outer_attrs (other.outer_attrs),
+      visibility (other.visibility), item_name (other.item_name),
+      locus (other.locus), where_clause (other.where_clause),
+      function_params (other.function_params)
   {
     node_id = other.node_id;
     // guard to prevent null pointer dereference

--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -610,6 +610,11 @@ public:
 
   std::string as_string () const override;
 
+  Pattern::Kind get_pattern_kind () override
+  {
+    return Pattern::Kind::MacroInvocation;
+  }
+
   /**
    * The default constructor you should use. Whenever we parse a macro call, we
    * cannot possibly know whether or not this call refers to a builtin macro or

--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -722,10 +722,11 @@ private:
   {}
 
   MacroInvocation (const MacroInvocation &other)
-    : TraitItem (other.locus), outer_attrs (other.outer_attrs),
-      locus (other.locus), node_id (other.node_id),
-      invoc_data (other.invoc_data), is_semi_coloned (other.is_semi_coloned),
-      kind (other.kind), builtin_kind (other.builtin_kind)
+    : TraitItem (other.locus), ExternalItem (Expr::node_id),
+      outer_attrs (other.outer_attrs), locus (other.locus),
+      node_id (other.node_id), invoc_data (other.invoc_data),
+      is_semi_coloned (other.is_semi_coloned), kind (other.kind),
+      builtin_kind (other.builtin_kind)
   {
     if (other.kind == InvocKind::Builtin)
       for (auto &pending : other.pending_eager_invocs)

--- a/gcc/rust/ast/rust-path.h
+++ b/gcc/rust/ast/rust-path.h
@@ -578,6 +578,8 @@ public:
   // TODO: this seems kinda dodgy
   std::vector<PathExprSegment> &get_segments () { return segments; }
   const std::vector<PathExprSegment> &get_segments () const { return segments; }
+
+  Pattern::Kind get_pattern_kind () override { return Pattern::Kind::Path; }
 };
 
 /* AST node representing a path-in-expression pattern (path that allows

--- a/gcc/rust/ast/rust-pattern.h
+++ b/gcc/rust/ast/rust-pattern.h
@@ -55,6 +55,8 @@ public:
 
   const Literal &get_literal () const { return lit; }
 
+  Pattern::Kind get_pattern_kind () override { return Pattern::Kind::Literal; }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */
@@ -149,6 +151,11 @@ public:
 
   NodeId get_node_id () const override { return node_id; }
 
+  Pattern::Kind get_pattern_kind () override
+  {
+    return Pattern::Kind::Identifier;
+  }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */
@@ -177,6 +184,8 @@ public:
 
   NodeId get_node_id () const override { return node_id; }
 
+  Pattern::Kind get_pattern_kind () override { return Pattern::Kind::Wildcard; }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */
@@ -203,6 +212,8 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   NodeId get_node_id () const override final { return node_id; }
+
+  Pattern::Kind get_pattern_kind () override { return Pattern::Kind::Rest; }
 
 protected:
   RestPattern *clone_pattern_impl () const override
@@ -431,6 +442,8 @@ public:
 
   NodeId get_node_id () const override { return node_id; }
 
+  Pattern::Kind get_pattern_kind () override { return Pattern::Kind::Range; }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */
@@ -498,6 +511,11 @@ public:
   bool get_is_mut () const { return is_mut; }
 
   NodeId get_node_id () const override { return node_id; }
+
+  Pattern::Kind get_pattern_kind () override
+  {
+    return Pattern::Kind::Reference;
+  }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather
@@ -934,6 +952,8 @@ public:
 
   NodeId get_node_id () const override { return node_id; }
 
+  Pattern::Kind get_pattern_kind () override { return Pattern::Kind::Struct; }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */
@@ -1174,6 +1194,11 @@ public:
 
   NodeId get_node_id () const override { return node_id; }
 
+  Pattern::Kind get_pattern_kind () override
+  {
+    return Pattern::Kind::TupleStruct;
+  }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */
@@ -1411,6 +1436,8 @@ public:
 
   NodeId get_node_id () const override { return node_id; }
 
+  Pattern::Kind get_pattern_kind () override { return Pattern::Kind::Tuple; }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */
@@ -1470,6 +1497,8 @@ public:
   }
 
   NodeId get_node_id () const override { return node_id; }
+
+  Pattern::Kind get_pattern_kind () override { return Pattern::Kind::Grouped; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather
@@ -1535,6 +1564,8 @@ public:
 
   NodeId get_node_id () const override { return node_id; }
 
+  Pattern::Kind get_pattern_kind () override { return Pattern::Kind::Slice; }
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */
@@ -1599,6 +1630,8 @@ public:
   }
 
   NodeId get_node_id () const override { return node_id; }
+
+  Pattern::Kind get_pattern_kind () override { return Pattern::Kind::Alt; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather

--- a/gcc/rust/checks/errors/rust-ast-validation.cc
+++ b/gcc/rust/checks/errors/rust-ast-validation.cc
@@ -65,25 +65,6 @@ ASTValidation::visit (AST::ConstantItem &const_item)
 }
 
 void
-ASTValidation::visit (AST::ExternalFunctionItem &item)
-{
-  auto &params = item.get_function_params ();
-
-  if (params.size () == 1 && params[0].is_variadic ())
-    rust_error_at (
-      params[0].get_locus (),
-      "C-variadic function must be declared with at least one named argument");
-
-  for (auto it = params.begin (); it != params.end (); it++)
-    if (it->is_variadic () && it + 1 != params.end ())
-      rust_error_at (
-	it->get_locus (),
-	"%<...%> must be the last argument of a C-variadic function");
-
-  AST::ContextualASTVisitor::visit (item);
-}
-
-void
 ASTValidation::visit (AST::Union &item)
 {
   if (item.get_variants ().empty ())

--- a/gcc/rust/checks/errors/rust-ast-validation.cc
+++ b/gcc/rust/checks/errors/rust-ast-validation.cc
@@ -122,23 +122,61 @@ ASTValidation::visit (AST::Function &function)
       function.get_self_param ()->get_locus (),
       "%<self%> parameter is only allowed in associated functions");
 
-  if (!function.has_body ())
+  if (function.is_external ())
     {
-      if (context.back () == Context::INHERENT_IMPL
-	  || context.back () == Context::TRAIT_IMPL)
+      if (function.has_body ())
+	rust_error_at (function.get_locus (), "cannot have a body");
+
+      auto &params = function.get_function_params ();
+
+      if (params.size () == 1 && function.is_variadic ())
 	rust_error_at (function.get_locus (),
-		       "associated function in %<impl%> without body");
-      else if (context.back () != Context::TRAIT)
-	rust_error_at (function.get_locus (), "free function without a body");
+		       "C-variadic function must be declared with at least one "
+		       "named argument");
+
+      for (auto it = params.begin (); it != params.end (); it++)
+	{
+	  if (it->get ()->is_variadic () && it + 1 != params.end ())
+	    rust_error_at (
+	      it->get ()->get_locus (),
+	      "%<...%> must be the last argument of a C-variadic function");
+
+	  // if functional parameter
+	  if (!it->get ()->is_self () && !it->get ()->is_variadic ())
+	    {
+	      auto param = static_cast<AST::FunctionParam *> (it->get ());
+	      auto kind = param->get_pattern ()->get_pattern_kind ();
+
+	      if (kind != AST::Pattern::Kind::Identifier
+		  && kind != AST::Pattern::Kind::Wildcard)
+		rust_error_at (it->get ()->get_locus (), ErrorCode::E0130,
+			       "pattern not allowed in foreign function");
+	    }
+	}
     }
 
-  auto &function_params = function.get_function_params ();
-  for (auto it = function_params.begin (); it != function_params.end (); it++)
+  else
     {
-      if (it->get ()->is_variadic ())
-	rust_error_at (it->get ()->get_locus (),
-		       "only foreign or %<unsafe extern \"C\"%> functions may "
-		       "be C-variadic");
+      if (!function.has_body ())
+	{
+	  if (context.back () == Context::INHERENT_IMPL
+	      || context.back () == Context::TRAIT_IMPL)
+	    rust_error_at (function.get_locus (),
+			   "associated function in %<impl%> without body");
+	  else if (context.back () != Context::TRAIT)
+	    rust_error_at (function.get_locus (),
+			   "free function without a body");
+	}
+      auto &function_params = function.get_function_params ();
+      for (auto it = function_params.begin (); it != function_params.end ();
+	   it++)
+	{
+	  if (it->get ()->is_variadic ())
+	    rust_error_at (
+	      it->get ()->get_locus (),
+	      "only foreign or %<unsafe extern \"C\"%> functions may "
+	      "be C-variadic");
+	}
     }
 
   AST::ContextualASTVisitor::visit (function);

--- a/gcc/rust/checks/errors/rust-ast-validation.h
+++ b/gcc/rust/checks/errors/rust-ast-validation.h
@@ -38,7 +38,6 @@ public:
   virtual void visit (AST::ConstantItem &const_item);
   virtual void visit (AST::Lifetime &lifetime);
   virtual void visit (AST::LoopLabel &label);
-  virtual void visit (AST::ExternalFunctionItem &item);
   virtual void visit (AST::Union &item);
   virtual void visit (AST::Function &function);
   virtual void visit (AST::Trait &trait);

--- a/gcc/rust/checks/errors/rust-feature-gate.cc
+++ b/gcc/rust/checks/errors/rust-feature-gate.cc
@@ -131,7 +131,8 @@ FeatureGate::visit (AST::MacroRulesDefinition &rules_def)
 void
 FeatureGate::visit (AST::Function &function)
 {
-  check_rustc_attri (function.get_outer_attrs ());
+  if (!function.is_external ())
+    check_rustc_attri (function.get_outer_attrs ());
 }
 
 void

--- a/gcc/rust/checks/errors/rust-feature-gate.h
+++ b/gcc/rust/checks/errors/rust-feature-gate.h
@@ -130,7 +130,6 @@ public:
   void visit (AST::Trait &trait) override {}
   void visit (AST::ExternalTypeItem &item) override;
   void visit (AST::ExternalStaticItem &item) override {}
-  void visit (AST::ExternalFunctionItem &item) override {}
   void visit (AST::ExternBlock &block) override;
   void visit (AST::MacroMatchFragment &match) override {}
   void visit (AST::MacroMatchRepetition &match) override {}

--- a/gcc/rust/expand/rust-cfg-strip.h
+++ b/gcc/rust/expand/rust-cfg-strip.h
@@ -150,7 +150,6 @@ public:
   void visit (AST::TraitImpl &impl) override;
   void visit (AST::ExternalTypeItem &item) override;
   void visit (AST::ExternalStaticItem &item) override;
-  void visit (AST::ExternalFunctionItem &item) override;
   void visit (AST::ExternBlock &block) override;
 
   // I don't think it would be possible to strip macros without expansion

--- a/gcc/rust/expand/rust-derive.h
+++ b/gcc/rust/expand/rust-derive.h
@@ -166,7 +166,6 @@ private:
   virtual void visit (TraitImpl &impl) override final{};
   virtual void visit (ExternalTypeItem &type) override final{};
   virtual void visit (ExternalStaticItem &item) override final{};
-  virtual void visit (ExternalFunctionItem &item) override final{};
   virtual void visit (ExternBlock &block) override final{};
   virtual void visit (MacroMatchFragment &match) override final{};
   virtual void visit (MacroMatchRepetition &match) override final{};

--- a/gcc/rust/expand/rust-expand-visitor.cc
+++ b/gcc/rust/expand/rust-expand-visitor.cc
@@ -923,23 +923,6 @@ ExpandVisitor::visit (AST::ExternalStaticItem &static_item)
 }
 
 void
-ExpandVisitor::visit (AST::ExternalFunctionItem &item)
-{
-  for (auto &param : item.get_generic_params ())
-    visit (param);
-
-  for (auto &param : item.get_function_params ())
-    if (!param.is_variadic ())
-      maybe_expand_type (param.get_type ());
-
-  if (item.has_return_type ())
-    maybe_expand_type (item.get_return_type ());
-
-  if (item.has_where_clause ())
-    expand_where_clause (item.get_where_clause ());
-}
-
-void
 ExpandVisitor::visit (AST::ExternBlock &block)
 {
   visit_inner_attrs (block);

--- a/gcc/rust/expand/rust-expand-visitor.h
+++ b/gcc/rust/expand/rust-expand-visitor.h
@@ -252,7 +252,6 @@ public:
   void visit (AST::TraitImpl &impl) override;
   void visit (AST::ExternalTypeItem &item) override;
   void visit (AST::ExternalStaticItem &item) override;
-  void visit (AST::ExternalFunctionItem &item) override;
   void visit (AST::ExternBlock &block) override;
 
   // I don't think it would be possible to strip macros without expansion

--- a/gcc/rust/hir/rust-ast-lower-base.cc
+++ b/gcc/rust/hir/rust-ast-lower-base.cc
@@ -345,9 +345,6 @@ void
 ASTLoweringBase::visit (AST::ExternalStaticItem &)
 {}
 void
-ASTLoweringBase::visit (AST::ExternalFunctionItem &)
-{}
-void
 ASTLoweringBase::visit (AST::ExternBlock &)
 {}
 

--- a/gcc/rust/hir/rust-ast-lower-base.h
+++ b/gcc/rust/hir/rust-ast-lower-base.h
@@ -186,7 +186,6 @@ public:
   //  virtual void visit(ExternalItem& item);
   virtual void visit (AST::ExternalTypeItem &item);
   virtual void visit (AST::ExternalStaticItem &item);
-  virtual void visit (AST::ExternalFunctionItem &item);
   virtual void visit (AST::ExternBlock &block);
 
   // rust-macro.h

--- a/gcc/rust/metadata/rust-export-metadata.cc
+++ b/gcc/rust/metadata/rust-export-metadata.cc
@@ -93,46 +93,9 @@ ExportContext::emit_function (const HIR::Function &fn)
       // FIXME assert that this is actually an AST::Function
       AST::Function &function = static_cast<AST::Function &> (vis_item);
 
-      // we can emit an extern block with abi of "rust"
-      Identifier item_name = function.get_function_name ();
-
-      // always empty for extern linkage
-      AST::WhereClause where_clause = AST::WhereClause::create_empty ();
-      std::vector<std::unique_ptr<AST::GenericParam>> generic_params;
-
-      AST::Visibility vis = function.get_visibility ();
-      std::unique_ptr<AST::Type> return_type
-	= std::unique_ptr<AST::Type> (nullptr);
-      if (function.has_return_type ())
-	{
-	  return_type = function.get_return_type ()->clone_type ();
-	}
-
-      std::vector<AST::NamedFunctionParam> function_params;
-      for (auto &p : function.get_function_params ())
-	{
-	  if (p->is_variadic () || p->is_self ())
-	    rust_unreachable ();
-	  auto param = static_cast<AST::FunctionParam *> (p.get ());
-	  std::string name = param->get_pattern ()->as_string ();
-	  std::unique_ptr<AST::Type> param_type
-	    = param->get_type ()->clone_type ();
-
-	  AST::NamedFunctionParam np (name, std::move (param_type), {},
-				      param->get_locus ());
-	  function_params.push_back (std::move (np));
-	}
-
-      AST::ExternalItem *external_item
-	= new AST::ExternalFunctionItem (item_name, {} /* generic_params */,
-					 std::move (return_type), where_clause,
-					 std::move (function_params), vis,
-					 function.get_outer_attrs (),
-					 function.get_locus ());
-
       std::vector<std::unique_ptr<AST::ExternalItem>> external_items;
-      external_items.push_back (
-	std::unique_ptr<AST::ExternalItem> (external_item));
+      external_items.push_back (std::unique_ptr<AST::ExternalItem> (
+	static_cast<AST::ExternalItem *> (&function)));
 
       AST::ExternBlock extern_block (get_string_from_abi (Rust::ABI::RUST),
 				     std::move (external_items),

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -2908,7 +2908,8 @@ Parser<ManagedTokenSource>::parse_use_tree ()
 template <typename ManagedTokenSource>
 std::unique_ptr<AST::Function>
 Parser<ManagedTokenSource>::parse_function (AST::Visibility vis,
-					    AST::AttrVec outer_attrs)
+					    AST::AttrVec outer_attrs,
+					    bool is_external)
 {
   location_t locus = lexer.peek_token ()->get_locus ();
   // Get qualifiers for function if they exist
@@ -2992,7 +2993,7 @@ Parser<ManagedTokenSource>::parse_function (AST::Visibility vis,
 		       std::move (generic_params), std::move (function_params),
 		       std::move (return_type), std::move (where_clause),
 		       std::move (body), std::move (vis),
-		       std::move (outer_attrs), locus));
+		       std::move (outer_attrs), locus, false, is_external));
 }
 
 // Parses function or method qualifiers (i.e. const, unsafe, and extern).
@@ -6166,6 +6167,7 @@ Parser<ManagedTokenSource>::parse_external_item ()
     case FN_KW:
       return parse_external_function_item (std::move (vis),
 					   std::move (outer_attrs));
+
     case TYPE:
       return parse_external_type_item (std::move (vis),
 				       std::move (outer_attrs));
@@ -10474,8 +10476,7 @@ Parser<ManagedTokenSource>::parse_pattern ()
     {
       lexer.skip_token ();
       alts.push_back (parse_pattern_no_alt ());
-    }
-  while (lexer.peek_token ()->get_id () == PIPE);
+  } while (lexer.peek_token ()->get_id () == PIPE);
 
   /* alternates */
   return std::unique_ptr<AST::Pattern> (

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -6034,68 +6034,6 @@ Parser<ManagedTokenSource>::parse_named_function_params (
   return params;
 }
 
-template <typename ManagedTokenSource>
-std::unique_ptr<AST::ExternalFunctionItem>
-Parser<ManagedTokenSource>::parse_external_function_item (
-  AST::Visibility vis, AST::AttrVec outer_attrs)
-{
-  location_t locus = lexer.peek_token ()->get_locus ();
-
-  // parse extern function declaration item
-  // skip function token
-  lexer.skip_token ();
-
-  // parse identifier
-  const_TokenPtr ident_tok = expect_token (IDENTIFIER);
-  if (ident_tok == nullptr)
-    {
-      skip_after_semicolon ();
-      return nullptr;
-    }
-  Identifier ident{ident_tok};
-
-  // parse (optional) generic params
-  std::vector<std::unique_ptr<AST::GenericParam>> generic_params
-    = parse_generic_params_in_angles ();
-
-  if (!skip_token (LEFT_PAREN))
-    {
-      skip_after_semicolon ();
-      return nullptr;
-    }
-
-  // parse parameters
-  std::vector<AST::NamedFunctionParam> function_params
-    = parse_named_function_params (
-      [] (TokenId id) { return id == RIGHT_PAREN; });
-
-  if (!skip_token (RIGHT_PAREN))
-    {
-      skip_after_semicolon ();
-      return nullptr;
-    }
-
-  // parse (optional) return type
-  std::unique_ptr<AST::Type> return_type = parse_function_return_type ();
-
-  // parse (optional) where clause
-  AST::WhereClause where_clause = parse_where_clause ();
-
-  if (!skip_token (SEMICOLON))
-    {
-      // skip somewhere?
-      return nullptr;
-    }
-
-  function_params.shrink_to_fit ();
-
-  return std::unique_ptr<AST::ExternalFunctionItem> (
-    new AST::ExternalFunctionItem (
-      std::move (ident), std::move (generic_params), std::move (return_type),
-      std::move (where_clause), std::move (function_params), std::move (vis),
-      std::move (outer_attrs), locus));
-}
-
 // Parses a single extern block item (static or function declaration).
 template <typename ManagedTokenSource>
 std::unique_ptr<AST::ExternalItem>

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -6165,8 +6165,7 @@ Parser<ManagedTokenSource>::parse_external_item ()
 				       std::move (outer_attrs), locus));
       }
     case FN_KW:
-      return parse_external_function_item (std::move (vis),
-					   std::move (outer_attrs));
+      return parse_function (std::move (vis), std::move (outer_attrs), true);
 
     case TYPE:
       return parse_external_type_item (std::move (vis),
@@ -10476,7 +10475,9 @@ Parser<ManagedTokenSource>::parse_pattern ()
     {
       lexer.skip_token ();
       alts.push_back (parse_pattern_no_alt ());
-  } while (lexer.peek_token ()->get_id () == PIPE);
+    }
+
+  while (lexer.peek_token ()->get_id () == PIPE);
 
   /* alternates */
   return std::unique_ptr<AST::Pattern> (

--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -253,7 +253,8 @@ private:
   parse_use_decl (AST::Visibility vis, AST::AttrVec outer_attrs);
   std::unique_ptr<AST::UseTree> parse_use_tree ();
   std::unique_ptr<AST::Function> parse_function (AST::Visibility vis,
-						 AST::AttrVec outer_attrs);
+						 AST::AttrVec outer_attrs,
+						 bool is_external = false);
   AST::FunctionQualifiers parse_function_qualifiers ();
   std::vector<std::unique_ptr<AST::GenericParam>>
   parse_generic_params_in_angles ();

--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -310,8 +310,6 @@ private:
   AST::Lifetime lifetime_from_token (const_TokenPtr tok);
   std::unique_ptr<AST::ExternalTypeItem>
   parse_external_type_item (AST::Visibility vis, AST::AttrVec outer_attrs);
-  std::unique_ptr<AST::ExternalFunctionItem>
-  parse_external_function_item (AST::Visibility vis, AST::AttrVec outer_attrs);
   AST::NamedFunctionParam parse_named_function_param ();
   template <typename EndTokenPred>
   std::vector<AST::NamedFunctionParam>

--- a/gcc/rust/resolve/rust-ast-resolve-base.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-base.cc
@@ -431,10 +431,6 @@ ResolverBase::visit (AST::ExternalStaticItem &)
 {}
 
 void
-ResolverBase::visit (AST::ExternalFunctionItem &)
-{}
-
-void
 ResolverBase::visit (AST::ExternBlock &)
 {}
 

--- a/gcc/rust/resolve/rust-ast-resolve-base.h
+++ b/gcc/rust/resolve/rust-ast-resolve-base.h
@@ -135,7 +135,6 @@ public:
 
   void visit (AST::ExternalTypeItem &);
   void visit (AST::ExternalStaticItem &);
-  void visit (AST::ExternalFunctionItem &);
   void visit (AST::ExternBlock &);
 
   void visit (AST::MacroMatchFragment &);

--- a/gcc/rust/resolve/rust-ast-resolve-implitem.h
+++ b/gcc/rust/resolve/rust-ast-resolve-implitem.h
@@ -189,11 +189,11 @@ public:
     item->accept_vis (resolver);
   };
 
-  void visit (AST::ExternalFunctionItem &function) override
+  void visit (AST::Function &function) override
   {
     auto decl
       = CanonicalPath::new_seg (function.get_node_id (),
-				function.get_identifier ().as_string ());
+				function.get_function_name ().as_string ());
     auto path = prefix.append (decl);
 
     resolver->get_name_scope ().insert (

--- a/gcc/rust/resolve/rust-ast-resolve-item.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-item.cc
@@ -1009,11 +1009,12 @@ ResolveExternItem::go (AST::ExternalItem *item, const CanonicalPath &prefix,
 }
 
 void
-ResolveExternItem::visit (AST::ExternalFunctionItem &function)
+ResolveExternItem::visit (AST::Function &function)
 {
   NodeId scope_node_id = function.get_node_id ();
-  auto decl = CanonicalPath::new_seg (function.get_node_id (),
-				      function.get_identifier ().as_string ());
+  auto decl
+    = CanonicalPath::new_seg (function.get_node_id (),
+			      function.get_function_name ().as_string ());
   auto path = prefix.append (decl);
   auto cpath = canonical_prefix.append (decl);
 
@@ -1038,9 +1039,12 @@ ResolveExternItem::visit (AST::ExternalFunctionItem &function)
 
   // we make a new scope so the names of parameters are resolved and shadowed
   // correctly
-  for (auto &param : function.get_function_params ())
-    if (!param.is_variadic ())
-      ResolveType::go (param.get_type ().get ());
+  for (auto &it : function.get_function_params ())
+    if (!it->is_variadic ())
+      {
+	auto param = static_cast<AST::FunctionParam *> (it.get ());
+	ResolveType::go (param->get_type ().get ());
+      }
 
   // done
   resolver->get_name_scope ().pop ();

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -111,7 +111,7 @@ public:
   static void go (AST::ExternalItem *item, const CanonicalPath &prefix,
 		  const CanonicalPath &canonical_prefix);
 
-  void visit (AST::ExternalFunctionItem &function) override;
+  void visit (AST::Function &function) override;
   void visit (AST::ExternalStaticItem &item) override;
 
 private:

--- a/gcc/rust/resolve/rust-default-resolver.cc
+++ b/gcc/rust/resolve/rust-default-resolver.cc
@@ -493,10 +493,6 @@ DefaultResolver::visit (AST::ExternalStaticItem &)
 {}
 
 void
-DefaultResolver::visit (AST::ExternalFunctionItem &)
-{}
-
-void
 DefaultResolver::visit (AST::MacroMatchRepetition &)
 {}
 

--- a/gcc/rust/resolve/rust-default-resolver.cc
+++ b/gcc/rust/resolve/rust-default-resolver.cc
@@ -62,7 +62,8 @@ DefaultResolver::visit (AST::Function &function)
 	if (p->is_variadic ())
 	  {
 	    auto param = static_cast<AST::VariadicParam *> (p.get ());
-	    param->get_pattern ()->accept_vis (*this);
+	    if (param->has_pattern ())
+	      param->get_pattern ()->accept_vis (*this);
 	  }
 	else if (p->is_self ())
 	  {

--- a/gcc/rust/resolve/rust-default-resolver.h
+++ b/gcc/rust/resolve/rust-default-resolver.h
@@ -118,7 +118,6 @@ public:
   void visit (AST::TraitItemType &);
   void visit (AST::ExternalTypeItem &);
   void visit (AST::ExternalStaticItem &);
-  void visit (AST::ExternalFunctionItem &);
   void visit (AST::MacroMatchRepetition &);
   void visit (AST::MacroMatcher &);
   void visit (AST::MacroRulesDefinition &);

--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -767,10 +767,6 @@ AttributeChecker::visit (AST::ExternalStaticItem &)
 {}
 
 void
-AttributeChecker::visit (AST::ExternalFunctionItem &)
-{}
-
-void
 AttributeChecker::visit (AST::ExternBlock &block)
 {
   check_proc_macro_non_function (block.get_outer_attrs ());

--- a/gcc/rust/util/rust-attributes.h
+++ b/gcc/rust/util/rust-attributes.h
@@ -199,7 +199,6 @@ private:
   void visit (AST::TraitImpl &impl) override;
   void visit (AST::ExternalTypeItem &item) override;
   void visit (AST::ExternalStaticItem &item) override;
-  void visit (AST::ExternalFunctionItem &item) override;
   void visit (AST::ExternBlock &block) override;
 
   // rust-macro.h

--- a/gcc/testsuite/rust/compile/extern_func_with_body.rs
+++ b/gcc/testsuite/rust/compile/extern_func_with_body.rs
@@ -1,0 +1,5 @@
+extern "C" {
+    fn myfun0(a:i32,...) {}
+    // { dg-error "cannot have a body" "" { target *-*-* } .-1 }
+}
+


### PR DESCRIPTION
Added support for external function in AST::Function. It can be verified it in AST validation as follows. But in line 6113 of rust-parse-impl.h, `parse_external_item()` needs return type ExternalItem from parse_function() which returns `Function`, thus we cannot directly use `parse_function()`. 
How should I proceed ?
