### PR TITLE
gccrs: Avoid *.bak suffixed tests - use dg-skip-if instead

### DIFF
--- a/gcc/testsuite/rust/compile/issue-1773.rs
+++ b/gcc/testsuite/rust/compile/issue-1773.rs
@@ -1,4 +1,5 @@
 #[lang = "sized"]
+// { dg-skip-if "" { *-*-* } }
 pub trait Sized {}
 
 trait Foo<T> {


### PR DESCRIPTION
On Fri, Feb 09, 2024 at 11:03:38AM +0100, Jakub Jelinek wrote:
> On Wed, Feb 07, 2024 at 12:43:59PM +0100, arthur.cohen@embecosm.com wrote:
> > This patch introduces one regression because generics are getting better
> > understood over time. The code here used to apply generics with the same
> > symbol from previous segments which was a bit of a hack with out limited
> > inference variable support. The regression looks like it will be related
> > to another issue which needs to default integer inference variables much
> > more aggresivly to default integer.
> >
> > Fixes #2723
> >     * rust/compile/issue-1773.rs: Moved to...
> >     * rust/compile/issue-1773.rs.bak: ...here.
>
> Please don't use such suffixes in the testsuite.
> Either delete the testcase, or xfail it somehow until the bug is fixed.

To be precise, I have scripts to look for backup files in the tree (*~,
*.bak, *.orig, *.rej etc.) and this stands in the way several times a day.

Here is a fix for that in patch form, tested on x86_64-linux with
make check-rust RUNTESTFLAGS='compile.exp=issue-1773.rs'

2024-02-15  Jakub Jelinek  <jakub@redhat.com>

	* rust/compile/issue-1773.rs.bak: Rename to ...
	* rust/compile/issue-1773.rs: ... this.  Add dg-skip-if directive.

