### PR TITLE
Return proper AST nodes from format_args!() expansion

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -118,6 +118,7 @@ GRS_OBJS = \
     rust/rust-ast-lower-expr.o \
     rust/rust-ast-lower-type.o \
     rust/rust-ast-lower-stmt.o \
+    rust/rust-ast-lower-format-args.o \
     rust/rust-rib.o \
     rust/rust-name-resolution-context.o \
     rust/rust-default-resolver.o \

--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -409,8 +409,8 @@ rust/%.o: rust/lex/%.cc
 	echo $@
 
 rust/libformat_parser.a: $(srcdir)/../libgrust/libformat_parser/Cargo.toml $(wildcard $(srcdir)/../libgrust/libformat_parser/src/*.rs)
-	cargo build --manifest-path $(srcdir)/../libgrust/libformat_parser/Cargo.toml --release # FIXME: Not always release, right?
-	cp $(srcdir)/../libgrust/libformat_parser/target/release/liblibformat_parser.a $@
+	cargo build --manifest-path $(srcdir)/../libgrust/libformat_parser/Cargo.toml # FIXME: Not always release, right?
+	cp $(srcdir)/../libgrust/libformat_parser/target/debug/liblibformat_parser.a $@
 
 # build all rust/parse files in rust folder, add cross-folder includes
 rust/%.o: rust/parse/%.cc

--- a/gcc/rust/ast/rust-ast-collector.cc
+++ b/gcc/rust/ast/rust-ast-collector.cc
@@ -2810,7 +2810,8 @@ TokenCollector::visit (BareFunctionType &type)
 void
 TokenCollector::visit (AST::FormatArgs &fmt)
 {
-  rust_sorry_at (0, "unimplemented format_args!() visitor");
+  rust_sorry_at (fmt.get_locus (), "%s:%u: unimplemented FormatArgs visitor",
+		 __FILE__, __LINE__);
 }
 
 } // namespace AST

--- a/gcc/rust/ast/rust-ast-collector.cc
+++ b/gcc/rust/ast/rust-ast-collector.cc
@@ -16,6 +16,8 @@
 // along with GCC; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 #include "rust-ast-collector.h"
+#include "rust-ast.h"
+#include "rust-diagnostics.h"
 #include "rust-item.h"
 #include "rust-keyword-values.h"
 
@@ -2803,6 +2805,12 @@ TokenCollector::visit (BareFunctionType &type)
       push (Rust::Token::make (RETURN_TYPE, UNDEF_LOCATION));
       visit (type.get_return_type ());
     }
+}
+
+void
+TokenCollector::visit (AST::FormatArgs &fmt)
+{
+  rust_sorry_at (0, "unimplemented format_args!() visitor");
 }
 
 } // namespace AST

--- a/gcc/rust/ast/rust-ast-collector.h
+++ b/gcc/rust/ast/rust-ast-collector.h
@@ -398,6 +398,8 @@ public:
   void visit (SliceType &type);
   void visit (InferredType &type);
   void visit (BareFunctionType &type);
+
+  void visit (FormatArgs &fmt);
 };
 } // namespace AST
 

--- a/gcc/rust/ast/rust-ast-full-decls.h
+++ b/gcc/rust/ast/rust-ast-full-decls.h
@@ -267,6 +267,9 @@ class SliceType;
 class InferredType;
 struct MaybeNamedParam;
 class BareFunctionType;
+
+// rust-builtin-ast-nodes.h
+class FormatArgs;
 } // namespace AST
 } // namespace Rust
 

--- a/gcc/rust/ast/rust-ast-full.h
+++ b/gcc/rust/ast/rust-ast-full.h
@@ -28,5 +28,6 @@
 #include "rust-stmt.h"
 #include "rust-type.h"
 #include "rust-macro.h"
+#include "rust-builtin-ast-nodes.h"
 
 #endif

--- a/gcc/rust/ast/rust-ast-visitor.cc
+++ b/gcc/rust/ast/rust-ast-visitor.cc
@@ -1396,6 +1396,12 @@ DefaultASTVisitor::visit (AST::BareFunctionType &type)
 }
 
 void
+DefaultASTVisitor::visit (AST::FormatArgs &)
+{
+  // FIXME: Do we have anything to do? any subnodes to visit? Probably, right?
+}
+
+void
 DefaultASTVisitor::visit (AST::VariadicParam &param)
 {
   if (param.has_pattern ())

--- a/gcc/rust/ast/rust-ast-visitor.h
+++ b/gcc/rust/ast/rust-ast-visitor.h
@@ -229,6 +229,9 @@ public:
   virtual void visit (InferredType &type) = 0;
   virtual void visit (BareFunctionType &type) = 0;
 
+  // special AST nodes for certain builtin macros such as `asm!()`
+  virtual void visit (FormatArgs &fmt) = 0;
+
   // TODO: rust-cond-compilation.h visiting? not currently used
 };
 
@@ -390,6 +393,7 @@ protected:
   virtual void visit (AST::SelfParam &self) override;
   virtual void visit (AST::FunctionParam &param) override;
   virtual void visit (AST::VariadicParam &param) override;
+  virtual void visit (AST::FormatArgs &fmt) override;
 
   template <typename T> void visit (T &node) { node.accept_vis (*this); }
 
@@ -422,6 +426,7 @@ protected:
   virtual void visit (AST::MacroTranscriber &transcriber);
   virtual void visit (AST::StructPatternElements &spe);
   virtual void visit (AST::MaybeNamedParam &param);
+
   void visit (AST::Attribute &attribute) {}
 
   template <typename T> void visit_outer_attrs (T &node)

--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -5065,7 +5065,7 @@ FormatArgs::as_string () const
 location_t
 FormatArgs::get_locus () const
 {
-  rust_unreachable ();
+  return loc;
 }
 
 bool

--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -5048,6 +5048,12 @@ MetaWord::accept_vis (ASTVisitor &vis)
   vis.visit (*this);
 }
 
+void
+FormatArgs::accept_vis (ASTVisitor &vis)
+{
+  vis.visit (*this);
+}
+
 } // namespace AST
 
 std::ostream &

--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -19,6 +19,7 @@ along with GCC; see the file COPYING3.  If not see
 
 #include "rust-ast.h"
 #include "optional.h"
+#include "rust-builtin-ast-nodes.h"
 #include "rust-system.h"
 #include "rust-ast-full.h"
 #include "rust-diagnostics.h"
@@ -5052,6 +5053,56 @@ void
 FormatArgs::accept_vis (ASTVisitor &vis)
 {
   vis.visit (*this);
+}
+
+std::string
+FormatArgs::as_string () const
+{
+  // FIXME(Arthur): Improve
+  return "FormatArgs";
+}
+
+location_t
+FormatArgs::get_locus () const
+{
+  rust_unreachable ();
+}
+
+bool
+FormatArgs::is_expr_without_block () const
+{
+  return false;
+}
+
+void
+FormatArgs::mark_for_strip ()
+{
+  marked_for_strip = true;
+}
+
+bool
+FormatArgs::is_marked_for_strip () const
+{
+  return marked_for_strip;
+}
+
+std::vector<Attribute> &
+FormatArgs::get_outer_attrs ()
+{
+  rust_unreachable ();
+}
+
+void FormatArgs::set_outer_attrs (std::vector<Attribute>)
+{
+  rust_unreachable ();
+}
+
+Expr *
+FormatArgs::clone_expr_impl () const
+{
+  std::cerr << "[ARTHUR] cloning FormatArgs! " << std::endl;
+
+  return new FormatArgs (*this);
 }
 
 } // namespace AST

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -2029,6 +2029,7 @@ public:
 class PathExpr : public ExprWithoutBlock
 {
 };
+
 } // namespace AST
 } // namespace Rust
 

--- a/gcc/rust/ast/rust-builtin-ast-nodes.h
+++ b/gcc/rust/ast/rust-builtin-ast-nodes.h
@@ -184,33 +184,18 @@ public:
 
   FormatArgs (location_t loc, Fmt::Pieces &&template_str,
 	      FormatArguments &&arguments)
-    : loc (loc), template_str (std::move (template_str)),
+    : loc (loc), template_pieces (std::move (template_str)),
       arguments (std::move (arguments))
   {}
 
-  FormatArgs (FormatArgs &&other)
-    : loc (std::move (other.loc)),
-      template_str (std::move (other.template_str)),
-      arguments (std::move (other.arguments))
-  {
-    std::cerr << "[ARTHUR] moving FormatArgs" << std::endl;
-  }
-
-  // FIXME: This might be invalid - we are reusing the same memory allocated
-  // on the Rust side for `other`. This is probably valid as long as we only
-  // ever read that memory and never write to it.
-  FormatArgs (const FormatArgs &other)
-    : loc (other.loc), template_str (other.template_str),
-      arguments (other.arguments)
-  {
-    std::cerr << "[ARTHUR] copying FormatArgs" << std::endl;
-  }
-
-  // FormatArgs &operator= (const FormatArgs &other) = default;
-  //   : template_str (other.template_str), arguments (other.arguments)
-  // {}
+  FormatArgs (FormatArgs &&other) = default;
+  FormatArgs (const FormatArgs &other) = default;
+  FormatArgs &operator= (const FormatArgs &other) = default;
 
   void accept_vis (AST::ASTVisitor &vis) override;
+
+  const Fmt::Pieces &get_template () const { return template_pieces; }
+  virtual location_t get_locus () const override;
 
 private:
   location_t loc;
@@ -218,14 +203,13 @@ private:
   // expansion of format_args!(). There is extra handling associated with it.
   // we can maybe do that in rust-fmt.cc? in collect_pieces()? like do the
   // transformation into something we can handle better
-  Fmt::Pieces template_str;
+  Fmt::Pieces template_pieces;
   FormatArguments arguments;
 
   bool marked_for_strip = false;
 
 protected:
   virtual std::string as_string () const override;
-  virtual location_t get_locus () const override;
   virtual bool is_expr_without_block () const override;
   virtual void mark_for_strip () override;
   virtual bool is_marked_for_strip () const override;

--- a/gcc/rust/ast/rust-builtin-ast-nodes.h
+++ b/gcc/rust/ast/rust-builtin-ast-nodes.h
@@ -1,0 +1,129 @@
+// Copyright (C) 2024 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_AST_BUILTIN_NODES_H
+#define RUST_AST_BUILTIN_NODES_H
+
+#include "rust-system.h"
+#include "line-map.h"
+#include "optional.h"
+#include "rust-ast.h"
+#include "rust-fmt.h"
+
+namespace Rust {
+namespace AST {
+
+// Definitions, from rustc's `FormatArgs` AST struct
+// https://github.com/rust-lang/rust/blob/1be468815c/compiler/rustc_ast/src/format.rs
+//
+// format_args!("hello {abc:.xyz$}!!", abc="world");
+// └──────────────────────────────────────────────┘
+//                     FormatArgs
+//
+// format_args!("hello {abc:.xyz$}!!", abc="world");
+//                                     └─────────┘
+//                                      argument
+//
+// format_args!("hello {abc:.xyz$}!!", abc="world");
+//              └───────────────────┘
+//                     template
+//
+// format_args!("hello {abc:.xyz$}!!", abc="world");
+//               └────┘└─────────┘└┘
+//                      pieces
+//
+// format_args!("hello {abc:.xyz$}!!", abc="world");
+//               └────┘           └┘
+//                   literal pieces
+//
+// format_args!("hello {abc:.xyz$}!!", abc="world");
+//                     └─────────┘
+//                     placeholder
+//
+// format_args!("hello {abc:.xyz$}!!", abc="world");
+//                      └─┘  └─┘
+//                      positions (could be names, numbers, empty, or `*`)
+
+class FormatArgumentKind
+{
+public:
+  Identifier &get_ident ()
+  {
+    rust_assert (kind == Kind::Captured || kind == Kind::Named);
+
+    return ident.value ();
+  }
+
+private:
+  enum class Kind
+  {
+    Normal,
+    Named,
+    Captured,
+  } kind;
+
+  tl::optional<Identifier> ident;
+};
+
+class FormatArgument
+{
+  FormatArgumentKind kind;
+  std::unique_ptr<Expr> expr;
+};
+
+class FormatArguments
+{
+  std::vector<FormatArgument> args;
+};
+
+// TODO: Format documentation better
+// Having a separate AST node for `format_args!()` expansion allows some
+// important optimizations which help reduce generated code a lot. For example,
+// turning `format_args!("a {} {} {}", 15, "hey", 'a')` directly into
+// `format_args!("a 15 hey a")`, since all arguments are literals. Or,
+// flattening imbricated `format_args!()` calls: `format_args!("heyo {}",
+// format_args!("result: {}", some_result))` -> `format_args!("heyo result: {}",
+// some_result)`
+// FIXME: Move to rust-macro.h
+class FormatArgs : public Visitable
+{
+public:
+  enum class Newline
+  {
+    Yes,
+    No
+  };
+
+  FormatArgs (location_t loc, Fmt::PieceSlice template_str,
+	      FormatArguments arguments)
+    : loc (loc), template_str (std::move (template_str)),
+      arguments (std::move (arguments))
+  {}
+
+  void accept_vis (AST::ASTVisitor &vis);
+
+private:
+  location_t loc;
+  Fmt::PieceSlice template_str;
+  FormatArguments arguments;
+};
+
+} // namespace AST
+} // namespace Rust
+
+#endif // ! RUST_AST_BUILTIN_NODES_H

--- a/gcc/rust/ast/rust-fmt.cc
+++ b/gcc/rust/ast/rust-fmt.cc
@@ -23,9 +23,9 @@ namespace Rust {
 namespace Fmt {
 
 Pieces
-Pieces::collect (std::string &&to_parse)
+Pieces::collect (std::string &&to_parse, bool append_newline)
 {
-  auto piece_slice = collect_pieces (to_parse.c_str ());
+  auto piece_slice = collect_pieces (to_parse.c_str (), append_newline);
 
   rust_debug ("[ARTHUR] %p, %lu", (const void *) piece_slice.base_ptr,
 	      piece_slice.len);
@@ -37,7 +37,39 @@ Pieces::collect (std::string &&to_parse)
   return Pieces (piece_slice, std::move (to_parse));
 }
 
-Pieces::~Pieces () { destroy_pieces (slice); }
+Pieces::~Pieces ()
+{
+  std::cerr << "Arthur: destoying pieces. this: " << (void *) this
+	    << " slice: " << slice.base_ptr << std::endl;
+  destroy_pieces (slice);
+}
+
+Pieces::Pieces (const Pieces &other) : to_parse (other.to_parse)
+{
+  slice = clone_pieces (other.slice.base_ptr, other.slice.len, other.slice.cap);
+  std::cerr << "Arthur: copying pieces: other.to_parse: "
+	    << (void *) other.to_parse.c_str ()
+	    << " ours to_parse: " << (void *) to_parse.c_str () << std::endl;
+  // auto pieces = std::vector (slice.base_ptr, slice.base_ptr + slice.len);
+}
+
+Pieces &
+Pieces::operator= (const Pieces &other)
+{
+  slice = clone_pieces (other.slice.base_ptr, other.slice.len, other.slice.cap);
+  to_parse = other.to_parse;
+
+  return *this;
+}
+
+Pieces::Pieces (Pieces &&other)
+  : slice (
+    clone_pieces (other.slice.base_ptr, other.slice.len, other.slice.cap)),
+    to_parse (std::move (other.to_parse))
+{
+  std::cerr << "Arthur: moving pieces. to_parse: " << (void *) to_parse.c_str ()
+	    << " base_ptr/slice: " << (void *) slice.base_ptr << std::endl;
+}
 
 } // namespace Fmt
 } // namespace Rust

--- a/gcc/rust/ast/rust-fmt.h
+++ b/gcc/rust/ast/rust-fmt.h
@@ -262,6 +262,8 @@ struct Pieces
 
   Pieces (Pieces &&other);
 
+  const std::vector<Piece> &get_pieces () const { return pieces_vector; }
+
   // {
   //   slice = clone_pieces (&other.slice);
   //   to_parse = other.to_parse;
@@ -270,10 +272,17 @@ struct Pieces
   // }
 
 private:
-  Pieces (PieceSlice slice, std::string &&to_parse)
-    : slice (slice), to_parse (std::move (to_parse))
+  Pieces (std::vector<Piece> &&pieces_vector, PieceSlice slice,
+	  std::string &&to_parse)
+    : pieces_vector (std::move (pieces_vector)), slice (slice),
+      to_parse (std::move (to_parse))
   {}
 
+  std::vector<Piece> pieces_vector;
+
+  // this memory is held for FFI reasons - it needs to be released and cloned
+  // precisely, so try to not access it/modify it if possible. you should
+  // instead work with `pieces_vector`
   PieceSlice slice;
   std::string to_parse;
 };

--- a/gcc/rust/ast/rust-fmt.h
+++ b/gcc/rust/ast/rust-fmt.h
@@ -222,7 +222,7 @@ struct Piece
 
   struct NextArgument_Body
   {
-    const Argument *_0;
+    Argument _0;
   };
 
   Tag tag;
@@ -243,7 +243,10 @@ struct PieceSlice
 extern "C" {
 
 PieceSlice
-collect_pieces (const char *input);
+collect_pieces (const char *input, bool append_newline);
+
+PieceSlice
+clone_pieces (const Piece *base_ptr, size_t len, size_t cap);
 
 void destroy_pieces (PieceSlice);
 
@@ -251,8 +254,20 @@ void destroy_pieces (PieceSlice);
 
 struct Pieces
 {
-  static Pieces collect (std::string &&to_parse);
+  static Pieces collect (std::string &&to_parse, bool append_newline);
   ~Pieces ();
+
+  Pieces (const Pieces &other);
+  Pieces &operator= (const Pieces &other);
+
+  Pieces (Pieces &&other);
+
+  // {
+  //   slice = clone_pieces (&other.slice);
+  //   to_parse = other.to_parse;
+
+  //   return *this;
+  // }
 
 private:
   Pieces (PieceSlice slice, std::string &&to_parse)

--- a/gcc/rust/expand/rust-derive.h
+++ b/gcc/rust/expand/rust-derive.h
@@ -221,6 +221,7 @@ private:
   virtual void visit (SelfParam &param) override final{};
   virtual void visit (FunctionParam &param) override final{};
   virtual void visit (VariadicParam &param) override final{};
+  virtual void visit (FormatArgs &param) override final{};
 };
 
 } // namespace AST

--- a/gcc/rust/expand/rust-macro-builtins.cc
+++ b/gcc/rust/expand/rust-macro-builtins.cc
@@ -17,6 +17,8 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "libproc_macro_internal/tokenstream.h"
+#include "rust-ast-full-decls.h"
+#include "rust-builtin-ast-nodes.h"
 #include "rust-token-converter.h"
 #include "rust-system.h"
 #include "rust-macro-builtins.h"
@@ -78,6 +80,14 @@ const BiMap<std::string, BuiltinMacro> MacroBuiltin::builtins = {{
 
 }};
 
+AST::MacroTranscriberFunc
+format_args_maker (AST::FormatArgs::Newline nl)
+{
+  return [nl] (location_t loc, AST::MacroInvocData &invoc) {
+    return MacroBuiltin::format_args_handler (loc, invoc, nl);
+  };
+}
+
 std::unordered_map<std::string, AST::MacroTranscriberFunc>
   MacroBuiltin::builtin_transcribers = {
     {"assert", MacroBuiltin::assert_handler},
@@ -92,10 +102,10 @@ std::unordered_map<std::string, AST::MacroTranscriberFunc>
     {"env", MacroBuiltin::env_handler},
     {"cfg", MacroBuiltin::cfg_handler},
     {"include", MacroBuiltin::include_handler},
-    {"format_args", MacroBuiltin::format_args_handler},
+    {"format_args", format_args_maker (AST::FormatArgs::Newline::No)},
+    {"format_args_nl", format_args_maker (AST::FormatArgs::Newline::Yes)},
     /* Unimplemented macro builtins */
     {"option_env", MacroBuiltin::sorry},
-    {"format_args_nl", MacroBuiltin::sorry},
     {"concat_idents", MacroBuiltin::sorry},
     {"module_path", MacroBuiltin::sorry},
     {"asm", MacroBuiltin::sorry},
@@ -286,6 +296,8 @@ try_expand_many_expr (Parser<MacroInvocLexer> &parser,
    and return the LiteralExpr for it. Allow for an optional trailing comma,
    but otherwise enforce that these are the only tokens.  */
 
+// FIXME(Arthur): This function needs a rework - it should not emit errors, it
+// should probably be smaller
 std::unique_ptr<AST::Expr>
 parse_single_string_literal (BuiltinMacro kind,
 			     AST::DelimTokenTree &invoc_token_tree,
@@ -946,17 +958,31 @@ MacroBuiltin::stringify_handler (location_t invoc_locus,
 
 tl::optional<AST::Fragment>
 MacroBuiltin::format_args_handler (location_t invoc_locus,
-				   AST::MacroInvocData &invoc)
+				   AST::MacroInvocData &invoc,
+				   AST::FormatArgs::Newline nl)
 {
+  // Remove the delimiters from the macro invocation:
+  // the invoc data for `format_args!(fmt, arg1, arg2)` is `(fmt, arg1, arg2)`,
+  // so we pop the front and back to remove the parentheses (or curly brackets,
+  // or brackets)
   auto tokens = invoc.get_delim_tok_tree ().to_token_stream ();
   tokens.erase (tokens.begin ());
   tokens.pop_back ();
 
-  std::stringstream stream;
-  for (const auto &tok : tokens)
-    stream << tok->as_string () << ' ';
+  auto append_newline = nl == AST::FormatArgs::Newline::Yes ? true : false;
+  auto fmt_arg
+    = parse_single_string_literal (append_newline ? BuiltinMacro::FormatArgsNl
+						  : BuiltinMacro::FormatArgs,
+				   invoc.get_delim_tok_tree (), invoc_locus,
+				   invoc.get_expander ());
 
-  rust_debug ("[ARTHU]: `%s`", stream.str ().c_str ());
+  if (!fmt_arg->is_literal ())
+    {
+      rust_sorry_at (
+	invoc_locus,
+	"cannot yet use eager macro invocations as format strings");
+      return AST::Fragment::create_empty ();
+    }
 
   // FIXME: We need to handle this
   // // if it is not a literal, it's an eager macro invocation - return it
@@ -967,7 +993,36 @@ MacroBuiltin::format_args_handler (location_t invoc_locus,
   // 	    token_tree.to_token_stream ());
   //   }
 
+  auto fmt_str = static_cast<AST::LiteralExpr &> (*fmt_arg.get ());
+
+  // Switch on the format string to know if the string is raw or cooked
+  switch (fmt_str.get_lit_type ())
+    {
+    // case AST::Literal::RAW_STRING:
+    case AST::Literal::STRING:
+      break;
+    case AST::Literal::CHAR:
+    case AST::Literal::BYTE:
+    case AST::Literal::BYTE_STRING:
+    case AST::Literal::INT:
+    case AST::Literal::FLOAT:
+    case AST::Literal::BOOL:
+    case AST::Literal::ERROR:
+      rust_unreachable ();
+    }
+
+  std::stringstream stream;
+  for (const auto &tok : tokens)
+    stream << tok->as_string () << ' ';
+
+  rust_debug ("[ARTHUR]: `%s`", stream.str ().c_str ());
+
   auto pieces = Fmt::Pieces::collect (stream.str ());
+
+  // TODO:
+  // do the transformation into an AST::FormatArgs node
+  // return that
+  // expand it during lowering
 
   return AST::Fragment::create_empty ();
 }

--- a/gcc/rust/expand/rust-macro-builtins.cc
+++ b/gcc/rust/expand/rust-macro-builtins.cc
@@ -1052,23 +1052,7 @@ MacroBuiltin::format_args_handler (location_t invoc_locus,
 {
   auto input = format_args_parse_arguments (invoc);
 
-  // auto fmt_arg
-  //   // FIXME: this eneds to be split up into a smaller function
-  //   = parse_single_string_literal (append_newline ?
-  //   BuiltinMacro::FormatArgsNl
-  // 				  : BuiltinMacro::FormatArgs,
-  // 		   invoc.get_delim_tok_tree (), invoc_locus,
-  // 		   invoc.get_expander ());
-
-  //  if (!fmt_arg->is_literal ())
-  //    {
-  //      rust_sorry_at (
-  // invoc_locus,
-  // "cannot yet use eager macro invocations as format strings");
-  //      return AST::Fragment::create_empty ();
-  //    }
-
-  // FIXME: We need to handle this
+  // TODO(Arthur): We need to handle this
   // // if it is not a literal, it's an eager macro invocation - return it
   // if (!fmt_expr->is_literal ())
   //   {
@@ -1077,10 +1061,10 @@ MacroBuiltin::format_args_handler (location_t invoc_locus,
   // 	    token_tree.to_token_stream ());
   //   }
 
-  // auto fmt_str = static_cast<AST::LiteralExpr &> (*fmt_arg.get ());
-
-  // Switch on the format string to know if the string is raw or cooked
-  // switch (fmt_str.get_lit_type ())
+  // TODO(Arthur): Handle this as well - raw strings are special for the
+  // format_args parser auto fmt_str = static_cast<AST::LiteralExpr &>
+  // (*fmt_arg.get ()); Switch on the format string to know if the string is raw
+  // or cooked switch (fmt_str.get_lit_type ())
   //   {
   //   // case AST::Literal::RAW_STRING:
   //   case AST::Literal::STRING:

--- a/gcc/rust/expand/rust-macro-builtins.h
+++ b/gcc/rust/expand/rust-macro-builtins.h
@@ -20,6 +20,7 @@
 #define RUST_MACRO_BUILTINS_H
 
 #include "rust-ast.h"
+#include "rust-builtin-ast-nodes.h"
 #include "rust-ast-fragment.h"
 #include "rust-location.h"
 #include "bi-map.h"
@@ -158,7 +159,8 @@ public:
 						   AST::MacroInvocData &invoc);
 
   static tl::optional<AST::Fragment>
-  format_args_handler (location_t invoc_locus, AST::MacroInvocData &invoc);
+  format_args_handler (location_t invoc_locus, AST::MacroInvocData &invoc,
+		       AST::FormatArgs::Newline nl);
 
   static tl::optional<AST::Fragment> sorry (location_t invoc_locus,
 					    AST::MacroInvocData &invoc);

--- a/gcc/rust/hir/rust-ast-lower-base.cc
+++ b/gcc/rust/hir/rust-ast-lower-base.cc
@@ -22,6 +22,7 @@
 #include "rust-ast-lower-extern.h"
 #include "rust-ast.h"
 #include "rust-attribute-values.h"
+#include "rust-diagnostics.h"
 #include "rust-item.h"
 #include "rust-system.h"
 

--- a/gcc/rust/hir/rust-ast-lower-base.cc
+++ b/gcc/rust/hir/rust-ast-lower-base.cc
@@ -20,6 +20,7 @@
 #include "rust-ast-lower-type.h"
 #include "rust-ast-lower-pattern.h"
 #include "rust-ast-lower-extern.h"
+#include "rust-ast.h"
 #include "rust-attribute-values.h"
 #include "rust-item.h"
 #include "rust-system.h"
@@ -521,6 +522,10 @@ ASTLoweringBase::visit (AST::VariadicParam &param)
 
 void
 ASTLoweringBase::visit (AST::SelfParam &param)
+{}
+
+void
+ASTLoweringBase::visit (AST::FormatArgs &fmt)
 {}
 
 HIR::Lifetime

--- a/gcc/rust/hir/rust-ast-lower-base.h
+++ b/gcc/rust/hir/rust-ast-lower-base.h
@@ -19,6 +19,7 @@
 #ifndef RUST_AST_LOWER_BASE
 #define RUST_AST_LOWER_BASE
 
+#include "rust-ast.h"
 #include "rust-system.h"
 #include "rust-ast-full.h"
 #include "rust-ast-visitor.h"
@@ -252,6 +253,8 @@ public:
   virtual void visit (AST::FunctionParam &param);
   virtual void visit (AST::VariadicParam &param);
   virtual void visit (AST::SelfParam &param);
+
+  virtual void visit (AST::FormatArgs &fmt);
 
 protected:
   ASTLoweringBase ()

--- a/gcc/rust/hir/rust-ast-lower-expr.cc
+++ b/gcc/rust/hir/rust-ast-lower-expr.cc
@@ -22,6 +22,8 @@
 #include "rust-ast-lower-struct-field-expr.h"
 #include "rust-ast-lower-pattern.h"
 #include "rust-ast-lower-type.h"
+#include "rust-ast.h"
+#include "rust-diagnostics.h"
 
 namespace Rust {
 namespace HIR {
@@ -826,6 +828,12 @@ ASTLoweringExpr::visit (AST::ClosureExprInnerTyped &expr)
 			    std::unique_ptr<HIR::Expr> (closure_expr),
 			    expr.get_has_move (), expr.get_outer_attrs (),
 			    expr.get_locus ());
+}
+
+void
+ASTLoweringExpr::visit (AST::FormatArgs &fmt)
+{
+  rust_sorry_at (0, "unimplemented format_args!() visitor");
 }
 
 } // namespace HIR

--- a/gcc/rust/hir/rust-ast-lower-expr.cc
+++ b/gcc/rust/hir/rust-ast-lower-expr.cc
@@ -19,6 +19,7 @@
 #include "rust-ast-lower-expr.h"
 #include "rust-ast-lower-base.h"
 #include "rust-ast-lower-block.h"
+#include "rust-ast-lower-format-args.h"
 #include "rust-ast-lower-struct-field-expr.h"
 #include "rust-ast-lower-pattern.h"
 #include "rust-ast-lower-type.h"
@@ -833,7 +834,11 @@ ASTLoweringExpr::visit (AST::ClosureExprInnerTyped &expr)
 void
 ASTLoweringExpr::visit (AST::FormatArgs &fmt)
 {
-  rust_sorry_at (0, "unimplemented format_args!() visitor");
+  // Lowering FormatArgs is complex, and this file is already very long
+  translated = FormatArgsLowering ().go (fmt);
+
+  rust_sorry_at (fmt.get_locus (),
+		 "FormatArgs lowering is not implemented yet");
 }
 
 } // namespace HIR

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -20,6 +20,7 @@
 #define RUST_AST_LOWER_EXPR
 
 #include "rust-ast-lower-base.h"
+#include "rust-ast.h"
 
 namespace Rust {
 namespace HIR {
@@ -120,6 +121,9 @@ public:
   void visit (AST::RangeFromToInclExpr &expr) override;
   void visit (AST::ClosureExprInner &expr) override;
   void visit (AST::ClosureExprInnerTyped &expr) override;
+
+  // Extra visitor for FormatArgs nodes
+  void visit (AST::FormatArgs &fmt) override;
 
 private:
   ASTLoweringExpr ();

--- a/gcc/rust/hir/rust-ast-lower-format-args.cc
+++ b/gcc/rust/hir/rust-ast-lower-format-args.cc
@@ -1,0 +1,41 @@
+// Copyright (C) 2024 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-ast-lower-format-args.h"
+#include "rust-ast-full.h"
+#include "rust-hir-full.h"
+
+namespace Rust {
+namespace HIR {
+
+FormatArgsLowering::FormatArgsLowering () {}
+
+HIR::Expr *
+FormatArgsLowering::go (AST::FormatArgs &fmt)
+{
+  // Eventually, we will ned to perform format_args!() expansion as part of HIR
+  // lowering - this enables a couple of interesting optimizations such as
+  // format_args flattening and the inlining of constants into the format
+  // strings. However, this is not a priority at the moment and it is easier to
+  // do "regular" macro expansion for `format_arsg!()`
+
+  return nullptr;
+}
+
+} // namespace HIR
+} // namespace Rust

--- a/gcc/rust/hir/rust-ast-lower-format-args.h
+++ b/gcc/rust/hir/rust-ast-lower-format-args.h
@@ -1,0 +1,40 @@
+// Copyright (C) 2024 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_AST_LOWER_FORMAT_ARGS
+#define RUST_AST_LOWER_FORMAT_ARGS
+
+#include "rust-ast-full-decls.h"
+#include "rust-hir-full-decls.h"
+
+namespace Rust {
+namespace HIR {
+
+class FormatArgsLowering
+{
+public:
+  FormatArgsLowering ();
+  HIR::Expr *go (AST::FormatArgs &fmt);
+
+private:
+};
+
+} // namespace HIR
+} // namespace Rust
+
+#endif // ! RUST_AST_LOWER_FORMAT_ARGS

--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -725,6 +725,7 @@ public:
   const ManagedTokenSource &get_token_source () const { return lexer; }
 
   const_TokenPtr peek_current_token () { return lexer.peek_token (0); }
+  const_TokenPtr peek (int n) { return lexer.peek_token (n); }
 
 private:
   // The token source (usually lexer) associated with the parser.

--- a/gcc/rust/resolve/rust-ast-resolve-base.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-base.cc
@@ -650,5 +650,11 @@ void
 ResolverBase::visit (AST::FunctionParam &)
 {}
 
+void
+ResolverBase::visit (AST::FormatArgs &fmt)
+{
+  rust_sorry_at (0, "unimplemented format_args!() visitor");
+}
+
 } // namespace Resolver
 } // namespace Rust

--- a/gcc/rust/resolve/rust-ast-resolve-base.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-base.cc
@@ -653,7 +653,8 @@ ResolverBase::visit (AST::FunctionParam &)
 void
 ResolverBase::visit (AST::FormatArgs &fmt)
 {
-  rust_sorry_at (0, "unimplemented format_args!() visitor");
+  rust_sorry_at (fmt.get_locus (), "%s:%u: unimplemented FormatArgs visitor",
+		 __FILE__, __LINE__);
 }
 
 } // namespace Resolver

--- a/gcc/rust/resolve/rust-ast-resolve-base.h
+++ b/gcc/rust/resolve/rust-ast-resolve-base.h
@@ -20,6 +20,7 @@
 #define RUST_AST_RESOLVE_BASE_H
 
 #include "rust-ast-visitor.h"
+#include "rust-ast.h"
 #include "rust-name-resolver.h"
 #include "rust-diagnostics.h"
 #include "rust-location.h"
@@ -197,6 +198,8 @@ public:
   void visit (AST::FunctionParam &param);
   void visit (AST::VariadicParam &param);
   void visit (AST::SelfParam &param);
+
+  void visit (AST::FormatArgs &fmt);
 
 protected:
   ResolverBase ()

--- a/libgrust/libformat_parser/src/bin.rs
+++ b/libgrust/libformat_parser/src/bin.rs
@@ -2,6 +2,9 @@ use libformat_parser::rust;
 
 fn main() {
     dbg!(rust::collect_pieces(
-        std::env::args().nth(1).unwrap().as_str()
+        std::env::args().nth(1).unwrap().as_str(),
+        None,
+        None,
+        false
     ));
 }


### PR DESCRIPTION
Needs #2822
Fixes #2856 

This PR creates the `FormatArgs` AST node, and starts the process of building one as part of the `format_args!()` macro expansion. Having a dedicated AST node is what is being done in modern versions of `rustc` - it allows for certain optimizations like flattening and inlining of format_args arguments which reduce the generated code size.

This AST node should be converted into the proper function call as part of HIR lowering.
