### PR TITLE
gccrs: minor cleanup in langhook.type_for_mode

### DIFF
--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -172,38 +172,29 @@ static tree
 grs_langhook_type_for_mode (machine_mode mode, int unsignedp)
 {
   // TODO: change all this later to match rustc types
+  if (mode == QImode)
+    return unsignedp ? unsigned_intQI_type_node : intQI_type_node;
+
+  if (mode == HImode)
+    return unsignedp ? unsigned_intHI_type_node : intHI_type_node;
+
+  if (mode == SImode)
+    return unsignedp ? unsigned_intSI_type_node : intSI_type_node;
+
+  if (mode == DImode)
+    return unsignedp ? unsigned_intDI_type_node : intDI_type_node;
+
+  if (mode == TYPE_MODE (intTI_type_node))
+    return unsignedp ? unsigned_intTI_type_node : intTI_type_node;
+
   if (mode == TYPE_MODE (float_type_node))
     return float_type_node;
 
   if (mode == TYPE_MODE (double_type_node))
     return double_type_node;
 
-  if (mode == TYPE_MODE (intQI_type_node)) // quarter integer mode - single byte
-					   // treated as integer
-    return unsignedp ? unsigned_intQI_type_node : intQI_type_node;
-  if (mode
-      == TYPE_MODE (intHI_type_node)) // half integer mode - two-byte integer
-    return unsignedp ? unsigned_intHI_type_node : intHI_type_node;
-  if (mode
-      == TYPE_MODE (intSI_type_node)) // single integer mode - four-byte integer
-    return unsignedp ? unsigned_intSI_type_node : intSI_type_node;
-  if (mode
-      == TYPE_MODE (
-	intDI_type_node)) // double integer mode - eight-byte integer
-    return unsignedp ? unsigned_intDI_type_node : intDI_type_node;
-  if (mode
-      == TYPE_MODE (intTI_type_node)) // tetra integer mode - 16-byte integer
-    return unsignedp ? unsigned_intTI_type_node : intTI_type_node;
-
-  if (mode == TYPE_MODE (integer_type_node))
-    return unsignedp ? unsigned_type_node : integer_type_node;
-
-  if (mode == TYPE_MODE (long_integer_type_node))
-    return unsignedp ? long_unsigned_type_node : long_integer_type_node;
-
-  if (mode == TYPE_MODE (long_long_integer_type_node))
-    return unsignedp ? long_long_unsigned_type_node
-		     : long_long_integer_type_node;
+  if (mode == TYPE_MODE (long_double_type_node))
+    return long_double_type_node;
 
   if (COMPLEX_MODE_P (mode))
     {


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* rust-lang.cc (grs_langhook_type_for_mode): simplify code for
        *Imode. Add missing long_double_type_node.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>