### PR TITLE
Add base for implementing extern types

### DIFF
--- a/gcc/rust/backend/rust-compile-extern.h
+++ b/gcc/rust/backend/rust-compile-extern.h
@@ -22,6 +22,8 @@
 #include "rust-compile-base.h"
 #include "rust-compile-intrinsic.h"
 #include "rust-compile-type.h"
+#include "rust-diagnostics.h"
+#include "rust-hir-full-decls.h"
 
 namespace Rust {
 namespace Compile {
@@ -150,6 +152,11 @@ public:
     ctx->insert_function_decl (fntype, fndecl);
 
     reference = address_expression (fndecl, ref_locus);
+  }
+
+  void visit (HIR::ExternalTypeItem &type) override
+  {
+    rust_sorry_at (type.get_locus (), "extern types are not supported yet");
   }
 
 private:

--- a/gcc/rust/checks/errors/borrowck/rust-bir-builder-struct.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-builder-struct.h
@@ -189,6 +189,7 @@ protected:
   void visit (HIR::ImplBlock &impl) override { rust_unreachable (); }
   void visit (HIR::ExternalStaticItem &item) override { rust_unreachable (); }
   void visit (HIR::ExternalFunctionItem &item) override { rust_unreachable (); }
+  void visit (HIR::ExternalTypeItem &item) override { rust_unreachable (); }
   void visit (HIR::ExternBlock &block) override { rust_unreachable (); }
   void visit (HIR::LiteralPattern &pattern) override { rust_unreachable (); }
   void visit (HIR::IdentifierPattern &pattern) override { rust_unreachable (); }

--- a/gcc/rust/checks/errors/borrowck/rust-function-collector.h
+++ b/gcc/rust/checks/errors/borrowck/rust-function-collector.h
@@ -155,6 +155,7 @@ public:
   void visit (HIR::ImplBlock &impl) override {}
   void visit (HIR::ExternalStaticItem &item) override {}
   void visit (HIR::ExternalFunctionItem &item) override {}
+  void visit (HIR::ExternalTypeItem &item) override {}
   void visit (HIR::ExternBlock &block) override {}
   void visit (HIR::LiteralPattern &pattern) override {}
   void visit (HIR::IdentifierPattern &pattern) override {}

--- a/gcc/rust/checks/errors/rust-const-checker.cc
+++ b/gcc/rust/checks/errors/rust-const-checker.cc
@@ -715,6 +715,10 @@ ConstChecker::visit (ExternalFunctionItem &)
 {}
 
 void
+ConstChecker::visit (ExternalTypeItem &)
+{}
+
+void
 ConstChecker::visit (ExternBlock &block)
 {
   // FIXME: Do we need to do this?

--- a/gcc/rust/checks/errors/rust-const-checker.h
+++ b/gcc/rust/checks/errors/rust-const-checker.h
@@ -162,6 +162,7 @@ private:
   virtual void visit (ImplBlock &impl) override;
   virtual void visit (ExternalStaticItem &item) override;
   virtual void visit (ExternalFunctionItem &item) override;
+  virtual void visit (ExternalTypeItem &item) override;
   virtual void visit (ExternBlock &block) override;
   virtual void visit (LiteralPattern &pattern) override;
   virtual void visit (IdentifierPattern &pattern) override;

--- a/gcc/rust/checks/errors/rust-unsafe-checker.cc
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.cc
@@ -784,6 +784,10 @@ UnsafeChecker::visit (ExternalFunctionItem &)
 {}
 
 void
+UnsafeChecker::visit (ExternalTypeItem &)
+{}
+
+void
 UnsafeChecker::visit (ExternBlock &block)
 {
   // FIXME: Do we need to do this?

--- a/gcc/rust/checks/errors/rust-unsafe-checker.h
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.h
@@ -144,6 +144,7 @@ private:
   virtual void visit (ImplBlock &impl) override;
   virtual void visit (ExternalStaticItem &item) override;
   virtual void visit (ExternalFunctionItem &item) override;
+  virtual void visit (ExternalTypeItem &item) override;
   virtual void visit (ExternBlock &block) override;
   virtual void visit (LiteralPattern &pattern) override;
   virtual void visit (IdentifierPattern &pattern) override;

--- a/gcc/rust/hir/rust-ast-lower-extern.h
+++ b/gcc/rust/hir/rust-ast-lower-extern.h
@@ -114,6 +114,11 @@ public:
       function.get_outer_attrs (), function.get_locus ());
   }
 
+  void visit (AST::ExternalTypeItem &type) override
+  {
+    rust_sorry_at (type.get_locus (), "extern types are not implemented yet");
+  }
+
 private:
   ASTLoweringExternItem () : translated (nullptr) {}
 

--- a/gcc/rust/hir/rust-ast-lower-extern.h
+++ b/gcc/rust/hir/rust-ast-lower-extern.h
@@ -22,6 +22,7 @@
 #include "rust-ast-lower-base.h"
 #include "rust-ast-lower-type.h"
 #include "rust-ast-lower.h"
+#include "rust-hir-full-decls.h"
 
 namespace Rust {
 namespace HIR {
@@ -116,7 +117,13 @@ public:
 
   void visit (AST::ExternalTypeItem &type) override
   {
-    rust_sorry_at (type.get_locus (), "extern types are not implemented yet");
+    auto crate_num = mappings->get_current_crate ();
+    Analysis::NodeMapping mapping (crate_num, type.get_node_id (),
+				   mappings->get_next_hir_id (crate_num),
+				   mappings->get_next_localdef_id (crate_num));
+
+    translated = new HIR::ExternalTypeItem (mapping, type.get_identifier (),
+					    type.get_locus ());
   }
 
 private:

--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -2000,6 +2000,16 @@ Dump::visit (ExternalFunctionItem &e)
 }
 
 void
+Dump::visit (ExternalTypeItem &e)
+{
+  begin ("ExternalTypeItem");
+
+  do_externalitem (e);
+
+  end ("ExternalTypeItem");
+}
+
+void
 Dump::visit (ExternBlock &e)
 {
   begin ("ExternBlock");

--- a/gcc/rust/hir/rust-hir-dump.h
+++ b/gcc/rust/hir/rust-hir-dump.h
@@ -201,6 +201,7 @@ private:
 
   virtual void visit (ExternalStaticItem &) override;
   virtual void visit (ExternalFunctionItem &) override;
+  virtual void visit (ExternalTypeItem &) override;
   virtual void visit (ExternBlock &) override;
 
   virtual void visit (LiteralPattern &) override;

--- a/gcc/rust/hir/tree/rust-hir-full-decls.h
+++ b/gcc/rust/hir/tree/rust-hir-full-decls.h
@@ -177,6 +177,7 @@ class ExternalItem;
 class ExternalStaticItem;
 struct NamedFunctionParam;
 class ExternalFunctionItem;
+class ExternalTypeItem;
 class ExternBlock;
 
 // rust-pattern.h

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -2859,6 +2859,7 @@ public:
   {
     Static,
     Function,
+    Type,
   };
 
   virtual ~ExternalItem () {}
@@ -3084,11 +3085,13 @@ public:
 
   // Copy constructor with clone
   ExternalFunctionItem (ExternalFunctionItem const &other)
-    : ExternalItem (other), return_type (other.return_type->clone_type ()),
-      where_clause (other.where_clause),
+    : ExternalItem (other), where_clause (other.where_clause),
       function_params (other.function_params),
       has_variadics (other.has_variadics)
   {
+    if (other.return_type)
+      return_type = other.return_type->clone_type ();
+
     generic_params.reserve (other.generic_params.size ());
     for (const auto &e : other.generic_params)
       generic_params.push_back (e->clone_generic_param ());
@@ -3098,10 +3101,13 @@ public:
   ExternalFunctionItem &operator= (ExternalFunctionItem const &other)
   {
     ExternalItem::operator= (other);
-    return_type = other.return_type->clone_type ();
+
     where_clause = other.where_clause;
     function_params = other.function_params;
     has_variadics = other.has_variadics;
+
+    if (other.return_type)
+      return_type = other.return_type->clone_type ();
 
     generic_params.reserve (other.generic_params.size ());
     for (const auto &e : other.generic_params)
@@ -3141,6 +3147,33 @@ protected:
   ExternalFunctionItem *clone_external_item_impl () const override
   {
     return new ExternalFunctionItem (*this);
+  }
+};
+
+class ExternalTypeItem : public ExternalItem
+{
+  ExternalTypeItem (Analysis::NodeMapping mappings, Identifier item_name,
+		    Visibility vis, AST::AttrVec outer_attrs, location_t locus)
+    : ExternalItem (std::move (mappings), std::move (item_name),
+		    std::move (vis), std::move (outer_attrs), locus)
+  {}
+
+  ExternalTypeItem (ExternalTypeItem const &other) : ExternalItem (other) {}
+
+  ExternalTypeItem (ExternalTypeItem &&other) = default;
+  ExternalTypeItem &operator= (ExternalTypeItem &&other) = default;
+
+  std::string as_string () const override;
+
+  void accept_vis (HIRFullVisitor &vis) override;
+  void accept_vis (HIRExternalItemVisitor &vis) override;
+
+  ExternKind get_extern_kind () override { return ExternKind::Type; }
+
+protected:
+  ExternalTypeItem *clone_external_item_impl () const override
+  {
+    return new ExternalTypeItem (*this);
   }
 };
 

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -3152,16 +3152,20 @@ protected:
 
 class ExternalTypeItem : public ExternalItem
 {
+public:
   ExternalTypeItem (Analysis::NodeMapping mappings, Identifier item_name,
-		    Visibility vis, AST::AttrVec outer_attrs, location_t locus)
+		    location_t locus)
     : ExternalItem (std::move (mappings), std::move (item_name),
-		    std::move (vis), std::move (outer_attrs), locus)
+		    Visibility (Visibility::PRIVATE),
+		    /* FIXME: Is that correct? */
+		    {}, locus)
   {}
 
   ExternalTypeItem (ExternalTypeItem const &other) : ExternalItem (other) {}
 
   ExternalTypeItem (ExternalTypeItem &&other) = default;
   ExternalTypeItem &operator= (ExternalTypeItem &&other) = default;
+  ExternalTypeItem &operator= (ExternalTypeItem const &other) = default;
 
   std::string as_string () const override;
 
@@ -3171,6 +3175,8 @@ class ExternalTypeItem : public ExternalItem
   ExternKind get_extern_kind () override { return ExternKind::Type; }
 
 protected:
+  /* Use covariance to implement clone function as returning this object
+   * rather than base */
   ExternalTypeItem *clone_external_item_impl () const override
   {
     return new ExternalTypeItem (*this);

--- a/gcc/rust/hir/tree/rust-hir-visitor.h
+++ b/gcc/rust/hir/tree/rust-hir-visitor.h
@@ -114,6 +114,7 @@ public:
   virtual void visit (ImplBlock &impl) = 0;
   virtual void visit (ExternalStaticItem &item) = 0;
   virtual void visit (ExternalFunctionItem &item) = 0;
+  virtual void visit (ExternalTypeItem &item) = 0;
   virtual void visit (ExternBlock &block) = 0;
   virtual void visit (LiteralPattern &pattern) = 0;
   virtual void visit (IdentifierPattern &pattern) = 0;
@@ -255,6 +256,7 @@ public:
 
   virtual void visit (ExternalStaticItem &) override {}
   virtual void visit (ExternalFunctionItem &) override {}
+  virtual void visit (ExternalTypeItem &) override {}
   virtual void visit (ExternBlock &) override {}
 
   virtual void visit (LiteralPattern &) override {}
@@ -306,6 +308,7 @@ class HIRExternalItemVisitor
 public:
   virtual void visit (ExternalStaticItem &item) = 0;
   virtual void visit (ExternalFunctionItem &item) = 0;
+  virtual void visit (ExternalTypeItem &item) = 0;
 };
 
 class HIRTraitItemVisitor

--- a/gcc/rust/hir/tree/rust-hir.cc
+++ b/gcc/rust/hir/tree/rust-hir.cc
@@ -3257,6 +3257,19 @@ ExternalFunctionItem::as_string () const
 }
 
 std::string
+ExternalTypeItem::as_string () const
+{
+  std::string str = ExternalItem::as_string ();
+
+  str += "type ";
+
+  // add name
+  str += get_item_name ().as_string ();
+
+  return str;
+}
+
+std::string
 NamedFunctionParam::as_string () const
 {
   std::string str = name.as_string ();
@@ -4273,6 +4286,12 @@ ExternalFunctionItem::accept_vis (HIRFullVisitor &vis)
 }
 
 void
+ExternalTypeItem::accept_vis (HIRFullVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+void
 ExternBlock::accept_vis (HIRFullVisitor &vis)
 {
   vis.visit (*this);
@@ -4538,6 +4557,12 @@ TraitItemFunc::accept_vis (HIRTraitItemVisitor &vis)
 
 void
 ExternalFunctionItem::accept_vis (HIRExternalItemVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+void
+ExternalTypeItem::accept_vis (HIRExternalItemVisitor &vis)
 {
   vis.visit (*this);
 }

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.cc
@@ -17,6 +17,7 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-hir-type-check-implitem.h"
+#include "rust-diagnostics.h"
 #include "rust-hir-type-check-base.h"
 #include "rust-hir-type-check-type.h"
 #include "rust-hir-type-check-expr.h"
@@ -181,6 +182,134 @@ TypeCheckTopLevelExternItem::visit (HIR::ExternalFunctionItem &function)
 
   context->insert_type (function.get_mappings (), fnType);
   resolved = fnType;
+}
+
+void
+TypeCheckTopLevelExternItem::visit (HIR::ExternalTypeItem &type)
+{
+  rust_sorry_at (type.get_locus (), "extern types are not supported yet");
+  //  auto binder_pin = context->push_clean_lifetime_resolver ();
+
+  //  std::vector<TyTy::SubstitutionParamMapping> substitutions;
+  //  if (function.has_generics ())
+  //    {
+  //      for (auto &generic_param : function.get_generic_params ())
+  // {
+  //   switch (generic_param.get ()->get_kind ())
+  //     {
+  //     case HIR::GenericParam::GenericKind::LIFETIME:
+  //       context->intern_and_insert_lifetime (
+  // 	static_cast<HIR::LifetimeParam &> (*generic_param)
+  // 	  .get_lifetime ());
+  //       // TODO: handle bounds
+  //       break;
+  //     case HIR::GenericParam::GenericKind::CONST:
+  //       // FIXME: Skipping Lifetime and Const completely until better
+  //       // handling.
+  //       break;
+
+  //       case HIR::GenericParam::GenericKind::TYPE: {
+  // 	auto param_type
+  // 	  = TypeResolveGenericParam::Resolve (generic_param.get ());
+  // 	context->insert_type (generic_param->get_mappings (),
+  // 			      param_type);
+
+  // 	substitutions.push_back (TyTy::SubstitutionParamMapping (
+  // 	  static_cast<HIR::TypeParam &> (*generic_param), param_type));
+  //       }
+  //       break;
+  //     }
+  // }
+  //    }
+
+  //  TyTy::RegionConstraints region_constraints;
+  //  if (function.has_where_clause ())
+  //    {
+  //      for (auto &where_clause_item : function.get_where_clause ().get_items
+  //      ())
+  // {
+  //   ResolveWhereClauseItem::Resolve (*where_clause_item.get (),
+  // 				   region_constraints);
+  // }
+  //    }
+
+  //  TyTy::BaseType *ret_type = nullptr;
+  //  if (!function.has_return_type ())
+  //    ret_type
+  //      = TyTy::TupleType::get_unit_type (function.get_mappings ().get_hirid
+  //      ());
+  //  else
+  //    {
+  //      auto resolved
+  // = TypeCheckType::Resolve (function.get_return_type ().get ());
+  //      if (resolved == nullptr)
+  // {
+  //   rust_error_at (function.get_locus (),
+  // 		 "failed to resolve return type");
+  //   return;
+  // }
+
+  //      ret_type = resolved->clone ();
+  //      ret_type->set_ref (
+  // function.get_return_type ()->get_mappings ().get_hirid ());
+  //    }
+
+  //  std::vector<std::pair<HIR::Pattern *, TyTy::BaseType *> > params;
+  //  for (auto &param : function.get_function_params ())
+  //    {
+  //      // get the name as well required for later on
+  //      auto param_tyty = TypeCheckType::Resolve (param.get_type ().get ());
+
+  //      // these are implicit mappings and not used
+  //      auto crate_num = mappings->get_current_crate ();
+  //      Analysis::NodeMapping mapping (crate_num, mappings->get_next_node_id
+  //      (),
+  // 			     mappings->get_next_hir_id (crate_num),
+  // 			     UNKNOWN_LOCAL_DEFID);
+
+  //      HIR::IdentifierPattern *param_pattern
+  // = new HIR::IdentifierPattern (mapping, param.get_param_name (),
+  // 			      UNDEF_LOCATION, false, Mutability::Imm,
+  // 			      std::unique_ptr<HIR::Pattern> (nullptr));
+
+  //      params.push_back (
+  // std::pair<HIR::Pattern *, TyTy::BaseType *> (param_pattern,
+  // 					     param_tyty));
+
+  //      context->insert_type (param.get_mappings (), param_tyty);
+
+  //      // FIXME do we need error checking for patterns here?
+  //      // see https://github.com/Rust-GCC/gccrs/issues/995
+  //    }
+
+  //  uint8_t flags = TyTy::FnType::FNTYPE_IS_EXTERN_FLAG;
+  //  if (function.is_variadic ())
+  //    {
+  //      flags |= TyTy::FnType::FNTYPE_IS_VARADIC_FLAG;
+  //      if (parent.get_abi () != Rust::ABI::C)
+  // {
+  //   rust_error_at (
+  //     function.get_locus (), ErrorCode::E0045,
+  //     "C-variadic function must have C or cdecl calling convention");
+  // }
+  //    }
+
+  //  RustIdent ident{
+  //    CanonicalPath::new_seg (function.get_mappings ().get_nodeid (),
+  // 		    function.get_item_name ().as_string ()),
+  //    function.get_locus ()};
+
+  //  auto fnType = new TyTy::FnType (
+  //    function.get_mappings ().get_hirid (),
+  //    function.get_mappings ().get_defid (),
+  //    function.get_item_name ().as_string (), ident, flags, parent.get_abi (),
+  //    std::move (params), ret_type, std::move (substitutions),
+  //    TyTy::SubstitutionArgumentMappings::empty (
+  //      context->get_lifetime_resolver ().get_num_bound_regions ()),
+  //    region_constraints);
+
+  //  context->insert_type (function.get_mappings (), fnType);
+  //  resolved = fnType;
 }
 
 TypeCheckImplItem::TypeCheckImplItem (

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.h
@@ -34,6 +34,7 @@ public:
 
   void visit (HIR::ExternalStaticItem &item) override;
   void visit (HIR::ExternalFunctionItem &function) override;
+  void visit (HIR::ExternalTypeItem &type) override;
 
 private:
   TypeCheckTopLevelExternItem (const HIR::ExternBlock &parent);


### PR DESCRIPTION
This PR adds the required HIR node and visitors for implementing extern types properly. The only step currently being performed is the lowering of AST extern types to their HIR counterpart.

- [x] Needs fixing of the commit format