### PR TITLE
Remove references to smart pointers in the AST API

### DIFF
--- a/gcc/rust/ast/rust-ast-collector.cc
+++ b/gcc/rust/ast/rust-ast-collector.cc
@@ -2546,8 +2546,7 @@ TokenCollector::visit (LetStmt &stmt)
 {
   push (Rust::Token::make (LET, stmt.get_locus ()));
   auto &pattern = stmt.get_pattern ();
-  if (pattern)
-    visit (pattern);
+  visit (pattern);
 
   if (stmt.has_type ())
     {

--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -2291,7 +2291,7 @@ std::string
 VariadicParam::as_string () const
 {
   if (has_pattern ())
-    return get_pattern ()->as_string () + " : ...";
+    return get_pattern ().as_string () + " : ...";
   else
     return "...";
 }
@@ -4258,7 +4258,7 @@ BlockExpr::normalize_tail_expr ()
 
 	  if (!stmt.is_semicolon_followed ())
 	    {
-	      expr = std::move (stmt.get_expr ());
+	      expr = std::move (stmt.take_expr ());
 	      statements.pop_back ();
 	    }
 	}

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -387,10 +387,10 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_borrowed_expr ()
+  Expr &get_borrowed_expr ()
   {
     rust_assert (main_or_left_expr != nullptr);
-    return main_or_left_expr;
+    return *main_or_left_expr;
   }
 
   bool get_is_mut () const { return is_mut; }
@@ -421,10 +421,10 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_dereferenced_expr ()
+  Expr &get_dereferenced_expr ()
   {
     rust_assert (main_or_left_expr != nullptr);
-    return main_or_left_expr;
+    return *main_or_left_expr;
   }
 
 protected:
@@ -452,10 +452,10 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_propagating_expr ()
+  Expr &get_propagating_expr ()
   {
     rust_assert (main_or_left_expr != nullptr);
-    return main_or_left_expr;
+    return *main_or_left_expr;
   }
 
 protected:
@@ -495,10 +495,10 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_negated_expr ()
+  Expr &get_negated_expr ()
   {
     rust_assert (main_or_left_expr != nullptr);
-    return main_or_left_expr;
+    return *main_or_left_expr;
   }
 
 protected:
@@ -561,14 +561,26 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_left_expr ()
+  Expr &get_left_expr ()
+  {
+    rust_assert (main_or_left_expr != nullptr);
+    return *main_or_left_expr;
+  }
+
+  std::unique_ptr<Expr> &get_left_expr_ptr ()
   {
     rust_assert (main_or_left_expr != nullptr);
     return main_or_left_expr;
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_right_expr ()
+  Expr &get_right_expr ()
+  {
+    rust_assert (right_expr != nullptr);
+    return *right_expr;
+  }
+
+  std::unique_ptr<Expr> &get_right_expr_ptr ()
   {
     rust_assert (right_expr != nullptr);
     return right_expr;
@@ -637,14 +649,26 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_left_expr ()
+  Expr &get_left_expr ()
+  {
+    rust_assert (main_or_left_expr != nullptr);
+    return *main_or_left_expr;
+  }
+
+  std::unique_ptr<Expr> &get_left_expr_ptr ()
   {
     rust_assert (main_or_left_expr != nullptr);
     return main_or_left_expr;
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_right_expr ()
+  Expr &get_right_expr ()
+  {
+    rust_assert (right_expr != nullptr);
+    return *right_expr;
+  }
+
+  std::unique_ptr<Expr> &get_right_expr_ptr ()
   {
     rust_assert (right_expr != nullptr);
     return right_expr;
@@ -713,14 +737,26 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_left_expr ()
+  Expr &get_left_expr ()
+  {
+    rust_assert (main_or_left_expr != nullptr);
+    return *main_or_left_expr;
+  }
+
+  std::unique_ptr<Expr> &get_left_expr_ptr ()
   {
     rust_assert (main_or_left_expr != nullptr);
     return main_or_left_expr;
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_right_expr ()
+  Expr &get_right_expr ()
+  {
+    rust_assert (right_expr != nullptr);
+    return *right_expr;
+  }
+
+  std::unique_ptr<Expr> &get_right_expr_ptr ()
   {
     rust_assert (right_expr != nullptr);
     return right_expr;
@@ -777,17 +813,17 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_casted_expr ()
+  Expr &get_casted_expr ()
   {
     rust_assert (main_or_left_expr != nullptr);
-    return main_or_left_expr;
+    return *main_or_left_expr;
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<TypeNoBounds> &get_type_to_cast_to ()
+  TypeNoBounds &get_type_to_cast_to ()
   {
     rust_assert (type_to_convert_to != nullptr);
-    return type_to_convert_to;
+    return *type_to_convert_to;
   }
 
 protected:
@@ -843,17 +879,29 @@ public:
   void visit_rhs (ASTVisitor &vis) { right_expr->accept_vis (vis); }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_left_expr ()
+  Expr &get_left_expr ()
+  {
+    rust_assert (main_or_left_expr != nullptr);
+    return *main_or_left_expr;
+  }
+
+  std::unique_ptr<Expr> &get_left_expr_ptr ()
   {
     rust_assert (main_or_left_expr != nullptr);
     return main_or_left_expr;
   }
 
-  // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_right_expr ()
+  std::unique_ptr<Expr> &get_right_expr_ptr ()
   {
     rust_assert (right_expr != nullptr);
     return right_expr;
+  }
+
+  // TODO: is this better? Or is a "vis_block" better?
+  Expr &get_right_expr ()
+  {
+    rust_assert (right_expr != nullptr);
+    return *right_expr;
   }
 
 protected:
@@ -917,14 +965,26 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_left_expr ()
+  Expr &get_left_expr ()
+  {
+    rust_assert (main_or_left_expr != nullptr);
+    return *main_or_left_expr;
+  }
+
+  std::unique_ptr<Expr> &get_left_expr_ptr ()
   {
     rust_assert (main_or_left_expr != nullptr);
     return main_or_left_expr;
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_right_expr ()
+  Expr &get_right_expr ()
+  {
+    rust_assert (right_expr != nullptr);
+    return *right_expr;
+  }
+
+  std::unique_ptr<Expr> &get_right_expr_ptr ()
   {
     rust_assert (right_expr != nullptr);
     return right_expr;
@@ -1012,7 +1072,13 @@ public:
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_expr_in_parens ()
+  Expr &get_expr_in_parens ()
+  {
+    rust_assert (expr_in_parens != nullptr);
+    return *expr_in_parens;
+  }
+
+  std::unique_ptr<Expr> &get_expr_in_parens_ptr ()
   {
     rust_assert (expr_in_parens != nullptr);
     return expr_in_parens;
@@ -1147,17 +1213,17 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_elem_to_copy ()
+  Expr &get_elem_to_copy ()
   {
     rust_assert (elem_to_copy != nullptr);
-    return elem_to_copy;
+    return *elem_to_copy;
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_num_copies ()
+  Expr &get_num_copies ()
   {
     rust_assert (num_copies != nullptr);
-    return num_copies;
+    return *num_copies;
   }
 
 protected:
@@ -1331,17 +1397,17 @@ public:
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_array_expr ()
+  Expr &get_array_expr ()
   {
     rust_assert (array_expr != nullptr);
-    return array_expr;
+    return *array_expr;
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_index_expr ()
+  Expr &get_index_expr ()
   {
     rust_assert (index_expr != nullptr);
-    return index_expr;
+    return *index_expr;
   }
 
   const std::vector<Attribute> &get_outer_attrs () const { return outer_attrs; }
@@ -1521,10 +1587,10 @@ public:
   bool is_marked_for_strip () const override { return tuple_expr == nullptr; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_tuple_expr ()
+  Expr &get_tuple_expr ()
   {
     rust_assert (tuple_expr != nullptr);
-    return tuple_expr;
+    return *tuple_expr;
   }
 
   const std::vector<Attribute> &get_outer_attrs () const { return outer_attrs; }
@@ -1664,10 +1730,10 @@ public:
   std::string as_string () const;
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_base_struct ()
+  Expr &get_base_struct ()
   {
     rust_assert (base_struct != nullptr);
-    return base_struct;
+    return *base_struct;
   }
 };
 
@@ -1763,10 +1829,10 @@ public:
   std::string as_string () const override;
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_value ()
+  Expr &get_value ()
   {
     rust_assert (value != nullptr);
-    return value;
+    return *value;
   }
 };
 
@@ -2021,10 +2087,10 @@ public:
   std::vector<std::unique_ptr<Expr> > &get_params () { return params; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_function_expr ()
+  Expr &get_function_expr ()
   {
     rust_assert (function != nullptr);
-    return function;
+    return *function;
   }
 
   const std::vector<Attribute> &get_outer_attrs () const { return outer_attrs; }
@@ -2121,10 +2187,10 @@ public:
   std::vector<std::unique_ptr<Expr> > &get_params () { return params; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_receiver_expr ()
+  Expr &get_receiver_expr ()
   {
     rust_assert (receiver != nullptr);
-    return receiver;
+    return *receiver;
   }
 
   const PathExprSegment &get_method_name () const { return method_name; }
@@ -2207,10 +2273,10 @@ public:
   bool is_marked_for_strip () const override { return receiver == nullptr; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_receiver_expr ()
+  Expr &get_receiver_expr ()
   {
     rust_assert (receiver != nullptr);
-    return receiver;
+    return *receiver;
   }
 
   Identifier get_field_name () const { return field; }
@@ -2304,13 +2370,19 @@ public:
   const std::vector<Attribute> &get_outer_attrs () const { return outer_attrs; }
   std::vector<Attribute> &get_outer_attrs () { return outer_attrs; }
 
-  std::unique_ptr<Pattern> &get_pattern ()
+  Pattern &get_pattern ()
   {
     rust_assert (pattern != nullptr);
-    return pattern;
+    return *pattern;
   }
 
-  std::unique_ptr<Type> &get_type ()
+  Type &get_type ()
+  {
+    rust_assert (has_type_given ());
+    return *type;
+  }
+
+  std::unique_ptr<Type> &get_type_ptr ()
   {
     rust_assert (has_type_given ());
     return type;
@@ -2411,10 +2483,10 @@ public:
     return closure_inner == nullptr;
   }
 
-  std::unique_ptr<Expr> &get_definition_expr ()
+  Expr &get_definition_expr ()
   {
     rust_assert (closure_inner != nullptr);
-    return closure_inner;
+    return *closure_inner;
   }
 
 protected:
@@ -2532,7 +2604,13 @@ public:
   std::vector<std::unique_ptr<Stmt> > &get_statements () { return statements; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_tail_expr ()
+  Expr &get_tail_expr ()
+  {
+    rust_assert (has_tail_expr ());
+    return *expr;
+  }
+
+  std::unique_ptr<Expr> &get_tail_expr_ptr ()
   {
     rust_assert (has_tail_expr ());
     return expr;
@@ -2651,14 +2729,20 @@ public:
   bool is_marked_for_strip () const override { return expr == nullptr; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<BlockExpr> &get_definition_block ()
+  BlockExpr &get_definition_block ()
   {
     rust_assert (expr != nullptr);
-    return expr;
+    return *expr;
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Type> &get_return_type ()
+  Type &get_return_type ()
+  {
+    rust_assert (return_type != nullptr);
+    return *return_type;
+  }
+
+  std::unique_ptr<Type> &get_return_type_ptr ()
   {
     rust_assert (return_type != nullptr);
     return return_type;
@@ -2794,10 +2878,10 @@ public:
   bool is_marked_for_strip () const override { return marked_for_strip; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_break_expr ()
+  Expr &get_break_expr ()
   {
     rust_assert (has_break_expr ());
-    return break_expr;
+    return *break_expr;
   }
 
   const std::vector<Attribute> &get_outer_attrs () const { return outer_attrs; }
@@ -2906,17 +2990,17 @@ public:
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_from_expr ()
+  Expr &get_from_expr ()
   {
     rust_assert (from != nullptr);
-    return from;
+    return *from;
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_to_expr ()
+  Expr &get_to_expr ()
   {
     rust_assert (to != nullptr);
-    return to;
+    return *to;
   }
 
 protected:
@@ -2974,10 +3058,10 @@ public:
   bool is_marked_for_strip () const override { return from == nullptr; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_from_expr ()
+  Expr &get_from_expr ()
   {
     rust_assert (from != nullptr);
-    return from;
+    return *from;
   }
 
 protected:
@@ -3036,10 +3120,10 @@ public:
   bool is_marked_for_strip () const override { return to == nullptr; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_to_expr ()
+  Expr &get_to_expr ()
   {
     rust_assert (to != nullptr);
-    return to;
+    return *to;
   }
 
 protected:
@@ -3142,17 +3226,17 @@ public:
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_from_expr ()
+  Expr &get_from_expr ()
   {
     rust_assert (from != nullptr);
-    return from;
+    return *from;
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_to_expr ()
+  Expr &get_to_expr ()
   {
     rust_assert (to != nullptr);
-    return to;
+    return *to;
   }
 
 protected:
@@ -3211,10 +3295,10 @@ public:
   bool is_marked_for_strip () const override { return to == nullptr; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_to_expr ()
+  Expr &get_to_expr ()
   {
     rust_assert (to != nullptr);
-    return to;
+    return *to;
   }
 
 protected:
@@ -3290,10 +3374,10 @@ public:
   bool is_marked_for_strip () const override { return marked_for_strip; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_returned_expr ()
+  Expr &get_returned_expr ()
   {
     rust_assert (return_expr != nullptr);
-    return return_expr;
+    return *return_expr;
   }
 
   const std::vector<Attribute> &get_outer_attrs () const { return outer_attrs; }
@@ -3372,10 +3456,10 @@ public:
   bool is_marked_for_strip () const override { return expr == nullptr; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<BlockExpr> &get_block_expr ()
+  BlockExpr &get_block_expr ()
   {
     rust_assert (expr != nullptr);
-    return expr;
+    return *expr;
   }
 
   const std::vector<Attribute> &get_outer_attrs () const { return outer_attrs; }
@@ -3461,10 +3545,10 @@ public:
   bool is_marked_for_strip () const override { return loop_block == nullptr; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<BlockExpr> &get_loop_block ()
+  BlockExpr &get_loop_block ()
   {
     rust_assert (loop_block != nullptr);
-    return loop_block;
+    return *loop_block;
   }
 
   const std::vector<Attribute> &get_outer_attrs () const { return outer_attrs; }
@@ -3544,10 +3628,10 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_predicate_expr ()
+  Expr &get_predicate_expr ()
   {
     rust_assert (condition != nullptr);
-    return condition;
+    return *condition;
   }
 
 protected:
@@ -3617,10 +3701,10 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_scrutinee_expr ()
+  Expr &get_scrutinee_expr ()
   {
     rust_assert (scrutinee != nullptr);
-    return scrutinee;
+    return *scrutinee;
   }
 
   // TODO: this mutable getter seems really dodgy. Think up better way.
@@ -3689,17 +3773,17 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_iterator_expr ()
+  Expr &get_iterator_expr ()
   {
     rust_assert (iterator_expr != nullptr);
-    return iterator_expr;
+    return *iterator_expr;
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Pattern> &get_pattern ()
+  Pattern &get_pattern ()
   {
     rust_assert (pattern != nullptr);
-    return pattern;
+    return *pattern;
   }
 
 protected:
@@ -3786,17 +3870,23 @@ public:
   void vis_if_block (ASTVisitor &vis) { if_block->accept_vis (vis); }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_condition_expr ()
+  Expr &get_condition_expr ()
+  {
+    rust_assert (condition != nullptr);
+    return *condition;
+  }
+
+  std::unique_ptr<Expr> &get_condition_expr_ptr ()
   {
     rust_assert (condition != nullptr);
     return condition;
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<BlockExpr> &get_if_block ()
+  BlockExpr &get_if_block ()
   {
     rust_assert (if_block != nullptr);
-    return if_block;
+    return *if_block;
   }
 
   // Invalid if if block or condition is null, so base stripping on that.
@@ -3874,10 +3964,10 @@ public:
   void vis_else_block (ASTVisitor &vis) { else_block->accept_vis (vis); }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<ExprWithBlock> &get_else_block ()
+  ExprWithBlock &get_else_block ()
   {
     rust_assert (else_block != nullptr);
-    return else_block;
+    return *else_block;
   }
 
 protected:
@@ -3975,17 +4065,23 @@ public:
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_value_expr ()
+  Expr &get_value_expr ()
+  {
+    rust_assert (value != nullptr);
+    return *value;
+  }
+
+  std::unique_ptr<Expr> &get_value_expr_ptr ()
   {
     rust_assert (value != nullptr);
     return value;
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<BlockExpr> &get_if_block ()
+  BlockExpr &get_if_block ()
   {
     rust_assert (if_block != nullptr);
-    return if_block;
+    return *if_block;
   }
 
   // TODO: this mutable getter seems really dodgy. Think up better way.
@@ -4067,10 +4163,10 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<ExprWithBlock> &get_else_block ()
+  ExprWithBlock &get_else_block ()
   {
     rust_assert (else_block != nullptr);
-    return else_block;
+    return *else_block;
   }
 
 protected:
@@ -4159,7 +4255,13 @@ public:
   std::string as_string () const;
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_guard_expr ()
+  Expr &get_guard_expr ()
+  {
+    rust_assert (has_match_arm_guard ());
+    return *guard_expr;
+  }
+
+  std::unique_ptr<Expr> &get_guard_expr_ptr ()
   {
     rust_assert (has_match_arm_guard ());
     return guard_expr;
@@ -4220,7 +4322,13 @@ public:
   std::string as_string () const;
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_expr ()
+  Expr &get_expr ()
+  {
+    rust_assert (expr != nullptr);
+    return *expr;
+  }
+
+  std::unique_ptr<Expr> &get_expr_ptr ()
   {
     rust_assert (expr != nullptr);
     return expr;
@@ -4315,10 +4423,10 @@ public:
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_scrutinee_expr ()
+  Expr &get_scrutinee_expr ()
   {
     rust_assert (branch_value != nullptr);
-    return branch_value;
+    return *branch_value;
   }
 
   const std::vector<MatchCase> &get_match_cases () const { return match_arms; }

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -1415,15 +1415,15 @@ public:
     return return_type;
   }
 
-  std::unique_ptr<Param> &get_self_param ()
+  Param &get_self_param ()
   {
     rust_assert (has_self_param ());
-    return function_params[0];
+    return *function_params[0];
   }
-  const std::unique_ptr<Param> &get_self_param () const
+  const Param &get_self_param () const
   {
     rust_assert (has_self_param ());
-    return function_params[0];
+    return *function_params[0];
   }
 
   // ExternalItem::node_id is same as Stmt::node_id

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -141,7 +141,13 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Type> &get_type ()
+  Type &get_type ()
+  {
+    rust_assert (type != nullptr);
+    return *type;
+  }
+
+  std::unique_ptr<Type> &get_type_ptr ()
   {
     rust_assert (type != nullptr);
     return type;
@@ -288,7 +294,13 @@ public:
 
   void accept_vis (ASTVisitor &vis) override;
 
-  std::unique_ptr<Type> &get_type ()
+  Type &get_type ()
+  {
+    rust_assert (bound_type != nullptr);
+    return *bound_type;
+  }
+
+  std::unique_ptr<Type> &get_type_ptr ()
   {
     rust_assert (bound_type != nullptr);
     return bound_type;
@@ -516,7 +528,13 @@ public:
   NodeId get_node_id () const { return node_id; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Type> &get_type ()
+  Type &get_type ()
+  {
+    rust_assert (has_type ());
+    return *type;
+  }
+
+  std::unique_ptr<Type> &get_type_ptr ()
   {
     rust_assert (has_type ());
     return type;
@@ -611,16 +629,16 @@ public:
     return new VariadicParam (*this);
   }
 
-  std::unique_ptr<Pattern> &get_pattern ()
+  Pattern &get_pattern ()
   {
     rust_assert (param_name != nullptr);
-    return param_name;
+    return *param_name;
   }
 
-  const std::unique_ptr<Pattern> &get_pattern () const
+  const Pattern &get_pattern () const
   {
     rust_assert (param_name != nullptr);
-    return param_name;
+    return *param_name;
   }
 
   bool has_pattern () const { return param_name != nullptr; }
@@ -694,16 +712,22 @@ public:
   const std::vector<Attribute> &get_outer_attrs () const { return outer_attrs; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Pattern> &get_pattern ()
+  Pattern &get_pattern ()
   {
     rust_assert (param_name != nullptr);
-    return param_name;
+    return *param_name;
   }
 
   bool has_name () const { return param_name != nullptr; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Type> &get_type ()
+  Type &get_type ()
+  {
+    rust_assert (type != nullptr);
+    return *type;
+  }
+
+  std::unique_ptr<Type> &get_type_ptr ()
   {
     rust_assert (type != nullptr);
     return type;
@@ -1409,7 +1433,13 @@ public:
   WhereClause &get_where_clause () { return where_clause; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Type> &get_return_type ()
+  Type &get_return_type ()
+  {
+    rust_assert (has_return_type ());
+    return *return_type;
+  }
+
+  std::unique_ptr<Type> &get_return_type_ptr ()
   {
     rust_assert (has_return_type ());
     return return_type;
@@ -1552,10 +1582,10 @@ public:
   WhereClause &get_where_clause () { return where_clause; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Type> &get_type_aliased ()
+  Type &get_type_aliased ()
   {
     rust_assert (existing_type != nullptr);
-    return existing_type;
+    return *existing_type;
   }
 
   Identifier get_new_type_name () const { return new_type_name; }
@@ -1750,7 +1780,13 @@ public:
   location_t get_locus () const { return locus; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Type> &get_field_type ()
+  Type &get_field_type ()
+  {
+    rust_assert (field_type != nullptr);
+    return *field_type;
+  }
+
+  std::unique_ptr<Type> &get_field_type_ptr ()
   {
     rust_assert (field_type != nullptr);
     return field_type;
@@ -1901,7 +1937,13 @@ public:
   const std::vector<Attribute> &get_outer_attrs () const { return outer_attrs; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Type> &get_field_type ()
+  Type &get_field_type ()
+  {
+    rust_assert (field_type != nullptr);
+    return *field_type;
+  }
+
+  std::unique_ptr<Type> &get_field_type_ptr ()
   {
     rust_assert (field_type != nullptr);
     return field_type;
@@ -2098,7 +2140,13 @@ public:
   bool has_expr () { return expression != nullptr; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_expr ()
+  Expr &get_expr ()
+  {
+    rust_assert (expression != nullptr);
+    return *expression;
+  }
+
+  std::unique_ptr<Expr> &get_expr_ptr ()
   {
     rust_assert (expression != nullptr);
     return expression;
@@ -2414,14 +2462,26 @@ public:
   bool has_expr () { return const_expr != nullptr; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_expr ()
+  Expr &get_expr ()
+  {
+    rust_assert (const_expr != nullptr);
+    return *const_expr;
+  }
+
+  std::unique_ptr<Expr> &get_expr_ptr ()
   {
     rust_assert (const_expr != nullptr);
     return const_expr;
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Type> &get_type ()
+  Type &get_type ()
+  {
+    rust_assert (type != nullptr);
+    return *type;
+  }
+
+  std::unique_ptr<Type> &get_type_ptr ()
   {
     rust_assert (type != nullptr);
     return type;
@@ -2521,14 +2581,26 @@ public:
   bool has_expr () { return expr != nullptr; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_expr ()
+  Expr &get_expr ()
+  {
+    rust_assert (expr != nullptr);
+    return *expr;
+  }
+
+  std::unique_ptr<Expr> &get_expr_ptr ()
   {
     rust_assert (expr != nullptr);
     return expr;
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Type> &get_type ()
+  Type &get_type ()
+  {
+    rust_assert (type != nullptr);
+    return *type;
+  }
+
+  std::unique_ptr<Type> &get_type_ptr ()
   {
     rust_assert (type != nullptr);
     return type;
@@ -2629,14 +2701,26 @@ public:
   bool has_expr () const { return expr != nullptr; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_expr ()
+  Expr &get_expr ()
+  {
+    rust_assert (has_expr ());
+    return *expr;
+  }
+
+  std::unique_ptr<Expr> &get_expr_ptr ()
   {
     rust_assert (has_expr ());
     return expr;
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Type> &get_type ()
+  Type &get_type ()
+  {
+    rust_assert (type != nullptr);
+    return *type;
+  }
+
+  std::unique_ptr<Type> &get_type_ptr ()
   {
     rust_assert (type != nullptr);
     return type;
@@ -2958,7 +3042,13 @@ public:
   WhereClause &get_where_clause () { return where_clause; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Type> &get_type ()
+  Type &get_type ()
+  {
+    rust_assert (trait_type != nullptr);
+    return *trait_type;
+  }
+
+  std::unique_ptr<Type> &get_type_ptr ()
   {
     rust_assert (trait_type != nullptr);
     return trait_type;
@@ -3409,7 +3499,13 @@ public:
   const std::vector<Attribute> &get_outer_attrs () const { return outer_attrs; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Type> &get_type ()
+  Type &get_type ()
+  {
+    rust_assert (item_type != nullptr);
+    return *item_type;
+  }
+
+  std::unique_ptr<Type> &get_type_ptr ()
   {
     rust_assert (item_type != nullptr);
     return item_type;
@@ -3542,7 +3638,13 @@ public:
   const std::vector<Attribute> &get_outer_attrs () const { return outer_attrs; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Type> &get_type ()
+  Type &get_type ()
+  {
+    rust_assert (param_type != nullptr);
+    return *param_type;
+  }
+
+  std::unique_ptr<Type> &get_type_ptr ()
   {
     rust_assert (param_type != nullptr);
     return param_type;
@@ -3700,7 +3802,13 @@ public:
   WhereClause &get_where_clause () { return where_clause; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Type> &get_return_type ()
+  Type &get_return_type ()
+  {
+    rust_assert (has_return_type ());
+    return *return_type;
+  }
+
+  std::unique_ptr<Type> &get_return_type_ptr ()
   {
     rust_assert (has_return_type ());
     return return_type;

--- a/gcc/rust/ast/rust-path.h
+++ b/gcc/rust/ast/rust-path.h
@@ -120,7 +120,13 @@ public:
   std::string as_string () const;
 
   // TODO: is this better? Or is a "vis_pattern" better?
-  std::unique_ptr<Type> &get_type ()
+  Type &get_type ()
+  {
+    rust_assert (type != nullptr);
+    return *type;
+  }
+
+  std::unique_ptr<Type> &get_type_ptr ()
   {
     rust_assert (type != nullptr);
     return type;
@@ -216,10 +222,10 @@ public:
     switch (get_kind ())
       {
       case Kind::Const:
-	get_expression ()->accept_vis (visitor);
+	get_expression ().accept_vis (visitor);
 	break;
       case Kind::Type:
-	get_type ()->accept_vis (visitor);
+	get_type ().accept_vis (visitor);
 	break;
       case Kind::Either:
 	break;
@@ -228,14 +234,28 @@ public:
       }
   }
 
-  std::unique_ptr<Expr> &get_expression ()
+  Expr &get_expression ()
+  {
+    rust_assert (kind == Kind::Const);
+
+    return *expression;
+  }
+
+  std::unique_ptr<Expr> &get_expression_ptr ()
   {
     rust_assert (kind == Kind::Const);
 
     return expression;
   }
 
-  std::unique_ptr<Type> &get_type ()
+  Type &get_type ()
+  {
+    rust_assert (kind == Kind::Type);
+
+    return *type;
+  }
+
+  std::unique_ptr<Type> &get_type_ptr ()
   {
     rust_assert (kind == Kind::Type);
 
@@ -352,11 +372,11 @@ public:
 
   Attribute &get_outer_attribute () { return outer_attr; }
 
-  std::unique_ptr<AST::Type> &get_type ()
+  AST::Type &get_type ()
   {
     rust_assert (has_type ());
 
-    return type;
+    return *type;
   }
 
   GenericArg &get_default_value ()
@@ -957,7 +977,13 @@ public:
   std::vector<std::unique_ptr<Type> > &get_params () { return inputs; }
 
   // TODO: is this better? Or is a "vis_pattern" better?
-  std::unique_ptr<Type> &get_return_type ()
+  Type &get_return_type ()
+  {
+    rust_assert (has_return_type ());
+    return *return_type;
+  }
+
+  std::unique_ptr<Type> &get_return_type_ptr ()
   {
     rust_assert (has_return_type ());
     return return_type;
@@ -1176,7 +1202,13 @@ public:
   location_t get_locus () const { return locus; }
 
   // TODO: is this better? Or is a "vis_pattern" better?
-  std::unique_ptr<Type> &get_type ()
+  Type &get_type ()
+  {
+    rust_assert (type_to_invoke_on != nullptr);
+    return *type_to_invoke_on;
+  }
+
+  std::unique_ptr<Type> &get_type_ptr ()
   {
     rust_assert (type_to_invoke_on != nullptr);
     return type_to_invoke_on;

--- a/gcc/rust/ast/rust-pattern.h
+++ b/gcc/rust/ast/rust-pattern.h
@@ -138,10 +138,10 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: is this better? Or is a "vis_pattern" better?
-  std::unique_ptr<Pattern> &get_pattern_to_bind ()
+  Pattern &get_pattern_to_bind ()
   {
     rust_assert (has_pattern_to_bind ());
-    return to_bind;
+    return *to_bind;
   }
 
   Identifier get_ident () const { return variable_ident; }
@@ -428,16 +428,16 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: is this better? or is a "vis_bound" better?
-  std::unique_ptr<RangePatternBound> &get_lower_bound ()
+  RangePatternBound &get_lower_bound ()
   {
     rust_assert (lower != nullptr);
-    return lower;
+    return *lower;
   }
 
-  std::unique_ptr<RangePatternBound> &get_upper_bound ()
+  RangePatternBound &get_upper_bound ()
   {
     rust_assert (upper != nullptr);
-    return upper;
+    return *upper;
   }
 
   NodeId get_node_id () const override { return node_id; }
@@ -500,10 +500,10 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: is this better? Or is a "vis_pattern" better?
-  std::unique_ptr<Pattern> &get_referenced_pattern ()
+  Pattern &get_referenced_pattern ()
   {
     rust_assert (pattern != nullptr);
-    return pattern;
+    return *pattern;
   }
 
   bool is_double_reference () const { return has_two_amps; }
@@ -663,10 +663,10 @@ public:
   TupleIndex get_index () { return index; }
 
   // TODO: is this better? Or is a "vis_pattern" better?
-  std::unique_ptr<Pattern> &get_index_pattern ()
+  Pattern &get_index_pattern ()
   {
     rust_assert (tuple_pattern != nullptr);
-    return tuple_pattern;
+    return *tuple_pattern;
   }
 
   ItemType get_item_type () const override final { return ItemType::TUPLE_PAT; }
@@ -743,10 +743,10 @@ public:
   const Identifier &get_identifier () const { return ident; }
 
   // TODO: is this better? Or is a "vis_pattern" better?
-  std::unique_ptr<Pattern> &get_ident_pattern ()
+  Pattern &get_ident_pattern ()
   {
     rust_assert (ident_pattern != nullptr);
-    return ident_pattern;
+    return *ident_pattern;
   }
 
   ItemType get_item_type () const override final { return ItemType::IDENT_PAT; }
@@ -1183,10 +1183,10 @@ public:
 
   void accept_vis (ASTVisitor &vis) override;
 
-  std::unique_ptr<TupleStructItems> &get_items ()
+  TupleStructItems &get_items ()
   {
     rust_assert (items != nullptr);
-    return items;
+    return *items;
   }
 
   PathInExpression &get_path () { return path; }
@@ -1428,10 +1428,10 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: seems kinda dodgy. Think of better way.
-  std::unique_ptr<TuplePatternItems> &get_items ()
+  TuplePatternItems &get_items ()
   {
     rust_assert (items != nullptr);
-    return items;
+    return *items;
   }
 
   NodeId get_node_id () const override { return node_id; }
@@ -1490,10 +1490,10 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: seems kinda dodgy. Think of better way.
-  std::unique_ptr<Pattern> &get_pattern_in_parens ()
+  Pattern &get_pattern_in_parens ()
   {
     rust_assert (pattern_in_parens != nullptr);
-    return pattern_in_parens;
+    return *pattern_in_parens;
   }
 
   NodeId get_node_id () const override { return node_id; }

--- a/gcc/rust/ast/rust-stmt.h
+++ b/gcc/rust/ast/rust-stmt.h
@@ -22,6 +22,7 @@
 #include "rust-ast.h"
 #include "rust-path.h"
 #include "rust-expr.h"
+#include <memory>
 
 namespace Rust {
 namespace AST {
@@ -155,19 +156,31 @@ public:
   const std::vector<Attribute> &get_outer_attrs () const { return outer_attrs; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_init_expr ()
+  Expr &get_init_expr ()
+  {
+    rust_assert (has_init_expr ());
+    return *init_expr;
+  }
+
+  std::unique_ptr<Expr> &get_init_expr_ptr ()
   {
     rust_assert (has_init_expr ());
     return init_expr;
   }
 
-  std::unique_ptr<Pattern> &get_pattern ()
+  Pattern &get_pattern ()
   {
     rust_assert (variables_pattern != nullptr);
-    return variables_pattern;
+    return *variables_pattern;
   }
 
-  std::unique_ptr<Type> &get_type ()
+  Type &get_type ()
+  {
+    rust_assert (has_type ());
+    return *type;
+  }
+
+  std::unique_ptr<Type> &get_type_ptr ()
   {
     rust_assert (has_type ());
     return type;
@@ -249,10 +262,22 @@ public:
   bool is_marked_for_strip () const override { return expr == nullptr; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  std::unique_ptr<Expr> &get_expr ()
+  Expr &get_expr ()
+  {
+    rust_assert (expr != nullptr);
+    return *expr;
+  }
+
+  std::unique_ptr<Expr> &get_expr_ptr ()
   {
     rust_assert (expr != nullptr);
     return expr;
+  }
+
+  std::unique_ptr<Expr> take_expr ()
+  {
+    rust_assert (expr != nullptr);
+    return std::move (expr);
   }
 
   bool is_semicolon_followed () const { return semicolon_followed; }

--- a/gcc/rust/ast/rust-type.h
+++ b/gcc/rust/ast/rust-type.h
@@ -513,10 +513,10 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: would a "vis_type" be better?
-  std::unique_ptr<TypeNoBounds> &get_type_pointed_to ()
+  TypeNoBounds &get_type_pointed_to ()
   {
     rust_assert (type != nullptr);
-    return type;
+    return *type;
   }
 
 protected:
@@ -580,17 +580,17 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: would a "vis_type" be better?
-  std::unique_ptr<TypeNoBounds> &get_type_referenced ()
+  TypeNoBounds &get_type_referenced ()
   {
     rust_assert (type != nullptr);
-    return type;
+    return *type;
   }
 
   bool get_has_mut () const { return has_mut; }
 
   Lifetime &get_lifetime () { return lifetime; }
 
-  std::unique_ptr<TypeNoBounds> &get_base_type () { return type; }
+  TypeNoBounds &get_base_type () { return *type; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather
@@ -641,17 +641,17 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: would a "vis_type" be better?
-  std::unique_ptr<Type> &get_elem_type ()
+  Type &get_elem_type ()
   {
     rust_assert (elem_type != nullptr);
-    return elem_type;
+    return *elem_type;
   }
 
   // TODO: would a "vis_expr" be better?
-  std::unique_ptr<Expr> &get_size_expr ()
+  Expr &get_size_expr ()
   {
     rust_assert (size != nullptr);
-    return size;
+    return *size;
   }
 
 protected:
@@ -701,10 +701,10 @@ public:
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: would a "vis_type" be better?
-  std::unique_ptr<Type> &get_elem_type ()
+  Type &get_elem_type ()
   {
     rust_assert (elem_type != nullptr);
-    return elem_type;
+    return *elem_type;
   }
 
 protected:
@@ -824,7 +824,13 @@ public:
   const std::vector<Attribute> &get_outer_attrs () const { return outer_attrs; }
 
   // TODO: would a "vis_type" be better?
-  std::unique_ptr<Type> &get_type ()
+  Type &get_type ()
+  {
+    rust_assert (param_type != nullptr);
+    return *param_type;
+  }
+
+  std::unique_ptr<Type> &get_type_ptr ()
   {
     rust_assert (param_type != nullptr);
     return param_type;
@@ -935,10 +941,10 @@ public:
   }
 
   // TODO: would a "vis_type" be better?
-  std::unique_ptr<TypeNoBounds> &get_return_type ()
+  TypeNoBounds &get_return_type ()
   {
     rust_assert (has_return_type ());
-    return return_type;
+    return *return_type;
   }
 
   FunctionQualifiers &get_function_qualifiers () { return function_qualifiers; }

--- a/gcc/rust/checks/errors/rust-ast-validation.cc
+++ b/gcc/rust/checks/errors/rust-ast-validation.cc
@@ -125,8 +125,8 @@ ASTValidation::visit (AST::Function &function)
 	  // if functional parameter
 	  if (!it->get ()->is_self () && !it->get ()->is_variadic ())
 	    {
-	      auto param = static_cast<AST::FunctionParam *> (it->get ());
-	      auto kind = param->get_pattern ()->get_pattern_kind ();
+	      auto &param = static_cast<AST::FunctionParam &> (**it);
+	      auto kind = param.get_pattern ().get_pattern_kind ();
 
 	      if (kind != AST::Pattern::Kind::Identifier
 		  && kind != AST::Pattern::Kind::Wildcard)

--- a/gcc/rust/checks/errors/rust-ast-validation.cc
+++ b/gcc/rust/checks/errors/rust-ast-validation.cc
@@ -100,7 +100,7 @@ ASTValidation::visit (AST::Function &function)
       && context.back () != Context::INHERENT_IMPL
       && function.has_self_param ())
     rust_error_at (
-      function.get_self_param ()->get_locus (),
+      function.get_self_param ().get_locus (),
       "%<self%> parameter is only allowed in associated functions");
 
   if (function.is_external ())

--- a/gcc/rust/expand/rust-cfg-strip.cc
+++ b/gcc/rust/expand/rust-cfg-strip.cc
@@ -184,11 +184,10 @@ CfgStrip::maybe_strip_struct_fields (std::vector<AST::StructField> &fields)
 
       // expand sub-types of type, but can't strip type itself
       auto &type = field.get_field_type ();
-      type->accept_vis (*this);
+      type.accept_vis (*this);
 
-      if (type->is_marked_for_strip ())
-	rust_error_at (type->get_locus (),
-		       "cannot strip type in this position");
+      if (type.is_marked_for_strip ())
+	rust_error_at (type.get_locus (), "cannot strip type in this position");
 
       // if nothing else happens, increment
       ++it;
@@ -212,10 +211,9 @@ CfgStrip::maybe_strip_tuple_fields (std::vector<AST::TupleField> &fields)
 
       // expand sub-types of type, but can't strip type itself
       auto &type = field.get_field_type ();
-      type->accept_vis (*this);
-      if (type->is_marked_for_strip ())
-	rust_error_at (type->get_locus (),
-		       "cannot strip type in this position");
+      type.accept_vis (*this);
+      if (type.is_marked_for_strip ())
+	rust_error_at (type.get_locus (), "cannot strip type in this position");
 
       // if nothing else happens, increment
       ++it;
@@ -242,16 +240,16 @@ CfgStrip::maybe_strip_function_params (
 
 	  // TODO: should an unwanted strip lead to break out of loop?
 	  auto &pattern = param->get_pattern ();
-	  pattern->accept_vis (*this);
-	  if (pattern->is_marked_for_strip ())
-	    rust_error_at (pattern->get_locus (),
+	  pattern.accept_vis (*this);
+	  if (pattern.is_marked_for_strip ())
+	    rust_error_at (pattern.get_locus (),
 			   "cannot strip pattern in this position");
 
 	  auto &type = param->get_type ();
-	  type->accept_vis (*this);
+	  type.accept_vis (*this);
 
-	  if (type->is_marked_for_strip ())
-	    rust_error_at (type->get_locus (),
+	  if (type.is_marked_for_strip ())
+	    rust_error_at (type.get_locus (),
 			   "cannot strip type in this position");
 	}
       // increment
@@ -272,19 +270,19 @@ CfgStrip::maybe_strip_generic_args (AST::GenericArgs &args)
 	{
 	  case AST::GenericArg::Kind::Type: {
 	    auto &type = arg.get_type ();
-	    type->accept_vis (*this);
+	    type.accept_vis (*this);
 
-	    if (type->is_marked_for_strip ())
-	      rust_error_at (type->get_locus (),
+	    if (type.is_marked_for_strip ())
+	      rust_error_at (type.get_locus (),
 			     "cannot strip type in this position");
 	    break;
 	  }
 	  case AST::GenericArg::Kind::Const: {
 	    auto &expr = arg.get_expression ();
-	    expr->accept_vis (*this);
+	    expr.accept_vis (*this);
 
-	    if (expr->is_marked_for_strip ())
-	      rust_error_at (expr->get_locus (),
+	    if (expr.is_marked_for_strip ())
+	      rust_error_at (expr.get_locus (),
 			     "cannot strip expression in this position");
 	    break;
 	  }
@@ -303,11 +301,10 @@ CfgStrip::maybe_strip_generic_args (AST::GenericArgs &args)
   for (auto &binding : args.get_binding_args ())
     {
       auto &type = binding.get_type ();
-      type->accept_vis (*this);
+      type.accept_vis (*this);
 
-      if (type->is_marked_for_strip ())
-	rust_error_at (type->get_locus (),
-		       "cannot strip type in this position");
+      if (type.is_marked_for_strip ())
+	rust_error_at (type.get_locus (), "cannot strip type in this position");
     }
 }
 
@@ -315,10 +312,10 @@ void
 CfgStrip::maybe_strip_qualified_path_type (AST::QualifiedPathType &path_type)
 {
   auto &type = path_type.get_type ();
-  type->accept_vis (*this);
+  type.accept_vis (*this);
 
-  if (type->is_marked_for_strip ())
-    rust_error_at (type->get_locus (), "cannot strip type in this position");
+  if (type.is_marked_for_strip ())
+    rust_error_at (type.get_locus (), "cannot strip type in this position");
 
   if (path_type.has_as_clause ())
     {
@@ -347,18 +344,18 @@ CfgStrip::CfgStrip::maybe_strip_closure_params (
 	}
 
       auto &pattern = param.get_pattern ();
-      pattern->accept_vis (*this);
-      if (pattern->is_marked_for_strip ())
-	rust_error_at (pattern->get_locus (),
+      pattern.accept_vis (*this);
+      if (pattern.is_marked_for_strip ())
+	rust_error_at (pattern.get_locus (),
 		       "cannot strip pattern in this position");
 
       if (param.has_type_given ())
 	{
 	  auto &type = param.get_type ();
-	  type->accept_vis (*this);
+	  type.accept_vis (*this);
 
-	  if (type->is_marked_for_strip ())
-	    rust_error_at (type->get_locus (),
+	  if (type.is_marked_for_strip ())
+	    rust_error_at (type.get_locus (),
 			   "cannot strip type in this position");
 	}
 
@@ -451,8 +448,8 @@ CfgStrip::visit (AST::TypePathSegmentFunction &segment)
     {
       auto &return_type = type_path_function.get_return_type ();
 
-      if (return_type->is_marked_for_strip ())
-	rust_error_at (return_type->get_locus (),
+      if (return_type.is_marked_for_strip ())
+	rust_error_at (return_type.get_locus (),
 		       "cannot strip type in this position");
     }
 }
@@ -516,8 +513,8 @@ CfgStrip::visit (AST::BorrowExpr &expr)
    * allowed to have external attributes in this position so can't be
    * stripped. */
   auto &borrowed_expr = expr.get_borrowed_expr ();
-  if (borrowed_expr->is_marked_for_strip ())
-    rust_error_at (borrowed_expr->get_locus (),
+  if (borrowed_expr.is_marked_for_strip ())
+    rust_error_at (borrowed_expr.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -536,9 +533,9 @@ CfgStrip::visit (AST::DereferenceExpr &expr)
    * allowed to have external attributes in this position so can't be
    * stripped. */
   auto &dereferenced_expr = expr.get_dereferenced_expr ();
-  dereferenced_expr->accept_vis (*this);
-  if (dereferenced_expr->is_marked_for_strip ())
-    rust_error_at (dereferenced_expr->get_locus (),
+  dereferenced_expr.accept_vis (*this);
+  if (dereferenced_expr.is_marked_for_strip ())
+    rust_error_at (dereferenced_expr.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -559,8 +556,8 @@ CfgStrip::visit (AST::ErrorPropagationExpr &expr)
    * allowed to have external attributes in this position so can't be
    * stripped. */
   auto &propagating_expr = expr.get_propagating_expr ();
-  if (propagating_expr->is_marked_for_strip ())
-    rust_error_at (propagating_expr->get_locus (),
+  if (propagating_expr.is_marked_for_strip ())
+    rust_error_at (propagating_expr.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -580,8 +577,8 @@ CfgStrip::visit (AST::NegationExpr &expr)
    * allowed to have external attributes in this position so can't be
    * stripped. */
   auto &negated_expr = expr.get_negated_expr ();
-  if (negated_expr->is_marked_for_strip ())
-    rust_error_at (negated_expr->get_locus (),
+  if (negated_expr.is_marked_for_strip ())
+    rust_error_at (negated_expr.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -593,13 +590,13 @@ CfgStrip::visit (AST::ArithmeticOrLogicalExpr &expr)
    * two direct descendant expressions, can strip ones below that */
 
   // ensure that they are not marked for strip
-  if (expr.get_left_expr ()->is_marked_for_strip ())
-    rust_error_at (expr.get_left_expr ()->get_locus (),
+  if (expr.get_left_expr ().is_marked_for_strip ())
+    rust_error_at (expr.get_left_expr ().get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes are never allowed "
 		   "before binary op exprs");
-  if (expr.get_right_expr ()->is_marked_for_strip ())
-    rust_error_at (expr.get_right_expr ()->get_locus (),
+  if (expr.get_right_expr ().is_marked_for_strip ())
+    rust_error_at (expr.get_right_expr ().get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -612,13 +609,13 @@ CfgStrip::visit (AST::ComparisonExpr &expr)
   AST::DefaultASTVisitor::visit (expr);
 
   // ensure that they are not marked for strip
-  if (expr.get_left_expr ()->is_marked_for_strip ())
-    rust_error_at (expr.get_left_expr ()->get_locus (),
+  if (expr.get_left_expr ().is_marked_for_strip ())
+    rust_error_at (expr.get_left_expr ().get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes are never allowed "
 		   "before binary op exprs");
-  if (expr.get_right_expr ()->is_marked_for_strip ())
-    rust_error_at (expr.get_right_expr ()->get_locus (),
+  if (expr.get_right_expr ().is_marked_for_strip ())
+    rust_error_at (expr.get_right_expr ().get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -631,13 +628,13 @@ CfgStrip::visit (AST::LazyBooleanExpr &expr)
   AST::DefaultASTVisitor::visit (expr);
 
   // ensure that they are not marked for strip
-  if (expr.get_left_expr ()->is_marked_for_strip ())
-    rust_error_at (expr.get_left_expr ()->get_locus (),
+  if (expr.get_left_expr ().is_marked_for_strip ())
+    rust_error_at (expr.get_left_expr ().get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes are never allowed "
 		   "before binary op exprs");
-  if (expr.get_right_expr ()->is_marked_for_strip ())
-    rust_error_at (expr.get_right_expr ()->get_locus (),
+  if (expr.get_right_expr ().is_marked_for_strip ())
+    rust_error_at (expr.get_right_expr ().get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -651,15 +648,15 @@ CfgStrip::visit (AST::TypeCastExpr &expr)
 
   auto &casted_expr = expr.get_casted_expr ();
   // ensure that they are not marked for strip
-  if (casted_expr->is_marked_for_strip ())
-    rust_error_at (casted_expr->get_locus (),
+  if (casted_expr.is_marked_for_strip ())
+    rust_error_at (casted_expr.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes are never allowed before cast exprs");
 
   // TODO: strip sub-types of type
   auto &type = expr.get_type_to_cast_to ();
-  if (type->is_marked_for_strip ())
-    rust_error_at (type->get_locus (), "cannot strip type in this position");
+  if (type.is_marked_for_strip ())
+    rust_error_at (type.get_locus (), "cannot strip type in this position");
 }
 void
 CfgStrip::visit (AST::AssignmentExpr &expr)
@@ -673,13 +670,13 @@ CfgStrip::visit (AST::AssignmentExpr &expr)
   AST::DefaultASTVisitor::visit (expr);
 
   // ensure that they are not marked for strip
-  if (expr.get_left_expr ()->is_marked_for_strip ())
-    rust_error_at (expr.get_left_expr ()->get_locus (),
+  if (expr.get_left_expr ().is_marked_for_strip ())
+    rust_error_at (expr.get_left_expr ().get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes are never allowed "
 		   "before binary op exprs");
-  if (expr.get_right_expr ()->is_marked_for_strip ())
-    rust_error_at (expr.get_right_expr ()->get_locus (),
+  if (expr.get_right_expr ().is_marked_for_strip ())
+    rust_error_at (expr.get_right_expr ().get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -691,13 +688,13 @@ CfgStrip::visit (AST::CompoundAssignmentExpr &expr)
   AST::DefaultASTVisitor::visit (expr);
 
   // ensure that they are not marked for strip
-  if (expr.get_left_expr ()->is_marked_for_strip ())
-    rust_error_at (expr.get_left_expr ()->get_locus (),
+  if (expr.get_left_expr ().is_marked_for_strip ())
+    rust_error_at (expr.get_left_expr ().get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes are never allowed "
 		   "before binary op exprs");
-  if (expr.get_right_expr ()->is_marked_for_strip ())
-    rust_error_at (expr.get_right_expr ()->get_locus (),
+  if (expr.get_right_expr ().is_marked_for_strip ())
+    rust_error_at (expr.get_right_expr ().get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -727,8 +724,8 @@ CfgStrip::visit (AST::GroupedExpr &expr)
   AST::DefaultASTVisitor::visit (expr);
 
   auto &inner_expr = expr.get_expr_in_parens ();
-  if (inner_expr->is_marked_for_strip ())
-    rust_error_at (inner_expr->get_locus (),
+  if (inner_expr.is_marked_for_strip ())
+    rust_error_at (inner_expr.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -750,15 +747,15 @@ CfgStrip::visit (AST::ArrayElemsCopied &elems)
 
   // only intend stripping for internal sub-expressions
   auto &copied_expr = elems.get_elem_to_copy ();
-  if (copied_expr->is_marked_for_strip ())
-    rust_error_at (copied_expr->get_locus (),
+  if (copied_expr.is_marked_for_strip ())
+    rust_error_at (copied_expr.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 
   auto &copy_count = elems.get_num_copies ();
-  copy_count->accept_vis (*this);
-  if (copy_count->is_marked_for_strip ())
-    rust_error_at (copy_count->get_locus (),
+  copy_count.accept_vis (*this);
+  if (copy_count.is_marked_for_strip ())
+    rust_error_at (copy_count.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -807,14 +804,14 @@ CfgStrip::visit (AST::ArrayIndexExpr &expr)
   AST::DefaultASTVisitor::visit (expr);
 
   const auto &array_expr = expr.get_array_expr ();
-  if (array_expr->is_marked_for_strip ())
-    rust_error_at (array_expr->get_locus (),
+  if (array_expr.is_marked_for_strip ())
+    rust_error_at (array_expr.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 
   const auto &index_expr = expr.get_index_expr ();
-  if (index_expr->is_marked_for_strip ())
-    rust_error_at (index_expr->get_locus (),
+  if (index_expr.is_marked_for_strip ())
+    rust_error_at (index_expr.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -861,8 +858,8 @@ CfgStrip::visit (AST::TupleIndexExpr &expr)
    * associated with this level), but any sub-expressions would be
    * stripped. Thus, no need to erase when strip check called. */
   auto &tuple_expr = expr.get_tuple_expr ();
-  if (tuple_expr->is_marked_for_strip ())
-    rust_error_at (tuple_expr->get_locus (),
+  if (tuple_expr.is_marked_for_strip ())
+    rust_error_at (tuple_expr.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -903,8 +900,8 @@ CfgStrip::visit (AST::StructExprFieldIdentifierValue &field)
   AST::DefaultASTVisitor::visit (field);
 
   auto &value = field.get_value ();
-  if (value->is_marked_for_strip ())
-    rust_error_at (value->get_locus (),
+  if (value.is_marked_for_strip ())
+    rust_error_at (value.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -916,8 +913,8 @@ CfgStrip::visit (AST::StructExprFieldIndexValue &field)
   AST::DefaultASTVisitor::visit (field);
 
   auto &value = field.get_value ();
-  if (value->is_marked_for_strip ())
-    rust_error_at (value->get_locus (),
+  if (value.is_marked_for_strip ())
+    rust_error_at (value.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -959,9 +956,9 @@ CfgStrip::visit (AST::StructExprStructFields &expr)
   if (expr.has_struct_base ())
     {
       auto &base_struct_expr = expr.get_struct_base ().get_base_struct ();
-      base_struct_expr->accept_vis (*this);
-      if (base_struct_expr->is_marked_for_strip ())
-	rust_error_at (base_struct_expr->get_locus (),
+      base_struct_expr.accept_vis (*this);
+      if (base_struct_expr.is_marked_for_strip ())
+	rust_error_at (base_struct_expr.get_locus (),
 		       "cannot strip expression in this position - outer "
 		       "attributes not allowed");
     }
@@ -998,9 +995,9 @@ CfgStrip::visit (AST::StructExprStructBase &expr)
    * the expression. as such, can only strip sub-expressions. */
   rust_assert (!expr.get_struct_base ().is_invalid ());
   auto &base_struct_expr = expr.get_struct_base ().get_base_struct ();
-  base_struct_expr->accept_vis (*this);
-  if (base_struct_expr->is_marked_for_strip ())
-    rust_error_at (base_struct_expr->get_locus (),
+  base_struct_expr.accept_vis (*this);
+  if (base_struct_expr.is_marked_for_strip ())
+    rust_error_at (base_struct_expr.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -1021,8 +1018,8 @@ CfgStrip::visit (AST::CallExpr &expr)
   AST::DefaultASTVisitor::visit (expr);
 
   auto &function = expr.get_function_expr ();
-  if (function->is_marked_for_strip ())
-    rust_error_at (function->get_locus (),
+  if (function.is_marked_for_strip ())
+    rust_error_at (function.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 
@@ -1049,8 +1046,8 @@ CfgStrip::visit (AST::MethodCallExpr &expr)
   AST::DefaultASTVisitor::visit (expr);
 
   auto &receiver = expr.get_receiver_expr ();
-  if (receiver->is_marked_for_strip ())
-    rust_error_at (receiver->get_locus (),
+  if (receiver.is_marked_for_strip ())
+    rust_error_at (receiver.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 
@@ -1079,8 +1076,8 @@ CfgStrip::visit (AST::FieldAccessExpr &expr)
   AST::DefaultASTVisitor::visit (expr);
 
   auto &receiver = expr.get_receiver_expr ();
-  if (receiver->is_marked_for_strip ())
-    rust_error_at (receiver->get_locus (),
+  if (receiver.is_marked_for_strip ())
+    rust_error_at (receiver.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -1103,8 +1100,8 @@ CfgStrip::visit (AST::ClosureExprInner &expr)
 
   // can't strip expression itself, but can strip sub-expressions
   auto &definition_expr = expr.get_definition_expr ();
-  if (definition_expr->is_marked_for_strip ())
-    rust_error_at (definition_expr->get_locus (),
+  if (definition_expr.is_marked_for_strip ())
+    rust_error_at (definition_expr.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -1138,7 +1135,7 @@ CfgStrip::visit (AST::BlockExpr &expr)
     {
       auto &tail_expr = expr.get_tail_expr ();
 
-      if (tail_expr->is_marked_for_strip ())
+      if (tail_expr.is_marked_for_strip ())
 	expr.strip_tail_expr ();
     }
 }
@@ -1163,14 +1160,14 @@ CfgStrip::visit (AST::ClosureExprInnerTyped &expr)
   // can't strip return type, but can strip sub-types
   auto &type = expr.get_return_type ();
 
-  if (type->is_marked_for_strip ())
-    rust_error_at (type->get_locus (), "cannot strip type in this position");
+  if (type.is_marked_for_strip ())
+    rust_error_at (type.get_locus (), "cannot strip type in this position");
 
   // can't strip expression itself, but can strip sub-expressions
   auto &definition_block = expr.get_definition_block ();
-  definition_block->accept_vis (*this);
-  if (definition_block->is_marked_for_strip ())
-    rust_error_at (definition_block->get_locus (),
+  definition_block.accept_vis (*this);
+  if (definition_block.is_marked_for_strip ())
+    rust_error_at (definition_block.get_locus (),
 		   "cannot strip block expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -1204,8 +1201,8 @@ CfgStrip::visit (AST::BreakExpr &expr)
     {
       auto &break_expr = expr.get_break_expr ();
 
-      if (break_expr->is_marked_for_strip ())
-	rust_error_at (break_expr->get_locus (),
+      if (break_expr.is_marked_for_strip ())
+	rust_error_at (break_expr.get_locus (),
 		       "cannot strip expression in this position - outer "
 		       "attributes not allowed");
     }
@@ -1218,13 +1215,13 @@ CfgStrip::visit (AST::RangeFromToExpr &expr)
   AST::DefaultASTVisitor::visit (expr);
 
   // ensure that they are not marked for strip
-  if (expr.get_from_expr ()->is_marked_for_strip ())
-    rust_error_at (expr.get_from_expr ()->get_locus (),
+  if (expr.get_from_expr ().is_marked_for_strip ())
+    rust_error_at (expr.get_from_expr ().get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes are never allowed "
 		   "before range exprs");
-  if (expr.get_to_expr ()->is_marked_for_strip ())
-    rust_error_at (expr.get_to_expr ()->get_locus (),
+  if (expr.get_to_expr ().is_marked_for_strip ())
+    rust_error_at (expr.get_to_expr ().get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -1238,8 +1235,8 @@ CfgStrip::visit (AST::RangeFromExpr &expr)
   /* should have no possibility for outer attrs as would be parsed
    * with outer expr */
   auto &from_expr = expr.get_from_expr ();
-  if (from_expr->is_marked_for_strip ())
-    rust_error_at (from_expr->get_locus (),
+  if (from_expr.is_marked_for_strip ())
+    rust_error_at (from_expr.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes are never allowed before range exprs");
 }
@@ -1253,8 +1250,8 @@ CfgStrip::visit (AST::RangeToExpr &expr)
   /* should syntactically not have outer attributes, though this may
    * not have worked in practice */
   auto &to_expr = expr.get_to_expr ();
-  if (to_expr->is_marked_for_strip ())
-    rust_error_at (to_expr->get_locus (),
+  if (to_expr.is_marked_for_strip ())
+    rust_error_at (to_expr.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -1268,13 +1265,13 @@ CfgStrip::visit (AST::RangeFromToInclExpr &expr)
   AST::DefaultASTVisitor::visit (expr);
 
   // ensure that they are not marked for strip
-  if (expr.get_from_expr ()->is_marked_for_strip ())
-    rust_error_at (expr.get_from_expr ()->get_locus (),
+  if (expr.get_from_expr ().is_marked_for_strip ())
+    rust_error_at (expr.get_from_expr ().get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes are never allowed "
 		   "before range exprs");
-  if (expr.get_to_expr ()->is_marked_for_strip ())
-    rust_error_at (expr.get_to_expr ()->get_locus (),
+  if (expr.get_to_expr ().is_marked_for_strip ())
+    rust_error_at (expr.get_to_expr ().get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -1288,8 +1285,8 @@ CfgStrip::visit (AST::RangeToInclExpr &expr)
   /* should syntactically not have outer attributes, though this may
    * not have worked in practice */
   auto &to_expr = expr.get_to_expr ();
-  if (to_expr->is_marked_for_strip ())
-    rust_error_at (to_expr->get_locus (),
+  if (to_expr.is_marked_for_strip ())
+    rust_error_at (to_expr.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -1312,8 +1309,8 @@ CfgStrip::visit (AST::ReturnExpr &expr)
   if (expr.has_returned_expr ())
     {
       auto &returned_expr = expr.get_returned_expr ();
-      if (returned_expr->is_marked_for_strip ())
-	rust_error_at (returned_expr->get_locus (),
+      if (returned_expr.is_marked_for_strip ())
+	rust_error_at (returned_expr.get_locus (),
 		       "cannot strip expression in this position - outer "
 		       "attributes not allowed");
     }
@@ -1338,8 +1335,8 @@ CfgStrip::visit (AST::UnsafeBlockExpr &expr)
 
   // can't strip block itself, but can strip sub-expressions
   auto &block_expr = expr.get_block_expr ();
-  if (block_expr->is_marked_for_strip ())
-    rust_error_at (block_expr->get_locus (),
+  if (block_expr.is_marked_for_strip ())
+    rust_error_at (block_expr.get_locus (),
 		   "cannot strip block expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -1358,8 +1355,8 @@ CfgStrip::visit (AST::LoopExpr &expr)
 
   // can't strip block itself, but can strip sub-expressions
   auto &loop_block = expr.get_loop_block ();
-  if (loop_block->is_marked_for_strip ())
-    rust_error_at (loop_block->get_locus (),
+  if (loop_block.is_marked_for_strip ())
+    rust_error_at (loop_block.get_locus (),
 		   "cannot strip block expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -1377,15 +1374,15 @@ CfgStrip::visit (AST::WhileLoopExpr &expr)
   AST::DefaultASTVisitor::visit (expr);
   // can't strip predicate expr itself, but can strip sub-expressions
   auto &predicate_expr = expr.get_predicate_expr ();
-  if (predicate_expr->is_marked_for_strip ())
-    rust_error_at (predicate_expr->get_locus (),
+  if (predicate_expr.is_marked_for_strip ())
+    rust_error_at (predicate_expr.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 
   // can't strip block itself, but can strip sub-expressions
   auto &loop_block = expr.get_loop_block ();
-  if (loop_block->is_marked_for_strip ())
-    rust_error_at (loop_block->get_locus (),
+  if (loop_block.is_marked_for_strip ())
+    rust_error_at (loop_block.get_locus (),
 		   "cannot strip block expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -1409,15 +1406,15 @@ CfgStrip::visit (AST::WhileLetLoopExpr &expr)
 
   // can't strip scrutinee expr itself, but can strip sub-expressions
   auto &scrutinee_expr = expr.get_scrutinee_expr ();
-  if (scrutinee_expr->is_marked_for_strip ())
-    rust_error_at (scrutinee_expr->get_locus (),
+  if (scrutinee_expr.is_marked_for_strip ())
+    rust_error_at (scrutinee_expr.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 
   // can't strip block itself, but can strip sub-expressions
   auto &loop_block = expr.get_loop_block ();
-  if (loop_block->is_marked_for_strip ())
-    rust_error_at (loop_block->get_locus (),
+  if (loop_block.is_marked_for_strip ())
+    rust_error_at (loop_block.get_locus (),
 		   "cannot strip block expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -1435,21 +1432,21 @@ CfgStrip::visit (AST::ForLoopExpr &expr)
   AST::DefaultASTVisitor::visit (expr);
   // strip sub-patterns of pattern
   auto &pattern = expr.get_pattern ();
-  if (pattern->is_marked_for_strip ())
-    rust_error_at (pattern->get_locus (),
+  if (pattern.is_marked_for_strip ())
+    rust_error_at (pattern.get_locus (),
 		   "cannot strip pattern in this position");
 
   // can't strip scrutinee expr itself, but can strip sub-expressions
   auto &iterator_expr = expr.get_iterator_expr ();
-  if (iterator_expr->is_marked_for_strip ())
-    rust_error_at (iterator_expr->get_locus (),
+  if (iterator_expr.is_marked_for_strip ())
+    rust_error_at (iterator_expr.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 
   // can't strip block itself, but can strip sub-expressions
   auto &loop_block = expr.get_loop_block ();
-  if (loop_block->is_marked_for_strip ())
-    rust_error_at (loop_block->get_locus (),
+  if (loop_block.is_marked_for_strip ())
+    rust_error_at (loop_block.get_locus (),
 		   "cannot strip block expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -1471,15 +1468,15 @@ CfgStrip::visit (AST::IfExpr &expr)
 
   // can't strip condition expr itself, but can strip sub-expressions
   auto &condition_expr = expr.get_condition_expr ();
-  if (condition_expr->is_marked_for_strip ())
-    rust_error_at (condition_expr->get_locus (),
+  if (condition_expr.is_marked_for_strip ())
+    rust_error_at (condition_expr.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 
   // can't strip if block itself, but can strip sub-expressions
   auto &if_block = expr.get_if_block ();
-  if (if_block->is_marked_for_strip ())
-    rust_error_at (if_block->get_locus (),
+  if (if_block.is_marked_for_strip ())
+    rust_error_at (if_block.get_locus (),
 		   "cannot strip block expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -1499,22 +1496,22 @@ CfgStrip::visit (AST::IfExprConseqElse &expr)
 
   // can't strip condition expr itself, but can strip sub-expressions
   auto &condition_expr = expr.get_condition_expr ();
-  if (condition_expr->is_marked_for_strip ())
-    rust_error_at (condition_expr->get_locus (),
+  if (condition_expr.is_marked_for_strip ())
+    rust_error_at (condition_expr.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 
   // can't strip if block itself, but can strip sub-expressions
   auto &if_block = expr.get_if_block ();
-  if (if_block->is_marked_for_strip ())
-    rust_error_at (if_block->get_locus (),
+  if (if_block.is_marked_for_strip ())
+    rust_error_at (if_block.get_locus (),
 		   "cannot strip block expression in this position - outer "
 		   "attributes not allowed");
 
   // can't strip else block itself, but can strip sub-expressions
   auto &else_block = expr.get_else_block ();
-  if (else_block->is_marked_for_strip ())
-    rust_error_at (else_block->get_locus (),
+  if (else_block.is_marked_for_strip ())
+    rust_error_at (else_block.get_locus (),
 		   "cannot strip block expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -1539,15 +1536,15 @@ CfgStrip::visit (AST::IfLetExpr &expr)
 
   // can't strip value expr itself, but can strip sub-expressions
   auto &value_expr = expr.get_value_expr ();
-  if (value_expr->is_marked_for_strip ())
-    rust_error_at (value_expr->get_locus (),
+  if (value_expr.is_marked_for_strip ())
+    rust_error_at (value_expr.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 
   // can't strip if block itself, but can strip sub-expressions
   auto &if_block = expr.get_if_block ();
-  if (if_block->is_marked_for_strip ())
-    rust_error_at (if_block->get_locus (),
+  if (if_block.is_marked_for_strip ())
+    rust_error_at (if_block.get_locus (),
 		   "cannot strip block expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -1571,22 +1568,22 @@ CfgStrip::visit (AST::IfLetExprConseqElse &expr)
 
   // can't strip value expr itself, but can strip sub-expressions
   auto &value_expr = expr.get_value_expr ();
-  if (value_expr->is_marked_for_strip ())
-    rust_error_at (value_expr->get_locus (),
+  if (value_expr.is_marked_for_strip ())
+    rust_error_at (value_expr.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 
   // can't strip if block itself, but can strip sub-expressions
   auto &if_block = expr.get_if_block ();
-  if (if_block->is_marked_for_strip ())
-    rust_error_at (if_block->get_locus (),
+  if (if_block.is_marked_for_strip ())
+    rust_error_at (if_block.get_locus (),
 		   "cannot strip block expression in this position - outer "
 		   "attributes not allowed");
 
   // can't strip else block itself, but can strip sub-expressions
   auto &else_block = expr.get_else_block ();
-  if (else_block->is_marked_for_strip ())
-    rust_error_at (else_block->get_locus (),
+  if (else_block.is_marked_for_strip ())
+    rust_error_at (else_block.get_locus (),
 		   "cannot strip block expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -1613,8 +1610,8 @@ CfgStrip::visit (AST::MatchExpr &expr)
 
   // can't strip scrutinee expr itself, but can strip sub-expressions
   auto &scrutinee_expr = expr.get_scrutinee_expr ();
-  if (scrutinee_expr->is_marked_for_strip ())
-    rust_error_at (scrutinee_expr->get_locus (),
+  if (scrutinee_expr.is_marked_for_strip ())
+    rust_error_at (scrutinee_expr.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 
@@ -1646,16 +1643,16 @@ CfgStrip::visit (AST::MatchExpr &expr)
       if (match_arm.has_match_arm_guard ())
 	{
 	  auto &guard_expr = match_arm.get_guard_expr ();
-	  if (guard_expr->is_marked_for_strip ())
-	    rust_error_at (guard_expr->get_locus (),
+	  if (guard_expr.is_marked_for_strip ())
+	    rust_error_at (guard_expr.get_locus (),
 			   "cannot strip expression in this position - outer "
 			   "attributes not allowed");
 	}
 
       // strip sub-expressions from match cases
       auto &case_expr = match_case.get_expr ();
-      if (case_expr->is_marked_for_strip ())
-	rust_error_at (case_expr->get_locus (),
+      if (case_expr.is_marked_for_strip ())
+	rust_error_at (case_expr.get_locus (),
 		       "cannot strip expression in this position - outer "
 		       "attributes not allowed");
 
@@ -1713,8 +1710,8 @@ CfgStrip::visit (AST::TypeParam &param)
 
   AST::DefaultASTVisitor::visit (param);
 
-  if (param.has_type () && param.get_type ()->is_marked_for_strip ())
-    rust_error_at (param.get_type ()->get_locus (),
+  if (param.has_type () && param.get_type ().is_marked_for_strip ())
+    rust_error_at (param.get_type ().get_locus (),
 		   "cannot strip type in this position");
 }
 
@@ -1725,8 +1722,8 @@ CfgStrip::visit (AST::TypeBoundWhereClauseItem &item)
   AST::DefaultASTVisitor::visit (item);
 
   auto &type = item.get_type ();
-  if (type->is_marked_for_strip ())
-    rust_error_at (type->get_locus (), "cannot strip type in this position");
+  if (type.is_marked_for_strip ())
+    rust_error_at (type.get_locus (), "cannot strip type in this position");
 }
 
 void
@@ -1807,8 +1804,8 @@ CfgStrip::visit (AST::Function &function)
   if (function.has_return_type ())
     {
       auto &return_type = function.get_return_type ();
-      if (return_type->is_marked_for_strip ())
-	rust_error_at (return_type->get_locus (),
+      if (return_type.is_marked_for_strip ())
+	rust_error_at (return_type.get_locus (),
 		       "cannot strip type in this position");
     }
 
@@ -1839,8 +1836,8 @@ CfgStrip::visit (AST::TypeAlias &type_alias)
   AST::DefaultASTVisitor::visit (type_alias);
 
   auto &type = type_alias.get_type_aliased ();
-  if (type->is_marked_for_strip ())
-    rust_error_at (type->get_locus (), "cannot strip type in this position");
+  if (type.is_marked_for_strip ())
+    rust_error_at (type.get_locus (), "cannot strip type in this position");
 }
 
 void
@@ -1933,8 +1930,8 @@ CfgStrip::visit (AST::EnumItemDiscriminant &item)
    * allowed to have external attributes in this position so can't be
    * stripped. */
   auto &expr = item.get_expr ();
-  if (expr->is_marked_for_strip ())
-    rust_error_at (expr->get_locus (),
+  if (expr.is_marked_for_strip ())
+    rust_error_at (expr.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -1987,8 +1984,8 @@ CfgStrip::visit (AST::ConstantItem &const_item)
 
   // strip any sub-types
   auto &type = const_item.get_type ();
-  if (type->is_marked_for_strip ())
-    rust_error_at (type->get_locus (), "cannot strip type in this position");
+  if (type.is_marked_for_strip ())
+    rust_error_at (type.get_locus (), "cannot strip type in this position");
 
   /* strip any internal sub-expressions - expression itself isn't
    * allowed to have external attributes in this position so can't be
@@ -1996,8 +1993,8 @@ CfgStrip::visit (AST::ConstantItem &const_item)
   if (const_item.has_expr ())
     {
       auto &expr = const_item.get_expr ();
-      if (expr->is_marked_for_strip ())
-	rust_error_at (expr->get_locus (),
+      if (expr.is_marked_for_strip ())
+	rust_error_at (expr.get_locus (),
 		       "cannot strip expression in this position - outer "
 		       "attributes not allowed");
     }
@@ -2018,15 +2015,15 @@ CfgStrip::visit (AST::StaticItem &static_item)
   // strip any sub-types
   auto &type = static_item.get_type ();
 
-  if (type->is_marked_for_strip ())
-    rust_error_at (type->get_locus (), "cannot strip type in this position");
+  if (type.is_marked_for_strip ())
+    rust_error_at (type.get_locus (), "cannot strip type in this position");
 
   /* strip any internal sub-expressions - expression itself isn't
    * allowed to have external attributes in this position so can't be
    * stripped. */
   auto &expr = static_item.get_expr ();
-  if (expr->is_marked_for_strip ())
-    rust_error_at (expr->get_locus (),
+  if (expr.is_marked_for_strip ())
+    rust_error_at (expr.get_locus (),
 		   "cannot strip expression in this position - outer "
 		   "attributes not allowed");
 }
@@ -2047,8 +2044,8 @@ CfgStrip::visit (AST::TraitItemConst &item)
   // strip any sub-types
   auto &type = item.get_type ();
 
-  if (type->is_marked_for_strip ())
-    rust_error_at (type->get_locus (), "cannot strip type in this position");
+  if (type.is_marked_for_strip ())
+    rust_error_at (type.get_locus (), "cannot strip type in this position");
 
   /* strip any internal sub-expressions - expression itself isn't
    * allowed to have external attributes in this position so can't be
@@ -2056,8 +2053,8 @@ CfgStrip::visit (AST::TraitItemConst &item)
   if (item.has_expression ())
     {
       auto &expr = item.get_expr ();
-      if (expr->is_marked_for_strip ())
-	rust_error_at (expr->get_locus (),
+      if (expr.is_marked_for_strip ())
+	rust_error_at (expr.get_locus (),
 		       "cannot strip expression in this position - outer "
 		       "attributes not allowed");
     }
@@ -2124,8 +2121,8 @@ CfgStrip::visit (AST::InherentImpl &impl)
 
   auto &type = impl.get_type ();
 
-  if (type->is_marked_for_strip ())
-    rust_error_at (type->get_locus (), "cannot strip type in this position");
+  if (type.is_marked_for_strip ())
+    rust_error_at (type.get_locus (), "cannot strip type in this position");
 
   maybe_strip_pointer_allow_strip (impl.get_impl_items ());
 }
@@ -2152,8 +2149,8 @@ CfgStrip::visit (AST::TraitImpl &impl)
   AST::DefaultASTVisitor::visit (impl);
 
   auto &type = impl.get_type ();
-  if (type->is_marked_for_strip ())
-    rust_error_at (type->get_locus (), "cannot strip type in this position");
+  if (type.is_marked_for_strip ())
+    rust_error_at (type.get_locus (), "cannot strip type in this position");
 
   auto &trait_path = impl.get_trait_path ();
   visit (trait_path);
@@ -2191,8 +2188,8 @@ CfgStrip::visit (AST::ExternalStaticItem &item)
   AST::DefaultASTVisitor::visit (item);
 
   auto &type = item.get_type ();
-  if (type->is_marked_for_strip ())
-    rust_error_at (type->get_locus (), "cannot strip type in this position");
+  if (type.is_marked_for_strip ())
+    rust_error_at (type.get_locus (), "cannot strip type in this position");
 }
 
 void
@@ -2239,8 +2236,8 @@ CfgStrip::visit (AST::IdentifierPattern &pattern)
   AST::DefaultASTVisitor::visit (pattern);
 
   auto &sub_pattern = pattern.get_pattern_to_bind ();
-  if (sub_pattern->is_marked_for_strip ())
-    rust_error_at (sub_pattern->get_locus (),
+  if (sub_pattern.is_marked_for_strip ())
+    rust_error_at (sub_pattern.get_locus (),
 		   "cannot strip pattern in this position");
 }
 
@@ -2270,8 +2267,8 @@ CfgStrip::visit (AST::ReferencePattern &pattern)
   AST::DefaultASTVisitor::visit (pattern);
 
   auto &sub_pattern = pattern.get_referenced_pattern ();
-  if (sub_pattern->is_marked_for_strip ())
-    rust_error_at (sub_pattern->get_locus (),
+  if (sub_pattern.is_marked_for_strip ())
+    rust_error_at (sub_pattern.get_locus (),
 		   "cannot strip pattern in this position");
 }
 void
@@ -2289,8 +2286,8 @@ CfgStrip::visit (AST::StructPatternFieldTuplePat &field)
 
   // strip sub-patterns (can't strip top-level pattern)
   auto &sub_pattern = field.get_index_pattern ();
-  if (sub_pattern->is_marked_for_strip ())
-    rust_error_at (sub_pattern->get_locus (),
+  if (sub_pattern.is_marked_for_strip ())
+    rust_error_at (sub_pattern.get_locus (),
 		   "cannot strip pattern in this position");
 }
 
@@ -2308,8 +2305,8 @@ CfgStrip::visit (AST::StructPatternFieldIdentPat &field)
   AST::DefaultASTVisitor::visit (field);
   // strip sub-patterns (can't strip top-level pattern)
   auto &sub_pattern = field.get_ident_pattern ();
-  if (sub_pattern->is_marked_for_strip ())
-    rust_error_at (sub_pattern->get_locus (),
+  if (sub_pattern.is_marked_for_strip ())
+    rust_error_at (sub_pattern.get_locus (),
 		   "cannot strip pattern in this position");
 }
 void
@@ -2442,8 +2439,8 @@ CfgStrip::visit (AST::GroupedPattern &pattern)
   // can't strip inner pattern, only sub-patterns
   auto &pattern_in_parens = pattern.get_pattern_in_parens ();
 
-  if (pattern_in_parens->is_marked_for_strip ())
-    rust_error_at (pattern_in_parens->get_locus (),
+  if (pattern_in_parens.is_marked_for_strip ())
+    rust_error_at (pattern_in_parens.get_locus (),
 		   "cannot strip pattern in this position");
 }
 
@@ -2489,8 +2486,8 @@ CfgStrip::visit (AST::LetStmt &stmt)
   AST::DefaultASTVisitor::visit (stmt);
   // can't strip pattern, but call for sub-patterns
   auto &pattern = stmt.get_pattern ();
-  if (pattern->is_marked_for_strip ())
-    rust_error_at (pattern->get_locus (),
+  if (pattern.is_marked_for_strip ())
+    rust_error_at (pattern.get_locus (),
 		   "cannot strip pattern in this position");
 
   // similar for type
@@ -2498,9 +2495,8 @@ CfgStrip::visit (AST::LetStmt &stmt)
     {
       auto &type = stmt.get_type ();
 
-      if (type->is_marked_for_strip ())
-	rust_error_at (type->get_locus (),
-		       "cannot strip type in this position");
+      if (type.is_marked_for_strip ())
+	rust_error_at (type.get_locus (), "cannot strip type in this position");
     }
 
   /* strip any internal sub-expressions - expression itself isn't
@@ -2510,8 +2506,8 @@ CfgStrip::visit (AST::LetStmt &stmt)
     {
       auto &init_expr = stmt.get_init_expr ();
 
-      if (init_expr->is_marked_for_strip ())
-	rust_error_at (init_expr->get_locus (),
+      if (init_expr.is_marked_for_strip ())
+	rust_error_at (init_expr.get_locus (),
 		       "cannot strip expression in this position - outer "
 		       "attributes not allowed");
     }
@@ -2529,7 +2525,7 @@ CfgStrip::visit (AST::ExprStmt &stmt)
   AST::DefaultASTVisitor::visit (stmt);
   // strip if expr is to be stripped
   auto &expr = stmt.get_expr ();
-  if (expr->is_marked_for_strip ())
+  if (expr.is_marked_for_strip ())
     {
       stmt.mark_for_strip ();
       return;
@@ -2580,8 +2576,8 @@ CfgStrip::visit (AST::RawPointerType &type)
   AST::DefaultASTVisitor::visit (type);
   // expand but don't strip type pointed to
   auto &pointed_type = type.get_type_pointed_to ();
-  if (pointed_type->is_marked_for_strip ())
-    rust_error_at (pointed_type->get_locus (),
+  if (pointed_type.is_marked_for_strip ())
+    rust_error_at (pointed_type.get_locus (),
 		   "cannot strip type in this position");
 }
 
@@ -2591,8 +2587,8 @@ CfgStrip::visit (AST::ReferenceType &type)
   AST::DefaultASTVisitor::visit (type);
   // expand but don't strip type referenced
   auto &referenced_type = type.get_type_referenced ();
-  if (referenced_type->is_marked_for_strip ())
-    rust_error_at (referenced_type->get_locus (),
+  if (referenced_type.is_marked_for_strip ())
+    rust_error_at (referenced_type.get_locus (),
 		   "cannot strip type in this position");
 }
 
@@ -2602,14 +2598,14 @@ CfgStrip::visit (AST::ArrayType &type)
   AST::DefaultASTVisitor::visit (type);
   // expand but don't strip type referenced
   auto &base_type = type.get_elem_type ();
-  if (base_type->is_marked_for_strip ())
-    rust_error_at (base_type->get_locus (),
+  if (base_type.is_marked_for_strip ())
+    rust_error_at (base_type.get_locus (),
 		   "cannot strip type in this position");
 
   // same for expression
   auto &size_expr = type.get_size_expr ();
-  if (size_expr->is_marked_for_strip ())
-    rust_error_at (size_expr->get_locus (),
+  if (size_expr.is_marked_for_strip ())
+    rust_error_at (size_expr.get_locus (),
 		   "cannot strip expression in this position");
 }
 void
@@ -2618,8 +2614,8 @@ CfgStrip::visit (AST::SliceType &type)
   AST::DefaultASTVisitor::visit (type);
   // expand but don't strip elem type
   auto &elem_type = type.get_elem_type ();
-  if (elem_type->is_marked_for_strip ())
-    rust_error_at (elem_type->get_locus (),
+  if (elem_type.is_marked_for_strip ())
+    rust_error_at (elem_type.get_locus (),
 		   "cannot strip type in this position");
 }
 
@@ -2644,9 +2640,8 @@ CfgStrip::visit (AST::BareFunctionType &type)
 	}
 
       auto &type = param.get_type ();
-      if (type->is_marked_for_strip ())
-	rust_error_at (type->get_locus (),
-		       "cannot strip type in this position");
+      if (type.is_marked_for_strip ())
+	rust_error_at (type.get_locus (), "cannot strip type in this position");
 
       // increment if nothing else happens
       ++it;
@@ -2661,8 +2656,8 @@ CfgStrip::visit (AST::BareFunctionType &type)
       // In that case, we need to handle AST::TypeNoBounds on top of just
       // AST::Types
       auto &return_type = type.get_return_type ();
-      if (return_type->is_marked_for_strip ())
-	rust_error_at (return_type->get_locus (),
+      if (return_type.is_marked_for_strip ())
+	rust_error_at (return_type.get_locus (),
 		       "cannot strip type in this position");
     }
 
@@ -2677,9 +2672,8 @@ CfgStrip::visit (AST::SelfParam &param)
   if (param.has_type ())
     {
       auto &type = param.get_type ();
-      if (type->is_marked_for_strip ())
-	rust_error_at (type->get_locus (),
-		       "cannot strip type in this position");
+      if (type.is_marked_for_strip ())
+	rust_error_at (type.get_locus (), "cannot strip type in this position");
     }
   /* TODO: maybe check for invariants being violated - e.g. both type and
    * lifetime? */

--- a/gcc/rust/expand/rust-expand-visitor.cc
+++ b/gcc/rust/expand/rust-expand-visitor.cc
@@ -360,7 +360,7 @@ ExpandVisitor::expand_struct_fields (std::vector<AST::StructField> &fields)
 {
   for (auto &field : fields)
     {
-      maybe_expand_type (field.get_field_type ());
+      maybe_expand_type (field.get_field_type_ptr ());
     }
 }
 
@@ -368,7 +368,7 @@ void
 ExpandVisitor::expand_tuple_fields (std::vector<AST::TupleField> &fields)
 {
   for (auto &field : fields)
-    maybe_expand_type (field.get_field_type ());
+    maybe_expand_type (field.get_field_type_ptr ());
 }
 
 // FIXME: This can definitely be refactored with the method above
@@ -388,10 +388,10 @@ ExpandVisitor::expand_generic_args (AST::GenericArgs &args)
       switch (arg.get_kind ())
 	{
 	case AST::GenericArg::Kind::Type:
-	  maybe_expand_type (arg.get_type ());
+	  maybe_expand_type (arg.get_type_ptr ());
 	  break;
 	case AST::GenericArg::Kind::Const:
-	  maybe_expand_expr (arg.get_expression ());
+	  maybe_expand_expr (arg.get_expression_ptr ());
 	  break;
 	default:
 	  break;
@@ -407,13 +407,13 @@ ExpandVisitor::expand_generic_args (AST::GenericArgs &args)
   // expand binding args - strip sub-types only
   // FIXME: ARTHUR: This needs a test! Foo<Item = macro!()>
   for (auto &binding : args.get_binding_args ())
-    maybe_expand_type (binding.get_type ());
+    maybe_expand_type (binding.get_type_ptr ());
 }
 
 void
 ExpandVisitor::expand_qualified_path_type (AST::QualifiedPathType &path_type)
 {
-  maybe_expand_type (path_type.get_type ());
+  maybe_expand_type (path_type.get_type_ptr ());
 
   // FIXME: ARTHUR: Can we do macro expansion in there? Needs a test!
   if (path_type.has_as_clause ())
@@ -426,7 +426,7 @@ ExpandVisitor::expand_closure_params (std::vector<AST::ClosureParam> &params)
   for (auto &param : params)
     {
       if (param.has_type_given ())
-	maybe_expand_type (param.get_type ());
+	maybe_expand_type (param.get_type_ptr ());
     }
 }
 
@@ -491,7 +491,7 @@ ExpandVisitor::visit (AST::TypePathSegmentFunction &segment)
     visit (type);
 
   if (type_path_function.has_return_type ())
-    maybe_expand_type (type_path_function.get_return_type ());
+    maybe_expand_type (type_path_function.get_return_type_ptr ());
 }
 
 void
@@ -545,42 +545,42 @@ ExpandVisitor::visit (AST::ErrorPropagationExpr &expr)
 void
 ExpandVisitor::visit (AST::ArithmeticOrLogicalExpr &expr)
 {
-  maybe_expand_expr (expr.get_left_expr ());
-  maybe_expand_expr (expr.get_right_expr ());
+  maybe_expand_expr (expr.get_left_expr_ptr ());
+  maybe_expand_expr (expr.get_right_expr_ptr ());
 }
 
 void
 ExpandVisitor::visit (AST::ComparisonExpr &expr)
 {
-  maybe_expand_expr (expr.get_left_expr ());
-  maybe_expand_expr (expr.get_right_expr ());
+  maybe_expand_expr (expr.get_left_expr_ptr ());
+  maybe_expand_expr (expr.get_right_expr_ptr ());
 }
 
 void
 ExpandVisitor::visit (AST::LazyBooleanExpr &expr)
 {
-  maybe_expand_expr (expr.get_left_expr ());
-  maybe_expand_expr (expr.get_right_expr ());
+  maybe_expand_expr (expr.get_left_expr_ptr ());
+  maybe_expand_expr (expr.get_right_expr_ptr ());
 }
 
 void
 ExpandVisitor::visit (AST::AssignmentExpr &expr)
 {
-  maybe_expand_expr (expr.get_left_expr ());
-  maybe_expand_expr (expr.get_right_expr ());
+  maybe_expand_expr (expr.get_left_expr_ptr ());
+  maybe_expand_expr (expr.get_right_expr_ptr ());
 }
 
 void
 ExpandVisitor::visit (AST::CompoundAssignmentExpr &expr)
 {
-  maybe_expand_expr (expr.get_left_expr ());
-  maybe_expand_expr (expr.get_right_expr ());
+  maybe_expand_expr (expr.get_left_expr_ptr ());
+  maybe_expand_expr (expr.get_right_expr_ptr ());
 }
 
 void
 ExpandVisitor::visit (AST::GroupedExpr &expr)
 {
-  maybe_expand_expr (expr.get_expr_in_parens ());
+  maybe_expand_expr (expr.get_expr_in_parens_ptr ());
 }
 
 void
@@ -620,7 +620,7 @@ ExpandVisitor::visit (AST::BlockExpr &expr)
 
   expand_tail_expr (expr, expander);
   if (expr.has_tail_expr ())
-    maybe_expand_expr (expr.get_tail_expr ());
+    maybe_expand_expr (expr.get_tail_expr_ptr ());
 }
 
 void
@@ -628,7 +628,7 @@ ExpandVisitor::visit (AST::ClosureExprInnerTyped &expr)
 {
   expand_closure_params (expr.get_params ());
 
-  maybe_expand_type (expr.get_return_type ());
+  maybe_expand_type (expr.get_return_type_ptr ());
 
   visit (expr.get_definition_block ());
 }
@@ -640,7 +640,7 @@ ExpandVisitor::visit (AST::ContinueExpr &expr)
 void
 ExpandVisitor::visit (AST::IfExpr &expr)
 {
-  maybe_expand_expr (expr.get_condition_expr ());
+  maybe_expand_expr (expr.get_condition_expr_ptr ());
 
   visit (expr.get_if_block ());
 }
@@ -648,7 +648,7 @@ ExpandVisitor::visit (AST::IfExpr &expr)
 void
 ExpandVisitor::visit (AST::IfExprConseqElse &expr)
 {
-  maybe_expand_expr (expr.get_condition_expr ());
+  maybe_expand_expr (expr.get_condition_expr_ptr ());
 
   visit (expr.get_if_block ());
   visit (expr.get_else_block ());
@@ -657,7 +657,7 @@ ExpandVisitor::visit (AST::IfExprConseqElse &expr)
 void
 ExpandVisitor::visit (AST::IfLetExpr &expr)
 {
-  maybe_expand_expr (expr.get_value_expr ());
+  maybe_expand_expr (expr.get_value_expr_ptr ());
 
   visit (expr.get_if_block ());
 }
@@ -665,7 +665,7 @@ ExpandVisitor::visit (AST::IfLetExpr &expr)
 void
 ExpandVisitor::visit (AST::IfLetExprConseqElse &expr)
 {
-  maybe_expand_expr (expr.get_value_expr ());
+  maybe_expand_expr (expr.get_value_expr_ptr ());
 
   visit (expr.get_if_block ());
   visit (expr.get_else_block ());
@@ -684,9 +684,9 @@ ExpandVisitor::visit (AST::MatchExpr &expr)
 	visit (pattern);
 
       if (arm.has_match_arm_guard ())
-	maybe_expand_expr (arm.get_guard_expr ());
+	maybe_expand_expr (arm.get_guard_expr_ptr ());
 
-      maybe_expand_expr (match_case.get_expr ());
+      maybe_expand_expr (match_case.get_expr_ptr ());
     }
 }
 
@@ -697,7 +697,7 @@ ExpandVisitor::visit (AST::TypeParam &param)
     visit (bound);
 
   if (param.has_type ())
-    maybe_expand_type (param.get_type ());
+    maybe_expand_type (param.get_type_ptr ());
 }
 
 void
@@ -707,7 +707,7 @@ ExpandVisitor::visit (AST::LifetimeWhereClauseItem &)
 void
 ExpandVisitor::visit (AST::TypeBoundWhereClauseItem &item)
 {
-  maybe_expand_type (item.get_type ());
+  maybe_expand_type (item.get_type_ptr ());
 
   for (auto &bound : item.get_type_param_bounds ())
     visit (bound);
@@ -745,7 +745,7 @@ ExpandVisitor::visit (AST::Function &function)
   expand_function_params (function.get_function_params ());
 
   if (function.has_return_type ())
-    maybe_expand_type (function.get_return_type ());
+    maybe_expand_type (function.get_return_type_ptr ());
 
   if (function.has_where_clause ())
     expand_where_clause (function.get_where_clause ());
@@ -797,7 +797,7 @@ ExpandVisitor::visit (AST::EnumItemStruct &item)
 void
 ExpandVisitor::visit (AST::EnumItemDiscriminant &item)
 {
-  maybe_expand_expr (item.get_expr ());
+  maybe_expand_expr (item.get_expr_ptr ());
 }
 
 void
@@ -812,27 +812,27 @@ ExpandVisitor::visit (AST::Union &union_item)
 void
 ExpandVisitor::visit (AST::ConstantItem &const_item)
 {
-  maybe_expand_type (const_item.get_type ());
+  maybe_expand_type (const_item.get_type_ptr ());
 
   if (const_item.has_expr ())
-    maybe_expand_expr (const_item.get_expr ());
+    maybe_expand_expr (const_item.get_expr_ptr ());
 }
 
 void
 ExpandVisitor::visit (AST::StaticItem &static_item)
 {
-  maybe_expand_type (static_item.get_type ());
+  maybe_expand_type (static_item.get_type_ptr ());
 
-  maybe_expand_expr (static_item.get_expr ());
+  maybe_expand_expr (static_item.get_expr_ptr ());
 }
 
 void
 ExpandVisitor::visit (AST::TraitItemConst &const_item)
 {
-  maybe_expand_type (const_item.get_type ());
+  maybe_expand_type (const_item.get_type_ptr ());
 
   if (const_item.has_expr ())
-    maybe_expand_expr (const_item.get_expr ());
+    maybe_expand_expr (const_item.get_expr_ptr ());
 }
 
 void
@@ -870,7 +870,7 @@ ExpandVisitor::visit (AST::InherentImpl &impl)
   // FIXME: Is that correct? How do we test that?
   expander.push_context (MacroExpander::ContextType::ITEM);
 
-  maybe_expand_type (impl.get_type ());
+  maybe_expand_type (impl.get_type_ptr ());
 
   expander.pop_context ();
 
@@ -895,7 +895,7 @@ ExpandVisitor::visit (AST::TraitImpl &impl)
   // FIXME: Is that correct? How do we test that?
   expander.push_context (MacroExpander::ContextType::ITEM);
 
-  maybe_expand_type (impl.get_type ());
+  maybe_expand_type (impl.get_type_ptr ());
 
   expander.pop_context ();
 
@@ -919,7 +919,7 @@ ExpandVisitor::visit (AST::ExternalTypeItem &item)
 void
 ExpandVisitor::visit (AST::ExternalStaticItem &static_item)
 {
-  maybe_expand_type (static_item.get_type ());
+  maybe_expand_type (static_item.get_type_ptr ());
 }
 
 void
@@ -978,16 +978,16 @@ ExpandVisitor::visit (AST::LetStmt &stmt)
   visit (stmt.get_pattern ());
 
   if (stmt.has_type ())
-    maybe_expand_type (stmt.get_type ());
+    maybe_expand_type (stmt.get_type_ptr ());
 
   if (stmt.has_init_expr ())
-    maybe_expand_expr (stmt.get_init_expr ());
+    maybe_expand_expr (stmt.get_init_expr_ptr ());
 }
 
 void
 ExpandVisitor::visit (AST::ExprStmt &stmt)
 {
-  maybe_expand_expr (stmt.get_expr ());
+  maybe_expand_expr (stmt.get_expr_ptr ());
 }
 
 void
@@ -995,7 +995,7 @@ ExpandVisitor::visit (AST::BareFunctionType &type)
 {
   for (auto &param : type.get_function_params ())
     {
-      maybe_expand_type (param.get_type ());
+      maybe_expand_type (param.get_type_ptr ());
     }
 
   if (type.has_return_type ())
@@ -1005,7 +1005,7 @@ ExpandVisitor::visit (AST::BareFunctionType &type)
 void
 ExpandVisitor::visit (AST::FunctionParam &param)
 {
-  maybe_expand_type (param.get_type ());
+  maybe_expand_type (param.get_type_ptr ());
 }
 
 void
@@ -1014,7 +1014,7 @@ ExpandVisitor::visit (AST::SelfParam &param)
   /* TODO: maybe check for invariants being violated - e.g. both type and
    * lifetime? */
   if (param.has_type ())
-    maybe_expand_type (param.get_type ());
+    maybe_expand_type (param.get_type_ptr ());
 }
 
 template <typename T>

--- a/gcc/rust/expand/rust-expand-visitor.h
+++ b/gcc/rust/expand/rust-expand-visitor.h
@@ -47,10 +47,16 @@ public:
 
   using AST::DefaultASTVisitor::visit;
 
-  /* Maybe expand a macro invocation in lieu of an expression */
+  /*
+     Maybe expand a macro invocation in lieu of an expression
+     expr : Core guidelines R33, this function reseat the pointer.
+  */
   void maybe_expand_expr (std::unique_ptr<AST::Expr> &expr);
 
-  /* Maybe expand a macro invocation in lieu of a type */
+  /*
+     Maybe expand a macro invocation in lieu of a type
+     type : Core guidelines R33, this function reseat the pointer.
+   */
   void maybe_expand_type (std::unique_ptr<AST::Type> &type);
 
   /**

--- a/gcc/rust/hir/rust-ast-lower-base.cc
+++ b/gcc/rust/hir/rust-ast-lower-base.cc
@@ -648,31 +648,31 @@ ASTLoweringBase::lower_generic_args (AST::GenericArgs &args)
 }
 
 HIR::SelfParam
-ASTLoweringBase::lower_self (std::unique_ptr<AST::Param> &param)
+ASTLoweringBase::lower_self (AST::Param &param)
 {
-  rust_assert (param->is_self ());
+  rust_assert (param.is_self ());
 
-  auto self = static_cast<AST::SelfParam *> (param.get ());
+  auto self = static_cast<AST::SelfParam &> (param);
   auto crate_num = mappings->get_current_crate ();
-  Analysis::NodeMapping mapping (crate_num, self->get_node_id (),
+  Analysis::NodeMapping mapping (crate_num, self.get_node_id (),
 				 mappings->get_next_hir_id (crate_num),
 				 mappings->get_next_localdef_id (crate_num));
 
-  if (self->has_type ())
+  if (self.has_type ())
     {
-      HIR::Type *type = ASTLoweringType::translate (self->get_type ().get ());
+      HIR::Type *type = ASTLoweringType::translate (self.get_type ().get ());
       return HIR::SelfParam (mapping, std::unique_ptr<HIR::Type> (type),
-			     self->get_is_mut (), self->get_locus ());
+			     self.get_is_mut (), self.get_locus ());
     }
-  else if (!self->get_has_ref ())
+  else if (!self.get_has_ref ())
     {
       return HIR::SelfParam (mapping, std::unique_ptr<HIR::Type> (nullptr),
-			     self->get_is_mut (), self->get_locus ());
+			     self.get_is_mut (), self.get_locus ());
     }
 
-  AST::Lifetime l = self->get_lifetime ();
-  return HIR::SelfParam (mapping, lower_lifetime (l), self->get_is_mut (),
-			 self->get_locus ());
+  AST::Lifetime l = self.get_lifetime ();
+  return HIR::SelfParam (mapping, lower_lifetime (l), self.get_is_mut (),
+			 self.get_locus ());
 }
 
 HIR::Type *

--- a/gcc/rust/hir/rust-ast-lower-base.h
+++ b/gcc/rust/hir/rust-ast-lower-base.h
@@ -280,9 +280,9 @@ protected:
 
   HIR::SelfParam lower_self (AST::Param &self);
 
-  HIR::Type *lower_type_no_bounds (AST::TypeNoBounds *type);
+  HIR::Type *lower_type_no_bounds (AST::TypeNoBounds &type);
 
-  HIR::TypeParamBound *lower_bound (AST::TypeParamBound *bound);
+  HIR::TypeParamBound *lower_bound (AST::TypeParamBound &bound);
 
   HIR::QualifiedPathType
   lower_qual_path_type (AST::QualifiedPathType &qual_path_type);
@@ -310,7 +310,7 @@ protected:
   lower_tuple_pattern_ranged (AST::TuplePatternItemsRanged &pattern);
 
   std::unique_ptr<HIR::RangePatternBound>
-  lower_range_pattern_bound (AST::RangePatternBound *bound);
+  lower_range_pattern_bound (AST::RangePatternBound &bound);
 
   HIR::Literal lower_literal (const AST::Literal &literal);
 

--- a/gcc/rust/hir/rust-ast-lower-base.h
+++ b/gcc/rust/hir/rust-ast-lower-base.h
@@ -278,7 +278,7 @@ protected:
 
   HIR::GenericArgsBinding lower_binding (AST::GenericArgsBinding &binding);
 
-  HIR::SelfParam lower_self (std::unique_ptr<AST::Param> &self);
+  HIR::SelfParam lower_self (AST::Param &self);
 
   HIR::Type *lower_type_no_bounds (AST::TypeNoBounds *type);
 

--- a/gcc/rust/hir/rust-ast-lower-block.h
+++ b/gcc/rust/hir/rust-ast-lower-block.h
@@ -30,11 +30,11 @@ class ASTLoweringBlock : public ASTLoweringBase
   using Rust::HIR::ASTLoweringBase::visit;
 
 public:
-  static HIR::BlockExpr *translate (AST::BlockExpr *expr, bool *terminated)
+  static HIR::BlockExpr *translate (AST::BlockExpr &expr, bool *terminated)
   {
     ASTLoweringBlock resolver;
-    expr->normalize_tail_expr ();
-    expr->accept_vis (resolver);
+    expr.normalize_tail_expr ();
+    expr.accept_vis (resolver);
     if (resolver.translated != nullptr)
       {
 	resolver.mappings->insert_hir_expr (resolver.translated);
@@ -44,16 +44,15 @@ public:
     return resolver.translated;
   }
 
-  static HIR::UnsafeBlockExpr *translate (AST::UnsafeBlockExpr *expr,
+  static HIR::UnsafeBlockExpr *translate (AST::UnsafeBlockExpr &expr,
 					  bool *terminated)
   {
     ASTLoweringBlock resolver;
 
     HIR::BlockExpr *block
-      = ASTLoweringBlock::translate (expr->get_block_expr ().get (),
-				     terminated);
+      = ASTLoweringBlock::translate (expr.get_block_expr (), terminated);
     auto crate_num = resolver.mappings->get_current_crate ();
-    Analysis::NodeMapping mapping (crate_num, expr->get_node_id (),
+    Analysis::NodeMapping mapping (crate_num, expr.get_node_id (),
 				   resolver.mappings->get_next_hir_id (
 				     crate_num),
 				   UNKNOWN_LOCAL_DEFID);
@@ -61,7 +60,7 @@ public:
     HIR::UnsafeBlockExpr *translated
       = new HIR::UnsafeBlockExpr (mapping,
 				  std::unique_ptr<HIR::BlockExpr> (block),
-				  expr->get_outer_attrs (), expr->get_locus ());
+				  expr.get_outer_attrs (), expr.get_locus ());
 
     resolver.mappings->insert_hir_expr (translated);
 
@@ -84,10 +83,10 @@ class ASTLoweringIfBlock : public ASTLoweringBase
   using Rust::HIR::ASTLoweringBase::visit;
 
 public:
-  static HIR::IfExpr *translate (AST::IfExpr *expr, bool *terminated)
+  static HIR::IfExpr *translate (AST::IfExpr &expr, bool *terminated)
   {
     ASTLoweringIfBlock resolver;
-    expr->accept_vis (resolver);
+    expr.accept_vis (resolver);
     if (resolver.translated != nullptr)
       {
 	resolver.mappings->insert_hir_expr (resolver.translated);
@@ -116,10 +115,10 @@ class ASTLoweringIfLetBlock : public ASTLoweringBase
   using Rust::HIR::ASTLoweringBase::visit;
 
 public:
-  static HIR::IfLetExpr *translate (AST::IfLetExpr *expr)
+  static HIR::IfLetExpr *translate (AST::IfLetExpr &expr)
   {
     ASTLoweringIfLetBlock resolver;
-    expr->accept_vis (resolver);
+    expr.accept_vis (resolver);
     if (resolver.translated != nullptr)
       {
 	resolver.mappings->insert_hir_expr (resolver.translated);
@@ -144,11 +143,11 @@ class ASTLoweringExprWithBlock : public ASTLoweringBase
   using Rust::HIR::ASTLoweringBase::visit;
 
 public:
-  static HIR::ExprWithBlock *translate (AST::ExprWithBlock *expr,
+  static HIR::ExprWithBlock *translate (AST::ExprWithBlock &expr,
 					bool *terminated)
   {
     ASTLoweringExprWithBlock resolver;
-    expr->accept_vis (resolver);
+    expr.accept_vis (resolver);
     if (resolver.translated != nullptr)
       {
 	resolver.mappings->insert_hir_expr (resolver.translated);
@@ -162,39 +161,38 @@ public:
 
   void visit (AST::IfExpr &expr) override
   {
-    translated = ASTLoweringIfBlock::translate (&expr, &terminated);
+    translated = ASTLoweringIfBlock::translate (expr, &terminated);
   }
 
   void visit (AST::IfExprConseqElse &expr) override
   {
-    translated = ASTLoweringIfBlock::translate (&expr, &terminated);
+    translated = ASTLoweringIfBlock::translate (expr, &terminated);
   }
 
   void visit (AST::IfLetExpr &expr) override
   {
-    translated = ASTLoweringIfLetBlock::translate (&expr);
+    translated = ASTLoweringIfLetBlock::translate (expr);
   }
 
   void visit (AST::IfLetExprConseqElse &expr) override
   {
-    translated = ASTLoweringIfLetBlock::translate (&expr);
+    translated = ASTLoweringIfLetBlock::translate (expr);
   }
 
   void visit (AST::BlockExpr &expr) override
   {
-    translated = ASTLoweringBlock::translate (&expr, &terminated);
+    translated = ASTLoweringBlock::translate (expr, &terminated);
   }
 
   void visit (AST::UnsafeBlockExpr &expr) override
   {
-    translated = ASTLoweringBlock::translate (&expr, &terminated);
+    translated = ASTLoweringBlock::translate (expr, &terminated);
   }
 
   void visit (AST::LoopExpr &expr) override
   {
     HIR::BlockExpr *loop_block
-      = ASTLoweringBlock::translate (expr.get_loop_block ().get (),
-				     &terminated);
+      = ASTLoweringBlock::translate (expr.get_loop_block (), &terminated);
 
     HIR::LoopLabel loop_label = lower_loop_label (expr.get_loop_label ());
 

--- a/gcc/rust/hir/rust-ast-lower-enumitem.h
+++ b/gcc/rust/hir/rust-ast-lower-enumitem.h
@@ -83,8 +83,7 @@ public:
     for (auto &field : item.get_tuple_fields ())
       {
 	HIR::Visibility vis = translate_visibility (field.get_visibility ());
-	HIR::Type *type
-	  = ASTLoweringType::translate (field.get_field_type ().get ());
+	HIR::Type *type = ASTLoweringType::translate (field.get_field_type ());
 
 	auto crate_num = mappings->get_current_crate ();
 	Analysis::NodeMapping field_mapping (
@@ -121,8 +120,7 @@ public:
     for (auto &field : item.get_struct_fields ())
       {
 	HIR::Visibility vis = translate_visibility (field.get_visibility ());
-	HIR::Type *type
-	  = ASTLoweringType::translate (field.get_field_type ().get ());
+	HIR::Type *type = ASTLoweringType::translate (field.get_field_type ());
 
 	auto crate_num = mappings->get_current_crate ();
 	Analysis::NodeMapping field_mapping (
@@ -160,7 +158,7 @@ public:
 		     "visibility qualifier %qs not allowed on enum item",
 		     item.get_visibility ().as_string ().c_str ());
 
-    HIR::Expr *expr = ASTLoweringExpr::translate (item.get_expr ().get ());
+    HIR::Expr *expr = ASTLoweringExpr::translate (item.get_expr ());
     translated
       = new HIR::EnumItemDiscriminant (mapping, item.get_identifier (),
 				       std::unique_ptr<HIR::Expr> (expr),

--- a/gcc/rust/hir/rust-ast-lower-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-expr.h
@@ -30,10 +30,10 @@ class ASTLowerPathInExpression : public ASTLoweringBase
   using Rust::HIR::ASTLoweringBase::visit;
 
 public:
-  static HIR::PathInExpression *translate (AST::PathInExpression *expr)
+  static HIR::PathInExpression *translate (AST::PathInExpression &expr)
   {
     ASTLowerPathInExpression compiler;
-    expr->accept_vis (compiler);
+    expr.accept_vis (compiler);
     rust_assert (compiler.translated);
     return compiler.translated;
   }
@@ -52,10 +52,10 @@ class ASTLowerQualPathInExpression : public ASTLoweringBase
 
 public:
   static HIR::QualifiedPathInExpression *
-  translate (AST::QualifiedPathInExpression *expr)
+  translate (AST::QualifiedPathInExpression &expr)
   {
     ASTLowerQualPathInExpression compiler;
-    expr->accept_vis (compiler);
+    expr.accept_vis (compiler);
     rust_assert (compiler.translated);
     return compiler.translated;
   }
@@ -73,7 +73,7 @@ class ASTLoweringExpr : public ASTLoweringBase
   using Rust::HIR::ASTLoweringBase::visit;
 
 public:
-  static HIR::Expr *translate (AST::Expr *expr, bool *terminated = nullptr);
+  static HIR::Expr *translate (AST::Expr &expr, bool *terminated = nullptr);
 
   void visit (AST::TupleIndexExpr &expr) override;
   void visit (AST::TupleExpr &expr) override;

--- a/gcc/rust/hir/rust-ast-lower-extern.h
+++ b/gcc/rust/hir/rust-ast-lower-extern.h
@@ -51,8 +51,7 @@ public:
   void visit (AST::ExternalStaticItem &item) override
   {
     HIR::Visibility vis = translate_visibility (item.get_visibility ());
-    HIR::Type *static_type
-      = ASTLoweringType::translate (item.get_type ().get ());
+    HIR::Type *static_type = ASTLoweringType::translate (item.get_type ());
 
     auto crate_num = mappings->get_current_crate ();
     Analysis::NodeMapping mapping (crate_num, item.get_node_id (),
@@ -77,7 +76,7 @@ public:
 
     HIR::Type *return_type
       = function.has_return_type ()
-	  ? ASTLoweringType::translate (function.get_return_type ().get ())
+	  ? ASTLoweringType::translate (function.get_return_type ())
 	  : nullptr;
 
     bool is_variadic = function.is_variadic ();
@@ -88,25 +87,24 @@ public:
     std::vector<HIR::NamedFunctionParam> function_params;
     for (auto it = begin; it != end; it++)
       {
-	auto param = static_cast<AST::FunctionParam *> (it->get ());
+	auto &param = static_cast<AST::FunctionParam &> (**it);
 
-	if (param->is_variadic () || param->is_self ())
+	if (param.is_variadic () || param.is_self ())
 	  continue;
-	auto param_kind = param->get_pattern ()->get_pattern_kind ();
+	auto param_kind = param.get_pattern ().get_pattern_kind ();
 
 	rust_assert (param_kind == AST::Pattern::Kind::Identifier
 		     || param_kind == AST::Pattern::Kind::Wildcard);
-	auto param_ident = static_cast<AST::IdentifierPattern *> (
-	  param->get_pattern ().get ());
+	auto &param_ident
+	  = static_cast<AST::IdentifierPattern &> (param.get_pattern ());
 	Identifier param_name = param_kind == AST::Pattern::Kind::Identifier
-				  ? param_ident->get_ident ()
+				  ? param_ident.get_ident ()
 				  : std::string ("_");
 
-	HIR::Type *param_type
-	  = ASTLoweringType::translate (param->get_type ().get ());
+	HIR::Type *param_type = ASTLoweringType::translate (param.get_type ());
 
 	auto crate_num = mappings->get_current_crate ();
-	Analysis::NodeMapping mapping (crate_num, param->get_node_id (),
+	Analysis::NodeMapping mapping (crate_num, param.get_node_id (),
 				       mappings->get_next_hir_id (crate_num),
 				       mappings->get_next_localdef_id (
 					 crate_num));

--- a/gcc/rust/hir/rust-ast-lower-implitem.h
+++ b/gcc/rust/hir/rust-ast-lower-implitem.h
@@ -29,7 +29,7 @@ class ASTLowerImplItem : public ASTLoweringBase
   using Rust::HIR::ASTLoweringBase::visit;
 
 public:
-  static HIR::ImplItem *translate (AST::AssociatedItem *item,
+  static HIR::ImplItem *translate (AST::AssociatedItem &item,
 				   HirId parent_impl_id);
   void visit (AST::TypeAlias &alias) override;
   void visit (AST::ConstantItem &constant) override;
@@ -47,7 +47,7 @@ class ASTLowerTraitItem : public ASTLoweringBase
   using Rust::HIR::ASTLoweringBase::visit;
 
 public:
-  static HIR::TraitItem *translate (AST::AssociatedItem *item);
+  static HIR::TraitItem *translate (AST::AssociatedItem &item);
   void visit (AST::Function &func) override;
   void visit (AST::TraitItemConst &constant) override;
   void visit (AST::TraitItemType &type) override;

--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -29,7 +29,7 @@ class ASTLoweringItem : public ASTLoweringBase
   using Rust::HIR::ASTLoweringBase::visit;
 
 public:
-  static HIR::Item *translate (AST::Item *item);
+  static HIR::Item *translate (AST::Item &item);
 
   void visit (AST::Module &module) override;
   void visit (AST::TypeAlias &alias) override;

--- a/gcc/rust/hir/rust-ast-lower-pattern.cc
+++ b/gcc/rust/hir/rust-ast-lower-pattern.cc
@@ -25,17 +25,17 @@ namespace HIR {
 ASTLoweringPattern::ASTLoweringPattern () : translated (nullptr) {}
 
 HIR::Pattern *
-ASTLoweringPattern::translate (AST::Pattern *pattern, bool is_let_top_level)
+ASTLoweringPattern::translate (AST::Pattern &pattern, bool is_let_top_level)
 {
   ASTLoweringPattern resolver;
   resolver.is_let_top_level = is_let_top_level;
-  pattern->accept_vis (resolver);
+  pattern.accept_vis (resolver);
 
   rust_assert (resolver.translated != nullptr);
 
   resolver.mappings->insert_hir_pattern (resolver.translated);
   resolver.mappings->insert_location (
-    resolver.translated->get_mappings ().get_hirid (), pattern->get_locus ());
+    resolver.translated->get_mappings ().get_hirid (), pattern.get_locus ());
 
   return resolver.translated;
 }
@@ -60,18 +60,18 @@ ASTLoweringPattern::visit (AST::IdentifierPattern &pattern)
 void
 ASTLoweringPattern::visit (AST::PathInExpression &pattern)
 {
-  translated = ASTLowerPathInExpression::translate (&pattern);
+  translated = ASTLowerPathInExpression::translate (pattern);
 }
 
 void
 ASTLoweringPattern::visit (AST::TupleStructPattern &pattern)
 {
   HIR::PathInExpression *path
-    = ASTLowerPathInExpression::translate (&pattern.get_path ());
+    = ASTLowerPathInExpression::translate (pattern.get_path ());
 
   TupleStructItems *lowered = nullptr;
   auto &items = pattern.get_items ();
-  switch (items->get_item_type ())
+  switch (items.get_item_type ())
     {
       case AST::TupleStructItems::RANGE: {
 	// TODO
@@ -81,13 +81,12 @@ ASTLoweringPattern::visit (AST::TupleStructPattern &pattern)
 
       case AST::TupleStructItems::NO_RANGE: {
 	AST::TupleStructItemsNoRange &items_no_range
-	  = static_cast<AST::TupleStructItemsNoRange &> (*items.get ());
+	  = static_cast<AST::TupleStructItemsNoRange &> (items);
 
 	std::vector<std::unique_ptr<HIR::Pattern>> patterns;
 	for (auto &inner_pattern : items_no_range.get_patterns ())
 	  {
-	    HIR::Pattern *p
-	      = ASTLoweringPattern::translate (inner_pattern.get ());
+	    HIR::Pattern *p = ASTLoweringPattern::translate (*inner_pattern);
 	    patterns.push_back (std::unique_ptr<HIR::Pattern> (p));
 	  }
 
@@ -109,7 +108,7 @@ void
 ASTLoweringPattern::visit (AST::StructPattern &pattern)
 {
   HIR::PathInExpression *path
-    = ASTLowerPathInExpression::translate (&pattern.get_path ());
+    = ASTLowerPathInExpression::translate (pattern.get_path ());
 
   auto &raw_elems = pattern.get_struct_pattern_elems ();
   rust_assert (!raw_elems.has_etc ());
@@ -121,7 +120,7 @@ ASTLoweringPattern::visit (AST::StructPattern &pattern)
       switch (field->get_item_type ())
 	{
 	  case AST::StructPatternField::ItemType::TUPLE_PAT: {
-	    AST::StructPatternFieldTuplePat &tuple
+	    auto &tuple
 	      = static_cast<AST::StructPatternFieldTuplePat &> (*field);
 
 	    auto crate_num = mappings->get_current_crate ();
@@ -130,8 +129,8 @@ ASTLoweringPattern::visit (AST::StructPattern &pattern)
 					     crate_num),
 					   UNKNOWN_LOCAL_DEFID);
 
-	    std::unique_ptr<HIR::Pattern> pat (ASTLoweringPattern::translate (
-	      tuple.get_index_pattern ().get ()));
+	    std::unique_ptr<HIR::Pattern> pat (
+	      ASTLoweringPattern::translate (tuple.get_index_pattern ()));
 
 	    f = new HIR::StructPatternFieldTuplePat (mapping,
 						     tuple.get_index (),
@@ -151,8 +150,8 @@ ASTLoweringPattern::visit (AST::StructPattern &pattern)
 					     crate_num),
 					   UNKNOWN_LOCAL_DEFID);
 
-	    std::unique_ptr<HIR::Pattern> pat (ASTLoweringPattern::translate (
-	      ident.get_ident_pattern ().get ()));
+	    std::unique_ptr<HIR::Pattern> pat (
+	      ASTLoweringPattern::translate (ident.get_ident_pattern ()));
 
 	    f = new HIR::StructPatternFieldIdentPat (mapping,
 						     ident.get_identifier (),
@@ -214,20 +213,19 @@ void
 ASTLoweringPattern::visit (AST::TuplePattern &pattern)
 {
   std::unique_ptr<HIR::TuplePatternItems> items;
-  switch (pattern.get_items ()->get_pattern_type ())
+  switch (pattern.get_items ().get_pattern_type ())
     {
       case AST::TuplePatternItems::TuplePatternItemType::MULTIPLE: {
 	AST::TuplePatternItemsMultiple &ref
-	  = *static_cast<AST::TuplePatternItemsMultiple *> (
-	    pattern.get_items ().get ());
+	  = static_cast<AST::TuplePatternItemsMultiple &> (
+	    pattern.get_items ());
 	items = lower_tuple_pattern_multiple (ref);
       }
       break;
 
       case AST::TuplePatternItems::TuplePatternItemType::RANGED: {
 	AST::TuplePatternItemsRanged &ref
-	  = *static_cast<AST::TuplePatternItemsRanged *> (
-	    pattern.get_items ().get ());
+	  = static_cast<AST::TuplePatternItemsRanged &> (pattern.get_items ());
 	items = lower_tuple_pattern_ranged (ref);
       }
       break;
@@ -258,10 +256,8 @@ ASTLoweringPattern::visit (AST::LiteralPattern &pattern)
 void
 ASTLoweringPattern::visit (AST::RangePattern &pattern)
 {
-  auto upper_bound
-    = lower_range_pattern_bound (pattern.get_upper_bound ().get ());
-  auto lower_bound
-    = lower_range_pattern_bound (pattern.get_lower_bound ().get ());
+  auto upper_bound = lower_range_pattern_bound (pattern.get_upper_bound ());
+  auto lower_bound = lower_range_pattern_bound (pattern.get_lower_bound ());
 
   auto crate_num = mappings->get_current_crate ();
   Analysis::NodeMapping mapping (crate_num, pattern.get_node_id (),
@@ -277,7 +273,7 @@ void
 ASTLoweringPattern::visit (AST::GroupedPattern &pattern)
 {
   is_let_top_level = false;
-  pattern.get_pattern_in_parens ()->accept_vis (*this);
+  pattern.get_pattern_in_parens ().accept_vis (*this);
 }
 
 void
@@ -289,7 +285,7 @@ ASTLoweringPattern::visit (AST::ReferencePattern &pattern)
 				 UNKNOWN_LOCAL_DEFID);
 
   HIR::Pattern *inner
-    = ASTLoweringPattern::translate (pattern.get_referenced_pattern ().get ());
+    = ASTLoweringPattern::translate (pattern.get_referenced_pattern ());
 
   translated
     = new HIR::ReferencePattern (mapping, std::unique_ptr<HIR::Pattern> (inner),
@@ -315,7 +311,7 @@ ASTLoweringPattern::visit (AST::SlicePattern &pattern)
   std::vector<std::unique_ptr<HIR::Pattern>> items;
   for (auto &p : pattern.get_items ())
     {
-      HIR::Pattern *item = ASTLoweringPattern::translate (p.get ());
+      HIR::Pattern *item = ASTLoweringPattern::translate (*p);
       items.push_back (std::unique_ptr<HIR::Pattern> (item));
     }
 
@@ -340,8 +336,8 @@ ASTLoweringPattern::visit (AST::AltPattern &pattern)
 
   for (auto &alt : pattern.get_alts ())
     {
-      alts.push_back (std::unique_ptr<HIR::Pattern> (
-	ASTLoweringPattern::translate (alt.get ())));
+      alts.push_back (
+	std::unique_ptr<HIR::Pattern> (ASTLoweringPattern::translate (*alt)));
     }
 
   translated

--- a/gcc/rust/hir/rust-ast-lower-pattern.h
+++ b/gcc/rust/hir/rust-ast-lower-pattern.h
@@ -29,7 +29,7 @@ class ASTLoweringPattern : public ASTLoweringBase
   using Rust::HIR::ASTLoweringBase::visit;
 
 public:
-  static HIR::Pattern *translate (AST::Pattern *pattern,
+  static HIR::Pattern *translate (AST::Pattern &pattern,
 				  bool is_let_top_level = false);
 
   void visit (AST::IdentifierPattern &pattern) override;

--- a/gcc/rust/hir/rust-ast-lower-stmt.cc
+++ b/gcc/rust/hir/rust-ast-lower-stmt.cc
@@ -46,8 +46,7 @@ ASTLoweringStmt::translate (AST::Stmt *stmt, bool *terminated)
 void
 ASTLoweringStmt::visit (AST::ExprStmt &stmt)
 {
-  HIR::Expr *expr
-    = ASTLoweringExpr::translate (stmt.get_expr ().get (), &terminated);
+  HIR::Expr *expr = ASTLoweringExpr::translate (stmt.get_expr (), &terminated);
 
   auto crate_num = mappings->get_current_crate ();
   Analysis::NodeMapping mapping (crate_num, stmt.get_node_id (),
@@ -61,21 +60,20 @@ ASTLoweringStmt::visit (AST::ExprStmt &stmt)
 void
 ASTLoweringStmt::visit (AST::ConstantItem &constant)
 {
-  translated = ASTLoweringItem::translate (&constant);
+  translated = ASTLoweringItem::translate (constant);
 }
 
 void
 ASTLoweringStmt::visit (AST::LetStmt &stmt)
 {
   HIR::Pattern *variables
-    = ASTLoweringPattern::translate (stmt.get_pattern ().get (), true);
+    = ASTLoweringPattern::translate (stmt.get_pattern (), true);
   HIR::Type *type = stmt.has_type ()
-		      ? ASTLoweringType::translate (stmt.get_type ().get ())
+		      ? ASTLoweringType::translate (stmt.get_type ())
 		      : nullptr;
   HIR::Expr *init_expression
-    = stmt.has_init_expr ()
-	? ASTLoweringExpr::translate (stmt.get_init_expr ().get ())
-	: nullptr;
+    = stmt.has_init_expr () ? ASTLoweringExpr::translate (stmt.get_init_expr ())
+			    : nullptr;
 
   auto crate_num = mappings->get_current_crate ();
   Analysis::NodeMapping mapping (crate_num, stmt.get_node_id (),
@@ -91,25 +89,25 @@ ASTLoweringStmt::visit (AST::LetStmt &stmt)
 void
 ASTLoweringStmt::visit (AST::TupleStruct &struct_decl)
 {
-  translated = ASTLoweringItem::translate (&struct_decl);
+  translated = ASTLoweringItem::translate (struct_decl);
 }
 
 void
 ASTLoweringStmt::visit (AST::StructStruct &struct_decl)
 {
-  translated = ASTLoweringItem::translate (&struct_decl);
+  translated = ASTLoweringItem::translate (struct_decl);
 }
 
 void
 ASTLoweringStmt::visit (AST::Union &union_decl)
 {
-  translated = ASTLoweringItem::translate (&union_decl);
+  translated = ASTLoweringItem::translate (union_decl);
 }
 
 void
 ASTLoweringStmt::visit (AST::Enum &enum_decl)
 {
-  translated = ASTLoweringItem::translate (&enum_decl);
+  translated = ASTLoweringItem::translate (enum_decl);
 }
 
 void
@@ -126,7 +124,7 @@ ASTLoweringStmt::visit (AST::EmptyStmt &empty)
 void
 ASTLoweringStmt::visit (AST::Function &function)
 {
-  translated = ASTLoweringItem::translate (&function);
+  translated = ASTLoweringItem::translate (function);
 }
 
 void
@@ -144,19 +142,19 @@ ASTLoweringStmt::visit (AST::MacroRulesDefinition &def)
 void
 ASTLoweringStmt::visit (AST::Trait &trait)
 {
-  translated = ASTLoweringItem::translate (&trait);
+  translated = ASTLoweringItem::translate (trait);
 }
 
 void
 ASTLoweringStmt::visit (AST::InherentImpl &impl_block)
 {
-  translated = ASTLoweringItem::translate (&impl_block);
+  translated = ASTLoweringItem::translate (impl_block);
 }
 
 void
 ASTLoweringStmt::visit (AST::TraitImpl &impl_block)
 {
-  translated = ASTLoweringItem::translate (&impl_block);
+  translated = ASTLoweringItem::translate (impl_block);
 }
 
 } // namespace HIR

--- a/gcc/rust/hir/rust-ast-lower-struct-field-expr.h
+++ b/gcc/rust/hir/rust-ast-lower-struct-field-expr.h
@@ -30,15 +30,15 @@ class ASTLowerStructExprField : public ASTLoweringBase
   using Rust::HIR::ASTLoweringBase::visit;
 
 public:
-  static HIR::StructExprField *translate (AST::StructExprField *field)
+  static HIR::StructExprField *translate (AST::StructExprField &field)
   {
     ASTLowerStructExprField compiler;
-    field->accept_vis (compiler);
+    field.accept_vis (compiler);
     rust_assert (compiler.translated != nullptr);
 
     compiler.mappings->insert_hir_struct_field (compiler.translated);
     compiler.mappings->insert_location (
-      compiler.translated->get_mappings ().get_hirid (), field->get_locus ());
+      compiler.translated->get_mappings ().get_hirid (), field.get_locus ());
 
     return compiler.translated;
   }

--- a/gcc/rust/hir/rust-ast-lower-type.h
+++ b/gcc/rust/hir/rust-ast-lower-type.h
@@ -63,7 +63,7 @@ class ASTLoweringType : public ASTLoweringBase
   using Rust::HIR::ASTLoweringBase::visit;
 
 public:
-  static HIR::Type *translate (AST::Type *type,
+  static HIR::Type *translate (AST::Type &type,
 			       bool default_to_static_lifetime = false);
 
   void visit (AST::BareFunctionType &fntype) override;
@@ -97,7 +97,7 @@ class ASTLowerGenericParam : public ASTLoweringBase
   using Rust::HIR::ASTLoweringBase::visit;
 
 public:
-  static HIR::GenericParam *translate (AST::GenericParam *param);
+  static HIR::GenericParam *translate (AST::GenericParam &param);
 
   void visit (AST::LifetimeParam &param) override;
   void visit (AST::ConstGenericParam &param) override;
@@ -114,7 +114,7 @@ class ASTLoweringTypeBounds : public ASTLoweringBase
   using Rust::HIR::ASTLoweringBase::visit;
 
 public:
-  static HIR::TypeParamBound *translate (AST::TypeParamBound *type);
+  static HIR::TypeParamBound *translate (AST::TypeParamBound &type);
 
   void visit (AST::TraitBound &bound) override;
   void visit (AST::Lifetime &bound) override;

--- a/gcc/rust/resolve/rust-ast-resolve-base.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-base.cc
@@ -30,7 +30,7 @@ ResolverBase::resolve_visibility (const AST::Visibility &vis)
   if (vis.has_path ())
     {
       auto path = vis.get_path ();
-      ResolvePath::go (&path);
+      ResolvePath::go (path);
 
       // Do we need to lookup something here?
       // Is it just about resolving the names correctly so we can look them up

--- a/gcc/rust/resolve/rust-ast-resolve-expr.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.cc
@@ -28,17 +28,17 @@ namespace Rust {
 namespace Resolver {
 
 void
-ResolveExpr::go (AST::Expr *expr, const CanonicalPath &prefix,
+ResolveExpr::go (AST::Expr &expr, const CanonicalPath &prefix,
 		 const CanonicalPath &canonical_prefix, bool funny_error)
 {
   ResolveExpr resolver (prefix, canonical_prefix, funny_error);
-  expr->accept_vis (resolver);
+  expr.accept_vis (resolver);
 }
 
 void
 ResolveExpr::visit (AST::TupleIndexExpr &expr)
 {
-  ResolveExpr::go (expr.get_tuple_expr ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_tuple_expr (), prefix, canonical_prefix);
 }
 
 void
@@ -48,41 +48,40 @@ ResolveExpr::visit (AST::TupleExpr &expr)
     return;
 
   for (auto &elem : expr.get_tuple_elems ())
-    ResolveExpr::go (elem.get (), prefix, canonical_prefix);
+    ResolveExpr::go (*elem, prefix, canonical_prefix);
 }
 
 void
 ResolveExpr::visit (AST::PathInExpression &expr)
 {
-  ResolvePath::go (&expr);
+  ResolvePath::go (expr);
 }
 
 void
 ResolveExpr::visit (AST::QualifiedPathInExpression &expr)
 {
-  ResolvePath::go (&expr);
+  ResolvePath::go (expr);
 }
 
 void
 ResolveExpr::visit (AST::ReturnExpr &expr)
 {
   if (expr.has_returned_expr ())
-    ResolveExpr::go (expr.get_returned_expr ().get (), prefix,
-		     canonical_prefix);
+    ResolveExpr::go (expr.get_returned_expr (), prefix, canonical_prefix);
 }
 
 void
 ResolveExpr::visit (AST::CallExpr &expr)
 {
-  ResolveExpr::go (expr.get_function_expr ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_function_expr (), prefix, canonical_prefix);
   for (auto &param : expr.get_params ())
-    ResolveExpr::go (param.get (), prefix, canonical_prefix);
+    ResolveExpr::go (*param, prefix, canonical_prefix);
 }
 
 void
 ResolveExpr::visit (AST::MethodCallExpr &expr)
 {
-  ResolveExpr::go (expr.get_receiver_expr ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_receiver_expr (), prefix, canonical_prefix);
 
   if (expr.get_method_name ().has_generic_args ())
     {
@@ -92,14 +91,14 @@ ResolveExpr::visit (AST::MethodCallExpr &expr)
 
   auto const &in_params = expr.get_params ();
   for (auto &param : in_params)
-    ResolveExpr::go (param.get (), prefix, canonical_prefix);
+    ResolveExpr::go (*param, prefix, canonical_prefix);
 }
 
 void
 ResolveExpr::visit (AST::AssignmentExpr &expr)
 {
-  ResolveExpr::go (expr.get_left_expr ().get (), prefix, canonical_prefix);
-  ResolveExpr::go (expr.get_right_expr ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_left_expr (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_right_expr (), prefix, canonical_prefix);
 }
 
 /* The "break rust" Easter egg.
@@ -178,63 +177,63 @@ ResolveExpr::visit (AST::IdentifierExpr &expr)
 void
 ResolveExpr::visit (AST::ArithmeticOrLogicalExpr &expr)
 {
-  ResolveExpr::go (expr.get_left_expr ().get (), prefix, canonical_prefix);
-  ResolveExpr::go (expr.get_right_expr ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_left_expr (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_right_expr (), prefix, canonical_prefix);
 }
 
 void
 ResolveExpr::visit (AST::CompoundAssignmentExpr &expr)
 {
-  ResolveExpr::go (expr.get_left_expr ().get (), prefix, canonical_prefix);
-  ResolveExpr::go (expr.get_right_expr ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_left_expr (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_right_expr (), prefix, canonical_prefix);
 }
 
 void
 ResolveExpr::visit (AST::ComparisonExpr &expr)
 {
-  ResolveExpr::go (expr.get_left_expr ().get (), prefix, canonical_prefix);
-  ResolveExpr::go (expr.get_right_expr ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_left_expr (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_right_expr (), prefix, canonical_prefix);
 }
 
 void
 ResolveExpr::visit (AST::LazyBooleanExpr &expr)
 {
-  ResolveExpr::go (expr.get_left_expr ().get (), prefix, canonical_prefix);
-  ResolveExpr::go (expr.get_right_expr ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_left_expr (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_right_expr (), prefix, canonical_prefix);
 }
 
 void
 ResolveExpr::visit (AST::NegationExpr &expr)
 {
-  ResolveExpr::go (expr.get_negated_expr ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_negated_expr (), prefix, canonical_prefix);
 }
 
 void
 ResolveExpr::visit (AST::TypeCastExpr &expr)
 {
-  ResolveType::go (expr.get_type_to_cast_to ().get ());
-  ResolveExpr::go (expr.get_casted_expr ().get (), prefix, canonical_prefix);
+  ResolveType::go (expr.get_type_to_cast_to ());
+  ResolveExpr::go (expr.get_casted_expr (), prefix, canonical_prefix);
 }
 
 void
 ResolveExpr::visit (AST::IfExpr &expr)
 {
-  ResolveExpr::go (expr.get_condition_expr ().get (), prefix, canonical_prefix);
-  ResolveExpr::go (expr.get_if_block ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_condition_expr (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_if_block (), prefix, canonical_prefix);
 }
 
 void
 ResolveExpr::visit (AST::IfExprConseqElse &expr)
 {
-  ResolveExpr::go (expr.get_condition_expr ().get (), prefix, canonical_prefix);
-  ResolveExpr::go (expr.get_if_block ().get (), prefix, canonical_prefix);
-  ResolveExpr::go (expr.get_else_block ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_condition_expr (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_if_block (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_else_block (), prefix, canonical_prefix);
 }
 
 void
 ResolveExpr::visit (AST::IfLetExpr &expr)
 {
-  ResolveExpr::go (expr.get_value_expr ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_value_expr (), prefix, canonical_prefix);
 
   NodeId scope_node_id = expr.get_node_id ();
   resolver->get_name_scope ().push (scope_node_id);
@@ -251,10 +250,10 @@ ResolveExpr::visit (AST::IfLetExpr &expr)
 
   for (auto &pattern : expr.get_patterns ())
     {
-      PatternDeclaration::go (pattern.get (), Rib::ItemType::Var, bindings);
+      PatternDeclaration::go (*pattern, Rib::ItemType::Var, bindings);
     }
 
-  ResolveExpr::go (expr.get_if_block ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_if_block (), prefix, canonical_prefix);
 
   resolver->get_name_scope ().pop ();
   resolver->get_type_scope ().pop ();
@@ -264,7 +263,7 @@ ResolveExpr::visit (AST::IfLetExpr &expr)
 void
 ResolveExpr::visit (AST::IfLetExprConseqElse &expr)
 {
-  ResolveExpr::go (expr.get_value_expr ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_value_expr (), prefix, canonical_prefix);
 
   NodeId scope_node_id = expr.get_node_id ();
   resolver->get_name_scope ().push (scope_node_id);
@@ -281,11 +280,11 @@ ResolveExpr::visit (AST::IfLetExprConseqElse &expr)
 
   for (auto &pattern : expr.get_patterns ())
     {
-      PatternDeclaration::go (pattern.get (), Rib::ItemType::Var, bindings);
+      PatternDeclaration::go (*pattern, Rib::ItemType::Var, bindings);
     }
 
-  ResolveExpr::go (expr.get_if_block ().get (), prefix, canonical_prefix);
-  ResolveExpr::go (expr.get_else_block ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_if_block (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_else_block (), prefix, canonical_prefix);
 
   resolver->get_name_scope ().pop ();
   resolver->get_type_scope ().pop ();
@@ -328,19 +327,19 @@ ResolveExpr::visit (AST::BlockExpr &expr)
   for (auto &s : expr.get_statements ())
     {
       if (s->is_item ())
-	ResolveStmt::go (s.get (), prefix, canonical_prefix,
+	ResolveStmt::go (*s, prefix, canonical_prefix,
 			 CanonicalPath::create_empty ());
     }
 
   for (auto &s : expr.get_statements ())
     {
       if (!s->is_item ())
-	ResolveStmt::go (s.get (), prefix, canonical_prefix,
+	ResolveStmt::go (*s, prefix, canonical_prefix,
 			 CanonicalPath::create_empty ());
     }
 
   if (expr.has_tail_expr ())
-    ResolveExpr::go (expr.get_tail_expr ().get (), prefix, canonical_prefix);
+    ResolveExpr::go (expr.get_tail_expr (), prefix, canonical_prefix);
 
   resolver->get_name_scope ().pop ();
   resolver->get_type_scope ().pop ();
@@ -350,14 +349,14 @@ ResolveExpr::visit (AST::BlockExpr &expr)
 void
 ResolveExpr::visit (AST::UnsafeBlockExpr &expr)
 {
-  expr.get_block_expr ()->accept_vis (*this);
+  expr.get_block_expr ().accept_vis (*this);
 }
 
 void
 ResolveExpr::visit (AST::ArrayElemsValues &elems)
 {
   for (auto &elem : elems.get_values ())
-    ResolveExpr::go (elem.get (), prefix, canonical_prefix);
+    ResolveExpr::go (*elem, prefix, canonical_prefix);
 }
 
 void
@@ -369,55 +368,53 @@ ResolveExpr::visit (AST::ArrayExpr &expr)
 void
 ResolveExpr::visit (AST::ArrayIndexExpr &expr)
 {
-  ResolveExpr::go (expr.get_array_expr ().get (), prefix, canonical_prefix);
-  ResolveExpr::go (expr.get_index_expr ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_array_expr (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_index_expr (), prefix, canonical_prefix);
 }
 
 void
 ResolveExpr::visit (AST::ArrayElemsCopied &expr)
 {
-  ResolveExpr::go (expr.get_num_copies ().get (), prefix, canonical_prefix);
-  ResolveExpr::go (expr.get_elem_to_copy ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_num_copies (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_elem_to_copy (), prefix, canonical_prefix);
 }
 
 // this this an empty struct constructor like 'S {}'
 void
 ResolveExpr::visit (AST::StructExprStruct &struct_expr)
 {
-  ResolveExpr::go (&struct_expr.get_struct_name (), prefix, canonical_prefix);
+  ResolveExpr::go (struct_expr.get_struct_name (), prefix, canonical_prefix);
 }
 
 // this this a struct constructor with fields
 void
 ResolveExpr::visit (AST::StructExprStructFields &struct_expr)
 {
-  ResolveExpr::go (&struct_expr.get_struct_name (), prefix, canonical_prefix);
+  ResolveExpr::go (struct_expr.get_struct_name (), prefix, canonical_prefix);
 
   if (struct_expr.has_struct_base ())
     {
       AST::StructBase &base = struct_expr.get_struct_base ();
-      ResolveExpr::go (base.get_base_struct ().get (), prefix,
-		       canonical_prefix);
+      ResolveExpr::go (base.get_base_struct (), prefix, canonical_prefix);
     }
 
   auto const &struct_fields = struct_expr.get_fields ();
   for (auto &struct_field : struct_fields)
     {
-      ResolveStructExprField::go (struct_field.get (), prefix,
-				  canonical_prefix);
+      ResolveStructExprField::go (*struct_field, prefix, canonical_prefix);
     }
 }
 
 void
 ResolveExpr::visit (AST::GroupedExpr &expr)
 {
-  ResolveExpr::go (expr.get_expr_in_parens ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_expr_in_parens (), prefix, canonical_prefix);
 }
 
 void
 ResolveExpr::visit (AST::FieldAccessExpr &expr)
 {
-  ResolveExpr::go (expr.get_receiver_expr ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_receiver_expr (), prefix, canonical_prefix);
 }
 
 void
@@ -444,7 +441,7 @@ ResolveExpr::visit (AST::LoopExpr &expr)
 	  rust_error_at (locus, "was defined here");
 	});
     }
-  ResolveExpr::go (expr.get_loop_block ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_loop_block (), prefix, canonical_prefix);
 }
 
 void
@@ -477,7 +474,7 @@ ResolveExpr::visit (AST::BreakExpr &expr)
   if (expr.has_break_expr ())
     {
       bool funny_error = false;
-      AST::Expr &break_expr = *expr.get_break_expr ().get ();
+      auto &break_expr = expr.get_break_expr ();
       if (break_expr.get_ast_kind () == AST::Kind::IDENTIFIER)
 	{
 	  /* This is a break with an expression, and the expression is just a
@@ -491,7 +488,7 @@ ResolveExpr::visit (AST::BreakExpr &expr)
 	  if (ident == "rust" || ident == "gcc")
 	    funny_error = true;
 	}
-      ResolveExpr::go (&break_expr, prefix, canonical_prefix, funny_error);
+      ResolveExpr::go (break_expr, prefix, canonical_prefix, funny_error);
     }
 }
 
@@ -520,8 +517,8 @@ ResolveExpr::visit (AST::WhileLoopExpr &expr)
 	});
     }
 
-  ResolveExpr::go (expr.get_predicate_expr ().get (), prefix, canonical_prefix);
-  ResolveExpr::go (expr.get_loop_block ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_predicate_expr (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_loop_block (), prefix, canonical_prefix);
 }
 
 void
@@ -559,9 +556,9 @@ ResolveExpr::visit (AST::ForLoopExpr &expr)
   resolver->push_new_label_rib (resolver->get_type_scope ().peek ());
 
   // resolve the expression
-  PatternDeclaration::go (expr.get_pattern ().get (), Rib::ItemType::Var);
-  ResolveExpr::go (expr.get_iterator_expr ().get (), prefix, canonical_prefix);
-  ResolveExpr::go (expr.get_loop_block ().get (), prefix, canonical_prefix);
+  PatternDeclaration::go (expr.get_pattern (), Rib::ItemType::Var);
+  ResolveExpr::go (expr.get_iterator_expr (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_loop_block (), prefix, canonical_prefix);
 
   // done
   resolver->get_name_scope ().pop ();
@@ -600,20 +597,19 @@ ResolveExpr::visit (AST::ContinueExpr &expr)
 void
 ResolveExpr::visit (AST::BorrowExpr &expr)
 {
-  ResolveExpr::go (expr.get_borrowed_expr ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_borrowed_expr (), prefix, canonical_prefix);
 }
 
 void
 ResolveExpr::visit (AST::DereferenceExpr &expr)
 {
-  ResolveExpr::go (expr.get_dereferenced_expr ().get (), prefix,
-		   canonical_prefix);
+  ResolveExpr::go (expr.get_dereferenced_expr (), prefix, canonical_prefix);
 }
 
 void
 ResolveExpr::visit (AST::MatchExpr &expr)
 {
-  ResolveExpr::go (expr.get_scrutinee_expr ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_scrutinee_expr (), prefix, canonical_prefix);
   for (auto &match_case : expr.get_match_cases ())
     {
       // each arm is in its own scope
@@ -628,8 +624,7 @@ ResolveExpr::visit (AST::MatchExpr &expr)
       // resolve
       AST::MatchArm &arm = match_case.get_arm ();
       if (arm.has_match_arm_guard ())
-	ResolveExpr::go (arm.get_guard_expr ().get (), prefix,
-			 canonical_prefix);
+	ResolveExpr::go (arm.get_guard_expr (), prefix, canonical_prefix);
 
       // We know expr.get_patterns () has one pattern at most
       // so there's no reason to handle it like an AltPattern.
@@ -639,11 +634,11 @@ ResolveExpr::visit (AST::MatchExpr &expr)
       // insert any possible new patterns
       for (auto &pattern : arm.get_patterns ())
 	{
-	  PatternDeclaration::go (pattern.get (), Rib::ItemType::Var, bindings);
+	  PatternDeclaration::go (*pattern, Rib::ItemType::Var, bindings);
 	}
 
       // resolve the body
-      ResolveExpr::go (match_case.get_expr ().get (), prefix, canonical_prefix);
+      ResolveExpr::go (match_case.get_expr (), prefix, canonical_prefix);
 
       // done
       resolver->get_name_scope ().pop ();
@@ -655,20 +650,20 @@ ResolveExpr::visit (AST::MatchExpr &expr)
 void
 ResolveExpr::visit (AST::RangeFromToExpr &expr)
 {
-  ResolveExpr::go (expr.get_from_expr ().get (), prefix, canonical_prefix);
-  ResolveExpr::go (expr.get_to_expr ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_from_expr (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_to_expr (), prefix, canonical_prefix);
 }
 
 void
 ResolveExpr::visit (AST::RangeFromExpr &expr)
 {
-  ResolveExpr::go (expr.get_from_expr ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_from_expr (), prefix, canonical_prefix);
 }
 
 void
 ResolveExpr::visit (AST::RangeToExpr &expr)
 {
-  ResolveExpr::go (expr.get_to_expr ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_to_expr (), prefix, canonical_prefix);
 }
 
 void
@@ -680,8 +675,8 @@ ResolveExpr::visit (AST::RangeFullExpr &)
 void
 ResolveExpr::visit (AST::RangeFromToInclExpr &expr)
 {
-  ResolveExpr::go (expr.get_from_expr ().get (), prefix, canonical_prefix);
-  ResolveExpr::go (expr.get_to_expr ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_from_expr (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_to_expr (), prefix, canonical_prefix);
 }
 
 void
@@ -705,8 +700,7 @@ ResolveExpr::visit (AST::ClosureExprInner &expr)
 
   resolver->push_closure_context (expr.get_node_id ());
 
-  ResolveExpr::go (expr.get_definition_expr ().get (), prefix,
-		   canonical_prefix);
+  ResolveExpr::go (expr.get_definition_expr (), prefix, canonical_prefix);
 
   resolver->pop_closure_context ();
 
@@ -734,12 +728,11 @@ ResolveExpr::visit (AST::ClosureExprInnerTyped &expr)
       resolve_closure_param (p, bindings);
     }
 
-  ResolveType::go (expr.get_return_type ().get ());
+  ResolveType::go (expr.get_return_type ());
 
   resolver->push_closure_context (expr.get_node_id ());
 
-  ResolveExpr::go (expr.get_definition_block ().get (), prefix,
-		   canonical_prefix);
+  ResolveExpr::go (expr.get_definition_block (), prefix, canonical_prefix);
 
   resolver->pop_closure_context ();
 
@@ -752,11 +745,10 @@ void
 ResolveExpr::resolve_closure_param (AST::ClosureParam &param,
 				    std::vector<PatternBinding> &bindings)
 {
-  PatternDeclaration::go (param.get_pattern ().get (), Rib::ItemType::Param,
-			  bindings);
+  PatternDeclaration::go (param.get_pattern (), Rib::ItemType::Param, bindings);
 
   if (param.has_type_given ())
-    ResolveType::go (param.get_type ().get ());
+    ResolveType::go (param.get_type ());
 }
 
 ResolveExpr::ResolveExpr (const CanonicalPath &prefix,

--- a/gcc/rust/resolve/rust-ast-resolve-expr.h
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.h
@@ -30,7 +30,7 @@ class ResolveExpr : public ResolverBase
   using Rust::Resolver::ResolverBase::visit;
 
 public:
-  static void go (AST::Expr *expr, const CanonicalPath &prefix,
+  static void go (AST::Expr &expr, const CanonicalPath &prefix,
 		  const CanonicalPath &canonical_prefix,
 		  bool funny_error = false);
 

--- a/gcc/rust/resolve/rust-ast-resolve-implitem.h
+++ b/gcc/rust/resolve/rust-ast-resolve-implitem.h
@@ -31,13 +31,13 @@ class ResolveToplevelImplItem : public ResolverBase
   using Rust::Resolver::ResolverBase::visit;
 
 public:
-  static void go (AST::AssociatedItem *item, const CanonicalPath &prefix)
+  static void go (AST::AssociatedItem &item, const CanonicalPath &prefix)
   {
-    if (item->is_marked_for_strip ())
+    if (item.is_marked_for_strip ())
       return;
 
     ResolveToplevelImplItem resolver (prefix);
-    item->accept_vis (resolver);
+    item.accept_vis (resolver);
   }
 
   void visit (AST::TypeAlias &type) override
@@ -183,10 +183,10 @@ class ResolveToplevelExternItem : public ResolverBase
   using Rust::Resolver::ResolverBase::visit;
 
 public:
-  static void go (AST::ExternalItem *item, const CanonicalPath &prefix)
+  static void go (AST::ExternalItem &item, const CanonicalPath &prefix)
   {
     ResolveToplevelExternItem resolver (prefix);
-    item->accept_vis (resolver);
+    item.accept_vis (resolver);
   };
 
   void visit (AST::Function &function) override

--- a/gcc/rust/resolve/rust-ast-resolve-item.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-item.cc
@@ -65,10 +65,10 @@ ResolveTraitItems::visit (AST::Function &function)
 
   if (function.has_generics ())
     for (auto &generic : function.get_generic_params ())
-      ResolveGenericParam::go (generic.get (), prefix, canonical_prefix);
+      ResolveGenericParam::go (*generic, prefix, canonical_prefix);
 
   if (function.has_return_type ())
-    ResolveType::go (function.get_return_type ().get ());
+    ResolveType::go (function.get_return_type ());
 
   // self turns into (self: Self) as a function param
   std::vector<PatternBinding> bindings
@@ -80,45 +80,45 @@ ResolveTraitItems::visit (AST::Function &function)
     {
       if (p->is_variadic ())
 	{
-	  auto param = static_cast<AST::VariadicParam *> (p.get ());
-	  PatternDeclaration::go (param->get_pattern ().get (),
-				  Rib::ItemType::Param, bindings);
+	  auto param = static_cast<AST::VariadicParam &> (*p);
+	  PatternDeclaration::go (param.get_pattern (), Rib::ItemType::Param,
+				  bindings);
 	}
       else if (p->is_self ())
 	{
-	  auto param = static_cast<AST::SelfParam *> (p.get ());
+	  auto &param = static_cast<AST::SelfParam &> (*p);
 	  // FIXME: which location should be used for Rust::Identifier `self`?
 	  AST::IdentifierPattern self_pattern (
-	    param->get_node_id (), {"self"}, param->get_locus (),
-	    param->get_has_ref (), param->get_is_mut (),
+	    param.get_node_id (), {"self"}, param.get_locus (),
+	    param.get_has_ref (), param.get_is_mut (),
 	    std::unique_ptr<AST::Pattern> (nullptr));
 
-	  PatternDeclaration::go (&self_pattern, Rib::ItemType::Param);
+	  PatternDeclaration::go (self_pattern, Rib::ItemType::Param);
 
-	  if (param->has_type ())
+	  if (param.has_type ())
 	    {
 	      // This shouldn't happen the parser should already error for this
-	      rust_assert (!param->get_has_ref ());
-	      ResolveType::go (param->get_type ().get ());
+	      rust_assert (!param.get_has_ref ());
+	      ResolveType::go (param.get_type ());
 	    }
 	  else
 	    {
 	      // here we implicitly make self have a type path of Self
 	      std::vector<std::unique_ptr<AST::TypePathSegment>> segments;
 	      segments.push_back (std::unique_ptr<AST::TypePathSegment> (
-		new AST::TypePathSegment ("Self", false, param->get_locus ())));
+		new AST::TypePathSegment ("Self", false, param.get_locus ())));
 
 	      AST::TypePath self_type_path (std::move (segments),
-					    param->get_locus ());
-	      ResolveType::go (&self_type_path);
+					    param.get_locus ());
+	      ResolveType::go (self_type_path);
 	    }
 	}
       else
 	{
-	  auto param = static_cast<AST::FunctionParam *> (p.get ());
-	  ResolveType::go (param->get_type ().get ());
-	  PatternDeclaration::go (param->get_pattern ().get (),
-				  Rib::ItemType::Param, bindings);
+	  auto &param = static_cast<AST::FunctionParam &> (*p);
+	  ResolveType::go (param.get_type ());
+	  PatternDeclaration::go (param.get_pattern (), Rib::ItemType::Param,
+				  bindings);
 	}
     }
 
@@ -127,7 +127,7 @@ ResolveTraitItems::visit (AST::Function &function)
 
   // trait items have an optional body
   if (function.has_body ())
-    ResolveExpr::go (function.get_definition ()->get (), path, cpath);
+    ResolveExpr::go (*function.get_definition ().value (), path, cpath);
 
   resolver->get_name_scope ().pop ();
   resolver->get_type_scope ().pop ();
@@ -143,7 +143,7 @@ ResolveTraitItems::visit (AST::TraitItemType &type)
   mappings->insert_canonical_path (type.get_node_id (), cpath);
 
   for (auto &bound : type.get_type_param_bounds ())
-    ResolveTypeBound::go (bound.get ());
+    ResolveTypeBound::go (*bound);
 }
 
 void
@@ -155,10 +155,10 @@ ResolveTraitItems::visit (AST::TraitItemConst &constant)
   auto cpath = canonical_prefix.append (decl);
   mappings->insert_canonical_path (constant.get_node_id (), cpath);
 
-  ResolveType::go (constant.get_type ().get ());
+  ResolveType::go (constant.get_type ());
 
   if (constant.has_expr ())
-    ResolveExpr::go (constant.get_expr ().get (), path, cpath);
+    ResolveExpr::go (constant.get_expr (), path, cpath);
 }
 
 ResolveItem::ResolveItem (const CanonicalPath &prefix,
@@ -167,11 +167,11 @@ ResolveItem::ResolveItem (const CanonicalPath &prefix,
 {}
 
 void
-ResolveItem::go (AST::Item *item, const CanonicalPath &prefix,
+ResolveItem::go (AST::Item &item, const CanonicalPath &prefix,
 		 const CanonicalPath &canonical_prefix)
 {
   ResolveItem resolver (prefix, canonical_prefix);
-  item->accept_vis (resolver);
+  item.accept_vis (resolver);
 }
 
 void
@@ -189,12 +189,12 @@ ResolveItem::visit (AST::TypeAlias &alias)
 
   if (alias.has_generics ())
     for (auto &generic : alias.get_generic_params ())
-      ResolveGenericParam::go (generic.get (), prefix, canonical_prefix);
+      ResolveGenericParam::go (*generic, prefix, canonical_prefix);
 
   if (alias.has_where_clause ())
     ResolveWhereClause::Resolve (alias.get_where_clause ());
 
-  ResolveType::go (alias.get_type_aliased ().get ());
+  ResolveType::go (alias.get_type_aliased ());
 
   resolver->get_type_scope ().pop ();
 }
@@ -221,11 +221,11 @@ ResolveItem::visit (AST::Module &module)
   // FIXME: Should we reinsert a child here? Any reason we ResolveTopLevel::go
   // in ResolveTopLevel::visit (AST::Module) as well as here?
   for (auto &item : module.get_items ())
-    ResolveTopLevel::go (item.get (), CanonicalPath::create_empty (), cpath);
+    ResolveTopLevel::go (*item, CanonicalPath::create_empty (), cpath);
 
   resolver->push_new_module_scope (module.get_node_id ());
   for (auto &item : module.get_items ())
-    ResolveItem::go (item.get (), path, cpath);
+    ResolveItem::go (*item, path, cpath);
 
   resolver->pop_module_scope ();
 
@@ -251,19 +251,19 @@ ResolveItem::visit (AST::TupleStruct &struct_decl)
 
   if (struct_decl.has_generics ())
     for (auto &generic : struct_decl.get_generic_params ())
-      ResolveGenericParam::go (generic.get (), prefix, canonical_prefix);
+      ResolveGenericParam::go (*generic, prefix, canonical_prefix);
 
   if (struct_decl.has_where_clause ())
     ResolveWhereClause::Resolve (struct_decl.get_where_clause ());
 
   for (AST::TupleField &field : struct_decl.get_fields ())
     {
-      if (field.get_field_type ()->is_marked_for_strip ())
+      if (field.get_field_type ().is_marked_for_strip ())
 	continue;
 
       resolve_visibility (field.get_visibility ());
 
-      ResolveType::go (field.get_field_type ().get ());
+      ResolveType::go (field.get_field_type ());
     }
 
   resolver->get_type_scope ().pop ();
@@ -285,14 +285,14 @@ ResolveItem::visit (AST::Enum &enum_decl)
 
   if (enum_decl.has_generics ())
     for (auto &generic : enum_decl.get_generic_params ())
-      ResolveGenericParam::go (generic.get (), prefix, cpath);
+      ResolveGenericParam::go (*generic, prefix, cpath);
 
   if (enum_decl.has_where_clause ())
     ResolveWhereClause::Resolve (enum_decl.get_where_clause ());
 
   /* The actual fields are inside the variants.  */
   for (auto &variant : enum_decl.get_variants ())
-    ResolveItem::go (variant.get (), path, cpath);
+    ResolveItem::go (*variant, path, cpath);
 
   resolver->get_type_scope ().pop ();
 }
@@ -322,10 +322,10 @@ ResolveItem::visit (AST::EnumItemTuple &item)
 
   for (auto &field : item.get_tuple_fields ())
     {
-      if (field.get_field_type ()->is_marked_for_strip ())
+      if (field.get_field_type ().is_marked_for_strip ())
 	continue;
 
-      ResolveType::go (field.get_field_type ().get ());
+      ResolveType::go (field.get_field_type ());
     }
 }
 
@@ -340,10 +340,10 @@ ResolveItem::visit (AST::EnumItemStruct &item)
 
   for (auto &field : item.get_struct_fields ())
     {
-      if (field.get_field_type ()->is_marked_for_strip ())
+      if (field.get_field_type ().is_marked_for_strip ())
 	continue;
 
-      ResolveType::go (field.get_field_type ().get ());
+      ResolveType::go (field.get_field_type ());
     }
 }
 
@@ -375,19 +375,19 @@ ResolveItem::visit (AST::StructStruct &struct_decl)
 
   if (struct_decl.has_generics ())
     for (auto &generic : struct_decl.get_generic_params ())
-      ResolveGenericParam::go (generic.get (), prefix, canonical_prefix);
+      ResolveGenericParam::go (*generic, prefix, canonical_prefix);
 
   if (struct_decl.has_where_clause ())
     ResolveWhereClause::Resolve (struct_decl.get_where_clause ());
 
   for (AST::StructField &field : struct_decl.get_fields ())
     {
-      if (field.get_field_type ()->is_marked_for_strip ())
+      if (field.get_field_type ().is_marked_for_strip ())
 	continue;
 
       resolve_visibility (field.get_visibility ());
 
-      ResolveType::go (field.get_field_type ().get ());
+      ResolveType::go (field.get_field_type ());
     }
 
   resolver->get_type_scope ().pop ();
@@ -410,17 +410,17 @@ ResolveItem::visit (AST::Union &union_decl)
 
   if (union_decl.has_generics ())
     for (auto &generic : union_decl.get_generic_params ())
-      ResolveGenericParam::go (generic.get (), prefix, canonical_prefix);
+      ResolveGenericParam::go (*generic, prefix, canonical_prefix);
 
   if (union_decl.has_where_clause ())
     ResolveWhereClause::Resolve (union_decl.get_where_clause ());
 
   for (AST::StructField &field : union_decl.get_variants ())
     {
-      if (field.get_field_type ()->is_marked_for_strip ())
+      if (field.get_field_type ().is_marked_for_strip ())
 	continue;
 
-      ResolveType::go (field.get_field_type ().get ());
+      ResolveType::go (field.get_field_type ());
     }
 
   resolver->get_type_scope ().pop ();
@@ -435,8 +435,8 @@ ResolveItem::visit (AST::StaticItem &var)
   auto cpath = canonical_prefix.append (decl);
   mappings->insert_canonical_path (var.get_node_id (), cpath);
 
-  ResolveType::go (var.get_type ().get ());
-  ResolveExpr::go (var.get_expr ().get (), path, cpath);
+  ResolveType::go (var.get_type ());
+  ResolveExpr::go (var.get_expr (), path, cpath);
 }
 
 void
@@ -450,8 +450,8 @@ ResolveItem::visit (AST::ConstantItem &constant)
 
   resolve_visibility (constant.get_visibility ());
 
-  ResolveType::go (constant.get_type ().get ());
-  ResolveExpr::go (constant.get_expr ().get (), path, cpath);
+  ResolveType::go (constant.get_type ());
+  ResolveExpr::go (constant.get_expr (), path, cpath);
 }
 
 void
@@ -477,14 +477,14 @@ ResolveItem::visit (AST::Function &function)
 
   if (function.has_generics ())
     for (auto &generic : function.get_generic_params ())
-      ResolveGenericParam::go (generic.get (), prefix, canonical_prefix);
+      ResolveGenericParam::go (*generic, prefix, canonical_prefix);
 
   // resolve any where clause items
   if (function.has_where_clause ())
     ResolveWhereClause::Resolve (function.get_where_clause ());
 
   if (function.has_return_type ())
-    ResolveType::go (function.get_return_type ().get ());
+    ResolveType::go (function.get_return_type ());
 
   if (function.has_self_param ())
     {
@@ -497,13 +497,13 @@ ResolveItem::visit (AST::Function &function)
 	self_param.get_node_id (), {"self"}, self_param.get_locus (),
 	self_param.get_has_ref (), self_param.get_is_mut (),
 	std::unique_ptr<AST::Pattern> (nullptr));
-      PatternDeclaration::go (&self_pattern, Rib::ItemType::Param);
+      PatternDeclaration::go (self_pattern, Rib::ItemType::Param);
 
       if (self_param.has_type ())
 	{
 	  // This shouldn't happen the parser should already error for this
 	  rust_assert (!self_param.get_has_ref ());
-	  ResolveType::go (self_param.get_type ().get ());
+	  ResolveType::go (self_param.get_type ());
 	}
       else
 	{
@@ -514,7 +514,7 @@ ResolveItem::visit (AST::Function &function)
 
 	  AST::TypePath self_type_path (std::move (segments),
 					self_param.get_locus ());
-	  ResolveType::go (&self_type_path);
+	  ResolveType::go (self_type_path);
 	}
     }
 
@@ -527,28 +527,28 @@ ResolveItem::visit (AST::Function &function)
     {
       if (p->is_variadic ())
 	{
-	  auto param = static_cast<AST::VariadicParam *> (p.get ());
-	  if (param->has_pattern ())
-	    PatternDeclaration::go (param->get_pattern ().get (),
-				    Rib::ItemType::Param, bindings);
+	  auto &param = static_cast<AST::VariadicParam &> (*p);
+	  if (param.has_pattern ())
+	    PatternDeclaration::go (param.get_pattern (), Rib::ItemType::Param,
+				    bindings);
 	}
       else if (p->is_self ())
 	{
-	  auto param = static_cast<AST::SelfParam *> (p.get ());
-	  if (param->has_type ())
-	    ResolveType::go (param->get_type ().get ());
+	  auto &param = static_cast<AST::SelfParam &> (*p);
+	  if (param.has_type ())
+	    ResolveType::go (param.get_type ());
 	}
       else
 	{
-	  auto param = static_cast<AST::FunctionParam *> (p.get ());
-	  ResolveType::go (param->get_type ().get ());
-	  PatternDeclaration::go (param->get_pattern ().get (),
-				  Rib::ItemType::Param, bindings);
+	  auto &param = static_cast<AST::FunctionParam &> (*p);
+	  ResolveType::go (param.get_type ());
+	  PatternDeclaration::go (param.get_pattern (), Rib::ItemType::Param,
+				  bindings);
 	}
     }
 
   // resolve the function body
-  ResolveExpr::go (function.get_definition ()->get (), path, cpath);
+  ResolveExpr::go (*function.get_definition ().value (), path, cpath);
 
   resolver->get_name_scope ().pop ();
   resolver->get_type_scope ().pop ();
@@ -568,7 +568,7 @@ ResolveItem::visit (AST::InherentImpl &impl_block)
 
   if (impl_block.has_generics ())
     for (auto &generic : impl_block.get_generic_params ())
-      ResolveGenericParam::go (generic.get (), prefix, canonical_prefix);
+      ResolveGenericParam::go (*generic, prefix, canonical_prefix);
 
   // resolve any where clause items
   if (impl_block.has_where_clause ())
@@ -577,12 +577,11 @@ ResolveItem::visit (AST::InherentImpl &impl_block)
   // FIXME this needs to be protected behind nominal type-checks see:
   // rustc --explain E0118
   // issue #2634
-  ResolveType::go (impl_block.get_type ().get ());
+  ResolveType::go (impl_block.get_type ());
 
   // Setup paths
   CanonicalPath self_cpath = CanonicalPath::create_empty ();
-  bool ok = ResolveTypeToCanonicalPath::go (impl_block.get_type ().get (),
-					    self_cpath);
+  bool ok = ResolveTypeToCanonicalPath::go (impl_block.get_type (), self_cpath);
   rust_assert (ok);
   rust_debug ("AST::InherentImpl resolve Self: {%s}",
 	      self_cpath.get ().c_str ());
@@ -609,22 +608,22 @@ ResolveItem::visit (AST::InherentImpl &impl_block)
   // done setup paths
 
   auto Self
-    = CanonicalPath::get_big_self (impl_block.get_type ()->get_node_id ());
+    = CanonicalPath::get_big_self (impl_block.get_type ().get_node_id ());
 
   resolver->get_type_scope ().insert (Self,
-				      impl_block.get_type ()->get_node_id (),
-				      impl_block.get_type ()->get_locus ());
+				      impl_block.get_type ().get_node_id (),
+				      impl_block.get_type ().get_locus ());
 
   for (auto &impl_item : impl_block.get_impl_items ())
     {
       rust_debug (
 	"AST::InherentImpl resolve_impl_item: impl_prefix={%s} cpath={%s}",
 	impl_prefix.get ().c_str (), cpath.get ().c_str ());
-      resolve_impl_item (impl_item.get (), impl_prefix, cpath);
+      resolve_impl_item (*impl_item, impl_prefix, cpath);
     }
 
   resolver->get_type_scope ().peek ()->clear_name (
-    Self, impl_block.get_type ()->get_node_id ());
+    Self, impl_block.get_type ().get_node_id ());
 
   resolver->get_type_scope ().pop ();
   resolver->get_name_scope ().pop ();
@@ -646,14 +645,14 @@ ResolveItem::visit (AST::TraitImpl &impl_block)
 
   if (impl_block.has_generics ())
     for (auto &generic : impl_block.get_generic_params ())
-      ResolveGenericParam::go (generic.get (), prefix, canonical_prefix);
+      ResolveGenericParam::go (*generic, prefix, canonical_prefix);
 
   // resolve any where clause items
   if (impl_block.has_where_clause ())
     ResolveWhereClause::Resolve (impl_block.get_where_clause ());
 
   // CanonicalPath canonical_trait_type = CanonicalPath::create_empty ();
-  NodeId trait_resolved_node = ResolveType::go (&impl_block.get_trait_path ());
+  NodeId trait_resolved_node = ResolveType::go (impl_block.get_trait_path ());
   if (trait_resolved_node == UNKNOWN_NODEID)
     {
       resolver->get_name_scope ().pop ();
@@ -663,7 +662,7 @@ ResolveItem::visit (AST::TraitImpl &impl_block)
     }
 
   //   CanonicalPath canonical_impl_type = CanonicalPath::create_empty ();
-  NodeId type_resolved_node = ResolveType::go (impl_block.get_type ().get ());
+  NodeId type_resolved_node = ResolveType::go (impl_block.get_type ());
   if (type_resolved_node == UNKNOWN_NODEID)
     {
       resolver->get_name_scope ().pop ();
@@ -675,7 +674,7 @@ ResolveItem::visit (AST::TraitImpl &impl_block)
   bool ok;
   // setup paths
   CanonicalPath canonical_trait_type = CanonicalPath::create_empty ();
-  ok = ResolveTypeToCanonicalPath::go (&impl_block.get_trait_path (),
+  ok = ResolveTypeToCanonicalPath::go (impl_block.get_trait_path (),
 				       canonical_trait_type);
   rust_assert (ok);
 
@@ -683,7 +682,7 @@ ResolveItem::visit (AST::TraitImpl &impl_block)
 	      canonical_trait_type.get ().c_str ());
 
   CanonicalPath canonical_impl_type = CanonicalPath::create_empty ();
-  ok = ResolveTypeToCanonicalPath::go (impl_block.get_type ().get (),
+  ok = ResolveTypeToCanonicalPath::go (impl_block.get_type (),
 				       canonical_impl_type);
   rust_assert (ok);
 
@@ -722,22 +721,22 @@ ResolveItem::visit (AST::TraitImpl &impl_block)
   // DONE setup canonical-path
 
   auto Self
-    = CanonicalPath::get_big_self (impl_block.get_type ()->get_node_id ());
+    = CanonicalPath::get_big_self (impl_block.get_type ().get_node_id ());
 
   resolver->get_type_scope ().insert (Self,
-				      impl_block.get_type ()->get_node_id (),
-				      impl_block.get_type ()->get_locus ());
+				      impl_block.get_type ().get_node_id (),
+				      impl_block.get_type ().get_locus ());
 
   for (auto &impl_item : impl_block.get_impl_items ())
     {
       rust_debug (
 	"AST::TraitImpl resolve_impl_item: impl_prefix={%s} cpath={%s}",
 	impl_prefix.get ().c_str (), cpath.get ().c_str ());
-      resolve_impl_item (impl_item.get (), impl_prefix, cpath);
+      resolve_impl_item (*impl_item, impl_prefix, cpath);
     }
 
   Rib *r = resolver->get_type_scope ().peek ();
-  r->clear_name (Self, impl_block.get_type ()->get_node_id ());
+  r->clear_name (Self, impl_block.get_type ().get_node_id ());
 
   resolver->get_name_scope ().pop ();
   resolver->get_type_scope ().pop ();
@@ -765,7 +764,7 @@ ResolveItem::visit (AST::Trait &trait)
   CanonicalPath Self = CanonicalPath::get_big_self (trait.get_node_id ());
 
   for (auto &generic : trait.get_generic_params ())
-    ResolveGenericParam::go (generic.get (), prefix, canonical_prefix);
+    ResolveGenericParam::go (*generic, prefix, canonical_prefix);
 
   // Self is an implicit TypeParam so lets mark it as such
   resolver->get_type_scope ().append_reference_for_def (
@@ -775,7 +774,7 @@ ResolveItem::visit (AST::Trait &trait)
     {
       for (auto &bound : trait.get_type_param_bounds ())
 	{
-	  ResolveTypeBound::go (bound.get ());
+	  ResolveTypeBound::go (*bound);
 	}
     }
 
@@ -804,12 +803,12 @@ ResolveItem::visit (AST::ExternBlock &extern_block)
 
   for (auto &item : extern_block.get_extern_items ())
     {
-      resolve_extern_item (item.get ());
+      resolve_extern_item (*item);
     }
 }
 
 void
-ResolveItem::resolve_impl_item (AST::AssociatedItem *item,
+ResolveItem::resolve_impl_item (AST::AssociatedItem &item,
 				const CanonicalPath &prefix,
 				const CanonicalPath &canonical_prefix)
 {
@@ -817,7 +816,7 @@ ResolveItem::resolve_impl_item (AST::AssociatedItem *item,
 }
 
 void
-ResolveItem::resolve_extern_item (AST::ExternalItem *item)
+ResolveItem::resolve_extern_item (AST::ExternalItem &item)
 {
   ResolveExternItem::go (item, prefix, canonical_prefix);
 }
@@ -953,7 +952,7 @@ ResolveItem::visit (AST::UseDeclaration &use_item)
       auto &path = import.get_path ();
 
       rust_debug ("resolving use-decl path: [%s]", path.as_string ().c_str ());
-      NodeId resolved_node_id = ResolvePath::go (&path);
+      NodeId resolved_node_id = ResolvePath::go (path);
       bool ok = resolved_node_id != UNKNOWN_NODEID;
       if (!ok)
 	continue;
@@ -977,14 +976,14 @@ ResolveImplItems::ResolveImplItems (const CanonicalPath &prefix,
 {}
 
 void
-ResolveImplItems::go (AST::AssociatedItem *item, const CanonicalPath &prefix,
+ResolveImplItems::go (AST::AssociatedItem &item, const CanonicalPath &prefix,
 		      const CanonicalPath &canonical_prefix)
 {
-  if (item->is_marked_for_strip ())
+  if (item.is_marked_for_strip ())
     return;
 
   ResolveImplItems resolver (prefix, canonical_prefix);
-  item->accept_vis (resolver);
+  item.accept_vis (resolver);
 }
 
 void
@@ -1000,11 +999,11 @@ ResolveImplItems::visit (AST::TypeAlias &alias)
 }
 
 void
-ResolveExternItem::go (AST::ExternalItem *item, const CanonicalPath &prefix,
+ResolveExternItem::go (AST::ExternalItem &item, const CanonicalPath &prefix,
 		       const CanonicalPath &canonical_prefix)
 {
   ResolveExternItem resolver (prefix, canonical_prefix);
-  item->accept_vis (resolver);
+  item.accept_vis (resolver);
 }
 
 void
@@ -1031,18 +1030,18 @@ ResolveExternItem::visit (AST::Function &function)
   // resolve the generics
   if (function.has_generics ())
     for (auto &generic : function.get_generic_params ())
-      ResolveGenericParam::go (generic.get (), prefix, canonical_prefix);
+      ResolveGenericParam::go (*generic, prefix, canonical_prefix);
 
   if (function.has_return_type ())
-    ResolveType::go (function.get_return_type ().get ());
+    ResolveType::go (function.get_return_type ());
 
   // we make a new scope so the names of parameters are resolved and shadowed
   // correctly
-  for (auto &it : function.get_function_params ())
-    if (!it->is_variadic ())
+  for (auto &param : function.get_function_params ())
+    if (!param->is_variadic ())
       {
-	auto param = static_cast<AST::FunctionParam *> (it.get ());
-	ResolveType::go (param->get_type ().get ());
+	auto &p = static_cast<AST::FunctionParam &> (*param);
+	ResolveType::go (p.get_type ());
       }
 
   // done
@@ -1056,7 +1055,7 @@ ResolveExternItem::visit (AST::ExternalStaticItem &item)
 {
   resolve_visibility (item.get_visibility ());
 
-  ResolveType::go (item.get_type ().get ());
+  ResolveType::go (item.get_type ());
 }
 
 } // namespace Resolver

--- a/gcc/rust/resolve/rust-ast-resolve-item.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-item.cc
@@ -489,32 +489,31 @@ ResolveItem::visit (AST::Function &function)
   if (function.has_self_param ())
     {
       // self turns into (self: Self) as a function param
-      std::unique_ptr<AST::Param> &s_param = function.get_self_param ();
-      auto self_param = static_cast<AST::SelfParam *> (s_param.get ());
+      AST::Param &s_param = function.get_self_param ();
+      auto &self_param = static_cast<AST::SelfParam &> (s_param);
 
       // FIXME: which location should be used for Rust::Identifier `self`?
       AST::IdentifierPattern self_pattern (
-	self_param->get_node_id (), {"self"}, self_param->get_locus (),
-	self_param->get_has_ref (), self_param->get_is_mut (),
+	self_param.get_node_id (), {"self"}, self_param.get_locus (),
+	self_param.get_has_ref (), self_param.get_is_mut (),
 	std::unique_ptr<AST::Pattern> (nullptr));
       PatternDeclaration::go (&self_pattern, Rib::ItemType::Param);
 
-      if (self_param->has_type ())
+      if (self_param.has_type ())
 	{
 	  // This shouldn't happen the parser should already error for this
-	  rust_assert (!self_param->get_has_ref ());
-	  ResolveType::go (self_param->get_type ().get ());
+	  rust_assert (!self_param.get_has_ref ());
+	  ResolveType::go (self_param.get_type ().get ());
 	}
       else
 	{
 	  // here we implicitly make self have a type path of Self
 	  std::vector<std::unique_ptr<AST::TypePathSegment>> segments;
 	  segments.push_back (std::unique_ptr<AST::TypePathSegment> (
-	    new AST::TypePathSegment ("Self", false,
-				      self_param->get_locus ())));
+	    new AST::TypePathSegment ("Self", false, self_param.get_locus ())));
 
 	  AST::TypePath self_type_path (std::move (segments),
-					self_param->get_locus ());
+					self_param.get_locus ());
 	  ResolveType::go (&self_type_path);
 	}
     }

--- a/gcc/rust/resolve/rust-ast-resolve-item.h
+++ b/gcc/rust/resolve/rust-ast-resolve-item.h
@@ -52,7 +52,7 @@ class ResolveItem : public ResolverBase
 public:
   using Rust::Resolver::ResolverBase::visit;
 
-  static void go (AST::Item *item, const CanonicalPath &prefix,
+  static void go (AST::Item &item, const CanonicalPath &prefix,
 		  const CanonicalPath &canonical_prefix);
 
   void visit (AST::TypeAlias &alias) override;
@@ -76,10 +76,10 @@ public:
   void visit (AST::UseDeclaration &) override;
 
 protected:
-  void resolve_impl_item (AST::AssociatedItem *item,
+  void resolve_impl_item (AST::AssociatedItem &item,
 			  const CanonicalPath &prefix,
 			  const CanonicalPath &canonical_prefix);
-  void resolve_extern_item (AST::ExternalItem *item);
+  void resolve_extern_item (AST::ExternalItem &item);
 
   ResolveItem (const CanonicalPath &prefix,
 	       const CanonicalPath &canonical_prefix);
@@ -93,7 +93,7 @@ class ResolveImplItems : public ResolveItem
   using Rust::Resolver::ResolveItem::visit;
 
 public:
-  static void go (AST::AssociatedItem *item, const CanonicalPath &prefix,
+  static void go (AST::AssociatedItem &item, const CanonicalPath &prefix,
 		  const CanonicalPath &canonical_prefix);
 
   void visit (AST::TypeAlias &alias) override;
@@ -108,7 +108,7 @@ class ResolveExternItem : public ResolverBase
   using Rust::Resolver::ResolverBase::visit;
 
 public:
-  static void go (AST::ExternalItem *item, const CanonicalPath &prefix,
+  static void go (AST::ExternalItem &item, const CanonicalPath &prefix,
 		  const CanonicalPath &canonical_prefix);
 
   void visit (AST::Function &function) override;

--- a/gcc/rust/resolve/rust-ast-resolve-path.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-path.cc
@@ -26,35 +26,35 @@ namespace Resolver {
 ResolvePath::ResolvePath () : ResolverBase () {}
 
 NodeId
-ResolvePath::go (AST::PathInExpression *expr)
+ResolvePath::go (AST::PathInExpression &expr)
 {
   ResolvePath resolver;
   return resolver.resolve_path (expr);
 }
 
 NodeId
-ResolvePath::go (AST::QualifiedPathInExpression *expr)
+ResolvePath::go (AST::QualifiedPathInExpression &expr)
 {
   ResolvePath resolver;
   return resolver.resolve_path (expr);
 }
 
 NodeId
-ResolvePath::go (AST::SimplePath *expr)
+ResolvePath::go (AST::SimplePath &expr)
 {
   ResolvePath resolver;
   return resolver.resolve_path (expr);
 }
 
 NodeId
-ResolvePath::resolve_path (AST::PathInExpression *expr)
+ResolvePath::resolve_path (AST::PathInExpression &expr)
 {
   NodeId resolved_node_id = UNKNOWN_NODEID;
   NodeId module_scope_id = resolver->peek_current_module_scope ();
   NodeId previous_resolved_node_id = module_scope_id;
-  for (size_t i = 0; i < expr->get_segments ().size (); i++)
+  for (size_t i = 0; i < expr.get_segments ().size (); i++)
     {
-      auto &segment = expr->get_segments ().at (i);
+      auto &segment = expr.get_segments ().at (i);
       const AST::PathIdentSegment &ident_seg = segment.get_ident_segment ();
       bool is_first_segment = i == 0;
       resolved_node_id = UNKNOWN_NODEID;
@@ -219,14 +219,14 @@ ResolvePath::resolve_path (AST::PathInExpression *expr)
       // name scope first
       if (resolver->get_name_scope ().decl_was_declared_here (resolved_node_id))
 	{
-	  resolver->insert_resolved_name (expr->get_node_id (),
+	  resolver->insert_resolved_name (expr.get_node_id (),
 					  resolved_node_id);
 	}
       // check the type scope
       else if (resolver->get_type_scope ().decl_was_declared_here (
 		 resolved_node_id))
 	{
-	  resolver->insert_resolved_type (expr->get_node_id (),
+	  resolver->insert_resolved_type (expr.get_node_id (),
 					  resolved_node_id);
 	}
       else
@@ -238,14 +238,14 @@ ResolvePath::resolve_path (AST::PathInExpression *expr)
 }
 
 NodeId
-ResolvePath::resolve_path (AST::QualifiedPathInExpression *expr)
+ResolvePath::resolve_path (AST::QualifiedPathInExpression &expr)
 {
-  AST::QualifiedPathType &root_segment = expr->get_qualified_path_type ();
-  ResolveType::go (root_segment.get_type ().get ());
+  auto &root_segment = expr.get_qualified_path_type ();
+  ResolveType::go (root_segment.get_type ());
   if (root_segment.has_as_clause ())
-    ResolveType::go (&root_segment.get_as_type_path ());
+    ResolveType::go (root_segment.get_as_type_path ());
 
-  for (auto &segment : expr->get_segments ())
+  for (auto &segment : expr.get_segments ())
     {
       // we cant actually do anything with the segment itself since this is all
       // the job of the type system to figure it out but we can resolve any
@@ -260,18 +260,18 @@ ResolvePath::resolve_path (AST::QualifiedPathInExpression *expr)
 }
 
 NodeId
-ResolvePath::resolve_path (AST::SimplePath *expr)
+ResolvePath::resolve_path (AST::SimplePath &expr)
 {
   NodeId crate_scope_id = resolver->peek_crate_module_scope ();
   NodeId module_scope_id = resolver->peek_current_module_scope ();
 
   NodeId previous_resolved_node_id = UNKNOWN_NODEID;
   NodeId resolved_node_id = UNKNOWN_NODEID;
-  for (size_t i = 0; i < expr->get_segments ().size (); i++)
+  for (size_t i = 0; i < expr.get_segments ().size (); i++)
     {
-      AST::SimplePathSegment &segment = expr->get_segments ().at (i);
+      AST::SimplePathSegment &segment = expr.get_segments ().at (i);
       bool is_first_segment = i == 0;
-      bool is_final_segment = i >= (expr->get_segments ().size () - 1);
+      bool is_final_segment = i >= (expr.get_segments ().size () - 1);
       resolved_node_id = UNKNOWN_NODEID;
 
       if (segment.is_crate_path_seg ())
@@ -393,14 +393,14 @@ ResolvePath::resolve_path (AST::SimplePath *expr)
       // name scope first
       if (resolver->get_name_scope ().decl_was_declared_here (resolved_node_id))
 	{
-	  resolver->insert_resolved_name (expr->get_node_id (),
+	  resolver->insert_resolved_name (expr.get_node_id (),
 					  resolved_node_id);
 	}
       // check the type scope
       else if (resolver->get_type_scope ().decl_was_declared_here (
 		 resolved_node_id))
 	{
-	  resolver->insert_resolved_type (expr->get_node_id (),
+	  resolver->insert_resolved_type (expr.get_node_id (),
 					  resolved_node_id);
 	}
       else

--- a/gcc/rust/resolve/rust-ast-resolve-path.h
+++ b/gcc/rust/resolve/rust-ast-resolve-path.h
@@ -29,16 +29,16 @@ class ResolvePath : public ResolverBase
   using Rust::Resolver::ResolverBase::visit;
 
 public:
-  static NodeId go (AST::PathInExpression *expr);
-  static NodeId go (AST::QualifiedPathInExpression *expr);
-  static NodeId go (AST::SimplePath *expr);
+  static NodeId go (AST::PathInExpression &expr);
+  static NodeId go (AST::QualifiedPathInExpression &expr);
+  static NodeId go (AST::SimplePath &expr);
 
 private:
   ResolvePath ();
 
-  NodeId resolve_path (AST::PathInExpression *expr);
-  NodeId resolve_path (AST::QualifiedPathInExpression *expr);
-  NodeId resolve_path (AST::SimplePath *expr);
+  NodeId resolve_path (AST::PathInExpression &expr);
+  NodeId resolve_path (AST::QualifiedPathInExpression &expr);
+  NodeId resolve_path (AST::SimplePath &expr);
 
   void
   resolve_simple_path_segments (CanonicalPath prefix, size_t offs,

--- a/gcc/rust/resolve/rust-ast-resolve-pattern.h
+++ b/gcc/rust/resolve/rust-ast-resolve-pattern.h
@@ -95,8 +95,8 @@ class PatternDeclaration : public ResolverBase
   using Rust::Resolver::ResolverBase::visit;
 
 public:
-  static void go (AST::Pattern *pattern, Rib::ItemType type);
-  static void go (AST::Pattern *pattern, Rib::ItemType type,
+  static void go (AST::Pattern &pattern, Rib::ItemType type);
+  static void go (AST::Pattern &pattern, Rib::ItemType type,
 		  std::vector<PatternBinding> &bindings);
 
   void visit (AST::IdentifierPattern &pattern) override;

--- a/gcc/rust/resolve/rust-ast-resolve-stmt.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-stmt.cc
@@ -30,31 +30,30 @@ ResolveStmt::visit (AST::ExternBlock &extern_block)
   resolve_visibility (extern_block.get_visibility ());
   for (auto &item : extern_block.get_extern_items ())
     {
-      ResolveToplevelExternItem::go (item.get (),
-				     CanonicalPath::create_empty ());
-      ResolveExternItem::go (item.get (), prefix, canonical_prefix);
+      ResolveToplevelExternItem::go (*item, CanonicalPath::create_empty ());
+      ResolveExternItem::go (*item, prefix, canonical_prefix);
     }
 }
 
 void
 ResolveStmt::visit (AST::Trait &trait)
 {
-  ResolveTopLevel::go (&trait, prefix, canonical_prefix);
-  ResolveItem::go (&trait, prefix, canonical_prefix);
+  ResolveTopLevel::go (trait, prefix, canonical_prefix);
+  ResolveItem::go (trait, prefix, canonical_prefix);
 }
 
 void
 ResolveStmt::visit (AST::InherentImpl &impl_block)
 {
-  ResolveTopLevel::go (&impl_block, prefix, canonical_prefix);
-  ResolveItem::go (&impl_block, prefix, canonical_prefix);
+  ResolveTopLevel::go (impl_block, prefix, canonical_prefix);
+  ResolveItem::go (impl_block, prefix, canonical_prefix);
 }
 
 void
 ResolveStmt::visit (AST::TraitImpl &impl_block)
 {
-  ResolveTopLevel::go (&impl_block, prefix, canonical_prefix);
-  ResolveItem::go (&impl_block, prefix, canonical_prefix);
+  ResolveTopLevel::go (impl_block, prefix, canonical_prefix);
+  ResolveItem::go (impl_block, prefix, canonical_prefix);
 }
 
 } // namespace Resolver

--- a/gcc/rust/resolve/rust-ast-resolve-struct-expr-field.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-struct-expr-field.cc
@@ -23,12 +23,12 @@ namespace Rust {
 namespace Resolver {
 
 void
-ResolveStructExprField::go (AST::StructExprField *field,
+ResolveStructExprField::go (AST::StructExprField &field,
 			    const CanonicalPath &prefix,
 			    const CanonicalPath &canonical_prefix)
 {
   ResolveStructExprField resolver (prefix, canonical_prefix);
-  field->accept_vis (resolver);
+  field.accept_vis (resolver);
 }
 
 ResolveStructExprField::ResolveStructExprField (
@@ -39,13 +39,13 @@ ResolveStructExprField::ResolveStructExprField (
 void
 ResolveStructExprField::visit (AST::StructExprFieldIdentifierValue &field)
 {
-  ResolveExpr::go (field.get_value ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (field.get_value (), prefix, canonical_prefix);
 }
 
 void
 ResolveStructExprField::visit (AST::StructExprFieldIndexValue &field)
 {
-  ResolveExpr::go (field.get_value ().get (), prefix, canonical_prefix);
+  ResolveExpr::go (field.get_value (), prefix, canonical_prefix);
 }
 
 void
@@ -54,7 +54,7 @@ ResolveStructExprField::visit (AST::StructExprFieldIdentifier &field)
   AST::IdentifierExpr expr (field.get_field_name (), {}, field.get_locus ());
   expr.set_node_id (field.get_node_id ());
 
-  ResolveExpr::go (&expr, prefix, canonical_prefix);
+  ResolveExpr::go (expr, prefix, canonical_prefix);
 }
 
 } // namespace Resolver

--- a/gcc/rust/resolve/rust-ast-resolve-struct-expr-field.h
+++ b/gcc/rust/resolve/rust-ast-resolve-struct-expr-field.h
@@ -31,7 +31,7 @@ class ResolveStructExprField : public ResolverBase
   using Rust::Resolver::ResolverBase::visit;
 
 public:
-  static void go (AST::StructExprField *field, const CanonicalPath &prefix,
+  static void go (AST::StructExprField &field, const CanonicalPath &prefix,
 		  const CanonicalPath &canonical_prefix);
 
   void visit (AST::StructExprFieldIdentifierValue &field) override;

--- a/gcc/rust/resolve/rust-ast-resolve-toplevel.h
+++ b/gcc/rust/resolve/rust-ast-resolve-toplevel.h
@@ -31,18 +31,18 @@ class ResolveTopLevel : public ResolverBase
   using Rust::Resolver::ResolverBase::visit;
 
 public:
-  static void go (AST::Item *item, const CanonicalPath &prefix,
+  static void go (AST::Item &item, const CanonicalPath &prefix,
 		  const CanonicalPath &canonical_prefix)
   {
-    if (item->is_marked_for_strip ())
+    if (item.is_marked_for_strip ())
       return;
 
     ResolveTopLevel resolver (prefix, canonical_prefix);
-    item->accept_vis (resolver);
+    item.accept_vis (resolver);
 
     NodeId current_module = resolver.resolver->peek_current_module_scope ();
     resolver.mappings->insert_child_item_to_parent_module_mapping (
-      item->get_node_id (), current_module);
+      item.get_node_id (), current_module);
   }
 
   void visit (AST::Module &module) override
@@ -67,7 +67,7 @@ public:
 
     resolver->push_new_module_scope (module.get_node_id ());
     for (auto &item : module.get_items ())
-      ResolveTopLevel::go (item.get (), path, cpath);
+      ResolveTopLevel::go (*item, path, cpath);
 
     resolver->pop_module_scope ();
 
@@ -137,7 +137,7 @@ public:
 
     resolver->push_new_module_scope (enum_decl.get_node_id ());
     for (auto &variant : enum_decl.get_variants ())
-      ResolveTopLevel::go (variant.get (), path, cpath);
+      ResolveTopLevel::go (*variant, path, cpath);
 
     resolver->pop_module_scope ();
 
@@ -343,9 +343,9 @@ public:
 
   void visit (AST::InherentImpl &impl_block) override
   {
-    std::string raw_impl_type_path = impl_block.get_type ()->as_string ();
+    std::string raw_impl_type_path = impl_block.get_type ().as_string ();
     CanonicalPath impl_type_seg
-      = CanonicalPath::new_seg (impl_block.get_type ()->get_node_id (),
+      = CanonicalPath::new_seg (impl_block.get_type ().get_node_id (),
 				raw_impl_type_path);
 
     CanonicalPath impl_type
@@ -354,14 +354,14 @@ public:
     CanonicalPath impl_prefix = prefix.append (impl_type_seg);
 
     for (auto &impl_item : impl_block.get_impl_items ())
-      ResolveToplevelImplItem::go (impl_item.get (), impl_prefix);
+      ResolveToplevelImplItem::go (*impl_item, impl_prefix);
   }
 
   void visit (AST::TraitImpl &impl_block) override
   {
-    std::string raw_impl_type_path = impl_block.get_type ()->as_string ();
+    std::string raw_impl_type_path = impl_block.get_type ().as_string ();
     CanonicalPath impl_type_seg
-      = CanonicalPath::new_seg (impl_block.get_type ()->get_node_id (),
+      = CanonicalPath::new_seg (impl_block.get_type ().get_node_id (),
 				raw_impl_type_path);
 
     std::string raw_trait_type_path = impl_block.get_trait_path ().as_string ();
@@ -385,7 +385,7 @@ public:
       });
 
     for (auto &impl_item : impl_block.get_impl_items ())
-      ResolveToplevelImplItem::go (impl_item.get (), impl_prefix);
+      ResolveToplevelImplItem::go (*impl_item, impl_prefix);
   }
 
   void visit (AST::Trait &trait) override
@@ -416,7 +416,7 @@ public:
   {
     for (auto &item : extern_block.get_extern_items ())
       {
-	ResolveToplevelExternItem::go (item.get (), prefix);
+	ResolveToplevelExternItem::go (*item, prefix);
       }
   }
 

--- a/gcc/rust/resolve/rust-ast-resolve.cc
+++ b/gcc/rust/resolve/rust-ast-resolve.cc
@@ -92,9 +92,8 @@ NameResolution::go (AST::Crate &crate)
   // first gather the top-level namespace names then we drill down so this
   // allows for resolving forward declarations since an impl block might have
   // a Self type Foo which is defined after the impl block for example.
-  for (auto it = crate.items.begin (); it != crate.items.end (); it++)
-    ResolveTopLevel::go (it->get (), CanonicalPath::create_empty (),
-			 crate_prefix);
+  for (auto &item : crate.items)
+    ResolveTopLevel::go (*item, CanonicalPath::create_empty (), crate_prefix);
 
   // FIXME remove this
   if (saw_errors ())
@@ -104,8 +103,8 @@ NameResolution::go (AST::Crate &crate)
     }
 
   // next we can drill down into the items and their scopes
-  for (auto it = crate.items.begin (); it != crate.items.end (); it++)
-    ResolveItem::go (it->get (), CanonicalPath::create_empty (), crate_prefix);
+  for (auto &item : crate.items)
+    ResolveItem::go (*item, CanonicalPath::create_empty (), crate_prefix);
 
   // done
   resolver->pop_module_scope ();

--- a/gcc/rust/resolve/rust-early-name-resolver.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver.cc
@@ -90,13 +90,13 @@ EarlyNameResolver::resolve_generic_args (AST::GenericArgs &generic_args)
     arg.accept_vis (*this);
 
   for (auto &arg : generic_args.get_binding_args ())
-    arg.get_type ()->accept_vis (*this);
+    arg.get_type ().accept_vis (*this);
 }
 
 void
 EarlyNameResolver::resolve_qualified_path_type (AST::QualifiedPathType &path)
 {
-  path.get_type ()->accept_vis (*this);
+  path.get_type ().accept_vis (*this);
 
   if (path.has_as_clause ())
     path.get_as_type_path ().accept_vis (*this);
@@ -227,7 +227,7 @@ EarlyNameResolver::visit (AST::BlockExpr &expr)
       stmt->accept_vis (*this);
 
     if (expr.has_tail_expr ())
-      expr.get_tail_expr ()->accept_vis (*this);
+      expr.get_tail_expr ().accept_vis (*this);
   });
 }
 
@@ -243,37 +243,37 @@ void
 EarlyNameResolver::visit (AST::ForLoopExpr &expr)
 {
   scoped (expr.get_node_id (), [&expr, this] () {
-    expr.get_pattern ()->accept_vis (*this);
-    expr.get_iterator_expr ()->accept_vis (*this);
-    expr.get_loop_block ()->accept_vis (*this);
+    expr.get_pattern ().accept_vis (*this);
+    expr.get_iterator_expr ().accept_vis (*this);
+    expr.get_loop_block ().accept_vis (*this);
   });
 }
 
 void
 EarlyNameResolver::visit (AST::IfLetExpr &expr)
 {
-  expr.get_value_expr ()->accept_vis (*this);
+  expr.get_value_expr ().accept_vis (*this);
 
   scoped (expr.get_node_id (),
-	  [&expr, this] () { expr.get_if_block ()->accept_vis (*this); });
+	  [&expr, this] () { expr.get_if_block ().accept_vis (*this); });
 }
 
 void
 EarlyNameResolver::visit (AST::MatchExpr &expr)
 {
-  expr.get_scrutinee_expr ()->accept_vis (*this);
+  expr.get_scrutinee_expr ().accept_vis (*this);
 
   scoped (expr.get_node_id (), [&expr, this] () {
     for (auto &arm : expr.get_match_cases ())
       {
 	scoped (arm.get_node_id (), [&arm, this] () {
 	  if (arm.get_arm ().has_match_arm_guard ())
-	    arm.get_arm ().get_guard_expr ()->accept_vis (*this);
+	    arm.get_arm ().get_guard_expr ().accept_vis (*this);
 
 	  for (auto &pattern : arm.get_arm ().get_patterns ())
 	    pattern->accept_vis (*this);
 
-	  arm.get_expr ()->accept_vis (*this);
+	  arm.get_expr ().accept_vis (*this);
 	});
       }
   });
@@ -365,7 +365,7 @@ EarlyNameResolver::visit (AST::Trait &trait)
 void
 EarlyNameResolver::visit (AST::InherentImpl &impl)
 {
-  impl.get_type ()->accept_vis (*this);
+  impl.get_type ().accept_vis (*this);
 
   for (auto &generic : impl.get_generic_params ())
     generic->accept_vis (*this);
@@ -379,7 +379,7 @@ EarlyNameResolver::visit (AST::InherentImpl &impl)
 void
 EarlyNameResolver::visit (AST::TraitImpl &impl)
 {
-  impl.get_type ()->accept_vis (*this);
+  impl.get_type ().accept_vis (*this);
 
   for (auto &generic : impl.get_generic_params ())
     generic->accept_vis (*this);
@@ -558,7 +558,7 @@ EarlyNameResolver::visit (AST::StructPattern &)
 void
 EarlyNameResolver::visit (AST::TupleStructPattern &pattern)
 {
-  pattern.get_items ()->accept_vis (*this);
+  pattern.get_items ().accept_vis (*this);
 }
 
 void

--- a/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
@@ -213,7 +213,7 @@ TopLevel::visit (AST::BlockExpr &expr)
       stmt->accept_vis (*this);
 
     if (expr.has_tail_expr ())
-      expr.get_tail_expr ()->accept_vis (*this);
+      expr.get_tail_expr ().accept_vis (*this);
   };
 
   ctx.scoped (Rib::Kind::Normal, expr.get_node_id (), sub_vis);
@@ -223,7 +223,7 @@ void
 TopLevel::visit (AST::StaticItem &static_item)
 {
   auto sub_vis
-    = [this, &static_item] () { static_item.get_expr ()->accept_vis (*this); };
+    = [this, &static_item] () { static_item.get_expr ().accept_vis (*this); };
 
   ctx.scoped (Rib::Kind::Item, static_item.get_node_id (), sub_vis);
 }
@@ -299,7 +299,7 @@ void
 TopLevel::visit (AST::ConstantItem &const_item)
 {
   auto expr_vis
-    = [this, &const_item] () { const_item.get_expr ()->accept_vis (*this); };
+    = [this, &const_item] () { const_item.get_expr ().accept_vis (*this); };
 
   ctx.scoped (Rib::Kind::ConstantItem, const_item.get_node_id (), expr_vis);
 }


### PR DESCRIPTION
Remove references to smart pointer as those could be replaced with references to the underlying object.