### PR TITLE
Adjust error checks to match name resolution 2.0

### DIFF
--- a/gcc/testsuite/rust/compile/bad_stmt_enums.rs
+++ b/gcc/testsuite/rust/compile/bad_stmt_enums.rs
@@ -5,17 +5,17 @@ fn main ()
       Alpha { alpha: i32 },
       pub Beta (u8),
       pub Gamma,
-      Gamma { gamma: u32 } // { dg-error "redefined" }
+      Gamma { gamma: u32 } // { dg-error "defined multiple times" }
     }
 
   struct EE2 { }
-  enum EE2 { } // { dg-error "redefined" }
+  enum EE2 { } // { dg-error "defined multiple times" }
 
   enum EE1
     {
       pub Alpha,
       Beta = 41,
-      Beta = 42, // { dg-error "redefined" }
+      Beta = 42, // { dg-error "defined multiple times" }
       pub Gamma = 3,
       D,
     }

--- a/gcc/testsuite/rust/compile/bad_toplevel_enums.rs
+++ b/gcc/testsuite/rust/compile/bad_toplevel_enums.rs
@@ -3,17 +3,17 @@ pub enum E
   pub A { a: i32 },
   B (u8),
   pub C,
-  B // { dg-error "redefined" }
+  B // { dg-error "defined multiple times" }
 }
 
 enum E2 { }
-struct E2 { } // { dg-error "redefined" }
+struct E2 { } // { dg-error "defined multiple times" }
 
 enum E1
 {
   A,
   pub B = 42,
   C = 3,
-  A { a: u8 }, // { dg-error "redefined" }
+  A { a: u8 }, // { dg-error "defined multiple times" }
   pub D
 }

--- a/gcc/testsuite/rust/compile/redef_error1.rs
+++ b/gcc/testsuite/rust/compile/redef_error1.rs
@@ -3,6 +3,6 @@ struct S1 {
     y: f64,
 }
 
-struct S1(i32, bool); // { dg-error "redefined multiple times" }
+struct S1(i32, bool); // { dg-error "defined multiple times" }
 
 fn main() {}

--- a/gcc/testsuite/rust/compile/redef_error3.rs
+++ b/gcc/testsuite/rust/compile/redef_error3.rs
@@ -2,7 +2,7 @@ fn test() -> bool {
     true
 }
 
-fn test() -> i32 { // { dg-error "redefined multiple times" }
+fn test() -> i32 { // { dg-error "defined multiple times" }
     123
 }
 

--- a/gcc/testsuite/rust/compile/redef_error4.rs
+++ b/gcc/testsuite/rust/compile/redef_error4.rs
@@ -9,7 +9,7 @@ impl Foo {
         test()
     }
 
-    fn test() -> bool { // { dg-error "redefined multiple times" }
+    fn test() -> bool { // { dg-error "defined multiple times" }
         true
     }
 }

--- a/gcc/testsuite/rust/compile/redef_error6.rs
+++ b/gcc/testsuite/rust/compile/redef_error6.rs
@@ -5,7 +5,7 @@ impl Foo<i32> {
         123
     }
 
-    fn test(self) -> i32 { // { dg-error "redefined multiple times" }
+    fn test(self) -> i32 { // { dg-error "defined multiple times" }
         self.0
     }
 }


### PR DESCRIPTION
The error messages produced during name resolution 2.0 are slightly different