### PR TITLE
Fix FixMe in changing return type of builtin_macro_from_string() from BuiltinMacro to tl::optional<BuiltinMacro>

### DIFF
--- a/gcc/rust/expand/rust-macro-builtins.cc
+++ b/gcc/rust/expand/rust-macro-builtins.cc
@@ -126,8 +126,7 @@ std::unordered_map<std::string, AST::MacroTranscriberFunc>
     {"Hash", MacroBuiltin::proc_macro_builtin},
 };
 
-// FIXME: This should return an tl::optional
-BuiltinMacro
+tl::optional<BuiltinMacro>
 builtin_macro_from_string (const std::string &identifier)
 {
   auto macro = MacroBuiltin::builtins.lookup (identifier);

--- a/gcc/rust/expand/rust-macro-builtins.h
+++ b/gcc/rust/expand/rust-macro-builtins.h
@@ -75,7 +75,7 @@ enum class BuiltinMacro
   Hash,
 };
 
-BuiltinMacro
+tl::optional<BuiltinMacro>
 builtin_macro_from_string (const std::string &identifier);
 
 /**

--- a/gcc/rust/resolve/rust-early-name-resolver.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver.cc
@@ -497,7 +497,7 @@ EarlyNameResolver::visit (AST::MacroInvocation &invoc)
     {
       auto builtin_kind
 	= builtin_macro_from_string (rules_def->get_rule_name ().as_string ());
-      invoc.map_to_builtin (builtin_kind);
+      invoc.map_to_builtin (builtin_kind.value ());
     }
 
   auto attributes = rules_def->get_outer_attrs ();


### PR DESCRIPTION


- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
```bash
                === rust Summary ===
# of expected passes            8402
# of expected failures          69
# of unsupported tests          1
```
- \[x] Run `clang-format`

---

I noticed a FixMe in `rust-macro-builtins.cc` that asks to change the return type of a function from BuiltInMacro to be wrapped in an optional so I changed it.

I then ran the codebase through `make -s -j16` to make sure there isn't any compiler error.
I then ran `make check-rust` to make sure there isn't any broken test-case. Results are as above.

I then run `clang-format`, add all the files edited and do a `git commit --signoff` and push them, creating a pull-request