### PR TITLE
Improve error [E0164] handling

### DIFF
--- a/gcc/rust/resolve/rust-early-name-resolver.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver.cc
@@ -558,6 +558,17 @@ EarlyNameResolver::visit (AST::StructPattern &)
 void
 EarlyNameResolver::visit (AST::TupleStructPattern &pattern)
 {
+  auto &segments = pattern.get_path ().get_segments ();
+  if (segments.size () > 1 && !pattern.has_items ())
+    {
+      rich_location rich_locus (line_table, pattern.get_locus ());
+      rich_locus.add_fixit_replace (
+	"function calls are not allowed in patterns");
+      rust_error_at (
+	rich_locus, ErrorCode::E0164,
+	"expected tuple struct or tuple variant, found associated function");
+      return;
+    }
   pattern.get_items ().accept_vis (*this);
 }
 


### PR DESCRIPTION
This PR is an improvement over #2565.
It checks for path segment size to ensure error [E0164] is correctly emitted in case of associated functions in a pattern.

Fixes #2846.

gcc/rust/ChangeLog:

	* resolve/rust-early-name-resolver.cc (EarlyNameResolver::visit):
	Use segment size to identify associated functions for [E0164].