### PR TITLE
Expand FormatArgs node as AST pass

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -205,6 +205,7 @@ GRS_OBJS = \
     rust/rust-unicode.o \
     rust/rust-punycode.o \
 	rust/rust-lang-item.o \
+	rust/rust-expand-format-args.o \
     $(END)
 # removed object files from here
 

--- a/gcc/rust/ast/rust-ast-builder.cc
+++ b/gcc/rust/ast/rust-ast-builder.cc
@@ -17,53 +17,73 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-ast-builder.h"
+#include "rust-ast-full-decls.h"
 #include "rust-ast-full.h"
+#include "rust-expr.h"
+#include "rust-token.h"
+#include "rust-make-unique.h"
 
 namespace Rust {
 namespace AST {
 
 std::unique_ptr<Expr>
-AstBuilder::call (std::unique_ptr<Expr> &&path,
-		  std::vector<std::unique_ptr<Expr>> &&args)
+Builder::literal_string (std::string &&content) const
+{
+  return std::unique_ptr<Expr> (
+    new AST::LiteralExpr (std::move (content), Literal::LitType::STRING,
+			  PrimitiveCoreType::CORETYPE_STR, {}, loc));
+}
+
+std::unique_ptr<Expr>
+Builder::call (std::unique_ptr<Expr> &&path,
+	       std::vector<std::unique_ptr<Expr>> &&args) const
 {
   return std::unique_ptr<Expr> (
     new CallExpr (std::move (path), std::move (args), {}, loc));
 }
 
 std::unique_ptr<Expr>
-AstBuilder::identifier (std::string name)
+Builder::array (std::vector<std::unique_ptr<Expr>> &&members) const
+{
+  auto elts = Rust::make_unique<ArrayElemsValues> (std::move (members), loc);
+
+  return std::unique_ptr<Expr> (new ArrayExpr (std::move (elts), {}, {}, loc));
+}
+
+std::unique_ptr<Expr>
+Builder::identifier (std::string name) const
 {
   return std::unique_ptr<Expr> (new IdentifierExpr (name, {}, loc));
 }
 
 std::unique_ptr<Expr>
-AstBuilder::tuple_idx (std::string receiver, int idx)
+Builder::tuple_idx (std::string receiver, int idx) const
 {
   return std::unique_ptr<Expr> (
     new TupleIndexExpr (identifier (receiver), idx, {}, loc));
 }
 
 FunctionQualifiers
-AstBuilder::fn_qualifiers ()
+Builder::fn_qualifiers () const
 {
   return FunctionQualifiers (loc, Async::No, Const::No, Unsafety::Normal);
 }
 
 PathExprSegment
-AstBuilder::path_segment (std::string seg)
+Builder::path_segment (std::string seg) const
 {
   return PathExprSegment (PathIdentSegment (seg, loc), loc);
 }
 
 std::unique_ptr<TypePathSegment>
-AstBuilder::type_path_segment (std::string seg)
+Builder::type_path_segment (std::string seg) const
 {
   return std::unique_ptr<TypePathSegment> (
     new TypePathSegment (seg, false, loc));
 }
 
 std::unique_ptr<Type>
-AstBuilder::single_type_path (std::string type)
+Builder::single_type_path (std::string type) const
 {
   auto segments = std::vector<std::unique_ptr<TypePathSegment>> ();
   segments.emplace_back (type_path_segment (type));
@@ -72,7 +92,7 @@ AstBuilder::single_type_path (std::string type)
 }
 
 PathInExpression
-AstBuilder::path_in_expression (std::vector<std::string> &&segments)
+Builder::path_in_expression (std::vector<std::string> &&segments) const
 {
   auto path_segments = std::vector<PathExprSegment> ();
   for (auto &seg : segments)
@@ -82,8 +102,8 @@ AstBuilder::path_in_expression (std::vector<std::string> &&segments)
 }
 
 std::unique_ptr<Expr>
-AstBuilder::block (std::vector<std::unique_ptr<Stmt>> &&stmts,
-		   std::unique_ptr<Expr> &&tail_expr)
+Builder::block (std::vector<std::unique_ptr<Stmt>> &&stmts,
+		std::unique_ptr<Expr> &&tail_expr) const
 {
   return std::unique_ptr<Expr> (new BlockExpr (std::move (stmts),
 					       std::move (tail_expr), {}, {},
@@ -91,8 +111,8 @@ AstBuilder::block (std::vector<std::unique_ptr<Stmt>> &&stmts,
 }
 
 std::unique_ptr<Stmt>
-AstBuilder::let (std::unique_ptr<Pattern> pattern, std::unique_ptr<Type> type,
-		 std::unique_ptr<Expr> init)
+Builder::let (std::unique_ptr<Pattern> pattern, std::unique_ptr<Type> type,
+	      std::unique_ptr<Expr> init) const
 {
   return std::unique_ptr<Stmt> (new LetStmt (std::move (pattern),
 					     std::move (init), std::move (type),
@@ -100,28 +120,29 @@ AstBuilder::let (std::unique_ptr<Pattern> pattern, std::unique_ptr<Type> type,
 }
 
 std::unique_ptr<Expr>
-AstBuilder::ref (std::unique_ptr<Expr> &&of, bool mut)
+Builder::ref (std::unique_ptr<Expr> &&of, bool mut) const
 {
   return std::unique_ptr<Expr> (
     new BorrowExpr (std::move (of), mut, /* is double */ false, {}, loc));
 }
 
 std::unique_ptr<Expr>
-AstBuilder::deref (std::unique_ptr<Expr> &&of)
+Builder::deref (std::unique_ptr<Expr> &&of) const
 {
   return std::unique_ptr<Expr> (new DereferenceExpr (std::move (of), {}, loc));
 }
 
 std::unique_ptr<Expr>
-AstBuilder::struct_expr_struct (std::string struct_name)
+Builder::struct_expr_struct (std::string struct_name) const
 {
   return std::unique_ptr<Expr> (
     new StructExprStruct (path_in_expression ({struct_name}), {}, {}, loc));
 }
 
 std::unique_ptr<Expr>
-AstBuilder::struct_expr (std::string struct_name,
-			 std::vector<std::unique_ptr<StructExprField>> &&fields)
+Builder::struct_expr (
+  std::string struct_name,
+  std::vector<std::unique_ptr<StructExprField>> &&fields) const
 {
   return std::unique_ptr<Expr> (
     new StructExprStructFields (path_in_expression ({struct_name}),
@@ -129,22 +150,23 @@ AstBuilder::struct_expr (std::string struct_name,
 }
 
 std::unique_ptr<StructExprField>
-AstBuilder::struct_expr_field (std::string field_name,
-			       std::unique_ptr<Expr> &&value)
+Builder::struct_expr_field (std::string field_name,
+			    std::unique_ptr<Expr> &&value) const
 {
   return std::unique_ptr<StructExprField> (
     new StructExprFieldIdentifierValue (field_name, std::move (value), loc));
 }
 
 std::unique_ptr<Expr>
-AstBuilder::field_access (std::unique_ptr<Expr> &&instance, std::string field)
+Builder::field_access (std::unique_ptr<Expr> &&instance,
+		       std::string field) const
 {
   return std::unique_ptr<Expr> (
     new FieldAccessExpr (std::move (instance), field, {}, loc));
 }
 
 std::unique_ptr<Pattern>
-AstBuilder::wildcard ()
+Builder::wildcard () const
 {
   return std::unique_ptr<Pattern> (new WildcardPattern (loc));
 }

--- a/gcc/rust/ast/rust-ast-builder.h
+++ b/gcc/rust/ast/rust-ast-builder.h
@@ -28,80 +28,93 @@ namespace AST {
 /* Builder class with helper methods to create AST nodes. This builder is
  * tailored towards generating multiple AST nodes from a single location, and
  * may not be suitable to other purposes */
-class AstBuilder
+class Builder
 {
 public:
-  AstBuilder (location_t loc) : loc (loc) {}
+  Builder (location_t loc) : loc (loc) {}
+
+  /* Create a string literal expression ("content") */
+  std::unique_ptr<Expr> literal_string (std::string &&content) const;
 
   /* Create an identifier expression (`variable`) */
-  std::unique_ptr<Expr> identifier (std::string name);
+  std::unique_ptr<Expr> identifier (std::string name) const;
 
   /* Create a tuple index expression (`receiver.0`) */
-  std::unique_ptr<Expr> tuple_idx (std::string receiver, int idx);
+  std::unique_ptr<Expr> tuple_idx (std::string receiver, int idx) const;
 
   /* Create a reference to an expression (`&of`) */
-  std::unique_ptr<Expr> ref (std::unique_ptr<Expr> &&of, bool mut = false);
+  std::unique_ptr<Expr> ref (std::unique_ptr<Expr> &&of,
+			     bool mut = false) const;
 
   /* Create a dereference of an expression (`*of`) */
-  std::unique_ptr<Expr> deref (std::unique_ptr<Expr> &&of);
+  std::unique_ptr<Expr> deref (std::unique_ptr<Expr> &&of) const;
 
   /* Create a block with an optional tail expression */
   std::unique_ptr<Expr> block (std::vector<std::unique_ptr<Stmt>> &&stmts,
-			       std::unique_ptr<Expr> &&tail_expr = nullptr);
+			       std::unique_ptr<Expr> &&tail_expr
+			       = nullptr) const;
 
   /* Create a let binding with an optional type and initializer (`let <name> :
    * <type> = <init>`) */
   std::unique_ptr<Stmt> let (std::unique_ptr<Pattern> pattern,
 			     std::unique_ptr<Type> type = nullptr,
-			     std::unique_ptr<Expr> init = nullptr);
+			     std::unique_ptr<Expr> init = nullptr) const;
 
   /**
    * Create a call expression to a function, struct or enum variant, given its
    * arguments (`path(arg0, arg1, arg2)`)
    */
   std::unique_ptr<Expr> call (std::unique_ptr<Expr> &&path,
-			      std::vector<std::unique_ptr<Expr>> &&args);
+			      std::vector<std::unique_ptr<Expr>> &&args) const;
+
+  /**
+   * Create an array expression (`[member0, member1, member2]`)
+   */
+  std::unique_ptr<Expr>
+  array (std::vector<std::unique_ptr<Expr>> &&members) const;
 
   /* Empty function qualifiers, with no specific qualifiers */
-  FunctionQualifiers fn_qualifiers ();
+  FunctionQualifiers fn_qualifiers () const;
 
   /* Create a single path segment from one string */
-  PathExprSegment path_segment (std::string seg);
+  PathExprSegment path_segment (std::string seg) const;
 
   /* And similarly for type path segments */
-  std::unique_ptr<TypePathSegment> type_path_segment (std::string seg);
+  std::unique_ptr<TypePathSegment> type_path_segment (std::string seg) const;
 
   /* Create a Type from a single string - the most basic kind of type in our AST
    */
-  std::unique_ptr<Type> single_type_path (std::string type);
+  std::unique_ptr<Type> single_type_path (std::string type) const;
 
   /**
    * Create a path in expression from multiple segments (`Clone::clone`). You
    * do not need to separate the segments using `::`, you can simply provide a
    * vector of strings to the functions which will get turned into path segments
    */
-  PathInExpression path_in_expression (std::vector<std::string> &&segments);
+  PathInExpression
+  path_in_expression (std::vector<std::string> &&segments) const;
 
   /* Create a struct expression for unit structs (`S`) */
-  std::unique_ptr<Expr> struct_expr_struct (std::string struct_name);
+  std::unique_ptr<Expr> struct_expr_struct (std::string struct_name) const;
 
   /**
    * Create an expression for struct instantiation with fields (`S { a, b: c }`)
    */
   std::unique_ptr<Expr>
   struct_expr (std::string struct_name,
-	       std::vector<std::unique_ptr<StructExprField>> &&fields);
+	       std::vector<std::unique_ptr<StructExprField>> &&fields) const;
 
   /* Create a field expression for struct instantiation (`field_name: value`) */
   std::unique_ptr<StructExprField>
-  struct_expr_field (std::string field_name, std::unique_ptr<Expr> &&value);
+  struct_expr_field (std::string field_name,
+		     std::unique_ptr<Expr> &&value) const;
 
   /* Create a field access expression (`instance.field`) */
   std::unique_ptr<Expr> field_access (std::unique_ptr<Expr> &&instance,
-				      std::string field);
+				      std::string field) const;
 
   /* Create a wildcard pattern (`_`) */
-  std::unique_ptr<Pattern> wildcard ();
+  std::unique_ptr<Pattern> wildcard () const;
 
 private:
   /**

--- a/gcc/rust/ast/rust-builtin-ast-nodes.h
+++ b/gcc/rust/ast/rust-builtin-ast-nodes.h
@@ -132,6 +132,9 @@ public:
     return *this;
   }
 
+  FormatArgumentKind get_kind () const { return kind; }
+  const Expr &get_expr () const { return *expr; }
+
 private:
   FormatArgument (FormatArgumentKind::Kind kind, tl::optional<Identifier> ident,
 		  std::unique_ptr<Expr> expr)
@@ -159,6 +162,7 @@ public:
   FormatArguments &operator= (const FormatArguments &other) = default;
 
   void push (FormatArgument &&elt) { args.emplace_back (std::move (elt)); }
+  const FormatArgument at (size_t idx) const { return args.at (idx); }
 
 private:
   std::vector<FormatArgument> args;
@@ -195,6 +199,7 @@ public:
   void accept_vis (AST::ASTVisitor &vis) override;
 
   const Fmt::Pieces &get_template () const { return template_pieces; }
+  const FormatArguments &get_arguments () const { return arguments; }
   virtual location_t get_locus () const override;
 
 private:

--- a/gcc/rust/expand/rust-derive.cc
+++ b/gcc/rust/expand/rust-derive.cc
@@ -24,7 +24,7 @@ namespace Rust {
 namespace AST {
 
 DeriveVisitor::DeriveVisitor (location_t loc)
-  : loc (loc), builder (AstBuilder (loc))
+  : loc (loc), builder (Builder (loc))
 {}
 
 std::unique_ptr<Item>

--- a/gcc/rust/expand/rust-derive.h
+++ b/gcc/rust/expand/rust-derive.h
@@ -41,7 +41,7 @@ protected:
   DeriveVisitor (location_t loc);
 
   location_t loc;
-  AstBuilder builder;
+  Builder builder;
 
 private:
   // the 4 "allowed" visitors, which a derive-visitor can specify and override

--- a/gcc/rust/expand/rust-expand-format-args.cc
+++ b/gcc/rust/expand/rust-expand-format-args.cc
@@ -28,10 +28,10 @@ expand_format_args (AST::FormatArgs &fmt)
     {
       switch (node.tag)
 	{
-	case Fmt::Piece::Tag::String:
+	case Fmt::ffi::Piece::Tag::String:
 	  // rust_debug ("[ARTHUR]: %s", node.string._0.c_str ());
 
-	case Fmt::Piece::Tag::NextArgument:
+	case Fmt::ffi::Piece::Tag::NextArgument:
 	  rust_debug ("[ARTHUR]: NextArgument");
 	  break;
 	}

--- a/gcc/rust/expand/rust-expand-format-args.cc
+++ b/gcc/rust/expand/rust-expand-format-args.cc
@@ -17,27 +17,122 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-expand-format-args.h"
+#include "rust-ast-fragment.h"
+#include "rust-ast.h"
 #include "rust-builtin-ast-nodes.h"
+#include "rust-ast-builder.h"
+#include "rust-diagnostics.h"
+#include "rust-expr.h"
+#include "rust-fmt.h"
+#include "rust-path.h"
+#include "rust-system.h"
+#include "rust-token.h"
 
 namespace Rust {
+namespace Fmt {
+
+static std::unique_ptr<AST::Expr>
+format_arg (const AST::Builder &builder, std::unique_ptr<AST::Expr> &&to_format,
+	    const std::string &trait)
+{
+  auto formatter_fn = std::unique_ptr<AST::Expr> (new AST::PathInExpression (
+    builder.path_in_expression ({"core", "fmt", trait, "fmt"})));
+
+  auto path = std::unique_ptr<AST::Expr> (new AST::PathInExpression (
+    builder.path_in_expression ({"core", "fmt", "ArgumentV1", "new"})));
+
+  auto args = std::vector<std::unique_ptr<AST::Expr>> ();
+  args.emplace_back (std::move (to_format));
+  args.emplace_back (std::move (formatter_fn));
+
+  return builder.call (std::move (path), std::move (args));
+}
+
+const std::string &
+get_trait_name (ffi::FormatSpec format_specifier)
+{
+  static const std::unordered_map<std::string, std::string> spec_map = {
+    {"", "Display"},   {"?", "Debug"},	  {"e", "LowerExp"},
+    {"E", "UpperExp"}, {"o", "Octal"},	  {"p", "Pointer"},
+    {"b", "Binary"},   {"x", "LowerHex"}, {"X", "UpperHex"},
+  };
+
+  auto it = spec_map.find (format_specifier.ty.to_string ());
+
+  if (it == spec_map.end ())
+    rust_unreachable ();
+
+  return it->second;
+}
 
 tl::optional<AST::Fragment>
-expand_format_args (AST::FormatArgs &fmt)
+expand_format_args (AST::FormatArgs &fmt,
+		    std::vector<std::unique_ptr<AST::Token>> &&tokens)
 {
+  auto loc = fmt.get_locus ();
+  auto builder = AST::Builder (loc);
+  auto &arguments = fmt.get_arguments ();
+
+  auto static_pieces = std::vector<std::unique_ptr<AST::Expr>> ();
+  auto args
+    = std::vector<std::pair<std::unique_ptr<AST::Expr>, ffi::FormatSpec>> ();
+
   for (const auto &node : fmt.get_template ().get_pieces ())
     {
       switch (node.tag)
 	{
-	case Fmt::ffi::Piece::Tag::String:
-	  // rust_debug ("[ARTHUR]: %s", node.string._0.c_str ());
+	case ffi::Piece::Tag::String:
+	  static_pieces.emplace_back (
+	    builder.literal_string (node.string._0.to_string ()));
+	  break;
+	  case ffi::Piece::Tag::NextArgument: {
+	    auto next_argument = node.next_argument._0;
+	    switch (node.next_argument._0.position.tag)
+	      {
+		case ffi::Position::Tag::ArgumentImplicitlyIs: {
+		  auto idx = next_argument.position.argument_implicitly_is._0;
+		  auto trait = next_argument.format;
+		  auto arg = arguments.at (idx);
 
-	case Fmt::ffi::Piece::Tag::NextArgument:
-	  rust_debug ("[ARTHUR]: NextArgument");
+		  // FIXME(Arthur): This API sucks
+		  rust_assert (arg.get_kind ().kind
+			       == AST::FormatArgumentKind::Kind::Normal);
+
+		  args.push_back ({arg.get_expr ().clone_expr (), trait});
+		}
+		break;
+	      case ffi::Position::Tag::ArgumentIs:
+	      case ffi::Position::Tag::ArgumentNamed:
+		rust_sorry_at (loc, "unhandled argument position specifier");
+		break;
+	      }
+	  }
 	  break;
 	}
     }
 
-  return tl::nullopt;
+  auto args_array = std::vector<std::unique_ptr<AST::Expr>> ();
+  for (auto &&arg : args)
+    args_array.emplace_back (format_arg (builder,
+					 builder.ref (std::move (arg.first)),
+					 get_trait_name (arg.second)));
+
+  auto pieces = builder.ref (builder.array (std::move (static_pieces)));
+  auto args_slice = builder.ref (builder.array (std::move (args_array)));
+
+  auto final_path = make_unique<AST::PathInExpression> (
+    builder.path_in_expression ({"core", "fmt", "Arguments", "new_v1"}));
+  auto final_args = std::vector<std::unique_ptr<AST::Expr>> ();
+  final_args.emplace_back (std::move (pieces));
+  final_args.emplace_back (std::move (args_slice));
+
+  auto final_call
+    = builder.call (std::move (final_path), std::move (final_args));
+
+  auto node = AST::SingleASTNode (std::move (final_call));
+
+  return AST::Fragment ({node}, std::move (tokens));
 }
 
+} // namespace Fmt
 } // namespace Rust

--- a/gcc/rust/expand/rust-expand-format-args.cc
+++ b/gcc/rust/expand/rust-expand-format-args.cc
@@ -1,0 +1,43 @@
+// Copyright (C) 2024 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-expand-format-args.h"
+#include "rust-builtin-ast-nodes.h"
+
+namespace Rust {
+
+tl::optional<AST::Fragment>
+expand_format_args (AST::FormatArgs &fmt)
+{
+  for (const auto &node : fmt.get_template ().get_pieces ())
+    {
+      switch (node.tag)
+	{
+	case Fmt::Piece::Tag::String:
+	  // rust_debug ("[ARTHUR]: %s", node.string._0.c_str ());
+
+	case Fmt::Piece::Tag::NextArgument:
+	  rust_debug ("[ARTHUR]: NextArgument");
+	  break;
+	}
+    }
+
+  return tl::nullopt;
+}
+
+} // namespace Rust

--- a/gcc/rust/expand/rust-expand-format-args.h
+++ b/gcc/rust/expand/rust-expand-format-args.h
@@ -23,10 +23,13 @@
 #include "rust-ast-fragment.h"
 
 namespace Rust {
+namespace Fmt {
 
 tl::optional<AST::Fragment>
-expand_format_args (AST::FormatArgs &fmt);
+expand_format_args (AST::FormatArgs &fmt,
+		    std::vector<std::unique_ptr<AST::Token>> &&tokens);
 
+} // namespace Fmt
 } // namespace Rust
 
 #endif //! RUST_EXPAND_FORMAT_ARGS_H

--- a/gcc/rust/expand/rust-expand-format-args.h
+++ b/gcc/rust/expand/rust-expand-format-args.h
@@ -1,0 +1,32 @@
+// Copyright (C) 2024 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_EXPAND_FORMAT_ARGS_H
+#define RUST_EXPAND_FORMAT_ARGS_H
+
+#include "optional.h"
+#include "rust-ast-fragment.h"
+
+namespace Rust {
+
+tl::optional<AST::Fragment>
+expand_format_args (AST::FormatArgs &fmt);
+
+} // namespace Rust
+
+#endif //! RUST_EXPAND_FORMAT_ARGS_H

--- a/gcc/rust/hir/rust-ast-lower-expr.cc
+++ b/gcc/rust/hir/rust-ast-lower-expr.cc
@@ -19,7 +19,6 @@
 #include "rust-ast-lower-expr.h"
 #include "rust-ast-lower-base.h"
 #include "rust-ast-lower-block.h"
-#include "rust-ast-lower-format-args.h"
 #include "rust-ast-lower-struct-field-expr.h"
 #include "rust-ast-lower-pattern.h"
 #include "rust-ast-lower-type.h"
@@ -824,9 +823,6 @@ ASTLoweringExpr::visit (AST::ClosureExprInnerTyped &expr)
 void
 ASTLoweringExpr::visit (AST::FormatArgs &fmt)
 {
-  // Lowering FormatArgs is complex, and this file is already very long
-  translated = FormatArgsLowering ().go (fmt);
-
   rust_sorry_at (fmt.get_locus (),
 		 "FormatArgs lowering is not implemented yet");
 }

--- a/gcc/rust/resolve/rust-ast-resolve-base.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-base.cc
@@ -648,10 +648,7 @@ ResolverBase::visit (AST::FunctionParam &)
 
 void
 ResolverBase::visit (AST::FormatArgs &fmt)
-{
-  rust_sorry_at (fmt.get_locus (), "%s:%u: unimplemented FormatArgs visitor",
-		 __FILE__, __LINE__);
-}
+{}
 
 } // namespace Resolver
 } // namespace Rust

--- a/gcc/testsuite/rust/compile/format_args_basic_expansion.rs
+++ b/gcc/testsuite/rust/compile/format_args_basic_expansion.rs
@@ -1,0 +1,47 @@
+#![feature(rustc_attrs)]
+
+#[rustc_builtin_macro]
+macro_rules! format_args {
+    () => {};
+}
+
+#[lang = "sized"]
+trait Sized {}
+
+pub mod core {
+    pub mod fmt {
+        pub struct Formatter;
+        pub struct Result;
+
+        pub struct Arguments<'a>;
+
+        impl<'a> Arguments<'a> {
+            pub fn new_v1(_: &'a [&'static str], _: &'a [ArgumentV1<'a>]) -> Arguments<'a> {
+                Arguments
+            }
+        }
+
+        pub struct ArgumentV1<'a>;
+
+        impl<'a> ArgumentV1<'a> {
+            pub fn new<'b, T>(_: &'b T, _: fn(&T, &mut Formatter) -> Result) -> ArgumentV1 {
+                ArgumentV1
+            }
+        }
+
+        pub trait Display {
+            fn fmt(&self, _: &mut Formatter) -> Result;
+        }
+
+        impl Display for i32 {
+            fn fmt(&self, _: &mut Formatter) -> Result {
+                // { dg-warning "unused name .self." "" { target *-*-* } .-1 }
+                Result
+            }
+        }
+    }
+}
+
+fn main() {
+    let _formatted = format_args!("hello {}", 15);
+}


### PR DESCRIPTION
Needs #2859
Needs #2917 for GCC 4.8 to have Rust 1.72 installed (for `String::leak`)

- ast: Add base nodes for FormatArgs
- macro-builtins: Add newline generic format_args!() handler
- parser: Add peek(n) method to parser
- format-args: Fix Rust interface and add input parsing.
- lower: Add base for lowering FormatArgs nodes
- format-args: Add base for expanding FormatArgs nodes
- format-args: Start storing string in Rust memory
- format-args: Add basic expansion of unnamed Display::fmt arguments.
- format-args: Add basic test case
