### PR TITLE
Add error emitting when we can't resolve id expr

### DIFF
--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
@@ -127,13 +127,20 @@ Late::visit (AST::IdentifierExpr &expr)
   auto value = ctx.values.get (expr.get_ident ());
 
   if (label)
-    resolved = label;
+    {
+      resolved = label;
+    }
   else if (value)
-    resolved = value;
-  else {
-      rust_error_at(expr.get_locus (), "could not resolve identifier expression: %qs", expr.get_ident ().as_string ().c_str ());
+    {
+      resolved = value;
+    }
+  else
+    {
+      rust_error_at (expr.get_locus (),
+		     "could not resolve identifier expression: %qs",
+		     expr.get_ident ().as_string ().c_str ());
       return;
-  }
+    }
 
   ctx.map_usage (expr.get_node_id (), *resolved);
 

--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
@@ -130,7 +130,10 @@ Late::visit (AST::IdentifierExpr &expr)
     resolved = label;
   else if (value)
     resolved = value;
-  // TODO: else emit error?
+  else {
+      rust_error_at(expr.get_locus (), "could not resolve identifier expression: %qs", expr.get_ident ().as_string ().c_str ());
+      return;
+  }
 
   ctx.map_usage (expr.get_node_id (), *resolved);
 


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* resolve/rust-late-name-resolver-2.0.cc (Late::visit): Add error emitting

From  issue #2876 , I clone gcc locally, then run from build dir
```
 ../gcc_src/configure '--with-pkgversion=basepoints/gcc-14-9118-g3232ebd91ed, built at 1708915534' --prefix=/tmp/gcc-x86_64-linux --enable-werror-always --enable-languages=rust --disable-gcov --disable-shared --disable-threads --target=x86_64-linux --without-headers --disable-multilib
```
to verify the crash.

Then i edit in-place of the recently cloned gcc the file `rust-late-name-resolver-2.0.cc` until the problem regarding the file goes away after rebuilding. The rest of the errors are in gcc error itself
```
../../gcc_src/gcc/gcc.cc: In function ‘void read_specs(const char*, bool, bool)’:
../../gcc_src/gcc/gcc.cc:2413:32: error: unknown conversion type character ‘t’ in format [-Werror=format=]
 2413 |                              "%td characters", p1 - buffer + 1);
      |                                ^
../../gcc_src/gcc/gcc.cc:2412:30: error: too many arguments for format [-Werror=format-extra-args]
 2412 |                              "specs %%include syntax malformed after "
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 2413 |                              "%td characters", p1 - buffer + 1);
      |                              ~~~~~~~~~~~~~~~~
../../gcc_src/gcc/gcc.cc:2433:32: error: unknown conversion type character ‘t’ in format [-Werror=format=]
 2433 |                              "%td characters", p1 - buffer + 1);
      |                                ^
../../gcc_src/gcc/gcc.cc:2432:30: error: too many arguments for format [-Werror=format-extra-args]
 2432 |                              "specs %%include syntax malformed after "
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 2433 |                              "%td characters", p1 - buffer + 1);
      |                              ~~~~~~~~~~~~~~~~
../../gcc_src/gcc/gcc.cc:2459:32: error: unknown conversion type character ‘t’ in format [-Werror=format=]
 2459 |                              "%td characters", p1 - buffer);
      |                                ^
../../gcc_src/gcc/gcc.cc:2458:30: error: too many arguments for format [-Werror=format-extra-args]
 2458 |                              "specs %%rename syntax malformed after "
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 2459 |                              "%td characters", p1 - buffer);
      |                              ~~~~~~~~~~~~~~~~
../../gcc_src/gcc/gcc.cc:2468:32: error: unknown conversion type character ‘t’ in format [-Werror=format=]
 2468 |                              "%td characters", p2 - buffer);
      |                                ^
../../gcc_src/gcc/gcc.cc:2467:30: error: too many arguments for format [-Werror=format-extra-args]
 2467 |                              "specs %%rename syntax malformed after "
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 2468 |                              "%td characters", p2 - buffer);
      |                              ~~~~~~~~~~~~~~~~
../../gcc_src/gcc/gcc.cc:2478:32: error: unknown conversion type character ‘t’ in format [-Werror=format=]
 2478 |                              "%td characters", p2 - buffer);
      |                                ^
../../gcc_src/gcc/gcc.cc:2477:30: error: too many arguments for format [-Werror=format-extra-args]
 2477 |                              "specs %%rename syntax malformed after "
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 2478 |                              "%td characters", p2 - buffer);
      |                              ~~~~~~~~~~~~~~~~
../../gcc_src/gcc/gcc.cc:2488:32: error: unknown conversion type character ‘t’ in format [-Werror=format=]
 2488 |                              "%td characters", p3 - buffer);
      |                                ^
../../gcc_src/gcc/gcc.cc:2487:30: error: too many arguments for format [-Werror=format-extra-args]
 2487 |                              "specs %%rename syntax malformed after "
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 2488 |                              "%td characters", p3 - buffer);
      |                              ~~~~~~~~~~~~~~~~
../../gcc_src/gcc/gcc.cc:2527:59: error: unknown conversion type character ‘t’ in format [-Werror=format=]
 2527 |                          "specs unknown %% command after %td characters",
      |                                                           ^
../../gcc_src/gcc/gcc.cc:2527:26: error: too many arguments for format [-Werror=format-extra-args]
 2527 |                          "specs unknown %% command after %td characters",
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../gcc_src/gcc/gcc.cc:2539:51: error: unknown conversion type character ‘t’ in format [-Werror=format=]
 2539 |                      "specs file malformed after %td characters",
      |                                                   ^
../../gcc_src/gcc/gcc.cc:2539:22: error: too many arguments for format [-Werror=format-extra-args]
 2539 |                      "specs file malformed after %td characters",
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../gcc_src/gcc/gcc.cc:2553:51: error: unknown conversion type character ‘t’ in format [-Werror=format=]
 2553 |                      "specs file malformed after %td characters",
      |                                                   ^
../../gcc_src/gcc/gcc.cc:2553:22: error: too many arguments for format [-Werror=format-extra-args]
 2553 |                      "specs file malformed after %td characters",
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[1]: *** [Makefile:1198: gcc.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory '/home/jjasmine/clone_dir/gcc/gcc_build/gcc'
make: *** [Makefile:5044: all-gcc] Error 2
```

I then transfer the newly edited portion to the gccrs codebase 