### PR TITLE
Improve handling of ```ConstantItem``` during name resolution 2.0

### DIFF
--- a/gcc/rust/resolve/rust-default-resolver.cc
+++ b/gcc/rust/resolve/rust-default-resolver.cc
@@ -487,7 +487,7 @@ DefaultResolver::visit (AST::ConstantItem &item)
       };
 
       // FIXME: Why do we need a Rib here?
-      ctx.scoped (Rib::Kind::Item, item.get_node_id (), expr_vis);
+      ctx.scoped (Rib::Kind::ConstantItem, item.get_node_id (), expr_vis);
     }
 }
 

--- a/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
@@ -424,10 +424,7 @@ TopLevel::visit (AST::ConstantItem &const_item)
   insert_or_error_out (const_item.get_identifier (), const_item,
 		       Namespace::Values);
 
-  auto expr_vis
-    = [this, &const_item] () { const_item.get_expr ().accept_vis (*this); };
-
-  ctx.scoped (Rib::Kind::ConstantItem, const_item.get_node_id (), expr_vis);
+  DefaultResolver::visit (const_item);
 }
 
 bool


### PR DESCRIPTION
Removes a redundant function override and replaces usage of ```Rib::Kind::Item``` with ```Rib::Kind::ConstantItem```.