### PR TITLE
unify: Always coerce `!` to the target type.

### DIFF
--- a/gcc/testsuite/rust/compile/match-never-ltype.rs
+++ b/gcc/testsuite/rust/compile/match-never-ltype.rs
@@ -1,0 +1,17 @@
+fn foo() {}
+
+enum Foo {
+    A,
+    B,
+}
+
+fn main() {
+    let a = Foo::A;
+
+    loop {
+        match a {
+            Foo::A => break,
+            Foo::B => foo(),
+        }
+    }
+}

--- a/gcc/testsuite/rust/compile/match-never-rtype.rs
+++ b/gcc/testsuite/rust/compile/match-never-rtype.rs
@@ -1,0 +1,17 @@
+fn foo() {}
+
+enum Foo {
+    A,
+    B,
+}
+
+fn main() {
+    let a = Foo::A;
+
+    loop {
+        match a {
+            Foo::B => foo(),
+            Foo::A => break,
+        }
+    }
+}


### PR DESCRIPTION
Never can... never... exist, so it should always be coerced to the type
it is being matched against. This is useful for breaking off of a loop
from inside a match, or an if condition, for example.

gcc/rust/ChangeLog:

	* typecheck/rust-unify.cc (UnifyRules::go): Always unify to `ltype` if
	we are matching against a `Never` in `rtype`.
	(UnifyRules::expect_never): Always unify to the expected type.

gcc/testsuite/ChangeLog:

	* rust/compile/match-never-ltype.rs: New test.
	* rust/compile/match-never-rtype.rs: New test.

Fixes #2908

This currently fails a bunch of tests, so leaving in draft. I'll revisit this tomorrow/later.
