### PR TITLE
Store visibility properly in ExternalTypeItem: Fixes #2897

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-extern.h
+++ b/gcc/rust/hir/rust-ast-lower-extern.h
@@ -133,8 +133,10 @@ public:
 				   mappings->get_next_hir_id (crate_num),
 				   mappings->get_next_localdef_id (crate_num));
 
+    HIR::Visibility vis = translate_visibility (type.get_visibility ());
+
     translated = new HIR::ExternalTypeItem (mapping, type.get_identifier (),
-					    type.get_locus ());
+					    vis, type.get_locus ());
   }
 
 private:

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -3154,9 +3154,9 @@ class ExternalTypeItem : public ExternalItem
 {
 public:
   ExternalTypeItem (Analysis::NodeMapping mappings, Identifier item_name,
-		    location_t locus)
+		    Visibility vis, location_t locus)
     : ExternalItem (std::move (mappings), std::move (item_name),
-		    Visibility (Visibility::PRIVATE),
+		    Visibility (std::move (vis)),
 		    /* FIXME: Is that correct? */
 		    {}, locus)
   {}


### PR DESCRIPTION
Ran through git-clang-format, make check-rust passes as expected. 

Check-list:

(x) Make sure that visibility modifier are parsed for extern type nodes: I made sure that `parse_external_type_item` has AST::Visibility within its declaration
```c++
// in rust-parse-impl.h
template <typename ManagedTokenSource>
std::unique_ptr<AST::ExternalTypeItem>
Parser<ManagedTokenSource>::parse_external_type_item (AST::Visibility vis,
						      AST::AttrVec outer_attrs);
```

(x) Make sure that visibility is assigned to `ExternalTypeItem` I made sure that in in the function mentioned above, its constructor, ExternalTypeItem(), handled visibility correctly via its parent's constructor
```c++
// In rust-item.h
ExternalTypeItem (Identifier item_name, Visibility vis,
		  std::vector<Attribute> outer_attrs, location_t locus)
  : ExternalItem (), outer_attrs (std::move (outer_attrs)), visibility (vis),
    item_name (std::move (item_name)), locus (locus), marked_for_strip (false)
{}

```

(x) Make sure that the AST visibility is correctly lowered to an HIR visibility I added a translate_visibility call via
`HIR::Visibility vis = translate_visibility (type.get_visibility ());` in the visit() function.

I also changed the constructor of HIR::ExternalTypeItem to accept a visibility and change the way it delegate visibility to its parent's constructor.

gcc/rust/ChangeLog:

	* hir/rust-ast-lower-extern.h: Add translate_visiblity
	* hir/tree/rust-hir-item.h: Fix constructor of ExternalTypeItem


Closes #2897 
