### PR TITLE
`Block.Rust::AST::ExprWithoutBlock::Rust::AST::Expr.Rust::AST::Expr::node_id’ is used uninitialized [-Werror=uninitialized]`

### DIFF
--- a/gcc/cfgexpand.cc
+++ b/gcc/cfgexpand.cc
@@ -859,7 +859,8 @@ update_alias_info_with_stack_vars (void)
 
       add_partitioned_vars_to_ptset (&cfun->gimple_df->escaped,
 				     decls_to_partitions, &visited, temp);
-
+      add_partitioned_vars_to_ptset (&cfun->gimple_df->escaped_return,
+				     decls_to_partitions, &visited, temp);
       delete decls_to_partitions;
       BITMAP_FREE (temp);
     }

--- a/gcc/gimple-ssa.h
+++ b/gcc/gimple-ssa.h
@@ -76,8 +76,10 @@ struct GTY(()) gimple_df {
   /* Artificial variable used for the virtual operand FUD chain.  */
   tree vop;
 
-  /* The PTA solution for the ESCAPED artificial variable.  */
+  /* The PTA solution for the ESCAPED and ESCAPED_RETURN artificial
+     variables.  */
   struct pt_solution escaped;
+  struct pt_solution escaped_return;
 
   /* A map of decls to artificial ssa-names that point to the partition
      of the decl.  */

--- a/gcc/ipa-icf.cc
+++ b/gcc/ipa-icf.cc
@@ -3505,6 +3505,7 @@ sem_item_optimizer::fixup_points_to_sets (void)
 	    && SSA_NAME_PTR_INFO (name))
 	  fixup_pt_set (&SSA_NAME_PTR_INFO (name)->pt);
       fixup_pt_set (&fn->gimple_df->escaped);
+      fixup_pt_set (&fn->gimple_df->escaped_return);
 
        /* The above gets us to 99% I guess, at least catching the
 	  address compares.  Below also gets us aliasing correct

--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -727,7 +727,7 @@ private:
   {}
 
   MacroInvocation (const MacroInvocation &other)
-    : TraitItem (other.locus), ExternalItem (Expr::node_id),
+    : TraitItem (other.locus), ExternalItem (other.node_id),
       outer_attrs (other.outer_attrs), locus (other.locus),
       node_id (other.node_id), invoc_data (other.invoc_data),
       is_semi_coloned (other.is_semi_coloned), kind (other.kind),

--- a/gcc/testsuite/g++.dg/tree-ssa/pr109849.C
+++ b/gcc/testsuite/g++.dg/tree-ssa/pr109849.C
@@ -1,0 +1,31 @@
+/* { dg-do compile } */
+/* { dg-options "-O2 -fdump-tree-sra" } */
+
+#include <vector>
+typedef unsigned int uint32_t;
+std::pair<uint32_t, uint32_t> pair;
+void
+test()
+{
+        std::vector<std::pair<uint32_t, uint32_t> > stack;
+        stack.push_back (pair);
+        while (!stack.empty()) {
+                std::pair<uint32_t, uint32_t> cur = stack.back();
+                stack.pop_back();
+                if (!cur.first)
+                {
+                        cur.second++;
+                        stack.push_back (cur);
+                }
+                if (cur.second > 10000)
+                        break;
+        }
+}
+int
+main()
+{
+        for (int i = 0; i < 10000; i++)
+          test();
+}
+
+/* { dg-final { scan-tree-dump "Created a replacement for stack offset" "sra"} } */

--- a/gcc/testsuite/g++.dg/tree-ssa/sra-eh-1.C
+++ b/gcc/testsuite/g++.dg/tree-ssa/sra-eh-1.C
@@ -1,0 +1,187 @@
+/* { dg-do run } */
+/* { dg-options "-O2 -fdump-tree-sra" } */
+
+struct E
+{
+  short c;
+  E (short param) : c(param) {};
+};
+
+volatile short vs = 0;
+long buf[16];
+long * volatile pbuf = (long *) &buf;
+
+static void __attribute__((noinline))
+unrelated_throwing (void)
+{
+  throw E (256);
+}
+
+struct S {
+  long  *b;
+  int c;
+  int s;
+};
+
+static void __attribute__((noinline))
+crazy_alloc_s (struct S *p)
+{
+  int s = p->c ? p->c * 2 : 16;
+
+  long *b = pbuf;
+  if (!b || s > 16)
+    {
+      p->s = -p->s;
+      throw E (127);
+    }
+
+  __builtin_memcpy (b, p->b, p->c);
+  p->b = b;
+  p->s = s;
+  pbuf = 0;
+  return;
+}
+
+long __attribute__((noipa))
+process (long v)
+{
+  return v + 1;
+}
+
+void __attribute__((noipa))
+check (int s, short c)
+{
+  if (vs < c)
+    vs = c;
+  if (c == 127)
+    {
+      if (s >= 0)
+	__builtin_abort ();
+    }
+  else
+    {
+      if (s != 0)
+	__builtin_abort ();
+    }
+  return;
+}
+
+
+void
+foo (void)
+{
+  struct S foo_stack;
+
+  foo_stack.c = 0;
+  crazy_alloc_s (&foo_stack);
+  foo_stack.b[0] = 1;
+  foo_stack.c = 1;
+
+  while (foo_stack.c)
+    {
+      long l = foo_stack.b[--foo_stack.c];
+
+      if (l > 0)
+	{
+	  for (int i = 0; i < 4; i++)
+	    {
+	      try
+		{
+		  if (foo_stack.s <= foo_stack.c + 1)
+		    crazy_alloc_s (&foo_stack);
+		}
+	      catch (E e)
+		{
+		  check (foo_stack.s, e.c);
+		  return;
+		}
+	      l = process (l);
+	      foo_stack.b[foo_stack.c++] = l;
+	    }
+	}
+    }
+  return;
+}
+
+
+volatile int vi;
+
+int __attribute__((noipa))
+save (int s)
+{
+  vi = s;
+  return 0;
+}
+
+int __attribute__((noipa))
+restore ()
+{
+  return vi;
+}
+
+
+void
+bar (void)
+{
+  struct S bar_stack;
+
+  bar_stack.c = 0;
+  crazy_alloc_s (&bar_stack);
+  bar_stack.b[0] = 1;
+  bar_stack.c = 1;
+
+  while (bar_stack.c)
+    {
+      long l = bar_stack.b[--bar_stack.c];
+
+      if (l > 0)
+	{
+	  for (int i = 0; i < 4; i++)
+	    {
+	      try
+		{
+		  if (i == 2)
+		    {
+		      bar_stack.s = save (bar_stack.s);
+		      unrelated_throwing ();
+		    }
+		  if (bar_stack.s <= bar_stack.c + 1)
+		    crazy_alloc_s (&bar_stack);
+		}
+	      catch (E e)
+		{
+		  check (bar_stack.s, e.c);
+		  if (e.c == 127)
+		    return;
+		  bar_stack.s = restore ();
+		  continue;
+		}
+	      l = process (l);
+	      bar_stack.b[bar_stack.c++] = l;
+	    }
+	}
+    }
+  return;
+}
+
+
+
+
+int main (int argc, char **argv)
+{
+  vs = 0;
+  pbuf = (long *) &buf;
+  foo ();
+  if (vs != 127)
+    __builtin_abort ();
+
+  vs = 0;
+  pbuf = (long *) &buf;
+  bar ();
+  if (vs != 256)
+    __builtin_abort ();
+  return 0;
+}
+
+/* { dg-final { scan-tree-dump "Created a replacement for foo_stack offset" "sra"} } */
+/* { dg-final { scan-tree-dump "Created a replacement for bar_stack offset" "sra"} } */

--- a/gcc/testsuite/gcc.dg/tree-ssa/pr109849.c
+++ b/gcc/testsuite/gcc.dg/tree-ssa/pr109849.c
@@ -1,0 +1,60 @@
+/* { dg-do compile } */
+/* { dg-options "-O2 -fdump-tree-sra" } */
+
+struct D
+{
+  long a;
+  short b;
+};
+
+struct S {
+  struct D *b;
+  int c;
+  int s;
+};
+
+struct D * __attribute__((malloc)) some_realloc_function (int c);
+
+static void __attribute__((noinline))
+realloc_s (struct S *p)
+{
+  int s = p->c ? p->c * 2 : 16;
+  p->b = some_realloc_function (s);
+  p->s = s;
+  return;
+}
+
+void modify (struct D *d);
+int test (struct D *d);
+
+static struct D gd;
+
+int
+foo (void)
+{
+  struct S stack;
+
+  stack.c = 1;
+  stack.s = 0;
+  realloc_s (&stack);
+  stack.b[0] = gd;
+  stack.c = 1;
+
+  while (stack.c)
+    {
+      struct D d = stack.b[--stack.c];
+      if (test (&d))
+	{
+	  for (int i = 0; i < 8; i++)
+	    {
+	      if (stack.s <= stack.c + 1)
+		realloc_s (&stack);
+	      modify(&d);
+	      stack.b[stack.c++] = d;
+	    }
+	}
+    }
+  return 0;
+}
+
+/* { dg-final { scan-tree-dump "Created a replacement for stack offset" "sra"} } */

--- a/gcc/testsuite/gcc.dg/tree-ssa/pta-return-1.c
+++ b/gcc/testsuite/gcc.dg/tree-ssa/pta-return-1.c
@@ -1,0 +1,16 @@
+/* PR112653 */
+/* { dg-do compile } */
+/* { dg-options "-O -fdump-tree-optimized" } */
+
+char *test;
+char *
+copy_test ()
+{
+  char *test2 = __builtin_malloc (1000);
+  __builtin_memmove (test2, test, 1000);
+  return test2;
+}
+
+/* We should be able to turn the memmove into memcpy by means of alias
+   analysis.  */
+/* { dg-final { scan-tree-dump "memcpy" "optimized" } } */

--- a/gcc/testsuite/gcc.dg/tree-ssa/sra-longjmp-1.c
+++ b/gcc/testsuite/gcc.dg/tree-ssa/sra-longjmp-1.c
@@ -1,0 +1,87 @@
+/* { dg-do run } */
+/* { dg-options "-O2 -fdump-tree-sra" } */
+/* { dg-require-effective-target indirect_jumps } */
+
+#include <setjmp.h>
+
+struct S {
+  long *b;
+  int c;
+  int s;
+};
+
+static jmp_buf the_jmpbuf;
+volatile short vs = 0;
+long buf[16];
+long * volatile pbuf = (long *) &buf;
+
+static void __attribute__((noinline))
+crazy_alloc_s (struct S *p)
+{
+  int s = p->c ? p->c * 2 : 16;
+
+  long *b = pbuf;
+  if (!b || s > 16)
+    {
+      p->s = -p->s;
+      vs = 127;
+      longjmp (the_jmpbuf, 1);
+    }
+
+  __builtin_memcpy (b, p->b, p->c);
+  p->b = b;
+  p->s = s;
+  pbuf = 0;
+  return;
+}
+
+long __attribute__((noipa))
+process (long v)
+{
+  return v + 1;
+}
+
+void
+foo (void)
+{
+  struct S stack;
+
+  if (setjmp (the_jmpbuf))
+    return;
+
+  stack.c = 0;
+  crazy_alloc_s (&stack);
+  stack.b[0] = 1;
+  stack.c = 1;
+
+  while (stack.c)
+    {
+      long l = stack.b[--stack.c];
+
+      if (l > 0)
+	{
+	  for (int i = 0; i < 4; i++)
+	    {
+	      if (stack.s <= stack.c + 1)
+		crazy_alloc_s (&stack);
+	      l = process (l);
+	      stack.b[stack.c++] = l;
+	    }
+	}
+    }
+
+  return;
+}
+
+int main (int argc, char **argv)
+{
+  vs = 0;
+  pbuf = (long *) &buf;
+  foo ();
+  if (vs != 127)
+    __builtin_abort ();
+
+  return 0;
+}
+
+/* { dg-final { scan-tree-dump-not "Created a replacement for stack offset" "sra"} } */

--- a/gcc/testsuite/gfortran.dg/pr43984.f90
+++ b/gcc/testsuite/gfortran.dg/pr43984.f90
@@ -1,5 +1,5 @@
 ! { dg-do compile }
-! { dg-options "-O2 -fno-tree-dominator-opts -fdump-tree-pre" }
+! { dg-options "-O2 -fno-tree-dominator-opts -fdump-tree-pre -fno-tree-sra" }
 module test
 
    type shell1quartet_type

--- a/gcc/tree-inline.cc
+++ b/gcc/tree-inline.cc
@@ -5133,7 +5133,10 @@ expand_call_inline (basic_block bb, gimple *stmt, copy_body_data *id,
 
   /* Reset the escaped solution.  */
   if (cfun->gimple_df)
-    pt_solution_reset (&cfun->gimple_df->escaped);
+    {
+      pt_solution_reset (&cfun->gimple_df->escaped);
+      pt_solution_reset (&cfun->gimple_df->escaped_return);
+    }
 
   /* Add new automatic variables to IFN_GOMP_SIMT_ENTER arguments.  */
   if (id->dst_simt_vars && id->dst_simt_vars->length () > 0)

--- a/gcc/tree-parloops.cc
+++ b/gcc/tree-parloops.cc
@@ -4141,7 +4141,10 @@ parallelize_loops (bool oacc_kernels_p)
      which local variables will escape.  Reset the points-to solution
      for ESCAPED.  */
   if (changed)
-    pt_solution_reset (&cfun->gimple_df->escaped);
+    {
+      pt_solution_reset (&cfun->gimple_df->escaped);
+      pt_solution_reset (&cfun->gimple_df->escaped_return);
+    }
 
   return changed;
 }

--- a/gcc/tree-sra.cc
+++ b/gcc/tree-sra.cc
@@ -2026,7 +2026,7 @@ maybe_add_sra_candidate (tree var)
        /* There are cases where non-addressable variables fail the
 	  pt_solutions_check test, e.g in gcc.dg/uninit-40.c. */
        || (TREE_ADDRESSABLE (var)
-	   && pt_solution_includes (&cfun->gimple_df->escaped, var))
+	   && pt_solution_includes (&cfun->gimple_df->escaped_return, var))
        || (TREE_CODE (var) == RESULT_DECL
 	   && !DECL_BY_REFERENCE (var)
 	   && aggregate_value_p (var, current_function_decl)))

--- a/gcc/tree-sra.cc
+++ b/gcc/tree-sra.cc
@@ -337,6 +337,9 @@ static bitmap should_scalarize_away_bitmap, cannot_scalarize_away_bitmap;
    because this would produce non-constant expressions (e.g. Ada).  */
 static bitmap disqualified_constants;
 
+/* Bitmap of candidates which are passed by reference in call arguments.  */
+static bitmap passed_by_ref_in_call;
+
 /* Obstack for creation of fancy names.  */
 static struct obstack name_obstack;
 
@@ -717,6 +720,7 @@ sra_initialize (void)
   should_scalarize_away_bitmap = BITMAP_ALLOC (NULL);
   cannot_scalarize_away_bitmap = BITMAP_ALLOC (NULL);
   disqualified_constants = BITMAP_ALLOC (NULL);
+  passed_by_ref_in_call = BITMAP_ALLOC (NULL);
   gcc_obstack_init (&name_obstack);
   base_access_vec = new hash_map<tree, auto_vec<access_p> >;
   memset (&sra_stats, 0, sizeof (sra_stats));
@@ -733,6 +737,7 @@ sra_deinitialize (void)
   BITMAP_FREE (should_scalarize_away_bitmap);
   BITMAP_FREE (cannot_scalarize_away_bitmap);
   BITMAP_FREE (disqualified_constants);
+  BITMAP_FREE (passed_by_ref_in_call);
   access_pool.release ();
   assign_link_pool.release ();
   obstack_free (&name_obstack, NULL);
@@ -905,9 +910,9 @@ create_access (tree expr, gimple *stmt, bool write)
 				  &reverse);
 
   /* For constant-pool entries, check we can substitute the constant value.  */
-  if (constant_decl_p (base))
+  if (constant_decl_p (base)
+      && !bitmap_bit_p (disqualified_constants, DECL_UID (base)))
     {
-      gcc_assert (!bitmap_bit_p (disqualified_constants, DECL_UID (base)));
       if (expr != base
 	  && !is_gimple_reg_type (TREE_TYPE (expr))
 	  && dump_file && (dump_flags & TDF_DETAILS))
@@ -1135,6 +1140,17 @@ sra_handled_bf_read_p (tree expr)
 static struct access *
 build_access_from_expr_1 (tree expr, gimple *stmt, bool write)
 {
+  /* We only allow ADDR_EXPRs in arguments of function calls and those must
+     have been dealt with in build_access_from_call_arg.  Any other address
+     taking should have been caught by scan_visit_addr.   */
+  if (TREE_CODE (expr) == ADDR_EXPR)
+    {
+      tree base = get_base_address (TREE_OPERAND (expr, 0));
+      gcc_assert (!DECL_P (base)
+		  || !bitmap_bit_p (candidate_bitmap, DECL_UID (base)));
+      return NULL;
+    }
+
   struct access *ret = NULL;
   bool partial_ref;
 
@@ -1222,6 +1238,77 @@ build_access_from_expr (tree expr, gimple *stmt, bool write)
     }
   return false;
 }
+
+enum out_edge_check { SRA_OUTGOING_EDGES_UNCHECKED, SRA_OUTGOING_EDGES_OK,
+		      SRA_OUTGOING_EDGES_FAIL };
+
+/* Return true if STMT terminates BB and there is an abnormal edge going out of
+   the BB and remember the decision in OE_CHECK.  */
+
+static bool
+abnormal_edge_after_stmt_p (gimple *stmt, enum out_edge_check *oe_check)
+{
+  if (*oe_check == SRA_OUTGOING_EDGES_OK)
+    return false;
+  if (*oe_check == SRA_OUTGOING_EDGES_FAIL)
+    return true;
+  if (stmt_ends_bb_p (stmt))
+    {
+      edge e;
+      edge_iterator ei;
+      FOR_EACH_EDGE (e, ei, gimple_bb (stmt)->succs)
+	if (e->flags & EDGE_ABNORMAL)
+	  {
+	    *oe_check = SRA_OUTGOING_EDGES_FAIL;
+	    return true;
+	  }
+    }
+  *oe_check = SRA_OUTGOING_EDGES_OK;
+  return false;
+}
+
+/* Scan expression EXPR which is an argument of a call and create access
+   structures for all accesses to candidates for scalarization.  Return true if
+   any access has been inserted.  STMT must be the statement from which the
+   expression is taken.  */
+
+static bool
+build_access_from_call_arg (tree expr, gimple *stmt,
+			    enum out_edge_check *oe_check)
+{
+  if (TREE_CODE (expr) == ADDR_EXPR)
+    {
+      tree base = get_base_address (TREE_OPERAND (expr, 0));
+
+      if (abnormal_edge_after_stmt_p (stmt, oe_check))
+	{
+	  disqualify_base_of_expr (base, "May lead to need to add statements "
+				   "to abnormal edge.");
+	  return false;
+	}
+
+      bool read =  build_access_from_expr (base, stmt, false);
+      bool write =  build_access_from_expr (base, stmt, true);
+      if (read || write)
+	{
+	  if (dump_file && (dump_flags & TDF_DETAILS))
+	    {
+	      fprintf (dump_file, "Allowed ADDR_EXPR of ");
+	      print_generic_expr (dump_file, base);
+	      fprintf (dump_file, " because of ");
+	      print_gimple_stmt (dump_file, stmt, 0);
+	      fprintf (dump_file, "\n");
+	    }
+	  bitmap_set_bit (passed_by_ref_in_call, DECL_UID (base));
+	  return true;
+	}
+      else
+	return false;
+    }
+
+  return build_access_from_expr (expr, stmt, false);
+}
+
 
 /* Return the single non-EH successor edge of BB or NULL if there is none or
    more than one.  */
@@ -1364,16 +1451,18 @@ build_accesses_from_assign (gimple *stmt)
   return lacc || racc;
 }
 
-/* Callback of walk_stmt_load_store_addr_ops visit_addr used to determine
-   GIMPLE_ASM operands with memory constrains which cannot be scalarized.  */
+/* Callback of walk_stmt_load_store_addr_ops visit_addr used to detect taking
+   addresses of candidates a places which are not call arguments.  Such
+   candidates are disqalified from SRA.  This also applies to GIMPLE_ASM
+   operands with memory constrains which cannot be scalarized.  */
 
 static bool
-asm_visit_addr (gimple *, tree op, tree, void *)
+scan_visit_addr (gimple *, tree op, tree, void *)
 {
   op = get_base_address (op);
   if (op
       && DECL_P (op))
-    disqualify_candidate (op, "Non-scalarizable GIMPLE_ASM operand.");
+    disqualify_candidate (op, "Address taken in a non-call-argument context.");
 
   return false;
 }
@@ -1390,11 +1479,19 @@ scan_function (void)
   FOR_EACH_BB_FN (bb, cfun)
     {
       gimple_stmt_iterator gsi;
+      for (gsi = gsi_start_phis (bb); !gsi_end_p (gsi); gsi_next (&gsi))
+	walk_stmt_load_store_addr_ops (gsi_stmt (gsi), NULL, NULL, NULL,
+				       scan_visit_addr);
+
       for (gsi = gsi_start_bb (bb); !gsi_end_p (gsi); gsi_next (&gsi))
 	{
 	  gimple *stmt = gsi_stmt (gsi);
 	  tree t;
 	  unsigned i;
+
+	  if (gimple_code (stmt) != GIMPLE_CALL)
+	    walk_stmt_load_store_addr_ops (stmt, NULL, NULL, NULL,
+					   scan_visit_addr);
 
 	  switch (gimple_code (stmt))
 	    {
@@ -1409,9 +1506,15 @@ scan_function (void)
 	      break;
 
 	    case GIMPLE_CALL:
-	      for (i = 0; i < gimple_call_num_args (stmt); i++)
-		ret |= build_access_from_expr (gimple_call_arg (stmt, i),
-					       stmt, false);
+	      {
+		enum out_edge_check oe_check = SRA_OUTGOING_EDGES_UNCHECKED;
+		for (i = 0; i < gimple_call_num_args (stmt); i++)
+		  ret |= build_access_from_call_arg (gimple_call_arg (stmt, i),
+						     stmt, &oe_check);
+		if (gimple_call_chain(stmt))
+		  ret |= build_access_from_call_arg (gimple_call_chain(stmt),
+						     stmt, &oe_check);
+	      }
 
 	      t = gimple_call_lhs (stmt);
 	      if (t && !disqualify_if_bad_bb_terminating_stmt (stmt, t, NULL))
@@ -1428,8 +1531,6 @@ scan_function (void)
 	    case GIMPLE_ASM:
 	      {
 		gasm *asm_stmt = as_a <gasm *> (stmt);
-		walk_stmt_load_store_addr_ops (asm_stmt, NULL, NULL, NULL,
-					       asm_visit_addr);
 		for (i = 0; i < gimple_asm_ninputs (asm_stmt); i++)
 		  {
 		    t = TREE_VALUE (gimple_asm_input_op (asm_stmt, i));
@@ -1920,10 +2021,19 @@ maybe_add_sra_candidate (tree var)
       reject (var, "not aggregate");
       return false;
     }
-  /* Allow constant-pool entries that "need to live in memory".  */
-  if (needs_to_live_in_memory (var) && !constant_decl_p (var))
+
+  if ((is_global_var (var)
+       /* There are cases where non-addressable variables fail the
+	  pt_solutions_check test, e.g in gcc.dg/uninit-40.c. */
+       || (TREE_ADDRESSABLE (var)
+	   && pt_solution_includes (&cfun->gimple_df->escaped, var))
+       || (TREE_CODE (var) == RESULT_DECL
+	   && !DECL_BY_REFERENCE (var)
+	   && aggregate_value_p (var, current_function_decl)))
+      /* Allow constant-pool entries that "need to live in memory".  */
+      && !constant_decl_p (var))
     {
-      reject (var, "needs to live in memory");
+      reject (var, "needs to live in memory and escapes or global");
       return false;
     }
   if (TREE_THIS_VOLATILE (var))
@@ -2121,6 +2231,23 @@ sort_and_splice_var_accesses (tree var)
       else
 	gcc_assert (access->offset >= low
 		    && access->offset + access->size <= high);
+
+      if (INTEGRAL_TYPE_P (access->type)
+	  && TYPE_PRECISION (access->type) != access->size
+	  && bitmap_bit_p (passed_by_ref_in_call, DECL_UID (access->base)))
+	{
+	  /* This can lead to performance regressions because we can generate
+	     excessive zero extensions.  */
+	  if (dump_file && (dump_flags & TDF_DETAILS))
+	    {
+	      fprintf (dump_file, "Won't scalarize ");
+	      print_generic_expr (dump_file, access->base);
+	      fprintf (dump_file, "(%d), it is passed by reference to a call "
+		       "and there are accesses with precision not covering "
+		       "their type size.", DECL_UID (access->base));
+	    }
+	  return NULL;
+	}
 
       grp_same_access_path = path_comparable_for_same_access (access->expr);
 
@@ -3774,12 +3901,18 @@ get_access_for_expr (tree expr)
 
 /* Replace the expression EXPR with a scalar replacement if there is one and
    generate other statements to do type conversion or subtree copying if
-   necessary.  GSI is used to place newly created statements, WRITE is true if
-   the expression is being written to (it is on a LHS of a statement or output
-   in an assembly statement).  */
+   necessary.  WRITE is true if the expression is being written to (it is on a
+   LHS of a statement or output in an assembly statement).  STMT_GSI is used to
+   place newly created statements before the processed statement, REFRESH_GSI
+   is used to place them afterwards - unless the processed statement must end a
+   BB in which case it is placed on the outgoing non-EH edge.  REFRESH_GSI and
+   is then used to continue iteration over the BB.  If sra_modify_expr is
+   called only once with WRITE equal to true on a given statement, both
+   iterator parameters can point to the same one.  */
 
 static bool
-sra_modify_expr (tree *expr, gimple_stmt_iterator *gsi, bool write)
+sra_modify_expr (tree *expr, bool write, gimple_stmt_iterator *stmt_gsi,
+		 gimple_stmt_iterator *refresh_gsi)
 {
   location_t loc;
   struct access *access;
@@ -3806,12 +3939,12 @@ sra_modify_expr (tree *expr, gimple_stmt_iterator *gsi, bool write)
   type = TREE_TYPE (*expr);
   orig_expr = *expr;
 
-  loc = gimple_location (gsi_stmt (*gsi));
+  loc = gimple_location (gsi_stmt (*stmt_gsi));
   gimple_stmt_iterator alt_gsi = gsi_none ();
-  if (write && stmt_ends_bb_p (gsi_stmt (*gsi)))
+  if (write && stmt_ends_bb_p (gsi_stmt (*stmt_gsi)))
     {
-      alt_gsi = gsi_start_edge (single_non_eh_succ (gsi_bb (*gsi)));
-      gsi = &alt_gsi;
+      alt_gsi = gsi_start_edge (single_non_eh_succ (gsi_bb (*stmt_gsi)));
+      refresh_gsi = &alt_gsi;
     }
 
   if (access->grp_to_be_replaced)
@@ -3831,7 +3964,8 @@ sra_modify_expr (tree *expr, gimple_stmt_iterator *gsi, bool write)
 	{
 	  tree ref;
 
-	  ref = build_ref_for_model (loc, orig_expr, 0, access, gsi, false);
+	  ref = build_ref_for_model (loc, orig_expr, 0, access, stmt_gsi,
+				     false);
 
 	  if (partial_cplx_access)
 	    {
@@ -3847,7 +3981,7 @@ sra_modify_expr (tree *expr, gimple_stmt_iterator *gsi, bool write)
 		  tree tmp = make_ssa_name (type);
 		  gassign *stmt = gimple_build_assign (tmp, t);
 		  /* This is always a read. */
-		  gsi_insert_before (gsi, stmt, GSI_SAME_STMT);
+		  gsi_insert_before (stmt_gsi, stmt, GSI_SAME_STMT);
 		  t = tmp;
 		}
 	      *expr = t;
@@ -3857,22 +3991,23 @@ sra_modify_expr (tree *expr, gimple_stmt_iterator *gsi, bool write)
 	      gassign *stmt;
 
 	      if (access->grp_partial_lhs)
-		ref = force_gimple_operand_gsi (gsi, ref, true, NULL_TREE,
-						 false, GSI_NEW_STMT);
+		ref = force_gimple_operand_gsi (refresh_gsi, ref, true,
+						NULL_TREE, false, GSI_NEW_STMT);
 	      stmt = gimple_build_assign (repl, ref);
 	      gimple_set_location (stmt, loc);
-	      gsi_insert_after (gsi, stmt, GSI_NEW_STMT);
+	      gsi_insert_after (refresh_gsi, stmt, GSI_NEW_STMT);
 	    }
 	  else
 	    {
 	      gassign *stmt;
 
 	      if (access->grp_partial_lhs)
-		repl = force_gimple_operand_gsi (gsi, repl, true, NULL_TREE,
-						 true, GSI_SAME_STMT);
+		repl = force_gimple_operand_gsi (stmt_gsi, repl, true,
+						 NULL_TREE, true,
+						 GSI_SAME_STMT);
 	      stmt = gimple_build_assign (ref, repl);
 	      gimple_set_location (stmt, loc);
-	      gsi_insert_before (gsi, stmt, GSI_SAME_STMT);
+	      gsi_insert_before (stmt_gsi, stmt, GSI_SAME_STMT);
 	    }
 	}
       else
@@ -3899,8 +4034,8 @@ sra_modify_expr (tree *expr, gimple_stmt_iterator *gsi, bool write)
     {
       gdebug *ds = gimple_build_debug_bind (get_access_replacement (access),
 					    NULL_TREE,
-					    gsi_stmt (*gsi));
-      gsi_insert_after (gsi, ds, GSI_NEW_STMT);
+					    gsi_stmt (*stmt_gsi));
+      gsi_insert_after (stmt_gsi, ds, GSI_NEW_STMT);
     }
 
   if (access->first_child && !TREE_READONLY (access->base))
@@ -3918,8 +4053,57 @@ sra_modify_expr (tree *expr, gimple_stmt_iterator *gsi, bool write)
 	start_offset = chunk_size = 0;
 
       generate_subtree_copies (access->first_child, orig_expr, access->offset,
-			       start_offset, chunk_size, gsi, write, write,
-			       loc);
+			       start_offset, chunk_size,
+			       write ? refresh_gsi : stmt_gsi,
+			       write, write, loc);
+    }
+  return true;
+}
+
+/* If EXPR, which must be a call argument, is an ADDR_EXPR, generate writes and
+   reads from its base before and after the call statement given in CALL_GSI
+   and return true if any copying took place.  Otherwise call sra_modify_expr
+   on EXPR and return its value.  FLAGS is what the gimple_call_arg_flags
+   return for the given parameter.  */
+
+static bool
+sra_modify_call_arg (tree *expr, gimple_stmt_iterator *call_gsi,
+		     gimple_stmt_iterator *refresh_gsi, int flags)
+{
+  if (TREE_CODE (*expr) != ADDR_EXPR)
+    return sra_modify_expr (expr, false, call_gsi, refresh_gsi);
+
+  if (flags & EAF_UNUSED)
+    return false;
+
+  tree base = get_base_address (TREE_OPERAND (*expr, 0));
+  if (!DECL_P (base))
+    return false;
+  struct access *access = get_access_for_expr (base);
+  if (!access)
+    return false;
+
+  gimple *stmt = gsi_stmt (*call_gsi);
+  location_t loc = gimple_location (stmt);
+  generate_subtree_copies (access, base, 0, 0, 0, call_gsi, false, false,
+			   loc);
+
+  if (flags & EAF_NO_DIRECT_CLOBBER)
+    return true;
+
+  if (!stmt_ends_bb_p (stmt))
+    generate_subtree_copies (access, base, 0, 0, 0, refresh_gsi, true,
+			     true, loc);
+  else
+    {
+      edge e;
+      edge_iterator ei;
+      FOR_EACH_EDGE (e, ei, gsi_bb (*call_gsi)->succs)
+	{
+	  gimple_stmt_iterator alt_gsi = gsi_start_edge (e);
+	  generate_subtree_copies (access, base, 0, 0, 0, &alt_gsi, true,
+				   true, loc);
+	}
     }
   return true;
 }
@@ -4278,9 +4462,9 @@ sra_modify_assign (gimple *stmt, gimple_stmt_iterator *gsi)
       || TREE_CODE (rhs) == BIT_FIELD_REF || TREE_CODE (lhs) == BIT_FIELD_REF)
     {
       modify_this_stmt = sra_modify_expr (gimple_assign_rhs1_ptr (stmt),
-					  gsi, false);
+					  false, gsi, gsi);
       modify_this_stmt |= sra_modify_expr (gimple_assign_lhs_ptr (stmt),
-					   gsi, true);
+					   true, gsi, gsi);
       return modify_this_stmt ? SRA_AM_MODIFIED : SRA_AM_NONE;
     }
 
@@ -4602,7 +4786,7 @@ sra_modify_function_body (void)
 	    case GIMPLE_RETURN:
 	      t = gimple_return_retval_ptr (as_a <greturn *> (stmt));
 	      if (*t != NULL_TREE)
-		modified |= sra_modify_expr (t, &gsi, false);
+		modified |= sra_modify_expr (t, false, &gsi, &gsi);
 	      break;
 
 	    case GIMPLE_ASSIGN:
@@ -4621,33 +4805,44 @@ sra_modify_function_body (void)
 		}
 	      else
 		{
-		  /* Operands must be processed before the lhs.  */
-		  for (i = 0; i < gimple_call_num_args (stmt); i++)
-		    {
-		      t = gimple_call_arg_ptr (stmt, i);
-		      modified |= sra_modify_expr (t, &gsi, false);
-		    }
+		  gcall *call = as_a <gcall *> (stmt);
+		  gimple_stmt_iterator call_gsi = gsi;
 
-	      	  if (gimple_call_lhs (stmt))
+		  /* Operands must be processed before the lhs.  */
+		  for (i = 0; i < gimple_call_num_args (call); i++)
 		    {
-		      t = gimple_call_lhs_ptr (stmt);
-		      modified |= sra_modify_expr (t, &gsi, true);
+		      int flags = gimple_call_arg_flags (call, i);
+		      t = gimple_call_arg_ptr (call, i);
+		      modified |= sra_modify_call_arg (t, &call_gsi, &gsi, flags);
+		    }
+		  if (gimple_call_chain (call))
+		    {
+		      t = gimple_call_chain_ptr (call);
+		      int flags = gimple_call_static_chain_flags (call);
+		      modified |= sra_modify_call_arg (t, &call_gsi, &gsi,
+						       flags);
+		    }
+		  if (gimple_call_lhs (call))
+		    {
+		      t = gimple_call_lhs_ptr (call);
+		      modified |= sra_modify_expr (t, true, &call_gsi, &gsi);
 		    }
 		}
 	      break;
 
 	    case GIMPLE_ASM:
 	      {
+		gimple_stmt_iterator stmt_gsi = gsi;
 		gasm *asm_stmt = as_a <gasm *> (stmt);
 		for (i = 0; i < gimple_asm_ninputs (asm_stmt); i++)
 		  {
 		    t = &TREE_VALUE (gimple_asm_input_op (asm_stmt, i));
-		    modified |= sra_modify_expr (t, &gsi, false);
+		    modified |= sra_modify_expr (t, false, &stmt_gsi, &gsi);
 		  }
 		for (i = 0; i < gimple_asm_noutputs (asm_stmt); i++)
 		  {
 		    t = &TREE_VALUE (gimple_asm_output_op (asm_stmt, i));
-		    modified |= sra_modify_expr (t, &gsi, true);
+		    modified |= sra_modify_expr (t, true, &stmt_gsi, &gsi);
 		  }
 	      }
 	      break;

--- a/gcc/tree-ssa-alias.cc
+++ b/gcc/tree-ssa-alias.cc
@@ -496,7 +496,8 @@ ref_may_alias_global_p_1 (tree base, bool escaped_local_p)
   if (DECL_P (base))
     return (is_global_var (base)
 	    || (escaped_local_p
-		&& pt_solution_includes (&cfun->gimple_df->escaped, base)));
+		&& pt_solution_includes (&cfun->gimple_df->escaped_return,
+					 base)));
   else if (TREE_CODE (base) == MEM_REF
 	   || TREE_CODE (base) == TARGET_MEM_REF)
     return ptr_deref_may_alias_global_p (TREE_OPERAND (base, 0),
@@ -578,6 +579,9 @@ dump_alias_info (FILE *file)
 
   fprintf (file, "\nESCAPED");
   dump_points_to_solution (file, &cfun->gimple_df->escaped);
+
+  fprintf (file, "\nESCAPED_RETURN");
+  dump_points_to_solution (file, &cfun->gimple_df->escaped_return);
 
   fprintf (file, "\n\nFlow-insensitive points-to information\n\n");
 

--- a/gcc/tree-ssa-structalias.cc
+++ b/gcc/tree-ssa-structalias.cc
@@ -365,8 +365,8 @@ vi_next (varinfo_t vi)
 /* Static IDs for the special variables.  Variable ID zero is unused
    and used as terminator for the sub-variable chain.  */
 enum { nothing_id = 1, anything_id = 2, string_id = 3,
-       escaped_id = 4, nonlocal_id = 5,
-       storedanything_id = 6, integer_id = 7 };
+       escaped_id = 4, nonlocal_id = 5, escaped_return_id = 6,
+       storedanything_id = 7, integer_id = 8 };
 
 /* Return a new variable info structure consisting for a variable
    named NAME, and using constraint graph node NODE.  Append it
@@ -5221,23 +5221,18 @@ find_func_aliases (struct function *fn, gimple *origt)
 	   && gimple_return_retval (as_a <greturn *> (t)) != NULL_TREE)
     {
       greturn *return_stmt = as_a <greturn *> (t);
-      fi = NULL;
-      if (!in_ipa_mode
-	  && SSA_VAR_P (gimple_return_retval (return_stmt)))
-	{
-	  /* We handle simple returns by post-processing the solutions.  */
-	  ;
-	}
-      if (!(fi = get_vi_for_tree (fn->decl)))
-	make_escape_constraint (gimple_return_retval (return_stmt));
-      else if (in_ipa_mode)
+      tree retval = gimple_return_retval (return_stmt);
+      if (!in_ipa_mode)
+	make_constraint_to (escaped_return_id, retval);
+      else
 	{
 	  struct constraint_expr lhs ;
 	  struct constraint_expr *rhsp;
 	  unsigned i;
 
+	  fi = lookup_vi_for_tree (fn->decl);
 	  lhs = get_function_part_constraint (fi, fi_result);
-	  get_constraint_for_rhs (gimple_return_retval (return_stmt), &rhsc);
+	  get_constraint_for_rhs (retval, &rhsc);
 	  FOR_EACH_VEC_ELT (rhsc, i, rhsp)
 	    process_constraint (new_constraint (lhs, *rhsp));
 	}
@@ -6665,6 +6660,7 @@ set_uids_in_ptset (bitmap into, bitmap from, struct pt_solution *pt,
   unsigned int i;
   bitmap_iterator bi;
   varinfo_t escaped_vi = get_varinfo (find (escaped_id));
+  varinfo_t escaped_return_vi = get_varinfo (find (escaped_return_id));
   bool everything_escaped
     = escaped_vi->solution && bitmap_bit_p (escaped_vi->solution, anything_id);
 
@@ -6682,6 +6678,9 @@ set_uids_in_ptset (bitmap into, bitmap from, struct pt_solution *pt,
 	  pt->vars_contains_escaped = true;
 	  pt->vars_contains_escaped_heap |= vi->is_heap_var;
 	}
+      if (escaped_return_vi->solution
+	  && bitmap_bit_p (escaped_return_vi->solution, i))
+	pt->vars_contains_escaped_heap |= vi->is_heap_var;
 
       if (vi->is_restrict_var)
 	pt->vars_contains_restrict = true;
@@ -7196,6 +7195,7 @@ init_base_vars (void)
   varinfo_t var_string;
   varinfo_t var_escaped;
   varinfo_t var_nonlocal;
+  varinfo_t var_escaped_return;
   varinfo_t var_storedanything;
   varinfo_t var_integer;
 
@@ -7271,6 +7271,16 @@ init_base_vars (void)
   var_nonlocal->fullsize = ~0;
   var_nonlocal->is_special_var = 1;
 
+  /* Create the ESCAPED_RETURN variable, used to represent the set of escaped
+     memory via a regular return stmt.  */
+  var_escaped_return = new_var_info (NULL_TREE, "ESCAPED_RETURN", false);
+  gcc_assert (var_escaped_return->id == escaped_return_id);
+  var_escaped_return->is_artificial_var = 1;
+  var_escaped_return->offset = 0;
+  var_escaped_return->size = ~0;
+  var_escaped_return->fullsize = ~0;
+  var_escaped_return->is_special_var = 0;
+
   /* ESCAPED = *ESCAPED, because escaped is may-deref'd at calls, etc.  */
   lhs.type = SCALAR;
   lhs.var = escaped_id;
@@ -7312,6 +7322,24 @@ init_base_vars (void)
   process_constraint (new_constraint (lhs, rhs));
   rhs.type = ADDRESSOF;
   rhs.var = escaped_id;
+  rhs.offset = 0;
+  process_constraint (new_constraint (lhs, rhs));
+
+  /* Transitively close ESCAPED_RETURN.
+     ESCAPED_RETURN = ESCAPED_RETURN + UNKNOWN_OFFSET
+     ESCAPED_RETURN = *ESCAPED_RETURN.  */
+  lhs.type = SCALAR;
+  lhs.var = escaped_return_id;
+  lhs.offset = 0;
+  rhs.type = SCALAR;
+  rhs.var = escaped_return_id;
+  rhs.offset = UNKNOWN_OFFSET;
+  process_constraint (new_constraint (lhs, rhs));
+  lhs.type = SCALAR;
+  lhs.var = escaped_return_id;
+  lhs.offset = 0;
+  rhs.type = DEREF;
+  rhs.var = escaped_return_id;
   rhs.offset = 0;
   process_constraint (new_constraint (lhs, rhs));
 
@@ -7555,70 +7583,6 @@ compute_points_to_sets (void)
   /* From the constraints compute the points-to sets.  */
   solve_constraints ();
 
-  /* Post-process solutions for escapes through returns.  */
-  edge_iterator ei;
-  edge e;
-  FOR_EACH_EDGE (e, ei, EXIT_BLOCK_PTR_FOR_FN (cfun)->preds)
-    if (greturn *ret = safe_dyn_cast <greturn *> (*gsi_last_bb (e->src)))
-      {
-	tree val = gimple_return_retval (ret);
-	/* ???  Easy to handle simple indirections with some work.
-	   Arbitrary references like foo.bar.baz are more difficult
-	   (but conservatively easy enough with just looking at the base).
-	   Mind to fixup find_func_aliases as well.  */
-	if (!val || !SSA_VAR_P (val))
-	  continue;
-	/* returns happen last in non-IPA so they only influence
-	   the ESCAPED solution and we can filter local variables.  */
-	varinfo_t escaped_vi = get_varinfo (find (escaped_id));
-	varinfo_t vi = lookup_vi_for_tree (val);
-	bitmap delta = BITMAP_ALLOC (&pta_obstack);
-	bitmap_iterator bi;
-	unsigned i;
-	for (; vi; vi = vi_next (vi))
-	  {
-	    varinfo_t part_vi = get_varinfo (find (vi->id));
-	    EXECUTE_IF_AND_COMPL_IN_BITMAP (part_vi->solution,
-					    escaped_vi->solution, 0, i, bi)
-	      {
-		varinfo_t pointed_to_vi = get_varinfo (i);
-		if (pointed_to_vi->is_global_var
-		    /* We delay marking of heap memory as global.  */
-		    || pointed_to_vi->is_heap_var)
-		  bitmap_set_bit (delta, i);
-	      }
-	  }
-
-	/* Now compute the transitive closure.  */
-	bitmap_ior_into (escaped_vi->solution, delta);
-	bitmap new_delta = BITMAP_ALLOC (&pta_obstack);
-	while (!bitmap_empty_p (delta))
-	  {
-	    EXECUTE_IF_SET_IN_BITMAP (delta, 0, i, bi)
-	      {
-		varinfo_t pointed_to_vi = get_varinfo (i);
-		pointed_to_vi = get_varinfo (find (pointed_to_vi->id));
-		unsigned j;
-		bitmap_iterator bi2;
-		EXECUTE_IF_AND_COMPL_IN_BITMAP (pointed_to_vi->solution,
-						escaped_vi->solution,
-						0, j, bi2)
-		  {
-		    varinfo_t pointed_to_vi2 = get_varinfo (j);
-		    if (pointed_to_vi2->is_global_var
-			/* We delay marking of heap memory as global.  */
-			|| pointed_to_vi2->is_heap_var)
-		      bitmap_set_bit (new_delta, j);
-		  }
-	      }
-	    bitmap_ior_into (escaped_vi->solution, new_delta);
-	    bitmap_clear (delta);
-	    std::swap (delta, new_delta);
-	  }
-	BITMAP_FREE (delta);
-	BITMAP_FREE (new_delta);
-      }
-
   if (dump_file && (dump_flags & TDF_STATS))
     dump_sa_stats (dump_file);
 
@@ -7633,6 +7597,12 @@ compute_points_to_sets (void)
      other solutions) does not reference itself.  This simplifies
      points-to solution queries.  */
   cfun->gimple_df->escaped.escaped = 0;
+
+  /* The ESCAPED_RETURN solution is what contains all memory that needs
+     to be considered global.  */
+  cfun->gimple_df->escaped_return
+    = find_what_var_points_to (cfun->decl, get_varinfo (escaped_return_id));
+  cfun->gimple_df->escaped_return.escaped = 1;
 
   /* Compute the points-to sets for pointer SSA_NAMEs.  */
   unsigned i;

--- a/gcc/tree-ssa.cc
+++ b/gcc/tree-ssa.cc
@@ -1216,6 +1216,7 @@ init_tree_ssa (struct function *fn, int size)
   fn->gimple_df = ggc_cleared_alloc<gimple_df> ();
   fn->gimple_df->default_defs = hash_table<ssa_name_hasher>::create_ggc (20);
   pt_solution_reset (&fn->gimple_df->escaped);
+  pt_solution_reset (&fn->gimple_df->escaped_return);
   init_ssanames (fn, size);
 }
 
@@ -1233,6 +1234,7 @@ delete_tree_ssa (struct function *fn)
   fn->gimple_df->default_defs->empty ();
   fn->gimple_df->default_defs = NULL;
   pt_solution_reset (&fn->gimple_df->escaped);
+  pt_solution_reset (&fn->gimple_df->escaped_return);
   if (fn->gimple_df->decls_to_pointers != NULL)
     delete fn->gimple_df->decls_to_pointers;
   fn->gimple_df->decls_to_pointers = NULL;


### PR DESCRIPTION
GCC upstream commit f7884f7673444b8a2c10ea0981d480f2e82dd16a "tree-optimization/112653 - PTA and return" (and prerequisite commit aae723d360ca26cd9fd0b039fb0a616bd0eae363 "sra: SRA of non-escaped aggregates passed by reference to calls") trigger a bootstrap failure, see below.  These commits are part of the next merge from GCC upstream into GCC/Rust; isolated here as two cherry-picks.

```
[...]
In file included from [...]/source-gcc/gcc/rust/ast/rust-expr.h:6,
                 from [...]/source-gcc/gcc/rust/ast/rust-ast-full.h:24,
                 from [...]/source-gcc/gcc/rust/ast/rust-ast.cc:24:
In copy constructor ‘Rust::AST::MacroInvocation::MacroInvocation(const Rust::AST::MacroInvocation&)’,
    inlined from ‘Rust::AST::MacroInvocation* Rust::AST::MacroInvocation::clone_macro_invocation_impl() const’ at [...]/source-gcc/gcc/rust/ast/rust-\
macro.h:798:38:
[...]/source-gcc/gcc/rust/ast/rust-macro.h:734:39: error: ‘*(Rust::AST::MacroInvocation*)<unknown>.Rust::AST::MacroInvocation::Rust::AST::ExprWithout\
Block.Rust::AST::ExprWithoutBlock::Rust::AST::Expr.Rust::AST::Expr::node_id’ is used uninitialized [-Werror=uninitialized]
  734 |       builtin_kind (other.builtin_kind)
      |                                       ^
cc1plus: all warnings being treated as errors
make[3]: *** [[...]/source-gcc/gcc/rust/Make-lang.in:423: rust/rust-ast.o] Error 1
[...]
In file included from [...]/source-gcc/gcc/rust/ast/rust-expr.h:6,
                 from [...]/source-gcc/gcc/rust/ast/rust-item.h:27,
                 from [...]/source-gcc/gcc/rust/parse/rust-parse.h:20,
                 from [...]/source-gcc/gcc/rust/expand/rust-macro-expand.h:24,
                 from [...]/source-gcc/gcc/rust/expand/rust-macro-expand.cc:19:
In copy constructor ‘Rust::AST::MacroInvocation::MacroInvocation(const Rust::AST::MacroInvocation&)’,
    inlined from ‘Rust::AST::MacroInvocation* Rust::AST::MacroInvocation::clone_macro_invocation_impl() const’ at [...]/source-gcc/gcc/rust/ast/rust-\
macro.h:798:38:
[...]/source-gcc/gcc/rust/ast/rust-macro.h:734:39: error: ‘*(Rust::AST::MacroInvocation*)<unknown>.Rust::AST::MacroInvocation::Rust::AST::ExprWithout\
Block.Rust::AST::ExprWithoutBlock::Rust::AST::Expr.Rust::AST::Expr::node_id’ is used uninitialized [-Werror=uninitialized]
  734 |       builtin_kind (other.builtin_kind)
      |                                       ^
cc1plus: all warnings being treated as errors
make[3]: *** [[...]/source-gcc/gcc/rust/Make-lang.in:433: rust/rust-macro-expand.o] Error 1
[...]
```

From a (very) quick look, it wasn't directly obvious to me what's wrong here.
