### PR TITLE
macro: Use MacroInvocation's node_id in ExternalItem constructor.

### DIFF
--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -727,7 +727,7 @@ private:
   {}
 
   MacroInvocation (const MacroInvocation &other)
-    : TraitItem (other.locus), ExternalItem (Expr::node_id),
+    : TraitItem (other.locus), ExternalItem (other.node_id),
       outer_attrs (other.outer_attrs), locus (other.locus),
       node_id (other.node_id), invoc_data (other.invoc_data),
       is_semi_coloned (other.is_semi_coloned), kind (other.kind),


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* ast/rust-macro.h: Use proper node id instead of the one in the base
	Expr class - which is uninitialized.

I think the `MacroInvocation` class would benefit from a cleanup on that part. It inherits from a ton of base classes, and its full constructor does not even call into the `ExternalItem` constructor. I'll open an issue.