### PR TITLE
Fix typo

### DIFF
--- a/gcc/rust/expand/rust-derive.cc
+++ b/gcc/rust/expand/rust-derive.cc
@@ -45,7 +45,7 @@ DeriveVisitor::derive (Item &item, const Attribute &attr,
     case BuiltinMacro::PartialOrd:
     case BuiltinMacro::Hash:
     default:
-      rust_sorry_at (attr.get_locus (), "uninmplemented builtin derive macro");
+      rust_sorry_at (attr.get_locus (), "unimplemented builtin derive macro");
       return nullptr;
     };
 }


### PR DESCRIPTION
It was originally a commit in https://github.com/Rust-GCC/gccrs/pull/2904 but since this PR won't get merged before some changes are done, let's move this commit out of it.