### PR TITLE
Remove system include in `gcc/rust/typecheck/rust-hir-type-check.h`

### DIFF
--- a/gcc/rust/rust-system.h
+++ b/gcc/rust/rust-system.h
@@ -46,6 +46,7 @@
 #include <fstream>
 #include <array>
 #include <algorithm>
+#include <stack>
 #include <limits>
 #include <numeric>
 


### PR DESCRIPTION
issue #2920

move system include to `rust-system.h` 
```c
#include <stack>
```