### PR TITLE
Recognize unstable as a builtin attribute

### DIFF
--- a/gcc/rust/util/rust-attribute-values.h
+++ b/gcc/rust/util/rust-attribute-values.h
@@ -51,6 +51,7 @@ public:
   static constexpr auto &RUSTC_INHERIT_OVERFLOW_CHECKS
     = "rustc_inherit_overflow_checks";
   static constexpr auto &STABLE = "stable";
+  static constexpr auto &UNSTABLE = "unstable";
 };
 } // namespace Values
 } // namespace Rust

--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -59,7 +59,8 @@ static const BuiltinAttrDefinition __definitions[]
      // From now on, these are reserved by the compiler and gated through
      // #![feature(rustc_attrs)]
      {Attrs::RUSTC_INHERIT_OVERFLOW_CHECKS, CODE_GENERATION},
-     {Attrs::STABLE, STATIC_ANALYSIS}};
+     {Attrs::STABLE, STATIC_ANALYSIS},
+     {Attrs::UNSTABLE, STATIC_ANALYSIS}};
 
 BuiltinAttributeMappings *
 BuiltinAttributeMappings::get ()

--- a/gcc/testsuite/rust/compile/unstable-fn.rs
+++ b/gcc/testsuite/rust/compile/unstable-fn.rs
@@ -1,0 +1,2 @@
+#[unstable(feature = "some_feature", issue = "12345")]
+pub fn foo() {}


### PR DESCRIPTION
In the future we'll have to produce [E0658](https://doc.rust-lang.org/error_codes/E0658.html), but this should allow us to compile code containing the ```unsafe``` attribute.