### PR TITLE
Improve parsing of raw byte string literals

### DIFF
--- a/gcc/testsuite/rust/compile/raw-byte-string-loc.rs
+++ b/gcc/testsuite/rust/compile/raw-byte-string-loc.rs
@@ -1,0 +1,6 @@
+const X: &'static u8 = br#"12
+12"#;
+
+BREAK
+// { dg-error "unrecognised token" "" { target *-*-* } .-1 }
+// { dg-excess-errors "error 'failed to parse item' does not have location" }


### PR DESCRIPTION
Ideally we would combine the string literal parsing functions somehow or use some abstraction to more easily track locations, but this should improve our current situation.