### PR TITLE
Recognize rustc_deprecated as a builtin attribute

### DIFF
--- a/gcc/rust/util/rust-attribute-values.h
+++ b/gcc/rust/util/rust-attribute-values.h
@@ -48,6 +48,7 @@ public:
   static constexpr auto &TARGET_FEATURE = "target_feature";
   // From now on, these are reserved by the compiler and gated through
   // #![feature(rustc_attrs)]
+  static constexpr auto &RUSTC_DEPRECATED = "rustc_deprecated";
   static constexpr auto &RUSTC_INHERIT_OVERFLOW_CHECKS
     = "rustc_inherit_overflow_checks";
   static constexpr auto &STABLE = "stable";

--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -58,6 +58,7 @@ static const BuiltinAttrDefinition __definitions[]
      {Attrs::TARGET_FEATURE, CODE_GENERATION},
      // From now on, these are reserved by the compiler and gated through
      // #![feature(rustc_attrs)]
+     {Attrs::RUSTC_DEPRECATED, STATIC_ANALYSIS},
      {Attrs::RUSTC_INHERIT_OVERFLOW_CHECKS, CODE_GENERATION},
      {Attrs::STABLE, STATIC_ANALYSIS}};
 

--- a/gcc/testsuite/rust/compile/deprecated-fn.rs
+++ b/gcc/testsuite/rust/compile/deprecated-fn.rs
@@ -1,0 +1,4 @@
+#![feature(rustc_attrs)]
+
+#[rustc_deprecated(since = "right now", reason = "a whim")]
+pub fn foo() {}


### PR DESCRIPTION
Similar to #2929, allows us to compile code which uses ```rustc_deprecated``` but doesn't handle the proper diagnostics yet.