### PR TITLE
raw-strings: Remove dg-excess-error directive

### DIFF
--- a/gcc/testsuite/rust/compile/raw-byte-string-loc.rs
+++ b/gcc/testsuite/rust/compile/raw-byte-string-loc.rs
@@ -3,4 +3,4 @@ const X: &'static u8 = br#"12
 
 BREAK
 // { dg-error "unrecognised token" "" { target *-*-* } .-1 }
-// { dg-excess-errors "error 'failed to parse item' does not have location" }
+// { dg-error "failed to parse item" "" { target *-*-* } .-2 }

--- a/gcc/testsuite/rust/compile/raw-string-loc.rs
+++ b/gcc/testsuite/rust/compile/raw-string-loc.rs
@@ -3,4 +3,4 @@ const X: &'static str = r#"12
 
 BREAK
 // { dg-error "unrecognised token" "" { target *-*-* } .-1 }
-// { dg-excess-errors "error 'failed to parse item' does not have location" }
+// { dg-error "failed to parse item" "" { target *-*-* } .-2 }


### PR DESCRIPTION
The error is actually expected and uses the correct location.

gcc/testsuite/ChangeLog:

	* rust/compile/raw-byte-string-loc.rs: Use dg-error instead of
	dg-excess-error.
	* rust/compile/raw-string-loc.rs: Likewise.

@powerboat9 how do you feel about this?
