### PR TITLE
Add an alternative solution on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ $ make
 
 ```
 
+Alternatively, a docker environment is avaiable for ARM-based Mac contributors.
+
+Please visit [gccrs-workspace](https://github.com/badumbatish/gccrs-workspace). 
+ 
+The image is based on Ubuntu ARM and came with dependencies all fetched.
+
 #### Running GCC Rust
 
 Running the compiler itself without make install we can simply invoke the compiler proper:

--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ $ make
 
 ```
 
-Alternatively, a docker environment is avaiable for ARM-based Mac contributors.
+Alternatively, a docker environment is available for ARM-based Mac contributors.
 
 Please visit [gccrs-workspace](https://github.com/badumbatish/gccrs-workspace). 
  
-The image is based on Ubuntu ARM and came with dependencies all fetched.
+The image is based on Ubuntu ARM and comes with dependencies all fetched.
 
 #### Running GCC Rust
 


### PR DESCRIPTION
For #2937, I only add the alternative instead of also the build documentation on Rosetta since it is still failing on my local Mac M2.


