### PR TITLE
Handle structs as scrutinee for match expressions

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -954,8 +954,8 @@ check_match_scrutinee (HIR::MatchExpr &expr, Context *ctx)
       // this will need to change but for now the first pass implementation,
       // lets assert this is the case
       TyTy::ADTType *adt = static_cast<TyTy::ADTType *> (scrutinee_expr_tyty);
-      rust_assert (adt->is_enum ());
-      rust_assert (adt->number_of_variants () > 0);
+      if (adt->is_enum ())
+	rust_assert (adt->number_of_variants () > 0);
     }
   else if (scrutinee_kind == TyTy::TypeKind::FLOAT)
     {

--- a/gcc/testsuite/rust/compile/issue-2906.rs
+++ b/gcc/testsuite/rust/compile/issue-2906.rs
@@ -1,0 +1,10 @@
+// { dg-warning "field is never read: .a." "" { target *-*-* } .-1 }
+struct Foo { a: i32 }
+
+fn main() {
+    let a = Foo { a: 15 };
+    
+    match a {
+        b => { }
+    }
+}

--- a/gcc/testsuite/rust/execute/torture/issue-2906.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-2906.rs
@@ -1,0 +1,34 @@
+// { dg-warning "field is never read: .x." "" { target *-*-* } .-1 }
+// { dg-warning "field is never read: .y." "" { target *-*-* } .-2 }
+struct Point {
+    x: u32,
+    y: u32,
+}
+
+fn is_origin(p: Point) -> bool {
+    match p {
+        Point { x, y } => {
+            if x == 0 && y == 0 {
+                return true;
+            }
+            false
+        }
+        _ => false,
+    }
+}
+
+fn main() -> i32 {
+    let p = Point { x: 0, y: 0 };
+    let q = Point { x: 0, y: 1 };
+    let mut retval = 2;
+    
+    if is_origin(p) {
+        retval -= 1;
+    }
+    
+    if !is_origin(q) {
+        retval -= 1;
+    }
+
+    retval
+}


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* backend/rust-compile-expr.cc (check_match_scrutinee): Handle structs

fixes #2906

We should now be able to use struct as scrutinee. I tested the code locally and it ran without issues but I was wondering if this patch also required a test case along with it.