### PR TITLE
mini-std: Add -frust-mini-std flag

### DIFF
--- a/gcc/rust/lang.opt
+++ b/gcc/rust/lang.opt
@@ -212,4 +212,8 @@ frust-borrowcheck
 Rust Var(flag_borrowcheck)
 Use the WIP borrow checker.
 
+frust-mini-std
+Rust Var(flag_mini_std)
+Include the experimental miniature standard library implementation shipped within the Rust frontend
+
 ; This comment is to ensure we retain the blank line above.


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* lang.opt: Add flag to lang options.

This flag should be used to enable the inclusion of @P-E-P's mini-std library, which is being worked on in #2957