### PR TITLE
libformat_parser: Lower minimum Rust version to 1.49

### DIFF
--- a/libgrust/libformat_parser/Cargo.toml
+++ b/libgrust/libformat_parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libformat_parser"
 version = "0.1.0"
-edition = "2021"
+edition = "2018"
 
 [workspace]
 

--- a/libgrust/libformat_parser/generic_format_parser/Cargo.toml
+++ b/libgrust/libformat_parser/generic_format_parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "generic_format_parser"
 version = "0.1.0"
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/libgrust/libformat_parser/generic_format_parser/src/lib.rs
+++ b/libgrust/libformat_parser/generic_format_parser/src/lib.rs
@@ -505,7 +505,7 @@ impl<'a> Parser<'a> {
             }
 
             pos = peek_pos;
-            description = format!("expected `'}}'`, found `{maybe:?}`");
+            description = format!("expected `'}}'`, found `{:?}`", maybe);
         } else {
             description = "expected `'}'` but string was terminated".to_owned();
             // point at closing `"`
@@ -690,12 +690,16 @@ impl<'a> Parser<'a> {
 
         // fill character
         if let Some(&(idx, c)) = self.cur.peek() {
-            if let Some((_, '>' | '<' | '^')) = self.cur.clone().nth(1) {
-                spec.fill = Some(c);
-                spec.fill_span = Some(self.span(idx, idx + 1));
-                self.cur.next();
+            match self.cur.clone().nth(1) {
+                Some((_, '>')) | Some((_, '<')) | Some((_, '^')) => {
+                    spec.fill = Some(c);
+                    spec.fill_span = Some(self.span(idx, idx + 1));
+                    self.cur.next();
+                }
+                _ => {}
             }
         }
+
         // Alignment
         if self.consume('<') {
             spec.align = AlignLeft;
@@ -908,7 +912,11 @@ impl<'a> Parser<'a> {
             );
         }
 
-        found.then_some(cur)
+        if found {
+            Some(cur)
+        } else {
+            None
+        }
     }
 
     fn suggest_format(&mut self) {
@@ -991,8 +999,9 @@ fn find_width_map_from_snippet(
     // If we only trimmed it off the input, `format!("\n")` would cause a mismatch as here we they actually match up.
     // Alternatively, we could just count the trailing newlines and only trim one from the input if they don't match up.
     let input_no_nl = input.trim_end_matches('\n');
-    let Some(unescaped) = unescape_string(snippet) else {
-        return InputStringKind::NotALiteral;
+    let unescaped = match unescape_string(snippet) {
+        Some(u) => u,
+        None => return InputStringKind::NotALiteral,
     };
 
     let unescaped_no_nl = unescaped.trim_end_matches('\n');
@@ -1023,7 +1032,13 @@ fn find_width_map_from_snippet(
 
                 width_mappings.push(InnerWidthMapping::new(pos, width, 0));
             }
-            ('\\', Some((_, 'n' | 't' | 'r' | '0' | '\\' | '\'' | '\"'))) => {
+            ('\\', Some((_, 'n')))
+            | ('\\', Some((_, 't')))
+            | ('\\', Some((_, 'r')))
+            | ('\\', Some((_, '0')))
+            | ('\\', Some((_, '\\')))
+            | ('\\', Some((_, '\'')))
+            | ('\\', Some((_, '\"'))) => {
                 width_mappings.push(InnerWidthMapping::new(pos, 2, 1));
                 let _ = s.next();
             }
@@ -1049,7 +1064,7 @@ fn find_width_map_from_snippet(
                             .as_str()
                             .get(..digits_len)
                             .and_then(|digits| u32::from_str_radix(digits, 16).ok())
-                            .and_then(char::from_u32)
+                            .and_then(std::char::from_u32)
                             .map_or(1, char::len_utf8);
 
                         // Skip the digits, for chars that encode to more than 1 utf-8 byte
@@ -1105,7 +1120,11 @@ fn unescape_string(string: &str) -> Option<string::String> {
     let buf = string::String::from(string);
     let ok = true;
 
-    ok.then_some(buf)
+    if ok {
+        Some(buf)
+    } else {
+        None
+    }
 }
 
 // Assert a reasonable size for `Piece`

--- a/libgrust/libformat_parser/src/lib.rs
+++ b/libgrust/libformat_parser/src/lib.rs
@@ -5,6 +5,16 @@
 
 use std::ffi::CStr;
 
+trait StringLeakExt {
+    fn leak<'a>(self) -> &'a mut str;
+}
+
+impl StringLeakExt for String {
+    fn leak<'a>(self) -> &'a mut str {
+        Box::leak(self.into_boxed_str())
+    }
+}
+
 trait IntoFFI<T> {
     fn into_ffi(self) -> T;
 }


### PR DESCRIPTION
libgrust/ChangeLog:

	* libformat_parser/Cargo.toml: Change Rust edition from 2021 to 2018.
	* libformat_parser/generic_format_parser/Cargo.toml: Likewise.
	* libformat_parser/generic_format_parser/src/lib.rs: Remove usage of
	then-unstable std features and language constructs.
	* libformat_parser/src/lib.rs: Likewise, plus provide extension trait
	for String::leak.

While changing this does not feel great, it will enable us to compile our dependencies with gccrs as soon as possible.