### PR TITLE
Remove unused ```Context``` parameter for some backend methods

### DIFF
--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -611,7 +611,7 @@ HIRCompileBase::compile_function_body (tree fndecl,
 	  ctx->add_statement (return_value);
 
 	  // now just return unit expression
-	  tree unit_expr = unit_expression (ctx, locus);
+	  tree unit_expr = unit_expression (locus);
 	  tree return_stmt
 	    = Backend::return_statement (fndecl, unit_expr, locus);
 	  ctx->add_statement (return_stmt);
@@ -622,7 +622,7 @@ HIRCompileBase::compile_function_body (tree fndecl,
       // we can only do this if the function is of unit type otherwise other
       // errors should have occurred
       location_t locus = function_body.get_locus ();
-      tree return_value = unit_expression (ctx, locus);
+      tree return_value = unit_expression (locus);
       tree return_stmt
 	= Backend::return_statement (fndecl, return_value, locus);
       ctx->add_statement (return_stmt);
@@ -991,9 +991,9 @@ HIRCompileBase::resolve_method_address (TyTy::FnType *fntype,
 }
 
 tree
-HIRCompileBase::unit_expression (Context *ctx, location_t locus)
+HIRCompileBase::unit_expression (location_t locus)
 {
-  tree unit_type = TyTyResolveCompile::get_unit_type (ctx);
+  tree unit_type = TyTyResolveCompile::get_unit_type ();
   return Backend::constructor_expression (unit_type, false, {}, -1, locus);
 }
 

--- a/gcc/rust/backend/rust-compile-base.h
+++ b/gcc/rust/backend/rust-compile-base.h
@@ -102,7 +102,7 @@ protected:
 			 const Resolver::CanonicalPath *canonical_path,
 			 TyTy::FnType *fntype);
 
-  static tree unit_expression (Context *ctx, location_t locus);
+  static tree unit_expression (location_t locus);
 
   void setup_fndecl (tree fndecl, bool is_main_entry_point, bool is_generic_fn,
 		     HIR::Visibility &visibility,

--- a/gcc/rust/backend/rust-compile-block.cc
+++ b/gcc/rust/backend/rust-compile-block.cc
@@ -75,7 +75,7 @@ CompileBlock::visit (HIR::BlockExpr &expr)
   else if (result != nullptr)
     {
       location_t locus = expr.get_locus ();
-      tree compiled_expr = unit_expression (ctx, expr.get_locus ());
+      tree compiled_expr = unit_expression (expr.get_locus ());
       tree result_reference = Backend::var_expression (result, locus);
 
       tree assignment

--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -76,7 +76,7 @@ CompileExpr::visit (HIR::TupleExpr &expr)
 {
   if (expr.is_unit ())
     {
-      translated = unit_expression (ctx, expr.get_locus ());
+      translated = unit_expression (expr.get_locus ());
       return;
     }
 
@@ -111,7 +111,7 @@ CompileExpr::visit (HIR::ReturnExpr &expr)
 
   tree return_value = expr.has_return_expr ()
 			? CompileExpr::Compile (expr.return_expr.get (), ctx)
-			: unit_expression (ctx, expr.get_locus ());
+			: unit_expression (expr.get_locus ());
 
   if (expr.has_return_expr ())
     {
@@ -401,7 +401,7 @@ CompileExpr::visit (HIR::StructExprStruct &struct_expr)
     }
 
   rust_assert (tyty->is_unit ());
-  translated = unit_expression (ctx, struct_expr.get_locus ());
+  translated = unit_expression (struct_expr.get_locus ());
 }
 
 void

--- a/gcc/rust/backend/rust-compile-pattern.cc
+++ b/gcc/rust/backend/rust-compile-pattern.cc
@@ -627,7 +627,7 @@ CompilePatternLet::visit (HIR::IdentifierPattern &pattern)
     {
       ctx->add_statement (init_expr);
 
-      auto unit_type_init_expr = unit_expression (ctx, rval_locus);
+      auto unit_type_init_expr = unit_expression (rval_locus);
       auto s = Backend::init_statement (fnctx.fndecl, var, unit_type_init_expr);
       ctx->add_statement (s);
     }

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -57,7 +57,7 @@ ResolvePathRef::attempt_constructor_expression_lookup (
 
   TyTy::ADTType *adt = static_cast<TyTy::ADTType *> (lookup);
   if (adt->is_unit ())
-    return unit_expression (ctx, expr_locus);
+    return unit_expression (expr_locus);
 
   if (!adt->is_enum ())
     return error_mark_node;

--- a/gcc/rust/backend/rust-compile-type.cc
+++ b/gcc/rust/backend/rust-compile-type.cc
@@ -54,7 +54,7 @@ TyTyResolveCompile::compile (Context *ctx, const TyTy::BaseType *ty,
 // see: gcc/c/c-decl.cc:8230-8241
 // https://github.com/Rust-GCC/gccrs/blob/0024bc2f028369b871a65ceb11b2fddfb0f9c3aa/gcc/c/c-decl.c#L8229-L8241
 tree
-TyTyResolveCompile::get_implicit_enumeral_node_type (Context *ctx)
+TyTyResolveCompile::get_implicit_enumeral_node_type ()
 {
   // static tree enum_node = NULL_TREE;
   // if (enum_node == NULL_TREE)
@@ -88,7 +88,7 @@ TyTyResolveCompile::get_implicit_enumeral_node_type (Context *ctx)
 }
 
 tree
-TyTyResolveCompile::get_unit_type (Context *ctx)
+TyTyResolveCompile::get_unit_type ()
 {
   static tree unit_type;
   if (unit_type == nullptr)
@@ -305,7 +305,7 @@ TyTyResolveCompile::visit (const TyTy::ADTType &type)
 
 	  // add in the qualifier field for the variant
 	  tree enumeral_type
-	    = TyTyResolveCompile::get_implicit_enumeral_node_type (ctx);
+	    = TyTyResolveCompile::get_implicit_enumeral_node_type ();
 	  Backend::typed_identifier f (RUST_ENUM_DISR_FIELD_NAME, enumeral_type,
 				       ctx->get_mappings ()->lookup_location (
 					 variant->get_id ()));
@@ -393,7 +393,7 @@ TyTyResolveCompile::visit (const TyTy::TupleType &type)
 {
   if (type.num_fields () == 0)
     {
-      translated = get_unit_type (ctx);
+      translated = get_unit_type ();
       return;
     }
 
@@ -686,7 +686,7 @@ TyTyResolveCompile::visit (const TyTy::StrType &type)
 void
 TyTyResolveCompile::visit (const TyTy::NeverType &)
 {
-  translated = get_unit_type (ctx);
+  translated = get_unit_type ();
 }
 
 void

--- a/gcc/rust/backend/rust-compile-type.h
+++ b/gcc/rust/backend/rust-compile-type.h
@@ -30,9 +30,9 @@ public:
   static tree compile (Context *ctx, const TyTy::BaseType *ty,
 		       bool trait_object_mode = false);
 
-  static tree get_implicit_enumeral_node_type (Context *ctx);
+  static tree get_implicit_enumeral_node_type ();
 
-  static tree get_unit_type (Context *ctx);
+  static tree get_unit_type ();
 
   void visit (const TyTy::InferType &) override;
   void visit (const TyTy::ADTType &) override;


### PR DESCRIPTION
These were leftover from an earlier refactor