### PR TITLE
Add a new CI step for windows environments

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -495,7 +495,7 @@ jobs:
       matrix:
         include:
           - { sys: mingw64, env: x86_64 }
-          - { sys: mingw32, env: i686 }
+          # - { sys: mingw32, env: i686 }
     name: 'Windows ${{ matrix.env }} ${{ matrix.sys }}'
     defaults:
       run:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -488,3 +488,50 @@ jobs:
             else \
               exit 0; \
             fi
+
+  build-and-check-windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        include:
+          - { sys: mingw64, env: x86_64 }
+          - { sys: mingw32, env: i686 }
+    name: 'Windows ${{ matrix.env }} ${{ matrix.sys }}'
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: '${{ matrix.sys }} Install deps'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{matrix.sys}}
+          update: true
+          install: >-
+            git
+            dejagnu
+            base-devel
+          pacboy: >-
+            toolchain:p
+            rust:p
+
+      - run: |
+          find . -name .cargo-checksum.json -exec sed -i.uncheck -e 's/"files":{[^}]*}/"files":{ }/' '{}' '+'
+
+
+      - name: Configure
+        run: |
+           mkdir -p gccrs-build;
+           cd gccrs-build;
+           ../configure \
+               --enable-languages=rust \
+               --disable-bootstrap
+      - name: Build
+        run: |
+           make -C gccrs-build -j1 # $(nproc)
+
+      - name: Run Tests
+        run: |
+           cd gccrs-build; \
+           make check-rust

--- a/configure
+++ b/configure
@@ -9202,20 +9202,15 @@ $as_echo "$as_me: WARNING: GDC is required to build $language" >&2;}
         esac
 
         # Disable Rust if we are missing some required C libraries for the Rust runtime.
-        case ${add_this_lang}:${language}:${missing_rust_dynlibs} in
-          *:rust:none)
-            # Nothing to do - we're not missing any C libraries
+        case ${add_this_lang}:${language}:${missing_rust_dynlibs}:${target} in
+          *:rust:none:* | *:rust:*:*-*-mingw*)
+            # Nothing to do - we're not missing any C libraries OR we're using win32
             ;;
-          yes:rust:*)
+          yes:rust:*:* | all:rust:*:*)
             as_fn_error $? "some C libraries are required to build $language: $missing_rust_dynlibs" "$LINENO" 5
             add_this_lang=unsupported
             ;;
-          all:rust:*)
-            { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: some C libraries are required to build $language: $missing_rust_dynlibs" >&5
-$as_echo "$as_me: WARNING: some C libraries are required to build $language: $missing_rust_dynlibs" >&2;}
-            add_this_lang=unsupported
-            ;;
-          *:rust:*)
+          *:rust:*:*)
             # Silently disable.
             add_this_lang=unsupported
             ;;

--- a/configure
+++ b/configure
@@ -8833,9 +8833,14 @@ fi
 # build of the Rust frontend in case a dep is missing.
 missing_rust_dynlibs=none
 
-save_LIBS="$LIBS"
-LIBS=
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing dlopen" >&5
+case "${target}" in
+  *-*-mingw*)
+    CRAB1_LIBS="-lkernel32 -luser32 -lmsvcrt -lmingwex -lmingw32 -lmingwex -lws2_32"
+    ;;
+  *)
+    save_LIBS="$LIBS"
+    LIBS=
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing dlopen" >&5
 $as_echo_n "checking for library containing dlopen... " >&6; }
 if ${ac_cv_search_dlopen+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -8891,7 +8896,7 @@ if test "$ac_res" != no; then :
 
 fi
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing pthread_create" >&5
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing pthread_create" >&5
 $as_echo_n "checking for library containing pthread_create... " >&6; }
 if ${ac_cv_search_pthread_create+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -8947,8 +8952,10 @@ if test "$ac_res" != no; then :
 
 fi
 
-CRAB1_LIBS="$LIBS"
-LIBS="$save_LIBS"
+    CRAB1_LIBS="$LIBS"
+    LIBS="$save_LIBS"
+    ;;
+esac
 
 if test "$ac_cv_search_dlopen" = no; then
     missing_rust_dynlibs="libdl"

--- a/configure.ac
+++ b/configure.ac
@@ -2042,12 +2042,19 @@ AC_SUBST(PICFLAG)
 # build of the Rust frontend in case a dep is missing.
 missing_rust_dynlibs=none
 
-save_LIBS="$LIBS"
-LIBS=
-AC_SEARCH_LIBS([dlopen], [dl])
-AC_SEARCH_LIBS([pthread_create], [pthread])
-CRAB1_LIBS="$LIBS"
-LIBS="$save_LIBS"
+case "${target}" in
+  *-*-mingw*)
+    CRAB1_LIBS="-lkernel32 -luser32 -lmsvcrt -lmingwex -lmingw32 -lmingwex -lws2_32"
+    ;;
+  *)
+    save_LIBS="$LIBS"
+    LIBS=
+    AC_SEARCH_LIBS([dlopen], [dl])
+    AC_SEARCH_LIBS([pthread_create], [pthread])
+    CRAB1_LIBS="$LIBS"
+    LIBS="$save_LIBS"
+    ;;
+esac
 
 if test "$ac_cv_search_dlopen" = no; then
     missing_rust_dynlibs="libdl"

--- a/configure.ac
+++ b/configure.ac
@@ -2297,19 +2297,15 @@ if test -d ${srcdir}/gcc; then
         esac
 
         # Disable Rust if we are missing some required C libraries for the Rust runtime.
-        case ${add_this_lang}:${language}:${missing_rust_dynlibs} in
-          *:rust:none)
-            # Nothing to do - we're not missing any C libraries
+        case ${add_this_lang}:${language}:${missing_rust_dynlibs}:${target} in
+          *:rust:none:* | *:rust:*:*-*-mingw*)
+            # Nothing to do - we're not missing any C libraries OR we're using win32
             ;;
-          yes:rust:*)
+          yes:rust:*:* | all:rust:*:*)
             AC_MSG_ERROR([some C libraries are required to build $language: $missing_rust_dynlibs])
             add_this_lang=unsupported
             ;;
-          all:rust:*)
-            AC_MSG_WARN([some C libraries are required to build $language: $missing_rust_dynlibs])
-            add_this_lang=unsupported
-            ;;
-          *:rust:*)
+          *:rust:*:*)
             # Silently disable.
             add_this_lang=unsupported
             ;;


### PR DESCRIPTION
Add a new CI step on Windows to ensure the project compiles on this platform with mingw.

Motivation: During upstreaming process we discovered some `dlsym` code was incorrectly disabled, the project does not compile using mingw anymore.