### PR TITLE
Fix all tests in execute to be \r\n

### DIFF
--- a/gcc/testsuite/rust/execute/torture/issue-2187.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-2187.rs
@@ -1,4 +1,4 @@
-/* { dg-output "L1\n\L2\nL3\nL4" } */
+/* { dg-output "L1\r*\n\L2\r*\nL3\r*\nL4" } */
 extern "C" {
     fn printf(s: *const i8, ...);
 }
@@ -20,4 +20,3 @@ L4\0";
 
     0
 }
-

--- a/gcc/testsuite/rust/execute/xfail/macro1.rs
+++ b/gcc/testsuite/rust/execute/xfail/macro1.rs
@@ -1,4 +1,4 @@
-// { dg-output "macro\nmacro\nmacro\nmacro\n" }
+// { dg-output "macro\r*\nmacro\r*\nmacro\r*\nmacro\r*\n" }
 extern "C" {
     fn printf(s: *const i8, ...);
 }


### PR DESCRIPTION
Fixes #2817

For builtin_macro_includes_bytes & include.txt: Change `the_bytes` to b"hello, include!\r\n" 

For issue-2187.rs, change expected test output dg-output
to "L1\r\n\L2\r\nL3\r\nL4" and "a = "%s\n\0" to "a = "%s\r\n\0"

The rest is accomplished with 
```
#!/bin/bash

# Use the find command to locate all files in the current directory and its subfolders
find . -type f | while read -r FILE; do
    # Run sed command on each line of the file to add \r
    sed -i 's/$/\r/' "$FILE"
    # Run sed command to ensure there's no multiple \r\n endings
    sed -i 's/\(.*\)\r\r\n/\r\n/g' "$FILE"
done
```
gcc/testsuite/ChangeLog:

	* rust/execute/same_field_name.rs: Likewise
	* rust/execute/torture/arrays.rs: Likewise
	* rust/execute/torture/atomic_load.rs: Likewise
	* rust/execute/torture/atomic_store.rs: Likewise
	* rust/execute/torture/block_expr1.rs: Likewise
	* rust/execute/torture/builtin_abort.rs: Likewise
	* rust/execute/torture/builtin_macro_cfg.rs: Likewise
	* rust/execute/torture/builtin_macro_concat.rs: Likewise
	* rust/execute/torture/builtin_macro_env.rs: Likewise
	* rust/execute/torture/builtin_macro_include_bytes.rs: Likewise
	* rust/execute/torture/builtin_macro_include_str.rs: Likewise
	* rust/execute/torture/builtin_macro_line.rs: Likewise
	* rust/execute/torture/builtin_macro_stringify.rs: Likewise
	* rust/execute/torture/builtin_macros1.rs: Likewise
	* rust/execute/torture/builtin_macros3.rs: Likewise
	* rust/execute/torture/cfg-tail.rs: Likewise
	* rust/execute/torture/cfg1.rs: Likewise
	* rust/execute/torture/cfg2.rs: Likewise
	* rust/execute/torture/cfg3.rs: Likewise
	* rust/execute/torture/cfg4.rs: Likewise
	* rust/execute/torture/cfg5.rs: Likewise
	* rust/execute/torture/closure1.rs: Likewise
	* rust/execute/torture/closure2.rs: Likewise
	* rust/execute/torture/closure3.rs: Likewise
	* rust/execute/torture/closure4.rs: Likewise
	* rust/execute/torture/coercion1.rs: Likewise
	* rust/execute/torture/coercion2.rs: Likewise
	* rust/execute/torture/coercion3.rs: Likewise
	* rust/execute/torture/const_fold1.rs: Likewise
	* rust/execute/torture/const_fold2.rs: Likewise
	* rust/execute/torture/copy_nonoverlapping1.rs: Likewise
	* rust/execute/torture/decl_macro1.rs: Likewise
	* rust/execute/torture/decl_macro2.rs: Likewise
	* rust/execute/torture/decl_macro3.rs: Likewise
	* rust/execute/torture/decl_macro4.rs: Likewise
	* rust/execute/torture/derive_macro1.rs: Likewise
	* rust/execute/torture/derive_macro3.rs: Likewise
	* rust/execute/torture/derive_macro4.rs: Likewise
	* rust/execute/torture/empty_main.rs: Likewise
	* rust/execute/torture/execute.exp: Likewise
	* rust/execute/torture/exit_error.rs: Likewise
	* rust/execute/torture/extern_mod4.rs: Likewise
	* rust/execute/torture/extern_mod4/modules/mod.rs: Likewise
	* rust/execute/torture/func1.rs: Likewise
	* rust/execute/torture/helloworld1.rs: Likewise
	* rust/execute/torture/helloworld2.rs: Likewise
	* rust/execute/torture/include.txt: Likewise
	* rust/execute/torture/index1.rs: Likewise
	* rust/execute/torture/issue-1120.rs: Likewise
	* rust/execute/torture/issue-1133.rs: Likewise
	* rust/execute/torture/issue-1198.rs: Likewise
	* rust/execute/torture/issue-1231.rs: Likewise
	* rust/execute/torture/issue-1232.rs: Likewise
	* rust/execute/torture/issue-1249.rs: Likewise
	* rust/execute/torture/issue-1436.rs: Likewise
	* rust/execute/torture/issue-1496.rs: Likewise
	* rust/execute/torture/issue-1720-2.rs: Likewise
	* rust/execute/torture/issue-1720.rs: Likewise
	* rust/execute/torture/issue-1852-1.rs: Likewise
	* rust/execute/torture/issue-1852.rs: Likewise
	* rust/execute/torture/issue-2052.rs: Likewise
	* rust/execute/torture/issue-2080.rs: Likewise
	* rust/execute/torture/issue-2179.rs: Likewise
	* rust/execute/torture/issue-2180.rs: Likewise
	* rust/execute/torture/issue-2187.rs: Likewise
	* rust/execute/torture/issue-2236.rs: Likewise
	* rust/execute/torture/issue-2583.rs: Likewise
	* rust/execute/torture/issue-647.rs: Likewise
	* rust/execute/torture/issue-845.rs: Likewise
	* rust/execute/torture/issue-851.rs: Likewise
	* rust/execute/torture/issue-858.rs: Likewise
	* rust/execute/torture/issue-976.rs: Likewise
	* rust/execute/torture/issue-995.rs: Likewise
	* rust/execute/torture/iter1.rs: Likewise
	* rust/execute/torture/let-pattern-1.rs: Likewise
	* rust/execute/torture/loop-condition-eval.rs: Likewise
	* rust/execute/torture/macro-issue1426.rs: Likewise
	* rust/execute/torture/macro_use1.rs: Likewise
	* rust/execute/torture/macros1.rs: Likewise
	* rust/execute/torture/macros10.rs: Likewise
	* rust/execute/torture/macros11.rs: Likewise
	* rust/execute/torture/macros12.rs: Likewise
	* rust/execute/torture/macros13.rs: Likewise
	* rust/execute/torture/macros14.rs: Likewise
	* rust/execute/torture/macros16.rs: Likewise
	* rust/execute/torture/macros17.rs: Likewise
	* rust/execute/torture/macros18.rs: Likewise
	* rust/execute/torture/macros19.rs: Likewise
	* rust/execute/torture/macros2.rs: Likewise
	* rust/execute/torture/macros20.rs: Likewise
	* rust/execute/torture/macros21.rs: Likewise
	* rust/execute/torture/macros22.rs: Likewise
	* rust/execute/torture/macros23.rs: Likewise
	* rust/execute/torture/macros24.rs: Likewise
	* rust/execute/torture/macros25.rs: Likewise
	* rust/execute/torture/macros26.rs: Likewise
	* rust/execute/torture/macros27.rs: Likewise
	* rust/execute/torture/macros28.rs: Likewise
	* rust/execute/torture/macros29.rs: Likewise
	* rust/execute/torture/macros3.rs: Likewise
	* rust/execute/torture/macros30.rs: Likewise
	* rust/execute/torture/macros31.rs: Likewise
	* rust/execute/torture/macros4.rs: Likewise
	* rust/execute/torture/macros5.rs: Likewise
	* rust/execute/torture/macros6.rs: Likewise
	* rust/execute/torture/macros7.rs: Likewise
	* rust/execute/torture/macros8.rs: Likewise
	* rust/execute/torture/macros9.rs: Likewise
	* rust/execute/torture/match1.rs: Likewise
	* rust/execute/torture/match2.rs: Likewise
	* rust/execute/torture/match3.rs: Likewise
	* rust/execute/torture/match_bool1.rs: Likewise
	* rust/execute/torture/match_byte1.rs: Likewise
	* rust/execute/torture/match_char1.rs: Likewise
	* rust/execute/torture/match_int1.rs: Likewise
	* rust/execute/torture/match_loop1.rs: Likewise
	* rust/execute/torture/match_range1.rs: Likewise
	* rust/execute/torture/match_range2.rs: Likewise
	* rust/execute/torture/match_tuple1.rs: Likewise
	* rust/execute/torture/matches_macro.rs: Likewise
	* rust/execute/torture/method1.rs: Likewise
	* rust/execute/torture/method2.rs: Likewise
	* rust/execute/torture/method3.rs: Likewise
	* rust/execute/torture/method4.rs: Likewise
	* rust/execute/torture/mod1.rs: Likewise
	* rust/execute/torture/name_resolution.rs: Likewise
	* rust/execute/torture/named_variadic.rs: Likewise
	* rust/execute/torture/operator_overload_1.rs: Likewise
	* rust/execute/torture/operator_overload_10.rs: Likewise
	* rust/execute/torture/operator_overload_11.rs: Likewise
	* rust/execute/torture/operator_overload_12.rs: Likewise
	* rust/execute/torture/operator_overload_2.rs: Likewise
	* rust/execute/torture/operator_overload_3.rs: Likewise
	* rust/execute/torture/operator_overload_4.rs: Likewise
	* rust/execute/torture/operator_overload_5.rs: Likewise
	* rust/execute/torture/operator_overload_6.rs: Likewise
	* rust/execute/torture/operator_overload_7.rs: Likewise
	* rust/execute/torture/operator_overload_8.rs: Likewise
	* rust/execute/torture/operator_overload_9.rs: Likewise
	* rust/execute/torture/overflow1.rs: Likewise
	* rust/execute/torture/prefetch_data.rs: Likewise
	* rust/execute/torture/ref-pattern1.rs: Likewise
	* rust/execute/torture/ref-pattern2.rs: Likewise
	* rust/execute/torture/slice-magic.rs: Likewise
	* rust/execute/torture/slice-magic2.rs: Likewise
	* rust/execute/torture/slice1.rs: Likewise
	* rust/execute/torture/str-layout1.rs: Likewise
	* rust/execute/torture/str-zero.rs: Likewise
	* rust/execute/torture/trait1.rs: Likewise
	* rust/execute/torture/trait10.rs: Likewise
	* rust/execute/torture/trait11.rs: Likewise
	* rust/execute/torture/trait12.rs: Likewise
	* rust/execute/torture/trait13.rs: Likewise
	* rust/execute/torture/trait2.rs: Likewise
	* rust/execute/torture/trait3.rs: Likewise
	* rust/execute/torture/trait4.rs: Likewise
	* rust/execute/torture/trait5.rs: Likewise
	* rust/execute/torture/trait6.rs: Likewise
	* rust/execute/torture/trait7.rs: Likewise
	* rust/execute/torture/trait8.rs: Likewise
	* rust/execute/torture/trait9.rs: Likewise
	* rust/execute/torture/transmute1.rs: Likewise
	* rust/execute/torture/wrapping_op1.rs: Likewise
	* rust/execute/torture/wrapping_op2.rs: Likewise
	* rust/execute/xfail/macro1.rs: Likewise


