### PR TITLE
Cleanup macro invoc

### DIFF
--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -672,17 +672,12 @@ public:
     outer_attrs = std::move (new_attrs);
   }
 
-  NodeId get_node_id () const override final
-  {
-    return ExprWithoutBlock::get_node_id ();
-  }
+  NodeId get_node_id () const override final { return node_id; }
 
   AST::Kind get_ast_kind () const override
   {
     return AST::Kind::MACRO_INVOCATION;
   }
-
-  NodeId get_macro_node_id () const { return node_id; }
 
   MacroInvocData &get_invoc_data () { return invoc_data; }
 
@@ -719,8 +714,10 @@ private:
     MacroInvocData invoc_data, std::vector<Attribute> outer_attrs,
     location_t locus, bool is_semi_coloned,
     std::vector<std::unique_ptr<MacroInvocation>> &&pending_eager_invocs)
-    : TraitItem (locus), outer_attrs (std::move (outer_attrs)), locus (locus),
-      node_id (Analysis::Mappings::get ().get_next_node_id ()),
+    : TraitItem (locus),
+      ExternalItem (Analysis::Mappings::get ().get_next_node_id ()),
+      outer_attrs (std::move (outer_attrs)), locus (locus),
+      node_id (ExternalItem::get_node_id ()),
       invoc_data (std::move (invoc_data)), is_semi_coloned (is_semi_coloned),
       kind (kind), builtin_kind (builtin_kind),
       pending_eager_invocs (std::move (pending_eager_invocs))

--- a/gcc/rust/resolve/rust-early-name-resolver.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver.cc
@@ -466,7 +466,7 @@ EarlyNameResolver::visit (AST::MacroInvocation &invoc)
   NodeId resolved_node = UNKNOWN_NODEID;
   NodeId source_node = UNKNOWN_NODEID;
   if (has_semicolon)
-    source_node = invoc.get_macro_node_id ();
+    source_node = invoc.get_node_id ();
   else
     source_node = invoc.get_node_id ();
   auto seg

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -913,17 +913,17 @@ void
 Mappings::insert_macro_invocation (AST::MacroInvocation &invoc,
 				   AST::MacroRulesDefinition *def)
 {
-  auto it = macroInvocations.find (invoc.get_macro_node_id ());
+  auto it = macroInvocations.find (invoc.get_node_id ());
   rust_assert (it == macroInvocations.end ());
 
-  macroInvocations[invoc.get_macro_node_id ()] = def;
+  macroInvocations[invoc.get_node_id ()] = def;
 }
 
 bool
 Mappings::lookup_macro_invocation (AST::MacroInvocation &invoc,
 				   AST::MacroRulesDefinition **def)
 {
-  auto it = macroInvocations.find (invoc.get_macro_node_id ());
+  auto it = macroInvocations.find (invoc.get_node_id ());
   if (it == macroInvocations.end ())
     return false;
 
@@ -1084,16 +1084,16 @@ void
 Mappings::insert_bang_proc_macro_invocation (AST::MacroInvocation &invoc,
 					     BangProcMacro def)
 {
-  auto it = procmacroBangInvocations.find (invoc.get_macro_node_id ());
+  auto it = procmacroBangInvocations.find (invoc.get_node_id ());
   rust_assert (it == procmacroBangInvocations.end ());
 
-  procmacroBangInvocations[invoc.get_macro_node_id ()] = def;
+  procmacroBangInvocations[invoc.get_node_id ()] = def;
 }
 
 tl::optional<BangProcMacro &>
 Mappings::lookup_bang_proc_macro_invocation (AST::MacroInvocation &invoc)
 {
-  auto it = procmacroBangInvocations.find (invoc.get_macro_node_id ());
+  auto it = procmacroBangInvocations.find (invoc.get_node_id ());
   if (it == procmacroBangInvocations.end ())
     return tl::nullopt;
 


### PR DESCRIPTION
MacroInvoc Refactor for #2919 
    
    Remove get_macro_node_id in favor of get_node_id in MacroInvocation
    Add ExteralItem node_id constructor to avoid extra get_node_id()
    
    gcc/rust/ChangeLog:
    
            * ast/rust-macro.h: Likewise.
            * resolve/rust-early-name-resolver.cc (EarlyNameResolver::visit): Likewise.
            * util/rust-hir-map.cc (Mappings::insert_macro_invocation): Likewise.
            (Mappings::lookup_macro_invocation): Likewise.
            (Mappings::insert_bang_proc_macro_invocation): Likewise.


