### PR TITLE
borrowck: Added location support to BIR nodes

### DIFF
--- a/gcc/rust/checks/errors/borrowck/rust-bir-builder-internal.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-builder-internal.h
@@ -307,7 +307,7 @@ protected: // Helpers to add BIR statements
 			location_t location)
   {
     auto mutability = ty->as<const TyTy::ReferenceType> ()->mutability ();
-    auto loan = ctx.place_db.add_loan ({mutability, place_id});
+    auto loan = ctx.place_db.add_loan ({mutability, place_id, location});
     push_tmp_assignment (new BorrowExpr (place_id, loan,
 					 ctx.place_db.get_next_free_region ()),
 			 ty, location);
@@ -600,7 +600,8 @@ protected:
   {
     // TODO: deduplicate with borrow_place
     auto loan = ctx.place_db.add_loan (
-      {ty->as<const TyTy::ReferenceType> ()->mutability (), place_id});
+      {ty->as<const TyTy::ReferenceType> ()->mutability (), place_id,
+       location});
     return_expr (new BorrowExpr (place_id, loan,
 				 ctx.place_db.get_next_free_region ()),
 		 ty, location);

--- a/gcc/rust/checks/errors/borrowck/rust-bir-builder-lazyboolexpr.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-builder-lazyboolexpr.h
@@ -45,13 +45,14 @@ public:
     PlaceId return_place = take_or_create_return_place (lookup_type (expr));
 
     short_circuit_bb = new_bb ();
-    push_assignment (return_place, visit_expr (expr));
+    push_assignment (return_place, visit_expr (expr), expr.get_locus ());
     auto final_bb = new_bb ();
     push_goto (final_bb);
 
     ctx.current_bb = short_circuit_bb;
     push_assignment (return_place,
-		     ctx.place_db.get_constant (lookup_type (expr)));
+		     ctx.place_db.get_constant (lookup_type (expr)),
+		     expr.get_locus ());
     push_goto (final_bb);
 
     ctx.current_bb = final_bb;
@@ -62,10 +63,11 @@ protected:
   void visit (HIR::LazyBooleanExpr &expr) override
   {
     auto lhs = visit_expr (*expr.get_lhs ());
-    push_switch (move_place (lhs), {short_circuit_bb});
+    push_switch (move_place (lhs, expr.get_lhs ()->get_locus ()),
+		 expr.get_locus (), {short_circuit_bb});
 
     start_new_consecutive_bb ();
-    return_place (visit_expr (*expr.get_rhs ()));
+    return_place (visit_expr (*expr.get_rhs ()), expr.get_locus ());
   }
   void visit (HIR::GroupedExpr &expr) override
   {
@@ -76,15 +78,15 @@ protected:
 public:
   void visit (HIR::QualifiedPathInExpression &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::PathInExpression &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::ClosureExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::StructExprStructFields &fields) override
   {
@@ -96,119 +98,119 @@ public:
   }
   void visit (HIR::LiteralExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::BorrowExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::DereferenceExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::ErrorPropagationExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::NegationExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::ArithmeticOrLogicalExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::ComparisonExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::TypeCastExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::AssignmentExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::CompoundAssignmentExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::ArrayExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::ArrayIndexExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::TupleExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::TupleIndexExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::CallExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::MethodCallExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::FieldAccessExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::BlockExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::UnsafeBlockExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::LoopExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::WhileLoopExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::WhileLetLoopExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::IfExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::IfExprConseqElse &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::IfLetExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::IfLetExprConseqElse &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::MatchExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::AwaitExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
   void visit (HIR::AsyncBlockExpr &expr) override
   {
-    return_place (ExprStmtBuilder (ctx).build (expr));
+    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
 
 protected: // Illegal at this position.

--- a/gcc/rust/checks/errors/borrowck/rust-bir-builder-pattern.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-builder-pattern.h
@@ -65,7 +65,7 @@ public:
   void go (HIR::Pattern &pattern) { pattern.accept_vis (*this); }
 
   void visit_identifier (const Analysis::NodeMapping &node, bool is_ref,
-			 bool is_mut = false)
+			 location_t location, bool is_mut = false)
   {
     if (is_ref)
       {
@@ -82,7 +82,7 @@ public:
 
     if (init.has_value ())
       {
-	push_assignment (translated, init.value ());
+	push_assignment (translated, init.value (), location);
       }
   }
 
@@ -91,7 +91,7 @@ public:
     // Top-level identifiers are resolved directly to avoid useless temporary
     // (for cleaner BIR).
     visit_identifier (pattern.get_mappings (), pattern.get_is_ref (),
-		      pattern.is_mut ());
+		      pattern.get_locus (), pattern.is_mut ());
   }
 
   void visit (HIR::ReferencePattern &pattern) override
@@ -210,6 +210,7 @@ public:
 						   field_index);
 	      visit_identifier (ident_field->get_mappings (),
 				ident_field->get_has_ref (),
+				ident_field->get_locus (),
 				ident_field->is_mut ());
 	      break;
 	    }

--- a/gcc/rust/checks/errors/borrowck/rust-bir-builder.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-builder.h
@@ -151,7 +151,8 @@ private:
 	  {
 	    push_assignment (RETURN_VALUE_PLACE,
 			     ctx.place_db.get_constant (
-			       ctx.place_db[RETURN_VALUE_PLACE].tyty));
+			       ctx.place_db[RETURN_VALUE_PLACE].tyty),
+			     body.get_end_locus ());
 	  }
 	ctx.get_current_bb ().statements.emplace_back (Statement::Kind::RETURN);
       }

--- a/gcc/rust/checks/errors/borrowck/rust-bir-place.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-place.h
@@ -162,6 +162,7 @@ struct Loan
 {
   Mutability mutability;
   PlaceId place;
+  location_t location;
 };
 
 /** Allocated places and keeps track of paths. */

--- a/gcc/rust/checks/errors/borrowck/rust-bir.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir.h
@@ -77,19 +77,25 @@ private:
   // otherwise: <unused>
   std::unique_ptr<AbstractExpr> expr;
   TyTy::BaseType *type;
+  // stores location of the actual expression from source code
+  // currently only available when kind == Kind::ASSIGNMENT
+  // FIXME: Add location for Statements other than ASSIGNMENT
+  location_t location;
 
 public:
-  Statement (PlaceId lhs, AbstractExpr *rhs)
-    : kind (Kind::ASSIGNMENT), place (lhs), expr (rhs)
+  Statement (PlaceId lhs, AbstractExpr *rhs, location_t location)
+    : kind (Kind::ASSIGNMENT), place (lhs), expr (rhs), location (location)
   {}
 
   explicit Statement (Kind kind, PlaceId place = INVALID_PLACE,
-		      AbstractExpr *expr = nullptr)
-    : kind (kind), place (place), expr (expr)
+		      AbstractExpr *expr = nullptr,
+		      location_t location = UNKNOWN_LOCATION)
+    : kind (kind), place (place), expr (expr), location (location)
   {}
 
-  explicit Statement (Kind kind, PlaceId place, TyTy::BaseType *type)
-    : kind (kind), place (place), type (type)
+  explicit Statement (Kind kind, PlaceId place, TyTy::BaseType *type,
+		      location_t location = UNKNOWN_LOCATION)
+    : kind (kind), place (place), type (type), location (location)
   {}
 
 public:
@@ -97,6 +103,7 @@ public:
   WARN_UNUSED_RESULT PlaceId get_place () const { return place; }
   WARN_UNUSED_RESULT AbstractExpr &get_expr () const { return *expr; }
   WARN_UNUSED_RESULT TyTy::BaseType *get_type () const { return type; }
+  WARN_UNUSED_RESULT location_t get_location () const { return location; }
 };
 
 /** Unique identifier for a basic block in the BIR. */


### PR DESCRIPTION
depends on #3076 
Added `location` field to BIR::Statement and BIR::Place, updated the BIR builders to take the source location from HIR and pass it to BIR node.
