### PR TITLE
Fix outer attribute parsing on generic parameters

### DIFF
--- a/gcc/rust/ast/rust-ast-collector.cc
+++ b/gcc/rust/ast/rust-ast-collector.cc
@@ -476,6 +476,7 @@ TokenCollector::visit (LifetimeParam &lifetime_param)
 
   // TODO what to do with outer attr? They are not mentioned in the reference.
 
+  visit_items_as_lines (lifetime_param.get_outer_attrs ());
   auto lifetime = lifetime_param.get_lifetime ();
   visit (lifetime);
 
@@ -495,6 +496,7 @@ TokenCollector::visit (ConstGenericParam &param)
   // Syntax:
   // const IDENTIFIER : Type ( = Block | IDENTIFIER | -?LITERAL )?
 
+  visit_items_as_lines (param.get_outer_attrs ());
   push (Rust::Token::make (CONST, param.get_locus ()));
   auto id = param.get_name ().as_string ();
   push (Rust::Token::make_identifier (UNDEF_LOCATION, std::move (id)));
@@ -1509,6 +1511,7 @@ TokenCollector::visit (TypeParam &param)
   // TypeParamBounds :
   //    TypeParamBound ( + TypeParamBound )* +?
 
+  visit_items_as_lines (param.get_outer_attrs ());
   auto id = param.get_type_representation ().as_string ();
   push (Rust::Token::make_identifier (param.get_locus (), std::move (id)));
   if (param.has_type_param_bounds ())

--- a/gcc/rust/ast/rust-ast-visitor.cc
+++ b/gcc/rust/ast/rust-ast-visitor.cc
@@ -69,7 +69,7 @@ DefaultASTVisitor::visit (AST::Lifetime &lifetime)
 void
 DefaultASTVisitor::visit (AST::LifetimeParam &lifetime_param)
 {
-  visit (lifetime_param.get_outer_attribute ());
+  visit_outer_attrs (lifetime_param);
   visit (lifetime_param.get_lifetime ());
   for (auto &lifetime_bound : lifetime_param.get_lifetime_bounds ())
     visit (lifetime_bound);
@@ -78,7 +78,7 @@ DefaultASTVisitor::visit (AST::LifetimeParam &lifetime_param)
 void
 DefaultASTVisitor::visit (AST::ConstGenericParam &const_param)
 {
-  visit (const_param.get_outer_attribute ());
+  visit_outer_attrs (const_param);
   if (const_param.has_type ())
     visit (const_param.get_type ());
   if (const_param.has_default_value ())
@@ -665,7 +665,7 @@ DefaultASTVisitor::visit (AST::AsyncBlockExpr &expr)
 void
 DefaultASTVisitor::visit (AST::TypeParam &param)
 {
-  visit (param.get_outer_attribute ());
+  visit_outer_attrs (param);
   for (auto &bound : param.get_type_param_bounds ())
     visit (bound);
   if (param.has_type ())

--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -2399,11 +2399,11 @@ LifetimeParam::as_string () const
 {
   std::string str ("LifetimeParam: ");
 
-  str += "\n Outer attribute: ";
+  str += "\n Outer attribute:";
   if (!has_outer_attribute ())
     str += "none";
-  else
-    str += outer_attr.as_string ();
+  for (auto &attr : outer_attrs)
+    str += " " + attr.as_string ();
 
   str += "\n Lifetime: " + lifetime.as_string ();
 
@@ -2495,11 +2495,11 @@ TypeParam::as_string () const
 {
   std::string str ("TypeParam: ");
 
-  str += "\n Outer attribute: ";
+  str += "\n Outer attribute:";
   if (!has_outer_attribute ())
     str += "none";
-  else
-    str += outer_attr.as_string ();
+  for (auto &attr : outer_attrs)
+    str += " " + attr.as_string ();
 
   str += "\n Identifier: " + type_representation.as_string ();
 

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -1602,7 +1602,7 @@ class LifetimeParam : public GenericParam
 {
   Lifetime lifetime;
   std::vector<Lifetime> lifetime_bounds;
-  Attribute outer_attr;
+  AST::AttrVec outer_attrs;
   location_t locus;
 
 public:
@@ -1610,7 +1610,7 @@ public:
 
   Lifetime &get_lifetime () { return lifetime; }
 
-  Attribute &get_outer_attribute () { return outer_attr; }
+  AST::AttrVec &get_outer_attrs () { return outer_attrs; }
 
   // Returns whether the lifetime param has any lifetime bounds.
   bool has_lifetime_bounds () const { return !lifetime_bounds.empty (); }
@@ -1618,13 +1618,12 @@ public:
   std::vector<Lifetime> &get_lifetime_bounds () { return lifetime_bounds; }
 
   // Returns whether the lifetime param has an outer attribute.
-  bool has_outer_attribute () const { return !outer_attr.is_empty (); }
+  bool has_outer_attribute () const { return !outer_attrs.empty (); }
 
   // Creates an error state lifetime param.
   static LifetimeParam create_error ()
   {
-    return LifetimeParam (Lifetime::error (), {}, Attribute::create_empty (),
-			  UNDEF_LOCATION);
+    return LifetimeParam (Lifetime::error (), {}, {}, UNDEF_LOCATION);
   }
 
   // Returns whether the lifetime param is in an error state.
@@ -1632,10 +1631,10 @@ public:
 
   // Constructor
   LifetimeParam (Lifetime lifetime, std::vector<Lifetime> lifetime_bounds,
-		 Attribute outer_attr, location_t locus)
+		 AST::AttrVec outer_attrs, location_t locus)
     : lifetime (std::move (lifetime)),
       lifetime_bounds (std::move (lifetime_bounds)),
-      outer_attr (std::move (outer_attr)), locus (locus)
+      outer_attrs (std::move (outer_attrs)), locus (locus)
   {}
 
   std::string as_string () const override;

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -53,7 +53,7 @@ class TypeParam : public GenericParam
 {
   // bool has_outer_attribute;
   // std::unique_ptr<Attribute> outer_attr;
-  Attribute outer_attr;
+  AST::AttrVec outer_attrs;
 
   Identifier type_representation;
 
@@ -77,17 +77,17 @@ public:
   bool has_type_param_bounds () const { return !type_param_bounds.empty (); }
 
   // Returns whether the type param has an outer attribute.
-  bool has_outer_attribute () const { return !outer_attr.is_empty (); }
+  bool has_outer_attribute () const { return !outer_attrs.empty (); }
 
-  Attribute &get_outer_attribute () { return outer_attr; }
+  AST::AttrVec &get_outer_attrs () { return outer_attrs; }
 
   TypeParam (Identifier type_representation, location_t locus = UNDEF_LOCATION,
 	     std::vector<std::unique_ptr<TypeParamBound>> type_param_bounds
 	     = std::vector<std::unique_ptr<TypeParamBound>> (),
 	     std::unique_ptr<Type> type = nullptr,
-	     Attribute outer_attr = Attribute::create_empty ())
+	     AST::AttrVec outer_attrs = {})
     : GenericParam (Analysis::Mappings::get ().get_next_node_id ()),
-      outer_attr (std::move (outer_attr)),
+      outer_attrs (std::move (outer_attrs)),
       type_representation (std::move (type_representation)),
       type_param_bounds (std::move (type_param_bounds)),
       type (std::move (type)), locus (locus)
@@ -95,7 +95,7 @@ public:
 
   // Copy constructor uses clone
   TypeParam (TypeParam const &other)
-    : GenericParam (other.node_id), outer_attr (other.outer_attr),
+    : GenericParam (other.node_id), outer_attrs (other.outer_attrs),
       type_representation (other.type_representation), locus (other.locus)
   {
     // guard to prevent null pointer dereference
@@ -111,7 +111,7 @@ public:
   TypeParam &operator= (TypeParam const &other)
   {
     type_representation = other.type_representation;
-    outer_attr = other.outer_attr;
+    outer_attrs = other.outer_attrs;
     locus = other.locus;
     node_id = other.node_id;
 

--- a/gcc/rust/ast/rust-path.h
+++ b/gcc/rust/ast/rust-path.h
@@ -347,21 +347,21 @@ class ConstGenericParam : public GenericParam
    */
   GenericArg default_value;
 
-  Attribute outer_attr;
+  AST::AttrVec outer_attrs;
   location_t locus;
 
 public:
   ConstGenericParam (Identifier name, std::unique_ptr<AST::Type> type,
-		     GenericArg default_value, Attribute outer_attr,
+		     GenericArg default_value, AST::AttrVec outer_attrs,
 		     location_t locus)
     : name (name), type (std::move (type)),
-      default_value (std::move (default_value)), outer_attr (outer_attr),
+      default_value (std::move (default_value)), outer_attrs (outer_attrs),
       locus (locus)
   {}
 
   ConstGenericParam (const ConstGenericParam &other)
     : GenericParam (), name (other.name), type (other.type->clone_type ()),
-      default_value (other.default_value), outer_attr (other.outer_attr),
+      default_value (other.default_value), outer_attrs (other.outer_attrs),
       locus (other.locus)
   {}
 
@@ -370,7 +370,7 @@ public:
 
   const Identifier &get_name () const { return name; }
 
-  Attribute &get_outer_attribute () { return outer_attr; }
+  AST::AttrVec &get_outer_attrs () { return outer_attrs; }
 
   AST::Type &get_type ()
   {

--- a/gcc/rust/checks/errors/rust-feature-gate.h
+++ b/gcc/rust/checks/errors/rust-feature-gate.h
@@ -40,8 +40,8 @@ public:
   void visit (AST::AttrInputMetaItemContainer &input) override {}
   void visit (AST::IdentifierExpr &ident_expr) override {}
   void visit (AST::Lifetime &lifetime) override {}
-  void visit (AST::LifetimeParam &lifetime_param) override {}
-  void visit (AST::ConstGenericParam &const_param) override {}
+  void visit (AST::LifetimeParam &lifetime_param) override;
+  void visit (AST::ConstGenericParam &const_param) override;
   void visit (AST::PathInExpression &path) override {}
   void visit (AST::TypePathSegment &segment) override {}
   void visit (AST::TypePathSegmentGeneric &segment) override {}
@@ -104,7 +104,7 @@ public:
   void visit (AST::MatchExpr &expr) override {}
   void visit (AST::AwaitExpr &expr) override {}
   void visit (AST::AsyncBlockExpr &expr) override {}
-  void visit (AST::TypeParam &param) override {}
+  void visit (AST::TypeParam &param) override;
   void visit (AST::LifetimeWhereClauseItem &item) override {}
   void visit (AST::TypeBoundWhereClauseItem &item) override {}
   void visit (AST::Module &module) override {}
@@ -188,6 +188,8 @@ public:
 private:
   void gate (Feature::Name name, location_t loc, const std::string &error_msg);
   void check_rustc_attri (const std::vector<AST::Attribute> &attributes);
+  void
+  check_may_dangle_attribute (const std::vector<AST::Attribute> &attributes);
   std::set<Feature::Name> valid_features;
 };
 } // namespace Rust

--- a/gcc/rust/checks/errors/rust-feature.cc
+++ b/gcc/rust/checks/errors/rust-feature.cc
@@ -48,6 +48,9 @@ Feature::create (Feature::Name name)
     case Feature::Name::BOX_SYNTAX:
       return Feature (Feature::Name::BOX_SYNTAX, Feature::State::ACTIVE,
 		      "box_syntax", "1.0.0", 49733, tl::nullopt, "");
+    case Feature::Name::DROPCK_EYEPATCH:
+      return Feature (Feature::Name::DROPCK_EYEPATCH, Feature::State::ACTIVE,
+		      "dropck_eyepatch", "1.10.0", 34761, tl::nullopt, "");
     default:
       rust_unreachable ();
     }
@@ -66,6 +69,7 @@ const std::map<std::string, Feature::Name> Feature::name_hash_map = {
   {"lang_items", Feature::Name::LANG_ITEMS},
   {"no_core", Feature::Name::NO_CORE},
   {"box_syntax", Feature::Name::BOX_SYNTAX},
+  {"dropck_eyepatch", Feature::Name::DROPCK_EYEPATCH},
 }; // namespace Rust
 
 tl::optional<Feature::Name>

--- a/gcc/rust/checks/errors/rust-feature.h
+++ b/gcc/rust/checks/errors/rust-feature.h
@@ -47,6 +47,7 @@ public:
     LANG_ITEMS,
     NO_CORE,
     BOX_SYNTAX,
+    DROPCK_EYEPATCH,
   };
 
   const std::string &as_string () { return m_name_str; }

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -3093,7 +3093,7 @@ template <typename EndTokenPred>
 std::unique_ptr<AST::GenericParam>
 Parser<ManagedTokenSource>::parse_generic_param (EndTokenPred is_end_token)
 {
-  auto outer_attrs = parse_outer_attribute ();
+  auto outer_attrs = parse_outer_attributes ();
   std::unique_ptr<AST::GenericParam> param;
   auto token = lexer.peek_token ();
 
@@ -3460,8 +3460,8 @@ template <typename ManagedTokenSource>
 AST::LifetimeParam
 Parser<ManagedTokenSource>::parse_lifetime_param ()
 {
-  // parse outer attribute, which is optional and may not exist
-  AST::Attribute outer_attr = parse_outer_attribute ();
+  // parse outer attributes, which are optional and may not exist
+  auto outer_attrs = parse_outer_attributes ();
 
   // save lifetime token - required
   const_TokenPtr lifetime_tok = lexer.peek_token ();
@@ -3484,7 +3484,7 @@ Parser<ManagedTokenSource>::parse_lifetime_param ()
     }
 
   return AST::LifetimeParam (std::move (lifetime), std::move (lifetime_bounds),
-			     std::move (outer_attr),
+			     std::move (outer_attrs),
 			     lifetime_tok->get_locus ());
 }
 
@@ -3561,8 +3561,8 @@ template <typename ManagedTokenSource>
 std::unique_ptr<AST::TypeParam>
 Parser<ManagedTokenSource>::parse_type_param ()
 {
-  // parse outer attribute, which is optional and may not exist
-  AST::Attribute outer_attr = parse_outer_attribute ();
+  // parse outer attributes, which are optional and may not exist
+  auto outer_attrs = parse_outer_attributes ();
 
   const_TokenPtr identifier_tok = lexer.peek_token ();
   if (identifier_tok->get_id () != IDENTIFIER)
@@ -3605,7 +3605,7 @@ Parser<ManagedTokenSource>::parse_type_param ()
   return std::unique_ptr<AST::TypeParam> (
     new AST::TypeParam (std::move (ident), identifier_tok->get_locus (),
 			std::move (type_param_bounds), std::move (type),
-			std::move (outer_attr)));
+			std::move (outer_attrs)));
 }
 
 /* Parses regular (i.e. non-generic) parameters in functions or methods. Also

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -3093,9 +3093,9 @@ template <typename EndTokenPred>
 std::unique_ptr<AST::GenericParam>
 Parser<ManagedTokenSource>::parse_generic_param (EndTokenPred is_end_token)
 {
-  auto token = lexer.peek_token ();
   auto outer_attrs = parse_outer_attribute ();
   std::unique_ptr<AST::GenericParam> param;
+  auto token = lexer.peek_token ();
 
   switch (token->get_id ())
     {

--- a/gcc/rust/util/rust-attribute-values.h
+++ b/gcc/rust/util/rust-attribute-values.h
@@ -55,6 +55,7 @@ public:
   static constexpr auto &UNSTABLE = "unstable";
   static constexpr auto &RUSTC_CONST_STABLE = "rustc_const_stable";
   static constexpr auto &RUSTC_CONST_UNSTABLE = "rustc_const_unstable";
+  static constexpr auto &MAY_DANGLE = "may_dangle";
 };
 } // namespace Values
 } // namespace Rust

--- a/gcc/testsuite/rust/compile/dropck_eyepatch_feature_gate.rs
+++ b/gcc/testsuite/rust/compile/dropck_eyepatch_feature_gate.rs
@@ -1,0 +1,8 @@
+// { dg-options "-frust-compile-until=lowering" }
+struct Test<T> {
+    _inner: T,
+}
+
+trait Action {}
+
+unsafe impl<#[may_dangle] T> Action for Test<T> {} //{ dg-error ".may_dangle. has unstable semantics and may be removed in the future." "" { target *-*-* }  }

--- a/gcc/testsuite/rust/compile/may_dangle.rs
+++ b/gcc/testsuite/rust/compile/may_dangle.rs
@@ -1,0 +1,10 @@
+// { dg-options "-fsyntax-only" }
+
+#![feature(dropck_eyepatch)]
+struct Test<T> {
+    _inner: T,
+}
+
+trait Action {}
+
+unsafe impl<#[may_dangle] T> Action for Test<T> {}


### PR DESCRIPTION
Outer attributes were not correctly parsed on generic parameter, this prevented the `#[may_dangle]` outer attribute from being used.

This feature also provides a new feature gate `dropck_eyepatch` to prevent `#[may_dangle]` attributes from being used in stable context.

Requires #3012

Content:
https://github.com/Rust-GCC/gccrs/compare/552c36c..3c311a9c33340382fd0ea043f365ddfef9068a8f