### PR TITLE
Add outer attributes to struct expr fields

### DIFF
--- a/gcc/rust/ast/rust-ast-collector.cc
+++ b/gcc/rust/ast/rust-ast-collector.cc
@@ -1096,8 +1096,7 @@ TokenCollector::visit (StructExprStruct &expr)
 void
 TokenCollector::visit (StructExprFieldIdentifier &expr)
 {
-  // TODO: Add attributes
-  // visit_items_as_lines (expr.get_attrs ());
+  visit_items_as_lines (expr.get_outer_attrs ());
   auto id = expr.get_field_name ().as_string ();
   push (Rust::Token::make_identifier (expr.get_locus (), std::move (id)));
 }
@@ -1105,8 +1104,7 @@ TokenCollector::visit (StructExprFieldIdentifier &expr)
 void
 TokenCollector::visit (StructExprFieldIdentifierValue &expr)
 {
-  // TODO: Add attributes
-  // visit_items_as_lines (expr.get_attrs ());
+  visit_items_as_lines (expr.get_outer_attrs ());
   auto id = expr.get_field_name ();
   push (Rust::Token::make_identifier (expr.get_locus (), std::move (id)));
   push (Rust::Token::make (COLON, UNDEF_LOCATION));
@@ -1116,8 +1114,7 @@ TokenCollector::visit (StructExprFieldIdentifierValue &expr)
 void
 TokenCollector::visit (StructExprFieldIndexValue &expr)
 {
-  // TODO: Add attributes
-  // visit_items_as_lines (expr.get_attrs ());
+  visit_items_as_lines (expr.get_outer_attrs ());
   push (Rust::Token::make_int (expr.get_locus (),
 			       std::to_string (expr.get_index ())));
   push (Rust::Token::make (COLON, UNDEF_LOCATION));

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -11678,6 +11678,7 @@ template <typename ManagedTokenSource>
 std::unique_ptr<AST::StructExprField>
 Parser<ManagedTokenSource>::parse_struct_expr_field ()
 {
+  AST::AttrVec outer_attrs = parse_outer_attributes ();
   const_TokenPtr t = lexer.peek_token ();
   switch (t->get_id ())
     {
@@ -11703,6 +11704,7 @@ Parser<ManagedTokenSource>::parse_struct_expr_field ()
 	  return std::unique_ptr<AST::StructExprFieldIdentifierValue> (
 	    new AST::StructExprFieldIdentifierValue (std::move (ident),
 						     std::move (expr),
+						     std::move (outer_attrs),
 						     t->get_locus ()));
 	}
       else
@@ -11713,6 +11715,7 @@ Parser<ManagedTokenSource>::parse_struct_expr_field ()
 
 	  return std::unique_ptr<AST::StructExprFieldIdentifier> (
 	    new AST::StructExprFieldIdentifier (std::move (ident),
+						std::move (outer_attrs),
 						t->get_locus ()));
 	}
       case INT_LITERAL: {
@@ -11740,6 +11743,7 @@ Parser<ManagedTokenSource>::parse_struct_expr_field ()
 
 	return std::unique_ptr<AST::StructExprFieldIndexValue> (
 	  new AST::StructExprFieldIndexValue (index, std::move (expr),
+					      std::move (outer_attrs),
 					      t->get_locus ()));
       }
     case DOT_DOT:
@@ -14059,6 +14063,7 @@ Parser<ManagedTokenSource>::parse_struct_expr_struct_partial (
       /* technically this would give a struct base-only struct, but this
        * algorithm should work too. As such, AST type not happening. */
     case IDENTIFIER:
+    case HASH:
       case INT_LITERAL: {
 	// struct with struct expr fields
 

--- a/gcc/testsuite/rust/compile/struct_expr_field_attributes.rs
+++ b/gcc/testsuite/rust/compile/struct_expr_field_attributes.rs
@@ -1,0 +1,22 @@
+pub struct Test {
+    #[cfg(not(any(
+        target_os = "solaris",
+        target_os = "illumos",
+        target_os = "fuchsia",
+        target_os = "redox",
+    )))]
+    value: bool,
+    // { dg-warning "field is never read" "" { target *-*-* } .-1 }
+}
+
+pub fn test() -> Test {
+    Test {
+        #[cfg(not(any(
+            target_os = "solaris",
+            target_os = "illumos",
+            target_os = "fuchsia",
+            target_os = "redox",
+        )))]
+        value: false,
+    }
+}


### PR DESCRIPTION
Struct fields can have outer attributes on their field for various purpose, this behavior should be reflected upon struct expr fields.

Fixes #3018