### PR TITLE
Corrected access specifiers

### DIFF
--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -302,7 +302,7 @@ protected:
 class OperatorExpr : public ExprWithoutBlock
 {
   // TODO: create binary and unary operator subclasses?
-public:
+private:
   location_t locus;
 
 protected:

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -160,7 +160,7 @@ protected:
 class OperatorExpr : public ExprWithoutBlock
 {
   // TODO: create binary and unary operator subclasses?
-public:
+private:
   location_t locus;
 
 protected:


### PR DESCRIPTION
`locus` should be private, we also have a getter for it
looks like the access specifier was misstyped