### PR TITLE
Convert Polonius output in rust to C++ format

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -171,6 +171,7 @@ GRS_OBJS = \
     rust/rust-borrow-checker.o \
     rust/rust-bir-builder-expr-stmt.o \
     rust/rust-bir-dump.o \
+    rust/rust-polonius.o\
     rust/rust-hir-dot-operator.o \
     rust/rust-hir-path-probe.o \
     rust/rust-type-util.o \
@@ -482,6 +483,12 @@ rust/%.o: rust/checks/errors/privacy/%.cc
 
 # build borrow checking pass files in rust folder
 rust/%.o: rust/checks/errors/borrowck/%.cc
+	$(COMPILE) $(RUST_CXXFLAGS) $(RUST_INCLUDES) $<
+	$(POSTCOMPILE)
+
+
+# build borrow checking pass polonius files in rust folder
+rust/%.o: rust/checks/errors/borrowck/polonius/%.cc
 	$(COMPILE) $(RUST_CXXFLAGS) $(RUST_INCLUDES) $<
 	$(POSTCOMPILE)
 

--- a/gcc/rust/checks/errors/borrowck/ffi-polonius/src/gccrs_ffi_generated.rs
+++ b/gcc/rust/checks/errors/borrowck/ffi-polonius/src/gccrs_ffi_generated.rs
@@ -51,6 +51,14 @@ pub struct FactsView {
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct FFIVector<T> {
+    pub data: *mut T,
+    pub size: usize,
+    capacity: usize,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct Output {
     pub loan_errors: bool,
     pub subset_errors: bool,

--- a/gcc/rust/checks/errors/borrowck/ffi-polonius/src/gccrs_ffi_generated.rs
+++ b/gcc/rust/checks/errors/borrowck/ffi-polonius/src/gccrs_ffi_generated.rs
@@ -54,7 +54,7 @@ pub struct FactsView {
 pub struct FFIVector<T> {
     pub data: *mut T,
     pub size: usize,
-    capacity: usize,
+    pub capacity: usize,
 }
 
 #[repr(C)]
@@ -63,4 +63,7 @@ pub struct Output {
     pub loan_errors: bool,
     pub subset_errors: bool,
     pub move_errors: bool,
+    pub loan_errors_vector: *mut FFIVector<Pair<usize, *mut FFIVector<usize>>>,
+    pub move_errors_vector: *mut FFIVector<Pair<usize, *mut FFIVector<usize>>>,
+    pub subset_errors_vector: *mut FFIVector<Triple<usize, usize, usize>>,
 }

--- a/gcc/rust/checks/errors/borrowck/ffi-polonius/src/gccrs_ffi_generated.rs
+++ b/gcc/rust/checks/errors/borrowck/ffi-polonius/src/gccrs_ffi_generated.rs
@@ -60,10 +60,7 @@ pub struct FFIVector<T> {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Output {
-    pub loan_errors: bool,
-    pub subset_errors: bool,
-    pub move_errors: bool,
-    pub loan_errors_vector: *mut FFIVector<Pair<usize, *mut FFIVector<usize>>>,
-    pub move_errors_vector: *mut FFIVector<Pair<usize, *mut FFIVector<usize>>>,
-    pub subset_errors_vector: *mut FFIVector<Triple<usize, usize, usize>>,
+    pub loan_errors: *mut FFIVector<Pair<usize, *mut FFIVector<usize>>>,
+    pub move_errors: *mut FFIVector<Pair<usize, *mut FFIVector<usize>>>,
+    pub subset_errors: *mut FFIVector<Triple<usize, usize, usize>>,
 }

--- a/gcc/rust/checks/errors/borrowck/ffi-polonius/src/lib.rs
+++ b/gcc/rust/checks/errors/borrowck/ffi-polonius/src/lib.rs
@@ -28,7 +28,25 @@ extern "C" {
     #[allow(dead_code)]
     fn FFIVector__new(capacity: usize) -> FFIVector<usize>;
     #[allow(dead_code)]
+    fn FFIVector__new_vec_pair(
+        capacity: usize,
+    ) -> FFIVector<gccrs_ffi::Pair<usize, *mut FFIVector<usize>>>;
+    #[allow(dead_code)]
+    fn FFIVector__new_vec_triple(
+        capacity: usize,
+    ) -> FFIVector<gccrs_ffi::Triple<usize, usize, usize>>;
+    #[allow(dead_code)]
     fn FFIVector__push(vector: *mut FFIVector<usize>, element: usize);
+    #[allow(dead_code)]
+    fn FFIVector__push_vec_pair(
+        vector: *mut FFIVector<gccrs_ffi::Pair<usize, *mut FFIVector<usize>>>,
+        element: gccrs_ffi::Pair<usize, *mut FFIVector<usize>>,
+    );
+    #[allow(dead_code)]
+    fn FFIVector__push_vec_triple(
+        vector: *mut FFIVector<gccrs_ffi::Triple<usize, usize, usize>>,
+        element: gccrs_ffi::Triple<usize, usize, usize>,
+    );
 }
 
 /// A single fact value.
@@ -179,7 +197,6 @@ pub unsafe extern "C" fn polonius_run(
             }
         }
     }
-
     return gccrs_ffi::Output {
         loan_errors: output.errors.len() > 0,
         subset_errors: output.subset_errors.len() > 0,

--- a/gcc/rust/checks/errors/borrowck/ffi-polonius/src/lib.rs
+++ b/gcc/rust/checks/errors/borrowck/ffi-polonius/src/lib.rs
@@ -19,9 +19,17 @@
 mod gccrs_ffi;
 mod gccrs_ffi_generated;
 
+use gccrs_ffi::FFIVector;
 use polonius_engine::{AllFacts, Atom, FactTypes, Output};
 use std::fmt::Debug;
 use std::hash::Hash;
+
+extern "C" {
+    #[allow(dead_code)]
+    fn FFIVector__new(capacity: usize) -> FFIVector<usize>;
+    #[allow(dead_code)]
+    fn FFIVector__push(vector: *mut FFIVector<usize>, element: usize);
+}
 
 /// A single fact value.
 /// For simplicity we use one type for all facts.

--- a/gcc/rust/checks/errors/borrowck/ffi-polonius/src/lib.rs
+++ b/gcc/rust/checks/errors/borrowck/ffi-polonius/src/lib.rs
@@ -199,7 +199,7 @@ pub unsafe extern "C" fn polonius_run(
         }
     }
 
-    let loan_errors_vector = FFIVector__new_vec_pair(output.errors.len());
+    let loan_errors = FFIVector__new_vec_pair(output.errors.len());
     for (keys, values) in output.errors.iter() {
         let loans_vec = FFIVector__new(values.len());
         for loan in values.iter() {
@@ -211,10 +211,10 @@ pub unsafe extern "C" fn polonius_run(
             first: point,
             second: loans_vec,
         };
-        FFIVector__push_vec_pair(loan_errors_vector, pair);
+        FFIVector__push_vec_pair(loan_errors, pair);
     }
 
-    let move_errors_vector = FFIVector__new_vec_pair(output.move_errors.len());
+    let move_errors = FFIVector__new_vec_pair(output.move_errors.len());
     for (keys, values) in output.move_errors.iter() {
         let paths_vec = FFIVector__new(values.len());
         for path in values.iter() {
@@ -226,10 +226,10 @@ pub unsafe extern "C" fn polonius_run(
             first: point,
             second: paths_vec,
         };
-        FFIVector__push_vec_pair(move_errors_vector, pair);
+        FFIVector__push_vec_pair(move_errors, pair);
     }
 
-    let subset_errors_vector = FFIVector__new_vec_triple(output.subset_errors.len());
+    let subset_errors = FFIVector__new_vec_triple(output.subset_errors.len());
     for (key, value) in output.subset_errors.iter() {
         let point: usize = key.into();
         for origin_pair in value.iter() {
@@ -240,16 +240,13 @@ pub unsafe extern "C" fn polonius_run(
                 second: origin_1,
                 third: origin_2,
             };
-            FFIVector__push_vec_triple(subset_errors_vector, triple);
+            FFIVector__push_vec_triple(subset_errors, triple);
         }
     }
 
     return gccrs_ffi::Output {
-        loan_errors: output.errors.len() > 0,
-        subset_errors: output.subset_errors.len() > 0,
-        move_errors: output.move_errors.len() > 0,
-        loan_errors_vector,
-        move_errors_vector,
-        subset_errors_vector,
+        loan_errors,
+        move_errors,
+        subset_errors,
     };
 }

--- a/gcc/rust/checks/errors/borrowck/polonius/rust-polonius-ffi.h
+++ b/gcc/rust/checks/errors/borrowck/polonius/rust-polonius-ffi.h
@@ -217,12 +217,9 @@ FFIVectorPair::drop ()
 
 struct Output
 {
-  bool loan_errors;
-  bool subset_errors;
-  bool move_errors;
-  FFIVectorPair *loan_errors_vector;
-  FFIVectorPair *move_errors_vector;
-  FFIVectorTriple *subset_errors_vector;
+  FFIVectorPair *loan_errors;
+  FFIVectorPair *move_errors;
+  FFIVectorTriple *subset_errors;
 };
 
 } // namespace FFI

--- a/gcc/rust/checks/errors/borrowck/polonius/rust-polonius.cc
+++ b/gcc/rust/checks/errors/borrowck/polonius/rust-polonius.cc
@@ -22,14 +22,41 @@ namespace Rust {
 namespace Polonius {
 
 extern "C" {
+
 FFI::FFIVector<size_t>
 FFIVector__new (size_t capacity)
 {
   return FFI::FFIVector<size_t>::make_new (capacity);
 }
 
+FFI::FFIVectorPair
+FFIVector__new_vec_pair (size_t capacity)
+{
+  return FFI::FFIVectorPair::make_new (capacity);
+}
+
+FFI::FFIVectorTriple
+FFIVector__new_triple (size_t capacity)
+{
+  return FFI::FFIVectorTriple::make_new (capacity);
+}
+
 void
-FFIVector__push (FFI::FFIVector<size_t> *vector, size_t element)
+FFIVector__push (FFI::FFIVectorSizet *vector, size_t element)
+{
+  vector->push (element);
+}
+
+void
+FFIVector__push_vec_pair (FFI::FFIVectorPair *vector,
+			  FFI::Pair<size_t, FFI::FFIVector<size_t> *> element)
+{
+  vector->push (element);
+}
+
+void
+FFIVector__push_vec_triple (FFI::FFIVectorTriple *vector,
+			    FFI::Triple<size_t, size_t, size_t> element)
 {
   vector->push (element);
 }

--- a/gcc/rust/checks/errors/borrowck/polonius/rust-polonius.cc
+++ b/gcc/rust/checks/errors/borrowck/polonius/rust-polonius.cc
@@ -1,0 +1,39 @@
+// Copyright (C) 2020-2024 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-polonius.h"
+
+namespace Rust {
+namespace Polonius {
+
+extern "C" {
+FFI::FFIVector<size_t>
+FFIVector__new (size_t capacity)
+{
+  return FFI::FFIVector<size_t>::make_new (capacity);
+}
+
+void
+FFIVector__push (FFI::FFIVector<size_t> *vector, size_t element)
+{
+  vector->push (element);
+}
+}
+
+} // namespace Polonius
+} // namespace Rust

--- a/gcc/rust/checks/errors/borrowck/polonius/rust-polonius.cc
+++ b/gcc/rust/checks/errors/borrowck/polonius/rust-polonius.cc
@@ -23,20 +23,20 @@ namespace Polonius {
 
 extern "C" {
 
-FFI::FFIVector<size_t>
+FFI::FFIVector<size_t> *
 FFIVector__new (size_t capacity)
 {
   return FFI::FFIVector<size_t>::make_new (capacity);
 }
 
-FFI::FFIVectorPair
+FFI::FFIVectorPair *
 FFIVector__new_vec_pair (size_t capacity)
 {
   return FFI::FFIVectorPair::make_new (capacity);
 }
 
-FFI::FFIVectorTriple
-FFIVector__new_triple (size_t capacity)
+FFI::FFIVectorTriple *
+FFIVector__new_vec_triple (size_t capacity)
 {
   return FFI::FFIVectorTriple::make_new (capacity);
 }

--- a/gcc/rust/checks/errors/borrowck/polonius/rust-polonius.h
+++ b/gcc/rust/checks/errors/borrowck/polonius/rust-polonius.h
@@ -227,11 +227,26 @@ polonius_run (FFI::FactsView input, bool dump_enabled);
 
 // Helper functions for FFIVector to be used on Rust side
 extern "C" {
-FFI::FFIVector<size_t>
+
+FFI::FFIVectorSizet
 FFIVector__new (size_t capacity = 0);
 
+FFI::FFIVectorPair
+FFIVector__new_vec_pair (size_t capacity = 0);
+
+FFI::FFIVectorTriple
+FFIVector__new_vec_triple (size_t capacity = 0);
+
 void
-FFIVector__push (FFI::FFIVector<size_t> *vector, size_t element);
+FFIVector__push (FFI::FFIVectorSizet *vector, size_t element);
+
+void
+FFIVector__push_vec_pair (FFI::FFIVectorPair *vector,
+			  FFI::Pair<size_t, FFI::FFIVector<size_t> *> element);
+
+void
+FFIVector__push_vec_triple (FFI::FFIVectorTriple *vector,
+			    FFI::Triple<size_t, size_t, size_t> element);
 }
 
 } // namespace Polonius

--- a/gcc/rust/checks/errors/borrowck/polonius/rust-polonius.h
+++ b/gcc/rust/checks/errors/borrowck/polonius/rust-polonius.h
@@ -225,6 +225,15 @@ struct Facts
 extern "C" FFI::Output
 polonius_run (FFI::FactsView input, bool dump_enabled);
 
+// Helper functions for FFIVector to be used on Rust side
+extern "C" {
+FFI::FFIVector<size_t>
+FFIVector__new (size_t capacity = 0);
+
+void
+FFIVector__push (FFI::FFIVector<size_t> *vector, size_t element);
+}
+
 } // namespace Polonius
 } // namespace Rust
 

--- a/gcc/rust/checks/errors/borrowck/polonius/rust-polonius.h
+++ b/gcc/rust/checks/errors/borrowck/polonius/rust-polonius.h
@@ -228,13 +228,13 @@ polonius_run (FFI::FactsView input, bool dump_enabled);
 // Helper functions for FFIVector to be used on Rust side
 extern "C" {
 
-FFI::FFIVectorSizet
+FFI::FFIVectorSizet *
 FFIVector__new (size_t capacity = 0);
 
-FFI::FFIVectorPair
+FFI::FFIVectorPair *
 FFIVector__new_vec_pair (size_t capacity = 0);
 
-FFI::FFIVectorTriple
+FFI::FFIVectorTriple *
 FFIVector__new_vec_triple (size_t capacity = 0);
 
 void

--- a/gcc/rust/checks/errors/borrowck/rust-borrow-checker.cc
+++ b/gcc/rust/checks/errors/borrowck/rust-borrow-checker.cc
@@ -156,28 +156,28 @@ BorrowChecker::go (HIR::Crate &crate)
 	= Polonius::polonius_run (facts.freeze (), rust_be_debug_p ());
 
       // convert to std::vector variation for easier navigation
-      auto loan_errors_vector = make_vector (result.loan_errors_vector);
-      auto move_errors_vector = make_vector (result.move_errors_vector);
-      auto subset_errors = make_vector (result.subset_errors_vector);
+      auto loan_errors = make_vector (result.loan_errors);
+      auto move_errors = make_vector (result.move_errors);
+      auto subset_errors = make_vector (result.subset_errors);
 
       // free the memory in C++ side as it was allocated in C++ side
-      result.loan_errors_vector->drop ();
-      result.move_errors_vector->drop ();
-      result.subset_errors_vector->drop ();
+      result.loan_errors->drop ();
+      result.move_errors->drop ();
+      result.subset_errors->drop ();
 
-      if (result.loan_errors)
+      if (loan_errors.size ())
 	{
 	  rust_error_at (func->get_locus (), "Found loan errors in function %s",
 			 func->get_function_name ().as_string ().c_str ());
 	}
-      if (result.subset_errors)
+      if (subset_errors.size ())
 	{
 	  rust_error_at (func->get_locus (),
 			 "Found subset errors in function %s. Some lifetime "
 			 "constraints need to be added.",
 			 func->get_function_name ().as_string ().c_str ());
 	}
-      if (result.move_errors)
+      if (move_errors.size ())
 	{
 	  rust_error_at (func->get_locus (), "Found move errors in function %s",
 			 func->get_function_name ().as_string ().c_str ());

--- a/gcc/rust/checks/errors/borrowck/rust-borrow-checker.cc
+++ b/gcc/rust/checks/errors/borrowck/rust-borrow-checker.cc
@@ -155,6 +155,16 @@ BorrowChecker::go (HIR::Crate &crate)
       auto result
 	= Polonius::polonius_run (facts.freeze (), rust_be_debug_p ());
 
+      // convert to std::vector variation for easier navigation
+      auto loan_errors_vector = make_vector (result.loan_errors_vector);
+      auto move_errors_vector = make_vector (result.move_errors_vector);
+      auto subset_errors = make_vector (result.subset_errors_vector);
+
+      // free the memory in C++ side as it was allocated in C++ side
+      result.loan_errors_vector->drop ();
+      result.move_errors_vector->drop ();
+      result.subset_errors_vector->drop ();
+
       if (result.loan_errors)
 	{
 	  rust_error_at (func->get_locus (), "Found loan errors in function %s",


### PR DESCRIPTION
1. DONE: Added FFIVector<T>, it will be used to convert Polonius output in rust to C++ format.
2. DONE: Provide helper implementations for all required types.
3. DONE: Construct the output and pass to C++.
4. DONE: Use the newly converted data to trigger borrow checking errors.