### PR TITLE
gccrs: configure.ac: Fix quoting around ldl/lpthread checks

### DIFF
--- a/configure
+++ b/configure
@@ -8827,7 +8827,7 @@ fi
 
 
 
-# Rust requires -ldl and -lpthread if you are using an old glibc that does not include them by
+# Rust requires -ldl and -lpthread if you are using a libc which does not include them by
 # default, so we check for them here
 
 missing_rust_dynlibs=none
@@ -8945,15 +8945,15 @@ if test "$ac_res" != no; then :
 fi
 
 
-if test $ac_cv_search_dlopen = -ldl; then
+if test "$ac_cv_search_dlopen" = -ldl; then
     CRAB1_LIBS="$CRAB1_LIBS -ldl"
-elif test $ac_cv_search_dlopen = no; then
+elif test "$ac_cv_search_dlopen" = no; then
     missing_rust_dynlibs="libdl"
 fi
 
-if test $ac_cv_search_pthread_create = -lpthread; then
+if test "$ac_cv_search_pthread_create" = -lpthread; then
     CRAB1_LIBS="$CRAB1_LIBS -lpthread"
-elif test $ac_cv_search_pthread_crate = no; then
+elif test "$ac_cv_search_pthread_create" = no; then
     missing_rust_dynlibs="$missing_rust_dynlibs, libpthread"
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -2036,7 +2036,7 @@ fi
 
 AC_SUBST(PICFLAG)
 
-# Rust requires -ldl and -lpthread if you are using an old glibc that does not include them by
+# Rust requires -ldl and -lpthread if you are using a libc which does not include them by
 # default, so we check for them here
 
 missing_rust_dynlibs=none
@@ -2044,15 +2044,15 @@ missing_rust_dynlibs=none
 AC_SEARCH_LIBS([dlopen], [dl])
 AC_SEARCH_LIBS([pthread_create], [pthread])
 
-if test $ac_cv_search_dlopen = -ldl; then
+if test "$ac_cv_search_dlopen" = -ldl; then
     CRAB1_LIBS="$CRAB1_LIBS -ldl"
-elif test $ac_cv_search_dlopen = no; then
+elif test "$ac_cv_search_dlopen" = no; then
     missing_rust_dynlibs="libdl"
 fi
 
-if test $ac_cv_search_pthread_create = -lpthread; then
+if test "$ac_cv_search_pthread_create" = -lpthread; then
     CRAB1_LIBS="$CRAB1_LIBS -lpthread"
-elif test $ac_cv_search_pthread_crate = no; then
+elif test "$ac_cv_search_pthread_create" = no; then
     missing_rust_dynlibs="$missing_rust_dynlibs, libpthread"
 fi
 


### PR DESCRIPTION
ChangeLog:

	* configure.ac: Add quoting around both variable checks performed, which
	will fix the noise reported when libc contains both ldl and lpthread. A
	typo around `pthread_create` being typed `pthread_crate` is also fixed.
	* configure: Regenerate.

Addresses [Bugzilla report #115453](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115453)
