### PR TITLE
Add test case for using asm! outside of unsafe {}

### DIFF
--- a/gcc/testsuite/rust/compile/inline_asm_outside_unsafe.rs
+++ b/gcc/testsuite/rust/compile/inline_asm_outside_unsafe.rs
@@ -1,0 +1,11 @@
+#![feature(rustc_attrs)]
+
+#[rustc_builtin_macro]
+macro_rules! asm {
+    () => {}
+}
+
+fn main() {
+    asm!("nop"); // { dg-error "use of inline assembly is unsafe and requires unsafe function or block" }
+}
+


### PR DESCRIPTION
I've added the unsafe guard check in #2982 but I haven't added it in since then 
