### PR TITLE
Added ExprType::InlineAsm

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -3893,8 +3893,7 @@ public:
 
   ExprType get_expression_type () const final override
   {
-    // TODO: Not sure if this expression type is UnsafeBlock or not.
-    return ExprType::UnsafeBlock;
+    return ExprType::InlineAsm;
   }
   std::vector<AST::InlineAsmTemplatePiece> get_template_ ()
   {

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -303,6 +303,7 @@ public:
     Await,
     AsyncBlock,
     Path,
+    InlineAsm,
   };
 
   BaseKind get_hir_kind () override final { return EXPR; }


### PR DESCRIPTION
Addresses #3062

gcc/rust/ChangeLog:

	* hir/tree/rust-hir-expr.h: Added ExprType::InlineAsm
	* hir/tree/rust-hir.h: Added ExprType::InlineAsm


