### PR TITLE
Desugar IfLet* expr to match

### DIFF
--- a/gcc/rust/backend/rust-compile-block.h
+++ b/gcc/rust/backend/rust-compile-block.h
@@ -96,8 +96,6 @@ public:
   void visit (HIR::LoopExpr &) override {}
   void visit (HIR::WhileLoopExpr &) override {}
   void visit (HIR::WhileLetLoopExpr &) override {}
-  void visit (HIR::IfLetExpr &) override {}
-  void visit (HIR::IfLetExprConseqElse &) override {}
   void visit (HIR::MatchExpr &) override {}
   void visit (HIR::AwaitExpr &) override {}
   void visit (HIR::AsyncBlockExpr &) override {}
@@ -180,8 +178,6 @@ public:
   void visit (HIR::LoopExpr &) override {}
   void visit (HIR::WhileLoopExpr &) override {}
   void visit (HIR::WhileLetLoopExpr &) override {}
-  void visit (HIR::IfLetExpr &) override {}
-  void visit (HIR::IfLetExprConseqElse &) override {}
   void visit (HIR::MatchExpr &) override {}
   void visit (HIR::AwaitExpr &) override {}
   void visit (HIR::AsyncBlockExpr &) override {}

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -77,8 +77,6 @@ public:
   // TODO
   // these need to be sugared in the HIR to if statements and a match
   void visit (HIR::WhileLetLoopExpr &) override {}
-  void visit (HIR::IfLetExpr &) override {}
-  void visit (HIR::IfLetExprConseqElse &) override {}
 
   // lets not worry about async yet....
   void visit (HIR::AwaitExpr &) override {}

--- a/gcc/rust/checks/errors/borrowck/rust-bir-builder-expr-stmt.cc
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-builder-expr-stmt.cc
@@ -612,18 +612,6 @@ ExprStmtBuilder::visit (HIR::IfExprConseqElse &expr)
 }
 
 void
-ExprStmtBuilder::visit (HIR::IfLetExpr &expr)
-{
-  rust_sorry_at (expr.get_locus (), "if let expressions are not supported");
-}
-
-void
-ExprStmtBuilder::visit (HIR::IfLetExprConseqElse &expr)
-{
-  rust_sorry_at (expr.get_locus (), "if let expressions are not supported");
-}
-
-void
 ExprStmtBuilder::visit (HIR::MatchExpr &expr)
 {
   rust_sorry_at (expr.get_locus (), "match expressions are not supported");

--- a/gcc/rust/checks/errors/borrowck/rust-bir-builder-expr-stmt.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-builder-expr-stmt.h
@@ -101,8 +101,6 @@ protected: // Expr
   void visit (HIR::IfExprConseqElse &expr) override;
   void visit (HIR::InlineAsm &expr) override;
 
-  void visit (HIR::IfLetExpr &expr) override;
-  void visit (HIR::IfLetExprConseqElse &expr) override;
   void visit (HIR::MatchExpr &expr) override;
   void visit (HIR::AwaitExpr &expr) override;
   void visit (HIR::AsyncBlockExpr &expr) override;

--- a/gcc/rust/checks/errors/borrowck/rust-bir-builder-lazyboolexpr.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-builder-lazyboolexpr.h
@@ -193,14 +193,6 @@ public:
   {
     return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
   }
-  void visit (HIR::IfLetExpr &expr) override
-  {
-    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
-  }
-  void visit (HIR::IfLetExprConseqElse &expr) override
-  {
-    return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());
-  }
   void visit (HIR::MatchExpr &expr) override
   {
     return_place (ExprStmtBuilder (ctx).build (expr), expr.get_locus ());

--- a/gcc/rust/checks/errors/borrowck/rust-bir-builder-struct.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-builder-struct.h
@@ -149,8 +149,6 @@ protected:
   void visit (HIR::WhileLetLoopExpr &expr) override { rust_unreachable (); }
   void visit (HIR::IfExpr &expr) override { rust_unreachable (); }
   void visit (HIR::IfExprConseqElse &expr) override { rust_unreachable (); }
-  void visit (HIR::IfLetExpr &expr) override { rust_unreachable (); }
-  void visit (HIR::IfLetExprConseqElse &expr) override { rust_unreachable (); }
   void visit (HIR::MatchExpr &expr) override { rust_unreachable (); }
   void visit (HIR::AwaitExpr &expr) override { rust_unreachable (); }
   void visit (HIR::AsyncBlockExpr &expr) override { rust_unreachable (); }

--- a/gcc/rust/checks/errors/borrowck/rust-function-collector.h
+++ b/gcc/rust/checks/errors/borrowck/rust-function-collector.h
@@ -119,8 +119,6 @@ public:
   void visit (HIR::WhileLetLoopExpr &expr) override {}
   void visit (HIR::IfExpr &expr) override {}
   void visit (HIR::IfExprConseqElse &expr) override {}
-  void visit (HIR::IfLetExpr &expr) override {}
-  void visit (HIR::IfLetExprConseqElse &expr) override {}
   void visit (HIR::MatchExpr &expr) override {}
   void visit (HIR::AwaitExpr &expr) override {}
   void visit (HIR::AsyncBlockExpr &expr) override {}

--- a/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
+++ b/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
@@ -595,21 +595,6 @@ PrivacyReporter::visit (HIR::IfExprConseqElse &expr)
 }
 
 void
-PrivacyReporter::visit (HIR::IfLetExpr &)
-{
-  // TODO: We need to visit the if_let_expr
-  // TODO: We need to visit the block as well
-}
-
-void
-PrivacyReporter::visit (HIR::IfLetExprConseqElse &)
-{
-  // TODO: We need to visit the if_let_expr
-  // TODO: We need to visit the if_block as well
-  // TODO: We need to visit the else_block as well
-}
-
-void
 PrivacyReporter::visit (HIR::MatchExpr &expr)
 {
   expr.get_scrutinee_expr ()->accept_vis (*this);

--- a/gcc/rust/checks/errors/privacy/rust-privacy-reporter.h
+++ b/gcc/rust/checks/errors/privacy/rust-privacy-reporter.h
@@ -121,8 +121,6 @@ types
   virtual void visit (HIR::WhileLetLoopExpr &expr);
   virtual void visit (HIR::IfExpr &expr);
   virtual void visit (HIR::IfExprConseqElse &expr);
-  virtual void visit (HIR::IfLetExpr &expr);
-  virtual void visit (HIR::IfLetExprConseqElse &expr);
   virtual void visit (HIR::MatchExpr &expr);
   virtual void visit (HIR::AwaitExpr &expr);
   virtual void visit (HIR::AsyncBlockExpr &expr);

--- a/gcc/rust/checks/errors/rust-const-checker.cc
+++ b/gcc/rust/checks/errors/rust-const-checker.cc
@@ -512,22 +512,6 @@ ConstChecker::visit (IfExprConseqElse &expr)
 }
 
 void
-ConstChecker::visit (IfLetExpr &expr)
-{
-  expr.get_scrutinee_expr ()->accept_vis (*this);
-  expr.get_if_block ()->accept_vis (*this);
-}
-
-void
-ConstChecker::visit (IfLetExprConseqElse &expr)
-{
-  expr.get_scrutinee_expr ()->accept_vis (*this);
-  expr.get_if_block ()->accept_vis (*this);
-
-  // TODO: Visit else expression
-}
-
-void
 ConstChecker::visit (MatchExpr &expr)
 {
   expr.get_scrutinee_expr ()->accept_vis (*this);

--- a/gcc/rust/checks/errors/rust-const-checker.h
+++ b/gcc/rust/checks/errors/rust-const-checker.h
@@ -128,8 +128,6 @@ private:
   virtual void visit (WhileLetLoopExpr &expr) override;
   virtual void visit (IfExpr &expr) override;
   virtual void visit (IfExprConseqElse &expr) override;
-  virtual void visit (IfLetExpr &expr) override;
-  virtual void visit (IfLetExprConseqElse &expr) override;
   virtual void visit (MatchExpr &expr) override;
   virtual void visit (AwaitExpr &expr) override;
   virtual void visit (AsyncBlockExpr &expr) override;

--- a/gcc/rust/checks/errors/rust-hir-pattern-analysis.cc
+++ b/gcc/rust/checks/errors/rust-hir-pattern-analysis.cc
@@ -390,22 +390,6 @@ PatternChecker::visit (IfExprConseqElse &expr)
 }
 
 void
-PatternChecker::visit (IfLetExpr &expr)
-{
-  expr.get_scrutinee_expr ()->accept_vis (*this);
-  expr.get_if_block ()->accept_vis (*this);
-}
-
-void
-PatternChecker::visit (IfLetExprConseqElse &expr)
-{
-  expr.get_scrutinee_expr ()->accept_vis (*this);
-  expr.get_if_block ()->accept_vis (*this);
-
-  expr.get_else_block ()->accept_vis (*this);
-}
-
-void
 PatternChecker::visit (MatchExpr &expr)
 {
   expr.get_scrutinee_expr ()->accept_vis (*this);

--- a/gcc/rust/checks/errors/rust-hir-pattern-analysis.h
+++ b/gcc/rust/checks/errors/rust-hir-pattern-analysis.h
@@ -102,8 +102,6 @@ private:
   virtual void visit (WhileLetLoopExpr &expr) override;
   virtual void visit (IfExpr &expr) override;
   virtual void visit (IfExprConseqElse &expr) override;
-  virtual void visit (IfLetExpr &expr) override;
-  virtual void visit (IfLetExprConseqElse &expr) override;
   virtual void visit (HIR::MatchExpr &expr) override;
   virtual void visit (AwaitExpr &expr) override;
   virtual void visit (AsyncBlockExpr &expr) override;

--- a/gcc/rust/checks/errors/rust-unsafe-checker.cc
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.cc
@@ -634,22 +634,6 @@ UnsafeChecker::visit (IfExprConseqElse &expr)
 }
 
 void
-UnsafeChecker::visit (IfLetExpr &expr)
-{
-  expr.get_scrutinee_expr ()->accept_vis (*this);
-  expr.get_if_block ()->accept_vis (*this);
-}
-
-void
-UnsafeChecker::visit (IfLetExprConseqElse &expr)
-{
-  expr.get_scrutinee_expr ()->accept_vis (*this);
-  expr.get_if_block ()->accept_vis (*this);
-
-  // TODO: Visit else expression
-}
-
-void
 UnsafeChecker::visit (MatchExpr &expr)
 {
   expr.get_scrutinee_expr ()->accept_vis (*this);

--- a/gcc/rust/checks/errors/rust-unsafe-checker.h
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.h
@@ -110,8 +110,6 @@ private:
   virtual void visit (WhileLetLoopExpr &expr) override;
   virtual void visit (IfExpr &expr) override;
   virtual void visit (IfExprConseqElse &expr) override;
-  virtual void visit (IfLetExpr &expr) override;
-  virtual void visit (IfLetExprConseqElse &expr) override;
   virtual void visit (MatchExpr &expr) override;
   virtual void visit (AwaitExpr &expr) override;
   virtual void visit (AsyncBlockExpr &expr) override;

--- a/gcc/rust/hir/rust-ast-lower-block.h
+++ b/gcc/rust/hir/rust-ast-lower-block.h
@@ -115,7 +115,7 @@ class ASTLoweringIfLetBlock : public ASTLoweringBase
   using Rust::HIR::ASTLoweringBase::visit;
 
 public:
-  static HIR::IfLetExpr *translate (AST::IfLetExpr &expr)
+  static HIR::MatchExpr *translate (AST::IfLetExpr &expr)
   {
     ASTLoweringIfLetBlock resolver;
     expr.accept_vis (resolver);
@@ -135,7 +135,10 @@ public:
 private:
   ASTLoweringIfLetBlock () : ASTLoweringBase (), translated (nullptr) {}
 
-  HIR::IfLetExpr *translated;
+  void desugar_iflet (AST::IfLetExpr &, HIR::Expr **, HIR::Expr *,
+		      std::vector<HIR::MatchCase> &);
+
+  HIR::MatchExpr *translated;
 };
 
 class ASTLoweringExprWithBlock : public ASTLoweringBase
@@ -149,9 +152,7 @@ public:
     ASTLoweringExprWithBlock resolver;
     expr.accept_vis (resolver);
     if (resolver.translated != nullptr)
-      {
-	resolver.mappings.insert_hir_expr (resolver.translated);
-      }
+      resolver.mappings.insert_hir_expr (resolver.translated);
 
     *terminated = resolver.terminated;
     return resolver.translated;

--- a/gcc/rust/hir/rust-ast-lower.h
+++ b/gcc/rust/hir/rust-ast-lower.h
@@ -39,6 +39,11 @@ struct_field_name_exists (std::vector<HIR::StructField> &fields,
 Visibility
 translate_visibility (const AST::Visibility &vis);
 
+/**
+ * Main base class used for lowering AST to HIR.
+ *
+ * Every subclass should provide a translate() method that takes an AST node and
+ * lowers it to some HIR stored in the TRANSLATED member. */
 class ASTLowering
 {
 public:

--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -464,17 +464,6 @@ Dump::do_baseloopexpr (BaseLoopExpr &e)
 }
 
 void
-Dump::do_ifletexpr (IfLetExpr &e)
-{
-  do_expr (e);
-
-  visit_collection ("match_arm_patterns", e.get_patterns ());
-
-  visit_field ("value", e.get_scrutinee_expr ());
-  visit_field ("if_block", e.get_if_block ());
-}
-
-void
 Dump::do_struct (Struct &e)
 {
   do_vis_item (e);
@@ -1439,23 +1428,6 @@ Dump::visit (IfExprConseqElse &e)
   visit_field ("else_block", e.get_else_block ());
 
   end ("IfExprConseqElse");
-}
-
-void
-Dump::visit (IfLetExpr &e)
-{
-  begin ("IfLetExpr");
-  do_ifletexpr (e);
-  end ("IfLetExpr");
-}
-
-void
-Dump::visit (IfLetExprConseqElse &e)
-{
-  begin ("IfLetExprConseqElse");
-  do_ifletexpr (e);
-  visit_field ("else_block", e.get_else_block ());
-  end ("IfLetExprConseqElse");
 }
 
 void

--- a/gcc/rust/hir/rust-hir-dump.h
+++ b/gcc/rust/hir/rust-hir-dump.h
@@ -80,7 +80,6 @@ private:
   void do_type (Type &);
   void do_expr (Expr &);
   void do_ifexpr (IfExpr &);
-  void do_ifletexpr (IfLetExpr &);
   void do_pathexpr (PathExpr &);
   void do_pathpattern (PathPattern &);
   void do_genericargs (GenericArgs &);
@@ -162,8 +161,6 @@ private:
   virtual void visit (WhileLetLoopExpr &) override;
   virtual void visit (IfExpr &) override;
   virtual void visit (IfExprConseqElse &) override;
-  virtual void visit (IfLetExpr &) override;
-  virtual void visit (IfLetExprConseqElse &) override;
 
   virtual void visit (MatchExpr &) override;
   virtual void visit (AwaitExpr &) override;

--- a/gcc/rust/hir/tree/rust-hir-full-decls.h
+++ b/gcc/rust/hir/tree/rust-hir-full-decls.h
@@ -113,8 +113,6 @@ class WhileLoopExpr;
 class WhileLetLoopExpr;
 class IfExpr;
 class IfExprConseqElse;
-class IfLetExpr;
-class IfLetExprConseqElse;
 struct MatchArm;
 // class MatchCase;
 // class MatchCaseBlockExpr;

--- a/gcc/rust/hir/tree/rust-hir-visitor.h
+++ b/gcc/rust/hir/tree/rust-hir-visitor.h
@@ -81,8 +81,6 @@ public:
   virtual void visit (WhileLetLoopExpr &expr) = 0;
   virtual void visit (IfExpr &expr) = 0;
   virtual void visit (IfExprConseqElse &expr) = 0;
-  virtual void visit (IfLetExpr &expr) = 0;
-  virtual void visit (IfLetExprConseqElse &expr) = 0;
   virtual void visit (MatchExpr &expr) = 0;
   virtual void visit (AwaitExpr &expr) = 0;
   virtual void visit (AsyncBlockExpr &expr) = 0;
@@ -219,8 +217,6 @@ public:
   virtual void visit (WhileLetLoopExpr &) override {}
   virtual void visit (IfExpr &) override {}
   virtual void visit (IfExprConseqElse &) override {}
-  virtual void visit (IfLetExpr &) override {}
-  virtual void visit (IfLetExprConseqElse &) override {}
 
   virtual void visit (MatchExpr &) override {}
   virtual void visit (AwaitExpr &) override {}
@@ -448,8 +444,6 @@ public:
   virtual void visit (WhileLetLoopExpr &expr) = 0;
   virtual void visit (IfExpr &expr) = 0;
   virtual void visit (IfExprConseqElse &expr) = 0;
-  virtual void visit (IfLetExpr &expr) = 0;
-  virtual void visit (IfLetExprConseqElse &expr) = 0;
   virtual void visit (InlineAsm &expr) = 0;
   virtual void visit (MatchExpr &expr) = 0;
   virtual void visit (AwaitExpr &expr) = 0;

--- a/gcc/rust/hir/tree/rust-hir.cc
+++ b/gcc/rust/hir/tree/rust-hir.cc
@@ -1572,41 +1572,6 @@ IfExprConseqElse::as_string () const
 }
 
 std::string
-IfLetExpr::as_string () const
-{
-  std::string str ("IfLetExpr: ");
-
-  str += "\n Condition match arm patterns: ";
-  if (match_arm_patterns.empty ())
-    {
-      str += "none";
-    }
-  else
-    {
-      for (const auto &pattern : match_arm_patterns)
-	{
-	  str += "\n  " + pattern->as_string ();
-	}
-    }
-
-  str += "\n Scrutinee expr: " + value->as_string ();
-
-  str += "\n If let block expr: " + if_block->as_string ();
-
-  return str;
-}
-
-std::string
-IfLetExprConseqElse::as_string () const
-{
-  std::string str = IfLetExpr::as_string ();
-
-  str += "\n Else expr: " + else_block->as_string ();
-
-  return str;
-}
-
-std::string
 RangeFromToInclExpr::as_string () const
 {
   return from->as_string () + "..=" + to->as_string ();
@@ -4150,18 +4115,6 @@ IfExprConseqElse::accept_vis (HIRFullVisitor &vis)
 }
 
 void
-IfLetExpr::accept_vis (HIRFullVisitor &vis)
-{
-  vis.visit (*this);
-}
-
-void
-IfLetExprConseqElse::accept_vis (HIRFullVisitor &vis)
-{
-  vis.visit (*this);
-}
-
-void
 MatchExpr::accept_vis (HIRFullVisitor &vis)
 {
   vis.visit (*this);
@@ -4907,18 +4860,6 @@ CallExpr::accept_vis (HIRExpressionVisitor &vis)
 
 void
 RangeFromToInclExpr::accept_vis (HIRExpressionVisitor &vis)
-{
-  vis.visit (*this);
-}
-
-void
-IfLetExprConseqElse::accept_vis (HIRExpressionVisitor &vis)
-{
-  vis.visit (*this);
-}
-
-void
-IfLetExpr::accept_vis (HIRExpressionVisitor &vis)
 {
   vis.visit (*this);
 }

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -300,7 +300,6 @@ public:
     UnsafeBlock,
     BaseLoop,
     If,
-    IfLet,
     Match,
     Await,
     AsyncBlock,

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -504,67 +504,6 @@ TypeCheckExpr::visit (HIR::IfExprConseqElse &expr)
 }
 
 void
-TypeCheckExpr::visit (HIR::IfLetExpr &expr)
-{
-  // this needs to perform a least upper bound coercion on the blocks and then
-  // unify the scruintee and arms
-  TyTy::BaseType *scrutinee_tyty
-    = TypeCheckExpr::Resolve (expr.get_scrutinee_expr ().get ());
-
-  for (auto &pattern : expr.get_patterns ())
-    {
-      TyTy::BaseType *kase_arm_ty
-	= TypeCheckPattern::Resolve (pattern.get (), scrutinee_tyty);
-
-      unify_site (expr.get_mappings ().get_hirid (),
-		  TyTy::TyWithLocation (scrutinee_tyty),
-		  TyTy::TyWithLocation (kase_arm_ty, pattern->get_locus ()),
-		  expr.get_locus ());
-    }
-
-  TypeCheckExpr::Resolve (expr.get_if_block ().get ());
-
-  infered = TyTy::TupleType::get_unit_type (expr.get_mappings ().get_hirid ());
-}
-
-void
-TypeCheckExpr::visit (HIR::IfLetExprConseqElse &expr)
-{
-  TyTy::BaseType *scrutinee_tyty
-    = TypeCheckExpr::Resolve (expr.get_scrutinee_expr ().get ());
-
-  for (auto &pattern : expr.get_patterns ())
-    {
-      TyTy::BaseType *kase_arm_ty
-	= TypeCheckPattern::Resolve (pattern.get (), scrutinee_tyty);
-
-      unify_site (expr.get_mappings ().get_hirid (),
-		  TyTy::TyWithLocation (scrutinee_tyty),
-		  TyTy::TyWithLocation (kase_arm_ty, pattern->get_locus ()),
-		  expr.get_locus ());
-    }
-
-  auto if_blk_resolved = TypeCheckExpr::Resolve (expr.get_if_block ().get ());
-  auto else_blk_resolved
-    = TypeCheckExpr::Resolve (expr.get_else_block ().get ());
-
-  if (if_blk_resolved->get_kind () == TyTy::NEVER)
-    infered = else_blk_resolved;
-  else if (else_blk_resolved->get_kind () == TyTy::NEVER)
-    infered = if_blk_resolved;
-  else
-    {
-      infered = unify_site (
-	expr.get_mappings ().get_hirid (),
-	TyTy::TyWithLocation (if_blk_resolved,
-			      expr.get_if_block ()->get_locus ()),
-	TyTy::TyWithLocation (else_blk_resolved,
-			      expr.get_else_block ()->get_locus ()),
-	expr.get_locus ());
-    }
-}
-
-void
 TypeCheckExpr::visit (HIR::UnsafeBlockExpr &expr)
 {
   infered = TypeCheckExpr::Resolve (expr.get_block_expr ().get ());

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -45,8 +45,6 @@ public:
   void visit (HIR::NegationExpr &expr) override;
   void visit (HIR::IfExpr &expr) override;
   void visit (HIR::IfExprConseqElse &expr) override;
-  void visit (HIR::IfLetExpr &expr) override;
-  void visit (HIR::IfLetExprConseqElse &) override;
   void visit (HIR::BlockExpr &expr) override;
   void visit (HIR::UnsafeBlockExpr &expr) override;
   void visit (HIR::ArrayIndexExpr &expr) override;

--- a/gcc/testsuite/rust/compile/if_let_expr.rs
+++ b/gcc/testsuite/rust/compile/if_let_expr.rs
@@ -7,8 +7,9 @@ pub enum Option<T> {
 }
 
 fn main() {
-    let x = Option::Some(3); // { dg-warning "unused name" }
-    let a = if let Option::Some(1) = x {
+    let x = Option::Some(3);
+
+    let a = if let Option::Some(1) = x {// { dg-warning "unused name" }
         1
     } else if x == Option::Some(2) {
         2

--- a/gcc/testsuite/rust/compile/if_let_expr_simple.rs
+++ b/gcc/testsuite/rust/compile/if_let_expr_simple.rs
@@ -1,0 +1,12 @@
+enum MyOption {
+    Some(i32),
+    None,
+}
+
+pub fn toto(i : MyOption) -> i32 {
+    if let MyOption::Some(v) = i {
+        v
+    } else {
+        23i32
+    }
+}

--- a/gcc/testsuite/rust/compile/iflet.rs
+++ b/gcc/testsuite/rust/compile/iflet.rs
@@ -1,0 +1,32 @@
+pub fn simple_iflet() -> i32 {
+    let mut res = 0;
+
+    enum E {
+        X(i32),
+    }
+    let v = E::X(4);
+    
+    if let E::X(n) = v {
+        res = 1;
+    }
+
+    res
+}
+
+pub fn simple_iflet_else() -> i32 {
+    let mut res = 0;
+
+    enum E {
+        X(i32),
+        Y,
+    }
+    let v = E::X(4);
+
+    if let E::Y = v {
+        res = 1;
+    } else {
+        res = 2;
+    }
+
+    res
+}

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -223,4 +223,7 @@ issue-2203.rs
 issue-2499.rs
 issue-3032-1.rs
 issue-3032-2.rs
+# https://github.com/Rust-GCC/gccrs/issues/3189
+if_let_expr_simple.rs
+iflet.rs
 # please don't delete the trailing newline

--- a/gcc/testsuite/rust/execute/torture/iflet.rs
+++ b/gcc/testsuite/rust/execute/torture/iflet.rs
@@ -1,0 +1,84 @@
+enum Res {
+    OK,
+    BAD,
+}
+
+enum LOption {
+    Some(i32),
+    None,
+}
+
+// Expect a Some(_)
+//
+// Check we can match a Some.
+fn test_can_destructure_Some(v: LOption) -> Res {
+    if let LOption::Some(v) = v {
+        return Res::OK;
+    }
+    return Res::BAD;
+}
+
+// Expect Some(100).
+//
+// Check we can destructure and the inner value is correct.
+fn test_inner_value_is_100(v: LOption) -> Res {
+    if let LOption::Some(v) = v {
+        return match v {
+            100 => Res::OK,
+            _   => Res::BAD,
+        }
+    }
+    return Res::BAD;
+}
+
+// Expect a None as actual parameter.
+//
+// Only when we FAIL to match a Some do we take the else and return OK.
+fn test_if_else(v: LOption) -> Res {
+    if let LOption::Some(v) = v {
+        return Res::BAD;
+    } else {
+        return Res::OK;
+    }
+}
+
+fn main() -> i32 {
+
+    // Passing a None, so the function should return BAD
+    match test_can_destructure_Some(LOption::None) {
+        Res::OK => return 1,
+        Res::BAD => (),
+    }
+
+    // Same, but with a Some, should return OK
+    match test_can_destructure_Some(LOption::Some(1)) {
+        Res::OK => (),
+        Res::BAD => return 1,
+    }
+
+    // Check the destructuring is correct by looking for Some(100)
+    match test_inner_value_is_100(LOption::Some(100)) {
+        Res::OK => (),
+        Res::BAD => return 1,
+    }
+
+    // ... passing Some(1) should return BAD
+    match test_inner_value_is_100(LOption::Some(1)) {
+        Res::OK => return 1,
+        Res::BAD => (),
+    }
+
+    // ... and so does passing None
+    match test_inner_value_is_100(LOption::None) {
+        Res::OK => return 1,
+        Res::BAD => (),
+    }
+
+    // Check if let... else ...
+    match test_if_else(LOption::None) {
+        Res::OK => (),
+        Res::BAD => return 1,
+    }
+
+    0
+}


### PR DESCRIPTION
Replace the "regular" AST->HIR lowering for IfLet* with a desugaring
into a MatchExpr.
Desugar a simple if let:

```
   if let Some(y) = some_value {
     bar();
   }
```

into:
```
   match some_value {
     Some(y) => {bar();},
     _ => ()
   }

```
Same applies for IfLetExprConseqElse (if let with an else block).

Desugar:

```
   if let Some(y) = some_value {
     bar();
   } else {
     baz();
   }
```

into:
```
   match some_value {
     Some(y) => {bar();},
     _ => {baz();}
   }
```

Fixes https://github.com/Rust-GCC/gccrs/issues/1177
