### PR TITLE
Add RAW_STRING_LITERAL

### DIFF
--- a/gcc/rust/ast/rust-ast-collector.cc
+++ b/gcc/rust/ast/rust-ast-collector.cc
@@ -398,6 +398,9 @@ TokenCollector::visit (Token &tok)
     case BYTE_STRING_LITERAL:
       push (Rust::Token::make_byte_string (tok.get_locus (), std::move (data)));
       break;
+    case RAW_STRING_LITERAL:
+      push (Rust::Token::make_raw_string (tok.get_locus (), std::move (data)));
+      break;
     case INNER_DOC_COMMENT:
       push (Rust::Token::make_inner_doc_comment (tok.get_locus (),
 						 std::move (data)));
@@ -776,6 +779,9 @@ TokenCollector::visit (Literal &lit, location_t locus)
       break;
     case Literal::LitType::BYTE_STRING:
       push (Rust::Token::make_byte_string (locus, std::move (value)));
+      break;
+    case Literal::LitType::RAW_STRING:
+      push (Rust::Token::make_raw_string (locus, std::move (value)));
       break;
     case Literal::LitType::INT:
       push (

--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -3506,6 +3506,7 @@ AttributeParser::parse_meta_item_inner ()
 	case STRING_LITERAL:
 	case BYTE_CHAR_LITERAL:
 	case BYTE_STRING_LITERAL:
+	case RAW_STRING_LITERAL:
 	case INT_LITERAL:
 	case FLOAT_LITERAL:
 	case TRUE_LITERAL:
@@ -3787,6 +3788,10 @@ AttributeParser::parse_literal ()
     case BYTE_STRING_LITERAL:
       skip_token ();
       return Literal (tok->as_string (), Literal::BYTE_STRING,
+		      tok->get_type_hint ());
+    case RAW_STRING_LITERAL:
+      skip_token ();
+      return Literal (tok->as_string (), Literal::RAW_STRING,
 		      tok->get_type_hint ());
     case INT_LITERAL:
       skip_token ();

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -250,6 +250,7 @@ public:
       {
       case STRING_LITERAL:
       case BYTE_STRING_LITERAL:
+      case RAW_STRING_LITERAL:
 	return true;
       default:
 	return false;
@@ -311,6 +312,7 @@ public:
     STRING,
     BYTE,
     BYTE_STRING,
+    RAW_STRING,
     INT,
     FLOAT,
     BOOL,

--- a/gcc/rust/hir/rust-ast-lower-base.cc
+++ b/gcc/rust/hir/rust-ast-lower-base.cc
@@ -928,6 +928,9 @@ ASTLoweringBase::lower_literal (const AST::Literal &literal)
     case AST::Literal::LitType::BYTE_STRING:
       type = HIR::Literal::LitType::BYTE_STRING;
       break;
+    case AST::Literal::LitType::RAW_STRING: // TODO: Lower raw string literals.
+      rust_unreachable ();
+      break;
     case AST::Literal::LitType::INT:
       type = HIR::Literal::LitType::INT;
       break;

--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -2218,7 +2218,7 @@ Lexer::parse_raw_string (location_t loc, int initial_hash_count)
 
   str.shrink_to_fit ();
 
-  return Token::make_string (loc, std::move (str));
+  return Token::make_raw_string (loc, std::move (str));
 }
 
 template <typename IsDigitFunc>

--- a/gcc/rust/lex/rust-token.cc
+++ b/gcc/rust/lex/rust-token.cc
@@ -247,6 +247,9 @@ Token::as_string () const
 	case BYTE_STRING_LITERAL:
 	  return "b\"" + escape_special_chars (get_str (), Context::String)
 		 + "\"";
+	case RAW_STRING_LITERAL:
+	  return "r\"" + escape_special_chars (get_str (), Context::String)
+		 + "\"";
 	case CHAR_LITERAL:
 	  return "'" + escape_special_chars (get_str (), Context::Char) + "'";
 	case BYTE_CHAR_LITERAL:

--- a/gcc/rust/lex/rust-token.h
+++ b/gcc/rust/lex/rust-token.h
@@ -128,6 +128,7 @@ enum PrimitiveCoreType
   RS_TOKEN (STRING_LITERAL, "string literal")                                  \
   RS_TOKEN (CHAR_LITERAL, "character literal")                                 \
   RS_TOKEN (BYTE_STRING_LITERAL, "byte string literal")                        \
+  RS_TOKEN (RAW_STRING_LITERAL, "raw string literal")                          \
   RS_TOKEN (BYTE_CHAR_LITERAL, "byte character literal")                       \
   RS_TOKEN (LIFETIME, "lifetime") /* TODO: improve token type */               \
   /* Have "interpolated" tokens (whatever that means)? identifer, path, type,  \
@@ -377,6 +378,12 @@ public:
     return TokenPtr (new Token (BYTE_STRING_LITERAL, locus, std::move (str)));
   }
 
+  // Makes and returns a new TokenPtr of type RAW_STRING_LITERAL.
+  static TokenPtr make_raw_string (location_t locus, std::string &&str)
+  {
+    return TokenPtr (new Token (RAW_STRING_LITERAL, locus, std::move (str)));
+  }
+
   // Makes and returns a new TokenPtr of type INNER_DOC_COMMENT.
   static TokenPtr make_inner_doc_comment (location_t locus, std::string &&str)
   {
@@ -450,6 +457,7 @@ return *str;
       case STRING_LITERAL:
       case BYTE_CHAR_LITERAL:
       case BYTE_STRING_LITERAL:
+      case RAW_STRING_LITERAL:
 	return true;
       default:
 	return false;

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -854,6 +854,9 @@ Parser<ManagedTokenSource>::parse_attr_input ()
 	  case BYTE_STRING_LITERAL:
 	    lit_type = AST::Literal::BYTE_STRING;
 	    break;
+	  case RAW_STRING_LITERAL:
+	    lit_type = AST::Literal::RAW_STRING;
+	    break;
 	  case STRING_LITERAL:
 	  default:
 	    lit_type = AST::Literal::STRING;
@@ -7511,6 +7514,11 @@ Parser<ManagedTokenSource>::parse_literal_expr (AST::AttrVec outer_attrs)
       literal_value = t->get_str ();
       lexer.skip_token ();
       break;
+    case RAW_STRING_LITERAL:
+      type = AST::Literal::RAW_STRING;
+      literal_value = t->get_str ();
+      lexer.skip_token ();
+      break;
     case INT_LITERAL:
       type = AST::Literal::INT;
       literal_value = t->get_str ();
@@ -10481,6 +10489,11 @@ Parser<ManagedTokenSource>::parse_pattern_no_alt ()
       return std::unique_ptr<AST::LiteralPattern> (
 	new AST::LiteralPattern (t->get_str (), AST::Literal::BYTE_STRING,
 				 t->get_locus (), t->get_type_hint ()));
+    case RAW_STRING_LITERAL:
+      lexer.skip_token ();
+      return std::unique_ptr<AST::LiteralPattern> (
+	new AST::LiteralPattern (t->get_str (), AST::Literal::RAW_STRING,
+				 t->get_locus (), t->get_type_hint ()));
     // raw string and raw byte string literals too if they are readded to
     // lexer
     case MINUS:
@@ -12274,6 +12287,10 @@ Parser<ManagedTokenSource>::null_denotation_not_path (
     case BYTE_STRING_LITERAL:
       return std::unique_ptr<AST::LiteralExpr> (
 	new AST::LiteralExpr (tok->get_str (), AST::Literal::BYTE_STRING,
+			      tok->get_type_hint (), {}, tok->get_locus ()));
+    case RAW_STRING_LITERAL:
+      return std::unique_ptr<AST::LiteralExpr> (
+	new AST::LiteralExpr (tok->get_str (), AST::Literal::RAW_STRING,
 			      tok->get_type_hint (), {}, tok->get_locus ()));
     case CHAR_LITERAL:
       return std::unique_ptr<AST::LiteralExpr> (


### PR DESCRIPTION
Add RAW_STRING_LITERAL token variant and the LitType::RAW_STRING variant.

gcc/rust/ChangeLog:

	* ast/rust-ast-collector.cc (TokenCollector::visit): Handle RAW_STRING case in TokenCollection::visit
	* ast/rust-ast.cc (AttributeParser::parse_meta_item_inner): Add RAW_STRING_LITERAL case to call parse_meta_item_lit() (AttributeParser::parse_literal): Add RAW_STRING_LITERAL case.
	* ast/rust-ast.h: Add RAW_STRING_LITERAL to is_stirng_lit(). Add RAW_STRING enum variant to LitType enum.
	* hir/rust-ast-lower-base.cc (ASTLoweringBase::lower_literal): Handle raw string literal type, falls back to rust_unreachable() for now.
	* lex/rust-lex.cc (Lexer::parse_raw_string): Use make_raw_string instead of make_string.
	* lex/rust-token.cc (Token::as_string): Handle case for RAW_STRING_LITERAL.
	* lex/rust-token.h (enum PrimitiveCoreType): Add RAW_STRING_LITERAL token type. Define make_raw_string function to create RAW_STRING_LITERAL token. Add RAW_STRING_LITERAL case to is_literal().
	* parse/rust-parse-impl.h (Parser::parse_attr_input): Handle case for RAW_STRING_LITERAL. (Parser::parse_literal_expr): Handle case for RAW_STRING_LITERAL (Parser::parse_pattern_no_alt): Handle case for RAW_STRING_LITERAL