### PR TITLE
Add `lang-item` paths

### DIFF
--- a/gcc/rust/ast/rust-ast-collector.cc
+++ b/gcc/rust/ast/rust-ast-collector.cc
@@ -21,6 +21,7 @@
 #include "rust-expr.h"
 #include "rust-item.h"
 #include "rust-keyword-values.h"
+#include "rust-system.h"
 #include "rust-token.h"
 
 namespace Rust {
@@ -558,6 +559,19 @@ TokenCollector::visit (PathInExpression &path)
     }
 
   visit_items_joined_by_separator (path.get_segments (), SCOPE_RESOLUTION);
+}
+
+void
+TokenCollector::visit (RegularPath &path)
+{
+  // FIXME: We probably want to have a proper implementation here, and call this
+  // function from things like the PathInExpression visitor
+}
+
+void
+TokenCollector::visit (LangItemPath &path)
+{
+  // TODO: Implement proper token collection for lang item paths
 }
 
 void

--- a/gcc/rust/ast/rust-ast-collector.h
+++ b/gcc/rust/ast/rust-ast-collector.h
@@ -234,6 +234,8 @@ public:
   void visit (PathExprSegment &segment);
   void visit (PathIdentSegment &segment);
   void visit (PathInExpression &path);
+  void visit (RegularPath &path);
+  void visit (LangItemPath &path);
   void visit (TypePathSegment &segment);
   void visit (TypePathSegmentGeneric &segment);
   void visit (TypePathSegmentFunction &segment);

--- a/gcc/rust/ast/rust-ast-full-decls.h
+++ b/gcc/rust/ast/rust-ast-full-decls.h
@@ -61,7 +61,7 @@ class PathIdentSegment;
 struct GenericArgsBinding;
 struct GenericArgs;
 class PathExprSegment;
-class PathPattern;
+class Path;
 class PathInExpression;
 class TypePathSegment;
 class TypePathSegmentGeneric;

--- a/gcc/rust/ast/rust-ast-visitor.cc
+++ b/gcc/rust/ast/rust-ast-visitor.cc
@@ -86,6 +86,17 @@ DefaultASTVisitor::visit (AST::ConstGenericParam &const_param)
 }
 
 void
+DefaultASTVisitor::visit (AST::RegularPath &path)
+{
+  for (auto &segment : path.get_segments ())
+    visit (segment);
+}
+
+void
+DefaultASTVisitor::visit (AST::LangItemPath &path)
+{}
+
+void
 DefaultASTVisitor::visit (AST::PathInExpression &path)
 {
   visit_outer_attrs (path);

--- a/gcc/rust/ast/rust-ast-visitor.h
+++ b/gcc/rust/ast/rust-ast-visitor.h
@@ -24,6 +24,7 @@
 #include "rust-ast-full-decls.h"
 #include "rust-ast.h"
 #include "rust-item.h"
+#include "rust-path.h"
 #include "rust-system.h"
 
 namespace Rust {
@@ -58,6 +59,8 @@ public:
   // virtual void visit(TraitImplItem& trait_impl_item) = 0;
 
   // rust-path.h
+  virtual void visit (RegularPath &path) = 0;
+  virtual void visit (LangItemPath &path) = 0;
   virtual void visit (PathInExpression &path) = 0;
   virtual void visit (TypePathSegment &segment) = 0;
   virtual void visit (TypePathSegmentGeneric &segment) = 0;
@@ -249,6 +252,8 @@ protected:
   virtual void visit (AST::Lifetime &lifetime) override;
   virtual void visit (AST::LifetimeParam &lifetime_param) override;
   virtual void visit (AST::ConstGenericParam &const_param) override;
+  virtual void visit (AST::RegularPath &path) override;
+  virtual void visit (AST::LangItemPath &path) override;
   virtual void visit (AST::PathInExpression &path) override;
   virtual void visit (AST::TypePathSegment &segment) override;
   virtual void visit (AST::TypePathSegmentGeneric &segment) override;

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -2048,11 +2048,6 @@ public:
   }
 };
 
-// Base path expression AST node - abstract
-class PathExpr : public ExprWithoutBlock
-{
-};
-
 } // namespace AST
 } // namespace Rust
 

--- a/gcc/rust/ast/rust-path.cc
+++ b/gcc/rust/ast/rust-path.cc
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with GCC; see the file COPYING3.  If not see
 <http://www.gnu.org/licenses/>.  */
 
+#include "rust-path.h"
 #include "rust-system.h"
 #include "rust-ast-full.h"
 #include "rust-diagnostics.h"
@@ -135,7 +136,7 @@ PathExprSegment::as_string () const
 }
 
 std::string
-PathPattern::as_string () const
+RegularPath::as_string () const
 {
   std::string str;
 
@@ -148,8 +149,15 @@ PathPattern::as_string () const
   return str;
 }
 
+std::string
+LangItemPath::as_string () const
+{
+  // FIXME: Handle #[lang] paths
+  rust_unreachable ();
+}
+
 SimplePath
-PathPattern::convert_to_simple_path (bool with_opening_scope_resolution) const
+RegularPath::convert_to_simple_path (bool with_opening_scope_resolution) const
 {
   if (!has_segments ())
     return SimplePath::create_empty ();
@@ -184,6 +192,18 @@ PathPattern::convert_to_simple_path (bool with_opening_scope_resolution) const
 }
 
 void
+RegularPath::accept_vis (ASTVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+void
+LangItemPath::accept_vis (ASTVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+void
 PathInExpression::accept_vis (ASTVisitor &vis)
 {
   vis.visit (*this);
@@ -197,7 +217,7 @@ PathInExpression::as_string () const
   if (has_opening_scope_resolution)
     str = "::";
 
-  return str + PathPattern::as_string ();
+  return str + path->as_string ();
 }
 
 std::string
@@ -297,7 +317,7 @@ TypePathFunction::as_string () const
 std::string
 QualifiedPathInExpression::as_string () const
 {
-  return path_type.as_string () + "::" + PathPattern::as_string ();
+  return path_type.as_string () + "::" + path->as_string ();
 }
 
 std::string

--- a/gcc/rust/ast/rust-path.h
+++ b/gcc/rust/ast/rust-path.h
@@ -581,13 +581,6 @@ protected:
    * possible, and creates a SimplePath from them. */
   SimplePath convert_to_simple_path (bool with_opening_scope_resolution) const;
 
-  // Removes all segments of the path.
-  void remove_all_segments ()
-  {
-    segments.clear ();
-    segments.shrink_to_fit ();
-  }
-
 public:
   /* Returns whether the path is a single segment (excluding qualified path
    * initial as segment). */
@@ -611,6 +604,8 @@ class PathInExpression : public PathPattern, public PathExpr
   location_t locus;
   NodeId _node_id;
 
+  bool marked_for_strip;
+
 public:
   std::string as_string () const override;
 
@@ -621,7 +616,8 @@ public:
     : PathPattern (std::move (path_segments)),
       outer_attrs (std::move (outer_attrs)),
       has_opening_scope_resolution (has_opening_scope_resolution),
-      locus (locus), _node_id (Analysis::Mappings::get ().get_next_node_id ())
+      locus (locus), _node_id (Analysis::Mappings::get ().get_next_node_id ()),
+      marked_for_strip (false)
   {}
 
   // Creates an error state path in expression.
@@ -650,9 +646,8 @@ public:
 
   void accept_vis (ASTVisitor &vis) override;
 
-  // Invalid if path is empty (error state), so base stripping on that.
-  void mark_for_strip () override { remove_all_segments (); }
-  bool is_marked_for_strip () const override { return is_error (); }
+  void mark_for_strip () override { marked_for_strip = true; }
+  bool is_marked_for_strip () const override { return marked_for_strip; }
 
   bool opening_scope_resolution () const
   {

--- a/gcc/rust/ast/rust-path.h
+++ b/gcc/rust/ast/rust-path.h
@@ -597,7 +597,7 @@ public:
 
 /* AST node representing a path-in-expression pattern (path that allows
  * generic arguments) */
-class PathInExpression : public PathPattern, public PathExpr
+class PathInExpression : public PathPattern, public ExprWithoutBlock
 {
   std::vector<Attribute> outer_attrs;
   bool has_opening_scope_resolution;
@@ -1221,7 +1221,7 @@ public:
 
 /* AST node representing a qualified path-in-expression pattern (path that
  * allows specifying trait functions) */
-class QualifiedPathInExpression : public PathPattern, public PathExpr
+class QualifiedPathInExpression : public PathPattern, public ExprWithoutBlock
 {
   std::vector<Attribute> outer_attrs;
   QualifiedPathType path_type;

--- a/gcc/rust/ast/rust-pattern.h
+++ b/gcc/rust/ast/rust-pattern.h
@@ -1657,7 +1657,7 @@ protected:
 };
 
 // Moved definition to rust-path.h
-class PathPattern;
+class Path;
 
 // Forward decls for paths (defined in rust-path.h)
 class PathInExpression;

--- a/gcc/rust/expand/rust-derive.h
+++ b/gcc/rust/expand/rust-derive.h
@@ -81,6 +81,8 @@ private:
   virtual void visit (Lifetime &lifetime) override final{};
   virtual void visit (LifetimeParam &lifetime_param) override final{};
   virtual void visit (ConstGenericParam &const_param) override final{};
+  virtual void visit (RegularPath &path) override final{};
+  virtual void visit (LangItemPath &path) override final{};
   virtual void visit (PathInExpression &path) override final{};
   virtual void visit (TypePathSegment &segment) override final{};
   virtual void visit (TypePathSegmentGeneric &segment) override final{};

--- a/gcc/rust/hir/rust-ast-lower-base.cc
+++ b/gcc/rust/hir/rust-ast-lower-base.cc
@@ -63,6 +63,12 @@ ASTLoweringBase::visit (AST::ConstGenericParam &)
 
 // rust-path.h
 void
+ASTLoweringBase::visit (AST::RegularPath &)
+{}
+void
+ASTLoweringBase::visit (AST::LangItemPath &)
+{}
+void
 ASTLoweringBase::visit (AST::PathInExpression &)
 {}
 void

--- a/gcc/rust/hir/rust-ast-lower-base.h
+++ b/gcc/rust/hir/rust-ast-lower-base.h
@@ -84,6 +84,8 @@ public:
   //  virtual void visit(TraitImplItem& trait_impl_item);
 
   // rust-path.h
+  virtual void visit (AST::RegularPath &path);
+  virtual void visit (AST::LangItemPath &path);
   virtual void visit (AST::PathInExpression &path);
   virtual void visit (AST::TypePathSegment &segment);
   virtual void visit (AST::TypePathSegmentGeneric &segment);

--- a/gcc/rust/resolve/rust-ast-resolve-base.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-base.cc
@@ -20,6 +20,7 @@
 #include "rust-ast-resolve-expr.h"
 #include "rust-ast-resolve-path.h"
 #include "rust-item.h"
+#include "rust-path.h"
 
 namespace Rust {
 namespace Resolver {
@@ -68,6 +69,14 @@ ResolverBase::visit (AST::LifetimeParam &)
 
 void
 ResolverBase::visit (AST::ConstGenericParam &)
+{}
+
+void
+ResolverBase::visit (AST::RegularPath &)
+{}
+
+void
+ResolverBase::visit (AST::LangItemPath &)
 {}
 
 void

--- a/gcc/rust/resolve/rust-ast-resolve-base.h
+++ b/gcc/rust/resolve/rust-ast-resolve-base.h
@@ -40,6 +40,8 @@ public:
   void visit (AST::Lifetime &);
   void visit (AST::LifetimeParam &);
   void visit (AST::ConstGenericParam &);
+  void visit (AST::RegularPath &);
+  void visit (AST::LangItemPath &);
   void visit (AST::PathInExpression &);
   void visit (AST::TypePathSegment &);
   void visit (AST::TypePathSegmentGeneric &);


### PR DESCRIPTION
This PR cleans up the existing base `Path*` nodes and creates a new `Path` tagged union for representing lang items paths.