### PR TITLE
Converted Rust Test Case to DejaGnu

### DIFF
--- a/gcc/testsuite/rust/compile/anon-params-denied-2018.rs
+++ b/gcc/testsuite/rust/compile/anon-params-denied-2018.rs
@@ -1,0 +1,30 @@
+// { dg-additional-options "-frust-edition=2018" }
+trait T {
+    fn foo(i32); // { dg-error "expecting .:. but .\\). found" ""  { target *-*-* } }
+
+    fn foo_with_ref(&mut i32); // { dg-error "expecting .:. but .\\). found" ""  { target *-*-* } }
+
+    fn foo_with_qualified_path(<Bar as T>::Baz); // { dg-error "expecting .:. but .\\). found" ""  { target *-*-* } }
+
+    fn foo_with_qualified_path_and_ref(&<Bar as T>::Baz); // { dg-error "expecting .:. but .\\). found" ""  { target *-*-* } }
+
+    fn foo_with_multiple_qualified_paths(<Bar as T>::Baz, <Bar as T>::Baz);
+    // { dg-error "expecting .:. but .,. found" ""  { target *-*-* } .-1 }
+    // { dg-error "expecting .\\). but .,. found" ""  { target *-*-* } .-2 }
+    // { dg-error "function declaration missing closing parentheses after parameter list" ""  { target *-*-* } .-3 }
+
+    fn bar_with_default_impl(String, String) {}
+    // { TODO "expecting .:. but .,. found" ""  { target *-*-* } .-1 }
+    // { TODO "expecting .\\). but .,. found" ""  { target *-*-* } .-2 }
+    //~^ ERROR expected one of `:`
+    //~| ERROR expected one of `:`
+
+    // do not complain about missing `b`
+    fn baz(a: usize, b, c: usize) -> usize {
+        // { dg-error "failed to parse trait item in trait" ""  { target *-*-* } .-1 }
+        // { dg-error "failed to parse item in crate" ""  { target *-*-* } .-2 }
+        a + b + c
+    }
+}
+
+fn main() {}

--- a/gcc/testsuite/rust/compile/anon-params-deprecated.rs
+++ b/gcc/testsuite/rust/compile/anon-params-deprecated.rs
@@ -1,0 +1,21 @@
+// { dg-do compile }
+// { dg-options "-frust-edition=2015" }
+// { dg-additional-options "-Wall" }
+// Test for the anonymous_parameters deprecation lint (RFC 1685)
+
+#![warn(anonymous_parameters)]
+
+#[allow(dead_code)]
+trait T {
+    fn foo(i32); // { dg-error "expecting .:. but .\\). found" ""  { target *-*-* } }
+                 // WARNING this is accepted in the latest rustc edition
+
+    fn bar_with_default_impl(String, String) {}
+    // { dg-error "expecting .:. but .,. found" ""  { target *-*-* } .-1 }
+    // { dg-error "expecting .\\). but .,. found" ""  { target *-*-* } .-2 }
+    // { dg-error "function declaration missing closing parentheses after parameter list" ""  { target *-*-* } .-3 }
+}
+// { dg-error "failed to parse trait item in trait" ""  { target *-*-* } .-1 }
+// { dg-error "failed to parse item in crate" ""  { target *-*-* } .-2 }
+
+fn main() {}


### PR DESCRIPTION
A very simple PR to Investigate test case from https://github.com/rust-lang/rust/tree/master/tests/ui/anon-params. To convert this into equivalent Rust source file with `dejagnu` directives instead of `ERROR` directives

---

`gcc/testsuite/ChangeLog`:

	* rust/compile/anon-params-denied-2018.rs: New test.
	* rust/compile/anon-params-deprecated.rs: New test.

---


<details><summary>Details</summary>
<p>

Thanks to this email thread: https://patchwork.ozlabs.org/project/gcc/patch/20160922200546.GH7282@tucnak.redhat.com/. I was able to understand the relative line number. Otherwise, it would be difficult to stop dejagnu from shouting

</p>
</details> 