### PR TITLE
Store parse result of parse_format_string(s)

### DIFF
--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -5057,9 +5057,12 @@ struct TupleClobber
 struct TupleTemplateStr
 {
   // as gccrs still doesn't contain a symbol class I have put them as strings
-  std::string symbol;
-  std::string optional_symbol;
   location_t loc;
+  std::string symbol;
+
+  TupleTemplateStr (location_t loc, const std::string &symbol)
+    : loc (loc), symbol (symbol)
+  {}
 };
 
 // Inline Assembly Node


### PR DESCRIPTION
I fixed the parse result of parse_format_strings first. 
gcc/rust/ChangeLog:

	* ast/rust-expr.h (struct TupleTemplateStr): Store parse result of parse_format_string(s)
	* expand/rust-macro-builtins-asm.cc (parse_format_strings): Likewise

I'm not sure how parse_asm_operand should be addressed for now (asm_codegen_il hasn't touched that part yet) so that would probably go into another PR)

Addresses #3069 (yes not fixed :) )