### PR TITLE
#[may_dangle] in safe impl

### DIFF
--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -311,7 +311,8 @@ Attribute::get_traits_to_derive ()
 
 // Copy constructor must deep copy attr_input as unique pointer
 Attribute::Attribute (Attribute const &other)
-  : path (other.path), locus (other.locus)
+  : path (other.path), locus (other.locus),
+    inner_attribute (other.inner_attribute)
 {
   // guard to protect from null pointer dereference
   if (other.attr_input != nullptr)
@@ -324,6 +325,7 @@ Attribute::operator= (Attribute const &other)
 {
   path = other.path;
   locus = other.locus;
+  inner_attribute = other.inner_attribute;
   // guard to protect from null pointer dereference
   if (other.attr_input != nullptr)
     attr_input = other.attr_input->clone_attr_input ();

--- a/gcc/rust/hir/rust-ast-lower-item.cc
+++ b/gcc/rust/hir/rust-ast-lower-item.cc
@@ -542,7 +542,7 @@ ASTLoweringItem::visit (AST::InherentImpl &impl_block)
     mapping, std::move (impl_items), std::move (generic_params),
     std::unique_ptr<HIR::Type> (impl_type), nullptr, where_clause, polarity,
     vis, impl_block.get_inner_attrs (), impl_block.get_outer_attrs (),
-    impl_block.get_locus ());
+    impl_block.get_locus (), false);
   translated = hir_impl_block;
 
   mappings.insert_hir_impl_block (hir_impl_block);
@@ -623,6 +623,7 @@ void
 ASTLoweringItem::visit (AST::TraitImpl &impl_block)
 {
   std::vector<std::unique_ptr<HIR::WhereClauseItem>> where_clause_items;
+  bool unsafe = impl_block.is_unsafe ();
   for (auto &item : impl_block.get_where_clause ().get_items ())
     {
       HIR::WhereClauseItem *i = ASTLowerWhereClauseItem::translate (*item);
@@ -696,7 +697,7 @@ ASTLoweringItem::visit (AST::TraitImpl &impl_block)
     std::unique_ptr<HIR::Type> (impl_type),
     std::unique_ptr<HIR::TypePath> (trait_ref), where_clause, polarity, vis,
     impl_block.get_inner_attrs (), impl_block.get_outer_attrs (),
-    impl_block.get_locus ());
+    impl_block.get_locus (), unsafe);
   translated = hir_impl_block;
 
   mappings.insert_hir_impl_block (hir_impl_block);

--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -1508,7 +1508,8 @@ void
 Dump::visit (TypeParam &e)
 {
   begin ("TypeParam");
-  put_field ("outer_attr", e.get_outer_attribute ().as_string ());
+  auto &outer_attrs = e.get_outer_attrs ();
+  do_outer_attrs (outer_attrs);
 
   put_field ("type_representation", e.get_type_representation ().as_string ());
 

--- a/gcc/rust/hir/tree/rust-hir.cc
+++ b/gcc/rust/hir/tree/rust-hir.cc
@@ -2017,14 +2017,19 @@ LifetimeParam::as_string () const
 {
   std::string str ("LifetimeParam: ");
 
-  str += "\n Outer attribute: ";
-  if (!has_outer_attribute ())
+  str += "\n Outer attributes: ";
+  if (outer_attrs.empty ())
     {
       str += "none";
     }
   else
     {
-      str += outer_attr.as_string ();
+      /* note that this does not print them with "outer attribute" syntax -
+       * just the body */
+      for (const auto &attr : outer_attrs)
+	{
+	  str += "\n " + attr.as_string ();
+	}
     }
 
   str += "\n Lifetime: " + lifetime.as_string ();
@@ -2106,14 +2111,19 @@ TypeParam::as_string () const
 {
   std::string str ("TypeParam: ");
 
-  str += "\n Outer attribute: ";
-  if (!has_outer_attribute ())
+  str += "\n Outer attributes: ";
+  if (outer_attrs.empty ())
     {
       str += "none";
     }
   else
     {
-      str += outer_attr.as_string ();
+      /* note that this does not print them with "outer attribute" syntax -
+       * just the body */
+      for (const auto &attr : outer_attrs)
+	{
+	  str += "\n " + attr.as_string ();
+	}
     }
 
   str += "\n Identifier: " + type_representation.as_string ();

--- a/gcc/testsuite/rust/compile/issue-3045-1.rs
+++ b/gcc/testsuite/rust/compile/issue-3045-1.rs
@@ -1,0 +1,21 @@
+#![feature(dropck_eyepatch)]
+#[allow(dead_code)]
+
+#[lang = "sized"]
+trait Sized {}
+
+struct Test<T> {
+    _inner: T,
+}
+
+struct Test2<T> {
+    _inner: T,
+}
+
+trait Action {}
+
+impl<#[may_dangle] T> Action for Test<T> {} // { dg-error "use of 'may_dangle' is unsafe and requires unsafe impl" "" { target *-*-* } 0 }
+
+unsafe impl<#[may_dangle] T> Action for Test2<T> {}
+
+fn main() {}

--- a/gcc/testsuite/rust/compile/issue-3045-2.rs
+++ b/gcc/testsuite/rust/compile/issue-3045-2.rs
@@ -1,0 +1,20 @@
+#![feature(dropck_eyepatch)]
+#[allow(dead_code)]
+
+#[lang = "sized"]
+trait Sized {}
+
+
+trait Action {}
+
+struct Inspector<'a>(&'a u8);
+struct Inspector2<'a>(&'a u8);
+
+impl<#[may_dangle] 'a> Action for Inspector<'a> {} // { dg-error "use of 'may_dangle' is unsafe and requires unsafe impl" "" { target *-*-* } 0 }
+
+unsafe impl<#[may_dangle] 'a> Action for Inspector2<'a> {}
+
+
+fn main() {
+
+}


### PR DESCRIPTION
```
    gcc/rust/ChangeLog:
            * ast/rust-ast.cc:
            Fix Attribute constructors to copy inner_attribute
            * checks/errors/rust-unsafe-checker.cc:
            Add pass for #[may_dangle] in safe impl's
            * hir/rust-ast-lower-item.cc:
            Add support for unsafe impl's
            * hir/rust-ast-lower-type.cc:
            Lower attributes in impl's from AST to HIR
            * hir/rust-hir-dump.cc:
            Change single attribute to AttrVec
            * hir/tree/rust-hir-item.h:
            Add unsafe support to Impl blocks in HIR
            * hir/tree/rust-hir.cc:
            Change single attribute to AttrVec
            * hir/tree/rust-hir.h:
            Add has/get_outer_attribute to GenericParam

    gcc/testsuite/ChangeLog:
            * rust/compile/issue-3045-1.rs:
            Add test for #[may_dangle] Generic Type triggering error
            * rust/compile/issue-3045-2.rs:
            Add test for #[may_dangle] Lifetime triggering error
```


Fixes #3045 

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`
- \[x] Added any relevant test cases to `gcc/testsuite/rust/`

---

Added support for rejecting safe Impl's that use #[may_dangle] for either lifetime parameters or generic type parameters