### PR TITLE
gccrs: Add external test directory for testsuite adaptor

### DIFF
--- a/gcc/testsuite/rust/rustc/README.md
+++ b/gcc/testsuite/rust/rustc/README.md
@@ -1,0 +1,4 @@
+This repository contains test cases from the 
+[rustc test suite](https://github.com/rust-lang/rust/tree/master/tests). The
+conversion of these tests into the DejaGnu format is done by the rustc 
+testsuite adaptor, a tool specifically designed for this purpose.

--- a/gcc/testsuite/rust/rustc/rustc.exp
+++ b/gcc/testsuite/rust/rustc/rustc.exp
@@ -1,0 +1,35 @@
+# Copyright (C) 2021-2024 Free Software Foundation, Inc.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with GCC; see the file COPYING3.  If not see
+# <http://www.gnu.org/licenses/>.
+
+# Compile tests, no torture testing.
+#
+# These tests raise errors in the front end; torture testing doesn't apply.
+
+# Load support procs.
+load_lib rust-dg.exp
+
+# Initialize `dg'.
+dg-init
+
+# Main loop.
+set saved-dg-do-what-default ${dg-do-what-default}
+
+set dg-do-what-default "compile"
+dg-runtest [lsort [glob -nocomplain $srcdir/$subdir/*.rs]] "" ""
+set dg-do-what-default ${saved-dg-do-what-default}
+
+# All done.
+dg-finish


### PR DESCRIPTION
_Originally posted by @tschwinge in https://github.com/Rust-GCC/gccrs/issues/3071#issuecomment-2199788719_


---

gcc/testsuite/ChangeLog:

	* rust/external/README.md: information about external directory.
	* rust/external/external.exp: New test.
