### PR TITLE
Add compile error to fix ICE when failing to find enum variants. 

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -194,7 +194,14 @@ TypeCheckExpr::visit (HIR::CallExpr &expr)
 	  HirId variant_id;
 	  bool ok = context->lookup_variant_definition (
 	    expr.get_fnexpr ()->get_mappings ().get_hirid (), &variant_id);
-	  rust_assert (ok);
+
+	  if (!ok)
+	    {
+	      rust_error_at (expr.get_locus (), ErrorCode::E0423,
+			     "expected function, tuple struct or tuple "
+			     "variant, found enum");
+	      return;
+	    }
 
 	  TyTy::VariantDef *lookup_variant = nullptr;
 	  ok = adt->lookup_variant_by_id (variant_id, &lookup_variant);

--- a/gcc/testsuite/rust/compile/issue-3046.rs
+++ b/gcc/testsuite/rust/compile/issue-3046.rs
@@ -1,0 +1,23 @@
+enum Res {
+    OK,
+    BAD,
+}
+
+enum LOption {
+    Some(i32),
+    None,
+}
+
+fn test(v: LOption) -> Res {
+    return Res::BAD;
+}
+
+
+fn main() {
+    // Should be:
+    // test(LOption::Some(2));
+    // 
+    test(LOption(2));
+    // { dg-error "expected function, tuple struct or tuple variant, found enum" "" { target *-*-* } .-1 }
+    // { dg-error "failed to resolve type for argument expr in CallExpr" "" { target *-*-* } .-2 }
+}


### PR DESCRIPTION
gcc/rust/ChangeLog:
	* typecheck/rust-hir-type-check-expr.cc: Fix ICE caused by not finding enum variant by adding new error message

gcc/testsuite/ChangeLog:
	* compile/issue-3046.rs: Add test for new error message

Fixes #3046

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`
- \[x] Added any relevant test cases to `gcc/testsuite/rust/`

---

Adds a compile error, "expected function, tuple struct or tuple variant, found enum" when TypeCheckExpr::visit is called on a HIR::CallExpr, but that CallExpr's function is actually an enum. 
