### PR TITLE
Improve error messages for operator expressions

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -417,6 +417,8 @@ public:
   std::unique_ptr<Expr> &get_lhs () { return main_or_left_expr; }
   std::unique_ptr<Expr> &get_rhs () { return right_expr; }
 
+  std::string get_operator_str () const;
+
 protected:
   /* Use covariance to implement clone function as returning this object rather
    * than base */
@@ -765,6 +767,8 @@ public:
 
   void visit_lhs (HIRFullVisitor &vis) { main_or_left_expr->accept_vis (vis); }
   void visit_rhs (HIRFullVisitor &vis) { right_expr->accept_vis (vis); }
+
+  std::string get_operator_str () const;
 
 protected:
   /* Use covariance to implement clone function as returning this object rather

--- a/gcc/rust/hir/tree/rust-hir.cc
+++ b/gcc/rust/hir/tree/rust-hir.cc
@@ -1299,7 +1299,7 @@ AssignmentExpr::as_string () const
 }
 
 std::string
-CompoundAssignmentExpr::as_string () const
+CompoundAssignmentExpr::get_operator_str () const
 {
   std::string operator_str;
   operator_str.reserve (1);
@@ -1344,7 +1344,14 @@ CompoundAssignmentExpr::as_string () const
 
   operator_str += "=";
 
+  return operator_str;
+}
+
+std::string
+CompoundAssignmentExpr::as_string () const
+{
   std::string str ("CompoundAssignmentExpr: ");
+  std::string operator_str = get_operator_str ();
   if (main_or_left_expr == nullptr || right_expr == nullptr)
     {
       str += "error. this is probably a parsing failure.";
@@ -1574,7 +1581,7 @@ ErrorPropagationExpr::as_string () const
 }
 
 std::string
-ArithmeticOrLogicalExpr::as_string () const
+ArithmeticOrLogicalExpr::get_operator_str () const
 {
   std::string operator_str;
   operator_str.reserve (1);
@@ -1617,8 +1624,14 @@ ArithmeticOrLogicalExpr::as_string () const
       break;
     }
 
+  return operator_str;
+}
+
+std::string
+ArithmeticOrLogicalExpr::as_string () const
+{
   std::string str = main_or_left_expr->as_string () + " ";
-  str += operator_str + " ";
+  str += get_operator_str () + " ";
   str += right_expr->as_string ();
 
   return "( " + str + " (" + get_mappings ().as_string () + "))";

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -272,7 +272,8 @@ TypeCheckExpr::visit (HIR::CompoundAssignmentExpr &expr)
   if (!valid)
     {
       rust_error_at (expr.get_locus (),
-		     "cannot apply this operator to types %s and %s",
+		     "cannot apply operator %qs to types %s and %s",
+		     expr.get_operator_str ().c_str (),
 		     lhs->as_string ().c_str (), rhs->as_string ().c_str ());
       return;
     }
@@ -303,7 +304,8 @@ TypeCheckExpr::visit (HIR::ArithmeticOrLogicalExpr &expr)
   if (!valid)
     {
       rust_error_at (expr.get_locus (),
-		     "cannot apply this operator to types %s and %s",
+		     "cannot apply operator %qs to types %s and %s",
+		     expr.get_operator_str ().c_str (),
 		     lhs->as_string ().c_str (), rhs->as_string ().c_str ());
       return;
     }

--- a/gcc/testsuite/rust/compile/shadow1.rs
+++ b/gcc/testsuite/rust/compile/shadow1.rs
@@ -2,5 +2,5 @@ fn main() {
     let mut x = 5;
     let mut x;
     x = true;
-    x = x + 2; // { dg-error "cannot apply this operator to types bool and <integer>"  }
+    x = x + 2; // { dg-error "cannot apply operator .+. to types bool and <integer>"  }
 }


### PR DESCRIPTION
gcc/rust/ChangeLog:
    * hir/tree/rust-hir-expr.h: Add new get_operator_str method in
      ArithmeticOrLogicalExpr and CompoundAssignmentExpr
    * hir/tree/rust-hir.cc: Likewise
    * typecheck/rust-hir-type-check-expr.cc: Improve error message for
      operator expressions to display the correct operator symbol

gcc/testsuite/ChangeLog:
    * rust/compile/shadow1.rs: Fix test for new error message

Fixes #2030

- \[ X] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[ X] Read contributing guidlines
- \[X ] `make check-rust` passes locally
- \[X ] Run `clang-format`
- \[ X] Added any relevant test cases to `gcc/testsuite/rust/`
