### PR TITLE
Fix CI bootstrap build with a nightly rust compiler

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -29,6 +29,7 @@ jobs:
                   gcc-multilib \
                   g++-multilib \
                   dejagnu
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=nightly;
 
     - name: Configure
       run: |


### PR DESCRIPTION
The CI failed to compile some new code that requires a nightly feature. This change allows the CI to use a nightly compiler instead.