### PR TITLE
Properly striping struct fields when using attrs

### DIFF
--- a/gcc/rust/expand/rust-cfg-strip.h
+++ b/gcc/rust/expand/rust-cfg-strip.h
@@ -36,6 +36,8 @@ public:
   void go (AST::Crate &crate);
 
   void maybe_strip_struct_fields (std::vector<AST::StructField> &fields);
+  void maybe_strip_struct_expr_fields (
+    std::vector<std::unique_ptr<AST::StructExprField>> &fields);
   void maybe_strip_tuple_fields (std::vector<AST::TupleField> &fields);
   void maybe_strip_function_params (
     std::vector<std::unique_ptr<AST::Param>> &params);

--- a/gcc/testsuite/rust/compile/macro-issue2983_2984.rs
+++ b/gcc/testsuite/rust/compile/macro-issue2983_2984.rs
@@ -1,0 +1,27 @@
+pub struct ReadDir {
+    pub inner: i32,
+    #[cfg(not(A))]
+    pub end_of_stream: bool,
+    #[cfg(A)]
+    pub end_of_stream_but_different: bool,
+}
+
+fn main() {
+    // Success
+    let _ = ReadDir {
+        inner: 14,
+        #[cfg(not(A))]
+        end_of_stream: false,
+        #[cfg(A)]
+        end_of_stream_but_different: false,
+    };
+
+    // Error
+    let _ = ReadDir {
+        inner: 14,
+        end_of_stream: false,
+        end_of_stream_but_different: false, // { dg-error "failed to resolve type for field" }
+        // { dg-error "unknown field" "" { target *-*-* } .-1 }
+        // { dg-prune-output "compilation terminated" }
+    };
+}


### PR DESCRIPTION
gcc/rust/ChangeLog:
  * expand/rust-cfg-strip.cc: Strip struct expr fields and strip fields in struct definition
  * expand/rust-cfg-strip.h: Signatures for new function maybe_strip_struct_expr_fields

gcc/testsuite/ChangeLog:
  * rust/compile/macro-issue2983_2984.rs: Add test to check for correct stripped fields

Fixes #2983
Fixes #2984

- \[X] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[X] Read contributing guidlines
- \[X] `make check-rust` passes locally
- \[X] Run `clang-format`
- \[X] Added any relevant test cases to `gcc/testsuite/rust/`

---
@CohenArthur 