### PR TITLE
gccrs: [E0576] Associated `item` not found in given `type`

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -220,7 +220,17 @@ TypeCheckType::visit (HIR::QualifiedPathInType &path)
     = specified_bound.lookup_associated_item (item_seg_identifier.as_string ());
   if (item.is_error ())
     {
-      rust_error_at (item_seg->get_locus (), "unknown associated item");
+      std::string item_seg_ident_name, rich_msg;
+      item_seg_ident_name = qual_path_type.get_trait ()->as_string ();
+      rich_msg = "not found in `" + item_seg_ident_name + "`";
+
+      rich_location richloc (line_table, item_seg->get_locus ());
+      richloc.add_fixit_replace (rich_msg.c_str ());
+
+      rust_error_at (richloc, ErrorCode::E0576,
+		     "cannot find associated type %qs in trait %qs",
+		     item_seg_identifier.as_string ().c_str (),
+		     item_seg_ident_name.c_str ());
       return;
     }
 

--- a/gcc/testsuite/rust/compile/unknown-associated-item.rs
+++ b/gcc/testsuite/rust/compile/unknown-associated-item.rs
@@ -1,0 +1,10 @@
+#![allow(unused)]
+fn main() {
+    trait Hello {
+        type Who;
+
+        fn hello() -> <Self as Hello>::You;
+        // { dg-error "cannot find associated type .You. in trait .Hello. .E0576." "" { target *-*-* } .-1 }
+        // { dg-error "failed to resolve return type" "" { target *-*-* } .-2 }
+    }
+}


### PR DESCRIPTION
## [E0576](https://doc.rust-lang.org/error_codes/E0576.html#error-code-e0576) Associated `item` not found in given `type` 


- Fixes subtask 1 of https://github.com/Rust-GCC/gccrs/issues/3079 (unable to create a subtask)

---

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-type.cc (TypeCheckType::visit): Add error message similiar to rustc with associaed type and trait name

gcc/testsuite/ChangeLog:

	* rust/compile/unknown-associated-item.rs: New test.

---