### PR TITLE
Added options for ParseMode

### DIFF
--- a/gcc/rust/ast/rust-fmt.cc
+++ b/gcc/rust/ast/rust-fmt.cc
@@ -29,9 +29,11 @@ ffi::RustHamster::to_string () const
 }
 
 Pieces
-Pieces::collect (const std::string &to_parse, bool append_newline)
+Pieces::collect (const std::string &to_parse, bool append_newline,
+		 ffi::ParseMode parse_mode)
 {
-  auto handle = ffi::collect_pieces (to_parse.c_str (), append_newline);
+  auto handle
+    = ffi::collect_pieces (to_parse.c_str (), append_newline, parse_mode);
 
   // this performs multiple copies, can we avoid them maybe?
   // TODO: Instead of just creating a vec of, basically, `ffi::Piece`s, we

--- a/gcc/rust/ast/rust-fmt.h
+++ b/gcc/rust/ast/rust-fmt.h
@@ -258,10 +258,16 @@ struct FormatArgsHandle
   RustString rust_string;
 };
 
+typedef enum
+{
+  Format,
+  InlineAsm,
+} ParseMode;
+
 extern "C" {
 
 FormatArgsHandle
-collect_pieces (const char *input, bool append_newline);
+collect_pieces (const char *input, bool append_newline, ParseMode parse_mode);
 
 FormatArgsHandle
 clone_pieces (const FormatArgsHandle &);
@@ -274,7 +280,8 @@ void destroy_pieces (FormatArgsHandle);
 
 struct Pieces
 {
-  static Pieces collect (const std::string &to_parse, bool append_newline);
+  static Pieces collect (const std::string &to_parse, bool append_newline,
+			 ffi::ParseMode parse_mode);
   ~Pieces ();
 
   Pieces (const Pieces &other);

--- a/gcc/rust/ast/rust-fmt.h
+++ b/gcc/rust/ast/rust-fmt.h
@@ -258,11 +258,11 @@ struct FormatArgsHandle
   RustString rust_string;
 };
 
-typedef enum
+enum ParseMode
 {
-  Format,
+  Format = 0,
   InlineAsm,
-} ParseMode;
+};
 
 extern "C" {
 

--- a/gcc/rust/expand/rust-macro-builtins-format-args.cc
+++ b/gcc/rust/expand/rust-macro-builtins-format-args.cc
@@ -16,6 +16,7 @@
 // along with GCC; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 #include "rust-ast-fragment.h"
+#include "rust-fmt.h"
 #include "rust-macro-builtins-helpers.h"
 #include "rust-expand-format-args.h"
 
@@ -162,7 +163,8 @@ MacroBuiltin::format_args_handler (location_t invoc_locus,
   if (append_newline)
     fmt_str += '\n';
 
-  auto pieces = Fmt::Pieces::collect (fmt_str, append_newline);
+  auto pieces = Fmt::Pieces::collect (fmt_str, append_newline,
+				      Fmt::ffi::ParseMode::Format);
 
   // TODO:
   // do the transformation into an AST::FormatArgs node

--- a/libgrust/libformat_parser/generic_format_parser/src/lib.rs
+++ b/libgrust/libformat_parser/generic_format_parser/src/lib.rs
@@ -78,6 +78,7 @@ enum InputStringKind {
 }
 
 /// The type of format string that we are parsing.
+#[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ParseMode {
     /// A normal format string as per `format_args!`.

--- a/libgrust/libformat_parser/generic_format_parser/src/lib.rs
+++ b/libgrust/libformat_parser/generic_format_parser/src/lib.rs
@@ -78,7 +78,6 @@ enum InputStringKind {
 }
 
 /// The type of format string that we are parsing.
-#[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ParseMode {
     /// A normal format string as per `format_args!`.

--- a/libgrust/libformat_parser/src/bin.rs
+++ b/libgrust/libformat_parser/src/bin.rs
@@ -5,6 +5,7 @@ fn main() {
         std::env::args().nth(1).unwrap().as_str(),
         None,
         None,
-        false
+        false,
+        generic_format_parser::ParseMode::Format
     ));
 }

--- a/libgrust/libformat_parser/src/bin.rs
+++ b/libgrust/libformat_parser/src/bin.rs
@@ -6,6 +6,6 @@ fn main() {
         None,
         None,
         false,
-        generic_format_parser::ParseMode::Format
+        libformat_parser::ffi::ParseMode::Format,
     ));
 }

--- a/libgrust/libformat_parser/src/lib.rs
+++ b/libgrust/libformat_parser/src/lib.rs
@@ -334,8 +334,9 @@ pub mod rust {
         style: Option<usize>,
         snippet: Option<String>,
         append_newline: bool,
+        parse_mode: ParseMode
     ) -> Vec<Piece<'_>> {
-        let parser = Parser::new(input, style, snippet, append_newline, ParseMode::Format);
+        let parser = Parser::new(input, style, snippet, append_newline, parse_mode);
 
         parser.into_iter().collect()
     }
@@ -360,10 +361,12 @@ pub struct RustString {
 #[repr(C)]
 pub struct FormatArgsHandle(PieceSlice, RustString);
 
+
 #[no_mangle]
 pub extern "C" fn collect_pieces(
     input: *const libc::c_char,
     append_newline: bool,
+    parse_mode : generic_format_parser::ParseMode 
 ) -> FormatArgsHandle {
     // FIXME: Add comment
     let str = unsafe { CStr::from_ptr(input) };
@@ -376,7 +379,7 @@ pub extern "C" fn collect_pieces(
     let s = unsafe { std::mem::transmute::<&'_ str, &'static str>(s) };
 
     // FIXME: No unwrap
-    let pieces: Vec<ffi::Piece<'_>> = rust::collect_pieces(s, None, None, append_newline)
+    let pieces: Vec<ffi::Piece<'_>> = rust::collect_pieces(s, None, None, append_newline, parse_mode)
         .into_iter()
         .map(Into::into)
         .collect();


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* ast/rust-fmt.cc (Pieces::collect): Added options for ParseMode
	* ast/rust-fmt.h (collect_pieces): Likewise. (struct Pieces): Likewise.
	* expand/rust-macro-builtins-format-args.cc (MacroBuiltin::format_args_handler): Likewise.

libgrust/ChangeLog:

	* libformat_parser/generic_format_parser/src/lib.rs: Likewise.
	* libformat_parser/src/bin.rs: Likewise.
	* libformat_parser/src/lib.rs: Likewise.


