### PR TITLE
[#2987] Patch ICE when deriving Clone and Copy

### DIFF
--- a/gcc/rust/expand/rust-expand-visitor.cc
+++ b/gcc/rust/expand/rust-expand-visitor.cc
@@ -167,10 +167,10 @@ ExpandVisitor::expand_inner_items (
 
   for (auto it = items.begin (); it != items.end (); it++)
     {
-      auto &item = *it;
-      if (item->has_outer_attrs ())
+      Rust::AST::Item &item = **it;
+      if (item.has_outer_attrs ())
 	{
-	  auto &attrs = item->get_outer_attrs ();
+	  auto &attrs = item.get_outer_attrs ();
 
 	  for (auto attr_it = attrs.begin (); attr_it != attrs.end ();
 	       /* erase => No increment*/)
@@ -190,16 +190,17 @@ ExpandVisitor::expand_inner_items (
 		      if (maybe_builtin.has_value ())
 			{
 			  auto new_item
-			    = builtin_derive_item (*item, current,
+			    = builtin_derive_item (item, current,
 						   maybe_builtin.value ());
-			  // this inserts the derive *before* the item - is it a
-			  // problem?
+
 			  it = items.insert (it, std::move (new_item));
 			}
 		      else
 			{
+			  // Macro is not a builtin, so it must be a
+			  // user-defined derive macro.
 			  auto new_items
-			    = derive_item (*item, to_derive, expander);
+			    = derive_item (item, to_derive, expander);
 			  std::move (new_items.begin (), new_items.end (),
 				     std::inserter (items, it));
 			}
@@ -215,7 +216,7 @@ ExpandVisitor::expand_inner_items (
 		    {
 		      attr_it = attrs.erase (attr_it);
 		      auto new_items
-			= expand_item_attribute (*item, current.get_path (),
+			= expand_item_attribute (item, current.get_path (),
 						 expander);
 		      it = items.erase (it);
 		      std::move (new_items.begin (), new_items.end (),

--- a/gcc/testsuite/rust/compile/issue-2987.rs
+++ b/gcc/testsuite/rust/compile/issue-2987.rs
@@ -1,0 +1,17 @@
+// { dg-options "-w" } Currently there are a lot of warnings produced from inside clone/copy
+// builtins
+
+#[lang = "copy"]
+trait Copy {}
+
+#[lang = "clone"]
+trait Clone {
+    fn clone(&self) -> Self;
+}
+
+#[derive(Copy)]
+#[derive(Clone)]
+struct Empty;
+
+#[derive(Copy,Clone)]
+struct Empty2;


### PR DESCRIPTION
```
gcc/rust/ChangeLog:
	* expand/rust-expand-visitor.cc: Fix ICE caused by unique_ptr UB and buggy iterator use

gcc/testsuite/ChangeLog:
	* rust/compile/issue-2987.rs: Add test for deriving Clone and Copy at the same time
```

Fixes #2987 


- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`
- \[x] Added any relevant test cases to `gcc/testsuite/rust/`

---

Fix an ICE caused by an improper use of iterators that prevented Clone and Copy from being applied to the same struct.

Fixes #2987 
