### PR TITLE
Add option_env support

### DIFF
--- a/gcc/rust/expand/rust-macro-builtins.cc
+++ b/gcc/rust/expand/rust-macro-builtins.cc
@@ -120,8 +120,8 @@ std::unordered_map<std::string, AST::MacroTranscriberFunc>
     {"format_args_nl", format_args_maker (AST::FormatArgs::Newline::Yes)},
     {"asm", inline_asm_maker (AST::AsmKind::Inline)},
     {"global_asm", inline_asm_maker (AST::AsmKind::Global)},
+    {"option_env", MacroBuiltin::option_env_handler},
     /* Unimplemented macro builtins */
-    {"option_env", MacroBuiltin::sorry},
     {"concat_idents", MacroBuiltin::sorry},
     {"module_path", MacroBuiltin::sorry},
     {"log_syntax", MacroBuiltin::sorry},

--- a/gcc/rust/expand/rust-macro-builtins.h
+++ b/gcc/rust/expand/rust-macro-builtins.h
@@ -159,6 +159,10 @@ public:
 						  AST::MacroInvocData &invoc,
 						  AST::InvocKind semicolon);
 
+  static tl::optional<AST::Fragment>
+  option_env_handler (location_t invoc_locus, AST::MacroInvocData &invoc,
+		      AST::InvocKind semicolon);
+
   static tl::optional<AST::Fragment> cfg_handler (location_t invoc_locus,
 						  AST::MacroInvocData &invoc,
 						  AST::InvocKind semicolon);

--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
@@ -254,6 +254,8 @@ Late::visit (AST::PathInExpression &expr)
   // TODO: How do we have a nice error with `can't capture dynamic environment
   // in a function item` error here?
   // do we emit it in `get<Namespace::Labels>`?
+  if (expr.is_lang_item ())
+    return;
 
   auto resolved
     = ctx.values.resolve_path (expr.get_segments ()).or_else ([&] () {

--- a/gcc/testsuite/rust/compile/macros/builtin/option_env1.rs
+++ b/gcc/testsuite/rust/compile/macros/builtin/option_env1.rs
@@ -1,0 +1,29 @@
+#![feature(rustc_attrs)]
+
+#[rustc_builtin_macro]
+macro_rules! option_env {
+    () => {}
+}
+
+#[lang = "sized"]
+trait Sized {}
+
+pub mod core {
+    pub mod option {
+        pub enum Option<T> {
+            #[lang = "Some"]
+            Some(T),
+            #[lang = "None"]
+            None,
+        }
+    }
+}
+
+use core::option::Option;
+
+
+fn main() {
+    // Both a guaranteed-to-exist variable and a failed find should compile
+    let _: Option<&str> = option_env!("PWD");
+    let _: Option<&str> = option_env!("PROBABLY_DOESNT_EXIST");
+}

--- a/gcc/testsuite/rust/compile/macros/builtin/option_env2.rs
+++ b/gcc/testsuite/rust/compile/macros/builtin/option_env2.rs
@@ -1,0 +1,27 @@
+#![feature(rustc_attrs)]
+
+#[rustc_builtin_macro]
+macro_rules! option_env {
+    () => {}
+}
+
+#[lang = "sized"]
+trait Sized {}
+
+pub mod core {
+    pub mod option {
+        pub enum Option<T> {
+            #[lang = "Some"]
+            Some(T),
+            #[lang = "None"]
+            None,
+        }
+    }
+}
+
+use core::option::Option;
+
+fn main() {
+    let _: Option<&str> = option_env!(42);
+    // { dg-error "argument must be a string literal" "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/compile/macros/builtin/option_env3.rs
+++ b/gcc/testsuite/rust/compile/macros/builtin/option_env3.rs
@@ -1,0 +1,28 @@
+#![feature(rustc_attrs)]
+
+#[rustc_builtin_macro]
+macro_rules! option_env {
+    () => {}
+}
+
+#[lang = "sized"]
+trait Sized {}
+
+pub mod core {
+    pub mod option {
+        pub enum Option<T> {
+            #[lang = "Some"]
+            Some(T),
+            #[lang = "None"]
+            None,
+        }
+    }
+}
+
+use core::option::Option;
+
+
+fn main() {
+    let _: Option<&str> = option_env!("A","B");
+    // { dg-error "'option_env!' takes 1 argument" "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/execute/torture/builtin_macro_option_env.rs
+++ b/gcc/testsuite/rust/execute/torture/builtin_macro_option_env.rs
@@ -1,0 +1,65 @@
+// { dg-output "VALUE\r*\nVALUE\r*\n" }
+// { dg-set-compiler-env-var ENV_MACRO_TEST "VALUE" }
+
+#![feature(rustc_attrs)]
+
+#[rustc_builtin_macro]
+macro_rules! option_env {
+    () => {{}};
+}
+
+#[lang = "sized"]
+trait Sized {}
+
+pub mod core {
+    pub mod option {
+        pub enum Option<T> {
+            #[lang = "Some"]
+            Some(T),
+            #[lang = "None"]
+            None,
+        }
+    }
+}
+
+use core::option::Option;
+
+extern "C" {
+    fn printf(fmt: *const i8, ...);
+}
+
+fn print(s: &str) {
+    unsafe {
+        printf(
+            "%s\n" as *const str as *const i8,
+            s as *const str as *const i8,
+        );
+    }
+}
+
+macro_rules! env_macro_test {
+    () => { "ENV_MACRO_TEST" }
+}
+
+fn main() -> i32 {
+    let val0: Option<&'static str> = option_env!("ENV_MACRO_TEST");
+
+    
+    match val0 {
+        Option::None => {},
+        Option::Some(s) => {
+            print(s);
+        }
+    }
+
+    //eager expansion test
+    let val1: Option<&'static str> = option_env!(env_macro_test!(),);
+
+    match val1 {
+        Option::None => {},
+        Option::Some(s) => {
+            print(s);
+        }
+    }
+    0
+}


### PR DESCRIPTION
```

    gcc/rust/ChangeLog:
            * expand/rust-macro-builtins-utility.cc: Add macro expansion for
            option_env with eager expansion
            * expand/rust-macro-builtins.cc: Add option_env to builtin list
            * expand/rust-macro-builtins.h: Add option_env handler to header
            file

    gcc/testsuite/ChangeLog:
            * rust/compile/macros/builtin/option_env1.rs: Add success case for option_env
            * rust/compile/macros/builtin/option_env2.rs: Add failure case for option_env
            * rust/execute/torture/builtin_macro_option_env.rs: Add
            execution case for option_env
            * rust/compile/nr2/exclude: Some issues with nr2 need to be
            resolved before allowing option_env with NR2.0.
```

Fixes #1806 

Addresses #927, #1791 

Here is a checklist to help you with your PR.

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`
- \[x] Added any relevant test cases to `gcc/testsuite/rust/`

---

Adds compiler support for option_env, adds eager expansion for option_env, adds tests for option_env
