### PR TITLE
Fixed bitwise operation in `extract_stmt`

### DIFF
--- a/gcc/rust/checks/errors/borrowck/polonius/rust-polonius.h
+++ b/gcc/rust/checks/errors/borrowck/polonius/rust-polonius.h
@@ -45,7 +45,7 @@ struct FullPoint
   static uint32_t extract_bb (Point point) { return point >> 16; }
   static uint32_t extract_stmt (Point point)
   {
-    return (point & ~(1 << 16)) >> 1;
+    return (point >> 1) & ((1 << 15) - 1);
   }
   static bool extract_mid (Point point) { return point & 1; }
 


### PR DESCRIPTION
1 << 16 gives : 10000000000000000
~(1 << 16) gives : 11111111111111101111111111111111
i think the assumption was output of ~(1 << 16) will be 1111111111111111, which results in extraction of wrong statement

this bug can be verified by checking nll_dump of this function
```rust
fn complex_cfg_subset<'a, 'b>(b: bool, x: &'a u32, y: &'b u32) -> &'a u32 {
    if b { 
        y
    } else {
        x
    }   
}
```