### PR TITLE
Fix 32-bits builds

### DIFF
--- a/gcc/rust/checks/errors/borrowck/rust-bir-builder.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-builder.h
@@ -91,7 +91,8 @@ private:
 	  ctx.fn_free_regions[bound.second.get_index ()]);
 
 	auto last_bound = universal_region_bounds.back ();
-	rust_debug ("\t\t %ld: %ld", last_bound.first, last_bound.second);
+	rust_debug ("\t\t %lu: %lu", (unsigned long) last_bound.first,
+		    (unsigned long) last_bound.second);
       }
 
     // TODO: handle type_region constraints

--- a/gcc/rust/checks/errors/borrowck/rust-bir-fact-collector.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-fact-collector.h
@@ -621,14 +621,16 @@ protected: // Generic BIR operations.
 protected: // Subset helpers.
   void push_subset (FreeRegion lhs, FreeRegion rhs)
   {
-    rust_debug ("\t\tpush_subset: '?%lu: '?%lu", lhs, rhs);
+    rust_debug ("\t\tpush_subset: '?%lu: '?%lu", (unsigned long) lhs,
+		(unsigned long) rhs);
 
     facts.subset_base.emplace_back (lhs, rhs, get_current_point_mid ());
   }
 
   void push_subset_all (FreeRegion lhs, FreeRegion rhs)
   {
-    rust_debug ("\t\tpush_subset_all: '?%lu: '?%lu", lhs, rhs);
+    rust_debug ("\t\tpush_subset_all: '?%lu: '?%lu", (unsigned long) lhs,
+		(unsigned long) rhs);
 
     for (auto point : cfg_points_all)
       facts.subset_base.emplace_back (lhs, rhs, point);

--- a/gcc/rust/checks/errors/borrowck/rust-bir-fact-collector.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-fact-collector.h
@@ -334,7 +334,7 @@ protected: // Main collection entry points (for different categories).
 		expr.get_rhs () - 1, current_bb, current_stmt);
 
     issue_read_move (expr.get_rhs ());
-    push_subset (lhs, expr.get_rhs ());
+    push_place_subset (lhs, expr.get_rhs ());
   }
 
   void visit (const CallExpr &expr) override
@@ -662,7 +662,7 @@ protected: // Subset helpers.
       }
   }
 
-  void push_subset (PlaceId lhs, PlaceId rhs)
+  void push_place_subset (PlaceId lhs, PlaceId rhs)
   {
     auto &lhs_place = place_db[lhs];
     auto &rhs_place = place_db[rhs];


### PR DESCRIPTION
Fixes this bugzilla PR: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116192

We are once again hitting issues for formatting `size_t` values in our printf-like macros. We should think about having a 32bit build CI for cases like these. Also, on architectures where `size_t` is `unsigned int`, such as 32bit x86, we encounter an issue with `PlaceId` and `FreeRegion` being aliases to the same types. This poses an issue for overloading functions for these two types, such as `push_subset` in that case. This commit renames one of these `push_subset` functions to avoid the issue, but this should be fixed with a newtype pattern for these two types, as is currently being discussed on Zulip