### PR TITLE
Add error message for E0532

### DIFF
--- a/gcc/testsuite/rust/compile/issue-2324-1.rs
+++ b/gcc/testsuite/rust/compile/issue-2324-1.rs
@@ -1,0 +1,19 @@
+enum State {
+    Succeeded,
+    Failed(u32),
+}
+
+fn print_on_failure(state: &State) {
+    match *state {
+        State::Succeeded => (),
+        State::Failed => (), // { dg-error "expected unit struct, unit variant or constant, found tuple variant" }
+        _ => ()
+    }
+}
+
+fn main() {
+    let b = State::Failed(1);
+
+    print_on_failure(&b);
+
+}

--- a/gcc/testsuite/rust/compile/issue-2324-2.rs
+++ b/gcc/testsuite/rust/compile/issue-2324-2.rs
@@ -1,0 +1,19 @@
+enum State {
+    Succeeded,
+    Failed { x: u32 },
+}
+
+fn print_on_failure(state: &State) {
+    match *state {
+        State::Succeeded => (),
+        State::Failed => (), // { dg-error "expected unit struct, unit variant or constant, found tuple variant" }
+        _ => ()
+    }
+}
+
+fn main() {
+    let b = State::Failed{x: 1};
+
+    print_on_failure(&b);
+
+}


### PR DESCRIPTION
I took the error message from rustc, but I *really* don't like it. Isn't the error message the direct opposite of the problem? 

Rustc error message: expected unit struct, unit variant or constant, found tuple variant
I want something like: referenced type is a non-unit enum variant, consider specifying the relevant variant fields

```
    gcc/rust/ChangeLog:
            * typecheck/rust-hir-type-check-pattern.cc:
            Emit E0532 when trying to reference a Tuple or Struct variant
            using a non Tuple or Struct pattern.

    gcc/testsuite/ChangeLog:
            * rust/compile/issue-2324-1.rs:
            add test for E0532 with tuple enum variant
            * rust/compile/issue-2324-1.rs:
            add test for E0532 with struct enum variant
```

Fixes #2324 , addresses #2553

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`
- \[x] Added any relevant test cases to `gcc/testsuite/rust/`

---

Adds error message for E0532
