### PR TITLE
Add check for path patterns.

### DIFF
--- a/gcc/rust/hir/tree/rust-hir.cc
+++ b/gcc/rust/hir/tree/rust-hir.cc
@@ -213,6 +213,44 @@ Module::as_string () const
 }
 
 std::string
+Item::item_kind_string (Item::ItemKind kind)
+{
+  switch (kind)
+    {
+    case Item::ItemKind::Static:
+      return "static";
+    case Item::ItemKind::Constant:
+      return "constant";
+    case Item::ItemKind::TypeAlias:
+      return "type alias";
+    case Item::ItemKind::Function:
+      return "function";
+    case Item::ItemKind::UseDeclaration:
+      return "use declaration";
+    case Item::ItemKind::ExternBlock:
+      return "extern block";
+    case Item::ItemKind::ExternCrate:
+      return "extern crate";
+    case Item::ItemKind::Struct:
+      return "struct";
+    case Item::ItemKind::Union:
+      return "union";
+    case Item::ItemKind::Enum:
+      return "enum";
+    case Item::ItemKind::EnumItem:
+      return "enum item";
+    case Item::ItemKind::Trait:
+      return "trait";
+    case Item::ItemKind::Impl:
+      return "impl";
+    case Item::ItemKind::Module:
+      return "module";
+    default:
+      rust_unreachable ();
+    }
+}
+
+std::string
 StaticItem::as_string () const
 {
   std::string str = VisItem::as_string ();

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -220,6 +220,8 @@ public:
     Module,
   };
 
+  static std::string item_kind_string (ItemKind kind);
+
   virtual ItemKind get_item_kind () const = 0;
 
   // Unique pointer custom clone function

--- a/gcc/testsuite/rust/compile/issue-2324-2.rs
+++ b/gcc/testsuite/rust/compile/issue-2324-2.rs
@@ -6,7 +6,7 @@ enum State {
 fn print_on_failure(state: &State) {
     match *state {
         State::Succeeded => (),
-        State::Failed => (), // { dg-error "expected unit struct, unit variant or constant, found tuple variant" }
+        State::Failed => (), // { dg-error "expected unit struct, unit variant or constant, found struct variant" }
         _ => ()
     }
 }

--- a/gcc/testsuite/rust/compile/match9.rs
+++ b/gcc/testsuite/rust/compile/match9.rs
@@ -1,0 +1,30 @@
+enum E {
+    A(),
+    B,
+}
+
+const CONST_E: E = E::A();
+
+static static_e: E = E::A();
+
+type type_alias = E;
+
+fn f(e: E) {
+    match e {
+        E::A => {}
+        // { dg-error "expected unit struct, unit variant or constant, found tuple variant .E::A." "" { target *-*-* } .-1 }
+        E::B => {}
+        crate::CONST_E => {}
+        crate::type_alias => {}
+        // { dg-error "expected unit struct, unit variant or constant, found type alias .crate::type_alias." "" { target *-*-* } .-1 }
+        crate::E => {}
+        // { dg-error "expected unit struct, unit variant or constant, found enum .crate::E." "" { target *-*-* } .-1 }
+        crate::static_e => {}
+        // { dg-error "expected unit struct, unit variant or constant, found static .crate::static_e." "" { target *-*-* } .-1 }
+        crate::f => {}
+        // { dg-error "expected unit struct, unit variant or constant, found function .crate::f." "" { target *-*-* } .-1 }
+        _ => {}
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Addresses #2553 #2094
Fix some incorrect error messages introduced in https://github.com/Rust-GCC/gccrs/pull/3118

```
gcc/rust/ChangeLog:

	* hir/tree/rust-hir.cc (Item::item_kind_string): New function.
	* hir/tree/rust-hir.h: New function.
	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::visit):
		Modify to check all arms in match expressions even if some of them
		has errors.
	* typecheck/rust-hir-type-check-pattern.cc (TypeCheckPattern::visit):
		Add and fix check for path patterns.

gcc/testsuite/ChangeLog:

	* rust/compile/issue-2324-2.rs: Fix error message.
	* rust/compile/match8.rs: New test.

```