### PR TITLE
Fixed testcase

### DIFF
--- a/gcc/testsuite/rust/borrowck/test_move.rs
+++ b/gcc/testsuite/rust/borrowck/test_move.rs
@@ -12,5 +12,5 @@ fn test_move_fixed() {
 
     let a = 1; // a is now primitive and can be copied
     let b = a;
-    let c = b;
+    let c = a;
 }


### PR DESCRIPTION
the current `test_move_fixed()` will not throw any error even if `a` couldn't be copied as we are not assigning from `a` twice

the correct way to test the move error is to assign twice from `a`, as done in above function

no changes in the output as this function should not throw any error