### PR TITLE
Attempted to access a nonexistent field [`E0609`]

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -85,7 +85,9 @@ TypeCheckExpr::visit (HIR::TupleIndexExpr &expr)
       TupleIndex index = expr.get_tuple_index ();
       if ((size_t) index >= tuple->num_fields ())
 	{
-	  rust_error_at (expr.get_locus (), "unknown field at index %i", index);
+	  rust_error_at (expr.get_locus (), ErrorCode::E0609,
+			 "no field %qi on type %qs", index,
+			 resolved->get_name ().c_str ());
 	  return;
 	}
 
@@ -1078,7 +1080,8 @@ TypeCheckExpr::visit (HIR::FieldAccessExpr &expr)
 				     &lookup, nullptr);
   if (!found)
     {
-      rust_error_at (expr.get_locus (), "unknown field [%s] for type [%s]",
+      rust_error_at (expr.get_locus (), ErrorCode::E0609,
+		     "no field %qs on type %qs",
 		     expr.get_field_name ().as_string ().c_str (),
 		     adt->as_string ().c_str ());
       return;

--- a/gcc/testsuite/rust/compile/nonexistent-field.rs
+++ b/gcc/testsuite/rust/compile/nonexistent-field.rs
@@ -1,0 +1,14 @@
+#![allow(unused)]
+fn main() {
+    struct StructWithFields {
+        x: u32,
+    }
+
+    let s = StructWithFields { x: 0 };
+    s.foo;
+    // { dg-error "no field .foo. on type .StructWithFields.StructWithFields .x.u32... .E0609." "" { target *-*-* } .-1 }
+
+    let numbers = (1, 2, 3);
+    numbers.3;
+    // { dg-error "no field .3. on type ..<integer>, <integer>, <integer>.. .E0609." "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
## Attempted to access a nonexistent field in a struct - [`E0609`](https://doc.rust-lang.org/error_codes/E0609.html#error-code-e0609)

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::visit): Add error code and update error message

gcc/testsuite/ChangeLog:

	* rust/compile/nonexistent-field.rs: New test.

---

- Fixes: https://github.com/Rust-GCC/gccrs/issues/3123
- Addresses: https://github.com/Rust-GCC/gccrs/issues/2553