### PR TITLE
Fix the disorder struct and class in inline asm

### DIFF
--- a/gcc/rust/ast/rust-ast-full-decls.h
+++ b/gcc/rust/ast/rust-ast-full-decls.h
@@ -148,7 +148,7 @@ class AsyncBlockExpr;
 enum class InlineAsmOption;
 struct AnonConst;
 struct InlineAsmRegOrRegClass;
-struct InlineAsmOperand;
+class InlineAsmOperand;
 struct InlineAsmPlaceHolder;
 struct InlineAsmTemplatePiece;
 struct TupleClobber;

--- a/gcc/rust/hir/tree/rust-hir-full-decls.h
+++ b/gcc/rust/hir/tree/rust-hir-full-decls.h
@@ -125,7 +125,8 @@ class AwaitExpr;
 class AsyncBlockExpr;
 class InlineAsmReg;
 class InlineAsmRegClass;
-struct InlineAsmRegOrRegClass;
+struct AnonConst;
+class InlineAsmOperand;
 class InlineAsm;
 
 // rust-stmt.h


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* ast/rust-ast-full-decls.h (struct InlineAsmOperand): Change to class (class InlineAsmOperand): Change from struct
	* hir/tree/rust-hir-full-decls.h (struct InlineAsmRegOrRegClass): Removed from decl, used from AST (struct AnonConst): new decl from rust-hir-expr.h (class InlineAsmOperand): new decl from rust-hir-expr.h

CI doesn't warn about ast decl having InlineAsmOperand as struct and in rust-expr.h having InlineAsmOperand as class.

Same for rust-hir-full-decls declaring HIR version of InlineAsmRegOrRegClass but doesn't define them in rust-hir-expr.h
