### PR TITLE
attributes: Start handling prelude_import properly

### DIFF
--- a/gcc/rust/checks/errors/rust-feature-gate.cc
+++ b/gcc/rust/checks/errors/rust-feature-gate.cc
@@ -217,4 +217,12 @@ FeatureGate::visit (AST::RangePattern &pattern)
 	  "exclusive range pattern syntax is experimental");
 }
 
+void
+FeatureGate::visit (AST::UseTreeGlob &use)
+{
+  // At the moment, UseTrees do not have outer attributes, but they should. we
+  // need to eventually gate `#[prelude_import]` on use-trees based on the
+  // #[feature(prelude_import)]
+}
+
 } // namespace Rust

--- a/gcc/rust/checks/errors/rust-feature-gate.h
+++ b/gcc/rust/checks/errors/rust-feature-gate.h
@@ -107,7 +107,7 @@ public:
   void visit (AST::TypeBoundWhereClauseItem &item) override {}
   void visit (AST::Module &module) override {}
   void visit (AST::ExternCrate &crate) override {}
-  void visit (AST::UseTreeGlob &use_tree) override {}
+  void visit (AST::UseTreeGlob &use_tree) override;
   void visit (AST::UseTreeList &use_tree) override {}
   void visit (AST::UseTreeRebind &use_tree) override {}
   void visit (AST::UseDeclaration &use_decl) override {}

--- a/gcc/rust/checks/errors/rust-feature.cc
+++ b/gcc/rust/checks/errors/rust-feature.cc
@@ -58,6 +58,9 @@ Feature::create (Feature::Name name)
       return Feature (Feature::Name::EXCLUSIVE_RANGE_PATTERN,
 		      Feature::State::ACTIVE, "exclusive_range_pattern",
 		      "1.11.0", 37854, tl::nullopt, "");
+    case Feature::Name::PRELUDE_IMPORT:
+      return Feature (Feature::Name::PRELUDE_IMPORT, Feature::State::ACTIVE,
+		      "prelude_import", "1.0.0", 0, tl::nullopt, "");
     default:
       rust_unreachable ();
     }
@@ -79,6 +82,7 @@ const std::map<std::string, Feature::Name> Feature::name_hash_map = {
   {"dropck_eyepatch", Feature::Name::DROPCK_EYEPATCH},
   {"raw_ref_op", Feature::Name::RAW_REF_OP},
   {"exclusive_range_pattern", Feature::Name::EXCLUSIVE_RANGE_PATTERN},
+  {"prelude_import", Feature::Name::PRELUDE_IMPORT},
 }; // namespace Rust
 
 tl::optional<Feature::Name>

--- a/gcc/rust/checks/errors/rust-feature.h
+++ b/gcc/rust/checks/errors/rust-feature.h
@@ -50,6 +50,7 @@ public:
     DROPCK_EYEPATCH,
     RAW_REF_OP,
     EXCLUSIVE_RANGE_PATTERN,
+    PRELUDE_IMPORT,
   };
 
   const std::string &as_string () { return m_name_str; }

--- a/gcc/rust/util/rust-attribute-values.h
+++ b/gcc/rust/util/rust-attribute-values.h
@@ -56,6 +56,7 @@ public:
   static constexpr auto &RUSTC_CONST_STABLE = "rustc_const_stable";
   static constexpr auto &RUSTC_CONST_UNSTABLE = "rustc_const_unstable";
   static constexpr auto &MAY_DANGLE = "may_dangle";
+  static constexpr auto &PRELUDE_IMPORT = "prelude_import";
 };
 } // namespace Values
 } // namespace Rust

--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -64,7 +64,8 @@ static const BuiltinAttrDefinition __definitions[]
      {Attrs::UNSTABLE, STATIC_ANALYSIS},
      // assuming we keep these for static analysis
      {Attrs::RUSTC_CONST_STABLE, STATIC_ANALYSIS},
-     {Attrs::RUSTC_CONST_UNSTABLE, STATIC_ANALYSIS}};
+     {Attrs::RUSTC_CONST_UNSTABLE, STATIC_ANALYSIS},
+     {Attrs::PRELUDE_IMPORT, NAME_RESOLUTION}};
 
 BuiltinAttributeMappings *
 BuiltinAttributeMappings::get ()

--- a/gcc/testsuite/rust/compile/prelude_import.rs
+++ b/gcc/testsuite/rust/compile/prelude_import.rs
@@ -1,0 +1,12 @@
+#![feature(prelude_import)]
+
+mod core {
+    mod prelude {
+        mod v1 {
+            // hehe
+        }
+    }
+}
+
+#[prelude_import]
+use core::prelude::v1::*;


### PR DESCRIPTION
This commit adds basic handling for the `#[prelude_import]` attribute,
without doing anything functionality wise.

gcc/rust/ChangeLog:

	* checks/errors/rust-feature-gate.cc (FeatureGate::visit): Add base
	feature gating for `#[feature(prelude_import)]`.
	* checks/errors/rust-feature-gate.h: Likewise.
	* checks/errors/rust-feature.cc (Feature::create): Likewise.
	* checks/errors/rust-feature.h: Likewise.
	* util/rust-attribute-values.h: Add base handling for `#[prelude_import]`
	attribute.
	* util/rust-attributes.cc: Likewise.

gcc/testsuite/ChangeLog:

	* rust/compile/prelude_import.rs: New test.

Fixes #2985
