### PR TITLE
gccrs: emit error code for E0758

### DIFF
--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -589,7 +589,8 @@ Lexer::build_token ()
 		  if (current_char.is_eof ())
 		    {
 		      rust_error_at (
-			loc, "unexpected EOF while looking for end of comment");
+			loc, ErrorCode::E0758,
+			"unexpected EOF while looking for end of comment");
 		      break;
 		    }
 		  str += current_char;
@@ -644,7 +645,8 @@ Lexer::build_token ()
 		  if (current_char.is_eof ())
 		    {
 		      rust_error_at (
-			loc, "unexpected EOF while looking for end of comment");
+			loc, ErrorCode::E0758,
+			"unexpected EOF while looking for end of comment");
 		      break;
 		    }
 
@@ -708,7 +710,8 @@ Lexer::build_token ()
 		  if (current_char.is_eof ())
 		    {
 		      rust_error_at (
-			loc, "unexpected EOF while looking for end of comment");
+			loc, ErrorCode::E0758,
+			"unexpected EOF while looking for end of comment");
 		      break;
 		    }
 

--- a/gcc/rust/lex/rust-lex.h
+++ b/gcc/rust/lex/rust-lex.h
@@ -115,14 +115,15 @@ private:
   // Request new Location for current column in line_table
   location_t get_current_location ();
 
-  // Skips the current input char.
+  // Skips the current input character.
   void skip_input ();
-  // Advances current input char to n + 1 chars ahead of current position.
+  // Advances current input character to n + 1 characters ahead of current
+  // position.
   void skip_input (int n);
 
-  // Peeks the current char.
+  // Peeks the current character.
   Codepoint peek_input ();
-  // Returns char n bytes ahead of current position.
+  // Returns character n characters ahead of current position.
   Codepoint peek_input (int n);
 
   // Classifies keyword (i.e. gets id for keyword).


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* lex/rust-lex.cc (Lexer::build_token): Emit error code.
	* lex/rust-lex.h: Fix comment.

Tests already exist.