### PR TITLE
Infer crate name after file opening

### DIFF
--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -396,31 +396,16 @@ Session::handle_input_files (int num_files, const char **files)
 
   const auto &file = files[0];
 
-  if (options.crate_name.empty ())
-    {
-      auto filename = "-";
-      if (num_files > 0)
-	filename = files[0];
-
-      auto crate_name = infer_crate_name (filename);
-      rust_debug ("inferred crate name: %s", crate_name.c_str ());
-      // set the preliminary crate name here
-      // we will figure out the real crate name in `handle_crate_name`
-      options.set_crate_name (crate_name);
-    }
-
-  CrateNum crate_num = mappings.get_next_crate_num (options.get_crate_name ());
-  mappings.set_current_crate (crate_num);
-
   rust_debug ("Attempting to parse file: %s", file);
   compile_crate (file);
 }
 
 void
-Session::handle_crate_name (const AST::Crate &parsed_crate)
+Session::handle_crate_name (const char *filename,
+			    const AST::Crate &parsed_crate)
 {
   auto &mappings = Analysis::Mappings::get ();
-  auto crate_name_changed = false;
+  auto crate_name_found = false;
   auto error = Error (UNDEF_LOCATION, std::string ());
 
   for (const auto &attr : parsed_crate.inner_attrs)
@@ -444,7 +429,6 @@ Session::handle_crate_name (const AST::Crate &parsed_crate)
 	  continue;
 	}
 
-      auto options = Session::get_instance ().options;
       if (options.crate_name_set_manually && (options.crate_name != msg_str))
 	{
 	  rust_error_at (attr.get_locus (),
@@ -452,19 +436,39 @@ Session::handle_crate_name (const AST::Crate &parsed_crate)
 			 "required to match, but %qs does not match %qs",
 			 options.crate_name.c_str (), msg_str.c_str ());
 	}
-      crate_name_changed = true;
+      crate_name_found = true;
       options.set_crate_name (msg_str);
-      mappings.set_crate_name (mappings.get_current_crate (), msg_str);
     }
 
-  options.crate_name_set_manually |= crate_name_changed;
-  if (!options.crate_name_set_manually
-      && !validate_crate_name (options.crate_name, error))
+  options.crate_name_set_manually |= crate_name_found;
+  if (!options.crate_name_set_manually)
     {
-      error.emit ();
-      rust_inform (linemap_position_for_column (line_table, 0),
-		   "crate name inferred from this file");
+      auto crate_name = infer_crate_name (filename);
+      if (crate_name.empty ())
+	{
+	  rust_error_at (UNDEF_LOCATION, "crate name is empty");
+	  rust_inform (linemap_position_for_column (line_table, 0),
+		       "crate name inferred from this file");
+	  return;
+	}
+
+      rust_debug ("inferred crate name: %s", crate_name.c_str ());
+      options.set_crate_name (crate_name);
+
+      if (!validate_crate_name (options.get_crate_name (), error))
+	{
+	  error.emit ();
+	  rust_inform (linemap_position_for_column (line_table, 0),
+		       "crate name inferred from this file");
+	  return;
+	}
     }
+
+  if (saw_errors ())
+    return;
+
+  CrateNum crate_num = mappings.get_next_crate_num (options.get_crate_name ());
+  mappings.set_current_crate (crate_num);
 }
 
 // Parses a single file with filename filename.
@@ -533,7 +537,7 @@ Session::compile_crate (const char *filename)
   std::unique_ptr<AST::Crate> ast_crate = parser.parse_crate ();
 
   // handle crate name
-  handle_crate_name (*ast_crate.get ());
+  handle_crate_name (filename, *ast_crate.get ());
 
   // dump options except lexer dump
   if (options.dump_option_enabled (CompileOptions::AST_DUMP_PRETTY))
@@ -1384,6 +1388,7 @@ rust_crate_name_validation_test (void)
   ASSERT_FALSE (Rust::validate_crate_name ("∀", error));
 
   /* Tests for crate name inference */
+  ASSERT_EQ (Rust::infer_crate_name (".rs"), "");
   ASSERT_EQ (Rust::infer_crate_name ("c.rs"), "c");
   // NOTE: ... but - is allowed when in the filename
   ASSERT_EQ (Rust::infer_crate_name ("a-b.rs"), "a_b");

--- a/gcc/rust/rust-session-manager.h
+++ b/gcc/rust/rust-session-manager.h
@@ -376,7 +376,7 @@ public:
 		      const struct cl_option_handlers *handlers);
   void handle_input_files (int num_files, const char **files);
   void init_options ();
-  void handle_crate_name (const AST::Crate &parsed_crate);
+  void handle_crate_name (const char *filename, const AST::Crate &parsed_crate);
 
   /* This function saves the filename data into the session manager using the
    * `move` semantics, and returns a C-style string referencing the input


### PR DESCRIPTION
gcc/rust/ChangeLog:

```
* rust-session-manager.cc (Session::handle_crate_name): Remove                    
  crate name inference                                                              
  (Session::compile_crate): Add crate name inference and error if                   
  inferred name is empty. Remove CompileOptions::get_instance ()                    
  that returned a local copy of the options. Rename                                 
  crate_name_changed to crate_name_found to match semantics.                        
  (rust_crate_name_validation_test): Test inferring ".rs" name                      
* rust-session-manager.h: Modify handle_crate_name definition to                  
  include filename.
```

Fixes #3129. Also fixes an issue where filenames such as ".rs" provided cause an ICE.

Note that I didn't make a test because I wasn't sure how to use DejaGnu to test that a directory was provided instead of a file (because if I created a test file, then it wouldn't be a directory!). I could've made a ".rs" test file to test the empty crate name behavior, but then the test would be hidden...

I did manually run the following tests:

```bash
workspace@ee59f2d37013:~/gccrs/build$ ./gcc/crab1 -frust-incomplete-and-experimental-compiler-do-not-use .rs
crab1: error: crate name from filename .rs is empty

workspace@ee59f2d37013:~/gccrs/build$ ./gcc/crab1 -frust-incomplete-and-experimental-compiler-do-not-use gcc/
crab1: error: cannot open filename gcc/: Is a directory

workspace@ee59f2d37013:~/gccrs/build$ ./gcc/crab1 -frust-incomplete-and-experimental-compiler-do-not-use ~/
crab1: error: cannot open filename /home/workspace/: Is a directory

workspace@ee59f2d37013:~/gccrs/build$ ./gcc/crab1 -frust-incomplete-and-experimental-compiler-do-not-use .rs.txt
crab1: error: invalid character ‘.’ in crate name: ‘.rs’
.rs.txt:1: note: crate name inferred from this file

workspace@ee59f2d37013:~/gccrs/build$ ./gcc/crab1 -frust-incomplete-and-experimental-compiler-do-not-use missing.rs
crab1: error: cannot open filename missing.rs: No such file or directory
```

Finally, I am waiting for confirmation from my employer that I own the copyright to these changes. This may take a while. I will add a DCO once I get that confirmation.


