### PR TITLE
Add virtual destructor to `AbstractExpr`

### DIFF
--- a/gcc/rust/checks/errors/borrowck/rust-bir.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir.h
@@ -172,6 +172,8 @@ class AbstractExpr : public Visitable
 public:
   explicit AbstractExpr (ExprKind kind) : kind (kind) {}
   WARN_UNUSED_RESULT ExprKind get_kind () const { return kind; }
+
+  virtual ~AbstractExpr () {}
 };
 
 class InitializerExpr : public VisitableImpl<AbstractExpr, InitializerExpr>


### PR DESCRIPTION
This allows `std::unique_ptr<AbstractExpr>` to be properly destructed, discovered during development of #3142.