### PR TITLE
Fix `v0-mangle1.rs` test when run with ASAN

### DIFF
--- a/gcc/rust/util/rust-canonical-path.h
+++ b/gcc/rust/util/rust-canonical-path.h
@@ -46,7 +46,9 @@ namespace Resolver {
 class CanonicalPath
 {
 public:
-  CanonicalPath (const CanonicalPath &other) : segs (other.segs) {}
+  CanonicalPath (const CanonicalPath &other)
+    : segs (other.segs), crate_num (other.crate_num)
+  {}
 
   CanonicalPath &operator= (const CanonicalPath &other)
   {

--- a/gcc/testsuite/rust/compile/v0-mangle1.rs
+++ b/gcc/testsuite/rust/compile/v0-mangle1.rs
@@ -36,7 +36,7 @@ fn main() {
     // cf. rustc 1.72.0: _RNvNtCshIBIgX6Bzox_10v0_mangle18module_a3bar
     module_a::bar();
 
-    // { dg-final { scan-assembler "_R.*NvNtNtC10v0_mangle18module_a8module_b3baz" } }
+    // { dg-final { scan-assembler "_R.*NvNtNtC.*10v0_mangle18module_a8module_b3baz" } }
     // cf. rustc 1.72.0: _RNvNtNtCshIBIgX6Bzox_10v0_mangle18module_a8module_b3baz
     module_a::module_b::baz();
 


### PR DESCRIPTION
Fixes a bug with the test case itself, and one with `crate_num` initialization in `CanonicalPath`