### PR TITLE
Provide input operand for gccrs

### DIFF
--- a/gcc/rust/backend/rust-compile-asm.cc
+++ b/gcc/rust/backend/rust-compile-asm.cc
@@ -1,5 +1,4 @@
 #include "rust-compile-asm.h"
-#include "rust-system.h"
 #include "rust-compile-expr.h"
 namespace Rust {
 namespace Compile {
@@ -107,7 +106,26 @@ tree
 CompileAsm::asm_construct_inputs (HIR::InlineAsm &expr)
 {
   // TODO: Do i need to do this?
-  return NULL_TREE;
+  tree head = NULL_TREE;
+  for (auto &input : expr.get_operands ())
+    {
+      if (input.get_register_type () == AST::InlineAsmOperand::RegisterType::In)
+	{
+	  auto in = input.get_in ();
+
+	  tree in_tree = CompileExpr::Compile (in.expr.get (), this->ctx);
+	  // expects a tree list
+	  // TODO: This assumes that the input is a register
+	  std::string expr_name = "r";
+	  auto name = build_string (expr_name.size () + 1, expr_name.c_str ());
+	  head
+	    = chainon (head, build_tree_list (build_tree_list (NULL_TREE, name),
+					      in_tree));
+
+	  /*head = chainon (head, out_tree);*/
+	}
+    }
+  return head;
 }
 
 tree

--- a/gcc/rust/expand/rust-macro-builtins-asm.cc
+++ b/gcc/rust/expand/rust-macro-builtins-asm.cc
@@ -314,6 +314,7 @@ parse_reg_operand_in (InlineAsmContext inline_asm_ctx)
   // For the keyword IN, currently we count it as a seperate keyword called
   // Rust::IN search for #define RS_TOKEN_LIST in code base.
   auto &parser = inline_asm_ctx.parser;
+  location_t locus = parser.peek_current_token ()->get_locus ();
   if (!inline_asm_ctx.is_global_asm () && parser.skip_token (IN))
     {
       auto reg = parse_reg (inline_asm_ctx);
@@ -331,7 +332,7 @@ parse_reg_operand_in (InlineAsmContext inline_asm_ctx)
       // TODO: When we've succesfully parse an expr, remember to clone_expr()
       // instead of nullptr
       struct AST::InlineAsmOperand::In in (reg, std::move (expr));
-      inline_asm_ctx.inline_asm.operands.push_back (in);
+      inline_asm_ctx.inline_asm.operands.emplace_back (in, locus);
       return inline_asm_ctx;
     }
   return tl::unexpected<InlineAsmParseError> (NONCOMMITED);

--- a/gcc/rust/expand/rust-macro-builtins-asm.cc
+++ b/gcc/rust/expand/rust-macro-builtins-asm.cc
@@ -330,8 +330,8 @@ parse_reg_operand_in (InlineAsmContext inline_asm_ctx)
 
       // TODO: When we've succesfully parse an expr, remember to clone_expr()
       // instead of nullptr
-      // struct AST::InlineAsmOperand::In in (reg, nullptr);
-      // inline_asm_ctx.inline_asm.operands.push_back (in);
+      struct AST::InlineAsmOperand::In in (reg, std::move (expr));
+      inline_asm_ctx.inline_asm.operands.push_back (in);
       return inline_asm_ctx;
     }
   return tl::unexpected<InlineAsmParseError> (NONCOMMITED);
@@ -792,8 +792,9 @@ expand_inline_asm_strings (InlineAsmContext inline_asm_ctx)
 		     * trait});*/
 
 		    transformed_template_str += "%" + std::to_string (idx);
-		    /*std::cout << "argument implicitly is: " << idx <<
-		     * std::endl;*/
+		    // std::cout << "argument implicitly is: " << idx <<
+		    // std::endl; std::cout << "transformed template str is:"
+		    // << transformed_template_str << std::endl;
 		    /*std::cout << "trait: " << trait.to_string () <<
 		     * std::endl;*/
 		    /*std::cout << "arg: " << arg.to_string () << std::endl;*/

--- a/gcc/testsuite/rust/compile/inline_asm_parse_operand.rs
+++ b/gcc/testsuite/rust/compile/inline_asm_parse_operand.rs
@@ -8,7 +8,7 @@ macro_rules! asm {
 fn main() -> i32 {
     unsafe {
         asm!(
-            "add {}, {}",
+            "add {}, 1",
             in(reg) 0
         );
     }
@@ -21,15 +21,15 @@ fn main() -> i32 {
     unsafe {
         asm!(
             "add {}, {}",
-            inout(reg) num1 =>_num1,
             in(reg) _num2,
+            out(reg) _num1,
         );
     }
 
     let mut _output_testing: u32 = 0;
     unsafe {
         asm!(
-            "add {}, {}",
+            "add {}, 1",
             in(reg) _num1,
             //out(reg) _,
         );

--- a/gcc/testsuite/rust/execute/torture/inline_asm_mov_x_5_ARM.rs
+++ b/gcc/testsuite/rust/execute/torture/inline_asm_mov_x_5_ARM.rs
@@ -1,5 +1,5 @@
 /* { dg-do run { target arm*-*-* } } */
-/* { dg-output "5\r*\n" }*/
+/* { dg-output "5\r*\n9\r*\n" }*/
 
 #![feature(rustc_attrs)]
 #[rustc_builtin_macro]
@@ -13,12 +13,24 @@ extern "C" {
 
 fn main() -> i32 {
     let mut _x: i32 = 0;
+    let mut _y: i32 = 9;
+
     unsafe {
         asm!(
             "mov {}, 5",
             out(reg) _x
         );
         printf("%d\n\0" as *const str as *const i8, _x);
+    };
+
+    unsafe {
+        asm!(
+            "mov {}, {}",
+            in(reg) _y,
+            out(reg) _x
+        );
+        printf("%d\n\0" as *const str as *const i8, _x);
     }
+
     0
 }

--- a/gcc/testsuite/rust/execute/torture/inline_asm_mov_x_5_x86_64.rs
+++ b/gcc/testsuite/rust/execute/torture/inline_asm_mov_x_5_x86_64.rs
@@ -1,5 +1,5 @@
 /* { dg-do run { target x86_64*-*-* } } */
-/* { dg-output "5\r*\n" }*/
+/* { dg-output "5\r*\n9\r*\n" }*/
 
 #![feature(rustc_attrs)]
 #[rustc_builtin_macro]
@@ -12,13 +12,24 @@ extern "C" {
 }
 
 fn main() -> i32 {
-    let mut _x: i32 = 0;
+    let mut x: i32 = 0;
+    let mut _y: i32 = 9; // Mark it as _y since it is only used as input operand, not printing
+
     unsafe {
         asm!(
             "mov $5, {}",
-            out(reg) _x
+            out(reg) x
         );
-        printf("%d\n\0" as *const str as *const i8, _x);
+        printf("%d\n\0" as *const str as *const i8, x);
+    };
+
+    unsafe {
+        asm!(
+            "mov {}, {}",
+            in(reg) _y,
+            out(reg) x,
+        );
+        printf("%d\n\0" as *const str as *const i8, x);
     }
     0
 }


### PR DESCRIPTION
fixes #3149 

gcc/rust/ChangeLog:

	* backend/rust-compile-asm.cc (CompileAsm::asm_construct_inputs): Provide input operand for gccrs
	* expand/rust-macro-builtins-asm.cc (parse_reg_operand_in): Move expr to In (expand_inline_asm_strings): Add comments to debug strings

gcc/testsuite/ChangeLog:

	* rust/compile/inline_asm_parse_operand.rs: Remove inout, functionality not supported. Remove redundant {}
	* rust/execute/torture/inline_asm_mov_x_5_ARM.rs: Add operand in
	* rust/execute/torture/inline_asm_mov_x_5_x86_64.rs: Likewise

