### PR TITLE
Fix clang-format CI

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Copy .clang-format file
       run: cp contrib/clang-format .clang-format
     - name: Check clang-format
-      uses: DoozyX/clang-format-lint-action@v0.11
+      uses: DoozyX/clang-format-lint-action@v0.18.2
       with:
         source: 'gcc/rust/ libgrust/'
         extensions: 'h,cc'


### PR DESCRIPTION
Distutils module was missing, hence the required bump