### PR TITLE
Avoid accidental insertion into map

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-pattern.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-pattern.cc
@@ -330,7 +330,8 @@ PatternDeclaration::check_bindings_consistency (
 	      if (!ident_is_outer_bound && !missing_bindings.count (ident))
 		missing_bindings.insert ({ident, inner_info});
 
-	      else if (outer_bindings_map[ident] != inner_info
+	      else if (outer_bindings_map.count (ident)
+		       && outer_bindings_map[ident] != inner_info
 		       && !inconsistent_bindings.count (ident))
 		inconsistent_bindings.insert ({ident, inner_info});
 	    }


### PR DESCRIPTION
[Indexing a map inserts an entry if one does not already exist](https://en.cppreference.com/w/cpp/container/map/operator_at). This should fix the issue with test `alt_patterns1.rs` in #3142