### PR TITLE
Emit error on auto-traits

### DIFF
--- a/gcc/rust/checks/errors/rust-feature-gate.cc
+++ b/gcc/rust/checks/errors/rust-feature-gate.cc
@@ -174,6 +174,15 @@ FeatureGate::visit (AST::TraitImpl &impl)
 }
 
 void
+FeatureGate::visit (AST::Trait &trait)
+{
+  if (trait.is_auto ())
+    gate (Feature::Name::AUTO_TRAITS, trait.get_locus (),
+	  "auto traits are experimental and possibly buggy");
+  AST::DefaultASTVisitor::visit (trait);
+}
+
+void
 FeatureGate::visit (AST::BoxExpr &expr)
 {
   gate (

--- a/gcc/rust/checks/errors/rust-feature-gate.h
+++ b/gcc/rust/checks/errors/rust-feature-gate.h
@@ -42,6 +42,7 @@ public:
   void visit (AST::UseTreeGlob &use_tree) override;
   void visit (AST::Function &function) override;
   void visit (AST::TraitImpl &impl) override;
+  void visit (AST::Trait &trait) override;
   void visit (AST::ExternalTypeItem &item) override;
   void visit (AST::ExternBlock &block) override;
   void visit (AST::MacroRulesDefinition &rules_def) override;

--- a/gcc/rust/checks/errors/rust-feature.cc
+++ b/gcc/rust/checks/errors/rust-feature.cc
@@ -55,6 +55,9 @@ Feature::create (Feature::Name f)
 		      "1.11.0", 37854);
     case Feature::Name::PRELUDE_IMPORT:
       return Feature (f, Feature::State::ACTIVE, "prelude_import", "1.0.0");
+    case Feature::Name::AUTO_TRAITS:
+      return Feature (f, Feature::State::ACTIVE, "optin_builtin_traits",
+		      "1.0.0", 13231);
     default:
       rust_unreachable ();
     }

--- a/gcc/testsuite/rust/compile/auto_trait.rs
+++ b/gcc/testsuite/rust/compile/auto_trait.rs
@@ -1,0 +1,1 @@
+auto trait Valid {} // { dg-error "auto traits are experimental and possibly buggy" }

--- a/gcc/testsuite/rust/compile/auto_trait_super_trait.rs
+++ b/gcc/testsuite/rust/compile/auto_trait_super_trait.rs
@@ -1,3 +1,4 @@
+#![feature(optin_builtin_traits)]
 trait Cold {}
 
 auto trait IsCool: Cold {}

--- a/gcc/testsuite/rust/compile/generic_auto_trait.rs
+++ b/gcc/testsuite/rust/compile/generic_auto_trait.rs
@@ -1,2 +1,3 @@
+#![feature(optin_builtin_traits)]
 auto trait IsCooler<G> {}
 // { dg-error "auto traits cannot have generic parameters .E0567." "" { target *-*-* } .-1 }


### PR DESCRIPTION
Throw an error when auto-traits used without feature attribute.

gcc/rust/ChangeLog:

	* checks/errors/rust-feature-gate.cc (FeatureGate::visit): Emit error on trait when auto field member true.
	* checks/errors/rust-feature-gate.h: add prototype of trait visitor.
	* checks/errors/rust-feature.cc (Feature::create): add optin_builtin_traits in match of feature.

gcc/testsuite/ChangeLog:

	* rust/compile/auto_trait_super_trait.rs: Add feature attribute.
	* rust/compile/generic_auto_trait.rs: likewise.

fixes #2963