### PR TITLE
Fix ICE on error propagation with generic

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-expr.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.cc
@@ -23,6 +23,7 @@
 #include "rust-ast-resolve-pattern.h"
 #include "rust-ast-resolve-path.h"
 #include "diagnostic.h"
+#include "rust-expr.h"
 
 namespace Rust {
 namespace Resolver {
@@ -92,6 +93,12 @@ ResolveExpr::visit (AST::MethodCallExpr &expr)
   auto const &in_params = expr.get_params ();
   for (auto &param : in_params)
     ResolveExpr::go (*param, prefix, canonical_prefix);
+}
+
+void
+ResolveExpr::visit (AST::ErrorPropagationExpr &expr)
+{
+  ResolveExpr::go (expr.get_propagating_expr (), prefix, canonical_prefix);
 }
 
 void

--- a/gcc/rust/resolve/rust-ast-resolve-expr.h
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.h
@@ -22,6 +22,7 @@
 #include "rust-ast-resolve-base.h"
 #include "rust-ast.h"
 #include "rust-ast-resolve-pattern.h"
+#include "rust-expr.h"
 
 namespace Rust {
 namespace Resolver {
@@ -80,6 +81,7 @@ public:
   void visit (AST::RangeFromToInclExpr &expr) override;
   void visit (AST::ClosureExprInner &expr) override;
   void visit (AST::ClosureExprInnerTyped &expr) override;
+  void visit (AST::ErrorPropagationExpr &expr) override;
 
 protected:
   void resolve_closure_param (AST::ClosureParam &param,


### PR DESCRIPTION
add a resolve expr visitor on error propagation to avoid internal compiler error when used with generics

gcc/rust/ChangeLog:

	* resolve/rust-ast-resolve-expr.cc (ResolveExpr::visit): Add implementation of error propagation visitor
	* resolve/rust-ast-resolve-expr.h: Add prototype of error propagation

fixes #3001 