### PR TITLE
mingw: Fix build with patch from Liu Hao

### DIFF
--- a/gcc/rust/checks/errors/borrowck/rust-borrow-checker.cc
+++ b/gcc/rust/checks/errors/borrowck/rust-borrow-checker.cc
@@ -28,20 +28,6 @@ namespace Rust {
 namespace HIR {
 
 void
-mkdir_wrapped (const std::string &dirname)
-{
-  int ret;
-#ifdef _WIN32
-  ret = _mkdir (dirname.c_str ());
-#elif unix
-  ret = mkdir (dirname.c_str (), 0775);
-#elif __APPLE__
-  ret = mkdir (dirname.c_str (), 0775);
-#endif
-  rust_assert (ret == 0 || errno == EEXIST);
-}
-
-void
 dump_function_bir (const std::string &filename, BIR::Function &func,
 		   const std::string &name)
 {
@@ -64,11 +50,11 @@ BorrowChecker::go (HIR::Crate &crate)
 
   if (enable_dump_bir)
     {
-      mkdir_wrapped ("bir_dump");
+      mkdir ("bir_dump", 0755);
       auto &mappings = Analysis::Mappings::get ();
       crate_name
 	= *mappings.get_crate_name (crate.get_mappings ().get_crate_num ());
-      mkdir_wrapped ("nll_facts_gccrs");
+      mkdir ("nll_facts_gccrs", 0755);
     }
 
   FunctionCollector collector;
@@ -96,8 +82,9 @@ BorrowChecker::go (HIR::Crate &crate)
 
       if (enable_dump_bir)
 	{
-	  mkdir_wrapped ("nll_facts_gccrs/"
-			 + func->get_function_name ().as_string ());
+	  auto dir
+	    = "nll_facts_gccrs/" + func->get_function_name ().as_string ();
+	  mkdir (dir.c_str (), 0755);
 	  auto dump_facts_to_file
 	    = [&] (const std::string &suffix,
 		   void (Polonius::Facts::*fn) (std::ostream &) const) {

--- a/gcc/rust/parse/rust-parse.cc
+++ b/gcc/rust/parse/rust-parse.cc
@@ -89,7 +89,7 @@ extract_module_path (const AST::AttrVec &inner_attrs,
   // Source: rustc compiler
   // (https://github.com/rust-lang/rust/blob/9863bf51a52b8e61bcad312f81b5193d53099f9f/compiler/rustc_expand/src/module.rs#L174)
 #if defined(HAVE_DOS_BASED_FILE_SYSTEM)
-  path.replace ('/', '\\');
+  std::replace (path.begin (), path.end (), '/', '\\');
 #endif /* HAVE_DOS_BASED_FILE_SYSTEM */
 
   return path;


### PR DESCRIPTION
This commit adds Liu Hao's patch from
https://github.com/lhmouse/MINGW-packages/blob/5859d27b2b6101204a08ad9702cb2937f8797be9/mingw-w64-gcc/0100-rust-fix.patch

gcc/rust/ChangeLog:

	* checks/errors/borrowck/rust-borrow-checker.cc (mkdir_wrapped): Remove.
	(BorrowChecker::go): Use `mkdir` instead.
	* expand/rust-proc-macro.cc (register_callback): Use Windows APIs to
	open dynamic proc macro library.
	(load_macros_array): Likewise.
	* parse/rust-parse.cc (defined): Replace separators in paths using
	std::replace.

This adds the patch from https://github.com/lhmouse/MINGW-packages/commit/16dad6ba10a5680ad3ca6304480210cef8366985 but reworked for our new changes.

@lhmouse could you check it looks okay and builds on your side?

Sidenote, this might not build on Linux either - I don't have access to my build machine atm so I'm using the CI to test this patch.