### PR TITLE
Change upload artifact github action version

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -49,7 +49,7 @@ jobs:
            cd gccrs-build; \
            make check-rust
     - name: Archive check-rust results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: check-rust-logs
         path: |


### PR DESCRIPTION
Version 2 of this github action has been deprecated, we shall bump the version used in the CI.