### PR TITLE
Avoid visiting nonexistant function parameter types during nr2.0

### DIFF
--- a/gcc/rust/ast/rust-ast-collector.cc
+++ b/gcc/rust/ast/rust-ast-collector.cc
@@ -1999,7 +1999,7 @@ TokenCollector::visit (SelfParam &param)
   if (param.has_type ())
     {
       push (Rust::Token::make (COLON, UNDEF_LOCATION));
-      visit (param.get_type ());
+      visit (param.get_type ().value ());
     }
 }
 

--- a/gcc/rust/ast/rust-ast-visitor.h
+++ b/gcc/rust/ast/rust-ast-visitor.h
@@ -406,6 +406,12 @@ public:
     node->accept_vis (*this);
   }
 
+  template <typename T> void visit (tl::optional<T &> opt)
+  {
+    if (opt.has_value ())
+      visit (opt.value ());
+  }
+
   virtual void visit (AST::GenericArgsBinding &binding);
   virtual void visit (AST::PathExprSegment &segment);
   virtual void visit (AST::GenericArgs &args);

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -528,10 +528,9 @@ public:
   NodeId get_node_id () const { return node_id; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  Type &get_type ()
+  tl::optional<Type &> get_type ()
   {
-    rust_assert (has_type ());
-    return *type;
+    return has_type () ? tl::optional<Type &> (*type) : tl::optional<Type &> ();
   }
 
   std::unique_ptr<Type> &get_type_ptr ()

--- a/gcc/rust/expand/rust-cfg-strip.cc
+++ b/gcc/rust/expand/rust-cfg-strip.cc
@@ -2701,7 +2701,7 @@ CfgStrip::visit (AST::SelfParam &param)
 
   if (param.has_type ())
     {
-      auto &type = param.get_type ();
+      auto &type = param.get_type ().value ();
       if (type.is_marked_for_strip ())
 	rust_error_at (type.get_locus (), "cannot strip type in this position");
     }

--- a/gcc/rust/hir/rust-ast-lower-base.cc
+++ b/gcc/rust/hir/rust-ast-lower-base.cc
@@ -669,7 +669,7 @@ ASTLoweringBase::lower_self (AST::Param &param)
 
   if (self.has_type ())
     {
-      HIR::Type *type = ASTLoweringType::translate (self.get_type ());
+      HIR::Type *type = ASTLoweringType::translate (self.get_type ().value ());
       return HIR::SelfParam (mapping, std::unique_ptr<HIR::Type> (type),
 			     self.get_is_mut (), self.get_locus ());
     }

--- a/gcc/rust/resolve/rust-ast-resolve-item.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-item.cc
@@ -99,7 +99,7 @@ ResolveTraitItems::visit (AST::Function &function)
 	    {
 	      // This shouldn't happen the parser should already error for this
 	      rust_assert (!param.get_has_ref ());
-	      ResolveType::go (param.get_type ());
+	      ResolveType::go (param.get_type ().value ());
 	    }
 	  else
 	    {
@@ -503,7 +503,7 @@ ResolveItem::visit (AST::Function &function)
 	{
 	  // This shouldn't happen the parser should already error for this
 	  rust_assert (!self_param.get_has_ref ());
-	  ResolveType::go (self_param.get_type ());
+	  ResolveType::go (self_param.get_type ().value ());
 	}
       else
 	{
@@ -536,7 +536,7 @@ ResolveItem::visit (AST::Function &function)
 	{
 	  auto &param = static_cast<AST::SelfParam &> (*p);
 	  if (param.has_type ())
-	    ResolveType::go (param.get_type ());
+	    ResolveType::go (param.get_type ().value ());
 	}
       else
 	{

--- a/gcc/rust/resolve/rust-ast-resolve-stmt.h
+++ b/gcc/rust/resolve/rust-ast-resolve-stmt.h
@@ -364,7 +364,7 @@ public:
 	else if (p->is_self ())
 	  {
 	    auto &param = static_cast<AST::SelfParam &> (*p);
-	    ResolveType::go (param.get_type ());
+	    ResolveType::go (param.get_type ().value ());
 	  }
 	else
 	  {


### PR DESCRIPTION
This makes 3 more tests pass with name resolution 2.0