### PR TITLE
rust fix ICE when hir lowering qualified path expressions without an as

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-type.cc
+++ b/gcc/rust/hir/rust-ast-lower-type.cc
@@ -145,8 +145,15 @@ ASTLowerQualifiedPathInType::visit (AST::QualifiedPathInType &path)
 
   HIR::Type *qual_type
     = ASTLoweringType::translate (path.get_qualified_path_type ().get_type ());
-  HIR::TypePath *qual_trait = ASTLowerTypePath::translate (
-    path.get_qualified_path_type ().get_as_type_path ());
+
+  HIR::TypePath *qual_trait = nullptr;
+  if (!path.get_qualified_path_type ().is_error ())
+    {
+      AST::QualifiedPathType &qualifier = path.get_qualified_path_type ();
+      if (qualifier.has_as_clause ())
+	qual_trait
+	  = ASTLowerTypePath::translate (qualifier.get_as_type_path ());
+    }
 
   HIR::QualifiedPathType qual_path_type (
     qual_mappings, std::unique_ptr<HIR::Type> (qual_type),

--- a/gcc/testsuite/rust/compile/issue-3082.rs
+++ b/gcc/testsuite/rust/compile/issue-3082.rs
@@ -1,0 +1,9 @@
+#![allow(unused)]
+fn main() {
+    trait Hello {
+        type Who;
+
+        fn hello() -> <i32>::You;
+        // { dg-error "failed to resolve return type" "" { target *-*-* } .-1 }
+    }
+}

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -277,3 +277,4 @@ dropck_eyepatch_feature_gate.rs
 inline_asm_parse_output_operand.rs
 issue-3030.rs
 issue-3035.rs
+issue-3082.rs


### PR DESCRIPTION
Qualified path expressions usually are <X as Y>::... but the as is optional this adds the extra checking in hir lowering to not hit that nullptr.

Fixes #3082

gcc/rust/ChangeLog:

	* hir/rust-ast-lower-type.cc (ASTLowerQualifiedPathInType::visit): check for valid as segment

gcc/testsuite/ChangeLog:

	* rust/compile/nr2/exclude:
	* rust/compile/issue-3082.rs: New test.