### PR TITLE
rust: fix ICE during name resolution for impls on unit-types

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-type.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-type.cc
@@ -507,6 +507,15 @@ ResolveTypeToCanonicalPath::visit (AST::NeverType &type)
   result = CanonicalPath::new_seg (type.get_node_id (), "!");
 }
 
+void
+ResolveTypeToCanonicalPath::visit (AST::TupleType &type)
+{
+  if (!type.is_unit_type ())
+    rust_unreachable ();
+
+  result = CanonicalPath::new_seg (type.get_node_id (), "()");
+}
+
 ResolveTypeToCanonicalPath::ResolveTypeToCanonicalPath ()
   : ResolverBase (), result (CanonicalPath::create_empty ())
 {}

--- a/gcc/rust/resolve/rust-ast-resolve-type.h
+++ b/gcc/rust/resolve/rust-ast-resolve-type.h
@@ -248,6 +248,8 @@ public:
 
   void visit (AST::NeverType &type) override;
 
+  void visit (AST::TupleType &type) override;
+
 private:
   ResolveTypeToCanonicalPath ();
 

--- a/gcc/testsuite/rust/compile/issue-3036.rs
+++ b/gcc/testsuite/rust/compile/issue-3036.rs
@@ -1,0 +1,14 @@
+#[lang = "sized"]
+trait Sized {}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+pub trait Default: Sized {
+    #[stable(feature = "rust1", since = "1.0.0")]
+    fn default() -> Self;
+}
+
+impl Default for () {
+    fn default() -> () {
+        ()
+    }
+}

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -252,3 +252,4 @@ issue-3082.rs
 issue-3139-1.rs
 issue-3139-2.rs
 issue-3139-3.rs
+issue-3036.rs


### PR DESCRIPTION
The canonical paths need to support unit-types which are technically a TupleType with no fields. This handles this case and adds an unreachable.

Fixes #3036

gcc/rust/ChangeLog:

	* resolve/rust-ast-resolve-type.cc (ResolveTypeToCanonicalPath::visit): add unit-type catch
	* resolve/rust-ast-resolve-type.h: likewise

gcc/testsuite/ChangeLog:

	* rust/compile/nr2/exclude: nr2 cant handle this
	* rust/compile/issue-3036.rs: New test.