### PR TITLE
rust: negative polarity removes restrictions on validation of impl blocks

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-item.cc
+++ b/gcc/rust/hir/rust-ast-lower-item.cc
@@ -690,8 +690,8 @@ ASTLoweringItem::visit (AST::TraitImpl &impl_block)
     }
 
   BoundPolarity polarity = impl_block.is_exclam ()
-			     ? BoundPolarity::RegularBound
-			     : BoundPolarity::NegativeBound;
+			     ? BoundPolarity::NegativeBound
+			     : BoundPolarity::RegularBound;
   HIR::ImplBlock *hir_impl_block = new HIR::ImplBlock (
     mapping, std::move (impl_items), std::move (generic_params),
     std::unique_ptr<HIR::Type> (impl_type),

--- a/gcc/rust/typecheck/rust-hir-type-check-item.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.cc
@@ -734,7 +734,8 @@ TypeCheckItem::validate_trait_impl_block (
   bool impl_block_missing_trait_items
     = !specified_bound.is_error ()
       && trait_reference->size () != trait_item_refs.size ();
-  if (impl_block_missing_trait_items)
+  if (impl_block_missing_trait_items
+      && impl_block.get_polarity () == BoundPolarity::RegularBound)
     {
       // filter the missing impl_items
       std::vector<std::reference_wrapper<const TraitItemReference>>

--- a/gcc/testsuite/rust/compile/issue-3030.rs
+++ b/gcc/testsuite/rust/compile/issue-3030.rs
@@ -1,0 +1,16 @@
+#![feature(negative_impls)]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+pub trait Deref {}
+
+pub trait DerefMut: Deref {
+    type Target;
+
+    /// Mutably dereferences the value.
+    #[stable(feature = "rust1", since = "1.0.0")]
+    fn deref_mut(&mut self) -> &mut Self::Target;
+}
+
+impl<T: ?Sized> !DerefMut for &T {}

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -291,3 +291,4 @@ unknown-associated-item.rs
 box_syntax_feature_gate.rs
 dropck_eyepatch_feature_gate.rs
 inline_asm_parse_output_operand.rs
+issue-3030.rs


### PR DESCRIPTION
Negative polarity means we can just ignore if any trait items are not implemented.

Fixes #3030

gcc/rust/ChangeLog:

	* hir/rust-ast-lower-item.cc (ASTLoweringItem::visit): the polarity was reversed
	* typecheck/rust-hir-type-check-item.cc: check the polarity

gcc/testsuite/ChangeLog:

	* rust/compile/nr2/exclude: nr2 cant handle this
	* rust/compile/issue-3030.rs: New test.
