### PR TITLE
rust: fix ICE when compiling impl block for !

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-type.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-type.cc
@@ -69,7 +69,7 @@ ResolveType::visit (AST::InferredType &)
 void
 ResolveType::visit (AST::NeverType &)
 {
-  // FIXME
+  resolved_node = resolver->get_never_type_node_id ();
 }
 
 void
@@ -499,6 +499,12 @@ ResolveTypeToCanonicalPath::visit (AST::TraitObjectType &)
 {
   // FIXME is this actually allowed? dyn A+B
   rust_unreachable ();
+}
+
+void
+ResolveTypeToCanonicalPath::visit (AST::NeverType &type)
+{
+  result = CanonicalPath::new_seg (type.get_node_id (), "!");
 }
 
 ResolveTypeToCanonicalPath::ResolveTypeToCanonicalPath ()

--- a/gcc/rust/resolve/rust-ast-resolve-type.h
+++ b/gcc/rust/resolve/rust-ast-resolve-type.h
@@ -246,6 +246,8 @@ public:
 
   void visit (AST::TraitObjectType &type) override;
 
+  void visit (AST::NeverType &type) override;
+
 private:
   ResolveTypeToCanonicalPath ();
 

--- a/gcc/rust/resolve/rust-name-resolver.cc
+++ b/gcc/rust/resolve/rust-name-resolver.cc
@@ -429,7 +429,10 @@ Resolver::generate_builtins ()
   setup_builtin ("isize", isize);
   setup_builtin ("char", char_tyty);
   setup_builtin ("str", str);
-  setup_builtin ("!", never);
+
+  // never type
+  NodeId never_node_id = setup_builtin ("!", never);
+  set_never_type_node_id (never_node_id);
 
   // unit type ()
   TyTy::TupleType *unit_tyty
@@ -443,7 +446,7 @@ Resolver::generate_builtins ()
   set_unit_type_node_id (unit_type->get_node_id ());
 }
 
-void
+NodeId
 Resolver::setup_builtin (const std::string &name, TyTy::BaseType *tyty)
 {
   AST::PathIdentSegment seg (name, BUILTINS_LOCATION);
@@ -459,6 +462,8 @@ Resolver::setup_builtin (const std::string &name, TyTy::BaseType *tyty)
   mappings.insert_canonical_path (
     builtin_type->get_node_id (),
     CanonicalPath::new_seg (builtin_type->get_node_id (), name));
+
+  return builtin_type->get_node_id ();
 }
 
 void

--- a/gcc/rust/resolve/rust-name-resolver.h
+++ b/gcc/rust/resolve/rust-name-resolver.h
@@ -163,8 +163,12 @@ public:
   Scope &get_macro_scope () { return macro_scope; }
 
   NodeId get_global_type_node_id () { return global_type_node_id; }
+
   void set_unit_type_node_id (NodeId id) { unit_ty_node_id = id; }
   NodeId get_unit_type_node_id () { return unit_ty_node_id; }
+
+  void set_never_type_node_id (NodeId id) { never_ty_node_id = id; }
+  NodeId get_never_type_node_id () { return never_ty_node_id; }
 
   void push_new_module_scope (NodeId module_id)
   {
@@ -208,7 +212,7 @@ private:
   Resolver ();
 
   void generate_builtins ();
-  void setup_builtin (const std::string &name, TyTy::BaseType *tyty);
+  NodeId setup_builtin (const std::string &name, TyTy::BaseType *tyty);
 
   Analysis::Mappings &mappings;
   TypeCheckContext *tyctx;
@@ -222,6 +226,7 @@ private:
 
   NodeId global_type_node_id;
   NodeId unit_ty_node_id;
+  NodeId never_ty_node_id;
 
   // map a AST Node to a Rib
   std::map<NodeId, Rib *> name_ribs;

--- a/gcc/testsuite/rust/compile/issue-3035.rs
+++ b/gcc/testsuite/rust/compile/issue-3035.rs
@@ -1,0 +1,25 @@
+#[lang = "sized"]
+trait Sized {}
+
+// ---- gccrs additions
+
+#[lang = "clone"]
+pub trait Clone: Sized {
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[must_use = "cloning is often expensive and is not expected to have side effects"]
+    fn clone(&self) -> Self;
+
+    #[inline]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    fn clone_from(&mut self, source: &Self) {
+        *self = source.clone()
+    }
+}
+
+#[unstable(feature = "never_type", issue = "35121")]
+impl Clone for ! {
+    #[inline]
+    fn clone(&self) -> Self {
+        *self
+    }
+}

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -292,3 +292,4 @@ box_syntax_feature_gate.rs
 dropck_eyepatch_feature_gate.rs
 inline_asm_parse_output_operand.rs
 issue-3030.rs
+issue-3035.rs


### PR DESCRIPTION
We need to resolve the never type which is its own special AST node so it doesnt magically get handled like the regular builtin type paths such as i32.

Fixes #3035

gcc/rust/ChangeLog:

	* resolve/rust-ast-resolve-type.cc (ResolveType::visit): handle never type (ResolveTypeToCanonicalPath::visit): likewise
	* resolve/rust-ast-resolve-type.h: missing never type
	* resolve/rust-name-resolver.cc (Resolver::generate_builtins): track never type node_id (Resolver::setup_builtin): likewise
	* resolve/rust-name-resolver.h: new never type getter

gcc/testsuite/ChangeLog:

	* rust/compile/nr2/exclude: nr2 cant handle this
	* rust/compile/issue-3035.rs: New test.
