### PR TITLE
gccrs: adjust hir dump of BlockExpr

### DIFF
--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -1270,6 +1270,8 @@ Dump::visit (BlockExpr &e)
   begin ("BlockExpr");
   do_expr (e);
   do_inner_attrs (e);
+  put_field ("tail_reachable", std::to_string (e.is_tail_reachable ()));
+  put_field ("label", e.get_label ().as_string ());
 
   visit_collection ("statements", e.get_statements ());
 


### PR DESCRIPTION
Add tail_reachable and label fields to the dump.
