### PR TITLE
gccrs: add test case to show impl block on ! works

### DIFF
--- a/gcc/testsuite/rust/compile/issue-2951.rs
+++ b/gcc/testsuite/rust/compile/issue-2951.rs
@@ -1,0 +1,13 @@
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "clone"]
+pub trait Clone: Sized {
+    fn clone(&self) -> Self;
+}
+
+impl Clone for ! {
+    fn clone(&self) -> Self {
+        *self
+    }
+}

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -253,3 +253,4 @@ issue-3139-1.rs
 issue-3139-2.rs
 issue-3139-3.rs
 issue-3036.rs
+issue-2951.rs


### PR DESCRIPTION
The resolution with ! was fixed in: 09cfe530f9c this adds a test case to show the other issue is also fixed.

Fixes #2951

gcc/testsuite/ChangeLog:

	* rust/compile/nr2/exclude: nr2 is crashing here
	* rust/compile/issue-2951.rs: New test.