### PR TITLE
gccrs: Add test case to show ICE is fixed

### DIFF
--- a/gcc/testsuite/rust/compile/issue-2203.rs
+++ b/gcc/testsuite/rust/compile/issue-2203.rs
@@ -1,0 +1,3 @@
+trait A {}
+
+impl A for () {}

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -254,3 +254,4 @@ issue-3139-2.rs
 issue-3139-3.rs
 issue-3036.rs
 issue-2951.rs
+issue-2203.rs


### PR DESCRIPTION
This was resolved in: 18422c9c386 which was missing the name resolution step for unit-types.

Fixes #2203

gcc/testsuite/ChangeLog:

	* rust/compile/nr2/exclude:
	* rust/compile/issue-2203.rs: New test.