### PR TITLE
gccrs: Fix ICE when typechecking non-trait item when we expect one

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-item.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.h
@@ -63,7 +63,8 @@ protected:
 				    bool &failure_flag);
 
   void validate_trait_impl_block (
-    HIR::ImplBlock &impl_block, TyTy::BaseType *self,
+    TraitReference *trait_reference, HIR::ImplBlock &impl_block,
+    TyTy::BaseType *self,
     std::vector<TyTy::SubstitutionParamMapping> &substitutions);
 
   TyTy::BaseType *resolve_impl_item (HIR::ImplBlock &impl_block,

--- a/gcc/testsuite/rust/compile/issue-2499.rs
+++ b/gcc/testsuite/rust/compile/issue-2499.rs
@@ -1,0 +1,11 @@
+#[lang = "sized"]
+pub trait Sized {}
+
+struct Foo;
+struct Bar;
+
+impl Foo for Bar {}
+// { dg-error "Expected a trait found .Foo. .E0404." "" { target *-*-* } .-1 }
+
+fn baz<T: Foo>(t: T) {}
+// { dg-error "Expected a trait found .Foo. .E0404." "" { target *-*-* } .-1 }

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -255,3 +255,4 @@ issue-3139-3.rs
 issue-3036.rs
 issue-2951.rs
 issue-2203.rs
+issue-2499.rs


### PR DESCRIPTION
We just had an assertion here for this case where we expect a trait. This changes the assertion into error handling producing the correct error code with fixit suggestion like rustc.

```
test.rs:7:6: error: Expected a trait found ‘Foo’ [E0404]
    7 | impl Foo for Bar {}
      |      ^~~
      |      not a trait
test.rs:10:11: error: Expected a trait found ‘Foo’ [E0404]
   10 | fn baz<T: Foo>(t: T) {}
      |           ^~~
      |           not a trait
```

Fixes #2499

gcc/rust/ChangeLog:

	* typecheck/rust-hir-trait-resolve.cc (TraitResolver::resolve_path_to_trait): use error handling instead of assertion
	* typecheck/rust-hir-type-check-item.cc (TypeCheckItem::visit): reuse trait reference
	* typecheck/rust-hir-type-check-item.h: update prototype

gcc/testsuite/ChangeLog:

	* rust/compile/nr2/exclude: nr2 cant handle this
	* rust/compile/issue-2499.rs: New test.