### PR TITLE
Improve `Rib::Definition` shadowing

### DIFF
--- a/gcc/rust/resolve/rust-finalize-imports-2.0.cc
+++ b/gcc/rust/resolve/rust-finalize-imports-2.0.cc
@@ -37,32 +37,32 @@ void
 GlobbingVisitor::visit (AST::Module &module)
 {
   if (module.get_visibility ().is_public ())
-    ctx.insert_shadowable (module.get_name (), module.get_node_id (),
-			   Namespace::Types);
+    ctx.insert_globbed (module.get_name (), module.get_node_id (),
+			Namespace::Types);
 }
 
 void
 GlobbingVisitor::visit (AST::MacroRulesDefinition &macro)
 {
   if (macro.get_visibility ().is_public ())
-    ctx.insert_shadowable (macro.get_rule_name (), macro.get_node_id (),
-			   Namespace::Macros);
+    ctx.insert_globbed (macro.get_rule_name (), macro.get_node_id (),
+			Namespace::Macros);
 }
 
 void
 GlobbingVisitor::visit (AST::Function &function)
 {
   if (function.get_visibility ().is_public ())
-    ctx.insert_shadowable (function.get_function_name (),
-			   function.get_node_id (), Namespace::Values);
+    ctx.insert_globbed (function.get_function_name (), function.get_node_id (),
+			Namespace::Values);
 }
 
 void
 GlobbingVisitor::visit (AST::StaticItem &static_item)
 {
   if (static_item.get_visibility ().is_public ())
-    ctx.insert_shadowable (static_item.get_identifier (),
-			   static_item.get_node_id (), Namespace::Values);
+    ctx.insert_globbed (static_item.get_identifier (),
+			static_item.get_node_id (), Namespace::Values);
 }
 
 void
@@ -70,11 +70,11 @@ GlobbingVisitor::visit (AST::StructStruct &struct_item)
 {
   if (struct_item.get_visibility ().is_public ())
     {
-      ctx.insert_shadowable (struct_item.get_identifier (),
-			     struct_item.get_node_id (), Namespace::Types);
+      ctx.insert_globbed (struct_item.get_identifier (),
+			  struct_item.get_node_id (), Namespace::Types);
       if (struct_item.is_unit_struct ())
-	ctx.insert_shadowable (struct_item.get_identifier (),
-			       struct_item.get_node_id (), Namespace::Values);
+	ctx.insert_globbed (struct_item.get_identifier (),
+			    struct_item.get_node_id (), Namespace::Values);
     }
 }
 
@@ -83,11 +83,11 @@ GlobbingVisitor::visit (AST::TupleStruct &tuple_struct)
 {
   if (tuple_struct.get_visibility ().is_public ())
     {
-      ctx.insert_shadowable (tuple_struct.get_identifier (),
-			     tuple_struct.get_node_id (), Namespace::Types);
+      ctx.insert_globbed (tuple_struct.get_identifier (),
+			  tuple_struct.get_node_id (), Namespace::Types);
 
-      ctx.insert_shadowable (tuple_struct.get_identifier (),
-			     tuple_struct.get_node_id (), Namespace::Values);
+      ctx.insert_globbed (tuple_struct.get_identifier (),
+			  tuple_struct.get_node_id (), Namespace::Values);
     }
 }
 
@@ -95,24 +95,24 @@ void
 GlobbingVisitor::visit (AST::Enum &enum_item)
 {
   if (enum_item.get_visibility ().is_public ())
-    ctx.insert_shadowable (enum_item.get_identifier (),
-			   enum_item.get_node_id (), Namespace::Types);
+    ctx.insert_globbed (enum_item.get_identifier (), enum_item.get_node_id (),
+			Namespace::Types);
 }
 
 void
 GlobbingVisitor::visit (AST::Union &union_item)
 {
   if (union_item.get_visibility ().is_public ())
-    ctx.insert_shadowable (union_item.get_identifier (),
-			   union_item.get_node_id (), Namespace::Values);
+    ctx.insert_globbed (union_item.get_identifier (), union_item.get_node_id (),
+			Namespace::Values);
 }
 
 void
 GlobbingVisitor::visit (AST::ConstantItem &const_item)
 {
   if (const_item.get_visibility ().is_public ())
-    ctx.insert_shadowable (const_item.get_identifier (),
-			   const_item.get_node_id (), Namespace::Values);
+    ctx.insert_globbed (const_item.get_identifier (), const_item.get_node_id (),
+			Namespace::Values);
 }
 
 void

--- a/gcc/rust/resolve/rust-forever-stack.h
+++ b/gcc/rust/resolve/rust-forever-stack.h
@@ -453,6 +453,22 @@ public:
 							      NodeId id);
 
   /**
+   * Insert a new glob-originated definition in the innermost `Rib` in this
+   * stack
+   *
+   * @param name The name of the definition
+   * @param id Its NodeId
+   *
+   * @return `DuplicateNameError` if that node was already present in the Rib,
+   * the node's `NodeId` otherwise.
+   *
+   * @aborts if there are no `Rib`s inserted in the current map, this function
+   *         aborts the program.
+   */
+  tl::expected<NodeId, DuplicateNameError> insert_globbed (Identifier name,
+							   NodeId id);
+
+  /**
    * Insert a new definition at the root of this stack
    *
    * @param name The name of the definition

--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
@@ -154,8 +154,8 @@ Late::visit (AST::IdentifierPattern &identifier)
   // do we insert functions in labels as well?
 
   // We do want to ignore duplicated data because some situations rely on it.
-  std::ignore
-    = ctx.values.insert (identifier.get_ident (), identifier.get_node_id ());
+  std::ignore = ctx.values.insert_shadowable (identifier.get_ident (),
+					      identifier.get_node_id ());
 }
 
 void

--- a/gcc/rust/resolve/rust-name-resolution-context.cc
+++ b/gcc/rust/resolve/rust-name-resolution-context.cc
@@ -64,6 +64,24 @@ NameResolutionContext::insert_shadowable (Identifier name, NodeId id,
     }
 }
 
+tl::expected<NodeId, DuplicateNameError>
+NameResolutionContext::insert_globbed (Identifier name, NodeId id, Namespace ns)
+{
+  switch (ns)
+    {
+    case Namespace::Values:
+      return values.insert_globbed (name, id);
+    case Namespace::Types:
+      return types.insert_globbed (name, id);
+    case Namespace::Macros:
+      return macros.insert_globbed (name, id);
+    case Namespace::Labels:
+    default:
+      // return labels.insert (name, id);
+      rust_unreachable ();
+    }
+}
+
 void
 NameResolutionContext::map_usage (Usage usage, Definition definition)
 {

--- a/gcc/rust/resolve/rust-name-resolution-context.h
+++ b/gcc/rust/resolve/rust-name-resolution-context.h
@@ -175,6 +175,9 @@ public:
   tl::expected<NodeId, DuplicateNameError>
   insert_shadowable (Identifier name, NodeId id, Namespace ns);
 
+  tl::expected<NodeId, DuplicateNameError>
+  insert_globbed (Identifier name, NodeId id, Namespace ns);
+
   /**
    * Run a lambda in a "scoped" context, meaning that a new `Rib` will be pushed
    * before executing the lambda and then popped. This is useful for all kinds

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -194,7 +194,6 @@ redef_error6.rs
 rustc_attr1.rs
 self-path1.rs
 self-path2.rs
-shadow1.rs
 sizeof-stray-infer-var-bug.rs
 specify-crate-name.rs
 stmt_with_block_dot.rs


### PR DESCRIPTION
This modifies `Rib::Definition` in order to better handle shadowing. It splits shadowing declarations into `shadowing` and `globbed` declarations, as shadowing declarations must shadow non-shadowing declarations, but non-shadowing declarations must shadow "globbed" declarations.