### PR TITLE
Use name resolver 2.0 during pattern typechecking

### DIFF
--- a/gcc/rust/resolve/rust-name-resolution-context.cc
+++ b/gcc/rust/resolve/rust-name-resolution-context.cc
@@ -92,7 +92,7 @@ NameResolutionContext::map_usage (Usage usage, Definition definition)
 }
 
 tl::optional<NodeId>
-NameResolutionContext::lookup (NodeId usage)
+NameResolutionContext::lookup (NodeId usage) const
 {
   auto it = resolved_nodes.find (Usage (usage));
 

--- a/gcc/rust/resolve/rust-name-resolution-context.h
+++ b/gcc/rust/resolve/rust-name-resolution-context.h
@@ -213,7 +213,7 @@ public:
   // TODO: Use newtype pattern for Usage and Definition
   void map_usage (Usage usage, Definition definition);
 
-  tl::optional<NodeId> lookup (NodeId usage);
+  tl::optional<NodeId> lookup (NodeId usage) const;
 
 private:
   /* Map of "usage" nodes which have been resolved to a "definition" node */


### PR DESCRIPTION
Also makes `NameResolutionContext::lookup` const qualified