### PR TITLE
Modify test `cfg1.rs` for name resolution 2.0

### DIFF
--- a/gcc/testsuite/rust/compile/cfg1.rs
+++ b/gcc/testsuite/rust/compile/cfg1.rs
@@ -1,4 +1,4 @@
-// { dg-additional-options "-w" }
+// { dg-additional-options "-w -frust-name-resolution-2.0" }
 extern "C" {
     fn printf(s: *const i8, ...);
 }
@@ -27,5 +27,5 @@ fn test() {
 
 fn main() {
     test();
-    // { dg-error "Cannot find path .test. in this scope" "" { target *-*-* } .-1 }
+    // { dg-error "could not resolve path expression: .test." "" { target *-*-* } .-1 }
 }

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -19,7 +19,6 @@ macros/builtin/recurse2.rs
 macros/builtin/include3.rs
 macros/builtin/include4.rs
 canonical_paths1.rs
-cfg1.rs
 cfg3.rs
 cfg4.rs
 cfg5.rs


### PR DESCRIPTION
This PR tweaks `cfg1.rs` so that it passes with name resolution 2.0. As an alternative we could modify the error message emitted by name resolution 2.0 to match that emitted by name resolution 1.0, or to match that emitted by rustc.