### PR TITLE
gccrs: Fix bad recursive operator overload call

### DIFF
--- a/gcc/rust/typecheck/rust-hir-trait-reference.h
+++ b/gcc/rust/typecheck/rust-hir-trait-reference.h
@@ -246,6 +246,8 @@ public:
 
   HIR::ImplBlock *get_impl_block ();
 
+  location_t get_locus () const;
+
   TyTy::BaseType *get_self ();
   const TyTy::BaseType *get_self () const;
 

--- a/gcc/rust/typecheck/rust-hir-trait-resolve.cc
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.cc
@@ -669,6 +669,12 @@ AssociatedImplTrait::reset_associated_types ()
   trait->clear_associated_types ();
 }
 
+location_t
+AssociatedImplTrait::get_locus () const
+{
+  return impl->get_locus ();
+}
+
 Analysis::NodeMapping
 TraitItemReference::get_parent_trait_mappings () const
 {

--- a/gcc/testsuite/rust/compile/issue-3032-1.rs
+++ b/gcc/testsuite/rust/compile/issue-3032-1.rs
@@ -1,0 +1,58 @@
+#![feature(negative_impls)]
+
+#[lang = "sized"]
+trait Sized {}
+
+#[lang = "deref"]
+pub trait Deref {
+    /// The resulting type after dereferencing.
+    #[stable(feature = "rust1", since = "1.0.0")]
+    // #[rustc_diagnostic_item = "deref_target"]
+    type Target: ?Sized;
+
+    /// Dereferences the value.
+    #[must_use]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    // #[rustc_diagnostic_item = "deref_method"]
+    fn deref(&self) -> &Self::Target;
+}
+
+impl<T: ?Sized> Deref for &T {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        *self
+    }
+}
+
+// this is added because of #3030
+extern "C" {
+    fn never() -> !;
+}
+
+impl<T: ?Sized> !DerefMut for &T {
+    fn deref_mut(&mut self) -> &mut T {
+        unsafe { never() }
+    }
+}
+
+impl<T: ?Sized> Deref for &mut T {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        *self
+    }
+}
+
+#[lang = "deref_mut"]
+pub trait DerefMut: Deref {
+    /// Mutably dereferences the value.
+    #[stable(feature = "rust1", since = "1.0.0")]
+    fn deref_mut(&mut self) -> &mut Self::Target;
+}
+
+impl<T: ?Sized> DerefMut for &mut T {
+    fn deref_mut(&mut self) -> &mut T {
+        *self
+    }
+}

--- a/gcc/testsuite/rust/compile/issue-3032-2.rs
+++ b/gcc/testsuite/rust/compile/issue-3032-2.rs
@@ -1,0 +1,49 @@
+#![feature(negative_impls)]
+
+#[lang = "sized"]
+trait Sized {}
+
+#[lang = "deref"]
+pub trait Deref {
+    /// The resulting type after dereferencing.
+    #[stable(feature = "rust1", since = "1.0.0")]
+    // #[rustc_diagnostic_item = "deref_target"]
+    type Target: ?Sized;
+
+    /// Dereferences the value.
+    #[must_use]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    // #[rustc_diagnostic_item = "deref_method"]
+    fn deref(&self) -> &Self::Target;
+}
+
+impl<T: ?Sized> Deref for &T {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        *self
+    }
+}
+
+impl<T: ?Sized> !DerefMut for &T {}
+
+impl<T: ?Sized> Deref for &mut T {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        *self
+    }
+}
+
+#[lang = "deref_mut"]
+pub trait DerefMut: Deref {
+    /// Mutably dereferences the value.
+    #[stable(feature = "rust1", since = "1.0.0")]
+    fn deref_mut(&mut self) -> &mut Self::Target;
+}
+
+impl<T: ?Sized> DerefMut for &mut T {
+    fn deref_mut(&mut self) -> &mut T {
+        *self
+    }
+}

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -235,3 +235,5 @@ issue-3036.rs
 issue-2951.rs
 issue-2203.rs
 issue-2499.rs
+issue-3032-1.rs
+issue-3032-2.rs


### PR DESCRIPTION
When we are typechecking the impl block for DerefMut for &mut T the implementation follows the usual operator overload check but this ended up just resolving directly to the Trait definition which ends up being recursive which we usually handle. The issue we had is that a dereference call can be for either the DEREF or DEREF_MUT lang item here it was looking for a recurisve call to the DEREF lang item but we were in the DEREF_MUT lang item so this case was not accounted for.

Fixes #3032

gcc/rust/ChangeLog:

	* typecheck/rust-hir-trait-reference.h: new get locus helper
	* typecheck/rust-hir-trait-resolve.cc (AssociatedImplTrait::get_locus): implemention
	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::resolve_operator_overload): fix overload

gcc/testsuite/ChangeLog:

	* rust/compile/nr2/exclude:
	* rust/compile/issue-3032-1.rs: New test.
	* rust/compile/issue-3032-2.rs: New test.
