### PR TITLE
Make `TyTy::TupleType::get_unit_type` cache its return value

### DIFF
--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
@@ -100,7 +100,7 @@ Late::setup_builtin_types ()
     }
 
   // ...here!
-  auto *unit_type = TyTy::TupleType::get_unit_type (next_hir_id ());
+  auto *unit_type = TyTy::TupleType::get_unit_type ();
   ty_ctx.insert_builtin (unit_type->get_ref (), next_node_id (), unit_type);
 }
 

--- a/gcc/rust/resolve/rust-name-resolver.cc
+++ b/gcc/rust/resolve/rust-name-resolver.cc
@@ -435,8 +435,7 @@ Resolver::generate_builtins ()
   set_never_type_node_id (never_node_id);
 
   // unit type ()
-  TyTy::TupleType *unit_tyty
-    = TyTy::TupleType::get_unit_type (mappings.get_next_hir_id ());
+  TyTy::TupleType *unit_tyty = TyTy::TupleType::get_unit_type ();
   std::vector<std::unique_ptr<AST::Type> > elems;
   AST::TupleType *unit_type
     = new AST::TupleType (std::move (elems), BUILTINS_LOCATION);

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -131,12 +131,7 @@ TypeCheckExpr::visit (HIR::TupleExpr &expr)
 {
   if (expr.is_unit ())
     {
-      auto unit_node_id = resolver->get_unit_type_node_id ();
-      if (!context->lookup_builtin (unit_node_id, &infered))
-	{
-	  rust_error_at (expr.get_locus (),
-			 "failed to lookup builtin unit type");
-	}
+      infered = TyTy::TupleType::get_unit_type ();
       return;
     }
 
@@ -165,10 +160,9 @@ TypeCheckExpr::visit (HIR::ReturnExpr &expr)
   location_t expr_locus = expr.has_return_expr ()
 			    ? expr.get_expr ()->get_locus ()
 			    : expr.get_locus ();
-  TyTy::BaseType *expr_ty
-    = expr.has_return_expr ()
-	? TypeCheckExpr::Resolve (expr.get_expr ().get ())
-	: TyTy::TupleType::get_unit_type (expr.get_mappings ().get_hirid ());
+  TyTy::BaseType *expr_ty = expr.has_return_expr ()
+			      ? TypeCheckExpr::Resolve (expr.get_expr ().get ())
+			      : TyTy::TupleType::get_unit_type ();
 
   coercion_site (expr.get_mappings ().get_hirid (),
 		 TyTy::TyWithLocation (fn_return_tyty),
@@ -242,7 +236,7 @@ TypeCheckExpr::visit (HIR::CallExpr &expr)
 void
 TypeCheckExpr::visit (HIR::AssignmentExpr &expr)
 {
-  infered = TyTy::TupleType::get_unit_type (expr.get_mappings ().get_hirid ());
+  infered = TyTy::TupleType::get_unit_type ();
 
   auto lhs = TypeCheckExpr::Resolve (expr.get_lhs ().get ());
   auto rhs = TypeCheckExpr::Resolve (expr.get_rhs ().get ());
@@ -256,7 +250,7 @@ TypeCheckExpr::visit (HIR::AssignmentExpr &expr)
 void
 TypeCheckExpr::visit (HIR::CompoundAssignmentExpr &expr)
 {
-  infered = TyTy::TupleType::get_unit_type (expr.get_mappings ().get_hirid ());
+  infered = TyTy::TupleType::get_unit_type ();
 
   auto lhs = TypeCheckExpr::Resolve (expr.get_lhs ().get ());
   auto rhs = TypeCheckExpr::Resolve (expr.get_rhs ().get ());
@@ -465,7 +459,7 @@ TypeCheckExpr::visit (HIR::IfExpr &expr)
 
   TypeCheckExpr::Resolve (expr.get_if_block ().get ());
 
-  infered = TyTy::TupleType::get_unit_type (expr.get_mappings ().get_hirid ());
+  infered = TyTy::TupleType::get_unit_type ();
 }
 
 void
@@ -538,8 +532,7 @@ TypeCheckExpr::visit (HIR::BlockExpr &expr)
 
       if (s->is_unit_check_needed () && !resolved->is_unit ())
 	{
-	  auto unit
-	    = TyTy::TupleType::get_unit_type (s->get_mappings ().get_hirid ());
+	  auto unit = TyTy::TupleType::get_unit_type ();
 	  resolved
 	    = unify_site (s->get_mappings ().get_hirid (),
 			  TyTy::TyWithLocation (unit),
@@ -550,8 +543,7 @@ TypeCheckExpr::visit (HIR::BlockExpr &expr)
   if (expr.has_expr ())
     infered = TypeCheckExpr::Resolve (expr.get_final_expr ().get ())->clone ();
   else if (expr.is_tail_reachable ())
-    infered
-      = TyTy::TupleType::get_unit_type (expr.get_mappings ().get_hirid ());
+    infered = TyTy::TupleType::get_unit_type ();
   else if (expr.has_label ())
     {
       TyTy::BaseType *loop_context_type = context->pop_loop_context ();
@@ -563,8 +555,7 @@ TypeCheckExpr::visit (HIR::BlockExpr &expr)
 		  != TyTy::InferType::GENERAL));
 
       infered = loop_context_type_infered ? loop_context_type
-					  : TyTy::TupleType::get_unit_type (
-					    expr.get_mappings ().get_hirid ());
+					  : TyTy::TupleType::get_unit_type ();
     }
   else
     {
@@ -773,8 +764,7 @@ TypeCheckExpr::visit (HIR::InlineAsm &expr)
   if (expr.options.count (AST::InlineAsmOption::NORETURN) == 1)
     infered = new TyTy::NeverType (expr.get_mappings ().get_hirid ());
   else
-    infered
-      = TyTy::TupleType::get_unit_type (expr.get_mappings ().get_hirid ());
+    infered = TyTy::TupleType::get_unit_type ();
 }
 
 void
@@ -1295,10 +1285,8 @@ TypeCheckExpr::visit (HIR::LoopExpr &expr)
 	  && (((TyTy::InferType *) loop_context_type)->get_infer_kind ()
 	      != TyTy::InferType::GENERAL));
 
-  infered
-    = loop_context_type_infered
-	? loop_context_type
-	: TyTy::TupleType::get_unit_type (expr.get_mappings ().get_hirid ());
+  infered = loop_context_type_infered ? loop_context_type
+				      : TyTy::TupleType::get_unit_type ();
 }
 
 void
@@ -1319,7 +1307,7 @@ TypeCheckExpr::visit (HIR::WhileLoopExpr &expr)
     }
 
   context->pop_loop_context ();
-  infered = TyTy::TupleType::get_unit_type (expr.get_mappings ().get_hirid ());
+  infered = TyTy::TupleType::get_unit_type ();
 }
 
 void
@@ -1506,8 +1494,7 @@ TypeCheckExpr::visit (HIR::MatchExpr &expr)
 
   if (kase_block_tys.size () == 0)
     {
-      infered
-	= TyTy::TupleType::get_unit_type (expr.get_mappings ().get_hirid ());
+      infered = TyTy::TupleType::get_unit_type ();
       return;
     }
 

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.cc
@@ -113,8 +113,7 @@ TypeCheckTopLevelExternItem::visit (HIR::ExternalFunctionItem &function)
 
   TyTy::BaseType *ret_type = nullptr;
   if (!function.has_return_type ())
-    ret_type
-      = TyTy::TupleType::get_unit_type (function.get_mappings ().get_hirid ());
+    ret_type = TyTy::TupleType::get_unit_type ();
   else
     {
       auto resolved
@@ -359,8 +358,7 @@ TypeCheckImplItem::visit (HIR::Function &function)
 
   TyTy::BaseType *ret_type = nullptr;
   if (!function.has_function_return_type ())
-    ret_type
-      = TyTy::TupleType::get_unit_type (function.get_mappings ().get_hirid ());
+    ret_type = TyTy::TupleType::get_unit_type ();
   else
     {
       auto resolved

--- a/gcc/rust/typecheck/rust-hir-type-check-item.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.cc
@@ -558,8 +558,7 @@ TypeCheckItem::visit (HIR::Function &function)
 
   TyTy::BaseType *ret_type = nullptr;
   if (!function.has_function_return_type ())
-    ret_type
-      = TyTy::TupleType::get_unit_type (function.get_mappings ().get_hirid ());
+    ret_type = TyTy::TupleType::get_unit_type ();
   else
     {
       auto resolved

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.cc
@@ -44,7 +44,7 @@ TypeCheckStmt::visit (HIR::ExprStmt &stmt)
 void
 TypeCheckStmt::visit (HIR::EmptyStmt &stmt)
 {
-  infered = TyTy::TupleType::get_unit_type (stmt.get_mappings ().get_hirid ());
+  infered = TyTy::TupleType::get_unit_type ();
 }
 
 void
@@ -74,7 +74,7 @@ TypeCheckStmt::visit (HIR::ConstantItem &constant)
 void
 TypeCheckStmt::visit (HIR::LetStmt &stmt)
 {
-  infered = TyTy::TupleType::get_unit_type (stmt.get_mappings ().get_hirid ());
+  infered = TyTy::TupleType::get_unit_type ();
 
   HIR::Pattern &stmt_pattern = *stmt.get_pattern ();
   TyTy::BaseType *init_expr_ty = nullptr;

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -88,7 +88,7 @@ TypeCheckType::visit (HIR::BareFunctionType &fntype)
     {
       // needs a new implicit ID
       HirId ref = mappings.get_next_hir_id ();
-      return_type = TyTy::TupleType::get_unit_type (ref);
+      return_type = TyTy::TupleType::get_unit_type ();
       context->insert_implicit_type (ref, return_type);
     }
 

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -206,7 +206,7 @@ TraitItemReference::get_type_from_fn (/*const*/ HIR::TraitItemFunc &fn) const
 
   TyTy::BaseType *ret_type = nullptr;
   if (!function.has_return_type ())
-    ret_type = TyTy::TupleType::get_unit_type (fn.get_mappings ().get_hirid ());
+    ret_type = TyTy::TupleType::get_unit_type ();
   else
     {
       auto resolved

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -1747,9 +1747,13 @@ TupleType::TupleType (HirId ref, HirId ty_ref, location_t locus,
 {}
 
 TupleType *
-TupleType::get_unit_type (HirId ref)
+TupleType::get_unit_type ()
 {
-  return new TupleType (ref, BUILTINS_LOCATION);
+  static TupleType *ret = nullptr;
+  if (ret == nullptr)
+    ret = new TupleType (Analysis::Mappings::get ().get_next_hir_id (),
+			 BUILTINS_LOCATION);
+  return ret;
 }
 
 size_t

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -447,7 +447,7 @@ public:
 	     std::vector<TyVar> fields = std::vector<TyVar> (),
 	     std::set<HirId> refs = std::set<HirId> ());
 
-  static TupleType *get_unit_type (HirId ref);
+  static TupleType *get_unit_type ();
 
   void accept_vis (TyVisitor &vis) override;
   void accept_vis (TyConstVisitor &vis) const override;


### PR DESCRIPTION
This removes a call to `Resolver::get_unit_type_node_id`, which relies on the old resolver calling `Resolver::set_unit_type_node_id`