### PR TITLE
gccrs: fix bad type inferencing on path's

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-path.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-path.cc
@@ -490,14 +490,6 @@ TypeCheckExpr::resolve_segments (NodeId root_resolved_node_id,
     }
 
   rust_assert (resolved_node_id != UNKNOWN_NODEID);
-  if (tyseg->needs_generic_substitutions () && !reciever_is_generic)
-    {
-      location_t locus = segments.back ().get_locus ();
-      tyseg = SubstMapper::InferSubst (tyseg, locus);
-      if (tyseg->get_kind () == TyTy::TypeKind::ERROR)
-	return;
-    }
-
   context->insert_receiver (expr_mappings.get_hirid (), prev_segment);
 
   // name scope first

--- a/gcc/testsuite/rust/compile/issue-3009.rs
+++ b/gcc/testsuite/rust/compile/issue-3009.rs
@@ -1,0 +1,24 @@
+#[lang = "sized"]
+trait Sized {}
+
+struct Foo {
+    // { dg-warning "struct is never constructed" "" { target *-*-* } .-1 }
+    t: u64,
+}
+
+impl Foo {
+    fn of<T>() -> Foo {
+        // { dg-warning "associated function is never used" "" { target *-*-* } .-1 }
+        Foo { t: 14 }
+    }
+}
+
+trait Bar {
+    fn bar() -> Foo;
+}
+
+impl<T> Bar for T {
+    fn bar() -> Foo {
+        Foo::of::<T>()
+    }
+}

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -221,4 +221,5 @@ issue-3032-2.rs
 if_let_expr_simple.rs
 iflet.rs
 issue-3033.rs
+issue-3009.rs
 # please don't delete the trailing newline


### PR DESCRIPTION
This catch to inject inference variables into generic paths was a catch all 'hack' that we needed before we handled generics correctly as we do now.

Fixes #3009

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-path.cc (TypeCheckExpr::resolve_segments): remove hack

gcc/testsuite/ChangeLog:

	* rust/compile/nr2/exclude: nr2 cant handle this
	* rust/compile/issue-3009.rs: New test.
