### PR TITLE
Remove usage of `Resolver::get_builtin_types`

### DIFF
--- a/gcc/rust/backend/rust-compile-context.cc
+++ b/gcc/rust/backend/rust-compile-context.cc
@@ -33,19 +33,8 @@ Context::Context ()
 void
 Context::setup_builtins ()
 {
-  auto builtins = resolver->get_builtin_types ();
-  for (auto it = builtins.begin (); it != builtins.end (); it++)
-    {
-      HirId ref;
-      bool ok = tyctx->lookup_type_by_node_id ((*it)->get_node_id (), &ref);
-      rust_assert (ok);
-
-      TyTy::BaseType *lookup;
-      ok = tyctx->lookup_type (ref, &lookup);
-      rust_assert (ok);
-
-      TyTyResolveCompile::compile (this, lookup);
-    }
+  for (auto &builtin : tyctx->get_builtins ())
+    TyTyResolveCompile::compile (this, builtin.get ());
 }
 
 hashval_t

--- a/gcc/rust/typecheck/rust-hir-type-check.h
+++ b/gcc/rust/typecheck/rust-hir-type-check.h
@@ -135,6 +135,7 @@ public:
   bool lookup_builtin (NodeId id, TyTy::BaseType **type);
   bool lookup_builtin (std::string name, TyTy::BaseType **type);
   void insert_builtin (HirId id, NodeId ref, TyTy::BaseType *type);
+  const std::vector<std::unique_ptr<TyTy::BaseType>> &get_builtins () const;
 
   void insert_type (const Analysis::NodeMapping &mappings,
 		    TyTy::BaseType *type);

--- a/gcc/rust/typecheck/rust-typecheck-context.cc
+++ b/gcc/rust/typecheck/rust-typecheck-context.cc
@@ -73,6 +73,12 @@ TypeCheckContext::insert_builtin (HirId id, NodeId ref, TyTy::BaseType *type)
   builtins.push_back (std::unique_ptr<TyTy::BaseType> (type));
 }
 
+const std::vector<std::unique_ptr<TyTy::BaseType>> &
+TypeCheckContext::get_builtins () const
+{
+  return builtins;
+}
+
 void
 TypeCheckContext::insert_type (const Analysis::NodeMapping &mappings,
 			       TyTy::BaseType *type)


### PR DESCRIPTION
This simplifies `Context::setup_builtins` and removes a direct dependency on the old name resolver