### PR TITLE
gccrs: fix bad type inference on local patterns

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-path.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-path.cc
@@ -245,6 +245,7 @@ TypeCheckExpr::resolve_root_path (HIR::PathInExpression &expr, size_t *offset,
 
       auto seg_is_module = mappings.lookup_module (ref).has_value ();
       auto seg_is_crate = mappings.is_local_hirid_crate (ref);
+      auto seg_is_pattern = mappings.lookup_hir_pattern (ref).has_value ();
       if (seg_is_module || seg_is_crate)
 	{
 	  // A::B::C::this_is_a_module::D::E::F
@@ -321,7 +322,7 @@ TypeCheckExpr::resolve_root_path (HIR::PathInExpression &expr, size_t *offset,
 	  if (lookup->get_kind () == TyTy::TypeKind::ERROR)
 	    return new TyTy::ErrorType (expr.get_mappings ().get_hirid ());
 	}
-      else if (lookup->needs_generic_substitutions ())
+      else if (lookup->needs_generic_substitutions () && !seg_is_pattern)
 	{
 	  lookup = SubstMapper::InferSubst (lookup, expr.get_locus ());
 	}

--- a/gcc/testsuite/rust/compile/issue-2323.rs
+++ b/gcc/testsuite/rust/compile/issue-2323.rs
@@ -1,0 +1,9 @@
+#[lang = "sized"]
+trait Sized {}
+
+pub struct S<T>(T);
+
+pub fn foo<T>(x: T) {
+    let y = S(x);
+    y.0;
+}

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -222,4 +222,5 @@ if_let_expr_simple.rs
 iflet.rs
 issue-3033.rs
 issue-3009.rs
+issue-2323.rs
 # please don't delete the trailing newline


### PR DESCRIPTION
We do not need to inject inference variables on generic patterns with generic blocks. This will just cause unconstrained inference variables as they may not unify against something.

Fixes #2323

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-path.cc (TypeCheckExpr::resolve_root_path): dont infer here

gcc/testsuite/ChangeLog:

	* rust/compile/nr2/exclude: nr2 cant handle this
	* rust/compile/issue-2323.rs: New test.
