### PR TITLE
Improve handling of implicit `Self` parameter in AST

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-item.cc
+++ b/gcc/rust/hir/rust-ast-lower-item.cc
@@ -572,6 +572,12 @@ ASTLoweringItem::visit (AST::Trait &trait)
       generic_params = lower_generic_params (trait.get_generic_params ());
     }
 
+  // TODO: separate "Self" from normal generic parameters
+  //       in HIR as well as in AST?
+  HIR::GenericParam *self_param
+    = ASTLowerGenericParam::translate (trait.get_implicit_self ());
+  generic_params.emplace (generic_params.begin (), self_param);
+
   std::vector<std::unique_ptr<HIR::TypeParamBound>> type_param_bounds;
   if (trait.has_type_param_bounds ())
     {

--- a/gcc/rust/resolve/rust-ast-resolve-item.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-item.cc
@@ -755,20 +755,14 @@ ResolveItem::visit (AST::Trait &trait)
   resolver->push_new_name_rib (resolver->get_name_scope ().peek ());
   resolver->push_new_type_rib (resolver->get_type_scope ().peek ());
 
-  // we need to inject an implicit self TypeParam here
-  // FIXME: which location should be used for Rust::Identifier `Self`?
-  AST::TypeParam *implicit_self
-    = new AST::TypeParam ({"Self"}, trait.get_locus ());
-  trait.insert_implict_self (
-    std::unique_ptr<AST::GenericParam> (implicit_self));
-  CanonicalPath Self = CanonicalPath::get_big_self (trait.get_node_id ());
-
+  ResolveGenericParam::go (trait.get_implicit_self (), prefix,
+			   canonical_prefix);
   for (auto &generic : trait.get_generic_params ())
     ResolveGenericParam::go (*generic, prefix, canonical_prefix);
 
   // Self is an implicit TypeParam so lets mark it as such
   resolver->get_type_scope ().append_reference_for_def (
-    Self.get_node_id (), implicit_self->get_node_id ());
+    trait.get_node_id (), trait.get_implicit_self ().get_node_id ());
 
   if (trait.has_type_param_bounds ())
     {

--- a/gcc/rust/resolve/rust-early-name-resolver.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver.cc
@@ -353,6 +353,8 @@ EarlyNameResolver::visit (AST::TraitItemType &)
 void
 EarlyNameResolver::visit (AST::Trait &trait)
 {
+  // shouldn't need to visit trait.get_implicit_self ()
+
   for (auto &generic : trait.get_generic_params ())
     generic->accept_vis (*this);
 

--- a/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
@@ -103,23 +103,6 @@ TopLevel::visit (AST::Module &module)
 void
 TopLevel::visit (AST::Trait &trait)
 {
-  // FIXME: This Self injection is dodgy. It even lead to issues with metadata
-  // export in the past (#2349). We cannot tell appart injected parameters from
-  // regular ones. Dumping generic parameters highlights this Self in metadata,
-  // during debug or proc macro collection. This is clearly a hack.
-  //
-  // For now I'll keep it here in the new name resolver even if it should
-  // probably not be there. We need to find another way to solve this.
-  // Maybe an additional attribute to Trait ?
-  //
-  // From old resolver:
-  //// we need to inject an implicit self TypeParam here
-  //// FIXME: which location should be used for Rust::Identifier `Self`?
-  AST::TypeParam *implicit_self
-    = new AST::TypeParam ({"Self"}, trait.get_locus ());
-  trait.insert_implict_self (
-    std::unique_ptr<AST::GenericParam> (implicit_self));
-
   insert_or_error_out (trait.get_identifier ().as_string (), trait,
 		       Namespace::Types);
 

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -1,9 +1,6 @@
 attr-mismatch-crate-name.rs
 attr_deprecated.rs
 attr_deprecated_2.rs
-auto_trait_super_trait.rs
-auto_trait_valid.rs
-auto_trait_invalid.rs
 bad=file-name.rs
 bounds1.rs
 break-rust2.rs
@@ -152,7 +149,6 @@ privacy1.rs
 privacy3.rs
 privacy4.rs
 privacy5.rs
-privacy6.rs
 privacy8.rs
 macros/proc/attribute_non_function.rs
 macros/proc/derive_non_function.rs
@@ -171,8 +167,6 @@ specify-crate-name.rs
 stmt_with_block_dot.rs
 struct-expr-parse.rs
 traits1.rs
-traits10.rs
-traits11.rs
 traits12.rs
 traits2.rs
 traits3.rs
@@ -181,7 +175,6 @@ traits5.rs
 traits6.rs
 traits7.rs
 traits8.rs
-traits9.rs
 type-bindings1.rs
 unconstrained_type_param.rs
 undeclared_label.rs
@@ -191,7 +184,6 @@ v0-mangle1.rs
 v0-mangle2.rs
 while_break_expr.rs
 negative_impls.rs
-auto_trait.rs
 exhaustiveness1.rs
 exhaustiveness2.rs
 exhaustiveness3.rs
@@ -199,7 +191,6 @@ trait13.rs
 trait14.rs
 issue-2324-1.rs
 issue-2324-2.rs
-issue-2725.rs
 issue-2987.rs
 issue-3045-1.rs
 issue-3045-2.rs

--- a/gcc/testsuite/rust/link/generic_function_0.rs
+++ b/gcc/testsuite/rust/link/generic_function_0.rs
@@ -1,6 +1,3 @@
-// { dg-xfail-if "https://github.com/Rust-GCC/gccrs/issues/2349" { *-*-* } }
-// { dg-excess-errors "" { xfail *-*-* } }
-
 extern crate generic_function_1;
 use generic_function_1::generic_function;
 

--- a/gcc/testsuite/rust/link/trait_import_0.rs
+++ b/gcc/testsuite/rust/link/trait_import_0.rs
@@ -1,6 +1,3 @@
-// { dg-xfail-if "https://github.com/Rust-GCC/gccrs/issues/2349" { *-*-* } }
-// { dg-excess-errors "" { xfail *-*-* } }
-
 extern crate trait_import_1;
 use trait_import_1::Add;
 

--- a/gcc/testsuite/rust/link/trait_import_1.rs
+++ b/gcc/testsuite/rust/link/trait_import_1.rs
@@ -1,3 +1,6 @@
+#[lang = "sized"]
+pub trait Sized {}
+
 #[lang = "add"]
 pub trait Add<Rhs = Self> {
     type Output;


### PR DESCRIPTION
This should partially address #2349, although I'm not sure why `trait_import_*.rs` tests are still failing