### PR TITLE
gccrs: add test case to show issue is fixed

### DIFF
--- a/gcc/testsuite/rust/compile/issue-1773.rs
+++ b/gcc/testsuite/rust/compile/issue-1773.rs
@@ -1,8 +1,4 @@
-#[lang = "sized"]
-// { dg-skip-if "" { *-*-* } }
-pub trait Sized {}
-
-trait Foo<T> {
+trait Foo {
     type A;
 
     fn test(a: Self::A) -> Self::A {
@@ -10,9 +6,14 @@ trait Foo<T> {
     }
 }
 
-struct Bar<T>(T);
-impl<T> Foo<T> for Bar<i32> {
-    type A = T;
+struct Bar(i32);
+impl Foo for Bar {
+    type A = i32;
+}
+
+struct Baz(f32);
+impl Foo for Baz {
+    type A = f32;
 }
 
 fn main() {
@@ -21,4 +22,10 @@ fn main() {
 
     let b;
     b = Bar::test(a.0);
+
+    let c;
+    c = Baz(123f32);
+
+    let d;
+    d = Baz::test(c.0);
 }

--- a/gcc/testsuite/rust/compile/issue-3242.rs
+++ b/gcc/testsuite/rust/compile/issue-3242.rs
@@ -1,0 +1,24 @@
+#[lang = "sized"]
+// { dg-skip-if "" { *-*-* } }
+pub trait Sized {}
+
+trait Foo<T> {
+    type A;
+
+    fn test(a: Self::A) -> Self::A {
+        a
+    }
+}
+
+struct Bar<T>(T);
+impl<T> Foo<T> for Bar<i32> {
+    type A = T;
+}
+
+fn main() {
+    let a;
+    a = Bar(123);
+
+    let b;
+    b = Bar::test(a.0);
+}

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -225,4 +225,5 @@ issue-3009.rs
 issue-2323.rs
 issue-2953-1.rs
 issue-2953-2.rs
+issue-1773.rs
 # please don't delete the trailing newline


### PR DESCRIPTION
The original test case 1773 has been moved to a new issue 3242 which is still open and test-case is skipped. The original issue in 1773 is fixed so this will close out that issue

Fixes #1773

gcc/testsuite/ChangeLog:

	* rust/compile/issue-1773.rs: new test case
	* rust/compile/nr2/exclude: nr2 cant handle this
	* rust/compile/issue-3242.rs: old test ranamed to match issue.