### PR TITLE
Cleanup clang warnings

### DIFF
--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -4810,14 +4810,14 @@ public:
       rust_assert (this->expr != nullptr);
     }
 
-    In (const struct In &other)
+    In (const In &other)
     {
       reg = other.reg;
 
       expr = other.expr->clone_expr ();
     }
 
-    In operator= (const struct In &other)
+    In operator= (const In &other)
     {
       reg = other.reg;
       expr = other.expr->clone_expr ();
@@ -4843,14 +4843,14 @@ public:
       rust_assert (this->expr != nullptr);
     }
 
-    Out (const struct Out &other)
+    Out (const Out &other)
     {
       reg = other.reg;
       late = other.late;
       expr = other.expr->clone_expr ();
     }
 
-    Out operator= (const struct Out &other)
+    Out operator= (const Out &other)
     {
       reg = other.reg;
       late = other.late;
@@ -4876,14 +4876,14 @@ public:
       rust_assert (this->expr != nullptr);
     }
 
-    InOut (const struct InOut &other)
+    InOut (const InOut &other)
     {
       reg = other.reg;
       late = other.late;
       expr = other.expr->clone_expr ();
     }
 
-    InOut operator= (const struct InOut &other)
+    InOut operator= (const InOut &other)
     {
       reg = other.reg;
       late = other.late;
@@ -4913,7 +4913,7 @@ public:
       rust_assert (this->out_expr != nullptr);
     }
 
-    SplitInOut (const struct SplitInOut &other)
+    SplitInOut (const SplitInOut &other)
     {
       reg = other.reg;
       late = other.late;
@@ -4921,7 +4921,7 @@ public:
       out_expr = other.out_expr->clone_expr ();
     }
 
-    SplitInOut operator= (const struct SplitInOut &other)
+    SplitInOut operator= (const SplitInOut &other)
     {
       reg = other.reg;
       late = other.late;
@@ -4953,12 +4953,12 @@ public:
     {
       rust_assert (this->expr != nullptr);
     }
-    Sym (const struct Sym &other)
+    Sym (const Sym &other)
     {
       expr = std::unique_ptr<Expr> (other.expr->clone_expr ());
     }
 
-    Sym operator= (const struct Sym &other)
+    Sym operator= (const Sym &other)
     {
       expr = std::unique_ptr<Expr> (other.expr->clone_expr ());
       return *this;
@@ -4981,12 +4981,12 @@ public:
       if (label_name.has_value ())
 	this->label_name = label_name.value ();
     }
-    Label (const struct Label &other)
+    Label (const Label &other)
     {
       expr = std::unique_ptr<Expr> (other.expr->clone_expr ());
     }
 
-    Label operator= (const struct Label &other)
+    Label operator= (const Label &other)
     {
       expr = std::unique_ptr<Expr> (other.expr->clone_expr ());
       return *this;

--- a/gcc/rust/backend/rust-compile-asm.cc
+++ b/gcc/rust/backend/rust-compile-asm.cc
@@ -3,9 +3,8 @@
 namespace Rust {
 namespace Compile {
 
-CompileAsm::CompileAsm (Context *ctx)
-  : HIRCompileBase (ctx), translated (error_mark_node)
-{}
+CompileAsm::CompileAsm (Context *ctx) : HIRCompileBase (ctx) {}
+
 tree
 CompileAsm::tree_codegen_asm (HIR::InlineAsm &expr)
 {

--- a/gcc/rust/backend/rust-compile-asm.h
+++ b/gcc/rust/backend/rust-compile-asm.h
@@ -28,8 +28,6 @@ namespace Compile {
 class CompileAsm : private HIRCompileBase
 {
 private:
-  tree translated;
-
   // RELEVANT MEMBER FUNCTIONS
 
   // The limit is 5 because it stands for the 5 things that the C version of

--- a/gcc/rust/checks/errors/rust-unsafe-checker.h
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.h
@@ -113,7 +113,7 @@ private:
   virtual void visit (MatchExpr &expr) override;
   virtual void visit (AwaitExpr &expr) override;
   virtual void visit (AsyncBlockExpr &expr) override;
-  virtual void visit (InlineAsm &expr);
+  virtual void visit (InlineAsm &expr) override;
   virtual void visit (TypeParam &param) override;
   virtual void visit (ConstGenericParam &param) override;
   virtual void visit (LifetimeWhereClauseItem &item) override;

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -3700,7 +3700,6 @@ struct AnonConst
     return *this;
   }
 };
-;
 
 class InlineAsmOperand
 {
@@ -3888,7 +3887,6 @@ private:
   tl::optional<struct Const> cnst;
   tl::optional<struct Sym> sym;
   tl::optional<struct Label> label;
-  location_t locus;
 
 public:
   InlineAsmOperand (const InlineAsmOperand &other)
@@ -3931,6 +3929,7 @@ public:
   struct Sym get_sym () const { return sym.value (); }
   struct Label get_label () const { return label.value (); }
 };
+
 // Inline Assembly Node
 class InlineAsm : public ExprWithoutBlock
 {
@@ -4009,6 +4008,7 @@ public:
 
   {}
 };
+
 } // namespace HIR
 } // namespace Rust
 

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -673,7 +673,7 @@ public:
   // Returns whether the lifetime param has an outer attribute.
   bool has_outer_attribute () const override { return outer_attrs.size () > 1; }
 
-  AST::AttrVec &get_outer_attrs () { return outer_attrs; }
+  AST::AttrVec &get_outer_attrs () override { return outer_attrs; }
 
   // Returns whether the lifetime param is in an error state.
   bool is_error () const { return lifetime.is_error (); }

--- a/gcc/rust/typecheck/rust-tyty-call.h
+++ b/gcc/rust/typecheck/rust-tyty-call.h
@@ -73,14 +73,12 @@ private:
   TypeCheckCallExpr (HIR::CallExpr &c, TyTy::VariantDef &variant,
 		     Resolver::TypeCheckContext *context)
     : resolved (new TyTy::ErrorType (c.get_mappings ().get_hirid ())), call (c),
-      variant (variant), context (context),
-      mappings (Analysis::Mappings::get ())
+      variant (variant), mappings (Analysis::Mappings::get ())
   {}
 
   BaseType *resolved;
   HIR::CallExpr &call;
   TyTy::VariantDef &variant;
-  Resolver::TypeCheckContext *context;
   Analysis::Mappings &mappings;
 };
 


### PR DESCRIPTION
- **hir: Mark AttrVec::get_outer_attrs as override**
- **typecheck: Remove unused parameter in TyTyCheckCallExpr**
- **asm: Fix clang warnings**
