### PR TITLE
Push ribs by kind rather than by value

### DIFF
--- a/gcc/rust/resolve/rust-forever-stack.h
+++ b/gcc/rust/resolve/rust-forever-stack.h
@@ -416,7 +416,7 @@ public:
    * @param path An optional path if the Rib was created due to a "named"
    *        lexical scope, like a module's.
    */
-  void push (Rib rib, NodeId id, tl::optional<Identifier> path = {});
+  void push (Rib::Kind rib_kind, NodeId id, tl::optional<Identifier> path = {});
 
   /**
    * Pop the innermost Rib from the stack

--- a/gcc/rust/resolve/rust-forever-stack.hxx
+++ b/gcc/rust/resolve/rust-forever-stack.hxx
@@ -52,9 +52,10 @@ ForeverStack<N>::Node::insert_child (Link link, Node child)
 
 template <Namespace N>
 void
-ForeverStack<N>::push (Rib rib, NodeId id, tl::optional<Identifier> path)
+ForeverStack<N>::push (Rib::Kind rib_kind, NodeId id,
+		       tl::optional<Identifier> path)
 {
-  push_inner (rib, Link (id, path));
+  push_inner (rib_kind, Link (id, path));
 }
 
 template <Namespace N>

--- a/gcc/rust/resolve/rust-name-resolution-context.cc
+++ b/gcc/rust/resolve/rust-name-resolution-context.cc
@@ -103,13 +103,13 @@ NameResolutionContext::lookup (NodeId usage) const
 }
 
 void
-NameResolutionContext::scoped (Rib rib, NodeId id,
+NameResolutionContext::scoped (Rib::Kind rib_kind, NodeId id,
 			       std::function<void (void)> lambda,
 			       tl::optional<Identifier> path)
 {
-  values.push (rib, id, path);
-  types.push (rib, id, path);
-  macros.push (rib, id, path);
+  values.push (rib_kind, id, path);
+  types.push (rib_kind, id, path);
+  macros.push (rib_kind, id, path);
   // labels.push (rib, id);
 
   lambda ();
@@ -121,17 +121,18 @@ NameResolutionContext::scoped (Rib rib, NodeId id,
 }
 
 void
-NameResolutionContext::scoped (Rib rib, Namespace ns, NodeId scope_id,
+NameResolutionContext::scoped (Rib::Kind rib_kind, Namespace ns,
+			       NodeId scope_id,
 			       std::function<void (void)> lambda,
 			       tl::optional<Identifier> path)
 {
   switch (ns)
     {
     case Namespace::Values:
-      values.push (rib, scope_id, path);
+      values.push (rib_kind, scope_id, path);
       break;
     case Namespace::Types:
-      types.push (rib, scope_id, path);
+      types.push (rib_kind, scope_id, path);
       break;
     case Namespace::Labels:
     case Namespace::Macros:

--- a/gcc/rust/resolve/rust-name-resolution-context.h
+++ b/gcc/rust/resolve/rust-name-resolution-context.h
@@ -185,8 +185,8 @@ public:
    * function. This variant of the function enters a new scope in *all*
    * namespaces, while the second variant enters a scope in *one* namespace.
    *
-   * @param rib New `Rib` to create when entering this scope. A function `Rib`,
-   *        or an item `Rib`... etc
+   * @param rib_kind New `Rib` to create when entering this scope. A function
+   *        `Rib`, or an item `Rib`... etc
    * @param scope_id node ID of the scope we are entering, e.g the block's
    *        `NodeId`.
    * @param lambda Function to run within that scope
@@ -196,9 +196,10 @@ public:
    */
   // FIXME: Do we want to handle something in particular for expected within the
   // scoped lambda?
-  void scoped (Rib rib, NodeId scope_id, std::function<void (void)> lambda,
+  void scoped (Rib::Kind rib_kind, NodeId scope_id,
+	       std::function<void (void)> lambda,
 	       tl::optional<Identifier> path = {});
-  void scoped (Rib rib, Namespace ns, NodeId scope_id,
+  void scoped (Rib::Kind rib_kind, Namespace ns, NodeId scope_id,
 	       std::function<void (void)> lambda,
 	       tl::optional<Identifier> path = {});
 


### PR DESCRIPTION
Usually, calling these methods would involve an implicit construction of `Rib` from `Rib::Kind`, but just using a `Rib::Kind` as long as possible should work better.