### PR TITLE
Prepend crate name to functions with nr2

### DIFF
--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -25,7 +25,8 @@
 #include "rust-compile-type.h"
 #include "rust-constexpr.h"
 #include "rust-diagnostics.h"
-#include "rust-expr.h"	// for AST::AttrInputLiteral
+#include "rust-expr.h" // for AST::AttrInputLiteral
+#include "rust-hir-map.h"
 #include "rust-macro.h" // for AST::MetaNameValueStr
 #include "rust-hir-path-probe.h"
 #include "rust-type-util.h"
@@ -38,6 +39,9 @@
 #include "attribs.h"
 #include "tree.h"
 #include "print-tree.h"
+
+// rust-name-resolution-2.0
+#include "options.h"
 
 namespace Rust {
 namespace Compile {
@@ -666,6 +670,11 @@ HIRCompileBase::compile_function (
       main_identifier_node = get_identifier (ir_symbol_name.c_str ());
     }
   std::string asm_name = fn_name;
+
+  auto &mappings = Analysis::Mappings::get ();
+
+  if (flag_name_resolution_2_0)
+    ir_symbol_name = mappings.get_current_crate_name () + "::" + ir_symbol_name;
 
   unsigned int flags = 0;
   tree fndecl = Backend::function (compiled_fn_type, ir_symbol_name,

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -1,7 +1,3 @@
-attr-mismatch-crate-name.rs
-attr_deprecated.rs
-attr_deprecated_2.rs
-bad=file-name.rs
 bounds1.rs
 break-rust2.rs
 break-rust3.rs
@@ -45,7 +41,6 @@ generics6.rs
 generics8.rs
 generics9.rs
 if_let_expr.rs
-infer-crate-name.rs
 issue-1019.rs
 issue-1031.rs
 issue-1034.rs
@@ -156,7 +151,6 @@ redef_error6.rs
 self-path1.rs
 self-path2.rs
 sizeof-stray-infer-var-bug.rs
-specify-crate-name.rs
 stmt_with_block_dot.rs
 struct-expr-parse.rs
 traits1.rs


### PR DESCRIPTION
Some pre nr2 were relying on function name, those name are prefixed with the crate's name.