### PR TITLE
Fix rust breakage with nr2

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -133,6 +133,7 @@ GRS_OBJS = \
     rust/rust-toplevel-name-resolver-2.0.o \
     rust/rust-early-name-resolver-2.0.o \
 	rust/rust-finalize-imports-2.0.o \
+	rust/rust-ice-finalizer.o \
     rust/rust-late-name-resolver-2.0.o \
 	rust/rust-immutable-name-resolution-context.o \
     rust/rust-early-name-resolver.o \

--- a/gcc/rust/resolve/rust-ast-resolve-expr.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.cc
@@ -22,8 +22,8 @@
 #include "rust-ast-resolve-type.h"
 #include "rust-ast-resolve-pattern.h"
 #include "rust-ast-resolve-path.h"
-#include "diagnostic.h"
 #include "rust-expr.h"
+#include "rust-ice-finalizer.h"
 
 namespace Rust {
 namespace Resolver {
@@ -106,45 +106,6 @@ ResolveExpr::visit (AST::AssignmentExpr &expr)
 {
   ResolveExpr::go (expr.get_left_expr (), prefix, canonical_prefix);
   ResolveExpr::go (expr.get_right_expr (), prefix, canonical_prefix);
-}
-
-/* The "break rust" Easter egg.
-
-   Backstory: once upon a time, there used to be a bug in rustc: it would ICE
-   during typechecking on a 'break' with an expression outside of a loop.  The
-   issue has been reported [0] and fixed [1], but in recognition of this, as a
-   special Easter egg, "break rust" was made to intentionally cause an ICE.
-
-   [0]: https://github.com/rust-lang/rust/issues/43162
-   [1]: https://github.com/rust-lang/rust/pull/43745
-
-   This was made in a way that does not break valid programs: namely, it only
-   happens when the 'break' is outside of a loop (so invalid anyway).
-
-   GCC Rust supports this essential feature as well, but in a slightly
-   different way.  Instead of delaying the error until type checking, we emit
-   it here in the resolution phase.  We, too, only do this to programs that
-   are already invalid: we only emit our funny ICE if the name "rust" (which
-   must be immediately inside a break-with-a-value expression) fails to
-   resolve.  Note that "break (rust)" does not trigger our ICE, only using
-   "break rust" directly does, and only if there's no "rust" in scope.  We do
-   this in the same way regardless of whether the "break" is outside of a loop
-   or inside one.
-
-   As a GNU extension, we also support "break gcc", much to the same effect,
-   subject to the same rules.  */
-
-/* The finalizer for our funny ICE.  This prints a custom message instead of
-   the default bug reporting instructions, as there is no bug to report.  */
-
-static void ATTRIBUTE_NORETURN
-funny_ice_finalizer (diagnostic_context *context,
-		     const diagnostic_info *diagnostic, diagnostic_t diag_kind)
-{
-  gcc_assert (diag_kind == DK_ICE_NOBT);
-  default_diagnostic_finalizer (context, diagnostic, diag_kind);
-  fnotice (stderr, "You have broken GCC Rust. This is a feature.\n");
-  exit (ICE_EXIT_CODE);
 }
 
 void

--- a/gcc/rust/resolve/rust-ice-finalizer.cc
+++ b/gcc/rust/resolve/rust-ice-finalizer.cc
@@ -1,0 +1,35 @@
+// Copyright (C) 2020-2024 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-ice-finalizer.h"
+
+namespace Rust {
+namespace Resolver {
+
+void ATTRIBUTE_NORETURN
+funny_ice_finalizer (diagnostic_context *context,
+		     const diagnostic_info *diagnostic, diagnostic_t diag_kind)
+{
+  gcc_assert (diag_kind == DK_ICE_NOBT);
+  default_diagnostic_finalizer (context, diagnostic, diag_kind);
+  fnotice (stderr, "You have broken GCC Rust. This is a feature.\n");
+  exit (ICE_EXIT_CODE);
+}
+
+} // namespace Resolver
+} // namespace Rust

--- a/gcc/rust/resolve/rust-ice-finalizer.h
+++ b/gcc/rust/resolve/rust-ice-finalizer.h
@@ -1,0 +1,64 @@
+// Copyright (C) 2020-2024 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_ICE_FINALIZER_H
+#define RUST_ICE_FINALIZER_H
+
+#include "rust-linemap.h"
+#include "diagnostic.h"
+
+namespace Rust {
+namespace Resolver {
+
+/* The "break rust" Easter egg.
+
+   Backstory: once upon a time, there used to be a bug in rustc: it would ICE
+   during typechecking on a 'break' with an expression outside of a loop.  The
+   issue has been reported [0] and fixed [1], but in recognition of this, as a
+   special Easter egg, "break rust" was made to intentionally cause an ICE.
+
+   [0]: https://github.com/rust-lang/rust/issues/43162
+   [1]: https://github.com/rust-lang/rust/pull/43745
+
+   This was made in a way that does not break valid programs: namely, it only
+   happens when the 'break' is outside of a loop (so invalid anyway).
+
+   GCC Rust supports this essential feature as well, but in a slightly
+   different way.  Instead of delaying the error until type checking, we emit
+   it here in the resolution phase.  We, too, only do this to programs that
+   are already invalid: we only emit our funny ICE if the name "rust" (which
+   must be immediately inside a break-with-a-value expression) fails to
+   resolve.  Note that "break (rust)" does not trigger our ICE, only using
+   "break rust" directly does, and only if there's no "rust" in scope.  We do
+   this in the same way regardless of whether the "break" is outside of a loop
+   or inside one.
+
+   As a GNU extension, we also support "break gcc", much to the same effect,
+   subject to the same rules.  */
+
+/* The finalizer for our funny ICE.  This prints a custom message instead of
+   the default bug reporting instructions, as there is no bug to report.  */
+
+void ATTRIBUTE_NORETURN
+funny_ice_finalizer (diagnostic_context *context,
+		     const diagnostic_info *diagnostic, diagnostic_t diag_kind);
+
+} // namespace Resolver
+} // namespace Rust
+
+#endif /* ! RUST_ICE_FINALIZER_H */

--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.h
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.h
@@ -45,6 +45,7 @@ public:
 
   // resolutions
   void visit (AST::IdentifierExpr &) override;
+  void visit (AST::BreakExpr &) override;
   void visit (AST::PathInExpression &) override;
   void visit (AST::LangItemPath &) override;
   void visit (AST::TypePath &) override;
@@ -59,6 +60,8 @@ public:
 private:
   /* Setup Rust's builtin types (u8, i32, !...) in the resolver */
   void setup_builtin_types ();
+
+  bool funny_error;
 };
 
 // TODO: Add missing mappings and data structures

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -1,6 +1,5 @@
 bounds1.rs
 break-rust2.rs
-break-rust3.rs
 canonical_paths1.rs
 cfg1.rs
 cfg3.rs


### PR DESCRIPTION
Nr2 did not emit the correct error message for break identifier "rust".