### PR TITLE
gccrs: improve handling of Self Type paths

### DIFF
--- a/gcc/rust/typecheck/rust-hir-trait-resolve.cc
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.cc
@@ -278,6 +278,7 @@ TraitResolver::resolve_trait (HIR::Trait *trait_reference)
     }
   self->inherit_bounds (specified_bounds);
 
+  context->push_block_context (TypeCheckBlockContextItem (trait_reference));
   std::vector<TraitItemReference> item_refs;
   for (auto &item : trait_reference->get_trait_items ())
     {
@@ -307,6 +308,7 @@ TraitResolver::resolve_trait (HIR::Trait *trait_reference)
   // resolve the blocks of functions etc because it can end up in a recursive
   // loop of trying to resolve traits as required by the types
   tref->on_resolved ();
+  context->pop_block_context ();
 
   return tref;
 }

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.cc
@@ -335,7 +335,10 @@ TypeCheckImplItem::Resolve (
 
   // resolve
   TypeCheckImplItem resolver (parent, self, substitutions);
+  resolver.context->push_block_context (TypeCheckBlockContextItem (&parent));
   item.accept_vis (resolver);
+  resolver.context->pop_block_context ();
+
   return resolver.result;
 }
 

--- a/gcc/rust/typecheck/rust-hir-type-check-path.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-path.cc
@@ -355,6 +355,7 @@ TypeCheckExpr::resolve_segments (NodeId root_resolved_node_id,
   NodeId resolved_node_id = root_resolved_node_id;
   TyTy::BaseType *prev_segment = tyseg;
   bool reciever_is_generic = prev_segment->get_kind () == TyTy::TypeKind::PARAM;
+  bool reciever_is_dyn = prev_segment->get_kind () == TyTy::TypeKind::DYNAMIC;
 
   for (size_t i = offset; i < segments.size (); i++)
     {
@@ -434,7 +435,7 @@ TypeCheckExpr::resolve_segments (NodeId root_resolved_node_id,
 	    }
 	}
 
-      if (associated_impl_block != nullptr)
+      if (associated_impl_block != nullptr && !reciever_is_dyn)
 	{
 	  // associated types
 	  HirId impl_block_id

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -82,13 +82,18 @@ private:
   {}
 
   TyTy::BaseType *resolve_root_path (HIR::TypePath &path, size_t *offset,
-				     NodeId *root_resolved_node_id);
+				     NodeId *root_resolved_node_id,
+				     bool *wasBigSelf);
 
   TyTy::BaseType *resolve_segments (
     NodeId root_resolved_node_id, HirId expr_id,
     std::vector<std::unique_ptr<HIR::TypePathSegment>> &segments, size_t offset,
     TyTy::BaseType *tyseg, const Analysis::NodeMapping &expr_mappings,
-    location_t expr_locus);
+    location_t expr_locus, bool tySegIsBigSelf);
+
+  bool resolve_associated_type (const std::string &search,
+				TypeCheckBlockContextItem &ctx,
+				TyTy::BaseType **result);
 
   TyTy::BaseType *translated;
 };

--- a/gcc/rust/typecheck/rust-hir-type-check.h
+++ b/gcc/rust/typecheck/rust-hir-type-check.h
@@ -82,6 +82,37 @@ private:
   Item item;
 };
 
+class TypeCheckBlockContextItem
+{
+public:
+  enum ItemType
+  {
+    IMPL_BLOCK,
+    TRAIT
+  };
+
+  TypeCheckBlockContextItem (HIR::ImplBlock *block);
+  TypeCheckBlockContextItem (HIR::Trait *trait);
+
+  bool is_impl_block () const;
+  bool is_trait_block () const;
+
+  HIR::ImplBlock &get_impl_block ();
+  HIR::Trait &get_trait ();
+
+private:
+  union Item
+  {
+    HIR::ImplBlock *block;
+    HIR::Trait *trait;
+
+    Item (HIR::ImplBlock *block);
+    Item (HIR::Trait *trait);
+  };
+  ItemType type;
+  Item item;
+};
+
 /**
  * Interned lifetime representation in TyTy
  *
@@ -154,6 +185,12 @@ public:
   void push_return_type (TypeCheckContextItem item,
 			 TyTy::BaseType *return_type);
   void pop_return_type ();
+
+  bool have_block_context () const;
+  TypeCheckBlockContextItem peek_block_context ();
+  void push_block_context (TypeCheckBlockContextItem item);
+  void pop_block_context ();
+
   void iterate (std::function<bool (HirId, TyTy::BaseType *)> cb);
 
   bool have_loop_context () const;
@@ -245,6 +282,7 @@ private:
   std::vector<std::pair<TypeCheckContextItem, TyTy::BaseType *>>
     return_type_stack;
   std::vector<TyTy::BaseType *> loop_type_stack;
+  std::vector<TypeCheckBlockContextItem> block_stack;
   std::map<DefId, TraitReference> trait_context;
   std::map<HirId, TyTy::BaseType *> receiver_context;
   std::map<HirId, AssociatedImplTrait> associated_impl_traits;

--- a/gcc/rust/typecheck/rust-typecheck-context.cc
+++ b/gcc/rust/typecheck/rust-typecheck-context.cc
@@ -177,6 +177,32 @@ TypeCheckContext::peek_context ()
   return return_type_stack.back ().first;
 }
 
+bool
+TypeCheckContext::have_block_context () const
+{
+  return !block_stack.empty ();
+}
+
+TypeCheckBlockContextItem
+TypeCheckContext::peek_block_context ()
+{
+  rust_assert (!block_stack.empty ());
+  return block_stack.back ();
+}
+
+void
+TypeCheckContext::push_block_context (TypeCheckBlockContextItem block)
+{
+  block_stack.push_back (block);
+}
+
+void
+TypeCheckContext::pop_block_context ()
+{
+  rust_assert (!block_stack.empty ());
+  block_stack.pop_back ();
+}
+
 void
 TypeCheckContext::iterate (std::function<bool (HirId, TyTy::BaseType *)> cb)
 {
@@ -800,6 +826,44 @@ TypeCheckContextItem::get_defid () const
     }
 
   return UNKNOWN_DEFID;
+}
+
+// TypeCheckBlockContextItem
+
+TypeCheckBlockContextItem::Item::Item (HIR::ImplBlock *b) : block (b) {}
+
+TypeCheckBlockContextItem::Item::Item (HIR::Trait *t) : trait (t) {}
+
+TypeCheckBlockContextItem::TypeCheckBlockContextItem (HIR::ImplBlock *block)
+  : type (TypeCheckBlockContextItem::ItemType::IMPL_BLOCK), item (block)
+{}
+
+TypeCheckBlockContextItem::TypeCheckBlockContextItem (HIR::Trait *trait)
+  : type (TypeCheckBlockContextItem::ItemType::TRAIT), item (trait)
+{}
+
+bool
+TypeCheckBlockContextItem::is_impl_block () const
+{
+  return type == IMPL_BLOCK;
+}
+
+bool
+TypeCheckBlockContextItem::is_trait_block () const
+{
+  return type == TRAIT;
+}
+
+HIR::ImplBlock &
+TypeCheckBlockContextItem::get_impl_block ()
+{
+  return *(item.block);
+}
+
+HIR::Trait &
+TypeCheckBlockContextItem::get_trait ()
+{
+  return *(item.trait);
 }
 
 } // namespace Resolver

--- a/gcc/testsuite/rust/compile/issue-2907.rs
+++ b/gcc/testsuite/rust/compile/issue-2907.rs
@@ -1,0 +1,33 @@
+#![feature(lang_items)]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+pub trait Bar {}
+
+pub trait Foo {
+    type Ty;
+
+    fn foo(self) -> Self::Ty;
+}
+
+impl<B: Bar> Foo for B {
+    type Ty = u32;
+
+    fn foo(self) -> Self::Ty {
+        // { dg-warning "unused name" "" { target *-*-* } .-1 }
+        14
+    }
+}
+
+struct Qux;
+
+impl Bar for Qux {}
+
+fn main() {
+    let a = Qux;
+    a.foo();
+
+    let b = Qux;
+    Foo::foo(b);
+}

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -205,4 +205,5 @@ issue-2953-2.rs
 issue-1773.rs
 issue-2905-1.rs
 issue-2905-2.rs
+issue-2907.rs
 # please don't delete the trailing newline


### PR DESCRIPTION
TypePaths have special handling for Self where we can look at the current ctx for more acurate TypeAlias information if required. We cant do this for Impl contexts but not for Traits as we might as well fall back to the TypePathProbe.

The other issue was the dyn type comming in because Foo::foo and Foo is a trait reference we represent this as a dyn type as the root resolved path but then find the associated impl block for this but we cannot do this when we have resolved to a Dyn because this is just a representation that we know we are talking about a trait not because we are actually working with a real Dyn type.

Fixes #2907

gcc/rust/ChangeLog:

	* typecheck/rust-hir-trait-resolve.cc (TraitResolver::resolve_trait): track trait
	* typecheck/rust-hir-type-check-implitem.cc: trait block
	* typecheck/rust-hir-type-check-path.cc (TypeCheckExpr::resolve_segments): dont when dyn
	* typecheck/rust-hir-type-check-type.cc (TypeCheckType::visit): look at Self contenxt (TypeCheckType::resolve_root_path): track if Self (TypeCheckType::resolve_associated_type): look at current context for associated types
	* typecheck/rust-hir-type-check-type.h: change prototype
	* typecheck/rust-hir-type-check.h (class TypeCheckBlockContextItem): new context system to track current state
	* typecheck/rust-typecheck-context.cc (TypeCheckContext::have_block_context): likewise (TypeCheckContext::peek_block_context): likewise (TypeCheckContext::push_block_context): likewise (TypeCheckContext::pop_block_context): likewise (TypeCheckBlockContextItem::Item::Item): likewise (TypeCheckBlockContextItem::TypeCheckBlockContextItem): likewise (TypeCheckBlockContextItem::is_impl_block): likewise (TypeCheckBlockContextItem::is_trait_block): likewise (TypeCheckBlockContextItem::get_impl_block): likewise (TypeCheckBlockContextItem::get_trait): likewise

gcc/testsuite/ChangeLog:

	* rust/compile/nr2/exclude: nr2 cant handle this
	* rust/compile/issue-2907.rs: New test.