### PR TITLE
Cleanup `ContextualASTVisitor`

### DIFF
--- a/gcc/rust/ast/rust-ast-visitor.cc
+++ b/gcc/rust/ast/rust-ast-visitor.cc
@@ -1453,33 +1453,33 @@ DefaultASTVisitor::visit (AST::VariadicParam &param)
 void
 ContextualASTVisitor::visit (AST::Crate &crate)
 {
-  push_context (Context::CRATE);
+  ctx.enter (Kind::CRATE);
   DefaultASTVisitor::visit (crate);
-  pop_context ();
+  ctx.exit ();
 }
 
 void
 ContextualASTVisitor::visit (AST::InherentImpl &impl)
 {
-  push_context (Context::INHERENT_IMPL);
+  ctx.enter (Kind::INHERENT_IMPL);
   DefaultASTVisitor::visit (impl);
-  pop_context ();
+  ctx.exit ();
 }
 
 void
 ContextualASTVisitor::visit (AST::TraitImpl &impl)
 {
-  push_context (Context::TRAIT_IMPL);
+  ctx.enter (Kind::TRAIT_IMPL);
   DefaultASTVisitor::visit (impl);
-  pop_context ();
+  ctx.exit ();
 }
 
 void
 ContextualASTVisitor::visit (AST::Trait &trait)
 {
-  push_context (Context::TRAIT);
+  ctx.enter (Kind::TRAIT);
   DefaultASTVisitor::visit (trait);
-  pop_context ();
+  ctx.exit ();
 }
 
 } // namespace AST

--- a/gcc/rust/ast/rust-ast-visitor.h
+++ b/gcc/rust/ast/rust-ast-visitor.h
@@ -26,6 +26,7 @@
 #include "rust-item.h"
 #include "rust-path.h"
 #include "rust-system.h"
+#include "rust-stacked-contexts.h"
 
 namespace Rust {
 namespace AST {
@@ -452,7 +453,7 @@ public:
 class ContextualASTVisitor : public DefaultASTVisitor
 {
 protected:
-  enum class Context
+  enum class Kind
   {
     FUNCTION,
     INHERENT_IMPL,
@@ -461,6 +462,7 @@ protected:
     MODULE,
     CRATE,
   };
+
   using DefaultASTVisitor::visit;
 
   virtual void visit (AST::Crate &crate) override;
@@ -476,11 +478,7 @@ protected:
     DefaultASTVisitor::visit (item);
   }
 
-  std::vector<Context> context;
-
-  void push_context (Context ctx) { context.push_back (ctx); }
-
-  void pop_context () { context.pop_back (); }
+  StackedContexts<Kind> ctx;
 };
 
 } // namespace AST

--- a/gcc/rust/checks/errors/rust-ast-validation.cc
+++ b/gcc/rust/checks/errors/rust-ast-validation.cc
@@ -56,7 +56,7 @@ ASTValidation::visit (AST::LoopLabel &label)
 void
 ASTValidation::visit (AST::ConstantItem &const_item)
 {
-  if (!const_item.has_expr () && context.back () != Context::TRAIT_IMPL)
+  if (!const_item.has_expr () && ctx.peek () != Kind::TRAIT_IMPL)
     {
       rust_error_at (const_item.get_locus (),
 		     "associated constant in %<impl%> without body");
@@ -82,23 +82,19 @@ ASTValidation::visit (AST::Function &function)
 		   "functions cannot be both %<const%> and %<async%>");
 
   if (qualifiers.is_const ()
-      && (context.back () == Context::TRAIT_IMPL
-	  || context.back () == Context::TRAIT))
+      && (ctx.peek () == Kind::TRAIT_IMPL || ctx.peek () == Kind::TRAIT))
     rust_error_at (function.get_locus (), ErrorCode::E0379,
 		   "functions in traits cannot be declared %<const%>");
 
   // may change soon
   if (qualifiers.is_async ()
-      && (context.back () == Context::TRAIT_IMPL
-	  || context.back () == Context::TRAIT))
+      && (ctx.peek () == Kind::TRAIT_IMPL || ctx.peek () == Kind::TRAIT))
     rust_error_at (function.get_locus (), ErrorCode::E0706,
 		   "functions in traits cannot be declared %<async%>");
 
   // if not an associated function but has a self parameter
-  if (context.back () != Context::TRAIT
-      && context.back () != Context::TRAIT_IMPL
-      && context.back () != Context::INHERENT_IMPL
-      && function.has_self_param ())
+  if (ctx.peek () != Kind::TRAIT && ctx.peek () != Kind::TRAIT_IMPL
+      && ctx.peek () != Kind::INHERENT_IMPL && function.has_self_param ())
     rust_error_at (
       function.get_self_param ().get_locus (),
       "%<self%> parameter is only allowed in associated functions");
@@ -140,11 +136,11 @@ ASTValidation::visit (AST::Function &function)
     {
       if (!function.has_body ())
 	{
-	  if (context.back () == Context::INHERENT_IMPL
-	      || context.back () == Context::TRAIT_IMPL)
+	  if (ctx.peek () == Kind::INHERENT_IMPL
+	      || ctx.peek () == Kind::TRAIT_IMPL)
 	    rust_error_at (function.get_locus (),
 			   "associated function in %<impl%> without body");
-	  else if (context.back () != Context::TRAIT)
+	  else if (ctx.peek () != Kind::TRAIT)
 	    rust_error_at (function.get_locus (),
 			   "free function without a body");
 	}

--- a/gcc/rust/util/rust-stacked-contexts.h
+++ b/gcc/rust/util/rust-stacked-contexts.h
@@ -71,6 +71,13 @@ public:
     return last;
   }
 
+  const T &peek ()
+  {
+    rust_assert (!stack.empty ());
+
+    return stack.back ();
+  }
+
   /**
    * Are we currently inside of a special context?
    */


### PR DESCRIPTION
As part of my cleanups for lang-items, which should land soon...

This uses the `StackedContexts` API which is safer than a simple vector for keeping track of context