### PR TITLE
hir: Remove duplicate function in TraitItemFunc

### DIFF
--- a/gcc/rust/backend/rust-compile-implitem.cc
+++ b/gcc/rust/backend/rust-compile-implitem.cc
@@ -57,7 +57,7 @@ CompileTraitItem::visit (HIR::TraitItemConst &constant)
 void
 CompileTraitItem::visit (HIR::TraitItemFunc &func)
 {
-  rust_assert (func.has_block_defined ());
+  rust_assert (func.has_definition ());
 
   rust_assert (concrete->get_kind () == TyTy::TypeKind::FNDEF);
   TyTy::FnType *fntype = static_cast<TyTy::FnType *> (concrete);

--- a/gcc/rust/checks/errors/rust-const-checker.cc
+++ b/gcc/rust/checks/errors/rust-const-checker.cc
@@ -678,7 +678,7 @@ ConstChecker::visit (StaticItem &static_item)
 void
 ConstChecker::visit (TraitItemFunc &item)
 {
-  if (item.has_block_defined ())
+  if (item.has_definition ())
     item.get_block_expr ().accept_vis (*this);
 }
 

--- a/gcc/rust/checks/errors/rust-hir-pattern-analysis.cc
+++ b/gcc/rust/checks/errors/rust-hir-pattern-analysis.cc
@@ -522,7 +522,7 @@ PatternChecker::visit (StaticItem &static_item)
 void
 PatternChecker::visit (TraitItemFunc &item)
 {
-  if (item.has_block_defined ())
+  if (item.has_definition ())
     item.get_block_expr ().accept_vis (*this);
 }
 

--- a/gcc/rust/checks/errors/rust-unsafe-checker.cc
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.cc
@@ -776,7 +776,7 @@ UnsafeChecker::visit (StaticItem &static_item)
 void
 UnsafeChecker::visit (TraitItemFunc &item)
 {
-  if (item.has_block_defined ())
+  if (item.has_definition ())
     item.get_block_expr ().accept_vis (*this);
 }
 

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -1991,8 +1991,6 @@ public:
 
   const TraitFunctionDecl &get_decl () const { return decl; }
 
-  bool has_block_defined () const { return block_expr != nullptr; }
-
   BlockExpr &get_block_expr () { return *block_expr; }
 
   const std::string trait_identifier () const override final

--- a/gcc/rust/typecheck/rust-hir-trait-resolve.cc
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.cc
@@ -69,7 +69,7 @@ ResolveTraitItemToRef::visit (HIR::TraitItemFunc &fn)
 {
   // create trait-item-ref
   location_t locus = fn.get_locus ();
-  bool is_optional = fn.has_block_defined ();
+  bool is_optional = fn.has_definition ();
   std::string identifier = fn.get_decl ().get_function_name ().as_string ();
 
   resolved = TraitItemReference (identifier, is_optional,


### PR DESCRIPTION
Both TraitItemFunc::has_definition() and TraitItemFunc::has_block_defined() were exactly the same implementation, so remove one.

gcc/rust/ChangeLog:

	* hir/tree/rust-hir-item.h: Remove TraitItemFunc::has_block_defined()
	* backend/rust-compile-implitem.cc (CompileTraitItem::visit): Call TraitItemFunc::has_definition() instead.
	* checks/errors/rust-const-checker.cc (ConstChecker::visit): Likewise.
	* checks/errors/rust-hir-pattern-analysis.cc (PatternChecker::visit): Likewise.
	* checks/errors/rust-unsafe-checker.cc (UnsafeChecker::visit): Likewise.
	* typecheck/rust-hir-trait-resolve.cc (ResolveTraitItemToRef::visit): Likewise.

