### PR TITLE
gccrs: add checks for division by zero and left shift overflow

### DIFF
--- a/gcc/rust/backend/rust-constexpr.cc
+++ b/gcc/rust/backend/rust-constexpr.cc
@@ -2929,8 +2929,13 @@ eval_store_expression (const constexpr_ctx *ctx, tree t, bool lval,
 	}
     }
 
+  if (*non_constant_p)
+    return t;
+
   /* Don't share a CONSTRUCTOR that might be changed later.  */
   init = unshare_constructor (init);
+  if (init == NULL_TREE)
+    return t;
 
   if (*valp && TREE_CODE (*valp) == CONSTRUCTOR
       && TREE_CODE (init) == CONSTRUCTOR)
@@ -3585,9 +3590,6 @@ eval_call_expression (const constexpr_ctx *ctx, tree t, bool lval,
 	      result = *ctx->global->values.get (res);
 	      if (result == NULL_TREE && !*non_constant_p)
 		{
-		  if (!ctx->quiet)
-		    error ("%<constexpr%> call flows off the end "
-			   "of the function");
 		  *non_constant_p = true;
 		}
 	    }

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -1106,6 +1106,17 @@ arithmetic_or_logical_expression (ArithmeticOrLogicalOperator op, tree left,
   if (floating_point && extended_type != NULL_TREE)
     ret = convert (original_type, ret);
 
+  if (op == ArithmeticOrLogicalOperator::DIVIDE
+      && (integer_zerop (right) || fixed_zerop (right)))
+    {
+      rust_error_at (location, "division by zero");
+    }
+  else if (op == ArithmeticOrLogicalOperator::LEFT_SHIFT
+	   && (compare_tree_int (right, TYPE_PRECISION (TREE_TYPE (ret))) >= 0))
+    {
+      rust_error_at (location, "left shift count >= width of type");
+    }
+
   return ret;
 }
 

--- a/gcc/testsuite/rust/compile/issue-2394.rs
+++ b/gcc/testsuite/rust/compile/issue-2394.rs
@@ -1,0 +1,14 @@
+const A: i32 = (1 / 0);
+// { dg-error "division by zero" "" { target *-*-* } .-1 }
+
+fn main() {
+    let a = 1 / 0;
+    // { dg-error "division by zero" "" { target *-*-* } .-1 }
+
+    let b = 3;
+    let c = b / 0;
+    // { dg-error "division by zero" "" { target *-*-* } .-1 }
+
+    let a = 1 << 500;
+    // { dg-error "left shift count >= width of type" "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
These are ported from the c-family code c-warn.cc and c-typchk.cc

Fixes Rust-GCC#2394

gcc/rust/ChangeLog:

	* backend/rust-constexpr.cc (eval_store_expression): check for null
	(eval_call_expression): formatting
	(eval_loop_expr): formatting
	* rust-gcc.cc (arithmetic_or_logical_expression): add warnings

gcc/testsuite/ChangeLog:

	* rust/compile/issue-2394.rs: New test.