### PR TITLE
gccrs: Remove bad assertion in name resolution

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-item.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-item.cc
@@ -582,7 +582,14 @@ ResolveItem::visit (AST::InherentImpl &impl_block)
   // Setup paths
   CanonicalPath self_cpath = CanonicalPath::create_empty ();
   bool ok = ResolveTypeToCanonicalPath::go (impl_block.get_type (), self_cpath);
-  rust_assert (ok);
+  if (!ok)
+    {
+      resolver->get_name_scope ().pop ();
+      resolver->get_type_scope ().pop ();
+      resolver->get_label_scope ().pop ();
+      return;
+    }
+
   rust_debug ("AST::InherentImpl resolve Self: {%s}",
 	      self_cpath.get ().c_str ());
 
@@ -671,12 +678,17 @@ ResolveItem::visit (AST::TraitImpl &impl_block)
       return;
     }
 
-  bool ok;
   // setup paths
   CanonicalPath canonical_trait_type = CanonicalPath::create_empty ();
-  ok = ResolveTypeToCanonicalPath::go (impl_block.get_trait_path (),
-				       canonical_trait_type);
-  rust_assert (ok);
+  bool ok = ResolveTypeToCanonicalPath::go (impl_block.get_trait_path (),
+					    canonical_trait_type);
+  if (!ok)
+    {
+      resolver->get_name_scope ().pop ();
+      resolver->get_type_scope ().pop ();
+      resolver->get_label_scope ().pop ();
+      return;
+    }
 
   rust_debug ("AST::TraitImpl resolve trait type: {%s}",
 	      canonical_trait_type.get ().c_str ());
@@ -684,7 +696,13 @@ ResolveItem::visit (AST::TraitImpl &impl_block)
   CanonicalPath canonical_impl_type = CanonicalPath::create_empty ();
   ok = ResolveTypeToCanonicalPath::go (impl_block.get_type (),
 				       canonical_impl_type);
-  rust_assert (ok);
+  if (!ok)
+    {
+      resolver->get_name_scope ().pop ();
+      resolver->get_type_scope ().pop ();
+      resolver->get_label_scope ().pop ();
+      return;
+    }
 
   rust_debug ("AST::TraitImpl resolve self: {%s}",
 	      canonical_impl_type.get ().c_str ());

--- a/gcc/testsuite/rust/compile/issue-2423.rs
+++ b/gcc/testsuite/rust/compile/issue-2423.rs
@@ -1,0 +1,14 @@
+impl NonExistant {
+    // { dg-error "failed to resolve" "" { target *-*-* } .-1 }
+    fn test() {}
+}
+
+impl NotFound for NonExistant {
+    // { dg-error "failed to resolve" "" { target *-*-* } .-1 }
+    fn test() {}
+}
+
+trait A {}
+
+impl A for NotFound {}
+// { dg-error "failed to resolve" "" { target *-*-* } .-1 }

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -206,4 +206,5 @@ issue-1773.rs
 issue-2905-1.rs
 issue-2905-2.rs
 issue-2907.rs
+issue-2423.rs
 # please don't delete the trailing newline


### PR DESCRIPTION
This was a handy debug assertion but only works for valid rust code. This needs to handle the case where the type is not resolved which is a valid case.

Fixes #2423

gcc/rust/ChangeLog:

	* resolve/rust-ast-resolve-item.cc (ResolveItem::visit): remove assertions

gcc/testsuite/ChangeLog:

	* rust/compile/nr2/exclude: nr2 can't handle this
	* rust/compile/issue-2423.rs: New test.
