### PR TITLE
gccrs: constant evaluation like these are coercion sites

### DIFF
--- a/gcc/rust/backend/rust-compile-base.h
+++ b/gcc/rust/backend/rust-compile-base.h
@@ -90,9 +90,11 @@ protected:
   void compile_function_body (tree fndecl, HIR::BlockExpr &function_body,
 			      TyTy::BaseType *fn_return_ty);
 
-  tree compile_constant_item (TyTy::BaseType *resolved_type,
+  tree compile_constant_item (HirId coercion_id, TyTy::BaseType *resolved_type,
+			      TyTy::BaseType *expected_type,
 			      const Resolver::CanonicalPath &canonical_path,
-			      HIR::Expr &const_value_expr, location_t locus);
+			      HIR::Expr &const_value_expr, location_t locus,
+			      location_t expr_locus);
 
   tree compile_function (const std::string &fn_name, HIR::SelfParam &self_param,
 			 std::vector<HIR::FunctionParam> &function_params,

--- a/gcc/rust/backend/rust-compile-implitem.cc
+++ b/gcc/rust/backend/rust-compile-implitem.cc
@@ -45,9 +45,16 @@ CompileTraitItem::visit (HIR::TraitItemConst &constant)
   rust_assert (canonical_path);
 
   HIR::Expr &const_value_expr = constant.get_expr ();
+  TyTy::BaseType *expr_type = nullptr;
+  bool ok = ctx->get_tyctx ()->lookup_type (
+    const_value_expr.get_mappings ().get_hirid (), &expr_type);
+  rust_assert (ok);
+
   tree const_expr
-    = compile_constant_item (resolved_type, *canonical_path, const_value_expr,
-			     constant.get_locus ());
+    = compile_constant_item (constant.get_mappings ().get_hirid (), expr_type,
+			     resolved_type, *canonical_path, const_value_expr,
+			     constant.get_locus (),
+			     const_value_expr.get_locus ());
   ctx->push_const (const_expr);
   ctx->insert_const_decl (constant.get_mappings ().get_hirid (), const_expr);
 

--- a/gcc/testsuite/rust/compile/issue-1525.rs
+++ b/gcc/testsuite/rust/compile/issue-1525.rs
@@ -1,0 +1,4 @@
+fn main() {
+    const slice: &[i32] = &[1, 2, 3];
+    let _slice2: &[i32] = slice;
+}


### PR DESCRIPTION
The code here was wrongly assuming the decl type from the folding of the expression would be the type of the constant decl. This is not the case for unsized coercions for slices, where the expression here is a reference to an array then we require the coercion to fix the result up to the expected type.

Fixes Rust-GCC#1525

gcc/rust/ChangeLog:

	* backend/rust-compile-base.cc: apply coercion site to result
	* backend/rust-compile-base.h: update prototype
	* backend/rust-compile-implitem.cc (CompileTraitItem::visit): send in coercion info
	* backend/rust-compile-item.cc (CompileItem::visit): likewise

gcc/testsuite/ChangeLog:

	* rust/compile/issue-1525.rs: New test.
