### PR TITLE
gccrs: add test case to show issue is fixed

### DIFF
--- a/gcc/testsuite/rust/compile/issue-266.rs
+++ b/gcc/testsuite/rust/compile/issue-266.rs
@@ -1,0 +1,3 @@
+fn main() {
+    'label: while break 'label {}
+}

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -207,4 +207,5 @@ issue-2905-1.rs
 issue-2905-2.rs
 issue-2907.rs
 issue-2423.rs
+issue-266.rs
 # please don't delete the trailing newline


### PR DESCRIPTION
Fixes Rust-GCC#266

gcc/testsuite/ChangeLog:

	* rust/compile/nr2/exclude: nr2 cant handle this
	* rust/compile/issue-266.rs: New test.
