### PR TITLE
gccrs: fix crash in hir dump

### DIFF
--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -1365,7 +1365,8 @@ Dump::visit (ReturnExpr &e)
   begin ("ReturnExpr");
   do_mappings (e.get_mappings ());
 
-  visit_field ("return_expr", e.get_expr ());
+  if (e.has_return_expr ())
+    visit_field ("return_expr", e.get_expr ());
 
   end ("ReturnExpr");
 }


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* hir/rust-hir-dump.cc (Dump::visit): add missing check for no return value

