### PR TITLE
gccrs: fix a compiler crash when path expression contains nothing

### DIFF
--- a/gcc/rust/ast/rust-path.h
+++ b/gcc/rust/ast/rust-path.h
@@ -727,9 +727,9 @@ public:
   }
 
   // Creates an error state path in expression.
-  static PathInExpression create_error ()
+  static PathInExpression create_error (location_t locus = UNDEF_LOCATION)
   {
-    return PathInExpression ({}, {}, UNDEF_LOCATION);
+    return PathInExpression ({}, {}, locus);
   }
 
   // Returns whether path in expression is in an error state.

--- a/gcc/testsuite/rust/compile/paamayim-nekudotayim.rs
+++ b/gcc/testsuite/rust/compile/paamayim-nekudotayim.rs
@@ -1,0 +1,5 @@
+// http://phpsadness.com/sad/1
+fn main() {
+    ::;
+    // { dg-error "expected identifier" "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* ast/rust-path.h: allows error nodes to specify the source
	location, so that it could be used in diagnostics later.
	* parse/rust-parse-impl.h: creates the PathInExpression error node
	with source location and prints proper diagnostics if the path
	is empty.

gcc/testsuite/ChangeLog:

	* rust/compile/paamayim-nekudotayim.rs: add a test for testing
	proper error recovery logic when there is no path names.