### PR TITLE
Use lang items as paths

### DIFF
--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -1299,7 +1299,7 @@ TraitImpl::as_string () const
   else
     str += "false";
 
-  str += "\n TypePath (to trait): " + trait_path.as_string ();
+  str += "\n TypePath (to trait): " + trait_path->as_string ();
 
   str += "\n Type (struct to impl on): " + trait_type->as_string ();
 
@@ -1561,7 +1561,7 @@ QualifiedPathType::as_string () const
   str += type_to_invoke_on->as_string ();
 
   if (has_as_clause ())
-    str += " as " + trait_path.as_string ();
+    str += " as " + trait_path->as_string ();
 
   return str + ">";
 }

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -3264,6 +3264,13 @@ public:
     return *trait_path;
   }
 
+  Type &get_trait_path_type ()
+  {
+    rust_assert (trait_path->get_path_kind () == Path::Kind::Type);
+
+    return (AST::Type &) static_cast<AST::TypePath &> (*trait_path);
+  }
+
 protected:
   /* Use covariance to implement clone function as returning this object
    * rather than base */

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -3172,7 +3172,7 @@ class TraitImpl : public Impl
 {
   bool has_unsafe;
   bool has_exclam;
-  TypePath trait_path;
+  std::unique_ptr<Path> trait_path;
 
   // bool has_impl_items;
   std::vector<std::unique_ptr<AssociatedItem>> impl_items;
@@ -3184,7 +3184,7 @@ public:
   bool has_impl_items () const { return !impl_items.empty (); }
 
   // Mega-constructor
-  TraitImpl (TypePath trait_path, bool is_unsafe, bool has_exclam,
+  TraitImpl (std::unique_ptr<Path> trait_path, bool is_unsafe, bool has_exclam,
 	     std::vector<std::unique_ptr<AssociatedItem>> impl_items,
 	     std::vector<std::unique_ptr<GenericParam>> generic_params,
 	     std::unique_ptr<Type> trait_type, WhereClause where_clause,
@@ -3197,10 +3197,26 @@ public:
       trait_path (std::move (trait_path)), impl_items (std::move (impl_items))
   {}
 
+  // Helper constructor with a typepath
+  TraitImpl (TypePath trait_path, bool is_unsafe, bool has_exclam,
+	     std::vector<std::unique_ptr<AssociatedItem>> impl_items,
+	     std::vector<std::unique_ptr<GenericParam>> generic_params,
+	     std::unique_ptr<Type> trait_type, WhereClause where_clause,
+	     Visibility vis, std::vector<Attribute> inner_attrs,
+	     std::vector<Attribute> outer_attrs, location_t locus)
+    : Impl (std::move (generic_params), std::move (trait_type),
+	    std::move (where_clause), std::move (vis), std::move (inner_attrs),
+	    std::move (outer_attrs), locus),
+      has_unsafe (is_unsafe), has_exclam (has_exclam),
+      trait_path (std::unique_ptr<TypePath> (new TypePath (trait_path))),
+      impl_items (std::move (impl_items))
+  {}
+
   // Copy constructor with vector clone
   TraitImpl (TraitImpl const &other)
     : Impl (other), has_unsafe (other.has_unsafe),
-      has_exclam (other.has_exclam), trait_path (other.trait_path)
+      has_exclam (other.has_exclam),
+      trait_path (other.trait_path->clone_path ())
   {
     impl_items.reserve (other.impl_items.size ());
     for (const auto &e : other.impl_items)
@@ -3211,7 +3227,7 @@ public:
   TraitImpl &operator= (TraitImpl const &other)
   {
     Impl::operator= (other);
-    trait_path = other.trait_path;
+    trait_path = other.trait_path->clone_path ();
     has_unsafe = other.has_unsafe;
     has_exclam = other.has_exclam;
 
@@ -3242,10 +3258,10 @@ public:
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  TypePath &get_trait_path ()
+  Path &get_trait_path ()
   {
     // TODO: assert that trait path is not empty?
-    return trait_path;
+    return *trait_path;
   }
 
 protected:

--- a/gcc/rust/ast/rust-path.cc
+++ b/gcc/rust/ast/rust-path.cc
@@ -152,8 +152,7 @@ RegularPath::as_string () const
 std::string
 LangItemPath::as_string () const
 {
-  // FIXME: Handle #[lang] paths
-  rust_unreachable ();
+  return "#[lang = \"" + LangItem::ToString (kind) + "\"]";
 }
 
 SimplePath

--- a/gcc/rust/expand/rust-derive-copy.cc
+++ b/gcc/rust/expand/rust-derive-copy.cc
@@ -18,6 +18,8 @@
 
 #include "rust-derive-copy.h"
 #include "rust-ast-full.h"
+#include "rust-mapping-common.h"
+#include "rust-path.h"
 
 namespace Rust {
 namespace AST {
@@ -44,7 +46,7 @@ DeriveCopy::copy_impl (
   // `$crate::core::marker::Copy` instead
   auto segments = std::vector<std::unique_ptr<TypePathSegment>> ();
   segments.emplace_back (builder.type_path_segment ("Copy"));
-  auto copy = TypePath (std::move (segments), loc);
+  auto copy = Rust::make_unique<LangItemPath> (LangItem::Kind::COPY, loc);
 
   // we need to build up the generics for this impl block which will be just a
   // clone of the types specified ones
@@ -116,7 +118,7 @@ DeriveCopy::copy_impl (
 	: builder.single_generic_type_path (name, generic_args_for_self);
 
   return std::unique_ptr<Item> (
-    new TraitImpl (copy, /* unsafe */ false,
+    new TraitImpl (std::move (copy), /* unsafe */ false,
 		   /* exclam */ false, /* trait items */ {},
 		   std::move (impl_generics), std::move (self_type_path),
 		   WhereClause::create_empty (), Visibility::create_private (),

--- a/gcc/rust/hir/rust-ast-lower-type.cc
+++ b/gcc/rust/hir/rust-ast-lower-type.cc
@@ -19,9 +19,18 @@
 #include "rust-ast-lower-type.h"
 #include "optional.h"
 #include "rust-attribute-values.h"
+#include "rust-path.h"
 
 namespace Rust {
 namespace HIR {
+
+HIR::TypePath *
+ASTLowerTypePath::translate (AST::Path &type)
+{
+  rust_assert (type.get_path_kind () == AST::Path::Kind::Type);
+
+  return ASTLowerTypePath::translate (static_cast<AST::TypePath &> (type));
+}
 
 HIR::TypePath *
 ASTLowerTypePath::translate (AST::TypePath &type)

--- a/gcc/rust/hir/rust-ast-lower-type.h
+++ b/gcc/rust/hir/rust-ast-lower-type.h
@@ -21,6 +21,7 @@
 
 #include "rust-ast-lower-base.h"
 #include "rust-ast-lower-expr.h"
+#include "rust-hir-path.h"
 
 namespace Rust {
 namespace HIR {
@@ -32,18 +33,21 @@ protected:
 
 public:
   static HIR::TypePath *translate (AST::Path &type);
-  static HIR::TypePath *translate (AST::TypePath &type);
 
   void visit (AST::TypePathSegmentFunction &segment) override;
   void visit (AST::TypePathSegment &segment) override;
   void visit (AST::TypePathSegmentGeneric &segment) override;
   void visit (AST::TypePath &path) override;
+  void visit (AST::LangItemPath &path) override;
 
 protected:
   HIR::TypePathSegment *translated_segment;
 
 private:
   HIR::TypePath *translated;
+
+  static HIR::TypePath *translate_type_path (AST::TypePath &type);
+  static HIR::TypePath *translate_lang_item_type_path (AST::LangItemPath &type);
 };
 
 class ASTLowerQualifiedPathInType : public ASTLowerTypePath

--- a/gcc/rust/hir/rust-ast-lower-type.h
+++ b/gcc/rust/hir/rust-ast-lower-type.h
@@ -31,6 +31,7 @@ protected:
   using Rust::HIR::ASTLoweringBase::visit;
 
 public:
+  static HIR::TypePath *translate (AST::Path &type);
   static HIR::TypePath *translate (AST::TypePath &type);
 
   void visit (AST::TypePathSegmentFunction &segment) override;

--- a/gcc/rust/resolve/rust-ast-resolve-item.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-item.cc
@@ -680,7 +680,7 @@ ResolveItem::visit (AST::TraitImpl &impl_block)
 
   // setup paths
   CanonicalPath canonical_trait_type = CanonicalPath::create_empty ();
-  bool ok = ResolveTypeToCanonicalPath::go (impl_block.get_trait_path (),
+  bool ok = ResolveTypeToCanonicalPath::go (impl_block.get_trait_path_type (),
 					    canonical_trait_type);
   if (!ok)
     {

--- a/gcc/rust/resolve/rust-ast-resolve-item.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-item.cc
@@ -678,16 +678,32 @@ ResolveItem::visit (AST::TraitImpl &impl_block)
       return;
     }
 
+  bool ok = true;
+
   // setup paths
   CanonicalPath canonical_trait_type = CanonicalPath::create_empty ();
-  bool ok = ResolveTypeToCanonicalPath::go (impl_block.get_trait_path_type (),
-					    canonical_trait_type);
-  if (!ok)
+  if (impl_block.get_trait_path ().get_path_kind ()
+      == AST::Path::Kind::LangItem)
     {
-      resolver->get_name_scope ().pop ();
-      resolver->get_type_scope ().pop ();
-      resolver->get_label_scope ().pop ();
-      return;
+      auto &lang_item
+	= static_cast<AST::LangItemPath &> (impl_block.get_trait_path ());
+
+      canonical_trait_type
+	= CanonicalPath::new_seg (lang_item.get_node_id (),
+				  LangItem::ToString (
+				    lang_item.get_lang_item_kind ()));
+    }
+  else
+    {
+      ok = ResolveTypeToCanonicalPath::go (impl_block.get_trait_path_type (),
+					   canonical_trait_type);
+      if (!ok)
+	{
+	  resolver->get_name_scope ().pop ();
+	  resolver->get_type_scope ().pop ();
+	  resolver->get_label_scope ().pop ();
+	  return;
+	}
     }
 
   rust_debug ("AST::TraitImpl resolve trait type: {%s}",

--- a/gcc/rust/resolve/rust-ast-resolve-type.h
+++ b/gcc/rust/resolve/rust-ast-resolve-type.h
@@ -71,12 +71,12 @@ public:
       {
 	auto &type = static_cast<AST::LangItemPath &> (type_path);
 
-	rust_debug ("[ARTHUR]: lang item kind: %s",
-		    LangItem::ToString (type.get_lang_item_kind ()).c_str ());
-
 	auto lang_item = Analysis::Mappings::get ()
 			   .lookup_lang_item_node (type.get_lang_item_kind ())
 			   .value ();
+
+	auto resolver = Resolver::get ();
+	resolver->insert_resolved_type (type.get_node_id (), lang_item);
 
 	return lang_item;
       }

--- a/gcc/rust/resolve/rust-ast-resolve-type.h
+++ b/gcc/rust/resolve/rust-ast-resolve-type.h
@@ -21,8 +21,10 @@
 
 #include "rust-ast-resolve-base.h"
 #include "rust-ast-resolve-expr.h"
+#include "rust-diagnostics.h"
 #include "rust-hir-map.h"
 #include "rust-path.h"
+#include "util/rust-hir-map.h"
 
 namespace Rust {
 namespace Resolver {
@@ -69,9 +71,14 @@ public:
       {
 	auto &type = static_cast<AST::LangItemPath &> (type_path);
 
-	Analysis::Mappings::get_lang_item (type);
+	rust_debug ("[ARTHUR]: lang item kind: %s",
+		    LangItem::ToString (type.get_lang_item_kind ()).c_str ());
 
-	type.get_node_id ();
+	auto lang_item = Analysis::Mappings::get ()
+			   .lookup_lang_item_node (type.get_lang_item_kind ())
+			   .value ();
+
+	return lang_item;
       }
 
     rust_assert (type_path.get_path_kind () == AST::Path::Kind::Type);

--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
@@ -18,6 +18,7 @@
 
 #include "optional.h"
 #include "rust-ast-full.h"
+#include "rust-diagnostics.h"
 #include "rust-hir-map.h"
 #include "rust-late-name-resolver-2.0.h"
 #include "rust-default-resolver.h"
@@ -245,6 +246,25 @@ Late::visit (AST::PathInExpression &expr)
     }
   ctx.map_usage (Usage (expr.get_node_id ()),
 		 Definition (resolved->get_node_id ()));
+}
+
+void
+Late::visit (AST::LangItemPath &type)
+{
+  auto &mappings = Rust::Analysis::Mappings::get ();
+  auto lang_item = mappings.lookup_lang_item_node (type.get_lang_item_kind ());
+
+  if (!lang_item)
+    {
+      rust_fatal_error (
+	type.get_locus (), "use of undeclared lang item %qs",
+	LangItem::ToString (type.get_lang_item_kind ()).c_str ());
+      return;
+    }
+
+  ctx.map_usage (Usage (type.get_node_id ()), Definition (lang_item.value ()));
+
+  DefaultResolver::visit (type);
 }
 
 void

--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.h
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.h
@@ -46,6 +46,7 @@ public:
   // resolutions
   void visit (AST::IdentifierExpr &) override;
   void visit (AST::PathInExpression &) override;
+  void visit (AST::LangItemPath &) override;
   void visit (AST::TypePath &) override;
   void visit (AST::StructExprStruct &) override;
   void visit (AST::StructExprStructBase &) override;


### PR DESCRIPTION
This PR makes it possible to use lang items as paths, for example when generating code for derives or for-loops. Instead of generating a complex path to something like `core::marker::Copy`, we can just use a `LangItemPath` to `LangItem::COPY`. This way, the code generation does not need to care about name resolution, about std's module hierarchy changing, or about duplicate definitions with the same module structure (e.g. if a user defines a copy trait in their own source file with their own `core` and `marker` module).

This is not going to build until #3289 is merged as it depends on those mappings - but it should still be reviewable