### PR TITLE
Changes made to ensure that '=>' token is parsed properly

### DIFF
--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -89,6 +89,8 @@ struct ParseRestrictions
   bool entered_from_unary = false;
   bool expr_can_be_null = false;
   bool expr_can_be_stmt = false;
+  bool stop_on_token
+    = false; // This is for stopping parsing at a specific token
   bool consume_semi = true;
   /* Macro invocations that are statements can expand without a semicolon after
    * the final statement, if it's an expression statement. */

--- a/gcc/testsuite/rust/compile/issue-3099.rs
+++ b/gcc/testsuite/rust/compile/issue-3099.rs
@@ -1,0 +1,16 @@
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+pub fn main() {
+    unsafe {
+        let value = 10;
+        let result = match value {
+            10 => 15,
+            _ => 20,
+        };
+
+        let format = "Result: %d\n\0" as *const str as *const i8;
+        printf(format, result);
+    }
+}


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* parse/rust-parse-impl.h (Parser::parse_expr): Updated parsing logic to stop on
	encountering '=>' or ',' while having restrictions.stop_on_token turned on.
	(Parser::left_denotations): Updated to stop parsing on the special tokens mentioned above.
	(Parser::null_denotation): Updated to stop parsing on the special tokens mentioned above.
	* parse/rust-parse.h (struct ParseRestrictions): Added a field stop_on_token (default false)
	to maintain the above functionality.

Fixes #3099 
Here is a checklist to help you with your PR.

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`
- \[x] Added any relevant test cases to `gcc/testsuite/rust/`


* I have made changes to 3 functions `Parser::parse_expr`, `Parser::left_denotations`, `Parser::null_denotation` So that they stop on special token like `=>` and `,`.  They would terminate the parsing to allow exatract expression.
* Also I have added a test to verify the running of this.
