### PR TITLE
gccrs: fix bad not expression in rust

### DIFF
--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -942,7 +942,7 @@ operator_to_tree_code (NegationOperator op)
     case NegationOperator::NEGATE:
       return NEGATE_EXPR;
     case NegationOperator::NOT:
-      return TRUTH_NOT_EXPR;
+      return BIT_NOT_EXPR;
     default:
       rust_unreachable ();
     }


### PR DESCRIPTION
Fixes Rust-GCC#3229

gcc/rust/ChangeLog:

	* rust-gcc.cc (operator_to_tree_code): ! expressions are BIT_NOT_EXPR