### PR TITLE
gccrs: implement the TuplePattern and use it for function patterns

### DIFF
--- a/gcc/rust/backend/rust-compile-fnparam.cc
+++ b/gcc/rust/backend/rust-compile-fnparam.cc
@@ -69,24 +69,35 @@ CompileFnParam::visit (HIR::WildcardPattern &pattern)
 }
 
 void
+CompileFnParam::visit (HIR::TuplePattern &pattern)
+{
+  compiled_param = create_tmp_param_var (decl_type);
+  CompilePatternBindings::Compile (
+    pattern, Backend::var_expression (compiled_param, locus), ctx);
+}
+
+void
 CompileFnParam::visit (HIR::StructPattern &pattern)
 {
-  tree tmp_param_var = create_tmp_param_var (decl_type);
-  CompilePatternBindings::Compile (pattern, tmp_param_var, ctx);
+  compiled_param = create_tmp_param_var (decl_type);
+  CompilePatternBindings::Compile (
+    pattern, Backend::var_expression (compiled_param, locus), ctx);
 }
 
 void
 CompileFnParam::visit (HIR::TupleStructPattern &pattern)
 {
-  tree tmp_param_var = create_tmp_param_var (decl_type);
-  CompilePatternBindings::Compile (pattern, tmp_param_var, ctx);
+  compiled_param = create_tmp_param_var (decl_type);
+  CompilePatternBindings::Compile (
+    pattern, Backend::var_expression (compiled_param, locus), ctx);
 }
 
 void
 CompileFnParam::visit (HIR::ReferencePattern &pattern)
 {
-  tree tmp_param_var = create_tmp_param_var (decl_type);
-  CompilePatternBindings::Compile (pattern, tmp_param_var, ctx);
+  compiled_param = create_tmp_param_var (decl_type);
+  CompilePatternBindings::Compile (
+    pattern, Backend::var_expression (compiled_param, locus), ctx);
 }
 
 Bvariable *
@@ -102,7 +113,7 @@ CompileSelfParam::compile (Context *ctx, tree fndecl, HIR::SelfParam &self,
   return Backend::parameter_variable (fndecl, "self", decl_type, locus);
 }
 
-tree
+Bvariable *
 CompileFnParam::create_tmp_param_var (tree decl_type)
 {
   // generate the anon param
@@ -110,10 +121,8 @@ CompileFnParam::create_tmp_param_var (tree decl_type)
   std::string cpp_str_identifier = std::string (IDENTIFIER_POINTER (tmp_ident));
 
   decl_type = Backend::immutable_type (decl_type);
-  compiled_param = Backend::parameter_variable (fndecl, cpp_str_identifier,
-						decl_type, locus);
-
-  return Backend::var_expression (compiled_param, locus);
+  return Backend::parameter_variable (fndecl, cpp_str_identifier, decl_type,
+				      locus);
 }
 
 } // namespace Compile

--- a/gcc/rust/backend/rust-compile-fnparam.h
+++ b/gcc/rust/backend/rust-compile-fnparam.h
@@ -47,12 +47,12 @@ public:
   void visit (HIR::QualifiedPathInExpression &) override {}
   void visit (HIR::RangePattern &) override {}
   void visit (HIR::SlicePattern &) override {}
-  void visit (HIR::TuplePattern &) override {}
+  void visit (HIR::TuplePattern &) override;
 
 private:
   CompileFnParam (Context *ctx, tree fndecl, tree decl_type, location_t locus);
 
-  tree create_tmp_param_var (tree decl_type);
+  Bvariable *create_tmp_param_var (tree decl_type);
 
   tree fndecl;
   tree decl_type;

--- a/gcc/rust/backend/rust-compile-pattern.h
+++ b/gcc/rust/backend/rust-compile-pattern.h
@@ -82,6 +82,7 @@ public:
   void visit (HIR::TupleStructPattern &pattern) override;
   void visit (HIR::ReferencePattern &pattern) override;
   void visit (HIR::IdentifierPattern &) override;
+  void visit (HIR::TuplePattern &pattern) override;
 
   // Empty visit for unused Pattern HIR nodes.
   void visit (HIR::AltPattern &) override {}
@@ -90,7 +91,6 @@ public:
   void visit (HIR::QualifiedPathInExpression &) override {}
   void visit (HIR::RangePattern &) override {}
   void visit (HIR::SlicePattern &) override {}
-  void visit (HIR::TuplePattern &) override {}
   void visit (HIR::WildcardPattern &) override {}
 
 protected:

--- a/gcc/testsuite/rust/compile/issue-2847.rs
+++ b/gcc/testsuite/rust/compile/issue-2847.rs
@@ -1,0 +1,8 @@
+pub fn myfun1((x, _): (i32, i32)) -> i32 {
+    x
+}
+
+pub fn myfun2() -> i32 {
+    let (x, _) = (1, 2);
+    x
+}


### PR DESCRIPTION
In order to handle the tuple pattern of: ````fn test ((x _) : (i32, i32)) -> i32 { x }``` we need to recognize that ABI wise this function still takes a tuple as the parameter to this function its just how we can address the "pattern" of the tuple changes.

So reall if this was C it would look like:

```c
  void test (struct tuple_type __prameter)
  {
    return __parameter.0
  }
```

The code here reuses our existing pattern code so that we generate these implicit bindings of the paramter with a field access so any time x is referenced it's really just emplacing __parameter.0 for the field access into the struct which is a tuple.

Fixes Rust-GCC#2847

gcc/rust/ChangeLog:

	* backend/rust-compile-fnparam.cc (CompileFnParam::visit): compile tuple patterns
	(CompileFnParam::create_tmp_param_var): return Bvariable not tree to stop ICE
	* backend/rust-compile-fnparam.h: update prototype
	* backend/rust-compile-pattern.cc (CompilePatternBindings::visit): implement TuplePattern
	* backend/rust-compile-pattern.h: update prototype

gcc/testsuite/ChangeLog:

	* rust/compile/issue-2847.rs: New test.
