### PR TITLE
refactor(typecheck): StackedContexts for blocks

### DIFF
--- a/gcc/rust/typecheck/rust-hir-trait-resolve.cc
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.cc
@@ -278,7 +278,7 @@ TraitResolver::resolve_trait (HIR::Trait *trait_reference)
     }
   self->inherit_bounds (specified_bounds);
 
-  context->push_block_context (TypeCheckBlockContextItem (trait_reference));
+  context->block_context ().enter (TypeCheckBlockContextItem (trait_reference));
   std::vector<TraitItemReference> item_refs;
   for (auto &item : trait_reference->get_trait_items ())
     {
@@ -308,7 +308,7 @@ TraitResolver::resolve_trait (HIR::Trait *trait_reference)
   // resolve the blocks of functions etc because it can end up in a recursive
   // loop of trying to resolve traits as required by the types
   tref->on_resolved ();
-  context->pop_block_context ();
+  context->block_context ().exit ();
 
   return tref;
 }

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.cc
@@ -335,9 +335,10 @@ TypeCheckImplItem::Resolve (
 
   // resolve
   TypeCheckImplItem resolver (parent, self, substitutions);
-  resolver.context->push_block_context (TypeCheckBlockContextItem (&parent));
+  resolver.context->block_context ().enter (
+    TypeCheckBlockContextItem (&parent));
   item.accept_vis (resolver);
-  resolver.context->pop_block_context ();
+  resolver.context->block_context ().exit ();
 
   return resolver.result;
 }

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -591,10 +591,11 @@ TypeCheckType::resolve_segments (
       bool first_segment = i == offset;
       bool selfResolveOk = false;
 
-      if (first_segment && tySegIsBigSelf && context->have_block_context ()
-	  && context->peek_block_context ().is_impl_block ())
+      if (first_segment && tySegIsBigSelf
+	  && context->block_context ().is_in_context ()
+	  && context->block_context ().peek ().is_impl_block ())
 	{
-	  TypeCheckBlockContextItem ctx = context->peek_block_context ();
+	  TypeCheckBlockContextItem ctx = context->block_context ().peek ();
 	  TyTy::BaseType *lookup = nullptr;
 	  selfResolveOk
 	    = resolve_associated_type (seg->as_string (), ctx, &lookup);

--- a/gcc/rust/typecheck/rust-hir-type-check.h
+++ b/gcc/rust/typecheck/rust-hir-type-check.h
@@ -22,6 +22,7 @@
 #include "rust-hir-map.h"
 #include "rust-tyty.h"
 #include "rust-hir-trait-reference.h"
+#include "rust-stacked-contexts.h"
 #include "rust-autoderef.h"
 #include "rust-tyty-region.h"
 #include "rust-tyty-variance-analysis.h"
@@ -186,10 +187,7 @@ public:
 			 TyTy::BaseType *return_type);
   void pop_return_type ();
 
-  bool have_block_context () const;
-  TypeCheckBlockContextItem peek_block_context ();
-  void push_block_context (TypeCheckBlockContextItem item);
-  void pop_block_context ();
+  StackedContexts<TypeCheckBlockContextItem> &block_context ();
 
   void iterate (std::function<bool (HirId, TyTy::BaseType *)> cb);
 
@@ -282,7 +280,7 @@ private:
   std::vector<std::pair<TypeCheckContextItem, TyTy::BaseType *>>
     return_type_stack;
   std::vector<TyTy::BaseType *> loop_type_stack;
-  std::vector<TypeCheckBlockContextItem> block_stack;
+  StackedContexts<TypeCheckBlockContextItem> block_stack;
   std::map<DefId, TraitReference> trait_context;
   std::map<HirId, TyTy::BaseType *> receiver_context;
   std::map<HirId, AssociatedImplTrait> associated_impl_traits;

--- a/gcc/rust/typecheck/rust-typecheck-context.cc
+++ b/gcc/rust/typecheck/rust-typecheck-context.cc
@@ -177,30 +177,10 @@ TypeCheckContext::peek_context ()
   return return_type_stack.back ().first;
 }
 
-bool
-TypeCheckContext::have_block_context () const
+StackedContexts<TypeCheckBlockContextItem> &
+TypeCheckContext::block_context ()
 {
-  return !block_stack.empty ();
-}
-
-TypeCheckBlockContextItem
-TypeCheckContext::peek_block_context ()
-{
-  rust_assert (!block_stack.empty ());
-  return block_stack.back ();
-}
-
-void
-TypeCheckContext::push_block_context (TypeCheckBlockContextItem block)
-{
-  block_stack.push_back (block);
-}
-
-void
-TypeCheckContext::pop_block_context ()
-{
-  rust_assert (!block_stack.empty ());
-  block_stack.pop_back ();
+  return block_stack;
 }
 
 void


### PR DESCRIPTION
Replaces the DIY vector stack with a StackedContexts object for block
scopes in the type checker context.

Fixes #3284.

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check.h (class TypeCheckContext): add
	header file and use StackedContexts for blocks
	* typecheck/rust-typecheck-context.cc: update methods
	* typecheck/rust-hir-trait-resolve.cc: refactor function calls
	* typecheck/rust-hir-type-check-implitem.cc: refactor function calls
	* typecheck/rust-hir-type-check-type.cc: refactor function calls

Signed-off-by: Prajwal S N <prajwalnadig21@gmail.com>