### PR TITLE
Add type check on if-expr

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -526,9 +526,18 @@ TypeCheckExpr::visit (HIR::IfExpr &expr)
 				    expr.get_if_condition ().get_locus ()),
 	      expr.get_locus ());
 
-  TypeCheckExpr::Resolve (expr.get_if_block ());
+  TyTy::BaseType *block_type = TypeCheckExpr::Resolve (expr.get_if_block ());
 
-  infered = TyTy::TupleType::get_unit_type ();
+  TyTy::BaseType *unit_ty = nullptr;
+  ok = context->lookup_builtin ("()", &unit_ty);
+  rust_assert (ok);
+
+  infered
+    = coercion_site (expr.get_mappings ().get_hirid (),
+		     TyTy::TyWithLocation (unit_ty),
+		     TyTy::TyWithLocation (block_type,
+					   expr.get_if_block ().get_locus ()),
+		     expr.get_locus ());
 }
 
 void

--- a/gcc/testsuite/rust/compile/if-without-else.rs
+++ b/gcc/testsuite/rust/compile/if-without-else.rs
@@ -1,0 +1,9 @@
+fn foo(pred: bool) -> u8 {
+    if pred { // { dg-error "mismatched types" }
+        1
+    }
+    3
+}
+
+fn main(){
+}

--- a/gcc/testsuite/rust/compile/implicit_returns_err3.rs
+++ b/gcc/testsuite/rust/compile/implicit_returns_err3.rs
@@ -1,6 +1,6 @@
 fn test(x: i32) -> i32 { // { dg-error "mismatched types, expected .i32. but got ...." }
     if x > 1 {
-        1
+        return 1;
     }
 }
 

--- a/gcc/testsuite/rust/compile/torture/if.rs
+++ b/gcc/testsuite/rust/compile/torture/if.rs
@@ -4,6 +4,10 @@ fn foo() -> bool {
 
 fn bar() {}
 
+fn baz(a: i32) {
+    a;
+}
+
 struct Foo1 {
     one: i32
 }
@@ -13,7 +17,7 @@ fn main() {
     if foo() {
         bar();
         let a = Foo1{one: 1};
-        a.one
+        baz (a.one);
     }
 
 }


### PR DESCRIPTION
Check if an if-expr return void type.

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::visit): Add check on if-expr.

gcc/testsuite/ChangeLog:

	* rust/compile/implicit_returns_err3.rs: Change test to be valid.
	* rust/compile/torture/if.rs: Likewise.
	* rust/compile/if-without-else.rs: New test.

Fixes: #3230 