### PR TITLE
gccrs: improve mutability checks

### DIFF
--- a/gcc/testsuite/rust/compile/mutability_checks1.rs
+++ b/gcc/testsuite/rust/compile/mutability_checks1.rs
@@ -1,0 +1,15 @@
+pub fn test() {
+    let a;
+    a = 1;
+    a = 2 + 1;
+    // { dg-error "assignment of read-only variable" "" { target *-*-* } .-1 }
+
+    struct Foo(i32);
+    let a = Foo(1);
+    a.0 = 2;
+    // { dg-error "assignment of read-only variable" "" { target *-*-* } .-1 }
+
+    let a = [1, 2, 3, 4];
+    a[0] = 1 + 2;
+    // { dg-error "assignment of read-only variable" "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/execute/torture/builtin_macro_include_bytes.rs
+++ b/gcc/testsuite/rust/execute/torture/builtin_macro_include_bytes.rs
@@ -25,7 +25,7 @@ fn print_int(value: i32) {
 fn check_bytes(bytes: &[u8; 16]) {
     let the_bytes = b"hello, include!\n";
 
-    let x = true;
+    let mut x = true;
     let mut i = 0;
 
     // X is true iff bytes == the_bytes


### PR DESCRIPTION
This ensures that we handle var decls readonly checks much better

Addresses: Rust-GCC#807 Rust-GCC#3287

gcc/rust/ChangeLog:

	* checks/errors/rust-readonly-check.cc (check_decl): improve mut check
	(emit_error): helper
	(check_modify_expr): likewise
	(readonly_walk_fn): reuse helper
	(ReadonlyCheck::Lint): cleanup context each run

gcc/testsuite/ChangeLog:

	* rust/execute/torture/builtin_macro_include_bytes.rs: missing mut