### PR TITLE
hir-dump: Fix more segfaults in the HIR dump

### DIFF
--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -315,6 +315,14 @@ Dump::do_functionparam (FunctionParam &e)
 void
 Dump::do_pathpattern (PathPattern &e)
 {
+  if (e.get_path_kind () == PathPattern::Kind::LangItem)
+    {
+      put_field ("segments", "#[lang = \""
+			       + LangItem::ToString (e.get_lang_item ())
+			       + "\"]");
+      return;
+    }
+
   std::string str = "";
 
   for (const auto &segment : e.get_segments ())
@@ -405,9 +413,12 @@ void
 Dump::do_qualifiedpathtype (QualifiedPathType &e)
 {
   do_mappings (e.get_mappings ());
-  visit_field ("type", e.get_type ());
+  if (e.has_type ())
+    visit_field ("type", e.get_type ());
+  else
+    put_field ("type", "none");
 
-  if (e.has_as_clause ())
+  if (e.has_trait ())
     visit_field ("trait", e.get_trait ());
 }
 
@@ -527,6 +538,8 @@ Dump::do_traitfunctiondecl (TraitFunctionDecl &e)
 
   if (e.has_return_type ())
     visit_field ("return_type", e.get_return_type ());
+  else
+    put_field ("return_type", "none");
 
   if (e.has_where_clause ())
     put_field ("where_clause", e.get_where_clause ().as_string ());
@@ -1306,6 +1319,8 @@ Dump::visit (BreakExpr &e)
 
   if (e.has_break_expr ())
     visit_field ("break_expr ", e.get_expr ());
+  else
+    put_field ("break_expr", "none");
 
   end ("BreakExpr");
 }

--- a/gcc/rust/hir/tree/rust-hir-path.h
+++ b/gcc/rust/hir/tree/rust-hir-path.h
@@ -733,13 +733,20 @@ public:
 
   Analysis::NodeMapping get_mappings () const { return mappings; }
 
+  bool has_type () { return type != nullptr; }
+  bool has_trait () { return trait != nullptr; }
+
   Type &get_type ()
   {
     rust_assert (type);
     return *type;
   }
 
-  TypePath &get_trait () { return *trait; }
+  TypePath &get_trait ()
+  {
+    rust_assert (trait);
+    return *trait;
+  }
 
   bool trait_has_generic_args () const;
 


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* hir/rust-hir-dump.cc: Check unique_ptr members are present before visiting them.
	* hir/tree/rust-hir-path.h: Add `has_{type, trait}` methods to QualifiedPathInType.
