### PR TITLE
typecheck-path: Fix typo (reciever -> receiver)

### DIFF
--- a/gcc/rust/typecheck/rust-hir-path-probe.cc
+++ b/gcc/rust/typecheck/rust-hir-path-probe.cc
@@ -168,7 +168,7 @@ PathProbeType::Probe (const TyTy::BaseType *receiver,
   if (!probe_bounds)
     return probe.candidates;
 
-  if (!probe.is_reciever_generic ())
+  if (!probe.is_receiver_generic ())
     {
       std::vector<std::pair<TraitReference *, HIR::ImplBlock *>> probed_bounds
 	= TypeBoundsProbe::Probe (receiver);
@@ -433,7 +433,7 @@ PathProbeType::union_bounds (
 }
 
 bool
-PathProbeType::is_reciever_generic () const
+PathProbeType::is_receiver_generic () const
 {
   const TyTy::BaseType *root = receiver->get_root ();
   bool receiver_is_type_param = root->get_kind () == TyTy::TypeKind::PARAM;

--- a/gcc/rust/typecheck/rust-hir-path-probe.h
+++ b/gcc/rust/typecheck/rust-hir-path-probe.h
@@ -145,7 +145,7 @@ protected:
     const std::vector<std::pair<const TraitReference *, HIR::ImplBlock *>> b)
     const;
 
-  bool is_reciever_generic () const;
+  bool is_receiver_generic () const;
 
   const TyTy::BaseType *receiver;
   const HIR::PathIdentSegment &search;

--- a/gcc/rust/typecheck/rust-hir-type-check-path.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-path.cc
@@ -354,13 +354,13 @@ TypeCheckExpr::resolve_segments (NodeId root_resolved_node_id,
 {
   NodeId resolved_node_id = root_resolved_node_id;
   TyTy::BaseType *prev_segment = tyseg;
-  bool reciever_is_generic = prev_segment->get_kind () == TyTy::TypeKind::PARAM;
-  bool reciever_is_dyn = prev_segment->get_kind () == TyTy::TypeKind::DYNAMIC;
+  bool receiver_is_generic = prev_segment->get_kind () == TyTy::TypeKind::PARAM;
+  bool receiver_is_dyn = prev_segment->get_kind () == TyTy::TypeKind::DYNAMIC;
 
   for (size_t i = offset; i < segments.size (); i++)
     {
       HIR::PathExprSegment &seg = segments.at (i);
-      bool probe_impls = !reciever_is_generic;
+      bool probe_impls = !receiver_is_generic;
 
       // probe the path is done in two parts one where we search impls if no
       // candidate is found then we search extensions from traits
@@ -435,7 +435,7 @@ TypeCheckExpr::resolve_segments (NodeId root_resolved_node_id,
 	    }
 	}
 
-      if (associated_impl_block != nullptr && !reciever_is_dyn)
+      if (associated_impl_block != nullptr && !receiver_is_dyn)
 	{
 	  // associated types
 	  HirId impl_block_id
@@ -492,7 +492,7 @@ TypeCheckExpr::resolve_segments (NodeId root_resolved_node_id,
 	  if (tyseg->get_kind () == TyTy::TypeKind::ERROR)
 	    return;
 	}
-      else if (tyseg->needs_generic_substitutions () && !reciever_is_generic)
+      else if (tyseg->needs_generic_substitutions () && !receiver_is_generic)
 	{
 	  location_t locus = seg.get_locus ();
 	  tyseg = SubstMapper::InferSubst (tyseg, locus);


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* typecheck/rust-hir-path-probe.cc: Fix typos.
	* typecheck/rust-hir-path-probe.h: Likewise.
	* typecheck/rust-hir-type-check-path.cc: Likewise.
