### PR TITLE
Allow float type to be casted as integer type

### DIFF
--- a/gcc/rust/typecheck/rust-casts.cc
+++ b/gcc/rust/typecheck/rust-casts.cc
@@ -225,6 +225,12 @@ TypeCastRules::cast_rules ()
     case TyTy::TypeKind::FLOAT:
       switch (to.get_ty ()->get_kind ())
 	{
+	case TyTy::TypeKind::USIZE:
+	case TyTy::TypeKind::ISIZE:
+	case TyTy::TypeKind::UINT:
+	case TyTy::TypeKind::INT:
+	  return TypeCoercionRules::CoercionResult{{}, to.get_ty ()->clone ()};
+
 	case TyTy::TypeKind::FLOAT:
 	  return TypeCoercionRules::CoercionResult{{}, to.get_ty ()->clone ()};
 

--- a/gcc/testsuite/rust/compile/cast_float_as_integer.rs
+++ b/gcc/testsuite/rust/compile/cast_float_as_integer.rs
@@ -1,0 +1,10 @@
+// { dg-options "-w" }
+fn main(){
+    let foo:f64 = 13.37;
+    let _ = foo as i64;
+    let _ = foo as u64;
+    let _ = foo as isize;
+    let _ = foo as usize;
+    let _ = foo as i8;
+    let _ = foo as u8;
+}


### PR DESCRIPTION
#3270 added rules for `int -> float` casts but not the opposite .
This PR should add  support for `float -> int` casts and fully fix #3261.