### PR TITLE
parser: Add testcases for multiline strings

### DIFF
--- a/gcc/testsuite/rust/compile/multiline-string.rs
+++ b/gcc/testsuite/rust/compile/multiline-string.rs
@@ -1,0 +1,14 @@
+fn main() {
+    let _a = "gcc
+    
+    rs";
+
+    let _b = "rust
+    
+    c
+    gcc
+    
+    
+    
+    rs";
+}

--- a/gcc/testsuite/rust/execute/torture/multiline-string.rs
+++ b/gcc/testsuite/rust/execute/torture/multiline-string.rs
@@ -1,0 +1,15 @@
+// { dg-output "gcc\n\nrs\n" }
+
+extern "C" {
+    fn printf(fmt: *const i8, ...);
+}
+
+fn main() -> i32 {
+    let a = "gcc
+
+rs\0";
+
+    unsafe { printf("%s\n\0" as *const str as *const i8, a as *const str as *const i8); }
+
+    0
+}


### PR DESCRIPTION
Regression checks for Rust-GCC#1399. Fixes #1399 