### PR TITLE
Resolve and lower parenthesized types

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-type.h
+++ b/gcc/rust/hir/rust-ast-lower-type.h
@@ -22,6 +22,7 @@
 #include "rust-ast-lower-base.h"
 #include "rust-ast-lower-expr.h"
 #include "rust-hir-path.h"
+#include "rust-type.h"
 
 namespace Rust {
 namespace HIR {
@@ -83,6 +84,7 @@ public:
   void visit (AST::NeverType &type) override;
   void visit (AST::TraitObjectTypeOneBound &type) override;
   void visit (AST::TraitObjectType &type) override;
+  void visit (AST::ParenthesisedType &type) override;
 
 private:
   ASTLoweringType (bool default_to_static_lifetime)

--- a/gcc/rust/resolve/rust-ast-resolve-type.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-type.cc
@@ -51,6 +51,12 @@ ResolveType::visit (AST::TraitObjectType &type)
 }
 
 void
+ResolveType::visit (AST::ParenthesisedType &type)
+{
+  resolved_node = ResolveType::go (*type.get_type_in_parens ());
+}
+
+void
 ResolveType::visit (AST::ReferenceType &type)
 {
   resolved_node = ResolveType::go (type.get_type_referenced ());

--- a/gcc/rust/resolve/rust-ast-resolve-type.h
+++ b/gcc/rust/resolve/rust-ast-resolve-type.h
@@ -24,6 +24,7 @@
 #include "rust-diagnostics.h"
 #include "rust-hir-map.h"
 #include "rust-path.h"
+#include "rust-type.h"
 #include "util/rust-hir-map.h"
 
 namespace Rust {
@@ -142,6 +143,8 @@ public:
   void visit (AST::TraitObjectTypeOneBound &type) override;
 
   void visit (AST::TraitObjectType &type) override;
+
+  void visit (AST::ParenthesisedType &type) override;
 
   void visit (AST::SliceType &type) override;
 

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -791,6 +791,12 @@ TypeCheckType::visit (HIR::TraitObjectType &type)
 }
 
 void
+TypeCheckType::visit (HIR::ParenthesisedType &type)
+{
+  translated = TypeCheckType::Resolve (type.get_type_in_parens ());
+}
+
+void
 TypeCheckType::visit (HIR::ArrayType &type)
 {
   auto capacity_type = TypeCheckExpr::Resolve (type.get_size_expr ());

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -59,6 +59,7 @@ public:
   void visit (HIR::InferredType &type) override;
   void visit (HIR::NeverType &type) override;
   void visit (HIR::TraitObjectType &type) override;
+  void visit (HIR::ParenthesisedType &type) override;
 
   void visit (HIR::TypePathSegmentFunction &segment) override
   { /* TODO */
@@ -67,9 +68,6 @@ public:
   { /* TODO */
   }
   void visit (HIR::ImplTraitType &type) override
-  { /* TODO */
-  }
-  void visit (HIR::ParenthesisedType &type) override
   { /* TODO */
   }
   void visit (HIR::ImplTraitTypeOneBound &type) override

--- a/gcc/testsuite/rust/compile/auto_traits1.rs
+++ b/gcc/testsuite/rust/compile/auto_traits1.rs
@@ -1,0 +1,27 @@
+// { dg-additional-options "-frust-compile-until=typecheck" }
+
+#![feature(optin_builtin_traits)]
+
+pub unsafe auto trait Send {}
+#[lang = "sync"]
+pub unsafe auto trait Sync {}
+
+trait A {
+    fn a_method(&self) {}
+}
+
+fn foo(a: &(dyn A + Send + Sync)) {
+    a.a_method();
+}
+
+struct S;
+
+impl A for S {
+    fn a_method(&self) {}
+}
+
+fn main() {
+    let s = S;
+
+    foo(&s);
+}

--- a/gcc/testsuite/rust/compile/auto_traits2.rs
+++ b/gcc/testsuite/rust/compile/auto_traits2.rs
@@ -1,0 +1,26 @@
+#![feature(optin_builtin_traits)]
+
+pub unsafe auto trait Send {}
+#[lang = "sync"]
+pub unsafe auto trait Sync {}
+
+trait A {
+    fn a_method(&self) {}
+}
+
+fn foo(a: &(dyn A + Send + Sync)) {
+    a.a_method();
+}
+
+struct S;
+
+impl A for S {
+    fn a_method(&self) {}
+}
+
+fn main() {
+    let s = S;
+
+    foo(&s); // { dg-error "bounds not satisfied" }
+             // { dg-error "mismatched type" "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/compile/auto_traits3.rs
+++ b/gcc/testsuite/rust/compile/auto_traits3.rs
@@ -1,0 +1,34 @@
+#![feature(optin_builtin_traits)]
+
+pub unsafe auto trait Send {}
+#[lang = "sync"]
+pub unsafe auto trait Sync {}
+
+trait A {
+    fn a_method(&self) {}
+}
+
+fn foo(a: &(dyn A + Send + Sync)) {
+    a.a_method();
+}
+
+struct S;
+
+impl A for S {
+    fn a_method(&self) {} // { dg-warning "unused" }
+}
+
+// These should not be necessary because they are both auto traits
+// They need to be removed once we figure out the proper implementation for each of them
+// However, it'd be silly to implement other traits in order to ensure the test is okay,
+// as these extra trait bounds are only allowed to use auto traits
+// FIXME: #3327
+// FIXME: #3326
+unsafe impl Send for S {}
+unsafe impl Sync for S {}
+
+fn main() {
+    let s = S;
+
+    foo(&s);
+}

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -207,4 +207,6 @@ issue-2907.rs
 issue-2423.rs
 issue-266.rs
 additional-trait-bounds2.rs
+auto_traits2.rs
+auto_traits3.rs
 # please don't delete the trailing newline


### PR DESCRIPTION
Needs #3324 

This allows us to start looking at more handling for auto traits and multiple trait bounds, as they are always represented as parenthesized types when used in function parameters