### PR TITLE
refactor all attribute functions in rust-compile-base.cc

### DIFF
--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -38,6 +38,65 @@ Attributes::is_known (const std::string &attribute_path)
   return !lookup.is_error ();
 }
 
+std::vector<std::string>
+Attributes::get_attributes (const AST::Attribute &attr)
+{
+  std::vector<std::string> result;
+
+  rust_assert (attr.get_attr_input ().get_attr_input_type ()
+	       == Rust::AST::AttrInput::TOKEN_TREE);
+  const auto &tt
+    = static_cast<const AST::DelimTokenTree &> (attr.get_attr_input ());
+
+  // TODO: Should we rely on fixed index ? Should we search for the
+  // attribute tokentree instead ?
+
+  // Derive proc macros have the following format:
+  // #[proc_macro_derive(TraitName, attributes(attr1, attr2, attr3))]
+  //                    -~~~~~~~~ - ~~~~~~~~~~---------------------
+  //                    ^0  ^1    ^2     ^3           ^4
+  // - "attributes" is stored at position 3 in the token tree
+  // - attribute are stored in the delimited token tree in position 4
+  constexpr size_t attr_kw_pos = 3;
+  constexpr size_t attribute_list_pos = 4;
+
+  if (tt.get_token_trees ().size () > attr_kw_pos)
+    {
+      rust_assert (tt.get_token_trees ()[attr_kw_pos]->as_string ()
+		   == "attributes");
+
+      auto attributes = static_cast<const AST::DelimTokenTree *> (
+	tt.get_token_trees ()[attribute_list_pos].get ());
+
+      auto &token_trees = attributes->get_token_trees ();
+
+      for (auto i = token_trees.cbegin () + 1; // Skip opening parenthesis
+	   i < token_trees.cend ();
+	   i += 2) // Skip comma and closing parenthesis
+	{
+	  result.push_back ((*i)->as_string ());
+	}
+    }
+  return result;
+}
+
+std::string
+Attributes::get_trait_name (const AST::Attribute &attr)
+{
+  // Derive proc macros have the following format:
+  // #[proc_macro_derive(TraitName, attributes(attr1, attr2, attr3))]
+  //                    -~~~~~~~~ - ~~~~~~~~~~---------------------
+  //                    ^0  ^1    ^2     ^3           ^4
+  // - The trait name is stored at position 1
+  constexpr size_t trait_name_pos = 1;
+
+  rust_assert (attr.get_attr_input ().get_attr_input_type ()
+	       == Rust::AST::AttrInput::TOKEN_TREE);
+  const auto &tt
+    = static_cast<const AST::DelimTokenTree &> (attr.get_attr_input ());
+  return tt.get_token_trees ()[trait_name_pos]->as_string ();
+}
+
 using Attrs = Values::Attributes;
 
 // https://doc.rust-lang.org/stable/nightly-rustc/src/rustc_feature/builtin_attrs.rs.html#248

--- a/gcc/rust/util/rust-attributes.h
+++ b/gcc/rust/util/rust-attributes.h
@@ -29,6 +29,8 @@ class Attributes
 {
 public:
   static bool is_known (const std::string &attribute_path);
+  static std::string get_trait_name (const AST::Attribute &attr);
+  static std::vector<std::string> get_attributes (const AST::Attribute &attr);
 };
 
 enum CompilerPass


### PR DESCRIPTION
gcc/rust/ChangeLog:	
        * backend/rust-compile-base.cc (get_attributes): (get_trait_name):
	* util/rust-attributes.cc (Attributes::get_attributes): (Attributes::get_trait_name):
	* util/rust-attributes.h:

Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[ ] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[ ] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[ ] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---

Fixes #3291 

*Please write a comment explaining your change. This is the message
that will be part of the merge commit.
