### PR TITLE
Refactoring attri

### DIFF
--- a/gcc/rust/ast/rust-collect-lang-items.cc
+++ b/gcc/rust/ast/rust-collect-lang-items.cc
@@ -40,12 +40,7 @@ get_lang_item_attr (const T &maybe_lang_item)
 	  continue;
 	}
 
-      bool is_lang_item = str_path == Values::Attributes::LANG
-			  && attr.has_attr_input ()
-			  && attr.get_attr_input ().get_attr_input_type ()
-			       == AST::AttrInput::AttrInputType::LITERAL;
-
-      if (is_lang_item)
+      if (Analysis::Attributes::is_lang_item (str_path, attr))
 	{
 	  auto &literal
 	    = static_cast<AST::AttrInputLiteral &> (attr.get_attr_input ());

--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -37,7 +37,14 @@ Attributes::is_known (const std::string &attribute_path)
 
   return !lookup.is_error ();
 }
-
+bool
+Attributes::is_lang_item (const std::string &attribute_path,
+			  AST::Attribute &attr)
+{
+  return ((attribute_path == Values::Attributes::LANG) && attr.has_attr_input ()
+	  && (attr.get_attr_input ().get_attr_input_type ()
+	      == AST::AttrInput::AttrInputType::LITERAL));
+}
 using Attrs = Values::Attributes;
 
 // https://doc.rust-lang.org/stable/nightly-rustc/src/rustc_feature/builtin_attrs.rs.html#248

--- a/gcc/rust/util/rust-attributes.h
+++ b/gcc/rust/util/rust-attributes.h
@@ -29,6 +29,8 @@ class Attributes
 {
 public:
   static bool is_known (const std::string &attribute_path);
+  static bool is_lang_item (const std::string &attribute_path,
+			    AST::Attribute &attr);
 };
 
 enum CompilerPass


### PR DESCRIPTION
gcc/rust/ChangeLog:
        * ast/rust-collect-lang-items.cc (get_lang_item_attr): "removed a static attribute checker function"
	* util/rust-attributes.cc (Attributes::is_lang_item): "added the checker function"
	* util/rust-attributes.h: "Header file"

Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[ ] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[ ] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[ ] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---
Addresses #3291 

*Please write a comment explaining your change. This is the message
that will be part of the merge commit.
