### PR TITLE
refactor all attribute functions in rust-privacy-reporter.cc

### DIFF
--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -223,19 +223,22 @@ check_doc_attribute (const AST::Attribute &attribute)
       }
     }
 }
-
-static bool
-is_proc_macro_type (const AST::Attribute &attribute)
+tl::optional<std::string>
+Attributes::is_proc_macro_type (const AST::Attribute &attribute)
 {
   BuiltinAttrDefinition result;
   if (!is_builtin (attribute, result))
-    return false;
+    return tl::nullopt;
 
   auto name = result.name;
-  return name == Attrs::PROC_MACRO || name == Attrs::PROC_MACRO_DERIVE
-	 || name == Attrs::PROC_MACRO_ATTRIBUTE;
+  if (name == Attrs::PROC_MACRO || name == Attrs::PROC_MACRO_DERIVE
+      || name == Attrs::PROC_MACRO_ATTRIBUTE)
+    {
+      return name;
+    }
+  else
+    return tl::nullopt;
 }
-
 // Emit an error when one encountered attribute is either #[proc_macro],
 // #[proc_macro_attribute] or #[proc_macro_derive]
 static void
@@ -243,7 +246,7 @@ check_proc_macro_non_function (const AST::AttrVec &attributes)
 {
   for (auto &attr : attributes)
     {
-      if (is_proc_macro_type (attr))
+      if (Attributes::is_proc_macro_type (attr) != tl::nullopt)
 	rust_error_at (
 	  attr.get_locus (),
 	  "the %<#[%s]%> attribute may only be used on bare functions",
@@ -258,7 +261,7 @@ check_proc_macro_non_root (AST::AttrVec attributes, location_t loc)
 {
   for (auto &attr : attributes)
     {
-      if (is_proc_macro_type (attr))
+      if (Attributes::is_proc_macro_type (attr) != tl::nullopt)
 	{
 	  rust_error_at (
 	    loc,

--- a/gcc/rust/util/rust-attributes.h
+++ b/gcc/rust/util/rust-attributes.h
@@ -29,6 +29,8 @@ class Attributes
 {
 public:
   static bool is_known (const std::string &attribute_path);
+  static tl::optional<std::string>
+  is_proc_macro_type (const AST::Attribute &attribute);
 };
 
 enum CompilerPass


### PR DESCRIPTION
gcc/rust/ChangeLog:	
        * checks/errors/privacy/rust-privacy-reporter.cc (find_proc_macro_attribute):"Removed checker function" (proc_macro_privacy_check): "modified checker implementation"
	* util/rust-attributes.cc (is_proc_macro_type): "modifed fn into Attributes class" (Attributes::is_proc_macro_type): "modifed fn" (check_proc_macro_non_function): "modified checker implementation" (check_proc_macro_non_root): "modified checker implementation"
	* util/rust-attributes.h: "included definition"

Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[ ] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[ ] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[ ] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---
Addresses #3291 
*Please write a comment explaining your change. This is the message
that will be part of the merge commit.
