### PR TITLE
refactor some attribute functions in rust-early-name-resolver.cc 

### DIFF
--- a/gcc/rust/resolve/rust-early-name-resolver.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver.cc
@@ -21,25 +21,17 @@
 #include "rust-name-resolver.h"
 #include "rust-macro-builtins.h"
 #include "rust-attribute-values.h"
+#include "rust-attributes.h"
 
 namespace Rust {
 namespace Resolver {
 
 // Check if a module contains the `#[macro_use]` attribute
-static bool
-is_macro_use_module (const AST::Module &mod)
-{
-  for (const auto &attr : mod.get_outer_attrs ())
-    if (attr.get_path ().as_string () == Values::Attributes::MACRO_USE)
-      return true;
-
-  return false;
-}
 
 std::vector<std::unique_ptr<AST::Item>>
 EarlyNameResolver::accumulate_escaped_macros (AST::Module &module)
 {
-  if (!is_macro_use_module (module))
+  if (!Analysis::Attributes::is_macro_use_module (module))
     return {};
 
   // Parse the module's items if they haven't been expanded and the file

--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -37,6 +37,15 @@ Attributes::is_known (const std::string &attribute_path)
 
   return !lookup.is_error ();
 }
+bool
+Attributes::is_macro_use_module (const AST::Module &mod)
+{
+  for (const auto &attr : mod.get_outer_attrs ())
+    if (attr.get_path ().as_string () == Values::Attributes::MACRO_USE)
+      return true;
+
+  return false;
+}
 
 using Attrs = Values::Attributes;
 

--- a/gcc/rust/util/rust-attributes.h
+++ b/gcc/rust/util/rust-attributes.h
@@ -29,6 +29,7 @@ class Attributes
 {
 public:
   static bool is_known (const std::string &attribute_path);
+  static bool is_macro_use_module (const AST::Module &mod);
 };
 
 enum CompilerPass


### PR DESCRIPTION
gcc/rust/ChangeLog:	
        * resolve/rust-early-name-resolver.cc (is_macro_use_module): "removed checker fn" (EarlyNameResolver::accumulate_escaped_macros): "modified "
	* util/rust-attributes.cc (Attributes::is_macro_use_module):"added checker fn"
	* util/rust-attributes.h: "added "

Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[ ] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[ ] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[ ] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---
Addresses #3291 
*Please write a comment explaining your change. This is the message
that will be part of the merge commit.
