### PR TITLE
Finish `derive(Clone)` for enums

### DIFF
--- a/gcc/rust/ast/rust-ast-builder.cc
+++ b/gcc/rust/ast/rust-ast-builder.cc
@@ -23,6 +23,7 @@
 #include "rust-expr.h"
 #include "rust-path.h"
 #include "rust-item.h"
+#include "rust-path.h"
 #include "rust-token.h"
 
 namespace Rust {
@@ -101,10 +102,25 @@ Builder::type_path_segment (std::string seg) const
 }
 
 std::unique_ptr<TypePathSegment>
-Builder::generic_type_path_segment (std::string seg, GenericArgs args) const
+Builder::type_path_segment (LangItem::Kind lang_item) const
+{
+  return std::unique_ptr<TypePathSegment> (
+    new TypePathSegment (lang_item, loc));
+}
+
+std::unique_ptr<TypePathSegment>
+Builder::type_path_segment_generic (std::string seg, GenericArgs args) const
 {
   return std::unique_ptr<TypePathSegment> (
     new TypePathSegmentGeneric (PathIdentSegment (seg, loc), false, args, loc));
+}
+
+std::unique_ptr<TypePathSegment>
+Builder::type_path_segment_generic (LangItem::Kind lang_item,
+				    GenericArgs args) const
+{
+  return std::unique_ptr<TypePathSegment> (
+    new TypePathSegmentGeneric (lang_item, args, loc));
 }
 
 std::unique_ptr<Type>
@@ -117,12 +133,49 @@ Builder::single_type_path (std::string type) const
 }
 
 std::unique_ptr<Type>
+Builder::single_type_path (LangItem::Kind lang_item) const
+{
+  return std::unique_ptr<Type> (new TypePath (lang_item, {}, loc));
+}
+
+std::unique_ptr<Type>
 Builder::single_generic_type_path (std::string type, GenericArgs args) const
 {
   auto segments = std::vector<std::unique_ptr<TypePathSegment>> ();
-  segments.emplace_back (generic_type_path_segment (type, args));
+  segments.emplace_back (type_path_segment_generic (type, args));
 
   return std::unique_ptr<Type> (new TypePath (std::move (segments), loc));
+}
+
+std::unique_ptr<Type>
+Builder::single_generic_type_path (LangItem::Kind lang_item,
+				   GenericArgs args) const
+{
+  auto segments = std::vector<std::unique_ptr<TypePathSegment>> ();
+  segments.emplace_back (type_path_segment_generic (lang_item, args));
+
+  return std::unique_ptr<Type> (new TypePath (std::move (segments), loc));
+}
+
+TypePath
+Builder::type_path (std::unique_ptr<TypePathSegment> &&segment) const
+{
+  auto segments = std::vector<std::unique_ptr<TypePathSegment>> ();
+  segments.emplace_back (std::move (segment));
+
+  return TypePath (std::move (segments), loc);
+}
+
+TypePath
+Builder::type_path (std::string type) const
+{
+  return type_path (type_path_segment (type));
+}
+
+TypePath
+Builder::type_path (LangItem::Kind lang_item) const
+{
+  return type_path (type_path_segment (lang_item));
 }
 
 PathInExpression

--- a/gcc/rust/ast/rust-ast-builder.cc
+++ b/gcc/rust/ast/rust-ast-builder.cc
@@ -18,9 +18,11 @@
 
 #include "rust-ast-builder.h"
 #include "rust-ast-builder-type.h"
+#include "rust-ast.h"
 #include "rust-common.h"
 #include "rust-expr.h"
 #include "rust-path.h"
+#include "rust-item.h"
 #include "rust-token.h"
 
 namespace Rust {
@@ -180,6 +182,19 @@ std::unique_ptr<Expr>
 Builder::deref (std::unique_ptr<Expr> &&of) const
 {
   return std::unique_ptr<Expr> (new DereferenceExpr (std::move (of), {}, loc));
+}
+
+std::unique_ptr<Stmt>
+Builder::struct_struct (std::string struct_name,
+			std::vector<std::unique_ptr<GenericParam>> &&generics,
+			std::vector<StructField> &&fields)
+{
+  auto is_unit = fields.empty ();
+
+  return std::unique_ptr<Stmt> (
+    new StructStruct (std::move (fields), struct_name, std::move (generics),
+		      WhereClause::create_empty (), is_unit,
+		      Visibility::create_private (), {}, loc));
 }
 
 std::unique_ptr<Expr>

--- a/gcc/rust/ast/rust-ast-builder.cc
+++ b/gcc/rust/ast/rust-ast-builder.cc
@@ -24,6 +24,7 @@
 #include "rust-path.h"
 #include "rust-item.h"
 #include "rust-path.h"
+#include "rust-system.h"
 #include "rust-token.h"
 
 namespace Rust {
@@ -262,9 +263,16 @@ Builder::struct_expr (
   std::string struct_name,
   std::vector<std::unique_ptr<StructExprField>> &&fields) const
 {
+  return struct_expr (path_in_expression ({struct_name}), std::move (fields));
+}
+
+std::unique_ptr<Expr>
+Builder::struct_expr (
+  PathInExpression struct_name,
+  std::vector<std::unique_ptr<StructExprField>> &&fields) const
+{
   return std::unique_ptr<Expr> (
-    new StructExprStructFields (path_in_expression ({struct_name}),
-				std::move (fields), loc));
+    new StructExprStructFields (struct_name, std::move (fields), loc));
 }
 
 std::unique_ptr<StructExprField>

--- a/gcc/rust/ast/rust-ast-builder.h
+++ b/gcc/rust/ast/rust-ast-builder.h
@@ -160,9 +160,14 @@ public:
 
   /**
    * Create an expression for struct instantiation with fields (`S { a, b: c }`)
+   * Tuple expressions are call expressions and can thus be constructed with
+   * `call`
    */
   std::unique_ptr<Expr>
   struct_expr (std::string struct_name,
+	       std::vector<std::unique_ptr<StructExprField>> &&fields) const;
+  std::unique_ptr<Expr>
+  struct_expr (PathInExpression struct_name,
 	       std::vector<std::unique_ptr<StructExprField>> &&fields) const;
 
   /* Create a field expression for struct instantiation (`field_name: value`) */

--- a/gcc/rust/ast/rust-ast-builder.h
+++ b/gcc/rust/ast/rust-ast-builder.h
@@ -114,16 +114,27 @@ public:
 
   /* And similarly for type path segments */
   std::unique_ptr<TypePathSegment> type_path_segment (std::string seg) const;
+  std::unique_ptr<TypePathSegment>
+  type_path_segment (LangItem::Kind lang_item) const;
 
   std::unique_ptr<TypePathSegment>
-  generic_type_path_segment (std::string seg, GenericArgs args) const;
+  type_path_segment_generic (std::string seg, GenericArgs args) const;
+  std::unique_ptr<TypePathSegment>
+  type_path_segment_generic (LangItem::Kind lang_item, GenericArgs args) const;
 
   /* Create a Type from a single string - the most basic kind of type in our AST
    */
   std::unique_ptr<Type> single_type_path (std::string type) const;
+  std::unique_ptr<Type> single_type_path (LangItem::Kind lang_item) const;
 
   std::unique_ptr<Type> single_generic_type_path (std::string type,
 						  GenericArgs args) const;
+  std::unique_ptr<Type> single_generic_type_path (LangItem::Kind lang_item,
+						  GenericArgs args) const;
+
+  TypePath type_path (std::unique_ptr<TypePathSegment> &&segment) const;
+  TypePath type_path (std::string type) const;
+  TypePath type_path (LangItem::Kind lang_item) const;
 
   /**
    * Create a path in expression from multiple segments (`Clone::clone`). You

--- a/gcc/rust/ast/rust-ast-builder.h
+++ b/gcc/rust/ast/rust-ast-builder.h
@@ -21,9 +21,34 @@
 
 #include "rust-ast-full.h"
 #include "rust-expr.h"
+#include "rust-ast.h"
+#include "rust-item.h"
 
 namespace Rust {
 namespace AST {
+
+template <typename T>
+std::vector<std::unique_ptr<T>>
+vec (std::unique_ptr<T> &&t)
+{
+  auto v = std::vector<std::unique_ptr<T>> ();
+
+  v.emplace_back (std::move (t));
+
+  return v;
+}
+
+template <typename T>
+std::vector<std::unique_ptr<T>>
+vec (std::unique_ptr<T> &&t1, std::unique_ptr<T> &&t2)
+{
+  auto v = std::vector<std::unique_ptr<T>> ();
+
+  v.emplace_back (std::move (t1));
+  v.emplace_back (std::move (t2));
+
+  return v;
+}
 
 // TODO: Use this builder when expanding regular macros
 /* Builder class with helper methods to create AST nodes. This builder is
@@ -112,6 +137,12 @@ public:
    * Create a path in expression from a lang item.
    */
   PathInExpression path_in_expression (LangItem::Kind lang_item) const;
+
+  /* Create a new struct */
+  std::unique_ptr<Stmt>
+  struct_struct (std::string struct_name,
+		 std::vector<std::unique_ptr<GenericParam>> &&generics,
+		 std::vector<StructField> &&fields);
 
   /* Create a struct expression for unit structs (`S`) */
   std::unique_ptr<Expr> struct_expr_struct (std::string struct_name) const;

--- a/gcc/rust/expand/rust-derive-clone.cc
+++ b/gcc/rust/expand/rust-derive-clone.cc
@@ -263,7 +263,7 @@ DeriveClone::visit_union (Union &item)
     {StructField (
       Identifier ("_t"),
       builder.single_generic_type_path (
-	"PhantomData",
+	LangItem::Kind::PHANTOM_DATA,
 	GenericArgs (
 	  {}, {GenericArg::create_type (builder.single_type_path ("T"))}, {})),
       Visibility::create_private (), item.get_locus ())});

--- a/gcc/rust/expand/rust-derive-clone.cc
+++ b/gcc/rust/expand/rust-derive-clone.cc
@@ -30,6 +30,15 @@ DeriveClone::clone_call (std::unique_ptr<Expr> &&to_clone)
   // $crate::core::clone::Clone::clone for the fully qualified path - we don't
   // link with `core` yet so that might be an issue. Use `Clone::clone` for now?
   // TODO: Factor this function inside the DeriveAccumulator
+
+  // Interestingly, later versions of Rust have a `clone_fn` lang item which
+  // corresponds to this. But because we are first targeting 1.49, we cannot use
+  // it yet. Once we target a new, more recent version of the language, we'll
+  // have figured out how to compile and distribute `core`, meaning we'll be
+  // able to directly call `::core::clone::Clone::clone()`
+
+  // Not sure how to call it properly in the meantime...
+
   auto path = std::unique_ptr<Expr> (
     new PathInExpression (builder.path_in_expression ({"Clone", "clone"})));
 
@@ -79,10 +88,7 @@ DeriveClone::clone_impl (
   std::unique_ptr<AssociatedItem> &&clone_fn, std::string name,
   const std::vector<std::unique_ptr<GenericParam>> &type_generics)
 {
-  // should that be `$crate::core::clone::Clone` instead?
-  auto segments = std::vector<std::unique_ptr<TypePathSegment>> ();
-  segments.emplace_back (builder.type_path_segment ("Clone"));
-  auto clone = TypePath (std::move (segments), loc);
+  auto clone = builder.type_path (LangItem::Kind::CLONE);
 
   auto trait_items = std::vector<std::unique_ptr<AssociatedItem>> ();
   trait_items.emplace_back (std::move (clone_fn));

--- a/gcc/rust/expand/rust-derive-clone.h
+++ b/gcc/rust/expand/rust-derive-clone.h
@@ -63,6 +63,9 @@ private:
   clone_impl (std::unique_ptr<AssociatedItem> &&clone_fn, std::string name,
 	      const std::vector<std::unique_ptr<GenericParam>> &type_generics);
 
+  MatchCase clone_enum_identifier (Enum &item,
+				   const std::unique_ptr<EnumItem> &variant);
+
   virtual void visit_struct (StructStruct &item);
   virtual void visit_tuple (TupleStruct &item);
   virtual void visit_enum (Enum &item);

--- a/gcc/rust/expand/rust-derive-clone.h
+++ b/gcc/rust/expand/rust-derive-clone.h
@@ -63,8 +63,20 @@ private:
   clone_impl (std::unique_ptr<AssociatedItem> &&clone_fn, std::string name,
 	      const std::vector<std::unique_ptr<GenericParam>> &type_generics);
 
+  /**
+   * Get the path to use for matching and creating a variant when matching on an
+   * enum. E.g. for the `Option` enum, with the `None` variant, this will create
+   * a path `Option::None`
+   */
+  PathInExpression variant_match_path (Enum &item, const Identifier &variant);
+
+  /**
+   * Implementation of clone for all possible variants of an enum
+   */
   MatchCase clone_enum_identifier (Enum &item,
 				   const std::unique_ptr<EnumItem> &variant);
+  MatchCase clone_enum_tuple (Enum &item, const EnumItemTuple &variant);
+  MatchCase clone_enum_struct (Enum &item, const EnumItemStruct &variant);
 
   virtual void visit_struct (StructStruct &item);
   virtual void visit_tuple (TupleStruct &item);

--- a/gcc/rust/expand/rust-derive-copy.cc
+++ b/gcc/rust/expand/rust-derive-copy.cc
@@ -18,6 +18,7 @@
 
 #include "rust-derive-copy.h"
 #include "rust-ast-full.h"
+#include "rust-hir-map.h"
 #include "rust-mapping-common.h"
 #include "rust-path.h"
 
@@ -43,12 +44,7 @@ DeriveCopy::copy_impl (
   std::string name,
   const std::vector<std::unique_ptr<GenericParam>> &type_generics)
 {
-  // `$crate::core::marker::Copy` instead
-  auto segments = std::vector<std::unique_ptr<TypePathSegment>> ();
-  segments.emplace_back (builder.type_path_segment ("Copy"));
-
-  auto copy = TypePath (std::move (segments), loc);
-  // auto copy = TypePath (LangItem::Kind::COPY, loc);
+  auto copy = builder.type_path (LangItem::Kind::COPY);
 
   // we need to build up the generics for this impl block which will be just a
   // clone of the types specified ones

--- a/gcc/testsuite/rust/compile/derive_clone_enum1.rs
+++ b/gcc/testsuite/rust/compile/derive_clone_enum1.rs
@@ -1,0 +1,16 @@
+#[lang = "clone"]
+trait Clone {
+    pub fn clone(&self) -> Self;
+}
+
+impl Clone for i32 {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+#[derive(Clone)]
+enum AllIdentifiers {
+    A,
+    B
+}

--- a/gcc/testsuite/rust/compile/derive_clone_enum2.rs
+++ b/gcc/testsuite/rust/compile/derive_clone_enum2.rs
@@ -1,0 +1,16 @@
+#[lang = "clone"]
+trait Clone {
+    pub fn clone(&self) -> Self;
+}
+
+impl Clone for i32 {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+#[derive(Clone)]
+enum TupleEnum {
+    A(i32),
+    B(i32, i32, i32)
+}

--- a/gcc/testsuite/rust/compile/derive_clone_enum3.rs
+++ b/gcc/testsuite/rust/compile/derive_clone_enum3.rs
@@ -1,0 +1,16 @@
+#[lang = "clone"]
+trait Clone {
+    pub fn clone(&self) -> Self;
+}
+
+impl Clone for i32 {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+#[derive(Clone)]
+enum StructEnum {
+    A { i0: i32 },
+    B { i0: i32, i1: i32, i2: i32 }
+}

--- a/gcc/testsuite/rust/compile/derive_macro1.rs
+++ b/gcc/testsuite/rust/compile/derive_macro1.rs
@@ -1,6 +1,7 @@
 #[lang = "sized"]
 pub trait Sized {}
 
+#[lang = "clone"]
 pub trait Clone {
     fn clone(&self) -> Self;
 }

--- a/gcc/testsuite/rust/compile/derive_macro3.rs
+++ b/gcc/testsuite/rust/compile/derive_macro3.rs
@@ -1,6 +1,7 @@
 #[lang = "sized"]
 pub trait Sized {}
 
+#[lang = "clone"]
 pub trait Clone {
     fn clone(&self) -> Self;
 }

--- a/gcc/testsuite/rust/compile/derive_macro4.rs
+++ b/gcc/testsuite/rust/compile/derive_macro4.rs
@@ -6,11 +6,8 @@ pub trait Clone {
     fn clone(&self) -> Self;
 }
 
+#[lang = "phantom_data"]
 struct PhantomData<T>;
-
-pub struct AssertParamIsCopy<T: Copy> {
-    _field: PhantomData<T>,
-}
 
 #[derive(Clone)] // { dg-error "bounds not satisfied for U .Copy. is not satisfied" }
 union U {

--- a/gcc/testsuite/rust/compile/derive_macro4.rs
+++ b/gcc/testsuite/rust/compile/derive_macro4.rs
@@ -1,7 +1,10 @@
 #[lang = "sized"]
 pub trait Sized {}
 
+#[lang = "copy"]
 pub trait Copy {}
+
+#[lang = "clone"]
 pub trait Clone {
     fn clone(&self) -> Self;
 }

--- a/gcc/testsuite/rust/compile/derive_macro6.rs
+++ b/gcc/testsuite/rust/compile/derive_macro6.rs
@@ -2,16 +2,15 @@
 pub trait Sized {}
 
 pub trait Copy {}
+
+
+#[lang = "clone"]
 pub trait Clone {
     fn clone(&self) -> Self;
 }
 
 #[lang = "phantom_data"]
 pub struct PhantomData<T>;
-
-pub struct AssertParamIsCopy<T: Copy> {
-    pub _field: PhantomData<T>,
-}
 
 impl Copy for i32 {}
 impl Copy for i64 {}

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -143,4 +143,7 @@ additional-trait-bounds2.rs
 auto_traits3.rs
 issue-3140.rs
 cmp1.rs
+derive_clone_enum1.rs
+derive_clone_enum2.rs
+derive_clone_enum3.rs
 # please don't delete the trailing newline

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -146,4 +146,9 @@ cmp1.rs
 derive_clone_enum1.rs
 derive_clone_enum2.rs
 derive_clone_enum3.rs
+derive_macro4.rs
+derive_macro6.rs
+issue-2987.rs
+issue-3139-1.rs
+issue-3139-3.rs
 # please don't delete the trailing newline

--- a/gcc/testsuite/rust/execute/torture/derive_clone_enum1.rs
+++ b/gcc/testsuite/rust/execute/torture/derive_clone_enum1.rs
@@ -1,0 +1,51 @@
+#[lang = "clone"]
+trait Clone {
+    pub fn clone(&self) -> Self;
+}
+
+impl Clone for i32 {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+#[derive(Clone)]
+enum MixAndMatch {
+    A,
+    B(i32),
+    C { inner: i32 }
+}
+
+fn main() -> i32 {
+    let a = MixAndMatch::A;
+    let a_copy = a.clone();
+
+    // we want res to stay at zero - when we don't match on the right thing, increase it
+
+    let mut res = match a_copy {
+        MixAndMatch::A => 0,
+        _ => 1,
+    };
+
+    let a = MixAndMatch::B(15);
+    let a_copy = a.clone();
+
+    match a_copy {
+        MixAndMatch::B(15) => {},
+        _ => res += 1,
+    };
+
+    let a = MixAndMatch::C { inner: 15 };
+    let a_copy = a.clone();
+
+    match a_copy {
+        MixAndMatch::C { inner } => {
+            if inner != 15 {
+                res += 1;
+            }
+        },
+        _ => res += 1,
+    };
+
+    res
+}

--- a/gcc/testsuite/rust/execute/torture/derive_macro3.rs
+++ b/gcc/testsuite/rust/execute/torture/derive_macro3.rs
@@ -1,6 +1,7 @@
 #[lang = "sized"]
 pub trait Sized {}
 
+#[lang = "clone"]
 pub trait Clone {
     fn clone(&self) -> Self;
 }

--- a/gcc/testsuite/rust/execute/torture/derive_macro4.rs
+++ b/gcc/testsuite/rust/execute/torture/derive_macro4.rs
@@ -1,6 +1,7 @@
 #[lang = "sized"]
 pub trait Sized {}
 
+#[lang = "clone"]
 pub trait Clone {
     fn clone(&self) -> Self;
 }


### PR DESCRIPTION
This PR changes how lang item paths are handled and subsequently finishes the implementation of `derive(Clone)` for enums and their variants. Putting it as a draft since it's a mess and needs cleaning up. Addresses #2996, but we still need to properly implement generic Clone I think?

I might instead split this up in multiple PRs to first refactor the lang item paths and then finish implementing `derive(Clone)` on top of it - next week.

Needs #3366 