### PR TITLE
gccrs: cleanup our enum type layout to be closer to rustc

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -538,24 +538,32 @@ CompileExpr::visit (HIR::StructExprStructFields &struct_expr)
 	}
     }
 
-  // the constructor depends on whether this is actually an enum or not if
-  // its an enum we need to setup the discriminator
-  std::vector<tree> ctor_arguments;
-  if (adt->is_enum ())
+  if (!adt->is_enum ())
     {
-      HIR::Expr &discrim_expr = variant->get_discriminant ();
-      tree discrim_expr_node = CompileExpr::Compile (discrim_expr, ctx);
-      tree folded_discrim_expr = fold_expr (discrim_expr_node);
-      tree qualifier = folded_discrim_expr;
-
-      ctor_arguments.push_back (qualifier);
+      translated
+	= Backend::constructor_expression (compiled_adt_type, adt->is_enum (),
+					   arguments, union_disriminator,
+					   struct_expr.get_locus ());
+      return;
     }
-  for (auto &arg : arguments)
-    ctor_arguments.push_back (arg);
+
+  HIR::Expr &discrim_expr = variant->get_discriminant ();
+  tree discrim_expr_node = CompileExpr::Compile (discrim_expr, ctx);
+  tree folded_discrim_expr = fold_expr (discrim_expr_node);
+  tree qualifier = folded_discrim_expr;
+
+  tree enum_root_files = TYPE_FIELDS (compiled_adt_type);
+  tree payload_root = DECL_CHAIN (enum_root_files);
+
+  tree payload = Backend::constructor_expression (TREE_TYPE (payload_root),
+						  adt->is_enum (), arguments,
+						  union_disriminator,
+						  struct_expr.get_locus ());
+
+  std::vector<tree> ctor_arguments = {qualifier, payload};
 
   translated
-    = Backend::constructor_expression (compiled_adt_type, adt->is_enum (),
-				       ctor_arguments, union_disriminator,
+    = Backend::constructor_expression (compiled_adt_type, 0, ctor_arguments, -1,
 				       struct_expr.get_locus ());
 }
 
@@ -1227,25 +1235,33 @@ CompileExpr::visit (HIR::CallExpr &expr)
 	  arguments.push_back (rvalue);
 	}
 
-      // the constructor depends on whether this is actually an enum or not if
-      // its an enum we need to setup the discriminator
-      std::vector<tree> ctor_arguments;
-      if (adt->is_enum ())
+      if (!adt->is_enum ())
 	{
-	  HIR::Expr &discrim_expr = variant->get_discriminant ();
-	  tree discrim_expr_node = CompileExpr::Compile (discrim_expr, ctx);
-	  tree folded_discrim_expr = fold_expr (discrim_expr_node);
-	  tree qualifier = folded_discrim_expr;
-
-	  ctor_arguments.push_back (qualifier);
+	  translated
+	    = Backend::constructor_expression (compiled_adt_type,
+					       adt->is_enum (), arguments,
+					       union_disriminator,
+					       expr.get_locus ());
+	  return;
 	}
-      for (auto &arg : arguments)
-	ctor_arguments.push_back (arg);
 
-      translated
-	= Backend::constructor_expression (compiled_adt_type, adt->is_enum (),
-					   ctor_arguments, union_disriminator,
+      HIR::Expr &discrim_expr = variant->get_discriminant ();
+      tree discrim_expr_node = CompileExpr::Compile (discrim_expr, ctx);
+      tree folded_discrim_expr = fold_expr (discrim_expr_node);
+      tree qualifier = folded_discrim_expr;
+
+      tree enum_root_files = TYPE_FIELDS (compiled_adt_type);
+      tree payload_root = DECL_CHAIN (enum_root_files);
+
+      tree payload
+	= Backend::constructor_expression (TREE_TYPE (payload_root), true,
+					   {arguments}, union_disriminator,
 					   expr.get_locus ());
+
+      std::vector<tree> ctor_arguments = {qualifier, payload};
+      translated = Backend::constructor_expression (compiled_adt_type, false,
+						    ctor_arguments, -1,
+						    expr.get_locus ());
 
       return;
     }

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -86,8 +86,9 @@ ResolvePathRef::attempt_constructor_expression_lookup (
   tree folded_discrim_expr = fold_expr (discrim_expr_node);
   tree qualifier = folded_discrim_expr;
 
-  return Backend::constructor_expression (compiled_adt_type, true, {qualifier},
-					  union_disriminator, expr_locus);
+  // false for is enum but this is an enum but we have a new layout
+  return Backend::constructor_expression (compiled_adt_type, false, {qualifier},
+					  -1, expr_locus);
 }
 
 tree

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -1352,7 +1352,7 @@ constructor_expression (tree type_tree, bool is_variant,
 	      if (!TREE_CONSTANT (elt->value))
 		is_constant = false;
 	    }
-	  gcc_assert (field == NULL_TREE);
+	  // gcc_assert (field == NULL_TREE);
 	}
     }
 


### PR DESCRIPTION
This changes our enum type layout so for example:

```rust
  enum Foo {
      A,
      B,
      C(char),
      D { x: i32, y: i32 },
  }
```

Used to get layed out like this in gccrs:

```c
  union {
    struct A { int RUST$ENUM$DISR; };
    struct B { int RUST$ENUM$DISR; };
    struct C { int RUST$ENUM$DISR; char __0; };
    struct D { int RUST$ENUM$DISR; i64 x; i64 y; };
  }
```

This has some issues notably with the constexpr because this is just a giant union it means its not simple to constify what enum variant we are looking at because the discriminant is a mess.

This now gets layed out as:

```c
  struct {
     int RUST$ENUM$DISR;
     union {
         struct A { };
         struct B { };
         struct C { char __0; };
         struct D { i64 x; i64 y; };
     } payload;
  }
```

This layout is much cleaner and allows for our constexpr to work properly.

gcc/rust/ChangeLog:

	* backend/rust-compile-expr.cc (CompileExpr::visit): new layout
	* backend/rust-compile-pattern.cc (CompilePatternCheckExpr::visit): likewise
	(CompilePatternBindings::visit): likewise
	* backend/rust-compile-resolve-path.cc: likewise
	* backend/rust-compile-type.cc (TyTyResolveCompile::visit): implement new layout
	* rust-gcc.cc (constructor_expression): get rid of useless assert

