### PR TITLE
Refactor lang item paths

### DIFF
--- a/gcc/rust/ast/rust-ast-builder.cc
+++ b/gcc/rust/ast/rust-ast-builder.cc
@@ -43,25 +43,7 @@ Builder::call (std::unique_ptr<Expr> &&path,
 }
 
 std::unique_ptr<Expr>
-Builder::call (std::unique_ptr<Path> &&path,
-	       std::vector<std::unique_ptr<Expr>> &&args) const
-{
-  return call (std::unique_ptr<Expr> (
-		 new PathInExpression (std::move (path), {}, loc)),
-	       std::move (args));
-}
-
-std::unique_ptr<Expr>
 Builder::call (std::unique_ptr<Expr> &&path, std::unique_ptr<Expr> &&arg) const
-{
-  auto args = std::vector<std::unique_ptr<Expr>> ();
-  args.emplace_back (std::move (arg));
-
-  return call (std::move (path), std::move (args));
-}
-
-std::unique_ptr<Expr>
-Builder::call (std::unique_ptr<Path> &&path, std::unique_ptr<Expr> &&arg) const
 {
   auto args = std::vector<std::unique_ptr<Expr>> ();
   args.emplace_back (std::move (arg));
@@ -242,7 +224,7 @@ Builder::wildcard () const
 std::unique_ptr<Path>
 Builder::lang_item_path (LangItem::Kind kind) const
 {
-  return std::unique_ptr<Path> (new LangItemPath (kind, loc));
+  return std::unique_ptr<Path> (new PathInExpression (kind, {}, loc));
 }
 
 std::unique_ptr<Expr>

--- a/gcc/rust/ast/rust-ast-builder.h
+++ b/gcc/rust/ast/rust-ast-builder.h
@@ -72,11 +72,7 @@ public:
    */
   std::unique_ptr<Expr> call (std::unique_ptr<Expr> &&path,
 			      std::vector<std::unique_ptr<Expr>> &&args) const;
-  std::unique_ptr<Expr> call (std::unique_ptr<Path> &&path,
-			      std::vector<std::unique_ptr<Expr>> &&args) const;
   std::unique_ptr<Expr> call (std::unique_ptr<Expr> &&path,
-			      std::unique_ptr<Expr> &&arg) const;
-  std::unique_ptr<Expr> call (std::unique_ptr<Path> &&path,
 			      std::unique_ptr<Expr> &&arg) const;
 
   /**

--- a/gcc/rust/ast/rust-ast-collector.cc
+++ b/gcc/rust/ast/rust-ast-collector.cc
@@ -543,10 +543,14 @@ TokenCollector::visit (TypePathSegment &segment)
 {
   // Syntax:
   //    PathIdentSegment
-  auto ident_segment = segment.get_ident_segment ();
-  auto id = ident_segment.as_string ();
-  push (
-    Rust::Token::make_identifier (ident_segment.get_locus (), std::move (id)));
+
+  auto locus = segment.is_lang_item ()
+		 ? segment.get_locus ()
+		 : segment.get_ident_segment ().get_locus ();
+  auto segment_string = segment.is_lang_item ()
+			  ? LangItem::PrettyString (segment.get_lang_item ())
+			  : segment.get_ident_segment ().as_string ();
+  push (Rust::Token::make_identifier (locus, std::move (segment_string)));
 }
 
 void
@@ -558,10 +562,13 @@ TokenCollector::visit (TypePathSegmentGeneric &segment)
   //    `<` `>`
   //    | `<` ( GenericArg `,` )* GenericArg `,`? `>`
 
-  auto ident_segment = segment.get_ident_segment ();
-  auto id = ident_segment.as_string ();
-  push (
-    Rust::Token::make_identifier (ident_segment.get_locus (), std::move (id)));
+  auto locus = segment.is_lang_item ()
+		 ? segment.get_locus ()
+		 : segment.get_ident_segment ().get_locus ();
+  auto segment_string = segment.is_lang_item ()
+			  ? LangItem::PrettyString (segment.get_lang_item ())
+			  : segment.get_ident_segment ().as_string ();
+  push (Rust::Token::make_identifier (locus, std::move (segment_string)));
 
   if (segment.get_separating_scope_resolution ())
     push (Rust::Token::make (SCOPE_RESOLUTION, UNDEF_LOCATION));

--- a/gcc/rust/ast/rust-ast-collector.cc
+++ b/gcc/rust/ast/rust-ast-collector.cc
@@ -2470,10 +2470,7 @@ TokenCollector::visit (StructPattern &pattern)
 void
 TokenCollector::visit (TupleStructItemsNoRange &pattern)
 {
-  for (auto &pat : pattern.get_patterns ())
-    {
-      visit (pat);
-    }
+  visit_items_joined_by_separator (pattern.get_patterns ());
 }
 
 void

--- a/gcc/rust/ast/rust-ast-collector.cc
+++ b/gcc/rust/ast/rust-ast-collector.cc
@@ -539,19 +539,6 @@ TokenCollector::visit (PathInExpression &path)
 }
 
 void
-TokenCollector::visit (RegularPath &path)
-{
-  // FIXME: We probably want to have a proper implementation here, and call this
-  // function from things like the PathInExpression visitor
-}
-
-void
-TokenCollector::visit (LangItemPath &path)
-{
-  // TODO: Implement proper token collection for lang item paths
-}
-
-void
 TokenCollector::visit (TypePathSegment &segment)
 {
   // Syntax:

--- a/gcc/rust/ast/rust-ast-collector.h
+++ b/gcc/rust/ast/rust-ast-collector.h
@@ -233,8 +233,6 @@ public:
   void visit (PathExprSegment &segment);
   void visit (PathIdentSegment &segment);
   void visit (PathInExpression &path);
-  void visit (RegularPath &path);
-  void visit (LangItemPath &path);
   void visit (TypePathSegment &segment);
   void visit (TypePathSegmentGeneric &segment);
   void visit (TypePathSegmentFunction &segment);

--- a/gcc/rust/ast/rust-ast-visitor.cc
+++ b/gcc/rust/ast/rust-ast-visitor.cc
@@ -86,17 +86,6 @@ DefaultASTVisitor::visit (AST::ConstGenericParam &const_param)
 }
 
 void
-DefaultASTVisitor::visit (AST::RegularPath &path)
-{
-  for (auto &segment : path.get_segments ())
-    visit (segment);
-}
-
-void
-DefaultASTVisitor::visit (AST::LangItemPath &path)
-{}
-
-void
 DefaultASTVisitor::visit (AST::PathInExpression &path)
 {
   visit_outer_attrs (path);

--- a/gcc/rust/ast/rust-ast-visitor.h
+++ b/gcc/rust/ast/rust-ast-visitor.h
@@ -60,8 +60,6 @@ public:
   // virtual void visit(TraitImplItem& trait_impl_item) = 0;
 
   // rust-path.h
-  virtual void visit (RegularPath &path) = 0;
-  virtual void visit (LangItemPath &path) = 0;
   virtual void visit (PathInExpression &path) = 0;
   virtual void visit (TypePathSegment &segment) = 0;
   virtual void visit (TypePathSegmentGeneric &segment) = 0;
@@ -252,8 +250,6 @@ public:
   virtual void visit (AST::Lifetime &lifetime) override;
   virtual void visit (AST::LifetimeParam &lifetime_param) override;
   virtual void visit (AST::ConstGenericParam &const_param) override;
-  virtual void visit (AST::RegularPath &path) override;
-  virtual void visit (AST::LangItemPath &path) override;
   virtual void visit (AST::PathInExpression &path) override;
   virtual void visit (AST::TypePathSegment &segment) override;
   virtual void visit (AST::TypePathSegmentGeneric &segment) override;

--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -1299,7 +1299,7 @@ TraitImpl::as_string () const
   else
     str += "false";
 
-  str += "\n TypePath (to trait): " + trait_path->as_string ();
+  str += "\n TypePath (to trait): " + trait_path.as_string ();
 
   str += "\n Type (struct to impl on): " + trait_type->as_string ();
 
@@ -1561,7 +1561,7 @@ QualifiedPathType::as_string () const
   str += type_to_invoke_on->as_string ();
 
   if (has_as_clause ())
-    str += " as " + trait_path->as_string ();
+    str += " as " + trait_path.as_string ();
 
   return str + ">";
 }

--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -4270,7 +4270,7 @@ BlockExpr::normalize_tail_expr ()
 
 	  if (!stmt.is_semicolon_followed ())
 	    {
-	      expr = std::move (stmt.take_expr ());
+	      expr = stmt.take_expr ();
 	      statements.pop_back ();
 	    }
 	}

--- a/gcc/rust/ast/rust-collect-lang-items.cc
+++ b/gcc/rust/ast/rust-collect-lang-items.cc
@@ -23,6 +23,7 @@
 #include "rust-attribute-values.h"
 #include "rust-attributes.h"
 #include "rust-hir-map.h"
+#include "rust-item.h"
 
 namespace Rust {
 namespace AST {
@@ -85,6 +86,14 @@ CollectLangItems::visit (AST::TraitItemType &item)
 
 void
 CollectLangItems::visit (AST::Function &item)
+{
+  maybe_add_lang_item (item);
+
+  DefaultASTVisitor::visit (item);
+}
+
+void
+CollectLangItems::visit (AST::StructStruct &item)
 {
   maybe_add_lang_item (item);
 

--- a/gcc/rust/ast/rust-collect-lang-items.cc
+++ b/gcc/rust/ast/rust-collect-lang-items.cc
@@ -36,7 +36,8 @@ get_lang_item_attr (const T &maybe_lang_item)
       const auto &str_path = attr.get_path ().as_string ();
       if (!Analysis::Attributes::is_known (str_path))
 	{
-	  rust_error_at (attr.get_locus (), "unknown attribute");
+	  rust_error_at (attr.get_locus (), "unknown attribute %qs",
+			 str_path.c_str ());
 	  continue;
 	}
 

--- a/gcc/rust/ast/rust-collect-lang-items.h
+++ b/gcc/rust/ast/rust-collect-lang-items.h
@@ -48,6 +48,7 @@ public:
   void visit (AST::Trait &item) override;
   void visit (AST::TraitItemType &item) override;
   void visit (AST::Function &item) override;
+  void visit (AST::StructStruct &item) override;
 
 private:
   template <typename T> void maybe_add_lang_item (const T &item);

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -3254,7 +3254,7 @@ class TraitImpl : public Impl
 {
   bool has_unsafe;
   bool has_exclam;
-  std::unique_ptr<Path> trait_path;
+  TypePath trait_path;
 
   // bool has_impl_items;
   std::vector<std::unique_ptr<AssociatedItem>> impl_items;
@@ -3266,7 +3266,7 @@ public:
   bool has_impl_items () const { return !impl_items.empty (); }
 
   // Mega-constructor
-  TraitImpl (std::unique_ptr<Path> trait_path, bool is_unsafe, bool has_exclam,
+  TraitImpl (TypePath trait_path, bool is_unsafe, bool has_exclam,
 	     std::vector<std::unique_ptr<AssociatedItem>> impl_items,
 	     std::vector<std::unique_ptr<GenericParam>> generic_params,
 	     std::unique_ptr<Type> trait_type, WhereClause where_clause,
@@ -3275,29 +3275,14 @@ public:
     : Impl (std::move (generic_params), std::move (trait_type),
 	    std::move (where_clause), std::move (vis), std::move (inner_attrs),
 	    std::move (outer_attrs), locus),
-      has_unsafe (is_unsafe), has_exclam (has_exclam),
-      trait_path (std::move (trait_path)), impl_items (std::move (impl_items))
-  {}
-
-  // Delegating constructor for TypePath
-  TraitImpl (TypePath trait_path, bool is_unsafe, bool has_exclam,
-	     std::vector<std::unique_ptr<AssociatedItem>> impl_items,
-	     std::vector<std::unique_ptr<GenericParam>> generic_params,
-	     std::unique_ptr<Type> trait_type, WhereClause where_clause,
-	     Visibility vis, std::vector<Attribute> inner_attrs,
-	     std::vector<Attribute> outer_attrs, location_t locus)
-    : TraitImpl (std::unique_ptr<Path> (new TypePath (trait_path)), is_unsafe,
-		 has_exclam, std::move (impl_items), std::move (generic_params),
-		 std::move (trait_type), std::move (where_clause),
-		 std::move (vis), std::move (inner_attrs),
-		 std::move (outer_attrs), locus)
+      has_unsafe (is_unsafe), has_exclam (has_exclam), trait_path (trait_path),
+      impl_items (std::move (impl_items))
   {}
 
   // Copy constructor with vector clone
   TraitImpl (TraitImpl const &other)
     : Impl (other), has_unsafe (other.has_unsafe),
-      has_exclam (other.has_exclam),
-      trait_path (other.trait_path->clone_path ())
+      has_exclam (other.has_exclam), trait_path (other.trait_path)
   {
     impl_items.reserve (other.impl_items.size ());
     for (const auto &e : other.impl_items)
@@ -3308,7 +3293,7 @@ public:
   TraitImpl &operator= (TraitImpl const &other)
   {
     Impl::operator= (other);
-    trait_path = other.trait_path->clone_path ();
+    trait_path = other.trait_path;
     has_unsafe = other.has_unsafe;
     has_exclam = other.has_exclam;
 
@@ -3339,18 +3324,7 @@ public:
   }
 
   // TODO: is this better? Or is a "vis_block" better?
-  Path &get_trait_path ()
-  {
-    // TODO: assert that trait path is not empty?
-    return *trait_path;
-  }
-
-  Type &get_trait_path_type ()
-  {
-    rust_assert (trait_path->get_path_kind () == Path::Kind::Type);
-
-    return (AST::Type &) static_cast<AST::TypePath &> (*trait_path);
-  }
+  TypePath &get_trait_path () { return trait_path; }
 
 protected:
   /* Use covariance to implement clone function as returning this object

--- a/gcc/rust/ast/rust-path.cc
+++ b/gcc/rust/ast/rust-path.cc
@@ -136,8 +136,11 @@ PathExprSegment::as_string () const
 }
 
 std::string
-RegularPath::as_string () const
+Path::as_string () const
 {
+  // FIXME: Impl for lang items
+  rust_assert (kind == Kind::Regular);
+
   std::string str;
 
   for (const auto &segment : segments)
@@ -149,15 +152,11 @@ RegularPath::as_string () const
   return str;
 }
 
-std::string
-LangItemPath::as_string () const
-{
-  return "#[lang = \"" + LangItem::ToString (kind) + "\"]";
-}
-
 SimplePath
-RegularPath::convert_to_simple_path (bool with_opening_scope_resolution) const
+Path::convert_to_simple_path (bool with_opening_scope_resolution) const
 {
+  rust_assert (kind == Kind::Regular);
+
   if (!has_segments ())
     return SimplePath::create_empty ();
 
@@ -191,18 +190,6 @@ RegularPath::convert_to_simple_path (bool with_opening_scope_resolution) const
 }
 
 void
-RegularPath::accept_vis (ASTVisitor &vis)
-{
-  vis.visit (*this);
-}
-
-void
-LangItemPath::accept_vis (ASTVisitor &vis)
-{
-  vis.visit (*this);
-}
-
-void
 PathInExpression::accept_vis (ASTVisitor &vis)
 {
   vis.visit (*this);
@@ -216,7 +203,7 @@ PathInExpression::as_string () const
   if (has_opening_scope_resolution)
     str = "::";
 
-  return str + path->as_string ();
+  return str + Path::as_string ();
 }
 
 std::string
@@ -316,7 +303,7 @@ TypePathFunction::as_string () const
 std::string
 QualifiedPathInExpression::as_string () const
 {
-  return path_type.as_string () + "::" + path->as_string ();
+  return path_type.as_string () + "::" + Path::as_string ();
 }
 
 std::string

--- a/gcc/rust/expand/rust-derive-copy.cc
+++ b/gcc/rust/expand/rust-derive-copy.cc
@@ -46,7 +46,9 @@ DeriveCopy::copy_impl (
   // `$crate::core::marker::Copy` instead
   auto segments = std::vector<std::unique_ptr<TypePathSegment>> ();
   segments.emplace_back (builder.type_path_segment ("Copy"));
-  auto copy = std::make_unique<LangItemPath> (LangItem::Kind::COPY, loc);
+
+  auto copy = TypePath (std::move (segments), loc);
+  // auto copy = TypePath (LangItem::Kind::COPY, loc);
 
   // we need to build up the generics for this impl block which will be just a
   // clone of the types specified ones

--- a/gcc/rust/expand/rust-derive.h
+++ b/gcc/rust/expand/rust-derive.h
@@ -81,8 +81,6 @@ private:
   virtual void visit (Lifetime &lifetime) override final{};
   virtual void visit (LifetimeParam &lifetime_param) override final{};
   virtual void visit (ConstGenericParam &const_param) override final{};
-  virtual void visit (RegularPath &path) override final{};
-  virtual void visit (LangItemPath &path) override final{};
   virtual void visit (PathInExpression &path) override final{};
   virtual void visit (TypePathSegment &segment) override final{};
   virtual void visit (TypePathSegmentGeneric &segment) override final{};

--- a/gcc/rust/hir/rust-ast-lower-base.cc
+++ b/gcc/rust/hir/rust-ast-lower-base.cc
@@ -64,12 +64,6 @@ ASTLoweringBase::visit (AST::ConstGenericParam &)
 
 // rust-path.h
 void
-ASTLoweringBase::visit (AST::RegularPath &)
-{}
-void
-ASTLoweringBase::visit (AST::LangItemPath &)
-{}
-void
 ASTLoweringBase::visit (AST::PathInExpression &)
 {}
 void

--- a/gcc/rust/hir/rust-ast-lower-base.h
+++ b/gcc/rust/hir/rust-ast-lower-base.h
@@ -84,8 +84,6 @@ public:
   //  virtual void visit(TraitImplItem& trait_impl_item);
 
   // rust-path.h
-  virtual void visit (AST::RegularPath &path);
-  virtual void visit (AST::LangItemPath &path);
   virtual void visit (AST::PathInExpression &path);
   virtual void visit (AST::TypePathSegment &segment);
   virtual void visit (AST::TypePathSegmentGeneric &segment);

--- a/gcc/rust/hir/rust-ast-lower-type.cc
+++ b/gcc/rust/hir/rust-ast-lower-type.cc
@@ -74,11 +74,20 @@ ASTLowerTypePath::visit (AST::TypePathSegment &segment)
   Analysis::NodeMapping mapping (crate_num, segment.get_node_id (), hirid,
 				 UNKNOWN_LOCAL_DEFID);
 
-  HIR::PathIdentSegment ident (segment.get_ident_segment ().as_string ());
-  translated_segment
-    = new HIR::TypePathSegment (std::move (mapping), ident,
-				segment.get_separating_scope_resolution (),
-				segment.get_locus ());
+  if (segment.is_lang_item ())
+    {
+      translated_segment = new HIR::TypePathSegment (std::move (mapping),
+						     segment.get_lang_item (),
+						     segment.get_locus ());
+    }
+  else
+    {
+      HIR::PathIdentSegment ident (segment.get_ident_segment ().as_string ());
+      translated_segment
+	= new HIR::TypePathSegment (std::move (mapping), ident,
+				    segment.get_separating_scope_resolution (),
+				    segment.get_locus ());
+    }
 }
 
 void
@@ -138,27 +147,6 @@ ASTLowerTypePath::visit (AST::TypePath &path)
 			 path.get_locus (),
 			 path.has_opening_scope_resolution_op ());
 }
-
-// void
-// ASTLowerTypePath::visit (AST::LangItemPath &path)
-// {
-//   auto crate_num = mappings.get_current_crate ();
-//   auto hirid = mappings.get_next_hir_id (crate_num);
-
-//   Analysis::NodeMapping mapping (crate_num, path.get_node_id (), hirid,
-// 				 mappings.get_next_localdef_id (crate_num));
-
-//   std::vector<std::unique_ptr<HIR::TypePathSegment>> translated_segments;
-//   translated_segments.emplace_back (std::unique_ptr<HIR::TypePathSegment> (
-//     new HIR::TypePathSegment (mapping,
-// 			      LangItem::ToString (path.get_lang_item_kind ()),
-// 			      false, path.get_locus ())));
-
-//   translated
-//     = new HIR::TypePath (std::move (mapping), std::move
-//     (translated_segments),
-// 			 path.get_locus ());
-// }
 
 HIR::QualifiedPathInType *
 ASTLowerQualifiedPathInType::translate (AST::QualifiedPathInType &type)

--- a/gcc/rust/hir/rust-ast-lower-type.h
+++ b/gcc/rust/hir/rust-ast-lower-type.h
@@ -33,22 +33,18 @@ protected:
   using Rust::HIR::ASTLoweringBase::visit;
 
 public:
-  static HIR::TypePath *translate (AST::Path &type);
+  static HIR::TypePath *translate (AST::TypePath &type);
 
   void visit (AST::TypePathSegmentFunction &segment) override;
   void visit (AST::TypePathSegment &segment) override;
   void visit (AST::TypePathSegmentGeneric &segment) override;
   void visit (AST::TypePath &path) override;
-  void visit (AST::LangItemPath &path) override;
 
 protected:
   HIR::TypePathSegment *translated_segment;
 
 private:
   HIR::TypePath *translated;
-
-  static HIR::TypePath *translate_type_path (AST::TypePath &type);
-  static HIR::TypePath *translate_lang_item_type_path (AST::LangItemPath &type);
 };
 
 class ASTLowerQualifiedPathInType : public ASTLowerTypePath

--- a/gcc/rust/hir/tree/rust-hir-path.cc
+++ b/gcc/rust/hir/tree/rust-hir-path.cc
@@ -17,6 +17,7 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-hir-path.h"
+#include "optional.h"
 #include "rust-hir-bound.h"
 
 namespace Rust {
@@ -164,9 +165,16 @@ TypePathSegment::TypePathSegment (Analysis::NodeMapping mappings,
 				  bool has_separating_scope_resolution,
 				  location_t locus)
   : mappings (std::move (mappings)), ident_segment (std::move (ident_segment)),
-    locus (locus),
+    lang_item (tl::nullopt), locus (locus),
     has_separating_scope_resolution (has_separating_scope_resolution),
     type (SegmentType::REG)
+{}
+
+TypePathSegment::TypePathSegment (Analysis::NodeMapping mappings,
+				  LangItem::Kind lang_item, location_t locus)
+  : mappings (std::move (mappings)), ident_segment (tl::nullopt),
+    lang_item (lang_item), locus (locus),
+    has_separating_scope_resolution (false), type (SegmentType::REG)
 {}
 
 TypePathSegment::TypePathSegment (Analysis::NodeMapping mappings,
@@ -174,7 +182,8 @@ TypePathSegment::TypePathSegment (Analysis::NodeMapping mappings,
 				  bool has_separating_scope_resolution,
 				  location_t locus)
   : mappings (std::move (mappings)),
-    ident_segment (PathIdentSegment (std::move (segment_name))), locus (locus),
+    ident_segment (PathIdentSegment (std::move (segment_name))),
+    lang_item (tl::nullopt), locus (locus),
     has_separating_scope_resolution (has_separating_scope_resolution),
     type (SegmentType::REG)
 {}
@@ -185,6 +194,14 @@ TypePathSegmentGeneric::TypePathSegmentGeneric (
   location_t locus)
   : TypePathSegment (std::move (mappings), std::move (ident_segment),
 		     has_separating_scope_resolution, locus),
+    generic_args (std::move (generic_args))
+{}
+
+TypePathSegmentGeneric::TypePathSegmentGeneric (Analysis::NodeMapping mappings,
+						LangItem::Kind lang_item,
+						GenericArgs generic_args,
+						location_t locus)
+  : TypePathSegment (std::move (mappings), lang_item, locus),
     generic_args (std::move (generic_args))
 {}
 

--- a/gcc/rust/resolve/rust-ast-resolve-base.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-base.cc
@@ -72,14 +72,6 @@ ResolverBase::visit (AST::ConstGenericParam &)
 {}
 
 void
-ResolverBase::visit (AST::RegularPath &)
-{}
-
-void
-ResolverBase::visit (AST::LangItemPath &)
-{}
-
-void
 ResolverBase::visit (AST::PathInExpression &)
 {}
 

--- a/gcc/rust/resolve/rust-ast-resolve-base.h
+++ b/gcc/rust/resolve/rust-ast-resolve-base.h
@@ -40,8 +40,6 @@ public:
   void visit (AST::Lifetime &);
   void visit (AST::LifetimeParam &);
   void visit (AST::ConstGenericParam &);
-  void visit (AST::RegularPath &);
-  void visit (AST::LangItemPath &);
   void visit (AST::PathInExpression &);
   void visit (AST::TypePathSegment &);
   void visit (AST::TypePathSegmentGeneric &);

--- a/gcc/rust/resolve/rust-ast-resolve-item.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-item.cc
@@ -682,28 +682,15 @@ ResolveItem::visit (AST::TraitImpl &impl_block)
 
   // setup paths
   CanonicalPath canonical_trait_type = CanonicalPath::create_empty ();
-  if (impl_block.get_trait_path ().get_path_kind ()
-      == AST::Path::Kind::LangItem)
-    {
-      auto &lang_item
-	= static_cast<AST::LangItemPath &> (impl_block.get_trait_path ());
 
-      canonical_trait_type
-	= CanonicalPath::new_seg (lang_item.get_node_id (),
-				  LangItem::ToString (
-				    lang_item.get_lang_item_kind ()));
-    }
-  else
+  ok = ResolveTypeToCanonicalPath::go (impl_block.get_trait_path (),
+				       canonical_trait_type);
+  if (!ok)
     {
-      ok = ResolveTypeToCanonicalPath::go (impl_block.get_trait_path_type (),
-					   canonical_trait_type);
-      if (!ok)
-	{
-	  resolver->get_name_scope ().pop ();
-	  resolver->get_type_scope ().pop ();
-	  resolver->get_label_scope ().pop ();
-	  return;
-	}
+      resolver->get_name_scope ().pop ();
+      resolver->get_type_scope ().pop ();
+      resolver->get_label_scope ().pop ();
+      return;
     }
 
   rust_debug ("AST::TraitImpl resolve trait type: {%s}",

--- a/gcc/rust/resolve/rust-ast-resolve-type.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-type.cc
@@ -20,6 +20,7 @@
 #include "rust-ast-resolve-expr.h"
 #include "rust-canonical-path.h"
 #include "rust-type.h"
+#include "rust-hir-map.h"
 
 namespace Rust {
 namespace Resolver {
@@ -99,45 +100,57 @@ ResolveRelativeTypePath::go (AST::TypePath &path, NodeId &resolved_node_id)
   for (size_t i = 0; i < path.get_segments ().size (); i++)
     {
       auto &segment = path.get_segments ().at (i);
-      const AST::PathIdentSegment &ident_seg = segment->get_ident_segment ();
       bool is_first_segment = i == 0;
+      NodeId crate_scope_id = resolver->peek_crate_module_scope ();
+      auto ident_string = segment->is_lang_item ()
+			    ? LangItem::PrettyString (segment->get_lang_item ())
+			    : segment->get_ident_segment ().as_string ();
+
       resolved_node_id = UNKNOWN_NODEID;
 
-      bool in_middle_of_path = i > 0;
-      if (in_middle_of_path && segment->is_lower_self_seg ())
+      if (segment->is_lang_item ())
 	{
-	  rust_error_at (segment->get_locus (), ErrorCode::E0433,
-			 "failed to resolve: %<%s%> in paths can only be used "
-			 "in start position",
-			 segment->as_string ().c_str ());
-	  return false;
+	  resolved_node_id = Analysis::Mappings::get ().get_lang_item_node (
+	    segment->get_lang_item ());
+	  previous_resolved_node_id = resolved_node_id;
 	}
-
-      NodeId crate_scope_id = resolver->peek_crate_module_scope ();
-      if (segment->is_crate_path_seg ())
+      else
 	{
-	  // what is the current crate scope node id?
-	  module_scope_id = crate_scope_id;
-	  previous_resolved_node_id = module_scope_id;
-	  resolver->insert_resolved_name (segment->get_node_id (),
-					  module_scope_id);
-
-	  continue;
-	}
-      else if (segment->is_super_path_seg ())
-	{
-	  if (module_scope_id == crate_scope_id)
+	  bool in_middle_of_path = i > 0;
+	  if (in_middle_of_path && segment->is_lower_self_seg ())
 	    {
-	      rust_error_at (segment->get_locus (),
-			     "cannot use super at the crate scope");
+	      rust_error_at (segment->get_locus (), ErrorCode::E0433,
+			     "failed to resolve: %qs in paths can only be used "
+			     "in start position",
+			     segment->as_string ().c_str ());
 	      return false;
 	    }
 
-	  module_scope_id = resolver->peek_parent_module_scope ();
-	  previous_resolved_node_id = module_scope_id;
-	  resolver->insert_resolved_name (segment->get_node_id (),
-					  module_scope_id);
-	  continue;
+	  if (segment->is_crate_path_seg ())
+	    {
+	      // what is the current crate scope node id?
+	      module_scope_id = crate_scope_id;
+	      previous_resolved_node_id = module_scope_id;
+	      resolver->insert_resolved_name (segment->get_node_id (),
+					      module_scope_id);
+
+	      continue;
+	    }
+	  else if (segment->is_super_path_seg ())
+	    {
+	      if (module_scope_id == crate_scope_id)
+		{
+		  rust_error_at (segment->get_locus (),
+				 "cannot use super at the crate scope");
+		  return false;
+		}
+
+	      module_scope_id = resolver->peek_parent_module_scope ();
+	      previous_resolved_node_id = module_scope_id;
+	      resolver->insert_resolved_name (segment->get_node_id (),
+					      module_scope_id);
+	      continue;
+	    }
 	}
 
       switch (segment->get_type ())
@@ -177,8 +190,7 @@ ResolveRelativeTypePath::go (AST::TypePath &path, NodeId &resolved_node_id)
 	  // name scope first
 	  NodeId resolved_node = UNKNOWN_NODEID;
 	  const CanonicalPath path
-	    = CanonicalPath::new_seg (segment->get_node_id (),
-				      ident_seg.as_string ());
+	    = CanonicalPath::new_seg (segment->get_node_id (), ident_string);
 	  if (resolver->get_type_scope ().lookup (path, &resolved_node))
 	    {
 	      resolver->insert_resolved_type (segment->get_node_id (),
@@ -191,7 +203,7 @@ ResolveRelativeTypePath::go (AST::TypePath &path, NodeId &resolved_node_id)
 					      resolved_node);
 	      resolved_node_id = resolved_node;
 	    }
-	  else if (segment->is_lower_self_seg ())
+	  else if (!segment->is_lang_item () && segment->is_lower_self_seg ())
 	    {
 	      // what is the current crate scope node id?
 	      module_scope_id = crate_scope_id;
@@ -207,8 +219,7 @@ ResolveRelativeTypePath::go (AST::TypePath &path, NodeId &resolved_node_id)
 	  && previous_resolved_node_id == module_scope_id)
 	{
 	  tl::optional<CanonicalPath &> resolved_child
-	    = mappings.lookup_module_child (module_scope_id,
-					    ident_seg.as_string ());
+	    = mappings.lookup_module_child (module_scope_id, ident_string);
 	  if (resolved_child.has_value ())
 	    {
 	      NodeId resolved_node = resolved_child->get_node_id ();

--- a/gcc/rust/resolve/rust-ast-resolve-type.h
+++ b/gcc/rust/resolve/rust-ast-resolve-type.h
@@ -61,37 +61,6 @@ class ResolveType : public ResolverBase
   using Rust::Resolver::ResolverBase::visit;
 
 public:
-  static NodeId go (AST::TypePath &type_path)
-  {
-    return ResolveType::go ((AST::Type &) type_path);
-  }
-
-  static NodeId go (AST::Path &type_path)
-  {
-    if (type_path.get_path_kind () == AST::Path::Kind::LangItem)
-      {
-	auto &type = static_cast<AST::LangItemPath &> (type_path);
-
-	auto lang_item = Analysis::Mappings::get ()
-			   .lookup_lang_item_node (type.get_lang_item_kind ())
-			   .value ();
-
-	auto resolver = Resolver::get ();
-	resolver->insert_resolved_type (type.get_node_id (), lang_item);
-
-	return lang_item;
-      }
-
-    rust_assert (type_path.get_path_kind () == AST::Path::Kind::Type);
-
-    // We have to do this dance to first downcast to a typepath, and then upcast
-    // to a Type. The altnernative is to split `go` into `go` and `go_inner` or
-    // something, but eventually this will need to change as we'll need
-    // `ResolveType::` to resolve other kinds of `Path`s as well.
-    return ResolveType::go (
-      (AST::Type &) static_cast<AST::TypePath &> (type_path));
-  }
-
   static NodeId go (AST::Type &type)
   {
     ResolveType resolver;

--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
@@ -249,25 +249,6 @@ Late::visit (AST::PathInExpression &expr)
 }
 
 void
-Late::visit (AST::LangItemPath &type)
-{
-  auto &mappings = Rust::Analysis::Mappings::get ();
-  auto lang_item = mappings.lookup_lang_item_node (type.get_lang_item_kind ());
-
-  if (!lang_item)
-    {
-      rust_fatal_error (
-	type.get_locus (), "use of undeclared lang item %qs",
-	LangItem::ToString (type.get_lang_item_kind ()).c_str ());
-      return;
-    }
-
-  ctx.map_usage (Usage (type.get_node_id ()), Definition (lang_item.value ()));
-
-  DefaultResolver::visit (type);
-}
-
-void
 Late::visit (AST::TypePath &type)
 {
   // should we add type path resolution in `ForeverStack` directly? Since it's

--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.h
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.h
@@ -46,7 +46,6 @@ public:
   // resolutions
   void visit (AST::IdentifierExpr &) override;
   void visit (AST::PathInExpression &) override;
-  void visit (AST::LangItemPath &) override;
   void visit (AST::TypePath &) override;
   void visit (AST::Trait &) override;
   void visit (AST::StructExprStruct &) override;

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -410,7 +410,7 @@ TypeCheckType::resolve_root_path (HIR::TypePath &path, size_t *offset,
 	    {
 	      rust_error_at (seg->get_locus (),
 			     "unknown reference for resolved name: %qs",
-			     seg->get_ident_segment ().as_string ().c_str ());
+			     seg->as_string ().c_str ());
 	      return new TyTy::ErrorType (path.get_mappings ().get_hirid ());
 	    }
 	  return root_tyty;

--- a/gcc/rust/util/rust-attribute-values.h
+++ b/gcc/rust/util/rust-attribute-values.h
@@ -29,6 +29,7 @@ public:
   static constexpr auto &COLD = "cold";
   static constexpr auto &CFG = "cfg";
   static constexpr auto &CFG_ATTR = "cfg_attr";
+  static constexpr auto &DERIVE_ATTR = "derive";
   static constexpr auto &DEPRECATED = "deprecated";
   static constexpr auto &ALLOW = "allow";
   static constexpr auto &ALLOW_INTERNAL_UNSTABLE = "allow_internal_unstable";

--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -46,6 +46,7 @@ static const BuiltinAttrDefinition __definitions[]
      {Attrs::COLD, CODE_GENERATION},
      {Attrs::CFG, EXPANSION},
      {Attrs::CFG_ATTR, EXPANSION},
+     {Attrs::DERIVE_ATTR, EXPANSION},
      {Attrs::DEPRECATED, STATIC_ANALYSIS},
      {Attrs::ALLOW, STATIC_ANALYSIS},
      {Attrs::ALLOW_INTERNAL_UNSTABLE, STATIC_ANALYSIS},

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -1299,5 +1299,15 @@ Mappings::lookup_lang_item_node (LangItem::Kind item_type)
   return it->second;
 }
 
+NodeId
+Mappings::get_lang_item_node (LangItem::Kind item_type)
+{
+  if (auto lookup = lookup_lang_item_node (item_type))
+    return *lookup;
+
+  rust_fatal_error (UNKNOWN_LOCATION, "failed to find lang item %qs",
+		    LangItem::ToString (item_type).c_str ());
+}
+
 } // namespace Analysis
 } // namespace Rust

--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -261,6 +261,7 @@ public:
 
   void insert_lang_item_node (LangItem::Kind item_type, NodeId node_id);
   tl::optional<NodeId &> lookup_lang_item_node (LangItem::Kind item_type);
+  NodeId get_lang_item_node (LangItem::Kind item_type);
 
   // This will fatal_error when this lang item does not exist
   DefId get_lang_item (LangItem::Kind item_type, location_t locus);

--- a/gcc/rust/util/rust-lang-item.cc
+++ b/gcc/rust/util/rust-lang-item.cc
@@ -118,6 +118,12 @@ LangItem::ToString (LangItem::Kind type)
   return str.value ();
 }
 
+std::string
+LangItem::PrettyString (LangItem::Kind type)
+{
+  return "#[lang = \"" + LangItem::ToString (type) + "\"]";
+}
+
 LangItem::Kind
 LangItem::OperatorToLangItem (ArithmeticOrLogicalOperator op)
 {

--- a/gcc/rust/util/rust-lang-item.h
+++ b/gcc/rust/util/rust-lang-item.h
@@ -134,6 +134,7 @@ public:
 
   static tl::optional<Kind> Parse (const std::string &item);
   static std::string ToString (Kind type);
+  static std::string PrettyString (Kind type);
   static Kind OperatorToLangItem (ArithmeticOrLogicalOperator op);
   static Kind
   CompoundAssignmentOperatorToLangItem (ArithmeticOrLogicalOperator op);


### PR DESCRIPTION
This PR contains the base for #3343 and refactors the way lang item paths are handled, either as path in expressions or as type paths. The changes are required for #3343 to work properly.