### PR TITLE
Improve `derive(Clone)` for generic types

### DIFF
--- a/gcc/rust/ast/rust-ast-builder.cc
+++ b/gcc/rust/ast/rust-ast-builder.cc
@@ -361,7 +361,8 @@ Builder::new_lifetime_param (LifetimeParam &param)
 }
 
 std::unique_ptr<GenericParam>
-Builder::new_type_param (TypeParam &param)
+Builder::new_type_param (
+  TypeParam &param, std::vector<std::unique_ptr<TypeParamBound>> extra_bounds)
 {
   location_t locus = param.get_locus ();
   AST::AttrVec outer_attrs = param.get_outer_attrs ();
@@ -371,6 +372,9 @@ Builder::new_type_param (TypeParam &param)
 
   if (param.has_type ())
     type = new_type (param.get_type ());
+
+  for (auto &&extra_bound : extra_bounds)
+    type_param_bounds.emplace_back (std::move (extra_bound));
 
   for (const auto &b : param.get_type_param_bounds ())
     {

--- a/gcc/rust/ast/rust-ast-builder.h
+++ b/gcc/rust/ast/rust-ast-builder.h
@@ -200,7 +200,9 @@ public:
   static std::unique_ptr<GenericParam>
   new_lifetime_param (LifetimeParam &param);
 
-  static std::unique_ptr<GenericParam> new_type_param (TypeParam &param);
+  static std::unique_ptr<GenericParam> new_type_param (
+    TypeParam &param,
+    std::vector<std::unique_ptr<TypeParamBound>> extra_trait_bounds = {});
 
   static Lifetime new_lifetime (const Lifetime &lifetime);
 

--- a/gcc/rust/expand/rust-derive-clone.cc
+++ b/gcc/rust/expand/rust-derive-clone.cc
@@ -422,17 +422,16 @@ DeriveClone::visit_union (Union &item)
   // FIXME: Should be $crate::core::clone::AssertParamIsCopy (or similar)
   // (Rust-GCC#3329)
 
-  auto copy_path = TypePath (vec (builder.type_path_segment ("Copy")), loc);
-  auto sized_path = TypePath (vec (builder.type_path_segment ("Sized")), loc);
+  auto copy_path = builder.type_path (LangItem::Kind::COPY);
+  auto sized_path = builder.type_path (LangItem::Kind::SIZED);
 
   auto copy_bound = std::unique_ptr<TypeParamBound> (
     new TraitBound (copy_path, item.get_locus ()));
   auto sized_bound = std::unique_ptr<TypeParamBound> (
-    new TraitBound (sized_path, item.get_locus (), false, true));
+    new TraitBound (sized_path, item.get_locus (), false,
+		    true /* opening_question_mark */));
 
-  auto bounds = std::vector<std::unique_ptr<TypeParamBound>> ();
-  bounds.emplace_back (std::move (copy_bound));
-  bounds.emplace_back (std::move (sized_bound));
+  auto bounds = vec (std::move (copy_bound), std::move (sized_bound));
 
   // struct AssertParamIsCopy<T: Copy + ?Sized> { _t: PhantomData<T> }
   auto assert_param_is_copy = "AssertParamIsCopy";

--- a/gcc/rust/expand/rust-derive-clone.cc
+++ b/gcc/rust/expand/rust-derive-clone.cc
@@ -97,15 +97,15 @@ DeriveClone::clone_impl (
   auto trait_items = std::vector<std::unique_ptr<AssociatedItem>> ();
   trait_items.emplace_back (std::move (clone_fn));
 
-  // we need to build up the generics for this impl block which will be just a
-  // clone of the types specified ones
+  // We need to build up the generics for this impl block which will be just a
+  // clone of the generics specified, with added `Clone` bounds
   //
-  // for example:
+  // For example with:
   //
   // #[derive(Clone)]
-  // struct Be<T: Clone> { ... }
+  // struct Be<T> { ... }
   //
-  // we need to generate the impl block:
+  // We need to generate the following impl block:
   //
   // impl<T: Clone> Clone for Be<T>
 
@@ -138,7 +138,12 @@ DeriveClone::clone_impl (
 	      = GenericArg::create_type (std::move (associated_type));
 	    generic_args.push_back (std::move (type_arg));
 
-	    auto impl_type_param = builder.new_type_param (type_param);
+	    std::vector<std::unique_ptr<TypeParamBound>> extra_bounds;
+	    extra_bounds.emplace_back (std::unique_ptr<TypeParamBound> (
+	      new TraitBound (builder.type_path (LangItem::Kind::CLONE), loc)));
+
+	    auto impl_type_param
+	      = builder.new_type_param (type_param, std::move (extra_bounds));
 	    impl_generics.push_back (std::move (impl_type_param));
 	  }
 	  break;

--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -388,7 +388,10 @@ void
 Dump::do_typepathsegment (TypePathSegment &e)
 {
   do_mappings (e.get_mappings ());
-  put_field ("ident_segment", e.get_ident_segment ().as_string ());
+  if (e.is_lang_item ())
+    put_field ("ident_segment", LangItem::PrettyString (e.get_lang_item ()));
+  else
+    put_field ("ident_segment", e.get_ident_segment ().as_string ());
 }
 
 void

--- a/gcc/testsuite/rust/compile/derive_macro6.rs
+++ b/gcc/testsuite/rust/compile/derive_macro6.rs
@@ -1,8 +1,8 @@
 #[lang = "sized"]
 pub trait Sized {}
 
+#[lang = "copy"]
 pub trait Copy {}
-
 
 #[lang = "clone"]
 pub trait Clone {


### PR DESCRIPTION
When deriving `Clone` for a type with generic, we need to bound the impl's generic to be `: Clone`. e.g. the derive of `struct Foo<T>` should always be `impl<T: Clone> Clone for Foo<T>` even if `T` isn't necessarily bound by `Clone` in the struct's definition. Requires #3343 and thus #3366 so only review the last 3 commits