### PR TITLE
Add receiver lang item

### DIFF
--- a/gcc/rust/util/rust-lang-item.cc
+++ b/gcc/rust/util/rust-lang-item.cc
@@ -46,6 +46,7 @@ const BiMap<std::string, LangItem::Kind> Rust::LangItem::lang_items = {{
   {"shr_assign", Kind::SHR_ASSIGN},
   {"deref", Kind::DEREF},
   {"deref_mut", Kind::DEREF_MUT},
+  {"receiver", Kind::RECEIVER},
   {"index", Kind::INDEX},
   {"index_mut", Kind::INDEX_MUT},
   {"RangeFull", Kind::RANGE_FULL},

--- a/gcc/rust/util/rust-lang-item.h
+++ b/gcc/rust/util/rust-lang-item.h
@@ -61,6 +61,7 @@ public:
 
     DEREF,
     DEREF_MUT,
+    RECEIVER,
 
     // https://github.com/rust-lang/rust/blob/master/library/core/src/ops/index.rs
     INDEX,

--- a/gcc/testsuite/rust/compile/issue-2954.rs
+++ b/gcc/testsuite/rust/compile/issue-2954.rs
@@ -1,0 +1,17 @@
+#[lang = "sized"]
+trait Sized {}
+
+#[lang = "receiver"]
+#[unstable(feature = "receiver_trait", issue = "none")]
+// #[doc(hidden)]
+pub trait Receiver {
+    // Empty.
+}
+
+#[unstable(feature = "receiver_trait", issue = "none")]
+impl<T: ?Sized> Receiver for &T {}
+
+#[unstable(feature = "receiver_trait", issue = "none")]
+impl<T: ?Sized> Receiver for &mut T {}
+
+


### PR DESCRIPTION
Add and implement a lang item (receiver) in source code.
Fix [#2954](https://github.com/Rust-GCC/gccrs/issues/2954)

gcc/rust/ChangeLog:

	* util/rust-lang-item.cc: Add receiver to map.
	* util/rust-lang-item.h: Define LangItem::Kind::RECEIVER.

gcc/testsuite/ChangeLog:

	* rust/compile/issue-2954.rs: New test.
