### PR TITLE
gccrs: add support for ref literal patterns

### DIFF
--- a/gcc/rust/backend/rust-compile-pattern.cc
+++ b/gcc/rust/backend/rust-compile-pattern.cc
@@ -481,8 +481,7 @@ CompilePatternBindings::visit (HIR::TupleStructPattern &pattern)
 						      tuple_field_index++,
 						      pattern->get_locus ());
 
-		ctx->insert_pattern_binding (
-		  pattern->get_mappings ().get_hirid (), binding);
+		CompilePatternBindings::Compile (*pattern, binding, ctx);
 	      }
 	  }
 	else
@@ -497,8 +496,7 @@ CompilePatternBindings::visit (HIR::TupleStructPattern &pattern)
 						      tuple_field_index++,
 						      pattern->get_locus ());
 
-		ctx->insert_pattern_binding (
-		  pattern->get_mappings ().get_hirid (), binding);
+		CompilePatternBindings::Compile (*pattern, binding, ctx);
 	      }
 	  }
       }
@@ -607,8 +605,16 @@ CompilePatternBindings::visit (HIR::ReferencePattern &pattern)
 void
 CompilePatternBindings::visit (HIR::IdentifierPattern &pattern)
 {
-  ctx->insert_pattern_binding (pattern.get_mappings ().get_hirid (),
-			       match_scrutinee_expr);
+  if (!pattern.get_is_ref ())
+    {
+      ctx->insert_pattern_binding (pattern.get_mappings ().get_hirid (),
+				   match_scrutinee_expr);
+      return;
+    }
+
+  tree ref = address_expression (match_scrutinee_expr,
+				 EXPR_LOCATION (match_scrutinee_expr));
+  ctx->insert_pattern_binding (pattern.get_mappings ().get_hirid (), ref);
 }
 
 void

--- a/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
@@ -519,9 +519,18 @@ TypeCheckPattern::visit (HIR::RangePattern &pattern)
 }
 
 void
-TypeCheckPattern::visit (HIR::IdentifierPattern &)
+TypeCheckPattern::visit (HIR::IdentifierPattern &pattern)
 {
-  infered = parent;
+  if (!pattern.get_is_ref ())
+    {
+      infered = parent;
+      return;
+    }
+
+  infered = new TyTy::ReferenceType (pattern.get_mappings ().get_hirid (),
+				     TyTy::TyVar (parent->get_ref ()),
+				     pattern.is_mut () ? Mutability::Mut
+						       : Mutability::Imm);
 }
 
 void

--- a/gcc/testsuite/rust/compile/issue-3174.rs
+++ b/gcc/testsuite/rust/compile/issue-3174.rs
@@ -1,0 +1,28 @@
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+enum Option {
+    Some(i32),
+    None,
+}
+
+impl Option {
+    fn add(&mut self) {
+        match *self {
+            Option::Some(ref mut a) => *a += 1,
+            Option::None => {}
+        }
+    }
+}
+
+fn main() {
+    unsafe {
+        let mut a = Option::None;
+        a.add();
+        let _s = "%d\n\0";
+        let _s = _s as *const str;
+        let s = _s as *const i8;
+        printf(s, a);
+    }
+}

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -150,4 +150,5 @@ issue-2953-1.rs
 issue-3030.rs
 traits12.rs
 try-trait.rs
+issue-3174.rs
 # please don't delete the trailing newline


### PR DESCRIPTION
Fixes Rust-GCC#3174