### PR TITLE
Check for type paths nr2.0 can't handle yet

### DIFF
--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
@@ -287,6 +287,14 @@ Late::visit (AST::TypePath &type)
   // maybe we can overload `resolve_path<Namespace::Types>` to only do
   // typepath-like path resolution? that sounds good
 
+  if (type.get_segments ().size () != 1)
+    {
+      rust_sorry_at (
+	type.get_locus (),
+	"name resolution 2.0 cannot resolve multi-segment type paths");
+      return;
+    }
+
   auto str = type.get_segments ().back ()->get_ident_segment ().as_string ();
   auto values = ctx.types.peek ().get_values ();
 

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -58,6 +58,7 @@ iterators1.rs
 lookup_err1.rs
 macros/mbe/macro13.rs
 macros/mbe/macro15.rs
+macros/mbe/macro20.rs
 macros/mbe/macro23.rs
 macros/mbe/macro40.rs
 macros/mbe/macro43.rs
@@ -151,4 +152,18 @@ derive_macro6.rs
 issue-2987.rs
 issue-3139-1.rs
 issue-3139-3.rs
+issue-1019.rs
+issue-1034.rs
+issue-2019-1.rs
+issue-2019-2.rs
+issue-2019-3.rs
+issue-2105.rs
+issue-2190-1.rs
+issue-2190-2.rs
+issue-2304.rs
+issue-2747.rs
+issue-2953-1.rs
+issue-3030.rs
+traits12.rs
+try-trait.rs
 # please don't delete the trailing newline


### PR DESCRIPTION
Some of our tests only work with name resolution 2.0 because the latter misinterprets type paths. This change should cause the compiler to error out if it would otherwise misinterpret a type path. A fix for type path resolution isn't included in this comment, since doing so would make it harder to track the meaningfulness of test regressions.