### PR TITLE
backend: Allow anything as a match scrutinee

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -31,6 +31,7 @@
 #include "convert.h"
 #include "print-tree.h"
 #include "rust-system.h"
+#include "rust-tyty.h"
 
 namespace Rust {
 namespace Compile {
@@ -1035,11 +1036,6 @@ check_match_scrutinee (HIR::MatchExpr &expr, Context *ctx)
     }
 
   TyTy::TypeKind scrutinee_kind = scrutinee_expr_tyty->get_kind ();
-  rust_assert ((TyTy::is_primitive_type_kind (scrutinee_kind)
-		&& scrutinee_kind != TyTy::TypeKind::NEVER)
-	       || scrutinee_kind == TyTy::TypeKind::ADT
-	       || scrutinee_kind == TyTy::TypeKind::TUPLE
-	       || scrutinee_kind == TyTy::TypeKind::REF);
 
   if (scrutinee_kind == TyTy::TypeKind::FLOAT)
     {


### PR DESCRIPTION
This commit is required for this type of pattern, which isn't really pattern matching:

```rust
match something {
    new_binding => { ... }
}
```

This is required for desugaring for-loops and error propagation expressions.