### PR TITLE
gccrs: catch missing guard for optional result

### DIFF
--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -248,12 +248,9 @@ HIRCompileBase::query_compile (HirId ref, TyTy::BaseType *lookup,
 	    return CompileInherentImplItem::Compile (resolved_item->first, ctx,
 						     lookup, true, expr_locus);
 	}
-      else
+      else if (auto trait_item
+	       = ctx->get_mappings ().lookup_hir_trait_item (ref))
 	{
-	  // it might be resolved to a trait item
-	  tl::optional<HIR::TraitItem *> trait_item
-	    = ctx->get_mappings ().lookup_hir_trait_item (ref);
-
 	  HIR::Trait *trait = ctx->get_mappings ().lookup_trait_item_mapping (
 	    trait_item.value ()->get_mappings ().get_hirid ());
 

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -63,7 +63,6 @@ macros/mbe/macro23.rs
 macros/mbe/macro40.rs
 macros/mbe/macro43.rs
 macros/mbe/macro44.rs
-macros/mbe/macro50.rs
 macros/mbe/macro54.rs
 macros/mbe/macro6.rs
 macros/mbe/macro_rules_macro_rules.rs
@@ -141,7 +140,6 @@ issue-2423.rs
 issue-266.rs
 additional-trait-bounds2.rs
 auto_traits2.rs
-auto_traits4.rs
 issue-3140.rs
 cmp1.rs
 derive_clone_enum1.rs


### PR DESCRIPTION
When we lookup here it returns an optional which can lead to a crash because it needs a guard if it has a value.

gcc/rust/ChangeLog:

	* backend/rust-compile-resolve-path.cc (HIRCompileBase::query_compile): add guard

gcc/testsuite/ChangeLog:

	* rust/compile/nr2/exclude: these tests now work it seems