### PR TITLE
gccrs: add new -frust-overflow-checks to control overflow checks

### DIFF
--- a/gcc/rust/lang.opt
+++ b/gcc/rust/lang.opt
@@ -225,4 +225,8 @@ Enum(frust_panic) String(unwind) Value(0)
 EnumValue
 Enum(frust_panic) String(abort) Value(1)
 
+frust-overflow-checks
+Rust Var(flag_overflow_checks) Init(1)
+Enable the overflow checks in code generation
+
 ; This comment is to ensure we retain the blank line above.


### PR DESCRIPTION
This will be crucial for more complex gimple debugging to make it easier to follow the code vs the original rust code.

gcc/rust/ChangeLog:

	* backend/rust-compile-expr.cc (CompileExpr::visit): disable overflow checks
	* lang.opt: new flag
