### PR TITLE
lang-items: Add From::from

### DIFF
--- a/gcc/rust/util/rust-lang-item.cc
+++ b/gcc/rust/util/rust-lang-item.cc
@@ -110,6 +110,8 @@ const BiMap<std::string, LangItem::Kind> Rust::LangItem::lang_items = {{
   {"into_result", Kind::TRY_INTO_RESULT},
   {"from_error", Kind::TRY_FROM_ERROR},
   {"from_ok", Kind::TRY_FROM_OK},
+
+  {"from", Kind::FROM_FROM},
 }};
 
 tl::optional<LangItem::Kind>

--- a/gcc/rust/util/rust-lang-item.h
+++ b/gcc/rust/util/rust-lang-item.h
@@ -141,6 +141,9 @@ public:
     TRY_INTO_RESULT,
     TRY_FROM_ERROR,
     TRY_FROM_OK,
+
+    // NOTE: This is not a lang item in later versions of Rust
+    FROM_FROM,
   };
 
   static const BiMap<std::string, Kind> lang_items;


### PR DESCRIPTION
In Rust 1.49, `From::from` is a lang item as it is used in the `<expr>?` desugar