### PR TITLE
ast: builder: Add Return expression builder

### DIFF
--- a/gcc/rust/ast/rust-ast-builder.cc
+++ b/gcc/rust/ast/rust-ast-builder.cc
@@ -214,6 +214,13 @@ Builder::block (std::vector<std::unique_ptr<Stmt>> &&stmts,
 					       LoopLabel::error (), loc, loc));
 }
 
+std::unique_ptr<Expr>
+Builder::return_expr (std::unique_ptr<Expr> &&to_return)
+{
+  return std::unique_ptr<Expr> (
+    new ReturnExpr (std::move (to_return), {}, loc));
+}
+
 std::unique_ptr<Stmt>
 Builder::let (std::unique_ptr<Pattern> pattern, std::unique_ptr<Type> type,
 	      std::unique_ptr<Expr> init) const

--- a/gcc/rust/ast/rust-ast-builder.h
+++ b/gcc/rust/ast/rust-ast-builder.h
@@ -85,6 +85,10 @@ public:
 			       std::unique_ptr<Expr> &&tail_expr
 			       = nullptr) const;
 
+  /* Create an early return expression with an optional expression */
+  std::unique_ptr<Expr> return_expr (std::unique_ptr<Expr> &&to_return
+				     = nullptr);
+
   /* Create a let binding with an optional type and initializer (`let <name> :
    * <type> = <init>`) */
   std::unique_ptr<Stmt> let (std::unique_ptr<Pattern> pattern,


### PR DESCRIPTION
Add new methods for building `return <x>;` expressions/statements in our AST.