### PR TITLE
WIP typecheck issues with Try

### DIFF
--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -757,7 +757,7 @@ HIRCompileBase::compile_function (
 
   ctx->add_statement (ret_var_stmt);
 
-  ctx->push_fn (fndecl, return_address, tyret);
+  ctx->push_fn (fndecl, return_address, tyret, fntype);
   compile_function_body (fndecl, *function_body, tyret);
   tree bind_tree = ctx->pop_block ();
 
@@ -825,7 +825,7 @@ HIRCompileBase::compile_constant_item (
 				   address_is_taken, locus, &ret_var_stmt);
 
   ctx->add_statement (ret_var_stmt);
-  ctx->push_fn (fndecl, return_address, resolved_type);
+  ctx->push_fn (fndecl, return_address, resolved_type, resolved_type);
 
   if (is_block_expr)
     {

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -37,6 +37,7 @@ struct fncontext
   tree fndecl;
   ::Bvariable *ret_addr;
   TyTy::BaseType *retty;
+  TyTy::BaseType *fnty;
 };
 
 struct CustomDeriveInfo
@@ -275,9 +276,10 @@ public:
     return true;
   }
 
-  void push_fn (tree fn, ::Bvariable *ret_addr, TyTy::BaseType *retty)
+  void push_fn (tree fn, ::Bvariable *ret_addr, TyTy::BaseType *retty,
+		TyTy::BaseType *fntype)
   {
-    fn_stack.push_back (fncontext{fn, ret_addr, retty});
+    fn_stack.push_back (fncontext{fn, ret_addr, retty, fntype});
   }
   void pop_fn () { fn_stack.pop_back (); }
 

--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -1211,6 +1211,8 @@ CompileExpr::visit (HIR::CallExpr &expr)
     {
       rust_assert (tyty->get_kind () == TyTy::TypeKind::ADT);
       TyTy::ADTType *adt = static_cast<TyTy::ADTType *> (tyty);
+      rust_debug ("111 XXXXXXXXXXXXXXXXXXXXXXX");
+      adt->debug ();
       tree compiled_adt_type = TyTyResolveCompile::compile (ctx, tyty);
 
       // what variant is it?
@@ -1272,6 +1274,9 @@ CompileExpr::visit (HIR::CallExpr &expr)
 					       expr.get_locus ());
 	  return;
 	}
+
+      rust_debug_loc (expr.get_locus (), "XXXXXXXXXX ADT CTOR");
+      debug_tree (compiled_adt_type);
 
       HIR::Expr &discrim_expr = variant->get_discriminant ();
       tree discrim_expr_node = CompileExpr::Compile (discrim_expr, ctx);

--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -1278,10 +1278,19 @@ CompileExpr::visit (HIR::CallExpr &expr)
       rust_debug_loc (expr.get_locus (), "XXXXXXXXXX ADT CTOR");
       debug_tree (compiled_adt_type);
 
+      const auto &c = ctx->peek_fn ();
+      c.fnty->debug ();
+
       HIR::Expr &discrim_expr = variant->get_discriminant ();
       tree discrim_expr_node = CompileExpr::Compile (discrim_expr, ctx);
       tree folded_discrim_expr = fold_expr (discrim_expr_node);
       tree qualifier = folded_discrim_expr;
+
+      if (compiled_adt_type == error_mark_node)
+	{
+	  rust_debug_loc (expr.get_fnexpr ().get_locus (),
+			  "XXX this is broken!!");
+	}
 
       tree enum_root_files = TYPE_FIELDS (compiled_adt_type);
       tree payload_root = DECL_CHAIN (enum_root_files);
@@ -2503,7 +2512,7 @@ CompileExpr::generate_closure_function (HIR::ClosureExpr &expr,
 
   ctx->add_statement (ret_var_stmt);
 
-  ctx->push_fn (fndecl, return_address, tyret);
+  ctx->push_fn (fndecl, return_address, tyret, fn_tyty);
 
   if (is_block_expr)
     {

--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -36,8 +36,8 @@ public:
     CompileItem compiler (ctx, concrete, ref_locus);
     item->accept_vis (compiler);
 
-    if (compiler.reference == error_mark_node)
-      rust_debug ("failed to compile item: %s", item->as_string ().c_str ());
+    // if (compiler.reference == error_mark_node)
+    //   rust_debug ("failed to compile item: %s", item->as_string ().c_str ());
 
     return compiler.reference;
   }

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -297,16 +297,25 @@ HIRCompileBase::query_compile (HirId ref, TyTy::BaseType *lookup,
 	    trait->get_mappings ().get_defid (), &trait_ref);
 	  rust_assert (ok);
 
-	  TyTy::BaseType *receiver = nullptr;
-	  ok = ctx->get_tyctx ()->lookup_receiver (mappings.get_hirid (),
-						   &receiver);
-	  rust_assert (ok);
-	  receiver = receiver->destructure ();
-
 	  // the type resolver can only resolve type bounds to their trait
 	  // item so its up to us to figure out if this path should resolve
 	  // to an trait-impl-block-item or if it can be defaulted to the
 	  // trait-impl-item's definition
+	  //
+	  // because we know this is resolved to a trait item we can actually
+	  // just grab the Self type parameter here for the receiver to match
+	  // the appropriate impl block
+
+	  rust_assert (lookup->is<TyTy::FnType> ());
+	  auto fn = lookup->as<TyTy::FnType> ();
+	  rust_assert (fn->get_num_type_params () > 0);
+	  auto &self = fn->get_substs ().at (0);
+	  auto receiver = self.get_param_ty ();
+
+	  rust_debug ("XXXXXXXXXX");
+	  lookup->debug ();
+	  receiver->debug ();
+
 	  auto candidates
 	    = Resolver::PathProbeImplTrait::Probe (receiver, final_segment,
 						   trait_ref);

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -349,12 +349,19 @@ HIRCompileBase::query_compile (HirId ref, TyTy::BaseType *lookup,
 	      rust_assert (ok);
 
 	      if (!lookup->has_substitutions_defined ())
-		return CompileInherentImplItem::Compile (impl_item, ctx,
-							 nullptr, true,
-							 expr_locus);
+		{
+		  rust_debug ("XXXXXXXXX YYY 1");
+		  return CompileInherentImplItem::Compile (impl_item, ctx,
+							   nullptr, true,
+							   expr_locus);
+		}
 	      else
-		return CompileInherentImplItem::Compile (impl_item, ctx, lookup,
-							 true, expr_locus);
+		{
+		  rust_debug ("XXXXXXXXX YYY 2");
+		  return CompileInherentImplItem::Compile (impl_item, ctx,
+							   lookup, true,
+							   expr_locus);
+		}
 	    }
 	}
     }

--- a/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
+++ b/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
@@ -243,10 +243,12 @@ PrivacyReporter::check_base_type_privacy (Analysis::NodeMapping &node_mappings,
 	   static_cast<const TyTy::TupleType *> (ty)->get_fields ())
 	recursive_check (param.get_tyty ());
       return;
-    case TyTy::PLACEHOLDER:
-      return recursive_check (
-	// FIXME: Can we use `resolve` here? Is that what we should do?
-	static_cast<const TyTy::PlaceholderType *> (ty)->resolve ());
+      case TyTy::PLACEHOLDER: {
+	const auto p = static_cast<const TyTy::PlaceholderType *> (ty);
+	if (!p->can_resolve ())
+	  return;
+	return recursive_check (p->resolve ());
+      }
     case TyTy::PROJECTION:
       return recursive_check (
 	static_cast<const TyTy::ProjectionType *> (ty)->get ());

--- a/gcc/rust/typecheck/rust-hir-path-probe.cc
+++ b/gcc/rust/typecheck/rust-hir-path-probe.cc
@@ -212,8 +212,8 @@ PathProbeType::visit (HIR::TypeAlias &alias)
     {
       HirId tyid = alias.get_mappings ().get_hirid ();
       TyTy::BaseType *ty = nullptr;
-      bool ok = query_type (tyid, &ty);
-      rust_assert (ok);
+      if (!query_type (tyid, &ty))
+	return;
 
       PathProbeCandidate::ImplItemCandidate impl_item_candidate{&alias,
 								current_impl};
@@ -232,8 +232,8 @@ PathProbeType::visit (HIR::ConstantItem &constant)
     {
       HirId tyid = constant.get_mappings ().get_hirid ();
       TyTy::BaseType *ty = nullptr;
-      bool ok = query_type (tyid, &ty);
-      rust_assert (ok);
+      if (!query_type (tyid, &ty))
+	return;
 
       PathProbeCandidate::ImplItemCandidate impl_item_candidate{&constant,
 								current_impl};
@@ -252,8 +252,8 @@ PathProbeType::visit (HIR::Function &function)
     {
       HirId tyid = function.get_mappings ().get_hirid ();
       TyTy::BaseType *ty = nullptr;
-      bool ok = query_type (tyid, &ty);
-      rust_assert (ok);
+      if (!query_type (tyid, &ty))
+	return;
 
       PathProbeCandidate::ImplItemCandidate impl_item_candidate{&function,
 								current_impl};

--- a/gcc/rust/typecheck/rust-substitution-mapper.cc
+++ b/gcc/rust/typecheck/rust-substitution-mapper.cc
@@ -194,6 +194,8 @@ SubstMapperInternal::visit (TyTy::FnType &type)
     = type.adjust_mappings_for_this (mappings);
   if (adjusted.is_error () && !mappings.trait_item_mode ())
     return;
+  if (adjusted.is_error () && mappings.trait_item_mode ())
+    adjusted = mappings;
 
   TyTy::BaseType *concrete = type.handle_substitions (adjusted);
   if (concrete != nullptr)
@@ -207,6 +209,8 @@ SubstMapperInternal::visit (TyTy::ADTType &type)
     = type.adjust_mappings_for_this (mappings);
   if (adjusted.is_error () && !mappings.trait_item_mode ())
     return;
+  if (adjusted.is_error () && mappings.trait_item_mode ())
+    adjusted = mappings;
 
   TyTy::BaseType *concrete = type.handle_substitions (adjusted);
   if (concrete != nullptr)

--- a/gcc/rust/typecheck/rust-substitution-mapper.cc
+++ b/gcc/rust/typecheck/rust-substitution-mapper.cc
@@ -192,7 +192,7 @@ SubstMapperInternal::visit (TyTy::FnType &type)
 {
   TyTy::SubstitutionArgumentMappings adjusted
     = type.adjust_mappings_for_this (mappings);
-  if (adjusted.is_error ())
+  if (adjusted.is_error () && !mappings.trait_item_mode ())
     return;
 
   TyTy::BaseType *concrete = type.handle_substitions (adjusted);
@@ -205,7 +205,7 @@ SubstMapperInternal::visit (TyTy::ADTType &type)
 {
   TyTy::SubstitutionArgumentMappings adjusted
     = type.adjust_mappings_for_this (mappings);
-  if (adjusted.is_error ())
+  if (adjusted.is_error () && !mappings.trait_item_mode ())
     return;
 
   TyTy::BaseType *concrete = type.handle_substitions (adjusted);

--- a/gcc/rust/typecheck/rust-type-util.cc
+++ b/gcc/rust/typecheck/rust-type-util.cc
@@ -217,8 +217,10 @@ coercion_site (HirId id, TyTy::TyWithLocation lhs, TyTy::TyWithLocation rhs,
   rust_debug ("coerce_default_unify(a={%s}, b={%s})",
 	      receiver->debug_str ().c_str (), expected->debug_str ().c_str ());
   TyTy::BaseType *coerced
-    = unify_site (id, lhs, TyTy::TyWithLocation (receiver, rhs.get_locus ()),
-		  locus);
+    = unify_site_and (id, lhs,
+		      TyTy::TyWithLocation (receiver, rhs.get_locus ()), locus,
+		      true /*emit_error*/, true /*commit*/, true /*infer*/,
+		      true /*cleanup*/);
   context->insert_autoderef_mappings (id, std::move (result.adjustments));
   return coerced;
 }

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -2226,12 +2226,24 @@ void
 ClosureType::setup_fn_once_output () const
 {
   // lookup the lang items
-  auto fn_once_lang_item = LangItem::Kind::FN_ONCE;
-  auto fn_once_output_lang_item = LangItem::Kind::FN_ONCE_OUTPUT;
+  auto fn_once_lookup = mappings.lookup_lang_item (LangItem::Kind::FN_ONCE);
+  auto fn_once_output_lookup
+    = mappings.lookup_lang_item (LangItem::Kind::FN_ONCE_OUTPUT);
+  if (!fn_once_lookup)
+    {
+      rust_fatal_error (UNKNOWN_LOCATION,
+			"Missing required %<fn_once%> lang item");
+      return;
+    }
+  if (!fn_once_output_lookup)
+    {
+      rust_fatal_error (UNKNOWN_LOCATION,
+			"Missing required %<fn_once_ouput%> lang item");
+      return;
+    }
 
-  DefId &trait_id = mappings.lookup_lang_item (fn_once_lang_item).value ();
-  DefId &trait_item_id
-    = mappings.lookup_lang_item (fn_once_output_lang_item).value ();
+  DefId &trait_id = fn_once_lookup.value ();
+  DefId &trait_item_id = fn_once_output_lookup.value ();
 
   // resolve to the trait
   HIR::Item *item = mappings.lookup_defid (trait_id).value ();

--- a/gcc/testsuite/rust/compile/issue-3382.rs
+++ b/gcc/testsuite/rust/compile/issue-3382.rs
@@ -1,0 +1,61 @@
+#[lang = "sized"]
+trait Sized {}
+
+enum Result<T, E> {
+    #[lang = "Ok"]
+    Ok(T),
+    #[lang = "Err"]
+    Err(E),
+}
+
+#[lang = "try"]
+pub trait Try {
+    /// The type of this value when viewed as successful.
+    // #[unstable(feature = "try_trait", issue = "42327")]
+    type Ok;
+    /// The type of this value when viewed as failed.
+    // #[unstable(feature = "try_trait", issue = "42327")]
+    type Error;
+
+    /// Applies the "?" operator. A return of `Ok(t)` means that the
+    /// execution should continue normally, and the result of `?` is the
+    /// value `t`. A return of `Err(e)` means that execution should branch
+    /// to the innermost enclosing `catch`, or return from the function.
+    ///
+    /// If an `Err(e)` result is returned, the value `e` will be "wrapped"
+    /// in the return type of the enclosing scope (which must itself implement
+    /// `Try`). Specifically, the value `X::from_error(From::from(e))`
+    /// is returned, where `X` is the return type of the enclosing function.
+    #[lang = "into_result"]
+    #[unstable(feature = "try_trait", issue = "42327")]
+    fn into_result(self) -> Result<Self::Ok, Self::Error>;
+
+    /// Wrap an error value to construct the composite result. For example,
+    /// `Result::Err(x)` and `Result::from_error(x)` are equivalent.
+    #[lang = "from_error"]
+    #[unstable(feature = "try_trait", issue = "42327")]
+    fn from_error(v: Self::Ok) -> Self;
+
+    /// Wrap an OK value to construct the composite result. For example,
+    /// `Result::Ok(x)` and `Result::from_ok(x)` are equivalent.
+    #[lang = "from_ok"]
+    #[unstable(feature = "try_trait", issue = "42327")]
+    fn from_ok(v: Self::Error) -> Self;
+}
+
+impl<T, E> Try for Result<T, E> {
+    type Ok = T;
+    type Error = E;
+
+    fn into_result(self) -> Result<T, E> {
+        self
+    }
+
+    fn from_ok(v: T) -> Self {
+        Result::Ok(v)
+    }
+
+    fn from_error(v: E) -> Self {
+        Result::Err(v)
+    }
+}

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -151,4 +151,5 @@ issue-3030.rs
 traits12.rs
 try-trait.rs
 issue-3174.rs
+issue-3382.rs
 # please don't delete the trailing newline


### PR DESCRIPTION
When we pass generic types as the Self on traits they need to be handled via a special case on fntypes, ADT's and placeholders as the type params won't necessarily match up because of the implicit Self.

Fixes Rust-GCC#3382

gcc/rust/ChangeLog:

	* typecheck/rust-substitution-mapper.cc (SubstMapperInternal::visit): special case

gcc/testsuite/ChangeLog:

	* rust/compile/nr2/exclude: nr2 cant handle this
	* rust/compile/issue-3382.rs: New test.
