### PR TITLE
Do not warn about unused fields if they start with '_'

### DIFF
--- a/gcc/rust/checks/lints/rust-lint-scan-deadcode.h
+++ b/gcc/rust/checks/lints/rust-lint-scan-deadcode.h
@@ -93,10 +93,11 @@ public:
 	  {
 	    HirId field_hir_id = field.get_mappings ().get_hirid ();
 	    if (should_warn (field_hir_id)
-		&& !field.get_visibility ().is_public ())
+		&& !field.get_visibility ().is_public ()
+		&& field.get_field_name ().as_string ().at (0) != '_')
 	      {
 		rust_warning_at (field.get_locus (), 0,
-				 "field is never read: %<%s%>",
+				 "field is never read: %qs",
 				 field.get_field_name ().as_string ().c_str ());
 	      }
 	  }


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* checks/lints/rust-lint-scan-deadcode.h: Check if the field name starts with an underscore before warning.
