### PR TITLE
lang-items: Add structural_{peq, teq}

### DIFF
--- a/gcc/rust/util/rust-lang-item.cc
+++ b/gcc/rust/util/rust-lang-item.cc
@@ -112,6 +112,9 @@ const BiMap<std::string, LangItem::Kind> Rust::LangItem::lang_items = {{
   {"from_ok", Kind::TRY_FROM_OK},
 
   {"from", Kind::FROM_FROM},
+
+  {"structural_peq", Kind::STRUCTURAL_PEQ},
+  {"structural_teq", Kind::STRUCTURAL_TEQ},
 }};
 
 tl::optional<LangItem::Kind>

--- a/gcc/rust/util/rust-lang-item.h
+++ b/gcc/rust/util/rust-lang-item.h
@@ -144,6 +144,9 @@ public:
 
     // NOTE: This is not a lang item in later versions of Rust
     FROM_FROM,
+
+    STRUCTURAL_PEQ,
+    STRUCTURAL_TEQ,
   };
 
   static const BiMap<std::string, Kind> lang_items;

--- a/gcc/testsuite/rust/compile/structural-eq-peq.rs
+++ b/gcc/testsuite/rust/compile/structural-eq-peq.rs
@@ -1,0 +1,9 @@
+#[lang = "structural_peq"]
+pub trait StructuralPartialEq {
+    // Empty.
+}
+
+#[lang = "structural_teq"]
+pub trait StructuralEq {
+    // Empty.
+}


### PR DESCRIPTION
These lang items are used when deriving Eq and PartialEq, and will be checked when compiling pattern matching.

gcc/rust/ChangeLog:

	* util/rust-lang-item.cc: New items.
	* util/rust-lang-item.h: Likewise.

gcc/testsuite/ChangeLog:

	* rust/compile/structural-eq-peq.rs: New test.
