### PR TITLE
gccrs: coercion sites allow for type inference as well.

### DIFF
--- a/gcc/rust/typecheck/rust-type-util.cc
+++ b/gcc/rust/typecheck/rust-type-util.cc
@@ -217,8 +217,10 @@ coercion_site (HirId id, TyTy::TyWithLocation lhs, TyTy::TyWithLocation rhs,
   rust_debug ("coerce_default_unify(a={%s}, b={%s})",
 	      receiver->debug_str ().c_str (), expected->debug_str ().c_str ());
   TyTy::BaseType *coerced
-    = unify_site (id, lhs, TyTy::TyWithLocation (receiver, rhs.get_locus ()),
-		  locus);
+    = unify_site_and (id, lhs,
+		      TyTy::TyWithLocation (receiver, rhs.get_locus ()), locus,
+		      true /*emit_error*/, true /*commit*/, true /*infer*/,
+		      true /*cleanup*/);
   context->insert_autoderef_mappings (id, std::move (result.adjustments));
   return coerced;
 }

--- a/gcc/testsuite/rust/compile/reference1.rs
+++ b/gcc/testsuite/rust/compile/reference1.rs
@@ -2,5 +2,5 @@ fn main() {
     let a = &123;
     let b: &mut i32 = a;
     // { dg-error "mismatched mutability" "" { target *-*-* } .-1 }
-    // { dg-error "mismatched types, expected .&mut i32. but got .& i32." "" { target *-*-* } .-2 }
+    // { dg-error "mismatched types, expected .&mut i32. but got .& <integer>." "" { target *-*-* } .-2 }
 }


### PR DESCRIPTION
Addresses Rust-GCC #3381 Rust-GCC #3382 

gcc/rust/ChangeLog:

	* typecheck/rust-type-util.cc (coercion_site): allow inference vars

gcc/testsuite/ChangeLog:

	* rust/compile/reference1.rs: fix error message
	
