### PR TITLE
gccrs: Fix crash in privay reporter for placeholder types

### DIFF
--- a/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
+++ b/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
@@ -243,10 +243,12 @@ PrivacyReporter::check_base_type_privacy (Analysis::NodeMapping &node_mappings,
 	   static_cast<const TyTy::TupleType *> (ty)->get_fields ())
 	recursive_check (param.get_tyty ());
       return;
-    case TyTy::PLACEHOLDER:
-      return recursive_check (
-	// FIXME: Can we use `resolve` here? Is that what we should do?
-	static_cast<const TyTy::PlaceholderType *> (ty)->resolve ());
+      case TyTy::PLACEHOLDER: {
+	const auto p = static_cast<const TyTy::PlaceholderType *> (ty);
+	if (!p->can_resolve ())
+	  return;
+	return recursive_check (p->resolve ());
+      }
     case TyTy::PROJECTION:
       return recursive_check (
 	static_cast<const TyTy::ProjectionType *> (ty)->get ());


### PR DESCRIPTION
This guards against a crash but i think this should actually be treated as if its a generic type like below. But for now this addresses a crash which can occur.

gcc/rust/ChangeLog:

	* checks/errors/privacy/rust-privacy-reporter.cc (PrivacyReporter::check_base_type_privacy): Add guard for placeholder

