### PR TITLE
derive(PartialEq): Add partial implementation (hehe)

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -98,6 +98,7 @@ GRS_OBJS = \
     rust/rust-derive-copy.o \
     rust/rust-derive-debug.o \
     rust/rust-derive-default.o \
+    rust/rust-derive-partial-eq.o \
     rust/rust-derive-eq.o \
     rust/rust-proc-macro.o \
     rust/rust-macro-invoc-lexer.o \

--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -98,6 +98,7 @@ GRS_OBJS = \
     rust/rust-derive-copy.o \
     rust/rust-derive-debug.o \
     rust/rust-derive-default.o \
+    rust/rust-derive-eq.o \
     rust/rust-proc-macro.o \
     rust/rust-macro-invoc-lexer.o \
     rust/rust-proc-macro-invoc-lexer.o \

--- a/gcc/rust/ast/rust-ast-builder.h
+++ b/gcc/rust/ast/rust-ast-builder.h
@@ -82,12 +82,12 @@ public:
   std::unique_ptr<Expr> deref (std::unique_ptr<Expr> &&of) const;
 
   /* Create a block with an optional tail expression */
-  std::unique_ptr<Expr> block (std::vector<std::unique_ptr<Stmt>> &&stmts,
-			       std::unique_ptr<Expr> &&tail_expr
-			       = nullptr) const;
-  std::unique_ptr<Expr> block (std::unique_ptr<Stmt> &&stmt,
-			       std::unique_ptr<Expr> &&tail_expr
-			       = nullptr) const;
+  std::unique_ptr<BlockExpr> block (std::vector<std::unique_ptr<Stmt>> &&stmts,
+				    std::unique_ptr<Expr> &&tail_expr
+				    = nullptr) const;
+  std::unique_ptr<BlockExpr> block (tl::optional<std::unique_ptr<Stmt>> &&stmt,
+				    std::unique_ptr<Expr> &&tail_expr
+				    = nullptr) const;
 
   /* Create an early return expression with an optional expression */
   std::unique_ptr<Expr> return_expr (std::unique_ptr<Expr> &&to_return

--- a/gcc/rust/ast/rust-ast-builder.h
+++ b/gcc/rust/ast/rust-ast-builder.h
@@ -23,6 +23,7 @@
 #include "rust-expr.h"
 #include "rust-ast.h"
 #include "rust-item.h"
+#include "rust-operators.h"
 
 namespace Rust {
 namespace AST {
@@ -62,6 +63,9 @@ public:
   /* Create a string literal expression ("content") */
   std::unique_ptr<Expr> literal_string (std::string &&content) const;
 
+  /* Create a boolean literal expression (true) */
+  std::unique_ptr<Expr> literal_bool (bool b) const;
+
   /* Create an identifier expression (`variable`) */
   std::unique_ptr<Expr> identifier (std::string name) const;
   std::unique_ptr<Pattern> identifier_pattern (std::string name,
@@ -80,6 +84,16 @@ public:
 
   /* Create a dereference of an expression (`*of`) */
   std::unique_ptr<Expr> deref (std::unique_ptr<Expr> &&of) const;
+
+  /* Build a comparison expression (`lhs == rhs`) */
+  std::unique_ptr<Expr> comparison_expr (std::unique_ptr<Expr> &&lhs,
+					 std::unique_ptr<Expr> &&rhs,
+					 ComparisonOperator op) const;
+
+  /* Build a lazy boolean operator expression (`lhs && rhs`) */
+  std::unique_ptr<Expr> boolean_operation (std::unique_ptr<Expr> &&lhs,
+					   std::unique_ptr<Expr> &&rhs,
+					   LazyBooleanOperator op) const;
 
   /* Create a block with an optional tail expression */
   std::unique_ptr<BlockExpr> block (std::vector<std::unique_ptr<Stmt>> &&stmts,
@@ -191,6 +205,10 @@ public:
    */
   PathInExpression path_in_expression (LangItem::Kind lang_item) const;
 
+  /* Create the path to an enum's variant (`Result::Ok`) */
+  PathInExpression variant_path (const std::string &enum_path,
+				 const std::string &variant) const;
+
   /* Create a new struct */
   std::unique_ptr<Stmt>
   struct_struct (std::string struct_name,
@@ -223,6 +241,8 @@ public:
 
   /* Create a wildcard pattern (`_`) */
   std::unique_ptr<Pattern> wildcard () const;
+  /* Create a reference pattern (`&pattern`) */
+  std::unique_ptr<Pattern> ref_pattern (std::unique_ptr<Pattern> &&inner) const;
 
   /* Create a lang item path usable as a general path */
   std::unique_ptr<Path> lang_item_path (LangItem::Kind) const;

--- a/gcc/rust/expand/rust-derive-clone.h
+++ b/gcc/rust/expand/rust-derive-clone.h
@@ -73,10 +73,12 @@ private:
   /**
    * Implementation of clone for all possible variants of an enum
    */
-  MatchCase clone_enum_identifier (Enum &item,
+  MatchCase clone_enum_identifier (PathInExpression variant_path,
 				   const std::unique_ptr<EnumItem> &variant);
-  MatchCase clone_enum_tuple (Enum &item, const EnumItemTuple &variant);
-  MatchCase clone_enum_struct (Enum &item, const EnumItemStruct &variant);
+  MatchCase clone_enum_tuple (PathInExpression variant_path,
+			      const EnumItemTuple &variant);
+  MatchCase clone_enum_struct (PathInExpression variant_path,
+			       const EnumItemStruct &variant);
 
   virtual void visit_struct (StructStruct &item);
   virtual void visit_tuple (TupleStruct &item);

--- a/gcc/rust/expand/rust-derive-eq.cc
+++ b/gcc/rust/expand/rust-derive-eq.cc
@@ -113,13 +113,17 @@ DeriveEq::eq_impls (
   std::unique_ptr<AssociatedItem> &&fn, std::string name,
   const std::vector<std::unique_ptr<GenericParam>> &type_generics)
 {
+  // We create two copies of the type-path to avoid duplicate NodeIds
   auto eq = builder.type_path ({"core", "cmp", "Eq"}, true);
+  auto eq_bound
+    = builder.trait_bound (builder.type_path ({"core", "cmp", "Eq"}, true));
+
   auto steq = builder.type_path (LangItem::Kind::STRUCTURAL_TEQ);
 
   auto trait_items = vec (std::move (fn));
 
   auto eq_generics
-    = setup_impl_generics (name, type_generics, builder.trait_bound (eq));
+    = setup_impl_generics (name, type_generics, std::move (eq_bound));
   auto steq_generics = setup_impl_generics (name, type_generics);
 
   auto eq_impl = builder.trait_impl (eq, std::move (eq_generics.self_type),

--- a/gcc/rust/expand/rust-derive-eq.cc
+++ b/gcc/rust/expand/rust-derive-eq.cc
@@ -1,0 +1,207 @@
+// Copyright (C) 2025 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-derive-eq.h"
+#include "rust-ast.h"
+#include "rust-expr.h"
+#include "rust-item.h"
+#include "rust-path.h"
+#include "rust-pattern.h"
+#include "rust-system.h"
+
+namespace Rust {
+namespace AST {
+
+std::unique_ptr<AssociatedItem>
+DeriveEq::assert_receiver_is_total_eq_fn (
+  std::vector<std::unique_ptr<Type>> &&types)
+{
+  auto stmts = std::vector<std::unique_ptr<Stmt>> ();
+
+  stmts.emplace_back (assert_param_is_eq ());
+
+  for (auto &&type : types)
+    stmts.emplace_back (assert_type_is_eq (std::move (type)));
+
+  auto block = std::unique_ptr<BlockExpr> (
+    new BlockExpr (std::move (stmts), nullptr, {}, {}, AST::LoopLabel::error (),
+		   loc, loc));
+
+  auto self = builder.self_ref_param ();
+
+  return builder.function ("assert_receiver_is_total_eq",
+			   vec (std::move (self)), {}, std::move (block));
+}
+
+std::unique_ptr<Stmt>
+DeriveEq::assert_param_is_eq ()
+{
+  auto eq_bound = std::unique_ptr<TypeParamBound> (
+    new TraitBound (builder.type_path ({"core", "cmp", "Eq"}, true), loc));
+
+  auto sized_bound = std::unique_ptr<TypeParamBound> (
+    new TraitBound (builder.type_path (LangItem::Kind::SIZED), loc, false,
+		    true /* opening_question_mark */));
+
+  auto bounds = vec (std::move (eq_bound), std::move (sized_bound));
+
+  auto assert_param_is_eq = "AssertParamIsEq";
+
+  auto t = std::unique_ptr<GenericParam> (
+    new TypeParam (Identifier ("T"), loc, std::move (bounds)));
+
+  return builder.struct_struct (
+    assert_param_is_eq, vec (std::move (t)),
+    {StructField (
+      Identifier ("_t"),
+      builder.single_generic_type_path (
+	LangItem::Kind::PHANTOM_DATA,
+	GenericArgs (
+	  {}, {GenericArg::create_type (builder.single_type_path ("T"))}, {})),
+      Visibility::create_private (), loc)});
+}
+
+std::unique_ptr<Stmt>
+DeriveEq::assert_type_is_eq (std::unique_ptr<Type> &&type)
+{
+  auto assert_param_is_eq = "AssertParamIsEq";
+
+  // AssertParamIsCopy::<Self>
+  auto assert_param_is_eq_ty
+    = std::unique_ptr<TypePathSegment> (new TypePathSegmentGeneric (
+      PathIdentSegment (assert_param_is_eq, loc), false,
+      GenericArgs ({}, {GenericArg::create_type (std::move (type))}, {}, loc),
+      loc));
+
+  // TODO: Improve this, it's really ugly
+  auto type_paths = std::vector<std::unique_ptr<TypePathSegment>> ();
+  type_paths.emplace_back (std::move (assert_param_is_eq_ty));
+
+  auto full_path
+    = std::unique_ptr<Type> (new TypePath ({std::move (type_paths)}, loc));
+
+  return builder.let (builder.wildcard (), std::move (full_path));
+}
+
+std::unique_ptr<Item>
+DeriveEq::eq_impl (
+  std::unique_ptr<AssociatedItem> &&fn, std::string name,
+  const std::vector<std::unique_ptr<GenericParam>> &type_generics)
+{
+  auto eq = builder.type_path ({"core", "cmp", "Eq"}, true);
+
+  auto trait_items = vec (std::move (fn));
+
+  auto generics
+    = setup_impl_generics (name, type_generics, builder.trait_bound (eq));
+
+  return builder.trait_impl (eq, std::move (generics.self_type),
+			     std::move (trait_items),
+			     std::move (generics.impl));
+}
+
+DeriveEq::DeriveEq (location_t loc) : DeriveVisitor (loc), expanded (nullptr) {}
+
+std::unique_ptr<AST::Item>
+DeriveEq::go (Item &item)
+{
+  item.accept_vis (*this);
+
+  rust_assert (expanded);
+
+  return std::move (expanded);
+}
+
+void
+DeriveEq::visit_tuple (TupleStruct &item)
+{
+  auto types = std::vector<std::unique_ptr<Type>> ();
+
+  for (auto &field : item.get_fields ())
+    types.emplace_back (field.get_field_type ().clone_type ());
+
+  expanded
+    = eq_impl (assert_receiver_is_total_eq_fn (std::move (types)),
+	       item.get_identifier ().as_string (), item.get_generic_params ());
+}
+
+void
+DeriveEq::visit_struct (StructStruct &item)
+{
+  auto types = std::vector<std::unique_ptr<Type>> ();
+
+  for (auto &field : item.get_fields ())
+    types.emplace_back (field.get_field_type ().clone_type ());
+
+  expanded
+    = eq_impl (assert_receiver_is_total_eq_fn (std::move (types)),
+	       item.get_identifier ().as_string (), item.get_generic_params ());
+}
+
+void
+DeriveEq::visit_enum (Enum &item)
+{
+  auto types = std::vector<std::unique_ptr<Type>> ();
+
+  for (auto &variant : item.get_variants ())
+    {
+      switch (variant->get_enum_item_kind ())
+	{
+	case EnumItem::Kind::Identifier:
+	case EnumItem::Kind::Discriminant:
+	  // nothing to do as they contain no inner types
+	  continue;
+	  case EnumItem::Kind::Tuple: {
+	    auto tuple = static_cast<EnumItemTuple &> (*variant);
+
+	    for (auto &field : tuple.get_tuple_fields ())
+	      types.emplace_back (field.get_field_type ().clone_type ());
+
+	    break;
+	  }
+	  case EnumItem::Kind::Struct: {
+	    auto tuple = static_cast<EnumItemStruct &> (*variant);
+
+	    for (auto &field : tuple.get_struct_fields ())
+	      types.emplace_back (field.get_field_type ().clone_type ());
+
+	    break;
+	  }
+	}
+    }
+
+  expanded
+    = eq_impl (assert_receiver_is_total_eq_fn (std::move (types)),
+	       item.get_identifier ().as_string (), item.get_generic_params ());
+}
+
+void
+DeriveEq::visit_union (Union &item)
+{
+  auto types = std::vector<std::unique_ptr<Type>> ();
+
+  for (auto &field : item.get_variants ())
+    types.emplace_back (field.get_field_type ().clone_type ());
+
+  expanded
+    = eq_impl (assert_receiver_is_total_eq_fn (std::move (types)),
+	       item.get_identifier ().as_string (), item.get_generic_params ());
+}
+
+} // namespace AST
+} // namespace Rust

--- a/gcc/rust/expand/rust-derive-eq.h
+++ b/gcc/rust/expand/rust-derive-eq.h
@@ -1,0 +1,82 @@
+// Copyright (C) 2025 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_DERIVE_EQ_H
+#define RUST_DERIVE_EQ_H
+
+#include "rust-derive.h"
+
+namespace Rust {
+namespace AST {
+
+// FIXME: Need to figure out structuraleq marker trait
+
+class DeriveEq : DeriveVisitor
+{
+public:
+  DeriveEq (location_t loc);
+
+  std::unique_ptr<AST::Item> go (Item &item);
+
+private:
+  std::unique_ptr<Item> expanded;
+
+  /**
+   * Create the actual `assert_receiver_is_total_eq` function of the
+   * implementation, which asserts that every type contained within our targeted
+   * type also implements `Eq`.
+   */
+  std::unique_ptr<AssociatedItem>
+  assert_receiver_is_total_eq_fn (std::vector<std::unique_ptr<Type>> &&types);
+
+  /**
+   * Create the Eq trait implementation for a type
+   *
+   * impl Eq for <type> {
+   *     <assert_receiver_is_total_eq>
+   * }
+   *
+   */
+  std::unique_ptr<Item>
+  eq_impl (std::unique_ptr<AssociatedItem> &&fn, std::string name,
+	   const std::vector<std::unique_ptr<GenericParam>> &type_generics);
+
+  /**
+   * Generate the following structure definition
+   *
+   * struct AssertParamIsEq<T: Eq + ?Sized> { _t: PhantomData<T> }
+   */
+  std::unique_ptr<Stmt> assert_param_is_eq ();
+
+  /**
+   * Generate a let statement to assert a type implements `Eq`
+   *
+   * let _: AssertParamIsEq<type>;
+   */
+  std::unique_ptr<Stmt> assert_type_is_eq (std::unique_ptr<Type> &&type);
+
+  virtual void visit_struct (StructStruct &item);
+  virtual void visit_tuple (TupleStruct &item);
+  virtual void visit_enum (Enum &item);
+  virtual void visit_union (Union &item);
+};
+
+} // namespace AST
+} // namespace Rust
+
+#endif // ! RUST_DERIVE_EQ_H

--- a/gcc/rust/expand/rust-derive-eq.h
+++ b/gcc/rust/expand/rust-derive-eq.h
@@ -31,10 +31,10 @@ class DeriveEq : DeriveVisitor
 public:
   DeriveEq (location_t loc);
 
-  std::unique_ptr<AST::Item> go (Item &item);
+  std::vector<std::unique_ptr<AST::Item>> go (Item &item);
 
 private:
-  std::unique_ptr<Item> expanded;
+  std::vector<std::unique_ptr<Item>> expanded;
 
   /**
    * Create the actual `assert_receiver_is_total_eq` function of the
@@ -52,9 +52,9 @@ private:
    * }
    *
    */
-  std::unique_ptr<Item>
-  eq_impl (std::unique_ptr<AssociatedItem> &&fn, std::string name,
-	   const std::vector<std::unique_ptr<GenericParam>> &type_generics);
+  std::vector<std::unique_ptr<Item>>
+  eq_impls (std::unique_ptr<AssociatedItem> &&fn, std::string name,
+	    const std::vector<std::unique_ptr<GenericParam>> &type_generics);
 
   /**
    * Generate the following structure definition

--- a/gcc/rust/expand/rust-derive-partial-eq.cc
+++ b/gcc/rust/expand/rust-derive-partial-eq.cc
@@ -1,0 +1,308 @@
+// Copyright (C) 2020-2024 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-derive-partial-eq.h"
+#include "rust-ast.h"
+#include "rust-expr.h"
+#include "rust-item.h"
+#include "rust-operators.h"
+#include "rust-path.h"
+#include "rust-pattern.h"
+#include "rust-system.h"
+
+namespace Rust {
+namespace AST {
+DerivePartialEq::DerivePartialEq (location_t loc)
+  : DeriveVisitor (loc), expanded (nullptr)
+{}
+
+std::unique_ptr<AST::Item>
+DerivePartialEq::go (Item &item)
+{
+  item.accept_vis (*this);
+
+  rust_assert (expanded);
+
+  return std::move (expanded);
+}
+
+std::unique_ptr<Item>
+DerivePartialEq::partial_eq_impl (
+  std::unique_ptr<AssociatedItem> &&eq_fn, std::string name,
+  const std::vector<std::unique_ptr<GenericParam>> &type_generics)
+{
+  auto eq = builder.type_path (LangItem::Kind::EQ);
+
+  auto trait_items = vec (std::move (eq_fn));
+
+  auto generics
+    = setup_impl_generics (name, type_generics, builder.trait_bound (eq));
+
+  return builder.trait_impl (eq, std::move (generics.self_type),
+			     std::move (trait_items),
+			     std::move (generics.impl));
+}
+
+std::unique_ptr<AssociatedItem>
+DerivePartialEq::eq_fn (std::unique_ptr<Expr> &&cmp_expression,
+			std::string type_name)
+{
+  auto block = builder.block (tl::nullopt, std::move (cmp_expression));
+
+  auto self_type
+    = std::unique_ptr<TypeNoBounds> (new TypePath (builder.type_path ("Self")));
+
+  auto params
+    = vec (builder.self_ref_param (),
+	   builder.function_param (builder.identifier_pattern ("other"),
+				   builder.reference_type (
+				     std::move (self_type))));
+
+  return builder.function ("eq", std::move (params),
+			   builder.single_type_path ("bool"),
+			   std::move (block));
+}
+
+DerivePartialEq::SelfOther
+DerivePartialEq::tuple_indexes (int idx)
+{
+  return SelfOther{
+    builder.tuple_idx ("self", idx),
+    builder.tuple_idx ("other", idx),
+  };
+}
+
+DerivePartialEq::SelfOther
+DerivePartialEq::field_acccesses (const std::string &field_name)
+{
+  return SelfOther{
+    builder.field_access (builder.identifier ("self"), field_name),
+    builder.field_access (builder.identifier ("other"), field_name),
+  };
+}
+
+std::unique_ptr<Expr>
+DerivePartialEq::build_eq_expression (
+  std::vector<SelfOther> &&field_expressions)
+{
+  // for unit structs or empty tuples, this is always true
+  if (field_expressions.empty ())
+    return builder.literal_bool (true);
+
+  auto cmp_expression
+    = builder.comparison_expr (std::move (field_expressions.at (0).self_expr),
+			       std::move (field_expressions.at (0).other_expr),
+			       ComparisonOperator::EQUAL);
+
+  for (size_t i = 1; i < field_expressions.size (); i++)
+    {
+      auto tmp = builder.comparison_expr (
+	std::move (field_expressions.at (i).self_expr),
+	std::move (field_expressions.at (i).other_expr),
+	ComparisonOperator::EQUAL);
+
+      cmp_expression
+	= builder.boolean_operation (std::move (cmp_expression),
+				     std::move (tmp),
+				     LazyBooleanOperator::LOGICAL_AND);
+    }
+
+  return cmp_expression;
+}
+
+void
+DerivePartialEq::visit_tuple (TupleStruct &item)
+{
+  auto type_name = item.get_struct_name ().as_string ();
+  auto fields = std::vector<SelfOther> ();
+
+  for (size_t idx = 0; idx < item.get_fields ().size (); idx++)
+    fields.emplace_back (tuple_indexes (idx));
+
+  auto fn = eq_fn (build_eq_expression (std::move (fields)), type_name);
+
+  expanded
+    = partial_eq_impl (std::move (fn), type_name, item.get_generic_params ());
+}
+
+void
+DerivePartialEq::visit_struct (StructStruct &item)
+{
+  auto type_name = item.get_struct_name ().as_string ();
+  auto fields = std::vector<SelfOther> ();
+
+  for (auto &field : item.get_fields ())
+    fields.emplace_back (
+      field_acccesses (field.get_field_name ().as_string ()));
+
+  auto fn = eq_fn (build_eq_expression (std::move (fields)), type_name);
+
+  expanded
+    = partial_eq_impl (std::move (fn), type_name, item.get_generic_params ());
+}
+
+MatchCase
+DerivePartialEq::match_enum_identifier (
+  PathInExpression variant_path, const std::unique_ptr<EnumItem> &variant)
+{
+  auto inner_ref_patterns
+    = vec (builder.ref_pattern (
+	     std::unique_ptr<Pattern> (new PathInExpression (variant_path))),
+	   builder.ref_pattern (
+	     std::unique_ptr<Pattern> (new PathInExpression (variant_path))));
+
+  auto tuple_items = std::make_unique<TuplePatternItemsMultiple> (
+    std::move (inner_ref_patterns));
+
+  auto pattern = std::make_unique<TuplePattern> (std::move (tuple_items), loc);
+
+  return builder.match_case (std::move (pattern), builder.literal_bool (true));
+}
+
+MatchCase
+DerivePartialEq::match_enum_tuple (PathInExpression variant_path,
+				   const EnumItemTuple &variant)
+{
+  auto self_patterns = std::vector<std::unique_ptr<Pattern>> ();
+  auto other_patterns = std::vector<std::unique_ptr<Pattern>> ();
+
+  auto self_other_exprs = std::vector<SelfOther> ();
+
+  for (size_t i = 0; i < variant.get_tuple_fields ().size (); i++)
+    {
+      // The patterns we're creating for each field are `self_<i>` and
+      // `other_<i>` where `i` is the index of the field. It doesn't actually
+      // matter what we use, as long as it's ordered, unique, and that we can
+      // reuse it in the match case's return expression to check that they are
+      // equal.
+
+      auto self_pattern_str = "__self_" + std::to_string (i);
+      auto other_pattern_str = "__other_" + std::to_string (i);
+
+      rust_debug ("]ARTHUR[ %s", self_pattern_str.c_str ());
+
+      self_patterns.emplace_back (
+	builder.identifier_pattern (self_pattern_str));
+      other_patterns.emplace_back (
+	builder.identifier_pattern (other_pattern_str));
+
+      self_other_exprs.emplace_back (SelfOther{
+	builder.identifier (self_pattern_str),
+	builder.identifier (other_pattern_str),
+      });
+    }
+
+  auto self_pattern_items = std::unique_ptr<TupleStructItems> (
+    new TupleStructItemsNoRange (std::move (self_patterns)));
+  auto other_pattern_items = std::unique_ptr<TupleStructItems> (
+    new TupleStructItemsNoRange (std::move (other_patterns)));
+
+  auto self_pattern = std::unique_ptr<Pattern> (
+    new ReferencePattern (std::unique_ptr<Pattern> (new TupleStructPattern (
+			    variant_path, std::move (self_pattern_items))),
+			  false, false, loc));
+  auto other_pattern = std::unique_ptr<Pattern> (
+    new ReferencePattern (std::unique_ptr<Pattern> (new TupleStructPattern (
+			    variant_path, std::move (other_pattern_items))),
+			  false, false, loc));
+
+  auto tuple_items = std::make_unique<TuplePatternItemsMultiple> (
+    vec (std::move (self_pattern), std::move (other_pattern)));
+
+  auto pattern = std::make_unique<TuplePattern> (std::move (tuple_items), loc);
+
+  auto expr = build_eq_expression (std::move (self_other_exprs));
+
+  return builder.match_case (std::move (pattern), std::move (expr));
+}
+
+MatchCase
+DerivePartialEq::match_enum_struct (PathInExpression variant_path,
+				    const EnumItemStruct &variant)
+{
+  // NOTE: We currently do not support compiling struct patterns where an
+  // identifier is assigned a new pattern, e.g. Bloop { f0: x }
+  // This is what we should be using to compile PartialEq for enum struct
+  // variants, as we need to be comparing the field of each instance meaning we
+  // need to give two different names to two different instances of the same
+  // field. We cannot just use the field's name like we do when deriving
+  // `Clone`.
+
+  rust_unreachable ();
+}
+
+void
+DerivePartialEq::visit_enum (Enum &item)
+{
+  auto cases = std::vector<MatchCase> ();
+
+  for (auto &variant : item.get_variants ())
+    {
+      auto variant_path
+	= builder.variant_path (item.get_identifier ().as_string (),
+				variant->get_identifier ().as_string ());
+
+      switch (variant->get_enum_item_kind ())
+	{
+	case EnumItem::Kind::Identifier:
+	case EnumItem::Kind::Discriminant:
+	  cases.emplace_back (match_enum_identifier (variant_path, variant));
+	  break;
+	case EnumItem::Kind::Tuple:
+	  cases.emplace_back (
+	    match_enum_tuple (variant_path,
+			      static_cast<EnumItemTuple &> (*variant)));
+	  break;
+	case EnumItem::Kind::Struct:
+	  rust_sorry_at (
+	    item.get_locus (),
+	    "cannot derive(PartialEq) for enum struct variants yet");
+	  break;
+	}
+    }
+
+  // NOTE: Mention using discriminant_value and skipping that last case, and
+  // instead skipping all identifiers/discriminant enum items and returning
+  // `true` in the wildcard case
+
+  // In case the two instances of `Self` don't have the same discriminant,
+  // automatically return false.
+  cases.emplace_back (
+    builder.match_case (builder.wildcard (), builder.literal_bool (false)));
+
+  auto match
+    = builder.match (builder.tuple (vec (builder.identifier ("self"),
+					 builder.identifier ("other"))),
+		     std::move (cases));
+
+  auto fn = eq_fn (std::move (match), item.get_identifier ().as_string ());
+
+  expanded
+    = partial_eq_impl (std::move (fn), item.get_identifier ().as_string (),
+		       item.get_generic_params ());
+}
+
+void
+DerivePartialEq::visit_union (Union &item)
+{
+  rust_error_at (item.get_locus (),
+		 "derive(PartialEq) cannot be used on unions");
+}
+
+} // namespace AST
+} // namespace Rust

--- a/gcc/rust/expand/rust-derive-partial-eq.h
+++ b/gcc/rust/expand/rust-derive-partial-eq.h
@@ -30,12 +30,16 @@ class DerivePartialEq : DeriveVisitor
 public:
   DerivePartialEq (location_t loc);
 
-  std::unique_ptr<AST::Item> go (Item &item);
+  std::vector<std::unique_ptr<AST::Item>> go (Item &item);
 
 private:
-  std::unique_ptr<Item> expanded;
+  std::vector<std::unique_ptr<Item>> expanded;
 
-  std::unique_ptr<Item> partial_eq_impl (
+  /**
+   * Generate both an implementation of `PartialEq` and `StructuralPartialEq`
+   * for the given type
+   */
+  std::vector<std::unique_ptr<Item>> partialeq_impls (
     std::unique_ptr<AssociatedItem> &&eq_fn, std::string name,
     const std::vector<std::unique_ptr<GenericParam>> &type_generics);
 

--- a/gcc/rust/expand/rust-derive-partial-eq.h
+++ b/gcc/rust/expand/rust-derive-partial-eq.h
@@ -1,0 +1,81 @@
+// Copyright (C) 2025 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_DERIVE_PARTIAL_EQ_H
+#define RUST_DERIVE_PARTIAL_EQ_H
+
+#include "rust-derive.h"
+#include "rust-path.h"
+
+namespace Rust {
+namespace AST {
+
+class DerivePartialEq : DeriveVisitor
+{
+public:
+  DerivePartialEq (location_t loc);
+
+  std::unique_ptr<AST::Item> go (Item &item);
+
+private:
+  std::unique_ptr<Item> expanded;
+
+  std::unique_ptr<Item> partial_eq_impl (
+    std::unique_ptr<AssociatedItem> &&eq_fn, std::string name,
+    const std::vector<std::unique_ptr<GenericParam>> &type_generics);
+
+  std::unique_ptr<AssociatedItem> eq_fn (std::unique_ptr<Expr> &&cmp_expression,
+					 std::string type_name);
+
+  /**
+   * A pair of two expressions from each instance being compared. E.g. this
+   * could be `self.0` and `other.0`, or `self.field` and `other.field`
+   */
+  struct SelfOther
+  {
+    std::unique_ptr<Expr> self_expr;
+    std::unique_ptr<Expr> other_expr;
+  };
+
+  SelfOther tuple_indexes (int idx);
+  SelfOther field_acccesses (const std::string &field_name);
+
+  /**
+   * Build a suite of equality arithmetic expressions chained together by a
+   * boolean AND operator
+   */
+  std::unique_ptr<Expr>
+  build_eq_expression (std::vector<SelfOther> &&field_expressions);
+
+  MatchCase match_enum_identifier (PathInExpression variant_path,
+				   const std::unique_ptr<EnumItem> &variant);
+  MatchCase match_enum_tuple (PathInExpression variant_path,
+			      const EnumItemTuple &variant);
+  MatchCase match_enum_struct (PathInExpression variant_path,
+			       const EnumItemStruct &variant);
+
+  virtual void visit_struct (StructStruct &item);
+  virtual void visit_tuple (TupleStruct &item);
+  virtual void visit_enum (Enum &item);
+  virtual void visit_union (Union &item);
+};
+
+} // namespace AST
+} // namespace Rust
+
+#endif // ! RUST_DERIVE_PARTIAL_EQ_H

--- a/gcc/rust/expand/rust-derive.cc
+++ b/gcc/rust/expand/rust-derive.cc
@@ -21,6 +21,7 @@
 #include "rust-derive-copy.h"
 #include "rust-derive-debug.h"
 #include "rust-derive-default.h"
+#include "rust-derive-eq.h"
 
 namespace Rust {
 namespace AST {
@@ -48,6 +49,7 @@ DeriveVisitor::derive (Item &item, const Attribute &attr,
     case BuiltinMacro::Default:
       return DeriveDefault (attr.get_locus ()).go (item);
     case BuiltinMacro::Eq:
+      return DeriveEq (attr.get_locus ()).go (item);
     case BuiltinMacro::PartialEq:
     case BuiltinMacro::Ord:
     case BuiltinMacro::PartialOrd:

--- a/gcc/rust/expand/rust-derive.cc
+++ b/gcc/rust/expand/rust-derive.cc
@@ -50,7 +50,7 @@ DeriveVisitor::derive (Item &item, const Attribute &attr,
     case BuiltinMacro::Default:
       return vec (DeriveDefault (attr.get_locus ()).go (item));
     case BuiltinMacro::Eq:
-      return vec (DeriveEq (attr.get_locus ()).go (item));
+      return DeriveEq (attr.get_locus ()).go (item);
     case BuiltinMacro::PartialEq:
       return DerivePartialEq (attr.get_locus ()).go (item);
     case BuiltinMacro::Ord:

--- a/gcc/rust/expand/rust-derive.cc
+++ b/gcc/rust/expand/rust-derive.cc
@@ -31,34 +31,34 @@ DeriveVisitor::DeriveVisitor (location_t loc)
   : loc (loc), builder (Builder (loc))
 {}
 
-std::unique_ptr<Item>
+std::vector<std::unique_ptr<Item>>
 DeriveVisitor::derive (Item &item, const Attribute &attr,
 		       BuiltinMacro to_derive)
 {
   switch (to_derive)
     {
     case BuiltinMacro::Clone:
-      return DeriveClone (attr.get_locus ()).go (item);
+      return vec (DeriveClone (attr.get_locus ()).go (item));
     case BuiltinMacro::Copy:
-      return DeriveCopy (attr.get_locus ()).go (item);
+      return vec (DeriveCopy (attr.get_locus ()).go (item));
     case BuiltinMacro::Debug:
       rust_warning_at (
 	attr.get_locus (), 0,
 	"derive(Debug) is not fully implemented yet and has no effect - only a "
 	"stub implementation will be generated");
-      return DeriveDebug (attr.get_locus ()).go (item);
+      return vec (DeriveDebug (attr.get_locus ()).go (item));
     case BuiltinMacro::Default:
-      return DeriveDefault (attr.get_locus ()).go (item);
+      return vec (DeriveDefault (attr.get_locus ()).go (item));
     case BuiltinMacro::Eq:
-      return DeriveEq (attr.get_locus ()).go (item);
+      return vec (DeriveEq (attr.get_locus ()).go (item));
     case BuiltinMacro::PartialEq:
-      return DerivePartialEq (attr.get_locus ()).go (item);
+      return vec (DerivePartialEq (attr.get_locus ()).go (item));
     case BuiltinMacro::Ord:
     case BuiltinMacro::PartialOrd:
     case BuiltinMacro::Hash:
     default:
       rust_sorry_at (attr.get_locus (), "unimplemented builtin derive macro");
-      return nullptr;
+      return {};
     };
 }
 

--- a/gcc/rust/expand/rust-derive.cc
+++ b/gcc/rust/expand/rust-derive.cc
@@ -22,6 +22,7 @@
 #include "rust-derive-debug.h"
 #include "rust-derive-default.h"
 #include "rust-derive-eq.h"
+#include "rust-derive-partial-eq.h"
 
 namespace Rust {
 namespace AST {
@@ -51,6 +52,7 @@ DeriveVisitor::derive (Item &item, const Attribute &attr,
     case BuiltinMacro::Eq:
       return DeriveEq (attr.get_locus ()).go (item);
     case BuiltinMacro::PartialEq:
+      return DerivePartialEq (attr.get_locus ()).go (item);
     case BuiltinMacro::Ord:
     case BuiltinMacro::PartialOrd:
     case BuiltinMacro::Hash:

--- a/gcc/rust/expand/rust-derive.cc
+++ b/gcc/rust/expand/rust-derive.cc
@@ -52,7 +52,7 @@ DeriveVisitor::derive (Item &item, const Attribute &attr,
     case BuiltinMacro::Eq:
       return vec (DeriveEq (attr.get_locus ()).go (item));
     case BuiltinMacro::PartialEq:
-      return vec (DerivePartialEq (attr.get_locus ()).go (item));
+      return DerivePartialEq (attr.get_locus ()).go (item);
     case BuiltinMacro::Ord:
     case BuiltinMacro::PartialOrd:
     case BuiltinMacro::Hash:

--- a/gcc/rust/expand/rust-derive.h
+++ b/gcc/rust/expand/rust-derive.h
@@ -34,8 +34,12 @@ namespace AST {
 class DeriveVisitor : public AST::ASTVisitor
 {
 public:
-  static std::unique_ptr<Item> derive (Item &item, const Attribute &derive,
-				       BuiltinMacro to_derive);
+  /**
+   * Expand a built-in derive macro on an item. This may generate multiple items
+   * which all need to be integrated to the existing AST
+   */
+  static std::vector<std::unique_ptr<Item>>
+  derive (Item &item, const Attribute &derive, BuiltinMacro to_derive);
 
 protected:
   DeriveVisitor (location_t loc);

--- a/gcc/rust/expand/rust-expand-visitor.cc
+++ b/gcc/rust/expand/rust-expand-visitor.cc
@@ -43,7 +43,7 @@ ExpandVisitor::go (AST::Crate &crate)
   visit (crate);
 }
 
-static std::unique_ptr<AST::Item>
+static std::vector<std::unique_ptr<AST::Item>>
 builtin_derive_item (AST::Item &item, const AST::Attribute &derive,
 		     BuiltinMacro to_derive)
 {
@@ -189,11 +189,12 @@ ExpandVisitor::expand_inner_items (
 			to_derive.get ().as_string ());
 		      if (maybe_builtin.has_value ())
 			{
-			  auto new_item
+			  auto new_items
 			    = builtin_derive_item (item, current,
 						   maybe_builtin.value ());
 
-			  it = items.insert (it, std::move (new_item));
+			  for (auto &&new_item : new_items)
+			    it = items.insert (it, std::move (new_item));
 			}
 		      else
 			{
@@ -276,12 +277,14 @@ ExpandVisitor::expand_inner_stmts (AST::BlockExpr &expr)
 			to_derive.get ().as_string ());
 		      if (maybe_builtin.has_value ())
 			{
-			  auto new_item
+			  auto new_items
 			    = builtin_derive_item (item, current,
 						   maybe_builtin.value ());
+
 			  // this inserts the derive *before* the item - is it a
 			  // problem?
-			  it = stmts.insert (it, std::move (new_item));
+			  for (auto &&new_item : new_items)
+			    it = stmts.insert (it, std::move (new_item));
 			}
 		      else
 			{

--- a/gcc/testsuite/rust/compile/derive-eq-invalid.rs
+++ b/gcc/testsuite/rust/compile/derive-eq-invalid.rs
@@ -1,5 +1,6 @@
 mod core {
     mod cmp {
+        #[lang = "eq"]
         pub trait PartialEq<Rhs: ?Sized = Self> {
             fn eq(&self, other: &Rhs) -> bool;
 
@@ -14,11 +15,11 @@ mod core {
     }
 }
 
-// #[lang = "phantom_data"]
-// struct PhantomData<T>;
+#[lang = "phantom_data"]
+struct PhantomData<T>;
 
-// #[lang = "sized"]
-// trait Sized {}
+#[lang = "sized"]
+trait Sized {}
 
 #[derive(PartialEq)]
 struct NotEq;

--- a/gcc/testsuite/rust/compile/derive-eq-invalid.rs
+++ b/gcc/testsuite/rust/compile/derive-eq-invalid.rs
@@ -1,0 +1,45 @@
+mod core {
+    mod cmp {
+        pub trait PartialEq<Rhs: ?Sized = Self> {
+            fn eq(&self, other: &Rhs) -> bool;
+
+            fn ne(&self, other: &Rhs) -> bool {
+                !self.eq(other)
+            }
+        }
+
+        pub trait Eq: PartialEq<Self> {
+            fn assert_receiver_is_total_eq(&self) {}
+        }
+    }
+}
+
+// #[lang = "phantom_data"]
+// struct PhantomData<T>;
+
+// #[lang = "sized"]
+// trait Sized {}
+
+#[derive(PartialEq)]
+struct NotEq;
+
+#[derive(Eq, PartialEq)] // { dg-error "bounds not satisfied for NotEq .Eq." }
+struct Container(NotEq);
+
+// #[derive(Eq)]
+// struct Foo { a: i32 }
+// #[derive(Eq)]
+// struct Bar(i32);
+
+// #[derive(Eq)]
+// enum Baz {
+//     A,
+//     B(i32),
+//     C { a: i32 }
+// }
+
+// #[derive(Eq)]
+// union Qux {
+//     a: i32,
+//     b: i64,
+// }

--- a/gcc/testsuite/rust/compile/derive-eq-invalid.rs
+++ b/gcc/testsuite/rust/compile/derive-eq-invalid.rs
@@ -21,6 +21,12 @@ struct PhantomData<T>;
 #[lang = "sized"]
 trait Sized {}
 
+#[lang = "structural_peq"]
+trait StructuralPartialEq {}
+
+#[lang = "structural_teq"]
+trait StructuralEq {}
+
 #[derive(PartialEq)]
 struct NotEq;
 

--- a/gcc/testsuite/rust/compile/derive-partialeq1.rs
+++ b/gcc/testsuite/rust/compile/derive-partialeq1.rs
@@ -1,0 +1,59 @@
+#![feature(intrinsics)]
+
+#[lang = "sized"]
+trait Sized {}
+
+#[lang = "copy"]
+trait Copy {}
+
+#[lang = "eq"]
+pub trait PartialEq<Rhs: ?Sized = Self> {
+    /// This method tests for `self` and `other` values to be equal, and is used
+    /// by `==`.
+    #[must_use]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    fn eq(&self, other: &Rhs) -> bool;
+
+    /// This method tests for `!=`.
+    #[inline]
+    #[must_use]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    fn ne(&self, other: &Rhs) -> bool {
+        !self.eq(other)
+    }
+}
+
+#[derive(PartialEq, Copy)] // { dg-warning "unused name" }
+struct Foo;
+
+#[derive(PartialEq)]
+struct Bar(Foo);
+
+#[derive(PartialEq)]
+struct Baz { _inner: Foo }
+
+extern "C" {
+    fn puts(s: *const i8);
+}
+
+fn print(b: bool) {
+    if b {
+        unsafe { puts("true" as *const str as *const i8) }
+    } else {
+        unsafe { puts("false" as *const str as *const i8) }
+    }
+}
+
+fn main() -> i32 {
+    let x = Foo;
+
+    let b1 = x == Foo;
+    let b2 = Bar(x) != Bar(Foo);
+    let b3 = Baz { _inner: Foo } != Baz { _inner: x };
+
+    print(b1);
+    print(b2);
+    print(b3);
+
+    0
+}

--- a/gcc/testsuite/rust/compile/derive-partialeq1.rs
+++ b/gcc/testsuite/rust/compile/derive-partialeq1.rs
@@ -6,6 +6,9 @@ trait Sized {}
 #[lang = "copy"]
 trait Copy {}
 
+#[lang = "structural_peq"]
+trait StructuralPartialEq {}
+
 #[lang = "eq"]
 pub trait PartialEq<Rhs: ?Sized = Self> {
     /// This method tests for `self` and `other` values to be equal, and is used

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -75,4 +75,6 @@ issue-3402-1.rs
 for-loop1.rs
 for-loop2.rs
 issue-3403.rs
+derive-eq-invalid.rs
+derive-partialeq1.rs
 # please don't delete the trailing newline

--- a/gcc/testsuite/rust/execute/torture/derive-partialeq1.rs
+++ b/gcc/testsuite/rust/execute/torture/derive-partialeq1.rs
@@ -25,6 +25,9 @@ pub trait PartialEq<Rhs: ?Sized = Self> {
     }
 }
 
+#[lang = "structural_peq"]
+trait StructuralPartialEq {}
+
 #[derive(PartialEq, Copy)] // { dg-warning "unused name" }
 struct Foo;
 

--- a/gcc/testsuite/rust/execute/torture/derive-partialeq1.rs
+++ b/gcc/testsuite/rust/execute/torture/derive-partialeq1.rs
@@ -1,0 +1,61 @@
+// { dg-output "true\r*\nfalse\r*\nfalse\r*\n" }
+
+#![feature(intrinsics)]
+
+#[lang = "sized"]
+trait Sized {}
+
+#[lang = "copy"]
+trait Copy {}
+
+#[lang = "eq"]
+pub trait PartialEq<Rhs: ?Sized = Self> {
+    /// This method tests for `self` and `other` values to be equal, and is used
+    /// by `==`.
+    #[must_use]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    fn eq(&self, other: &Rhs) -> bool;
+
+    /// This method tests for `!=`.
+    #[inline]
+    #[must_use]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    fn ne(&self, other: &Rhs) -> bool {
+        !self.eq(other)
+    }
+}
+
+#[derive(PartialEq, Copy)] // { dg-warning "unused name" }
+struct Foo;
+
+#[derive(PartialEq)]
+struct Bar(Foo);
+
+#[derive(PartialEq)]
+struct Baz { _inner: Foo }
+
+extern "C" {
+    fn puts(s: *const i8);
+}
+
+fn print(b: bool) {
+    if b {
+        unsafe { puts("true" as *const str as *const i8) }
+    } else {
+        unsafe { puts("false" as *const str as *const i8) }
+    }
+}
+
+fn main() -> i32 {
+    let x = Foo;
+
+    let b1 = x == Foo;
+    let b2 = Bar(x) != Bar(Foo);
+    let b3 = Baz { _inner: Foo } != Baz { _inner: x };
+
+    print(b1);
+    print(b2);
+    print(b3);
+
+    0
+}


### PR DESCRIPTION
Fixes #2992 

This adds a base for deriving `PartialEq` and `Eq` but misses some more complex stuff like struct enum items, as we need to add more to our nameres and codegen to handle these rebinding patterns.

~~We also need to rework this part of the expansion pass as `derive(Eq)` and `derive(PartialEq)` should both create *two* impls: one of their trait, and one of the associated `Structural*` trait~~ this is now done in this PR.

This is ready for reviewing and merging IMO as a first basic implementation of `derive(PartialEq)` even if it does not support all types of Rust enums