### PR TITLE
gccrs: Add test case to show issue is fixed

### DIFF
--- a/gcc/testsuite/rust/compile/issue-3402-1.rs
+++ b/gcc/testsuite/rust/compile/issue-3402-1.rs
@@ -1,0 +1,29 @@
+pub struct Foo {
+    a: i32,
+    // { dg-warning "field is never read" "" { target *-*-* } .-1 }
+}
+pub struct Bar(i32);
+
+#[lang = "sized"]
+trait Sized {}
+
+pub mod core {
+    pub mod default {
+        pub trait Default: Sized {
+            fn default() -> Self;
+        }
+
+        impl Default for i32 {
+            fn default() -> Self {
+                0
+            }
+        }
+    }
+}
+
+impl ::core::default::Default for Bar {
+    #[inline]
+    fn default() -> Bar {
+        Bar(core::default::Default::default())
+    }
+}

--- a/gcc/testsuite/rust/compile/issue-3402-2.rs
+++ b/gcc/testsuite/rust/compile/issue-3402-2.rs
@@ -1,0 +1,18 @@
+pub struct Bar(i32);
+
+#[lang = "sized"]
+trait Sized {}
+
+pub trait A: Sized {
+    fn foo() -> Self;
+}
+
+impl A for i32 {
+    fn foo() -> Self {
+        0
+    }
+}
+
+pub fn bar() {
+    let _ = Bar(A::foo());
+}

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -125,4 +125,5 @@ try-trait.rs
 derive-debug1.rs
 issue-3382.rs
 derive-default1.rs
+issue-3402-1.rs
 # please don't delete the trailing newline


### PR DESCRIPTION
This was fixed as part of: c63ecb2f032

Fixes Rust-GCC#3402

gcc/testsuite/ChangeLog:

	* rust/compile/nr2/exclude: nr2 cant handle this
	* rust/compile/issue-3402-1.rs: New test.
	* rust/compile/issue-3402-2.rs: New test.

