### PR TITLE
gccrs: remove bad type checking diagnostic

### DIFF
--- a/gcc/rust/typecheck/rust-tyty-subst.cc
+++ b/gcc/rust/typecheck/rust-tyty-subst.cc
@@ -934,27 +934,8 @@ SubstitutionRef::monomorphize ()
 	  auto associated
 	    = Resolver::lookup_associated_impl_block (bound, binding,
 						      &ambigious);
-	  if (associated == nullptr && ambigious)
-	    {
-	      // go for the first one? or error out?
-	      auto &mappings = Analysis::Mappings::get ();
-	      const auto &type_param = subst.get_generic_param ();
-	      const auto *trait_ref = bound.get ();
-
-	      rich_location r (line_table, type_param.get_locus ());
-	      r.add_range (bound.get_locus ());
-	      r.add_range (mappings.lookup_location (binding->get_ref ()));
-
-	      rust_error_at (r, "ambiguous type bound for trait %s and type %s",
-			     trait_ref->get_name ().c_str (),
-			     binding->get_name ().c_str ());
-	      return false;
-	    }
-
 	  if (associated != nullptr)
-	    {
-	      associated->setup_associated_types (binding, bound);
-	    }
+	    associated->setup_associated_types (binding, bound);
 	}
     }
 

--- a/gcc/testsuite/rust/compile/issue-3403.rs
+++ b/gcc/testsuite/rust/compile/issue-3403.rs
@@ -1,0 +1,38 @@
+pub struct Foo {
+    a: i32,
+    // { dg-warning "field is never read" "" { target *-*-* } .-1 }
+}
+pub struct Bar(i32);
+
+#[lang = "sized"]
+trait Sized {}
+
+pub mod core {
+    pub mod default {
+        pub trait Default: Sized {
+            fn default() -> Self;
+        }
+
+        impl Default for i32 {
+            fn default() -> Self {
+                0
+            }
+        }
+    }
+}
+
+impl ::core::default::Default for Bar {
+    #[inline]
+    fn default() -> Bar {
+        Bar(core::default::Default::default())
+    }
+}
+
+impl ::core::default::Default for Foo {
+    #[inline]
+    fn default() -> Foo {
+        Foo {
+            a: core::default::Default::default(),
+        }
+    }
+}

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -123,4 +123,5 @@ derive-default1.rs
 issue-3402-1.rs
 for-loop1.rs
 for-loop2.rs
+issue-3403.rs
 # please don't delete the trailing newline


### PR DESCRIPTION
This was a bad diagnostic added when I was working on slices and iterators also the name of the function is also bad. This is all about setting up associated types based on the current context of the bounds assocated with the associated trait bounds on this function.

The tell tale is that this didnt have an associated rust error code so this is most definetly not the correct error diagnostic.

Fixes Rust-GCC#3403

gcc/rust/ChangeLog:

	* typecheck/rust-tyty-subst.cc (SubstitutionRef::monomorphize): remove diagnostic

gcc/testsuite/ChangeLog:

	* rust/compile/nr2/exclude: nr2 cant handle this
	* rust/compile/issue-3403.rs: New test.
