### PR TITLE
Get rid of duplicate interface #3396

### DIFF
--- a/gcc/rust/typecheck/rust-autoderef.cc
+++ b/gcc/rust/typecheck/rust-autoderef.cc
@@ -113,7 +113,7 @@ Adjuster::try_unsize_type (TyTy::BaseType *ty)
   auto slice
     = new TyTy::SliceType (mappings.get_next_hir_id (), ty->get_ident ().locus,
 			   TyTy::TyVar (slice_elem->get_ref ()));
-  context->insert_implicit_type (slice);
+  context->insert_implicit_type (slice->get_ref (), slice);
 
   return Adjustment (Adjustment::AdjustmentType::UNSIZE, ty, slice);
 }

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -1576,7 +1576,7 @@ TypeCheckExpr::visit (HIR::ClosureExpr &expr)
   TyTy::TupleType *closure_args
     = new TyTy::TupleType (implicit_args_id, expr.get_locus (),
 			   parameter_types);
-  context->insert_implicit_type (closure_args);
+  context->insert_implicit_type (closure_args->get_ref (), closure_args);
 
   location_t result_type_locus = expr.has_return_type ()
 				   ? expr.get_return_type ().get_locus ()

--- a/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
@@ -653,7 +653,8 @@ ClosureParamInfer::Resolve (HIR::Pattern &pattern)
 
   if (resolver.infered->get_kind () != TyTy::TypeKind::ERROR)
     {
-      resolver.context->insert_implicit_type (resolver.infered);
+      resolver.context->insert_implicit_type (resolver.infered->get_ref (),
+					      resolver.infered);
       resolver.mappings.insert_location (resolver.infered->get_ref (),
 					 pattern.get_locus ());
     }

--- a/gcc/rust/typecheck/rust-hir-type-check.h
+++ b/gcc/rust/typecheck/rust-hir-type-check.h
@@ -171,7 +171,6 @@ public:
 
   void insert_type (const Analysis::NodeMapping &mappings,
 		    TyTy::BaseType *type);
-  void insert_implicit_type (TyTy::BaseType *type);
   bool lookup_type (HirId id, TyTy::BaseType **type) const;
   void clear_type (TyTy::BaseType *ty);
 

--- a/gcc/rust/typecheck/rust-typecheck-context.cc
+++ b/gcc/rust/typecheck/rust-typecheck-context.cc
@@ -91,13 +91,6 @@ TypeCheckContext::insert_type (const Analysis::NodeMapping &mappings,
 }
 
 void
-TypeCheckContext::insert_implicit_type (TyTy::BaseType *type)
-{
-  rust_assert (type != nullptr);
-  resolved[type->get_ref ()] = type;
-}
-
-void
 TypeCheckContext::insert_implicit_type (HirId id, TyTy::BaseType *type)
 {
   rust_assert (type != nullptr);


### PR DESCRIPTION
- Updated single-parameter calls to pass an explicit HirId alongside the type.

- This refactor ensures that all calls to insert_implicit_type consistently use the two-parameter version, improving clarity and maintainability of type mapping tracking.

Fixes https://github.com/Rust-GCC/gccrs/issues/3396

Signed-off-by: Guransh Singh <guransh766@gmail.com>