### PR TITLE
gccrs: add discriminant value intrinsic

### DIFF
--- a/gcc/rust/typecheck/rust-hir-trait-resolve.cc
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.cc
@@ -359,6 +359,7 @@ TraitItemReference::resolve_item (HIR::TraitItemType &type)
 {
   TyTy::BaseType *ty
     = new TyTy::PlaceholderType (type.get_name ().as_string (),
+				 type.get_mappings ().get_defid (),
 				 type.get_mappings ().get_hirid ());
   context->insert_type (type.get_mappings (), ty);
 }

--- a/gcc/rust/typecheck/rust-hir-type-check-base.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.cc
@@ -292,6 +292,10 @@ TypeCheckBase::parse_repr_options (const AST::AttrVec &attrs, location_t locus)
   repr.pack = 0;
   repr.align = 0;
 
+  // FIXME handle repr types....
+  bool ok = context->lookup_builtin ("isize", &repr.repr);
+  rust_assert (ok);
+
   for (const auto &attr : attrs)
     {
       bool is_repr = attr.get_path ().as_string () == Values::Attributes::REPR;

--- a/gcc/rust/typecheck/rust-hir-type-check-item.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.cc
@@ -337,6 +337,11 @@ TypeCheckItem::visit (HIR::Enum &enum_decl)
   if (enum_decl.has_generics ())
     resolve_generic_params (enum_decl.get_generic_params (), substitutions);
 
+  // Process #[repr(X)] attribute, if any
+  const AST::AttrVec &attrs = enum_decl.get_outer_attrs ();
+  TyTy::ADTType::ReprOptions repr
+    = parse_repr_options (attrs, enum_decl.get_locus ());
+
   std::vector<TyTy::VariantDef *> variants;
   int64_t discriminant_value = 0;
   for (auto &variant : enum_decl.get_variants ())
@@ -375,7 +380,7 @@ TypeCheckItem::visit (HIR::Enum &enum_decl)
 			 enum_decl.get_mappings ().get_hirid (),
 			 enum_decl.get_identifier ().as_string (), ident,
 			 TyTy::ADTType::ADTKind::ENUM, std::move (variants),
-			 std::move (substitutions));
+			 std::move (substitutions), repr);
 
   context->insert_type (enum_decl.get_mappings (), type);
   infered = type;

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -218,14 +218,6 @@ TypeCheckType::visit (HIR::QualifiedPathInType &path)
   if (trait_ref->is_error ())
     return;
 
-  // does this type actually implement this type-bound?
-  if (!TypeBoundsProbe::is_bound_satisfied_for_type (root, trait_ref))
-    {
-      rust_error_at (qual_path_type.get_locus (),
-		     "root does not satisfy specified trait-bound");
-      return;
-    }
-
   // get the predicate for the bound
   auto specified_bound = get_predicate_from_bound (qual_path_type.get_trait (),
 						   qual_path_type.get_type ());

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -3483,20 +3483,20 @@ NeverType::clone () const
 
 // placeholder type
 
-PlaceholderType::PlaceholderType (std::string symbol, HirId ref,
+PlaceholderType::PlaceholderType (std::string symbol, DefId id, HirId ref,
 				  std::set<HirId> refs)
   : BaseType (ref, ref, KIND,
 	      {Resolver::CanonicalPath::create_empty (), BUILTINS_LOCATION},
 	      refs),
-    symbol (symbol)
+    symbol (symbol), defId (id)
 {}
 
-PlaceholderType::PlaceholderType (std::string symbol, HirId ref, HirId ty_ref,
-				  std::set<HirId> refs)
+PlaceholderType::PlaceholderType (std::string symbol, DefId id, HirId ref,
+				  HirId ty_ref, std::set<HirId> refs)
   : BaseType (ref, ty_ref, KIND,
 	      {Resolver::CanonicalPath::create_empty (), BUILTINS_LOCATION},
 	      refs),
-    symbol (symbol)
+    symbol (symbol), defId (id)
 {}
 
 std::string
@@ -3540,8 +3540,8 @@ PlaceholderType::can_eq (const BaseType *other, bool emit_errors) const
 BaseType *
 PlaceholderType::clone () const
 {
-  return new PlaceholderType (get_symbol (), get_ref (), get_ty_ref (),
-			      get_combined_refs ());
+  return new PlaceholderType (get_symbol (), get_def_id (), get_ref (),
+			      get_ty_ref (), get_combined_refs ());
 }
 
 void
@@ -3600,6 +3600,12 @@ PlaceholderType::is_equal (const BaseType &other) const
 
   auto other2 = static_cast<const PlaceholderType &> (other);
   return get_symbol ().compare (other2.get_symbol ()) == 0;
+}
+
+DefId
+PlaceholderType::get_def_id () const
+{
+  return defId;
 }
 
 // Projection type

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -648,6 +648,7 @@ public:
     // parsing the #[repr] attribute.
     unsigned char align = 0;
     unsigned char pack = 0;
+    BaseType *repr = nullptr;
   };
 
   ADTType (HirId ref, std::string identifier, RustIdent ident, ADTKind adt_kind,
@@ -1530,9 +1531,9 @@ class PlaceholderType : public BaseType
 public:
   static constexpr auto KIND = TypeKind::PLACEHOLDER;
 
-  PlaceholderType (std::string symbol, HirId ref,
+  PlaceholderType (std::string symbol, DefId id, HirId ref,
 		   std::set<HirId> refs = std::set<HirId> ());
-  PlaceholderType (std::string symbol, HirId ref, HirId ty_ref,
+  PlaceholderType (std::string symbol, DefId id, HirId ref, HirId ty_ref,
 		   std::set<HirId> refs = std::set<HirId> ());
 
   void accept_vis (TyVisitor &vis) override;
@@ -1558,8 +1559,11 @@ public:
 
   bool is_equal (const BaseType &other) const override;
 
+  DefId get_def_id () const;
+
 private:
   std::string symbol;
+  DefId defId;
 };
 
 class ProjectionType : public BaseType, public SubstitutionRef

--- a/gcc/rust/util/rust-lang-item.cc
+++ b/gcc/rust/util/rust-lang-item.cc
@@ -115,6 +115,9 @@ const BiMap<std::string, LangItem::Kind> Rust::LangItem::lang_items = {{
 
   {"structural_peq", Kind::STRUCTURAL_PEQ},
   {"structural_teq", Kind::STRUCTURAL_TEQ},
+
+  {"discriminant_kind", Kind::DISCRIMINANT_KIND},
+  {"discriminant_type", Kind::DISCRIMINANT_TYPE},
 }};
 
 tl::optional<LangItem::Kind>

--- a/gcc/rust/util/rust-lang-item.h
+++ b/gcc/rust/util/rust-lang-item.h
@@ -147,6 +147,9 @@ public:
 
     STRUCTURAL_PEQ,
     STRUCTURAL_TEQ,
+
+    DISCRIMINANT_TYPE,
+    DISCRIMINANT_KIND,
   };
 
   static const BiMap<std::string, Kind> lang_items;

--- a/gcc/testsuite/rust/execute/torture/enum_intrinsics1.rs
+++ b/gcc/testsuite/rust/execute/torture/enum_intrinsics1.rs
@@ -1,0 +1,48 @@
+/* { dg-output "0\r*\n2\r*\n" } */
+#![feature(intrinsics)]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+enum BookFormat {
+    Paperback,
+    Hardback,
+    Ebook,
+}
+
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+mod core {
+    mod intrinsics {
+        #[lang = "discriminant_kind"]
+        pub trait DiscriminantKind {
+            #[lang = "discriminant_type"]
+            type Discriminant;
+        }
+
+        extern "rust-intrinsic" {
+            pub fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discriminant;
+        }
+    }
+}
+
+pub fn main() -> i32 {
+    let a = BookFormat::Paperback;
+    let b = BookFormat::Ebook;
+
+    unsafe {
+        let val1: isize = core::intrinsics::discriminant_value(&a);
+        let val2 = core::intrinsics::discriminant_value(&b);
+
+        let a = "%i\n";
+        let b = a as *const str;
+        let c = b as *const i8;
+
+        printf(c, val1 as i32);
+        printf(c, val2 as i32);
+    }
+
+    0
+}


### PR DESCRIPTION
This is pretty nasty piece of rust in my opinion the return type of this intrinsic results into a lang item associated type:

  ```<T as DiscriminantKind>::Discriminant```

This is a special case which needs to support mapping onto the repr type of the associated ADT that is passed in, but defaults to isize otherwise.

This patch assumes we only come accross this case in a HIR::CALL_EXPR, so and makes assumutions that its always of this function signiture. I will do some checking in libcore to verify that assumption. More work is needed to parse the repr type on enums but the code is there to support this when its in to change the types etc.

Addresses Rust-GCC#3348

gcc/rust/ChangeLog:

	* backend/rust-compile-intrinsic.cc (discriminant_value_handler): new handler
	* typecheck/rust-hir-trait-resolve.cc (TraitItemReference::resolve_item): track the defid
	* typecheck/rust-hir-type-check-base.cc (TypeCheckBase::parse_repr_options): default isize
	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::visit): special case CallExpr
	* typecheck/rust-hir-type-check-item.cc (TypeCheckItem::visit): parse repr options enum
	* typecheck/rust-hir-type-check-type.cc (TypeCheckType::visit): remove bad diagnostic
	* typecheck/rust-tyty.cc (PlaceholderType::PlaceholderType): track defid
	(PlaceholderType::clone): likewise
	(PlaceholderType::get_def_id): likeiwse
	* typecheck/rust-tyty.h: placeholder track defid
	* util/rust-lang-item.cc: add new lang items
	* util/rust-lang-item.h: likewise

gcc/testsuite/ChangeLog:

	* rust/execute/torture/enum_intrinsics1.rs: New test.
