### PR TITLE
gccrs: add variant_count intrinsic

### DIFF
--- a/gcc/testsuite/rust/execute/torture/enum_intrinsics2.rs
+++ b/gcc/testsuite/rust/execute/torture/enum_intrinsics2.rs
@@ -1,0 +1,25 @@
+#![feature(intrinsics)]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+enum BookFormat {
+    Paperback,
+    Hardback,
+    Ebook,
+}
+
+mod core {
+    mod intrinsics {
+        extern "rust-intrinsic" {
+            #[rustc_const_unstable(feature = "variant_count", issue = "73662")]
+            pub fn variant_count<T>() -> usize;
+        }
+    }
+}
+
+pub fn main() -> i32 {
+    let count = core::intrinsics::variant_count::<BookFormat>();
+
+    (count as i32) - 3
+}


### PR DESCRIPTION
Addresses Rust-GCC#3348

gcc/rust/ChangeLog:

	* backend/rust-compile-intrinsic.cc (variant_count_handler): new intrinsic

gcc/testsuite/ChangeLog:

	* rust/execute/torture/enum_intrinsics2.rs: New test.