### PR TITLE
NR2: Use parent scope instead of enum scope to resolve enum content

### DIFF
--- a/gcc/rust/resolve/rust-forever-stack.h
+++ b/gcc/rust/resolve/rust-forever-stack.h
@@ -650,7 +650,8 @@ public:
    * @return a valid option with the Definition if the identifier is present in
    * the current map, an empty one otherwise.
    */
-  tl::optional<Rib::Definition> get (const Identifier &name);
+  tl::optional<Rib::Definition> get (const Identifier &name,
+				     bool from_parent = false);
 
   /**
    * Resolve a path to its definition in the current `ForeverStack`
@@ -663,7 +664,8 @@ public:
   template <typename S>
   tl::optional<Rib::Definition> resolve_path (
     const std::vector<S> &segments,
-    std::function<void (const S &, NodeId)> insert_segment_resolution);
+    std::function<void (const S &, NodeId)> insert_segment_resolution,
+    bool from_parent = false);
 
   // FIXME: Documentation
   tl::optional<Resolver::CanonicalPath> to_canonical_path (NodeId id) const;

--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
@@ -300,7 +300,8 @@ Late::visit (AST::TypePath &type)
 
   // this *should* mostly work
   // TODO: make sure typepath-like path resolution (?) is working
-  auto resolved = ctx.resolve_path (type.get_segments (), Namespace::Types);
+  auto resolved
+    = ctx.resolve_path (type.get_segments (), Namespace::Types, true);
 
   if (resolved.has_value ())
     ctx.map_usage (Usage (type.get_node_id ()),

--- a/gcc/rust/resolve/rust-name-resolution-context.h
+++ b/gcc/rust/resolve/rust-name-resolution-context.h
@@ -218,7 +218,8 @@ public:
 
   template <typename S>
   tl::optional<Rib::Definition> resolve_path (const std::vector<S> &segments,
-					      Namespace ns)
+					      Namespace ns,
+					      bool from_parent = false)
   {
     std::function<void (const S &, NodeId)> insert_segment_resolution
       = [this] (const S &seg, NodeId id) {
@@ -229,13 +230,17 @@ public:
     switch (ns)
       {
       case Namespace::Values:
-	return values.resolve_path (segments, insert_segment_resolution);
+	return values.resolve_path (segments, insert_segment_resolution,
+				    from_parent);
       case Namespace::Types:
-	return types.resolve_path (segments, insert_segment_resolution);
+	return types.resolve_path (segments, insert_segment_resolution,
+				   from_parent);
       case Namespace::Macros:
-	return macros.resolve_path (segments, insert_segment_resolution);
+	return macros.resolve_path (segments, insert_segment_resolution,
+				    from_parent);
       case Namespace::Labels:
-	return labels.resolve_path (segments, insert_segment_resolution);
+	return labels.resolve_path (segments, insert_segment_resolution,
+				    from_parent);
       default:
 	rust_unreachable ();
       }


### PR DESCRIPTION
```rust
struct E2 /* (1) */;

enum Test {
    E1,
    E2 /* (2) */ (E2 /* (3) */),
}
```


E2 (3) is resolved as E2 (2) instead of E2(1) because enum's scope has been pushed. In `Late::visit(TypePath &type)` we should map the usage to E2(1) definition.

For now I'm trying to find an elegant solution (resolve the `TypePath` from it's scope's parent) but this should only work for `Enum` (Reuse `ContextualVisitor` ?).

I'm not a fan of big forever stack modification, and obviously modifying it for that kind of edge case feels off.

- We could introduce a new `resolve_from_parent` instead of that extra boolean
- If we keep that extra argument I should probably change it to an explicit enum
- Should we introduce a function to resolve from anywhere instead of the node's parent ? Would it be used anywhere ?
- Should we look for parent module instead of parent scope ?


Should fix nr2 test `exhaustiveness2.rs`