### PR TITLE
gccrs: add diagnostic for E0229 no associated type arguments allowed here

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-base.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.h
@@ -40,7 +40,8 @@ protected:
   TyTy::TypeBoundPredicate get_predicate_from_bound (
     HIR::TypePath &path,
     tl::optional<std::reference_wrapper<HIR::Type>> associated_self,
-    BoundPolarity polarity = BoundPolarity::RegularBound);
+    BoundPolarity polarity = BoundPolarity::RegularBound,
+    bool is_qualified_type = false);
 
   bool check_for_unconstrained (
     const std::vector<TyTy::SubstitutionParamMapping> &params_to_constrain,

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -193,8 +193,10 @@ TypeCheckType::visit (HIR::QualifiedPathInType &path)
     return;
 
   // get the predicate for the bound
-  auto specified_bound = get_predicate_from_bound (qual_path_type.get_trait (),
-						   qual_path_type.get_type ());
+  auto specified_bound
+    = get_predicate_from_bound (qual_path_type.get_trait (),
+				qual_path_type.get_type (),
+				BoundPolarity::RegularBound, true);
   if (specified_bound.is_error ())
     return;
 

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -80,14 +80,13 @@ private:
   {}
 
   TyTy::BaseType *resolve_root_path (HIR::TypePath &path, size_t *offset,
-				     NodeId *root_resolved_node_id,
 				     bool *wasBigSelf);
 
   TyTy::BaseType *resolve_segments (
-    NodeId root_resolved_node_id, HirId expr_id,
-    std::vector<std::unique_ptr<HIR::TypePathSegment>> &segments, size_t offset,
-    TyTy::BaseType *tyseg, const Analysis::NodeMapping &expr_mappings,
-    location_t expr_locus, bool tySegIsBigSelf);
+    HirId expr_id, std::vector<std::unique_ptr<HIR::TypePathSegment>> &segments,
+    size_t offset, TyTy::BaseType *tyseg,
+    const Analysis::NodeMapping &expr_mappings, location_t expr_locus,
+    bool tySegIsBigSelf);
 
   bool resolve_associated_type (const std::string &search,
 				TypeCheckBlockContextItem &ctx,

--- a/gcc/testsuite/rust/compile/issue-2369.rs
+++ b/gcc/testsuite/rust/compile/issue-2369.rs
@@ -1,0 +1,21 @@
+#[lang = "sized"]
+trait Sized {}
+
+fn main() {
+    pub trait Foo {
+        type A;
+        fn boo(&self) -> <Self as Foo>::A;
+    }
+
+    struct Bar;
+
+    impl Foo for isize {
+        type A = usize;
+        fn boo(&self) -> usize {
+            42
+        }
+    }
+
+    fn baz<I>(x: &<I as Foo<A = Bar>>::A) {}
+    // { dg-error "associated type bindings are not allowed here .E0229." "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
    gccrs: add diagnostic for E0229 no associated type arguments allowed here
    
    It seems bounds in qualified paths are not allowed to specify associated
    type bindings because its going to be associated with the impl block
    anyway.
    
    Fixes Rust-GCC#2369
    
    gcc/rust/ChangeLog:
    
            * typecheck/rust-hir-type-check-base.h: add flag
            * typecheck/rust-hir-type-check-type.cc (TypeCheckType::visit): likewise
            * typecheck/rust-tyty-bounds.cc: new diagnostic
    
    gcc/testsuite/ChangeLog:
    
            * rust/compile/issue-2369.rs: New test.
    
    Signed-off-by: Philip Herron <herron.philip@googlemail.com>