### PR TITLE
gccrs: self paths are patterns but we dont have mappings for it

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-base.cc
+++ b/gcc/rust/hir/rust-ast-lower-base.cc
@@ -666,6 +666,7 @@ ASTLoweringBase::lower_self (AST::Param &param)
   Analysis::NodeMapping mapping (crate_num, self.get_node_id (),
 				 mappings.get_next_hir_id (crate_num),
 				 mappings.get_next_localdef_id (crate_num));
+  mappings.insert_location (mapping.get_hirid (), param.get_locus ());
 
   if (self.has_type ())
     {

--- a/gcc/rust/typecheck/rust-hir-type-check-path.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-path.cc
@@ -312,6 +312,8 @@ TypeCheckExpr::resolve_root_path (HIR::PathInExpression &expr, size_t *offset,
       auto seg_is_module = mappings.lookup_module (ref).has_value ();
       auto seg_is_crate = mappings.is_local_hirid_crate (ref);
       auto seg_is_pattern = mappings.lookup_hir_pattern (ref).has_value ();
+      auto seg_is_self = is_root && !have_more_segments
+			 && seg.get_segment ().as_string () == "self";
       if (seg_is_module || seg_is_crate)
 	{
 	  // A::B::C::this_is_a_module::D::E::F
@@ -388,7 +390,8 @@ TypeCheckExpr::resolve_root_path (HIR::PathInExpression &expr, size_t *offset,
 	  if (lookup->get_kind () == TyTy::TypeKind::ERROR)
 	    return new TyTy::ErrorType (expr.get_mappings ().get_hirid ());
 	}
-      else if (lookup->needs_generic_substitutions () && !seg_is_pattern)
+      else if (lookup->needs_generic_substitutions () && !seg_is_pattern
+	       && !seg_is_self)
 	{
 	  lookup = SubstMapper::InferSubst (lookup, expr.get_locus ());
 	}

--- a/gcc/testsuite/rust/compile/issue-3022.rs
+++ b/gcc/testsuite/rust/compile/issue-3022.rs
@@ -1,0 +1,18 @@
+#[lang = "sized"]
+trait Sized {}
+
+trait Foo<T> {
+    fn foo(self) -> T;
+}
+
+struct Bar<T, U> {
+    // { dg-warning "struct is never constructed" "" { target *-*-* } .-1 }
+    value: U,
+    valte: T,
+}
+
+impl<T: Foo<U>, U> Foo<U> for Bar<T, U> {
+    fn foo(self) -> U {
+        self.value
+    }
+}


### PR DESCRIPTION
With simple patterns we dont introduce any more inference varaibles as
they are already declared in a specific way. This would only lead to
more unconstrained inference varaibles than is required.
    
Fixes Rust-GCC#3022

Depends on https://github.com/Rust-GCC/gccrs/pull/3435