### PR TITLE
gccrs: improve error diagnostic for bad type-resolution in CallExpr

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -225,12 +225,17 @@ TypeCheckExpr::visit (HIR::CallExpr &expr)
   if (resolved_fn_trait_call)
     return;
 
-  bool valid_tyty = function_tyty->get_kind () == TyTy::TypeKind::FNDEF
-		    || function_tyty->get_kind () == TyTy::TypeKind::FNPTR;
+  bool valid_tyty
+    = function_tyty->is<TyTy::FnType> () || function_tyty->is<TyTy::FnPtr> ();
   if (!valid_tyty)
     {
-      rust_error_at (expr.get_locus (),
-		     "Failed to resolve expression of function call");
+      bool emit_error = !function_tyty->is<TyTy::ErrorType> ();
+      if (emit_error)
+	{
+	  rich_location r (line_table, expr.get_locus ());
+	  rust_error_at (r, ErrorCode::E0618, "expected function, found %<%s%>",
+			 function_tyty->get_name ().c_str ());
+	}
       return;
     }
 

--- a/gcc/testsuite/rust/compile/generics4.rs
+++ b/gcc/testsuite/rust/compile/generics4.rs
@@ -6,7 +6,6 @@ struct GenericStruct<T>(T, usize);
 fn main() {
     let a2;
     a2 = GenericStruct::<i8, i32>(1, 456); // { dg-error "generic item takes at most 1 type arguments but 2 were supplied" }
-                                           // { dg-error {Failed to resolve expression of function call} "" { target *-*-* } .-1 }
 
     let b2: i32 = a2.0;
     // { dg-error {Expected Tuple or ADT got: T\?} "" { target *-*-* } .-1 }

--- a/gcc/testsuite/rust/compile/generics6.rs
+++ b/gcc/testsuite/rust/compile/generics6.rs
@@ -27,6 +27,5 @@ impl Foo<f32> {
 
 fn main() {
     let a: i32 = Foo::test(); // { dg-error "multiple applicable items in scope for: .test." }
-    // { dg-error {Failed to resolve expression of function call} "" { target *-*-* } .-1 }
 }
 

--- a/gcc/testsuite/rust/compile/issue-2035.rs
+++ b/gcc/testsuite/rust/compile/issue-2035.rs
@@ -1,0 +1,10 @@
+fn func(i: i32) {
+    i();
+    // { dg-error "expected function, found .i32. .E0618." "" { target *-*-* } .-1 }
+}
+
+fn main() {
+    let i = 0i32;
+    i();
+    // { dg-error "expected function, found .i32. .E0618." "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/compile/type-bindings1.rs
+++ b/gcc/testsuite/rust/compile/type-bindings1.rs
@@ -7,5 +7,4 @@ fn main() {
     let a;
     a = Foo::<A = i32, B = f32>(123f32);
     // { dg-error "associated type bindings are not allowed here" "" { target *-*-* } .-1 }
-    // { dg-error {Failed to resolve expression of function call} "" { target *-*-* } .-2 }
 }

--- a/gcc/testsuite/rust/compile/unconstrained_type_param.rs
+++ b/gcc/testsuite/rust/compile/unconstrained_type_param.rs
@@ -13,5 +13,4 @@ impl<X, Y> Foo<X> {
 fn main() {
     let a = Foo::test();
     // { dg-error "expected" "" { target *-*-* } .-1 }
-    // { dg-error "Failed to resolve expression of function call" "" { target *-*-* } .-2 }
 }


### PR DESCRIPTION
We have the type information for the resolved call lets tell the user about it in the diagnostic and apply the correct error code.

Fixes Rust-GCC#2035

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::visit): improve error diag

gcc/testsuite/ChangeLog:

	* rust/compile/generics4.rs: cleanup
	* rust/compile/generics6.rs: likewise
	* rust/compile/type-bindings1.rs: likewise
	* rust/compile/unconstrained_type_param.rs: likewise
	* rust/compile/issue-2035.rs: New test.

