### PR TITLE
gccrs: Add name resolution and HIR lowering for ImplTraitType's

### DIFF
--- a/gcc/rust/checks/errors/borrowck/rust-bir-builder-struct.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-builder-struct.h
@@ -250,10 +250,6 @@ protected:
   void visit (HIR::ImplTraitType &type) override { rust_unreachable (); }
   void visit (HIR::TraitObjectType &type) override { rust_unreachable (); }
   void visit (HIR::ParenthesisedType &type) override { rust_unreachable (); }
-  void visit (HIR::ImplTraitTypeOneBound &type) override
-  {
-    rust_unreachable ();
-  }
   void visit (HIR::TupleType &type) override { rust_unreachable (); }
   void visit (HIR::NeverType &type) override { rust_unreachable (); }
   void visit (HIR::RawPointerType &type) override { rust_unreachable (); }

--- a/gcc/rust/checks/errors/borrowck/rust-function-collector.h
+++ b/gcc/rust/checks/errors/borrowck/rust-function-collector.h
@@ -180,7 +180,6 @@ public:
   void visit (HIR::ImplTraitType &type) override {}
   void visit (HIR::TraitObjectType &type) override {}
   void visit (HIR::ParenthesisedType &type) override {}
-  void visit (HIR::ImplTraitTypeOneBound &type) override {}
   void visit (HIR::TupleType &type) override {}
   void visit (HIR::NeverType &type) override {}
   void visit (HIR::RawPointerType &type) override {}

--- a/gcc/rust/checks/errors/rust-const-checker.cc
+++ b/gcc/rust/checks/errors/rust-const-checker.cc
@@ -847,10 +847,6 @@ ConstChecker::visit (ParenthesisedType &)
 {}
 
 void
-ConstChecker::visit (ImplTraitTypeOneBound &)
-{}
-
-void
 ConstChecker::visit (TupleType &)
 {}
 

--- a/gcc/rust/checks/errors/rust-const-checker.h
+++ b/gcc/rust/checks/errors/rust-const-checker.h
@@ -191,7 +191,6 @@ private:
   virtual void visit (ImplTraitType &type) override;
   virtual void visit (TraitObjectType &type) override;
   virtual void visit (ParenthesisedType &type) override;
-  virtual void visit (ImplTraitTypeOneBound &type) override;
   virtual void visit (TupleType &type) override;
   virtual void visit (NeverType &type) override;
   virtual void visit (RawPointerType &type) override;

--- a/gcc/rust/checks/errors/rust-hir-pattern-analysis.cc
+++ b/gcc/rust/checks/errors/rust-hir-pattern-analysis.cc
@@ -685,10 +685,6 @@ PatternChecker::visit (ParenthesisedType &)
 {}
 
 void
-PatternChecker::visit (ImplTraitTypeOneBound &)
-{}
-
-void
 PatternChecker::visit (TupleType &)
 {}
 

--- a/gcc/rust/checks/errors/rust-hir-pattern-analysis.h
+++ b/gcc/rust/checks/errors/rust-hir-pattern-analysis.h
@@ -164,7 +164,6 @@ private:
   virtual void visit (ImplTraitType &type) override;
   virtual void visit (TraitObjectType &type) override;
   virtual void visit (ParenthesisedType &type) override;
-  virtual void visit (ImplTraitTypeOneBound &type) override;
   virtual void visit (TupleType &type) override;
   virtual void visit (NeverType &type) override;
   virtual void visit (RawPointerType &type) override;

--- a/gcc/rust/checks/errors/rust-unsafe-checker.cc
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.cc
@@ -957,10 +957,6 @@ UnsafeChecker::visit (ParenthesisedType &)
 {}
 
 void
-UnsafeChecker::visit (ImplTraitTypeOneBound &)
-{}
-
-void
 UnsafeChecker::visit (TupleType &)
 {}
 

--- a/gcc/rust/checks/errors/rust-unsafe-checker.h
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.h
@@ -172,7 +172,6 @@ private:
   virtual void visit (ImplTraitType &type) override;
   virtual void visit (TraitObjectType &type) override;
   virtual void visit (ParenthesisedType &type) override;
-  virtual void visit (ImplTraitTypeOneBound &type) override;
   virtual void visit (TupleType &type) override;
   virtual void visit (NeverType &type) override;
   virtual void visit (RawPointerType &type) override;

--- a/gcc/rust/hir/rust-ast-lower-type.cc
+++ b/gcc/rust/hir/rust-ast-lower-type.cc
@@ -477,6 +477,42 @@ ASTLoweringType::visit (AST::ParenthesisedType &type)
 				  type.get_locus ());
 }
 
+void
+ASTLoweringType::visit (AST::ImplTraitType &type)
+{
+  std::vector<std::unique_ptr<HIR::TypeParamBound>> bounds;
+  for (auto &bound : type.get_type_param_bounds ())
+    {
+      auto b = ASTLoweringTypeBounds::translate (*bound.get ());
+      bounds.push_back (std::unique_ptr<HIR::TypeParamBound> (b));
+    }
+
+  auto crate_num = mappings.get_current_crate ();
+  Analysis::NodeMapping mapping (crate_num, type.get_node_id (),
+				 mappings.get_next_hir_id (crate_num),
+				 mappings.get_next_localdef_id (crate_num));
+
+  translated
+    = new HIR::ImplTraitType (mapping, std::move (bounds), type.get_locus ());
+}
+
+void
+ASTLoweringType::visit (AST::ImplTraitTypeOneBound &type)
+{
+  std::vector<std::unique_ptr<HIR::TypeParamBound>> bounds;
+
+  auto b = ASTLoweringTypeBounds::translate (type.get_trait_bound ());
+  bounds.push_back (std::unique_ptr<HIR::TypeParamBound> (b));
+
+  auto crate_num = mappings.get_current_crate ();
+  Analysis::NodeMapping mapping (crate_num, type.get_node_id (),
+				 mappings.get_next_hir_id (crate_num),
+				 mappings.get_next_localdef_id (crate_num));
+
+  translated
+    = new HIR::ImplTraitType (mapping, std::move (bounds), type.get_locus ());
+}
+
 HIR::GenericParam *
 ASTLowerGenericParam::translate (AST::GenericParam &param)
 {

--- a/gcc/rust/hir/rust-ast-lower-type.h
+++ b/gcc/rust/hir/rust-ast-lower-type.h
@@ -82,6 +82,9 @@ public:
   void visit (AST::TraitObjectType &type) override;
   void visit (AST::ParenthesisedType &type) override;
 
+  void visit (AST::ImplTraitType &type) override;
+  void visit (AST::ImplTraitTypeOneBound &type) override;
+
 private:
   ASTLoweringType (bool default_to_static_lifetime)
     : ASTLoweringBase (),

--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -2333,15 +2333,6 @@ Dump::visit (ParenthesisedType &e)
 }
 
 void
-Dump::visit (ImplTraitTypeOneBound &e)
-{
-  begin ("ImplTraitTypeOneBound");
-  do_type (e);
-  visit_field ("trait_bound", e.get_trait_bound ());
-  end ("ImplTraitTypeOneBound");
-}
-
-void
 Dump::visit (TupleType &e)
 {
   begin ("TupleType");

--- a/gcc/rust/hir/rust-hir-dump.h
+++ b/gcc/rust/hir/rust-hir-dump.h
@@ -237,7 +237,6 @@ private:
   virtual void visit (ImplTraitType &) override;
   virtual void visit (TraitObjectType &) override;
   virtual void visit (ParenthesisedType &) override;
-  virtual void visit (ImplTraitTypeOneBound &) override;
   virtual void visit (TupleType &) override;
   virtual void visit (NeverType &) override;
   virtual void visit (RawPointerType &) override;

--- a/gcc/rust/hir/tree/rust-hir-full-decls.h
+++ b/gcc/rust/hir/tree/rust-hir-full-decls.h
@@ -211,7 +211,6 @@ class TraitBound;
 class ImplTraitType;
 class TraitObjectType;
 class ParenthesisedType;
-class ImplTraitTypeOneBound;
 class TupleType;
 class NeverType;
 class RawPointerType;

--- a/gcc/rust/hir/tree/rust-hir-type.h
+++ b/gcc/rust/hir/tree/rust-hir-type.h
@@ -164,38 +164,6 @@ public:
   void accept_vis (HIRTypeVisitor &vis) override;
 };
 
-// Impl trait with a single bound? Poor reference material here.
-class ImplTraitTypeOneBound : public TypeNoBounds
-{
-  TraitBound trait_bound;
-
-protected:
-  /* Use covariance to implement clone function as returning this object rather
-   * than base */
-  ImplTraitTypeOneBound *clone_type_impl () const override
-  {
-    return new ImplTraitTypeOneBound (*this);
-  }
-
-  /* Use covariance to implement clone function as returning this object rather
-   * than base */
-  ImplTraitTypeOneBound *clone_type_no_bounds_impl () const override
-  {
-    return new ImplTraitTypeOneBound (*this);
-  }
-
-public:
-  ImplTraitTypeOneBound (Analysis::NodeMapping mappings, TraitBound trait_bound,
-			 location_t locus)
-    : TypeNoBounds (mappings, locus), trait_bound (std::move (trait_bound))
-  {}
-
-  std::string as_string () const override;
-  TraitBound &get_trait_bound () { return trait_bound; }
-  void accept_vis (HIRFullVisitor &vis) override;
-  void accept_vis (HIRTypeVisitor &vis) override;
-};
-
 /* A type consisting of the "product" of others (the tuple's elements) in a
  * specific order */
 class TupleType : public TypeNoBounds

--- a/gcc/rust/hir/tree/rust-hir-visitor.h
+++ b/gcc/rust/hir/tree/rust-hir-visitor.h
@@ -142,7 +142,6 @@ public:
   virtual void visit (ImplTraitType &type) = 0;
   virtual void visit (TraitObjectType &type) = 0;
   virtual void visit (ParenthesisedType &type) = 0;
-  virtual void visit (ImplTraitTypeOneBound &type) = 0;
   virtual void visit (TupleType &type) = 0;
   virtual void visit (NeverType &type) = 0;
   virtual void visit (RawPointerType &type) = 0;
@@ -290,7 +289,6 @@ public:
   virtual void visit (ImplTraitType &) override {}
   virtual void visit (TraitObjectType &) override {}
   virtual void visit (ParenthesisedType &) override {}
-  virtual void visit (ImplTraitTypeOneBound &) override {}
   virtual void visit (TupleType &) override {}
   virtual void visit (NeverType &) override {}
   virtual void visit (RawPointerType &) override {}
@@ -354,7 +352,6 @@ public:
   virtual void visit (ImplTraitType &type) = 0;
   virtual void visit (TraitObjectType &type) = 0;
   virtual void visit (ParenthesisedType &type) = 0;
-  virtual void visit (ImplTraitTypeOneBound &type) = 0;
   virtual void visit (TupleType &type) = 0;
   virtual void visit (NeverType &type) = 0;
   virtual void visit (RawPointerType &type) = 0;

--- a/gcc/rust/hir/tree/rust-hir.cc
+++ b/gcc/rust/hir/tree/rust-hir.cc
@@ -2866,14 +2866,6 @@ BareFunctionType::as_string () const
 }
 
 std::string
-ImplTraitTypeOneBound::as_string () const
-{
-  std::string str ("ImplTraitTypeOneBound: \n TraitBound: ");
-
-  return str + trait_bound.as_string ();
-}
-
-std::string
 TypePathSegmentGeneric::as_string () const
 {
   return TypePathSegment::as_string () + "<" + generic_args.as_string () + ">";
@@ -4526,12 +4518,6 @@ ParenthesisedType::accept_vis (HIRFullVisitor &vis)
 }
 
 void
-ImplTraitTypeOneBound::accept_vis (HIRFullVisitor &vis)
-{
-  vis.visit (*this);
-}
-
-void
 TupleType::accept_vis (HIRFullVisitor &vis)
 {
   vis.visit (*this);
@@ -4719,12 +4705,6 @@ SliceType::accept_vis (HIRTypeVisitor &vis)
 
 void
 ArrayType::accept_vis (HIRTypeVisitor &vis)
-{
-  vis.visit (*this);
-}
-
-void
-ImplTraitTypeOneBound::accept_vis (HIRTypeVisitor &vis)
 {
   vis.visit (*this);
 }

--- a/gcc/rust/resolve/rust-ast-resolve-type.h
+++ b/gcc/rust/resolve/rust-ast-resolve-type.h
@@ -61,61 +61,23 @@ class ResolveType : public ResolverBase
   using Rust::Resolver::ResolverBase::visit;
 
 public:
-  static NodeId go (AST::Type &type)
-  {
-    ResolveType resolver;
-    type.accept_vis (resolver);
-    return resolver.resolved_node;
-  }
+  static NodeId go (AST::Type &type);
 
-  void visit (AST::BareFunctionType &fntype) override
-  {
-    for (auto &param : fntype.get_function_params ())
-      ResolveType::go (param.get_type ());
-
-    if (fntype.has_return_type ())
-      ResolveType::go (fntype.get_return_type ());
-  }
-
-  void visit (AST::TupleType &tuple) override
-  {
-    if (tuple.is_unit_type ())
-      {
-	resolved_node = resolver->get_unit_type_node_id ();
-	return;
-      }
-
-    for (auto &elem : tuple.get_elems ())
-      ResolveType::go (*elem);
-  }
-
-  void visit (AST::TypePath &path) override
-  {
-    ResolveRelativeTypePath::go (path, resolved_node);
-  }
-
-  void visit (AST::QualifiedPathInType &path) override
-  {
-    ResolveRelativeQualTypePath::go (path);
-  }
-
+  void visit (AST::BareFunctionType &fntype) override;
+  void visit (AST::TupleType &tuple) override;
+  void visit (AST::TypePath &path) override;
+  void visit (AST::QualifiedPathInType &path) override;
   void visit (AST::ArrayType &type) override;
-
   void visit (AST::ReferenceType &type) override;
-
   void visit (AST::InferredType &type) override;
-
   void visit (AST::NeverType &type) override;
-
   void visit (AST::RawPointerType &type) override;
-
   void visit (AST::TraitObjectTypeOneBound &type) override;
-
   void visit (AST::TraitObjectType &type) override;
-
   void visit (AST::ParenthesisedType &type) override;
-
   void visit (AST::SliceType &type) override;
+  void visit (AST::ImplTraitType &type) override;
+  void visit (AST::ImplTraitTypeOneBound &type) override;
 
 private:
   ResolveType () : ResolverBase () {}

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -70,9 +70,6 @@ public:
   void visit (HIR::ImplTraitType &type) override
   { /* TODO */
   }
-  void visit (HIR::ImplTraitTypeOneBound &type) override
-  { /* TODO */
-  }
 
 private:
   TypeCheckType (HirId id)


### PR DESCRIPTION
Our AST has ImplTraitType for multiple bounds and a singular ImplTraitTypeOneBound, this patch desugars these into a simple HIR::ImplTraitType. It also does the name resolution for this.

gcc/rust/ChangeLog:

	* checks/errors/borrowck/rust-bir-builder-struct.h: remove HIR::ImplTraitTypeOneBound
	* checks/errors/borrowck/rust-function-collector.h: likewise
	* checks/errors/rust-const-checker.cc (ConstChecker::visit): likewise
	* checks/errors/rust-const-checker.h: likewise
	* checks/errors/rust-hir-pattern-analysis.cc (PatternChecker::visit): likewise
	* checks/errors/rust-hir-pattern-analysis.h: likewise
	* checks/errors/rust-unsafe-checker.cc (UnsafeChecker::visit): likewise
	* checks/errors/rust-unsafe-checker.h: likewise
	* hir/rust-ast-lower-type.cc (ASTLoweringType::translate): likewise
	(ASTLoweringType::visit): likewise
	* hir/rust-ast-lower-type.h: cleanup
	* hir/rust-hir-dump.cc (Dump::visit): remove ImplTraitTypeOneBound
	* hir/rust-hir-dump.h: likewise
	* hir/tree/rust-hir-full-decls.h (class ImplTraitTypeOneBound): likewise
	* hir/tree/rust-hir-type.h (class ImplTraitTypeOneBound): likewise
	* hir/tree/rust-hir-visitor.h: likewise
	* hir/tree/rust-hir.cc (ImplTraitTypeOneBound::as_string):  likewise
	(ImplTraitTypeOneBound::accept_vis):  likewise
	* resolve/rust-ast-resolve-type.cc (ResolveType::go): likewise
	(ResolveType::visit): likewise
	* resolve/rust-ast-resolve-type.h: add name resolution
	* typecheck/rust-hir-type-check-type.h: likewise
