### PR TITLE
gccrs: initial setup for new OpaqueType to represent Impl types

### DIFF
--- a/gcc/rust/backend/rust-compile-type.cc
+++ b/gcc/rust/backend/rust-compile-type.cc
@@ -731,6 +731,12 @@ TyTyResolveCompile::visit (const TyTy::DynamicObjectType &type)
 				    type.get_ident ().locus);
 }
 
+void
+TyTyResolveCompile::visit (const TyTy::OpaqueType &type)
+{
+  translated = error_mark_node;
+}
+
 tree
 TyTyResolveCompile::create_dyn_obj_record (const TyTy::DynamicObjectType &type)
 {

--- a/gcc/rust/backend/rust-compile-type.h
+++ b/gcc/rust/backend/rust-compile-type.h
@@ -56,6 +56,7 @@ public:
   void visit (const TyTy::ProjectionType &) override;
   void visit (const TyTy::DynamicObjectType &) override;
   void visit (const TyTy::ClosureType &) override;
+  void visit (const TyTy::OpaqueType &) override;
 
 public:
   static hashval_t type_hasher (tree type);

--- a/gcc/rust/checks/errors/borrowck/rust-bir-fact-collector.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-fact-collector.h
@@ -815,6 +815,7 @@ protected: // Subset helpers.
       case TyTy::PLACEHOLDER:
       case TyTy::INFER:
       case TyTy::PARAM:
+      case TyTy::OPAQUE:
 	rust_unreachable ();
       }
     rust_unreachable ();

--- a/gcc/rust/checks/errors/borrowck/rust-bir-place.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-place.h
@@ -485,6 +485,7 @@ private:
       case TyTy::PROJECTION: // TODO: DUNNO
       case TyTy::CLOSURE:    // TODO: DUNNO
       case TyTy::DYNAMIC:    // TODO: dunno
+      case TyTy::OPAQUE:
 	return false;
       }
     rust_unreachable ();

--- a/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
+++ b/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
@@ -271,6 +271,8 @@ PrivacyReporter::check_base_type_privacy (Analysis::NodeMapping &node_mappings,
       // We shouldn't have inference types here, ever
     case TyTy::INFER:
       return;
+    case TyTy::OPAQUE:
+      return;
     case TyTy::ERROR:
       return;
     }

--- a/gcc/rust/typecheck/rust-hir-type-check-type.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.h
@@ -60,16 +60,11 @@ public:
   void visit (HIR::NeverType &type) override;
   void visit (HIR::TraitObjectType &type) override;
   void visit (HIR::ParenthesisedType &type) override;
+  void visit (HIR::ImplTraitType &type) override;
 
-  void visit (HIR::TypePathSegmentFunction &segment) override
-  { /* TODO */
-  }
-  void visit (HIR::TraitBound &bound) override
-  { /* TODO */
-  }
-  void visit (HIR::ImplTraitType &type) override
-  { /* TODO */
-  }
+  // These dont need to be implemented as they are segments or part of types
+  void visit (HIR::TypePathSegmentFunction &segment) override {}
+  void visit (HIR::TraitBound &bound) override {}
 
 private:
   TypeCheckType (HirId id)

--- a/gcc/rust/typecheck/rust-substitution-mapper.cc
+++ b/gcc/rust/typecheck/rust-substitution-mapper.cc
@@ -346,6 +346,11 @@ SubstMapperInternal::visit (TyTy::DynamicObjectType &type)
 {
   resolved = type.clone ();
 }
+void
+SubstMapperInternal::visit (TyTy::OpaqueType &type)
+{
+  resolved = type.handle_substitions (mappings);
+}
 
 // SubstMapperFromExisting
 

--- a/gcc/rust/typecheck/rust-substitution-mapper.h
+++ b/gcc/rust/typecheck/rust-substitution-mapper.h
@@ -63,6 +63,7 @@ public:
   void visit (TyTy::NeverType &) override { rust_unreachable (); }
   void visit (TyTy::DynamicObjectType &) override { rust_unreachable (); }
   void visit (TyTy::ClosureType &) override { rust_unreachable (); }
+  void visit (TyTy::OpaqueType &) override { rust_unreachable (); }
 
 private:
   SubstMapper (HirId ref, HIR::GenericArgs *generics,
@@ -107,6 +108,7 @@ public:
   void visit (TyTy::StrType &type) override;
   void visit (TyTy::NeverType &type) override;
   void visit (TyTy::DynamicObjectType &type) override;
+  void visit (TyTy::OpaqueType &type) override;
 
 private:
   SubstMapperInternal (HirId ref, TyTy::SubstitutionArgumentMappings &mappings);
@@ -146,6 +148,7 @@ public:
   void visit (TyTy::PlaceholderType &) override { rust_unreachable (); }
   void visit (TyTy::ProjectionType &) override { rust_unreachable (); }
   void visit (TyTy::DynamicObjectType &) override { rust_unreachable (); }
+  void visit (TyTy::OpaqueType &type) override { rust_unreachable (); }
 
 private:
   SubstMapperFromExisting (TyTy::BaseType *concrete, TyTy::BaseType *receiver);
@@ -185,6 +188,7 @@ public:
   void visit (const TyTy::PlaceholderType &) override {}
   void visit (const TyTy::ProjectionType &) override {}
   void visit (const TyTy::DynamicObjectType &) override {}
+  void visit (const TyTy::OpaqueType &type) override {}
 
 private:
   GetUsedSubstArgs ();

--- a/gcc/rust/typecheck/rust-tyty-bounds.cc
+++ b/gcc/rust/typecheck/rust-tyty-bounds.cc
@@ -136,6 +136,7 @@ TypeBoundsProbe::assemble_sized_builtin ()
     case TyTy::NEVER:
     case TyTy::PLACEHOLDER:
     case TyTy::PROJECTION:
+    case TyTy::OPAQUE:
       assemble_builtin_candidate (LangItem::Kind::SIZED);
       break;
 

--- a/gcc/rust/typecheck/rust-tyty-call.h
+++ b/gcc/rust/typecheck/rust-tyty-call.h
@@ -61,6 +61,7 @@ public:
   void visit (ProjectionType &) override { rust_unreachable (); }
   void visit (DynamicObjectType &) override { rust_unreachable (); }
   void visit (ClosureType &type) override { rust_unreachable (); }
+  void visit (OpaqueType &type) override { rust_unreachable (); }
 
   // tuple-structs
   void visit (ADTType &type) override;

--- a/gcc/rust/typecheck/rust-tyty-cmp.h
+++ b/gcc/rust/typecheck/rust-tyty-cmp.h
@@ -431,6 +431,22 @@ public:
       }
   }
 
+  virtual void visit (const OpaqueType &type) override
+  {
+    ok = false;
+    if (emit_error_flag)
+      {
+	location_t ref_locus = mappings.lookup_location (type.get_ref ());
+	location_t base_locus
+	  = mappings.lookup_location (get_base ()->get_ref ());
+	rich_location r (line_table, ref_locus);
+	r.add_range (base_locus);
+	rust_error_at (r, "expected [%s] got [%s]",
+		       get_base ()->as_string ().c_str (),
+		       type.as_string ().c_str ());
+      }
+  }
+
 protected:
   BaseCmp (const BaseType *base, bool emit_errors)
     : mappings (Analysis::Mappings::get ()),
@@ -1569,6 +1585,23 @@ private:
   const BaseType *get_base () const override { return base; }
 
   const DynamicObjectType *base;
+};
+
+class OpaqueCmp : public BaseCmp
+{
+  using Rust::TyTy::BaseCmp::visit;
+
+public:
+  OpaqueCmp (const OpaqueType *base, bool emit_errors)
+    : BaseCmp (base, emit_errors), base (base)
+  {}
+
+  // TODO
+
+private:
+  const BaseType *get_base () const override { return base; }
+
+  const OpaqueType *base;
 };
 
 } // namespace TyTy

--- a/gcc/rust/typecheck/rust-tyty-variance-analysis-private.h
+++ b/gcc/rust/typecheck/rust-tyty-variance-analysis-private.h
@@ -168,6 +168,8 @@ public:
   {
     // TODO
   }
+
+  void visit (OpaqueType &type) override {}
 };
 
 /** Per crate context for generic type variance analysis. */

--- a/gcc/rust/typecheck/rust-tyty-visitor.h
+++ b/gcc/rust/typecheck/rust-tyty-visitor.h
@@ -51,6 +51,7 @@ public:
   virtual void visit (ProjectionType &type) = 0;
   virtual void visit (DynamicObjectType &type) = 0;
   virtual void visit (ClosureType &type) = 0;
+  virtual void visit (OpaqueType &type) = 0;
 };
 
 class TyConstVisitor
@@ -80,6 +81,7 @@ public:
   virtual void visit (const ProjectionType &type) = 0;
   virtual void visit (const DynamicObjectType &type) = 0;
   virtual void visit (const ClosureType &type) = 0;
+  virtual void visit (const OpaqueType &type) = 0;
 };
 
 } // namespace TyTy

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -73,6 +73,7 @@ enum TypeKind
   PROJECTION,
   DYNAMIC,
   CLOSURE,
+  OPAQUE,
   // there are more to add...
   ERROR
 };
@@ -406,6 +407,39 @@ private:
   bool is_trait_self;
   std::string symbol;
   HIR::GenericParam &param;
+};
+
+class OpaqueType : public BaseType
+{
+public:
+  static constexpr auto KIND = TypeKind::OPAQUE;
+
+  OpaqueType (location_t locus, HirId ref,
+	      std::vector<TypeBoundPredicate> specified_bounds,
+	      std::set<HirId> refs = std::set<HirId> ());
+
+  OpaqueType (location_t locus, HirId ref, HirId ty_ref,
+	      std::vector<TypeBoundPredicate> specified_bounds,
+	      std::set<HirId> refs = std::set<HirId> ());
+
+  void accept_vis (TyVisitor &vis) override;
+  void accept_vis (TyConstVisitor &vis) const override;
+
+  std::string as_string () const override;
+
+  bool can_eq (const BaseType *other, bool emit_errors) const override final;
+
+  BaseType *clone () const final override;
+
+  bool can_resolve () const;
+
+  BaseType *resolve () const;
+
+  std::string get_name () const override final;
+
+  bool is_equal (const BaseType &other) const override;
+
+  OpaqueType *handle_substitions (SubstitutionArgumentMappings &mappings);
 };
 
 class StructFieldType

--- a/gcc/rust/typecheck/rust-unify.cc
+++ b/gcc/rust/typecheck/rust-unify.cc
@@ -189,7 +189,7 @@ UnifyRules::go ()
 	       == TyTy::InferType::GENERAL;
       bool expected_is_concrete
 	= ltype->is_concrete () && !lhs_is_general_infer_var;
-      bool rneeds_infer = expected_is_concrete && rgot_param;
+      bool rneeds_infer = expected_is_concrete && (rgot_param);
 
       bool lgot_param = ltype->get_kind () == TyTy::TypeKind::PARAM;
       bool rhs_is_infer_var = rtype->get_kind () == TyTy::TypeKind::INFER;
@@ -199,7 +199,7 @@ UnifyRules::go ()
 	       == TyTy::InferType::GENERAL;
       bool receiver_is_concrete
 	= rtype->is_concrete () && !rhs_is_general_infer_var;
-      bool lneeds_infer = receiver_is_concrete && lgot_param;
+      bool lneeds_infer = receiver_is_concrete && (lgot_param);
 
       if (rneeds_infer)
 	{
@@ -312,6 +312,9 @@ UnifyRules::go ()
     case TyTy::CLOSURE:
       return expect_closure (static_cast<TyTy::ClosureType *> (ltype), rtype);
 
+    case TyTy::OPAQUE:
+      return expect_opaque (static_cast<TyTy::OpaqueType *> (ltype), rtype);
+
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -400,7 +403,8 @@ UnifyRules::expect_inference_variable (TyTy::InferType *ltype,
     case TyTy::PLACEHOLDER:
     case TyTy::PROJECTION:
     case TyTy::DYNAMIC:
-      case TyTy::CLOSURE: {
+    case TyTy::CLOSURE:
+      case TyTy::OPAQUE: {
 	bool is_valid = (ltype->get_infer_kind ()
 			 == TyTy::InferType::InferTypeKind::GENERAL);
 	if (is_valid)
@@ -528,6 +532,7 @@ UnifyRules::expect_adt (TyTy::ADTType *ltype, TyTy::BaseType *rtype)
     case TyTy::PROJECTION:
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
+    case TyTy::OPAQUE:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -572,6 +577,7 @@ UnifyRules::expect_str (TyTy::StrType *ltype, TyTy::BaseType *rtype)
     case TyTy::PROJECTION:
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
+    case TyTy::OPAQUE:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -642,6 +648,7 @@ UnifyRules::expect_reference (TyTy::ReferenceType *ltype, TyTy::BaseType *rtype)
     case TyTy::PROJECTION:
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
+    case TyTy::OPAQUE:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -712,6 +719,7 @@ UnifyRules::expect_pointer (TyTy::PointerType *ltype, TyTy::BaseType *rtype)
     case TyTy::PROJECTION:
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
+    case TyTy::OPAQUE:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -773,6 +781,7 @@ UnifyRules::expect_param (TyTy::ParamType *ltype, TyTy::BaseType *rtype)
     case TyTy::PROJECTION:
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
+    case TyTy::OPAQUE:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -832,6 +841,7 @@ UnifyRules::expect_array (TyTy::ArrayType *ltype, TyTy::BaseType *rtype)
     case TyTy::PROJECTION:
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
+    case TyTy::OPAQUE:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -890,6 +900,7 @@ UnifyRules::expect_slice (TyTy::SliceType *ltype, TyTy::BaseType *rtype)
     case TyTy::PROJECTION:
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
+    case TyTy::OPAQUE:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -980,6 +991,7 @@ UnifyRules::expect_fndef (TyTy::FnType *ltype, TyTy::BaseType *rtype)
     case TyTy::PROJECTION:
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
+    case TyTy::OPAQUE:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1096,6 +1108,7 @@ UnifyRules::expect_fnptr (TyTy::FnPtr *ltype, TyTy::BaseType *rtype)
     case TyTy::PROJECTION:
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
+    case TyTy::OPAQUE:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1166,6 +1179,7 @@ UnifyRules::expect_tuple (TyTy::TupleType *ltype, TyTy::BaseType *rtype)
     case TyTy::PROJECTION:
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
+    case TyTy::OPAQUE:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1213,6 +1227,7 @@ UnifyRules::expect_bool (TyTy::BoolType *ltype, TyTy::BaseType *rtype)
     case TyTy::PROJECTION:
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
+    case TyTy::OPAQUE:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1260,6 +1275,7 @@ UnifyRules::expect_char (TyTy::CharType *ltype, TyTy::BaseType *rtype)
     case TyTy::PROJECTION:
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
+    case TyTy::OPAQUE:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1314,6 +1330,7 @@ UnifyRules::expect_int (TyTy::IntType *ltype, TyTy::BaseType *rtype)
     case TyTy::PROJECTION:
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
+    case TyTy::OPAQUE:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1368,6 +1385,7 @@ UnifyRules::expect_uint (TyTy::UintType *ltype, TyTy::BaseType *rtype)
     case TyTy::PROJECTION:
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
+    case TyTy::OPAQUE:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1422,6 +1440,7 @@ UnifyRules::expect_float (TyTy::FloatType *ltype, TyTy::BaseType *rtype)
     case TyTy::PROJECTION:
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
+    case TyTy::OPAQUE:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1469,6 +1488,7 @@ UnifyRules::expect_isize (TyTy::ISizeType *ltype, TyTy::BaseType *rtype)
     case TyTy::PROJECTION:
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
+    case TyTy::OPAQUE:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1516,6 +1536,7 @@ UnifyRules::expect_usize (TyTy::USizeType *ltype, TyTy::BaseType *rtype)
     case TyTy::PROJECTION:
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
+    case TyTy::OPAQUE:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1581,6 +1602,7 @@ UnifyRules::expect_placeholder (TyTy::PlaceholderType *ltype,
     case TyTy::USIZE:
     case TyTy::ISIZE:
     case TyTy::NEVER:
+    case TyTy::OPAQUE:
       if (infer_flag)
 	return rtype->clone ();
       gcc_fallthrough ();
@@ -1632,6 +1654,7 @@ UnifyRules::expect_projection (TyTy::ProjectionType *ltype,
     case TyTy::ISIZE:
     case TyTy::NEVER:
     case TyTy::PLACEHOLDER:
+    case TyTy::OPAQUE:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1690,6 +1713,7 @@ UnifyRules::expect_dyn (TyTy::DynamicObjectType *ltype, TyTy::BaseType *rtype)
     case TyTy::NEVER:
     case TyTy::PLACEHOLDER:
     case TyTy::PROJECTION:
+    case TyTy::OPAQUE:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1739,6 +1763,65 @@ UnifyRules::expect_closure (TyTy::ClosureType *ltype, TyTy::BaseType *rtype)
       }
       break;
 
+    case TyTy::SLICE:
+    case TyTy::PARAM:
+    case TyTy::POINTER:
+    case TyTy::STR:
+    case TyTy::ADT:
+    case TyTy::REF:
+    case TyTy::ARRAY:
+    case TyTy::FNDEF:
+    case TyTy::FNPTR:
+    case TyTy::TUPLE:
+    case TyTy::BOOL:
+    case TyTy::CHAR:
+    case TyTy::INT:
+    case TyTy::UINT:
+    case TyTy::FLOAT:
+    case TyTy::USIZE:
+    case TyTy::ISIZE:
+    case TyTy::NEVER:
+    case TyTy::PLACEHOLDER:
+    case TyTy::PROJECTION:
+    case TyTy::DYNAMIC:
+    case TyTy::OPAQUE:
+    case TyTy::ERROR:
+      return new TyTy::ErrorType (0);
+    }
+  return new TyTy::ErrorType (0);
+}
+
+TyTy::BaseType *
+UnifyRules::expect_opaque (TyTy::OpaqueType *ltype, TyTy::BaseType *rtype)
+{
+  switch (rtype->get_kind ())
+    {
+      case TyTy::INFER: {
+	TyTy::InferType *r = static_cast<TyTy::InferType *> (rtype);
+	bool is_valid
+	  = r->get_infer_kind () == TyTy::InferType::InferTypeKind::GENERAL;
+	if (is_valid)
+	  return ltype->clone ();
+      }
+      break;
+
+      case TyTy::OPAQUE: {
+	auto &type = *static_cast<TyTy::OpaqueType *> (rtype);
+	if (ltype->num_specified_bounds () != type.num_specified_bounds ())
+	  {
+	    return new TyTy::ErrorType (0);
+	  }
+
+	if (!ltype->bounds_compatible (type, locus, true))
+	  {
+	    return new TyTy::ErrorType (0);
+	  }
+
+	return ltype->clone ();
+      }
+      break;
+
+    case TyTy::CLOSURE:
     case TyTy::SLICE:
     case TyTy::PARAM:
     case TyTy::POINTER:

--- a/gcc/rust/typecheck/rust-unify.h
+++ b/gcc/rust/typecheck/rust-unify.h
@@ -82,6 +82,8 @@ protected:
 			      TyTy::BaseType *rtype);
   TyTy::BaseType *expect_closure (TyTy::ClosureType *ltype,
 				  TyTy::BaseType *rtype);
+  TyTy::BaseType *expect_opaque (TyTy::OpaqueType *ltype,
+				 TyTy::BaseType *rtype);
 
 private:
   UnifyRules (TyTy::TyWithLocation lhs, TyTy::TyWithLocation rhs,


### PR DESCRIPTION
This completes the initial setup and boilerplate for the new type in the
typesystem. This is not functional yet but its a big patch already.