### PR TITLE
nr2.0: Fix issue with external crates

### DIFF
--- a/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
@@ -163,7 +163,16 @@ void
 TopLevel::visit (AST::ExternCrate &crate)
 {
   auto &mappings = Analysis::Mappings::get ();
-  CrateNum num = *mappings.lookup_crate_name (crate.get_referenced_crate ());
+  auto num_opt = mappings.lookup_crate_name (crate.get_referenced_crate ());
+
+  if (!num_opt)
+    {
+      rust_error_at (crate.get_locus (), "unknown crate %qs",
+		     crate.get_referenced_crate ().c_str ());
+      return;
+    }
+
+  CrateNum num = *num_opt;
 
   auto attribute_macros = mappings.lookup_attribute_proc_macros (num);
 

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -46,9 +46,6 @@ not_find_value_in_scope.rs
 privacy4.rs
 privacy5.rs
 privacy8.rs
-macros/proc/attribute_non_function.rs
-macros/proc/derive_non_function.rs
-macros/proc/non_function.rs
 pub_restricted_1.rs
 pub_restricted_2.rs
 pub_restricted_3.rs


### PR DESCRIPTION
When visiting an external crate declaration, handle failed crate name lookups. This can happen when `Session::load_extern_crate` fails to load a crate during the `CfgStrip` phase.