### PR TITLE
Prevent duplicate resolution insertions

### DIFF
--- a/gcc/rust/expand/rust-derive-copy.cc
+++ b/gcc/rust/expand/rust-derive-copy.cc
@@ -42,13 +42,16 @@ DeriveCopy::copy_impl (
   std::string name,
   const std::vector<std::unique_ptr<GenericParam>> &type_generics)
 {
-  auto copy = builder.type_path (LangItem::Kind::COPY);
+  // we should have two of these, so we don't run into issues with
+  // two paths sharing a node id
+  auto copy_bound = builder.type_path (LangItem::Kind::COPY);
+  auto copy_trait_path = builder.type_path (LangItem::Kind::COPY);
 
-  auto generics
-    = setup_impl_generics (name, type_generics, builder.trait_bound (copy));
+  auto generics = setup_impl_generics (name, type_generics,
+				       builder.trait_bound (copy_bound));
 
-  return builder.trait_impl (copy, std::move (generics.self_type), {},
-			     std::move (generics.impl));
+  return builder.trait_impl (copy_trait_path, std::move (generics.self_type),
+			     {}, std::move (generics.impl));
 }
 
 void

--- a/gcc/rust/resolve/rust-ast-resolve-item.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-item.cc
@@ -903,7 +903,18 @@ flatten_list (const AST::UseTreeList &list, std::vector<Import> &imports)
 
       for (auto import = imports.begin () + start_idx; import != imports.end ();
 	   import++)
-	import->add_prefix (prefix);
+	{
+	  // avoid duplicate node ids
+	  auto prefix_copy
+	    = AST::SimplePath ({}, prefix.has_opening_scope_resolution (),
+			       prefix.get_locus ());
+	  for (auto &seg : prefix.get_segments ())
+	    prefix_copy.get_segments ().push_back (
+	      AST::SimplePathSegment (seg.get_segment_name (),
+				      seg.get_locus ()));
+
+	  import->add_prefix (std::move (prefix_copy));
+	}
     }
 }
 

--- a/gcc/rust/resolve/rust-ast-resolve-path.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-path.cc
@@ -80,8 +80,16 @@ ResolvePath::resolve_path (AST::PathInExpression &expr)
 	  // what is the current crate scope node id?
 	  module_scope_id = crate_scope_id;
 	  previous_resolved_node_id = module_scope_id;
-	  resolver->insert_resolved_name (segment.get_node_id (),
-					  module_scope_id);
+
+	  NodeId existing = UNKNOWN_NODEID;
+	  bool ok = resolver->lookup_resolved_name (segment.get_node_id (),
+						    &existing);
+
+	  if (ok)
+	    rust_assert (existing == module_scope_id);
+	  else
+	    resolver->insert_resolved_name (segment.get_node_id (),
+					    module_scope_id);
 	  continue;
 	}
       else if (segment.is_super_path_seg ())
@@ -95,8 +103,16 @@ ResolvePath::resolve_path (AST::PathInExpression &expr)
 
 	  module_scope_id = resolver->peek_parent_module_scope ();
 	  previous_resolved_node_id = module_scope_id;
-	  resolver->insert_resolved_name (segment.get_node_id (),
-					  module_scope_id);
+
+	  NodeId existing = UNKNOWN_NODEID;
+	  bool ok = resolver->lookup_resolved_name (segment.get_node_id (),
+						    &existing);
+
+	  if (ok)
+	    rust_assert (existing == module_scope_id);
+	  else
+	    resolver->insert_resolved_name (segment.get_node_id (),
+					    module_scope_id);
 	  continue;
 	}
 
@@ -140,23 +156,45 @@ ResolvePath::resolve_path (AST::PathInExpression &expr)
 				      ident_seg.as_string ());
 	  if (resolver->get_name_scope ().lookup (path, &resolved_node))
 	    {
-	      resolver->insert_resolved_name (segment.get_node_id (),
-					      resolved_node);
+	      NodeId existing = UNKNOWN_NODEID;
+	      bool ok = resolver->lookup_resolved_name (segment.get_node_id (),
+							&existing);
+
+	      if (ok)
+		rust_assert (existing == resolved_node);
+	      else
+		resolver->insert_resolved_name (segment.get_node_id (),
+						resolved_node);
 	      resolved_node_id = resolved_node;
 	    }
 	  // check the type scope
 	  else if (resolver->get_type_scope ().lookup (path, &resolved_node))
 	    {
-	      resolver->insert_resolved_type (segment.get_node_id (),
-					      resolved_node);
+	      NodeId existing = UNKNOWN_NODEID;
+	      bool ok = resolver->lookup_resolved_type (segment.get_node_id (),
+							&existing);
+
+	      if (ok)
+		rust_assert (existing == resolved_node);
+	      else
+		resolver->insert_resolved_type (segment.get_node_id (),
+						resolved_node);
 	      resolved_node_id = resolved_node;
 	    }
 	  else if (segment.is_lower_self_seg ())
 	    {
 	      module_scope_id = crate_scope_id;
 	      previous_resolved_node_id = module_scope_id;
-	      resolver->insert_resolved_name (segment.get_node_id (),
-					      module_scope_id);
+
+	      NodeId existing = UNKNOWN_NODEID;
+	      bool ok = resolver->lookup_resolved_name (segment.get_node_id (),
+							&existing);
+
+	      if (ok)
+		rust_assert (existing == module_scope_id);
+	      else
+		resolver->insert_resolved_name (segment.get_node_id (),
+						module_scope_id);
 	      continue;
 	    }
 	  else
@@ -179,15 +217,33 @@ ResolvePath::resolve_path (AST::PathInExpression &expr)
 		    resolved_node))
 		{
 		  resolved_node_id = resolved_node;
-		  resolver->insert_resolved_name (segment.get_node_id (),
-						  resolved_node);
+
+		  NodeId existing = UNKNOWN_NODEID;
+		  bool ok
+		    = resolver->lookup_resolved_name (segment.get_node_id (),
+						      &existing);
+
+		  if (ok)
+		    rust_assert (existing == resolved_node);
+		  else
+		    resolver->insert_resolved_name (segment.get_node_id (),
+						    resolved_node);
 		}
 	      else if (resolver->get_type_scope ().decl_was_declared_here (
 			 resolved_node))
 		{
 		  resolved_node_id = resolved_node;
-		  resolver->insert_resolved_type (segment.get_node_id (),
-						  resolved_node);
+
+		  NodeId existing = UNKNOWN_NODEID;
+		  bool ok
+		    = resolver->lookup_resolved_type (segment.get_node_id (),
+						      &existing);
+
+		  if (ok)
+		    rust_assert (existing == resolved_node);
+		  else
+		    resolver->insert_resolved_type (segment.get_node_id (),
+						    resolved_node);
 		}
 	      else
 		{
@@ -224,15 +280,29 @@ ResolvePath::resolve_path (AST::PathInExpression &expr)
       // name scope first
       if (resolver->get_name_scope ().decl_was_declared_here (resolved_node_id))
 	{
-	  resolver->insert_resolved_name (expr.get_node_id (),
-					  resolved_node_id);
+	  NodeId existing = UNKNOWN_NODEID;
+	  bool ok
+	    = resolver->lookup_resolved_name (expr.get_node_id (), &existing);
+
+	  if (ok)
+	    rust_assert (existing == resolved_node_id);
+	  else
+	    resolver->insert_resolved_name (expr.get_node_id (),
+					    resolved_node_id);
 	}
       // check the type scope
       else if (resolver->get_type_scope ().decl_was_declared_here (
 		 resolved_node_id))
 	{
-	  resolver->insert_resolved_type (expr.get_node_id (),
-					  resolved_node_id);
+	  NodeId existing = UNKNOWN_NODEID;
+	  bool ok
+	    = resolver->lookup_resolved_type (expr.get_node_id (), &existing);
+
+	  if (ok)
+	    rust_assert (existing == resolved_node_id);
+	  else
+	    resolver->insert_resolved_type (expr.get_node_id (),
+					    resolved_node_id);
 	}
       else
 	{
@@ -284,8 +354,16 @@ ResolvePath::resolve_path (AST::SimplePath &expr)
 	  // what is the current crate scope node id?
 	  module_scope_id = crate_scope_id;
 	  previous_resolved_node_id = module_scope_id;
-	  resolver->insert_resolved_name (segment.get_node_id (),
-					  module_scope_id);
+
+	  NodeId existing = UNKNOWN_NODEID;
+	  bool ok = resolver->lookup_resolved_name (segment.get_node_id (),
+						    &existing);
+
+	  if (ok)
+	    rust_assert (existing == module_scope_id);
+	  else
+	    resolver->insert_resolved_name (segment.get_node_id (),
+					    module_scope_id);
 	  resolved_node_id = module_scope_id;
 
 	  continue;
@@ -301,8 +379,16 @@ ResolvePath::resolve_path (AST::SimplePath &expr)
 
 	  module_scope_id = resolver->peek_parent_module_scope ();
 	  previous_resolved_node_id = module_scope_id;
-	  resolver->insert_resolved_name (segment.get_node_id (),
-					  module_scope_id);
+
+	  NodeId existing = UNKNOWN_NODEID;
+	  bool ok = resolver->lookup_resolved_name (segment.get_node_id (),
+						    &existing);
+
+	  if (ok)
+	    rust_assert (existing == module_scope_id);
+	  else
+	    resolver->insert_resolved_name (segment.get_node_id (),
+					    module_scope_id);
 	  resolved_node_id = module_scope_id;
 
 	  continue;
@@ -318,15 +404,31 @@ ResolvePath::resolve_path (AST::SimplePath &expr)
 		resolved_node))
 	    {
 	      resolved_node_id = resolved_node;
-	      resolver->insert_resolved_name (segment.get_node_id (),
-					      resolved_node);
+
+	      NodeId existing = UNKNOWN_NODEID;
+	      bool ok = resolver->lookup_resolved_name (segment.get_node_id (),
+							&existing);
+
+	      if (ok)
+		rust_assert (existing == resolved_node);
+	      else
+		resolver->insert_resolved_name (segment.get_node_id (),
+						resolved_node);
 	    }
 	  else if (resolver->get_type_scope ().decl_was_declared_here (
 		     resolved_node))
 	    {
 	      resolved_node_id = resolved_node;
-	      resolver->insert_resolved_type (segment.get_node_id (),
-					      resolved_node);
+
+	      NodeId existing = UNKNOWN_NODEID;
+	      bool ok = resolver->lookup_resolved_type (segment.get_node_id (),
+							&existing);
+
+	      if (ok)
+		rust_assert (existing == resolved_node);
+	      else
+		resolver->insert_resolved_type (segment.get_node_id (),
+						resolved_node);
 	    }
 	  else
 	    {
@@ -347,15 +449,31 @@ ResolvePath::resolve_path (AST::SimplePath &expr)
 	  if (resolver->get_name_scope ().lookup (path, &resolved_node))
 	    {
 	      resolved_node_id = resolved_node;
-	      resolver->insert_resolved_name (segment.get_node_id (),
-					      resolved_node);
+
+	      NodeId existing = UNKNOWN_NODEID;
+	      bool ok = resolver->lookup_resolved_name (segment.get_node_id (),
+							&existing);
+
+	      if (ok)
+		rust_assert (existing == resolved_node);
+	      else
+		resolver->insert_resolved_name (segment.get_node_id (),
+						resolved_node);
 	    }
 	  // check the type scope
 	  else if (resolver->get_type_scope ().lookup (path, &resolved_node))
 	    {
 	      resolved_node_id = resolved_node;
-	      resolver->insert_resolved_type (segment.get_node_id (),
-					      resolved_node);
+
+	      NodeId existing = UNKNOWN_NODEID;
+	      bool ok = resolver->lookup_resolved_type (segment.get_node_id (),
+							&existing);
+
+	      if (ok)
+		rust_assert (existing == resolved_node);
+	      else
+		resolver->insert_resolved_type (segment.get_node_id (),
+						resolved_node);
 	    }
 	}
 
@@ -398,15 +516,29 @@ ResolvePath::resolve_path (AST::SimplePath &expr)
       // name scope first
       if (resolver->get_name_scope ().decl_was_declared_here (resolved_node_id))
 	{
-	  resolver->insert_resolved_name (expr.get_node_id (),
-					  resolved_node_id);
+	  NodeId existing = UNKNOWN_NODEID;
+	  bool ok
+	    = resolver->lookup_resolved_name (expr.get_node_id (), &existing);
+
+	  if (ok)
+	    rust_assert (existing == resolved_node_id);
+	  else
+	    resolver->insert_resolved_name (expr.get_node_id (),
+					    resolved_node_id);
 	}
       // check the type scope
       else if (resolver->get_type_scope ().decl_was_declared_here (
 		 resolved_node_id))
 	{
-	  resolver->insert_resolved_type (expr.get_node_id (),
-					  resolved_node_id);
+	  NodeId existing = UNKNOWN_NODEID;
+	  bool ok
+	    = resolver->lookup_resolved_type (expr.get_node_id (), &existing);
+
+	  if (ok)
+	    rust_assert (existing == resolved_node_id);
+	  else
+	    resolver->insert_resolved_type (expr.get_node_id (),
+					    resolved_node_id);
 	}
       else
 	{

--- a/gcc/rust/resolve/rust-ast-resolve-type.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-type.cc
@@ -249,14 +249,28 @@ ResolveRelativeTypePath::go (AST::TypePath &path, NodeId &resolved_node_id)
 	    = CanonicalPath::new_seg (segment->get_node_id (), ident_string);
 	  if (resolver->get_type_scope ().lookup (path, &resolved_node))
 	    {
-	      resolver->insert_resolved_type (segment->get_node_id (),
-					      resolved_node);
+	      NodeId existing = UNKNOWN_NODEID;
+	      bool ok = resolver->lookup_resolved_type (segment->get_node_id (),
+							&existing);
+
+	      if (ok)
+		rust_assert (existing == resolved_node);
+	      else
+		resolver->insert_resolved_type (segment->get_node_id (),
+						resolved_node);
 	      resolved_node_id = resolved_node;
 	    }
 	  else if (resolver->get_name_scope ().lookup (path, &resolved_node))
 	    {
-	      resolver->insert_resolved_name (segment->get_node_id (),
-					      resolved_node);
+	      NodeId existing = UNKNOWN_NODEID;
+	      bool ok = resolver->lookup_resolved_name (segment->get_node_id (),
+							&existing);
+
+	      if (ok)
+		rust_assert (existing == resolved_node);
+	      else
+		resolver->insert_resolved_name (segment->get_node_id (),
+						resolved_node);
 	      resolved_node_id = resolved_node;
 	    }
 	  else if (!segment->is_lang_item () && segment->is_lower_self_seg ())
@@ -264,8 +278,16 @@ ResolveRelativeTypePath::go (AST::TypePath &path, NodeId &resolved_node_id)
 	      // what is the current crate scope node id?
 	      module_scope_id = crate_scope_id;
 	      previous_resolved_node_id = module_scope_id;
-	      resolver->insert_resolved_name (segment->get_node_id (),
-					      module_scope_id);
+
+	      NodeId existing = UNKNOWN_NODEID;
+	      bool ok = resolver->lookup_resolved_name (segment->get_node_id (),
+							&existing);
+
+	      if (ok)
+		rust_assert (existing == module_scope_id);
+	      else
+		resolver->insert_resolved_name (segment->get_node_id (),
+						module_scope_id);
 
 	      continue;
 	    }
@@ -283,15 +305,33 @@ ResolveRelativeTypePath::go (AST::TypePath &path, NodeId &resolved_node_id)
 		    resolved_node))
 		{
 		  resolved_node_id = resolved_node;
-		  resolver->insert_resolved_name (segment->get_node_id (),
-						  resolved_node);
+
+		  NodeId existing = UNKNOWN_NODEID;
+		  bool ok
+		    = resolver->lookup_resolved_name (segment->get_node_id (),
+						      &existing);
+
+		  if (ok)
+		    rust_assert (existing == resolved_node);
+		  else
+		    resolver->insert_resolved_name (segment->get_node_id (),
+						    resolved_node);
 		}
 	      else if (resolver->get_type_scope ().decl_was_declared_here (
 			 resolved_node))
 		{
 		  resolved_node_id = resolved_node;
-		  resolver->insert_resolved_type (segment->get_node_id (),
-						  resolved_node);
+
+		  NodeId existing = UNKNOWN_NODEID;
+		  bool ok
+		    = resolver->lookup_resolved_type (segment->get_node_id (),
+						      &existing);
+
+		  if (ok)
+		    rust_assert (existing == resolved_node);
+		  else
+		    resolver->insert_resolved_type (segment->get_node_id (),
+						    resolved_node);
 		}
 	      else
 		{
@@ -327,15 +367,29 @@ ResolveRelativeTypePath::go (AST::TypePath &path, NodeId &resolved_node_id)
       // name scope first
       if (resolver->get_name_scope ().decl_was_declared_here (resolved_node_id))
 	{
-	  resolver->insert_resolved_name (path.get_node_id (),
-					  resolved_node_id);
+	  NodeId existing = UNKNOWN_NODEID;
+	  bool ok
+	    = resolver->lookup_resolved_name (path.get_node_id (), &existing);
+
+	  if (ok)
+	    rust_assert (existing == resolved_node_id);
+	  else
+	    resolver->insert_resolved_name (path.get_node_id (),
+					    resolved_node_id);
 	}
       // check the type scope
       else if (resolver->get_type_scope ().decl_was_declared_here (
 		 resolved_node_id))
 	{
-	  resolver->insert_resolved_type (path.get_node_id (),
-					  resolved_node_id);
+	  NodeId existing = UNKNOWN_NODEID;
+	  bool ok
+	    = resolver->lookup_resolved_type (path.get_node_id (), &existing);
+
+	  if (ok)
+	    rust_assert (existing == resolved_node_id);
+	  else
+	    resolver->insert_resolved_type (path.get_node_id (),
+					    resolved_node_id);
 	}
       else
 	{

--- a/gcc/rust/resolve/rust-name-resolver.cc
+++ b/gcc/rust/resolve/rust-name-resolver.cc
@@ -472,6 +472,8 @@ void
 Resolver::insert_resolved_name (NodeId refId, NodeId defId)
 {
   rust_assert (!flag_name_resolution_2_0);
+  rust_assert (resolved_names.find (refId) == resolved_names.end ());
+
   resolved_names[refId] = defId;
   get_name_scope ().append_reference_for_def (refId, defId);
   insert_captured_item (defId);
@@ -492,9 +494,8 @@ Resolver::lookup_resolved_name (NodeId refId, NodeId *defId)
 void
 Resolver::insert_resolved_type (NodeId refId, NodeId defId)
 {
-  // auto it = resolved_types.find (refId);
-  // rust_assert (it == resolved_types.end ());
   rust_assert (!flag_name_resolution_2_0);
+  rust_assert (resolved_types.find (refId) == resolved_types.end ());
 
   resolved_types[refId] = defId;
   get_type_scope ().append_reference_for_def (refId, defId);

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -2124,13 +2124,26 @@ TypeCheckExpr::resolve_fn_trait_call (HIR::CallExpr &expr,
       auto &nr_ctx = const_cast<Resolver2_0::NameResolutionContext &> (
 	Resolver2_0::ImmutableNameResolutionContext::get ().resolver ());
 
-      nr_ctx.map_usage (Resolver2_0::Usage (expr.get_mappings ().get_nodeid ()),
-			Resolver2_0::Definition (resolved_node_id));
+      auto existing = nr_ctx.lookup (expr.get_mappings ().get_nodeid ());
+      if (existing)
+	rust_assert (*existing == resolved_node_id);
+      else
+	nr_ctx.map_usage (Resolver2_0::Usage (
+			    expr.get_mappings ().get_nodeid ()),
+			  Resolver2_0::Definition (resolved_node_id));
     }
   else
     {
-      resolver->insert_resolved_name (expr.get_mappings ().get_nodeid (),
-				      resolved_node_id);
+      NodeId existing = UNKNOWN_NODEID;
+      bool ok
+	= resolver->lookup_resolved_name (expr.get_mappings ().get_nodeid (),
+					  &existing);
+
+      if (ok)
+	rust_assert (existing == resolved_node_id);
+      else
+	resolver->insert_resolved_name (expr.get_mappings ().get_nodeid (),
+					resolved_node_id);
     }
 
   // return the result of the function back

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -5,7 +5,6 @@ const_generics_3.rs
 const_generics_4.rs
 feature_rust_attri0.rs
 generics9.rs
-issue-1483.rs
 issue-1901.rs
 issue-1981.rs
 issue-2043.rs
@@ -35,14 +34,9 @@ undeclared_label.rs
 use_1.rs
 while_break_expr.rs
 issue-3139-2.rs
-issue-2953-2.rs
 issue-2905-2.rs
 issue-266.rs
-derive_clone_enum1.rs
-derive_clone_enum2.rs
 derive_clone_enum3.rs
-issue-3139-1.rs
-issue-3139-3.rs
 derive-debug1.rs
 derive-default1.rs
 issue-3402-1.rs


### PR DESCRIPTION
The 1.0 name resolver allows insertions of resolutions to duplicate (or even overwrite) past resolutions. This PR as-is introduces assertions to prevent duplicate resolution insertions. Allowing duplicate-but-identical resolution insertions (inserting `(a, b)` and `(a, c)` is allowed iff `b == c`) would be an alternative approach.