### PR TITLE
expansion: Correctly expand `$crate` metavar

### DIFF
--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -23,6 +23,7 @@
 #include "rust-ast-full.h"
 #include "rust-ast-visitor.h"
 #include "rust-diagnostics.h"
+#include "rust-macro.h"
 #include "rust-parse.h"
 #include "rust-cfg-strip.h"
 #include "rust-early-name-resolver.h"
@@ -119,7 +120,7 @@ MacroExpander::expand_decl_macro (location_t invoc_locus,
   for (auto &ent : matched_fragments)
     matched_fragments_ptr.emplace (ent.first, ent.second.get ());
 
-  return transcribe_rule (*matched_rule, invoc_token_tree,
+  return transcribe_rule (rules_def, *matched_rule, invoc_token_tree,
 			  matched_fragments_ptr, semicolon, peek_context ());
 }
 
@@ -1024,7 +1025,8 @@ tokens_to_str (std::vector<std::unique_ptr<AST::Token>> &tokens)
 
 AST::Fragment
 MacroExpander::transcribe_rule (
-  AST::MacroRule &match_rule, AST::DelimTokenTree &invoc_token_tree,
+  AST::MacroRulesDefinition &definition, AST::MacroRule &match_rule,
+  AST::DelimTokenTree &invoc_token_tree,
   std::map<std::string, MatchedFragmentContainer *> &matched_fragments,
   AST::InvocKind invoc_kind, ContextType ctx)
 {
@@ -1038,8 +1040,8 @@ MacroExpander::transcribe_rule (
   auto invoc_stream = invoc_token_tree.to_token_stream ();
   auto macro_rule_tokens = transcribe_tree.to_token_stream ();
 
-  auto substitute_context
-    = SubstituteCtx (invoc_stream, macro_rule_tokens, matched_fragments);
+  auto substitute_context = SubstituteCtx (invoc_stream, macro_rule_tokens,
+					   matched_fragments, definition);
   std::vector<std::unique_ptr<AST::Token>> substituted_tokens
     = substitute_context.substitute_tokens ();
 

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -331,7 +331,8 @@ struct MacroExpander
 		       AST::DelimTokenTree &invoc_token_tree);
 
   AST::Fragment transcribe_rule (
-    AST::MacroRule &match_rule, AST::DelimTokenTree &invoc_token_tree,
+    AST::MacroRulesDefinition &definition, AST::MacroRule &match_rule,
+    AST::DelimTokenTree &invoc_token_tree,
     std::map<std::string, MatchedFragmentContainer *> &matched_fragments,
     AST::InvocKind invoc_kind, ContextType ctx);
 

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -874,7 +874,7 @@ Mappings::insert_macro_def (AST::MacroRulesDefinition *macro)
   auto it = macroMappings.find (macro->get_node_id ());
   rust_assert (it == macroMappings.end ());
 
-  macroMappings[macro->get_node_id ()] = macro;
+  macroMappings[macro->get_node_id ()] = {macro, currentCrateNum};
 }
 
 tl::optional<AST::MacroRulesDefinition *>
@@ -884,7 +884,17 @@ Mappings::lookup_macro_def (NodeId id)
   if (it == macroMappings.end ())
     return tl::nullopt;
 
-  return it->second;
+  return it->second.first;
+}
+
+tl::optional<CrateNum>
+Mappings::lookup_macro_def_crate (NodeId id)
+{
+  auto it = macroMappings.find (id);
+  if (it == macroMappings.end ())
+    return tl::nullopt;
+
+  return it->second.second;
 }
 
 void

--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -269,6 +269,7 @@ public:
   void insert_macro_def (AST::MacroRulesDefinition *macro);
 
   tl::optional<AST::MacroRulesDefinition *> lookup_macro_def (NodeId id);
+  tl::optional<CrateNum> lookup_macro_def_crate (NodeId id);
 
   void insert_macro_invocation (AST::MacroInvocation &invoc,
 				AST::MacroRulesDefinition *def);
@@ -402,7 +403,8 @@ private:
   std::map<CrateNum, std::set<HirId>> hirNodesWithinCrate;
 
   // MBE macros
-  std::map<NodeId, AST::MacroRulesDefinition *> macroMappings;
+  std::map<NodeId, std::pair<AST::MacroRulesDefinition *, CrateNum>>
+    macroMappings;
   std::map<NodeId, AST::MacroRulesDefinition *> macroInvocations;
   std::vector<NodeId> exportedMacros;
 

--- a/gcc/testsuite/rust/compile/crate-metavar1.rs
+++ b/gcc/testsuite/rust/compile/crate-metavar1.rs
@@ -1,0 +1,14 @@
+macro_rules! foo {
+    () => {
+        $crate::inner::bar()
+    }
+}
+
+pub mod inner {
+    pub fn bar() { }
+}
+
+fn main() {
+    foo!();
+    crate::inner::bar();
+}

--- a/gcc/testsuite/rust/execute/crate-metavar1.rs
+++ b/gcc/testsuite/rust/execute/crate-metavar1.rs
@@ -1,0 +1,11 @@
+macro_rules! foo {
+    () => {
+        $crate::bar()
+    }
+}
+
+pub fn bar() -> i32 { 1 }
+
+fn main() -> i32 {
+    foo!() - crate::bar()
+}


### PR DESCRIPTION
This is better than what we currently do but it is missing a test for checking that we can properly call macros from external crates. I might add it later but it's a bit of a pain. Fixes #2833 