### PR TITLE
Reduce usage of `rust-session-manager.h`

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -235,6 +235,7 @@ GRS_OBJS = \
     rust/rust-unicode.o \
     rust/rust-punycode.o \
     rust/rust-unwrap-segment.o \
+    rust/rust-edition.o \
 	rust/rust-expand-format-args.o \
 	rust/rust-lang-item.o \
 	rust/rust-collect-lang-items.o \

--- a/gcc/rust/ast/rust-pattern.cc
+++ b/gcc/rust/ast/rust-pattern.cc
@@ -22,7 +22,6 @@ along with GCC; see the file COPYING3.  If not see
 #include "rust-diagnostics.h"
 #include "rust-ast-visitor.h"
 #include "rust-macro.h"
-#include "rust-session-manager.h"
 #include "rust-lex.h"
 #include "rust-parse.h"
 #include "rust-operators.h"

--- a/gcc/rust/checks/errors/rust-feature.h
+++ b/gcc/rust/checks/errors/rust-feature.h
@@ -19,7 +19,7 @@
 #ifndef RUST_FEATURE_H
 #define RUST_FEATURE_H
 
-#include "rust-session-manager.h"
+#include "rust-edition.h"
 #include "optional.h"
 
 namespace Rust {
@@ -66,7 +66,7 @@ private:
   Feature (Name name, State state, const char *name_str,
 	   const char *rustc_since,
 	   tl::optional<unsigned> issue_number = tl::nullopt,
-	   const tl::optional<CompileOptions::Edition> &edition = tl::nullopt,
+	   const tl::optional<Edition> &edition = tl::nullopt,
 	   const char *description = "")
     : m_state (state), m_name (name), m_name_str (name_str),
       m_rustc_since (rustc_since), m_issue (issue_number), edition (edition),
@@ -78,7 +78,7 @@ private:
   std::string m_name_str;
   std::string m_rustc_since;
   tl::optional<unsigned> m_issue;
-  tl::optional<CompileOptions::Edition> edition;
+  tl::optional<Edition> edition;
   std::string m_description; // TODO: Switch to optional?
 
   static const std::map<std::string, Name> name_hash_map;

--- a/gcc/rust/expand/rust-macro-builtins-helpers.h
+++ b/gcc/rust/expand/rust-macro-builtins-helpers.h
@@ -29,7 +29,6 @@
 #include "rust-macro-invoc-lexer.h"
 #include "rust-macro.h"
 #include "rust-parse.h"
-#include "rust-session-manager.h"
 #include "rust-system.h"
 #include "rust-token.h"
 namespace Rust {

--- a/gcc/rust/expand/rust-macro-builtins-include.cc
+++ b/gcc/rust/expand/rust-macro-builtins-include.cc
@@ -20,6 +20,7 @@
 #include "rust-common.h"
 #include "rust-macro-builtins.h"
 #include "rust-macro-builtins-helpers.h"
+#include "rust-session-manager.h"
 #include "optional.h"
 namespace Rust {
 /* Expand builtin macro include_bytes!("filename"), which includes the contents

--- a/gcc/rust/expand/rust-macro-builtins-utility.cc
+++ b/gcc/rust/expand/rust-macro-builtins-utility.cc
@@ -20,6 +20,7 @@
 #include "rust-ast-builder.h"
 #include "rust-macro-builtins.h"
 #include "rust-macro-builtins-helpers.h"
+#include "rust-session-manager.h"
 
 namespace Rust {
 

--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -26,7 +26,6 @@
 #include "rust-parse.h"
 #include "rust-cfg-strip.h"
 #include "rust-early-name-resolver.h"
-#include "rust-session-manager.h"
 #include "rust-proc-macro.h"
 
 namespace Rust {

--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -21,7 +21,7 @@
 #include "rust-lex.h"
 #include "rust-diagnostics.h"
 #include "rust-linemap.h"
-#include "rust-session-manager.h"
+#include "rust-edition.h"
 #include "safe-ctype.h"
 #include "cpplib.h"
 #include "rust-keyword-values.h"
@@ -277,9 +277,7 @@ Lexer::classify_keyword (const std::string &str)
   // https://doc.rust-lang.org/reference/keywords.html#reserved-keywords
 
   // `try` is not a reserved keyword before 2018
-  if (Session::get_instance ().options.get_edition ()
-	== CompileOptions::Edition::E2015
-      && id == TRY)
+  if (get_rust_edition () == Edition::E2015 && id == TRY)
     return IDENTIFIER;
 
   return id;

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -32,7 +32,7 @@
 #include "rust-dir-owner.h"
 #include "rust-attribute-values.h"
 #include "rust-keyword-values.h"
-#include "rust-session-manager.h"
+#include "rust-edition.h"
 
 #include "optional.h"
 
@@ -1453,8 +1453,7 @@ Parser<ManagedTokenSource>::parse_async_item (AST::Visibility vis,
   auto offset = (lexer.peek_token ()->get_id () == CONST) ? 1 : 0;
   const_TokenPtr t = lexer.peek_token (offset);
 
-  if (Session::get_instance ().options.get_edition ()
-      == CompileOptions::Edition::E2015)
+  if (get_rust_edition () == Edition::E2015)
     {
       add_error (Error (t->get_locus (), ErrorCode::E0670,
 			"%<async fn%> is not permitted in Rust 2015"));

--- a/gcc/rust/util/rust-edition.cc
+++ b/gcc/rust/util/rust-edition.cc
@@ -1,0 +1,40 @@
+// Copyright (C) 2025 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-edition.h"
+#include "rust-session-manager.h"
+
+namespace Rust {
+
+Edition
+get_rust_edition ()
+{
+  switch (Session::get_instance ().options.get_edition ())
+    {
+    case CompileOptions::Edition::E2015:
+      return Edition::E2015;
+    case CompileOptions::Edition::E2018:
+      return Edition::E2018;
+    case CompileOptions::Edition::E2021:
+      return Edition::E2021;
+    default:
+      rust_unreachable ();
+    }
+}
+
+} // namespace Rust

--- a/gcc/rust/util/rust-edition.h
+++ b/gcc/rust/util/rust-edition.h
@@ -1,0 +1,41 @@
+// Copyright (C) 2025 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_EDITION_H
+#define RUST_EDITION_H
+
+/*
+ * This header exists to avoid including rust-session-manager.h
+ * when we only need information on the selected rust edition
+ */
+
+namespace Rust {
+
+enum class Edition
+{
+  E2015,
+  E2018,
+  E2021
+};
+
+Edition
+get_rust_edition ();
+
+} // namespace Rust
+
+#endif // !RUST_EDITION_H


### PR DESCRIPTION
I ran into some issues getting edition information in `rust-forever-stack.hxx`, created `rust-edition.h` and `rust-edition.cc`, and realized this would make sense as a separate patch