### PR TITLE
Refactored to use implicit insert (#3395)

### DIFF
--- a/gcc/rust/typecheck/rust-substitution-mapper.cc
+++ b/gcc/rust/typecheck/rust-substitution-mapper.cc
@@ -152,18 +152,13 @@ SubstMapperInternal::Resolve (TyTy::BaseType *base,
     = context->lookup_type (mapper.resolved->get_ty_ref (), &unused);
   if (!is_ty_available)
     {
-      context->insert_type (
-	Analysis::NodeMapping (0, 0, mapper.resolved->get_ty_ref (), 0),
-	mapper.resolved);
+      context->insert_implicit_type(mapper.resolved->get_ty_ref () , mapper.resolved);
     }
   bool is_ref_available
     = context->lookup_type (mapper.resolved->get_ref (), &unused);
   if (!is_ref_available)
     {
-      context->insert_type (Analysis::NodeMapping (0, 0,
-						   mapper.resolved->get_ref (),
-						   0),
-			    mapper.resolved);
+      context->insert_implicit_type(mapper.resolved->get_ref () ,  mapper.resolved)
     }
 
   return mapper.resolved;


### PR DESCRIPTION
This solution addresses issue #3395 by refactoring the code to use "insert_implicit_type" instead of "insert_type", resulting in a cleaner and more maintainable implementation