### PR TITLE
Typecheck `else` expression of `let-else` to ensure it diverges

### DIFF
--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
@@ -119,7 +119,7 @@ Late::visit (AST::LetStmt &let)
   ctx.bindings.exit ();
 
   if (let.has_else_expr ())
-    visit (let.get_init_expr ());
+    visit (let.get_else_expr ());
 
   // how do we deal with the fact that `let a = blipbloup` should look for a
   // label and cannot go through function ribs, but `let a = blipbloup()` can?

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.cc
@@ -17,12 +17,14 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-hir-type-check-stmt.h"
+#include "rich-location.h"
 #include "rust-hir-type-check-type.h"
 #include "rust-hir-type-check-expr.h"
 #include "rust-hir-type-check-implitem.h"
 #include "rust-hir-type-check-item.h"
 #include "rust-hir-type-check-pattern.h"
 #include "rust-type-util.h"
+#include "rust-tyty.h"
 
 namespace Rust {
 namespace Resolver {
@@ -84,6 +86,7 @@ TypeCheckStmt::visit (HIR::LetStmt &stmt)
   auto &stmt_pattern = stmt.get_pattern ();
   TyTy::BaseType *init_expr_ty = nullptr;
   location_t init_expr_locus = UNKNOWN_LOCATION;
+
   if (stmt.has_init_expr ())
     {
       init_expr_locus = stmt.get_init_expr ().get_locus ();
@@ -101,6 +104,22 @@ TypeCheckStmt::visit (HIR::LetStmt &stmt)
     {
       specified_ty = TypeCheckType::Resolve (stmt.get_type ());
       specified_ty_locus = stmt.get_type ().get_locus ();
+    }
+
+  if (stmt.has_else_expr ())
+    {
+      auto &else_expr = stmt.get_else_expr ();
+      auto else_expr_ty = TypeCheckExpr::Resolve (else_expr);
+
+      if (else_expr_ty->get_kind () != TyTy::TypeKind::NEVER)
+	{
+	  rust_error_at (else_expr.get_locus (),
+			 "%<else%> clause of let-else does not diverge");
+	  return;
+	}
+
+      // FIXME: Is that enough? Do we need to do something like
+      // `append_reference` here as well?
     }
 
   // let x:i32 = 123;

--- a/gcc/testsuite/rust/compile/let-else-invalid-type.rs
+++ b/gcc/testsuite/rust/compile/let-else-invalid-type.rs
@@ -1,0 +1,8 @@
+enum FakeOption {
+    Some(i32),
+    None,
+}
+
+fn main() {
+    let FakeOption::Some(a) = FakeOption::None else { FakeOption::Some(15) }; // { dg-error "does not diverge" }
+}


### PR DESCRIPTION
The `else` expression of a `let-else` must always diverge, which we enforce during typecheck. Needs #3468