### PR TITLE
Refactored to use implicit insert and remove insert_type method from context object  #3395

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check.h
+++ b/gcc/rust/typecheck/rust-hir-type-check.h
@@ -169,8 +169,6 @@ public:
   void insert_builtin (HirId id, NodeId ref, TyTy::BaseType *type);
   const std::vector<std::unique_ptr<TyTy::BaseType>> &get_builtins () const;
 
-  void insert_type (const Analysis::NodeMapping &mappings,
-		    TyTy::BaseType *type);
   bool lookup_type (HirId id, TyTy::BaseType **type) const;
   void clear_type (TyTy::BaseType *ty);
 

--- a/gcc/rust/typecheck/rust-substitution-mapper.cc
+++ b/gcc/rust/typecheck/rust-substitution-mapper.cc
@@ -152,18 +152,15 @@ SubstMapperInternal::Resolve (TyTy::BaseType *base,
     = context->lookup_type (mapper.resolved->get_ty_ref (), &unused);
   if (!is_ty_available)
     {
-      context->insert_type (
-	Analysis::NodeMapping (0, 0, mapper.resolved->get_ty_ref (), 0),
-	mapper.resolved);
+      context->insert_implicit_type(mapper.resolved->get_ty_ref (),
+                                   mapper.resolved);
     }
   bool is_ref_available
     = context->lookup_type (mapper.resolved->get_ref (), &unused);
   if (!is_ref_available)
     {
-      context->insert_type (Analysis::NodeMapping (0, 0,
-						   mapper.resolved->get_ref (),
-						   0),
-			    mapper.resolved);
+      context->insert_implicit_type(mapper.resolved->get_ref (),
+                                   mapper.resolved);
     }
 
   return mapper.resolved;

--- a/gcc/rust/typecheck/rust-typecheck-context.cc
+++ b/gcc/rust/typecheck/rust-typecheck-context.cc
@@ -80,17 +80,6 @@ TypeCheckContext::get_builtins () const
 }
 
 void
-TypeCheckContext::insert_type (const Analysis::NodeMapping &mappings,
-			       TyTy::BaseType *type)
-{
-  rust_assert (type != nullptr);
-  NodeId ref = mappings.get_nodeid ();
-  HirId id = mappings.get_hirid ();
-  node_id_refs[ref] = id;
-  resolved[id] = type;
-}
-
-void
 TypeCheckContext::insert_implicit_type (HirId id, TyTy::BaseType *type)
 {
   rust_assert (type != nullptr);


### PR DESCRIPTION
This solution resolves issue #3395 by refactoring the code to use implicit_insert_type instead of insert_type, improving clarity and eliminating the insert_type method from the context object.
Changed files:
    -typecheck/rust-substitution-mapper.cc: Updated to use insert_implicit_type instead of insert_type.
    -typecheck/rust-hir-type-check.h: Removed the insert_type declaration from the TypeCheckContext class.
    -typecheck/rust-typecheck-context.cc: Removed the insert_type definition.