### PR TITLE
Fix fnptr not auto implement fn once

### DIFF
--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -1030,7 +1030,41 @@ BaseType::get_subst_argument_mappings () const
 
   return empty;
 }
+// CallableTypeInterface
+void
+CallableTypeInterface::setup_fn_once_output () const
+{
+  DefId trait_id
+    = mappings.get_lang_item (LangItem::Kind::FN_ONCE, UNKNOWN_LOCATION);
+  DefId trait_item_id
+    = mappings.get_lang_item (LangItem::Kind::FN_ONCE_OUTPUT, UNKNOWN_LOCATION);
 
+  // resolve to the trait
+  HIR::Item *item = mappings.lookup_defid (trait_id).value ();
+  rust_assert (item->get_item_kind () == HIR::Item::ItemKind::Trait);
+  HIR::Trait *trait = static_cast<HIR::Trait *> (item);
+
+  Resolver::TraitReference *trait_ref
+    = Resolver::TraitResolver::Resolve (*trait);
+  rust_assert (!trait_ref->is_error ());
+
+  // resolve to trait item
+  HIR::TraitItem *trait_item
+    = mappings.lookup_trait_item_defid (trait_item_id).value ();
+  rust_assert (trait_item->get_item_kind ()
+	       == HIR::TraitItem::TraitItemKind::TYPE);
+  std::string item_identifier = trait_item->trait_identifier ();
+
+  // setup associated types  #[lang = "fn_once_output"]
+  Resolver::TraitItemReference *item_reference = nullptr;
+  bool found = trait_ref->lookup_trait_item_by_type (
+    item_identifier, Resolver::TraitItemReference::TraitItemType::TYPE,
+    &item_reference);
+  rust_assert (found);
+
+  // setup
+  item_reference->associated_type_set (get_return_type ());
+}
 // InferType
 
 InferType::InferType (HirId ref, InferTypeKind infer_kind, TypeHint hint,
@@ -2348,56 +2382,6 @@ FnPtr::clone () const
 }
 
 void
-FnPtr::setup_fn_once_output () const
-{
-  // lookup the lang items
-  auto fn_once_lookup = mappings.lookup_lang_item (LangItem::Kind::FN_ONCE);
-  auto fn_once_output_lookup
-    = mappings.lookup_lang_item (LangItem::Kind::FN_ONCE_OUTPUT);
-  if (!fn_once_lookup)
-    {
-      rust_fatal_error (UNKNOWN_LOCATION,
-			"Missing required %<fn_once%> lang item");
-      return;
-    }
-  if (!fn_once_output_lookup)
-    {
-      rust_fatal_error (UNKNOWN_LOCATION,
-			"Missing required %<fn_once_ouput%> lang item");
-      return;
-    }
-
-  DefId &trait_id = fn_once_lookup.value ();
-  DefId &trait_item_id = fn_once_output_lookup.value ();
-
-  // resolve to the trait
-  HIR::Item *item = mappings.lookup_defid (trait_id).value ();
-  rust_assert (item->get_item_kind () == HIR::Item::ItemKind::Trait);
-  HIR::Trait *trait = static_cast<HIR::Trait *> (item);
-
-  Resolver::TraitReference *trait_ref
-    = Resolver::TraitResolver::Resolve (*trait);
-  rust_assert (!trait_ref->is_error ());
-
-  // resolve to trait item
-  HIR::TraitItem *trait_item
-    = mappings.lookup_trait_item_defid (trait_item_id).value ();
-  rust_assert (trait_item->get_item_kind ()
-	       == HIR::TraitItem::TraitItemKind::TYPE);
-  std::string item_identifier = trait_item->trait_identifier ();
-
-  // setup associated types  #[lang = "fn_once_output"]
-  Resolver::TraitItemReference *item_reference = nullptr;
-  bool found = trait_ref->lookup_trait_item_by_type (
-    item_identifier, Resolver::TraitItemReference::TraitItemType::TYPE,
-    &item_reference);
-  rust_assert (found);
-
-  // setup
-  item_reference->associated_type_set (&get_result_type ());
-}
-
-void
 ClosureType::accept_vis (TyVisitor &vis)
 {
   vis.visit (*this);
@@ -2453,56 +2437,6 @@ ClosureType::handle_substitions (SubstitutionArgumentMappings &mappings)
 {
   rust_unreachable ();
   return nullptr;
-}
-
-void
-ClosureType::setup_fn_once_output () const
-{
-  // lookup the lang items
-  auto fn_once_lookup = mappings.lookup_lang_item (LangItem::Kind::FN_ONCE);
-  auto fn_once_output_lookup
-    = mappings.lookup_lang_item (LangItem::Kind::FN_ONCE_OUTPUT);
-  if (!fn_once_lookup)
-    {
-      rust_fatal_error (UNKNOWN_LOCATION,
-			"Missing required %<fn_once%> lang item");
-      return;
-    }
-  if (!fn_once_output_lookup)
-    {
-      rust_fatal_error (UNKNOWN_LOCATION,
-			"Missing required %<fn_once_ouput%> lang item");
-      return;
-    }
-
-  DefId &trait_id = fn_once_lookup.value ();
-  DefId &trait_item_id = fn_once_output_lookup.value ();
-
-  // resolve to the trait
-  HIR::Item *item = mappings.lookup_defid (trait_id).value ();
-  rust_assert (item->get_item_kind () == HIR::Item::ItemKind::Trait);
-  HIR::Trait *trait = static_cast<HIR::Trait *> (item);
-
-  Resolver::TraitReference *trait_ref
-    = Resolver::TraitResolver::Resolve (*trait);
-  rust_assert (!trait_ref->is_error ());
-
-  // resolve to trait item
-  HIR::TraitItem *trait_item
-    = mappings.lookup_trait_item_defid (trait_item_id).value ();
-  rust_assert (trait_item->get_item_kind ()
-	       == HIR::TraitItem::TraitItemKind::TYPE);
-  std::string item_identifier = trait_item->trait_identifier ();
-
-  // setup associated types  #[lang = "fn_once_output"]
-  Resolver::TraitItemReference *item_reference = nullptr;
-  bool found = trait_ref->lookup_trait_item_by_type (
-    item_identifier, Resolver::TraitItemReference::TraitItemType::TYPE,
-    &item_reference);
-  rust_assert (found);
-
-  // setup
-  item_reference->associated_type_set (&get_result_type ());
 }
 
 void

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -271,6 +271,7 @@ public:
   WARN_UNUSED_RESULT virtual BaseType *
   get_param_type_at (size_t index) const = 0;
   WARN_UNUSED_RESULT virtual BaseType *get_return_type () const = 0;
+  void setup_fn_once_output() const;
 };
 
 class InferType : public BaseType
@@ -1063,8 +1064,6 @@ public:
   std::vector<TyVar> &get_params () { return params; }
   const std::vector<TyVar> &get_params () const { return params; }
 
-  void setup_fn_once_output () const;
-
 private:
   std::vector<TyVar> params;
   TyVar result_type;
@@ -1146,8 +1145,6 @@ public:
   TyTy::BaseType &get_result_type () const { return *result_type.get_tyty (); }
 
   DefId get_def_id () const { return id; }
-
-  void setup_fn_once_output () const;
 
   const std::set<NodeId> &get_captures () const { return captures; }
 

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -1013,7 +1013,9 @@ public:
 			     {Resolver::CanonicalPath::create_empty (), locus},
 			     refs),
       params (std::move (params)), result_type (result_type)
-  {}
+  {
+    setup_fn_once_output ();
+  }
 
   FnPtr (HirId ref, HirId ty_ref, location_t locus, std::vector<TyVar> params,
 	 TyVar result_type, std::set<HirId> refs = std::set<HirId> ())
@@ -1021,7 +1023,9 @@ public:
 			     {Resolver::CanonicalPath::create_empty (), locus},
 			     refs),
       params (params), result_type (result_type)
-  {}
+  {
+    setup_fn_once_output ();
+  }
 
   std::string get_name () const override final { return as_string (); }
 
@@ -1042,6 +1046,7 @@ public:
 
   const TyVar &get_var_return_type () const { return result_type; }
 
+  TyTy::BaseType &get_result_type () const { return *result_type.get_tyty (); }
   size_t num_params () const { return params.size (); }
 
   void accept_vis (TyVisitor &vis) override;
@@ -1057,6 +1062,8 @@ public:
 
   std::vector<TyVar> &get_params () { return params; }
   const std::vector<TyVar> &get_params () const { return params; }
+
+  void setup_fn_once_output () const;
 
 private:
   std::vector<TyVar> params;

--- a/gcc/testsuite/rust/compile/format_args_basic_expansion.rs
+++ b/gcc/testsuite/rust/compile/format_args_basic_expansion.rs
@@ -8,6 +8,14 @@ macro_rules! format_args {
 #[lang = "sized"]
 trait Sized {}
 
+#[lang = "fn_once"]
+pub trait FnOnce<Args> {
+    #[lang = "fn_once_output"]
+    type Output;
+
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+}
+
 pub mod core {
     pub mod fmt {
         pub struct Formatter;

--- a/gcc/testsuite/rust/compile/format_args_extra_comma.rs
+++ b/gcc/testsuite/rust/compile/format_args_extra_comma.rs
@@ -8,6 +8,14 @@ macro_rules! format_args {
 #[lang = "sized"]
 trait Sized {}
 
+#[lang = "fn_once"]
+pub trait FnOnce<Args> {
+    #[lang = "fn_once_output"]
+    type Output;
+
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+}
+
 pub mod core {
     pub mod fmt {
         pub struct Formatter;

--- a/gcc/testsuite/rust/compile/issue-2042.rs
+++ b/gcc/testsuite/rust/compile/issue-2042.rs
@@ -1,3 +1,15 @@
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "fn_once"]
+pub trait FnOnce<Args> {
+    #[lang = "fn_once_output"]
+    type Output;
+
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+}
+
+
 fn f<'r>(p: &'r mut fn(p: &mut ())) {
     (*p)(())
     // { dg-error "expected .&mut ()." "" { target *-*-* } .-1 }

--- a/gcc/testsuite/rust/compile/issue-3615.rs
+++ b/gcc/testsuite/rust/compile/issue-3615.rs
@@ -1,3 +1,14 @@
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "fn_once"]
+pub trait FnOnce<Args> {
+    #[lang = "fn_once_output"]
+    type Output;
+
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+}
+
 pub trait Trait {
     pub fn nrvo(init: fn()) -> [u8; 4096] {
         let mut buf = [0; 4096];

--- a/gcc/testsuite/rust/compile/issue-3647.rs
+++ b/gcc/testsuite/rust/compile/issue-3647.rs
@@ -1,4 +1,14 @@
 #![allow(dead_code)]
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "fn_once"]
+pub trait FnOnce<Args> {
+    #[lang = "fn_once_output"]
+    type Output;
+
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+}
 type A = fn();
 
 type B = for<'static> fn();

--- a/gcc/testsuite/rust/compile/issue-3654.rs
+++ b/gcc/testsuite/rust/compile/issue-3654.rs
@@ -1,3 +1,14 @@
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "fn_once"]
+pub trait FnOnce<Args> {
+    #[lang = "fn_once_output"]
+    type Output;
+
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+}
+
 type Meeshka = Mow<!>;
 // { dg-error "generic arguments are not allowed for this type .E0109." "" { target *-*-* } .-1 }
 type Mow = &'static fn(!) -> !;

--- a/gcc/testsuite/rust/compile/privacy6.rs
+++ b/gcc/testsuite/rust/compile/privacy6.rs
@@ -1,3 +1,13 @@
+
+#[lang = "fn_once"]
+pub trait FnOnce<Args> {
+    #[lang = "fn_once_output"]
+    type Output;
+
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+}
+
+
 // { dg-additional-options "-w" }
 
 #[lang = "sized"]

--- a/gcc/testsuite/rust/compile/rust_abi.rs
+++ b/gcc/testsuite/rust/compile/rust_abi.rs
@@ -1,1 +1,12 @@
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "fn_once"]
+pub trait FnOnce<Args> {
+    #[lang = "fn_once_output"]
+    type Output;
+
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+}
+
 pub fn f(_: extern "Rust" fn()) {}

--- a/gcc/testsuite/rust/compile/torture/function_reference2.rs
+++ b/gcc/testsuite/rust/compile/torture/function_reference2.rs
@@ -1,3 +1,14 @@
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "fn_once"]
+pub trait FnOnce<Args> {
+    #[lang = "fn_once_output"]
+    type Output;
+
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+}
+
 fn test(a: i32) -> i32 {
     a + 1
 }

--- a/gcc/testsuite/rust/compile/torture/function_reference3.rs
+++ b/gcc/testsuite/rust/compile/torture/function_reference3.rs
@@ -1,3 +1,15 @@
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "fn_once"]
+pub trait FnOnce<Args> {
+    #[lang = "fn_once_output"]
+    type Output;
+
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+}
+
+
 struct Foo {
     a: fn(i32) -> i32,
     b: i32,

--- a/gcc/testsuite/rust/compile/torture/function_reference4.rs
+++ b/gcc/testsuite/rust/compile/torture/function_reference4.rs
@@ -1,3 +1,14 @@
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "fn_once"]
+pub trait FnOnce<Args> {
+    #[lang = "fn_once_output"]
+    type Output;
+
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+}
+
 fn test(a: i32) -> i32 {
     a + 1
 }

--- a/gcc/testsuite/rust/compile/try-catch-unwind-new.rs
+++ b/gcc/testsuite/rust/compile/try-catch-unwind-new.rs
@@ -1,6 +1,17 @@
 // { dg-options "-O2 -w -fdump-tree-optimized" }
 #![feature(intrinsics)]
 
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "fn_once"]
+pub trait FnOnce<Args> {
+    #[lang = "fn_once_output"]
+    type Output;
+
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+}
+
 extern "rust-intrinsic" {
     // { dg-final { scan-tree-dump-times "__builtin_eh_pointer" 1 "optimized" } }
     fn catch_unwind(try_fn: fn(_: *mut u8), data: *mut u8, catch_fn: fn(_: *mut u8, _: *mut u8));

--- a/gcc/testsuite/rust/compile/try-catch-unwind-old.rs
+++ b/gcc/testsuite/rust/compile/try-catch-unwind-old.rs
@@ -1,6 +1,17 @@
 // { dg-options "-O2 -w -fdump-tree-optimized" }
 #![feature(intrinsics)]
 
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "fn_once"]
+pub trait FnOnce<Args> {
+    #[lang = "fn_once_output"]
+    type Output;
+
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+}
+
 extern "rust-intrinsic" {
     // { dg-final { scan-tree-dump-times "__builtin_eh_pointer" 1 "optimized" } }
     fn r#try(try_fn: fn(_: *mut u8), data: *mut u8, catch_fn: fn(_: *mut u8, _: *mut u8)) -> i32;


### PR DESCRIPTION
im a bit rather new to this area...

this fixes #3354 

gcc/rust/ChangeLog:

	* typecheck/rust-tyty.cc (VariantDef::clone): reformat 
	* (VariantDef::monomorphized_clone): reformat 
	* (FnPtr::setup_fn_once_output): Fix fnptr not auto implement fn once
	* typecheck/rust-tyty.h: Likewise.

gcc/testsuite/ChangeLog:

	* rust/compile/format_args_basic_expansion.rs: add sized and fn_once
	* rust/compile/issue-2042.rs: add sized and fn_once
	* rust/compile/privacy6.rs: add sized and fn_once
	* rust/compile/rust_abi.rs: add sized and fn_once
	* rust/compile/torture/function_reference2.rs: add sized and fn_once
	* rust/compile/torture/function_reference3.rs: add sized and fn_once
	* rust/compile/torture/function_reference4.rs: add sized and fn_once
	* rust/compile/try-catch-unwind-new.rs: add sized and fn_once
	* rust/compile/try-catch-unwind-old.rs: add sized and fn_once


