### PR TITLE
testsuite: Add more testcases for `cfg()` in core

### DIFF
--- a/gcc/testsuite/rust/compile/cfg-core1.rs
+++ b/gcc/testsuite/rust/compile/cfg-core1.rs
@@ -1,0 +1,12 @@
+// { dg-additional-options "-frust-cfg=A -frust-cfg=B" }
+
+#[cfg_attr(A, cfg(B))]
+struct Foo0;
+
+#[cfg_attr(A, cfg(C))]
+struct Bar0;
+
+fn main() {
+    let a = Foo0; // { dg-error "cannot find value" }
+    let a = Bar0;
+}

--- a/gcc/testsuite/rust/compile/cfg-core2.rs
+++ b/gcc/testsuite/rust/compile/cfg-core2.rs
@@ -1,0 +1,12 @@
+// { dg-additional-options "-frust-cfg=B" }
+
+#[cfg(not(any(A, B)))]
+struct Foo0;
+
+#[cfg(not(any(A, C)))]
+struct Bar0;
+
+fn main() {
+    let a = Foo0; // { dg-error "cannot find value" }
+    let a = Bar0;
+}


### PR DESCRIPTION
This adds a couple more testcases extracted from `cfg` directives in `core` 1.49 to ensure we can properly compile them and don't introduce regressions later on.

gcc/testsuite/ChangeLog:

	* rust/compile/cfg-core1.rs: New test.
	* rust/compile/cfg-core2.rs: New test.

