### PR TITLE
ci: disable network

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -42,7 +42,8 @@ jobs:
     - name: Build
       run: |
            cd gccrs-build; \
-           make -j $(nproc)
+           # Build without network access
+           unshare --net --ipc -r /bin/bash -c "make -j $(nproc)"
 
     - name: Run Tests
       run: |

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -61,8 +61,9 @@ jobs:
       run: |
            cd gccrs-build; \
            # Add cargo to our path quickly
-           . "$HOME/.cargo/env";
-           make -Otarget -j $(nproc) 2>&1 | tee log
+           . "$HOME/.cargo/env"; \
+           # Build without network access
+           unshare --net --ipc -r /bin/bash -c "make -Otarget -j $(nproc) 2>&1 | tee log ; exit \${PIPESTATUS[0]}"
 
     - name: Check for new warnings
       run: |


### PR DESCRIPTION
```
Disable network access via 'unshare' in two CI workflows to catch issues
like PR119333 where importing polonius meant bootstrap tried to pull crates
from the internet.

ChangeLog:
	PR rust/119333

	* .github/workflows/bootstrap.yml: Disable network via 'unshare'.
	* .github/workflows/ccpp.yml: Ditto.
```