### PR TITLE
rust: force cargo to build offline

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -525,5 +525,5 @@ rust/%.o: rust/metadata/%.cc
 rust/libffi_polonius.a: \
 	rust/checks/errors/borrowck/ffi-polonius/Cargo.toml \
 	$(wildcard $(srcdir)/rust/checks/errors/borrowck/ffi-polonius/src/*)
-	cargo build --manifest-path $(srcdir)/rust/checks/errors/borrowck/ffi-polonius/Cargo.toml --release --target-dir rust/ffi-polonius
+	cargo build --manifest-path $(srcdir)/rust/checks/errors/borrowck/ffi-polonius/Cargo.toml --offline --release --target-dir rust/ffi-polonius
 	cp rust/ffi-polonius/release/libffi_polonius.a rust/libffi_polonius.a


### PR DESCRIPTION
```
gcc/rust/Changelog:
	PR rust/119333

    * Make-lang.in: Force offline mode for cargo.
```