### PR TITLE
nr2.0: Fix `StructExprFieldIdentifier` handling

### DIFF
--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
@@ -252,6 +252,34 @@ Late::visit (AST::IdentifierExpr &expr)
 }
 
 void
+Late::visit (AST::StructExprFieldIdentifier &expr)
+{
+  tl::optional<Rib::Definition> resolved = tl::nullopt;
+
+  if (auto value = ctx.values.get (expr.get_field_name ()))
+    {
+      resolved = value;
+    }
+  // seems like we don't need a type namespace lookup
+  else
+    {
+      rust_error_at (expr.get_locus (), "could not resolve struct field: %qs",
+		     expr.get_field_name ().as_string ().c_str ());
+      return;
+    }
+
+  if (resolved->is_ambiguous ())
+    {
+      rust_error_at (expr.get_locus (), ErrorCode::E0659, "%qs is ambiguous",
+		     expr.as_string ().c_str ());
+      return;
+    }
+
+  ctx.map_usage (Usage (expr.get_node_id ()),
+		 Definition (resolved->get_node_id ()));
+}
+
+void
 Late::visit (AST::PathInExpression &expr)
 {
   // TODO: How do we have a nice error with `can't capture dynamic environment

--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.h
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.h
@@ -46,6 +46,7 @@ public:
 
   // resolutions
   void visit (AST::IdentifierExpr &) override;
+  void visit (AST::StructExprFieldIdentifier &) override;
   void visit (AST::BreakExpr &) override;
   void visit (AST::PathInExpression &) override;
   void visit (AST::TypePath &) override;

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -30,7 +30,6 @@ redef_error2.rs
 redef_error5.rs
 self-path2.rs
 sizeof-stray-infer-var-bug.rs
-struct-expr-parse.rs
 undeclared_label.rs
 use_1.rs
 while_break_expr.rs
@@ -53,16 +52,9 @@ derive-eq-invalid.rs
 derive-hash1.rs
 torture/alt_patterns1.rs
 torture/builtin_abort.rs
-torture/impl_block3.rs
-torture/issue-1434.rs
 torture/loop4.rs
 torture/loop8.rs
-torture/methods1.rs
-torture/methods2.rs
-torture/methods3.rs
 torture/name_resolve1.rs
-torture/nested_struct1.rs
-torture/struct_init_3.rs
 torture/uninit-intrinsic-1.rs
 torture/generics1.rs
 torture/generics10.rs


### PR DESCRIPTION
Fixes #3484