### PR TITLE
chore: refactoring rust_error_at "redefined multiple times"

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-base.h
+++ b/gcc/rust/resolve/rust-ast-resolve-base.h
@@ -27,6 +27,11 @@
 
 namespace Rust {
 namespace Resolver {
+inline void
+redefined_error (const rich_location &loc)
+{
+  rust_error_at (loc, "redefined multiple times");
+}
 
 class ResolverBase : public AST::ASTVisitor
 {

--- a/gcc/rust/resolve/rust-ast-resolve-implitem.h
+++ b/gcc/rust/resolve/rust-ast-resolve-implitem.h
@@ -51,7 +51,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, type.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
   }
 
@@ -67,7 +67,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, constant.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
   }
 
@@ -84,7 +84,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, function.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
   }
 
@@ -124,7 +124,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, function.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     mappings.insert_canonical_path (function.get_node_id (), cpath);
@@ -144,7 +144,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, constant.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     mappings.insert_canonical_path (constant.get_node_id (), cpath);
@@ -162,7 +162,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, type.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     mappings.insert_canonical_path (type.get_node_id (), cpath);
@@ -202,7 +202,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, function.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     NodeId current_module = resolver->peek_current_module_scope ();
@@ -221,7 +221,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, item.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     NodeId current_module = resolver->peek_current_module_scope ();
@@ -239,8 +239,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, type.get_locus ());
 	r.add_range (locus);
-
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     NodeId current_module = resolver->peek_current_module_scope ();

--- a/gcc/rust/resolve/rust-ast-resolve-stmt.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-stmt.cc
@@ -70,7 +70,7 @@ ResolveStmt::visit (AST::StaticItem &var)
     [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
       rich_location r (line_table, var.get_locus ());
       r.add_range (locus);
-      rust_error_at (r, "defined multiple times");
+      redefined_error (r);
     });
 
   ResolveType::go (var.get_type ());

--- a/gcc/rust/resolve/rust-ast-resolve-stmt.h
+++ b/gcc/rust/resolve/rust-ast-resolve-stmt.h
@@ -63,7 +63,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, constant.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     ResolveType::go (constant.get_type ());
@@ -97,7 +97,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, struct_decl.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     NodeId scope_node_id = struct_decl.get_node_id ();
@@ -128,7 +128,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, enum_decl.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     NodeId scope_node_id = enum_decl.get_node_id ();
@@ -158,7 +158,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, item.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     // Done, no fields.
@@ -178,7 +178,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, item.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     for (auto &field : item.get_tuple_fields ())
@@ -204,7 +204,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, item.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     for (auto &field : item.get_struct_fields ())
@@ -230,7 +230,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, item.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     // Done, no fields.
@@ -251,7 +251,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, struct_decl.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     NodeId scope_node_id = struct_decl.get_node_id ();
@@ -287,7 +287,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, union_decl.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     NodeId scope_node_id = union_decl.get_node_id ();
@@ -323,7 +323,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, function.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     NodeId scope_node_id = function.get_node_id ();

--- a/gcc/rust/resolve/rust-ast-resolve-toplevel.h
+++ b/gcc/rust/resolve/rust-ast-resolve-toplevel.h
@@ -58,7 +58,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, module.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     NodeId current_module = resolver->peek_current_module_scope ();
@@ -88,7 +88,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, alias.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     NodeId current_module = resolver->peek_current_module_scope ();
@@ -110,7 +110,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, struct_decl.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     NodeId current_module = resolver->peek_current_module_scope ();
@@ -132,7 +132,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, enum_decl.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     resolver->push_new_module_scope (enum_decl.get_node_id ());
@@ -158,7 +158,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, item.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     mappings.insert_canonical_path (item.get_node_id (), cpath);
@@ -180,7 +180,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, item.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     mappings.insert_canonical_path (item.get_node_id (), cpath);
@@ -202,7 +202,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, item.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     mappings.insert_canonical_path (item.get_node_id (), cpath);
@@ -224,7 +224,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, item.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     mappings.insert_canonical_path (item.get_node_id (), cpath);
@@ -246,7 +246,7 @@ public:
       = [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
       rich_location r (line_table, struct_decl.get_locus ());
       r.add_range (locus);
-      rust_error_at (r, "defined multiple times");
+      redefined_error (r);
     };
 
     resolver->get_type_scope ().insert (path, struct_decl.get_node_id (),
@@ -277,7 +277,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, union_decl.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     NodeId current_module = resolver->peek_current_module_scope ();
@@ -297,7 +297,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, var.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     NodeId current_module = resolver->peek_current_module_scope ();
@@ -318,7 +318,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, constant.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     NodeId current_module = resolver->peek_current_module_scope ();
@@ -340,7 +340,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, function.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     NodeId current_module = resolver->peek_current_module_scope ();
@@ -388,7 +388,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, impl_block.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     for (auto &impl_item : impl_block.get_impl_items ())
@@ -408,7 +408,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, trait.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
 
     for (auto &item : trait.get_trait_items ())
@@ -480,7 +480,7 @@ public:
       [&] (const CanonicalPath &, NodeId, location_t locus) -> void {
 	rich_location r (line_table, extern_crate.get_locus ());
 	r.add_range (locus);
-	rust_error_at (r, "defined multiple times");
+	redefined_error (r);
       });
   }
 


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* resolve/rust-ast-resolve-base.h (redefined_error): created a function for rust_error_at for redefined at multiple times.
	* resolve/rust-ast-resolve-implitem.h: changed rust_error_at to redefined_error.
	* resolve/rust-ast-resolve-stmt.cc (ResolveStmt::visit): changed rust_error_at to redefined_error.
	* resolve/rust-ast-resolve-stmt.h: changed rust_error_at to redefined_error.
	* resolve/rust-ast-resolve-toplevel.h: changed rust_error_at to redefined_error.

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`
- Fixes #2436 

