### PR TITLE
Recognize `#[track_caller]`

### DIFF
--- a/gcc/rust/expand/rust-macro-builtins.cc
+++ b/gcc/rust/expand/rust-macro-builtins.cc
@@ -137,6 +137,7 @@ std::unordered_map<std::string, AST::MacroTranscriberFunc>
     {"cfg_accessible", MacroBuiltin::sorry},
     {"rustc_const_stable", MacroBuiltin::sorry},
     {"rustc_const_unstable", MacroBuiltin::sorry},
+    {"track_caller", MacroBuiltin::sorry},
     /* Derive builtins do not need a real transcriber, but still need one. It
        should however never be called since builtin derive macros get expanded
        differently, and benefit from knowing on what kind of items they are

--- a/gcc/rust/util/rust-attribute-values.h
+++ b/gcc/rust/util/rust-attribute-values.h
@@ -58,6 +58,7 @@ public:
   static constexpr auto &RUSTC_CONST_UNSTABLE = "rustc_const_unstable";
   static constexpr auto &MAY_DANGLE = "may_dangle";
   static constexpr auto &PRELUDE_IMPORT = "prelude_import";
+  static constexpr auto &TRACK_CALLER = "track_caller";
 };
 } // namespace Values
 } // namespace Rust

--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -75,7 +75,8 @@ static const BuiltinAttrDefinition __definitions[]
      // assuming we keep these for static analysis
      {Attrs::RUSTC_CONST_STABLE, STATIC_ANALYSIS},
      {Attrs::RUSTC_CONST_UNSTABLE, STATIC_ANALYSIS},
-     {Attrs::PRELUDE_IMPORT, NAME_RESOLUTION}};
+     {Attrs::PRELUDE_IMPORT, NAME_RESOLUTION},
+     {Attrs::TRACK_CALLER, CODE_GENERATION}};
 
 BuiltinAttributeMappings *
 BuiltinAttributeMappings::get ()

--- a/gcc/testsuite/rust/compile/track_caller.rs
+++ b/gcc/testsuite/rust/compile/track_caller.rs
@@ -1,0 +1,6 @@
+#[track_caller]
+fn foo() {}
+
+fn main() {
+    foo();
+}


### PR DESCRIPTION
Fixes #3026 by adding `#[track_caller]` as a recognizable builtin macro.

gcc/rust/ChangeLog:
```
* expand/rust-macro-builtins.cc (MacroBuiltin::builtin_transcribers): Add entry for track_caller.
* util/rust-attribute-values.h: add `TRACK_CALLER` attribute.
* util/rust-attributes.cc: add `track_caller` attribute definition.
```

gcc/testsuite/ChangeLog:
```
* rust/compile/track_caller.rs: New test.
```

Signed-off-by: Bhavesh Mandalapu <mandalapubhavesh@gmail.com>