### PR TITLE
gccrs: support generic super traits recursively

### DIFF
--- a/gcc/rust/typecheck/rust-hir-path-probe.cc
+++ b/gcc/rust/typecheck/rust-hir-path-probe.cc
@@ -346,7 +346,7 @@ PathProbeType::process_associated_trait_for_candidates (
 
   const TyTy::TypeBoundPredicate p (*trait_ref, BoundPolarity::RegularBound,
 				    UNDEF_LOCATION);
-  TyTy::TypeBoundPredicateItem item (&p, trait_item_ref);
+  TyTy::TypeBoundPredicateItem item (p, trait_item_ref);
 
   TyTy::BaseType *trait_item_tyty = item.get_raw_item ()->get_tyty ();
   if (receiver->get_kind () != TyTy::DYNAMIC)

--- a/gcc/rust/typecheck/rust-hir-trait-reference.h
+++ b/gcc/rust/typecheck/rust-hir-trait-reference.h
@@ -144,7 +144,7 @@ class TraitReference
 public:
   TraitReference (const HIR::Trait *hir_trait_ref,
 		  std::vector<TraitItemReference> item_refs,
-		  std::vector<const TraitReference *> super_traits,
+		  std::vector<TyTy::TypeBoundPredicate> super_traits,
 		  std::vector<TyTy::SubstitutionParamMapping> substs);
 
   TraitReference (TraitReference const &other);
@@ -196,7 +196,8 @@ public:
 			      const TraitItemReference **ref) const;
 
   bool lookup_trait_item (const std::string &ident,
-			  const TraitItemReference **ref) const;
+			  const TraitItemReference **ref,
+			  bool lookup_supers = true) const;
 
   const TraitItemReference *
   lookup_trait_item (const std::string &ident,
@@ -217,7 +218,7 @@ public:
 
   bool is_equal (const TraitReference &other) const;
 
-  const std::vector<const TraitReference *> get_super_traits () const;
+  std::vector<TyTy::TypeBoundPredicate> get_super_traits () const;
 
   bool is_object_safe (bool emit_error, location_t locus) const;
 
@@ -230,7 +231,7 @@ public:
 private:
   const HIR::Trait *hir_trait_ref;
   std::vector<TraitItemReference> item_refs;
-  std::vector<const TraitReference *> super_traits;
+  std::vector<TyTy::TypeBoundPredicate> super_traits;
   std::vector<TyTy::SubstitutionParamMapping> trait_substs;
 };
 

--- a/gcc/rust/typecheck/rust-hir-trait-resolve.cc
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.cc
@@ -266,7 +266,7 @@ TraitResolver::resolve_trait (HIR::Trait *trait_reference)
   specified_bounds.push_back (self_hrtb);
 
   // look for any
-  std::vector<const TraitReference *> super_traits;
+  std::vector<TyTy::TypeBoundPredicate> super_traits;
   if (trait_reference->has_type_param_bounds ())
     {
       for (auto &bound : trait_reference->get_type_param_bounds ())
@@ -284,7 +284,7 @@ TraitResolver::resolve_trait (HIR::Trait *trait_reference)
 		return &TraitReference::error_node ();
 
 	      specified_bounds.push_back (predicate);
-	      super_traits.push_back (predicate.get ());
+	      super_traits.push_back (predicate);
 	    }
 	}
     }
@@ -305,8 +305,7 @@ TraitResolver::resolve_trait (HIR::Trait *trait_reference)
       item_refs.push_back (std::move (trait_item_ref));
     }
 
-  TraitReference trait_object (trait_reference, item_refs,
-			       std::move (super_traits),
+  TraitReference trait_object (trait_reference, item_refs, super_traits,
 			       std::move (substitutions));
   context->insert_trait_reference (
     trait_reference->get_mappings ().get_defid (), std::move (trait_object));

--- a/gcc/rust/typecheck/rust-tyty-bounds.h
+++ b/gcc/rust/typecheck/rust-tyty-bounds.h
@@ -34,31 +34,6 @@ namespace TyTy {
 
 class BaseType;
 class TypeBoundPredicate;
-class TypeBoundPredicateItem
-{
-public:
-  TypeBoundPredicateItem (const TypeBoundPredicate *parent,
-			  const Resolver::TraitItemReference *trait_item_ref);
-
-  static TypeBoundPredicateItem error ();
-
-  bool is_error () const;
-
-  BaseType *get_tyty_for_receiver (const TyTy::BaseType *receiver);
-
-  const Resolver::TraitItemReference *get_raw_item () const;
-
-  bool needs_implementation () const;
-
-  const TypeBoundPredicate *get_parent () const;
-
-  location_t get_locus () const;
-
-private:
-  const TypeBoundPredicate *parent;
-  const Resolver::TraitItemReference *trait_item_ref;
-};
-
 class TypeBoundsMappings
 {
 protected:

--- a/gcc/rust/typecheck/rust-tyty-subst.cc
+++ b/gcc/rust/typecheck/rust-tyty-subst.cc
@@ -788,7 +788,7 @@ SubstitutionRef::infer_substitions (location_t locus)
 
 SubstitutionArgumentMappings
 SubstitutionRef::adjust_mappings_for_this (
-  SubstitutionArgumentMappings &mappings)
+  SubstitutionArgumentMappings &mappings, bool trait_mode)
 {
   std::vector<SubstitutionArg> resolved_mappings;
   for (size_t i = 0; i < substitutions.size (); i++)
@@ -816,7 +816,7 @@ SubstitutionRef::adjust_mappings_for_this (
 	}
 
       bool ok = !arg.is_error ();
-      if (ok)
+      if (ok || (trait_mode && i == 0))
 	{
 	  SubstitutionArg adjusted (&subst, arg.get_tyty ());
 	  resolved_mappings.push_back (std::move (adjusted));

--- a/gcc/rust/typecheck/rust-tyty-subst.h
+++ b/gcc/rust/typecheck/rust-tyty-subst.h
@@ -253,6 +253,7 @@ private:
   bool error_flag;
 };
 
+class TypeBoundPredicateItem;
 class SubstitutionRef
 {
 public:
@@ -319,7 +320,8 @@ public:
   // we have bindings for X Y Z and need to propagate the binding Y,Z into Foo
   // Which binds to A,B
   SubstitutionArgumentMappings
-  adjust_mappings_for_this (SubstitutionArgumentMappings &mappings);
+  adjust_mappings_for_this (SubstitutionArgumentMappings &mappings,
+			    bool trait_mode = false);
 
   // Are the mappings here actually bound to this type. For example imagine the
   // case:

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -545,6 +545,8 @@ public:
   void apply_generic_arguments (HIR::GenericArgs *generic_args,
 				bool has_associated_self);
 
+  void apply_argument_mappings (SubstitutionArgumentMappings &arguments);
+
   bool contains_item (const std::string &search) const;
 
   TypeBoundPredicateItem
@@ -587,6 +589,36 @@ private:
   location_t locus;
   bool error_flag;
   BoundPolarity polarity;
+  std::vector<TyTy::TypeBoundPredicate> super_traits;
+};
+
+class TypeBoundPredicateItem
+{
+public:
+  TypeBoundPredicateItem (const TypeBoundPredicate parent,
+			  const Resolver::TraitItemReference *trait_item_ref);
+
+  TypeBoundPredicateItem (const TypeBoundPredicateItem &other);
+
+  TypeBoundPredicateItem &operator= (const TypeBoundPredicateItem &other);
+
+  static TypeBoundPredicateItem error ();
+
+  bool is_error () const;
+
+  BaseType *get_tyty_for_receiver (const TyTy::BaseType *receiver);
+
+  const Resolver::TraitItemReference *get_raw_item () const;
+
+  bool needs_implementation () const;
+
+  const TypeBoundPredicate *get_parent () const;
+
+  location_t get_locus () const;
+
+private:
+  TypeBoundPredicate parent;
+  const Resolver::TraitItemReference *trait_item_ref;
 };
 
 // https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/struct.VariantDef.html

--- a/gcc/testsuite/rust/execute/torture/issue-3502.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-3502.rs
@@ -1,0 +1,52 @@
+/* { dg-output "parent 123\r*\nchild\r*\n" } */
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+#[lang = "sized"]
+pub trait Sized {}
+
+struct Foo {
+    my_int: u32,
+    // { dg-warning "field is never read: .my_int." "" { target *-*-* } .-1 }
+}
+
+trait Parent<T> {
+    fn parent(&self) -> T;
+}
+
+trait Child: Parent<u32> {
+    fn child(&self);
+}
+
+impl Parent<u32> for Foo {
+    fn parent(&self) -> u32 {
+        unsafe {
+            let parent = "parent %u\n\0";
+            let msg = parent as *const str;
+            printf(msg as *const i8, self.my_int);
+            return self.my_int;
+        }
+    }
+}
+
+impl Child for Foo {
+    fn child(&self) {
+        let _ = self;
+        unsafe {
+            let child = "child\n\0";
+            let msg = child as *const str;
+            printf(msg as *const i8);
+        }
+    }
+}
+
+pub fn main() -> i32 {
+    let a = Foo { my_int: 123 };
+    let b: &dyn Child = &a;
+
+    b.parent();
+    b.child();
+
+    0
+}


### PR DESCRIPTION
In order to handle generic super traits on any trait bound we need to ensure we track the TypeBoundPredicate as part of the TraitReference instead of just the raw TraitReferences because these will have any applied generics enplace.

Then for any TypeBoundPredicate it takes a copy of the super traits because this is the usage of a TraitBound and we can apply generics which then need to be recursively applied up the chain of super predicates.

The main tweak is around TypeBoundPredicate::lookup_associated_item because we need to associate the predicate with the item we are looking up so the caller can respect the generics correctly as well.

Fixes Rust-GCC#3502

gcc/rust/ChangeLog:

	* typecheck/rust-hir-path-probe.cc: update call
	* typecheck/rust-hir-trait-reference.cc (TraitReference::lookup_trait_item): track predicate
	(TraitReference::is_equal): likewise
	(TraitReference::is_object_safe): likewise
	(TraitReference::satisfies_bound): likewise
	* typecheck/rust-hir-trait-reference.h: likewise
	* typecheck/rust-hir-trait-resolve.cc (TraitResolver::resolve_trait): likewise
	* typecheck/rust-tyty-bounds.cc (TypeBoundPredicate::TypeBoundPredicate): track super traits
	(TypeBoundPredicate::operator=): likewise
	(TypeBoundPredicate::apply_generic_arguments): ensure we apply to super predicates
	(TypeBoundPredicateItem::operator=): take copy of parent predicate
	(TypeBoundPredicateItem::error): pass error instead of nullptr
	(TypeBoundPredicateItem::is_error): update to no longer check for nullptr
	(TypeBoundPredicateItem::get_parent): updated
	(TypeBoundPredicateItem::get_tyty_for_receiver): likewise
	(TypeBoundPredicate::get_associated_type_items): likewise
	* typecheck/rust-tyty-bounds.h (class TypeBoundPredicateItem): move
	* typecheck/rust-tyty-subst.cc: flag to handle placeholder Self on traits
	* typecheck/rust-tyty-subst.h (class TypeBoundPredicateItem): likewise
	* typecheck/rust-tyty.h (class TypeBoundPredicateItem): refactored

gcc/testsuite/ChangeLog:

	* rust/execute/torture/issue-3502.rs: New test.