### PR TITLE
gccrs: Fix ICE when array elements are not a value

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -1902,6 +1902,14 @@ CompileExpr::array_value_expr (location_t expr_locus,
   for (auto &elem : elems.get_values ())
     {
       tree translated_expr = CompileExpr::Compile (*elem, ctx);
+      if (translated_expr == error_mark_node)
+	{
+	  rich_location r (line_table, expr_locus);
+	  r.add_fixit_replace (elem->get_locus (), "not a value");
+	  rust_error_at (r, ErrorCode::E0423, "expected value");
+	  return error_mark_node;
+	}
+
       constructor.push_back (translated_expr);
       indexes.push_back (i++);
     }
@@ -2003,6 +2011,9 @@ HIRCompileBase::resolve_adjustements (
   tree e = expression;
   for (auto &adjustment : adjustments)
     {
+      if (e == error_mark_node)
+	return error_mark_node;
+
       switch (adjustment.get_type ())
 	{
 	case Resolver::Adjustment::AdjustmentType::ERROR:

--- a/gcc/testsuite/rust/compile/issue-3567.rs
+++ b/gcc/testsuite/rust/compile/issue-3567.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let _: &[i8] = &[i8];
+    // { dg-error "expected value .E0423." "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
We need to check for error_mark_node when doing adjustments from coercion sites otherwise we hit assetions as part of the coercion. That fixes the ICE but the reason for the error_mark_node is because the array element value.

Fixes Rust-GCC#3567

gcc/rust/ChangeLog:

	* backend/rust-compile-expr.cc (CompileExpr::array_value_expr): add value chk for array expr

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3567.rs: New test.

