### PR TITLE
gccrs: Fix ICE when using super mid way though path

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-path.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-path.cc
@@ -370,6 +370,12 @@ ResolvePath::resolve_path (AST::SimplePath &expr)
 	}
       else if (segment.is_super_path_seg ())
 	{
+	  if (!is_first_segment)
+	    {
+	      rust_error_at (segment.get_locus (),
+			     "%<super%> can only be used in start position");
+	      return UNKNOWN_NODEID;
+	    }
 	  if (module_scope_id == crate_scope_id)
 	    {
 	      rust_error_at (segment.get_locus (),

--- a/gcc/testsuite/rust/compile/issue-3568.rs
+++ b/gcc/testsuite/rust/compile/issue-3568.rs
@@ -1,0 +1,7 @@
+pub type T = ();
+mod foo {
+    pub use super::T;
+}
+
+pub use foo::super::foo::S as T;
+// { dg-error ".super. can only be used in start position" "" { target *-*-* } .-1 }

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -36,4 +36,5 @@ torture/alt_patterns1.rs
 torture/loop4.rs
 torture/loop8.rs
 torture/name_resolve1.rs
+issue-3568.rs
 # please don't delete the trailing newline


### PR DESCRIPTION
Fixes Rust-GCC#3568

gcc/rust/ChangeLog:

	* resolve/rust-ast-resolve-path.cc (ResolvePath::resolve_path): check for super mid path

gcc/testsuite/ChangeLog:

	* rust/compile/nr2/exclude: nr2 puts out a different error multiple times
	* rust/compile/issue-3568.rs: New test.
