### PR TITLE
gccrs: Add check for super traits being implemented by Self

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-item.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.cc
@@ -725,11 +725,11 @@ TypeCheckItem::resolve_impl_block_substitutions (HIR::ImplBlock &impl_block,
 
       // we don't error out here see: gcc/testsuite/rust/compile/traits2.rs
       // for example
-      specified_bound = get_predicate_from_bound (ref, impl_block.get_type ());
+      specified_bound = get_predicate_from_bound (ref, impl_block.get_type (),
+						  impl_block.get_polarity ());
     }
 
   TyTy::BaseType *self = TypeCheckType::Resolve (impl_block.get_type ());
-
   if (self->is<TyTy::ErrorType> ())
     {
       // we cannot check for unconstrained type arguments when the Self type is
@@ -771,7 +771,14 @@ TypeCheckItem::validate_trait_impl_block (
 
       // we don't error out here see: gcc/testsuite/rust/compile/traits2.rs
       // for example
-      specified_bound = get_predicate_from_bound (ref, impl_block.get_type ());
+      specified_bound = get_predicate_from_bound (ref, impl_block.get_type (),
+						  impl_block.get_polarity ());
+
+      // need to check that if this specified bound has super traits does this
+      // Self
+      // implement them?
+      specified_bound.validate_type_implements_super_traits (
+	*self, impl_block.get_type (), impl_block.get_trait_ref ());
     }
 
   bool is_trait_impl_block = !trait_reference->is_error ();

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -578,6 +578,14 @@ public:
 
   bool is_equal (const TypeBoundPredicate &other) const;
 
+  bool validate_type_implements_super_traits (TyTy::BaseType &self,
+					      HIR::Type &impl_type,
+					      HIR::Type &trait) const;
+
+  bool validate_type_implements_this (TyTy::BaseType &self,
+				      HIR::Type &impl_type,
+				      HIR::Type &trait) const;
+
 private:
   struct mark_is_error
   {

--- a/gcc/testsuite/rust/compile/issue-3553.rs
+++ b/gcc/testsuite/rust/compile/issue-3553.rs
@@ -1,0 +1,18 @@
+trait Foo {
+    fn f(&self) -> isize;
+}
+
+trait Bar: Foo {
+    fn g(&self) -> isize;
+}
+
+struct A {
+    x: isize,
+}
+
+impl Bar for A {
+    // { dg-error "the trait bound .A: Foo. is not satisfied .E0277." "" { target *-*-* } .-1 }
+    fn g(&self) -> isize {
+        self.f()
+    }
+}


### PR DESCRIPTION
We need to recursively check the super traits of the predicate the Self type is trying to implement. Otherwise its cannot implement it.

This now outputs an error thats super close to rustc which looks like: compare to https://godbolt.org/z/3eM4YYG7j

```
test.rs:13:6: error: the trait bound ‘A: Foo’ is not satisfied [E0277]
    5 | trait Bar: Foo {
      |               required by this bound in: Bar
......
   13 | impl Bar for A {
      |      ^~~
      |         the trait Foo is not implemented for A
```

Fixes Rust-GCC#3553

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-item.cc (TypeCheckItem::resolve_impl_block_substitutions): Track the polarity
	* typecheck/rust-tyty-bounds.cc (TypeBoundPredicate::validate_type_implements_this): new validator
	* typecheck/rust-tyty.h: new prototypes

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3553.rs: New test.
