### PR TITLE
gccrs: Fix ICE when doing method resolution on trait predicates

### DIFF
--- a/gcc/rust/typecheck/rust-hir-dot-operator.cc
+++ b/gcc/rust/typecheck/rust-hir-dot-operator.cc
@@ -472,8 +472,11 @@ MethodResolver::get_predicate_items (
       if (ty->get_kind () == TyTy::TypeKind::FNDEF)
 	{
 	  TyTy::FnType *fnty = static_cast<TyTy::FnType *> (ty);
-	  predicate_candidate candidate{lookup, fnty};
-	  predicate_items.push_back (candidate);
+	  if (fnty->is_method ())
+	    {
+	      predicate_candidate candidate{lookup, fnty};
+	      predicate_items.push_back (candidate);
+	    }
 	}
     }
 

--- a/gcc/testsuite/rust/compile/issue-3554-1.rs
+++ b/gcc/testsuite/rust/compile/issue-3554-1.rs
@@ -1,0 +1,8 @@
+trait Tr {
+    fn foo();
+
+    fn bar(&self) {
+        self.foo()
+        // { dg-error "no method named .foo. found in the current scope .E0599." "" { target *-*-* } .-1 }
+    }
+}

--- a/gcc/testsuite/rust/compile/issue-3554-2.rs
+++ b/gcc/testsuite/rust/compile/issue-3554-2.rs
@@ -1,0 +1,18 @@
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "fn_once"]
+pub trait FnOnce<Args> {
+    #[lang = "fn_once_output"]
+    type Output;
+
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+}
+trait Tr {
+    fn foo();
+
+    fn bar(&self) {
+        (|| self.foo())()
+        // { dg-error "no method named .foo. found in the current scope .E0599." "" { target *-*-* } .-1 }
+    }
+}


### PR DESCRIPTION
We need to ensure we are adding methods to the possible candidates.

Fixes Rust-GCC#3554

gcc/rust/ChangeLog:

	* typecheck/rust-hir-dot-operator.cc:

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3554-1.rs: New test.
	* rust/compile/issue-3554-2.rs: New test.

