### PR TITLE
gccrs: Fix ICE when compiling path which resolves to trait constant

### DIFF
--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -1932,7 +1932,9 @@ Dump::visit (TraitItemConst &e)
 
   put_field ("name", e.get_name ().as_string ());
   visit_field ("type", e.get_type ());
-  visit_field ("expr", e.get_expr ());
+  if (e.has_expr ())
+    visit_field ("expr", e.get_expr ());
+
   end ("TraitItemConst");
 }
 

--- a/gcc/testsuite/rust/compile/issue-3552.rs
+++ b/gcc/testsuite/rust/compile/issue-3552.rs
@@ -1,0 +1,14 @@
+trait Foo {
+    const BAR: u32;
+}
+
+const TRAIT_REF_BAR: u32 = <Foo>::BAR;
+// { dg-error "no default expression on trait constant" "" { target *-*-* } .-1 }
+
+struct GlobalTraitRef;
+
+impl Foo for GlobalTraitRef {
+    const BAR: u32 = TRAIT_REF_BAR;
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes Rust-GCC#3552

gcc/rust/ChangeLog:

	* backend/rust-compile-resolve-path.cc (HIRCompileBase::query_compile): check for Expr trait item
	* hir/rust-hir-dump.cc (Dump::visit): expr is optional

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3552.rs: New test.

