### PR TITLE
gccrs: Fix ICE during const expr eval on array expressions

### DIFF
--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -72,7 +72,10 @@ public:
       return it->second;
 
     compiled_type_map.insert ({h, type});
-    push_type (type);
+
+    if (TYPE_NAME (type) != NULL)
+      push_type (type);
+
     return type;
   }
 

--- a/gcc/rust/backend/rust-compile-type.cc
+++ b/gcc/rust/backend/rust-compile-type.cc
@@ -472,6 +472,8 @@ TyTyResolveCompile::visit (const TyTy::ArrayType &type)
   tree folded_capacity_expr = fold_expr (capacity_expr);
 
   translated = Backend::array_type (element_type, folded_capacity_expr);
+  if (translated != error_mark_node)
+    translated = ctx->insert_compiled_type (translated);
 }
 
 void

--- a/gcc/testsuite/rust/compile/issue-3588.rs
+++ b/gcc/testsuite/rust/compile/issue-3588.rs
@@ -1,0 +1,5 @@
+const FOO: i32 = if true { [1, 2, 3] } else { [2, 3, 4] }[0];
+
+pub fn test() -> i32 {
+    FOO
+}


### PR DESCRIPTION
Array expressions are still getting turned into VIEW_CONVERT_EXPR's becuase TYPE_MAIN_VARIANT is not set so then we might as well reuse the type-hasher to sort this out.

Fixes Rust-GCC#3588

gcc/rust/ChangeLog:

	* backend/rust-compile-context.h: only push named types
	* backend/rust-compile-type.cc (TyTyResolveCompile::visit): run the type hasher

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3588.rs: New test.
