### PR TITLE
gccrs: Fix ICE in array ref constexpr

### DIFF
--- a/gcc/rust/backend/rust-constexpr.cc
+++ b/gcc/rust/backend/rust-constexpr.cc
@@ -2697,10 +2697,8 @@ eval_store_expression (const constexpr_ctx *ctx, tree t, bool lval,
 	      }
 	    if (TREE_CODE (probe) == ARRAY_REF)
 	      {
-		// TODO
-		rust_unreachable ();
-		// elt = eval_and_check_array_index (ctx, probe, false,
-		// 				  non_constant_p, overflow_p);
+		elt = eval_and_check_array_index (ctx, probe, false,
+						  non_constant_p, overflow_p);
 		if (*non_constant_p)
 		  return t;
 	      }

--- a/gcc/testsuite/rust/compile/issue-3563.rs
+++ b/gcc/testsuite/rust/compile/issue-3563.rs
@@ -1,0 +1,17 @@
+pub struct AA {
+    pub data: [u8; 10],
+}
+
+impl AA {
+    pub const fn new() -> Self {
+        let mut res: AA = AA { data: [0; 10] };
+        res.data[0] = 5;
+        res
+    }
+}
+
+static mut BB: AA = AA::new();
+
+fn main() {
+    let _ptr = unsafe { &mut BB };
+}


### PR DESCRIPTION
Since 898d55ad7e2 was fixed to remove the VIEW_CONVERT_EXPR from array expressions we can now turn on the array element access const expr.

Fixes Rust-GCC#3563

gcc/rust/ChangeLog:

	* backend/rust-constexpr.cc (eval_store_expression): turn this back on

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3563.rs: New test.
