### PR TITLE
gccrs: FIX ICE when working with HIR::BareFunctionType

### DIFF
--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -2440,7 +2440,9 @@ Dump::visit (BareFunctionType &e)
       end_field ("params");
     }
 
-  visit_field ("return_type", e.get_return_type ());
+  if (e.has_return_type ())
+    visit_field ("return_type", e.get_return_type ());
+
   put_field ("is_variadic", std::to_string (e.get_is_variadic ()));
   end ("BareFunctionType");
 }

--- a/gcc/rust/hir/tree/rust-hir-type.cc
+++ b/gcc/rust/hir/tree/rust-hir-type.cc
@@ -268,7 +268,8 @@ BareFunctionType::BareFunctionType (BareFunctionType const &other)
     for_lifetimes (other.for_lifetimes),
     function_qualifiers (other.function_qualifiers), params (other.params),
     is_variadic (other.is_variadic),
-    return_type (other.return_type->clone_type ())
+    return_type (other.has_return_type () ? other.return_type->clone_type ()
+					  : nullptr)
 {}
 
 BareFunctionType &

--- a/gcc/testsuite/rust/compile/issue-3615.rs
+++ b/gcc/testsuite/rust/compile/issue-3615.rs
@@ -1,0 +1,7 @@
+pub trait Trait {
+    pub fn nrvo(init: fn()) -> [u8; 4096] {
+        let mut buf = [0; 4096];
+
+        buf
+    }
+}


### PR DESCRIPTION
Fixes Rust-GCC#3615

gcc/rust/ChangeLog:

	* hir/rust-hir-dump.cc (Dump::visit): check has type
	* hir/tree/rust-hir-type.cc (BareFunctionType::BareFunctionType): likewise

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3615.rs: New test.
