### PR TITLE
gccrs: FIX ICE for malformed repr attribute

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-base.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.cc
@@ -305,6 +305,12 @@ TypeCheckBase::parse_repr_options (const AST::AttrVec &attrs, location_t locus)
   for (const auto &attr : attrs)
     {
       bool is_repr = attr.get_path ().as_string () == Values::Attributes::REPR;
+      if (is_repr && !attr.has_attr_input ())
+	{
+	  rust_error_at (attr.get_locus (), "malformed %qs attribute", "repr");
+	  continue;
+	}
+
       if (is_repr)
 	{
 	  const AST::AttrInput &input = attr.get_attr_input ();

--- a/gcc/testsuite/rust/compile/issue-3614.rs
+++ b/gcc/testsuite/rust/compile/issue-3614.rs
@@ -1,0 +1,3 @@
+#[repr] // { dg-error "malformed .repr. attribute" }
+
+struct _B {}


### PR DESCRIPTION
Fixes Rust-GCC#3614

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-base.cc (TypeCheckBase::parse_repr_options): check for input

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3614.rs: New test.

