### PR TITLE
gccrs: fix ice when setting up regions

### DIFF
--- a/gcc/rust/typecheck/rust-tyty-subst.h
+++ b/gcc/rust/typecheck/rust-tyty-subst.h
@@ -125,7 +125,7 @@ public:
 				     std::vector<Region> subst)
   {
     RegionParamList list (num_regions);
-    for (size_t i = 0; i < subst.size (); i++)
+    for (size_t i = 0; i < MIN (num_regions, subst.size ()); i++)
       list.regions.at (i) = subst.at (i);
     for (size_t i = subst.size (); i < num_regions; i++)
       {

--- a/gcc/testsuite/rust/compile/issue-3605.rs
+++ b/gcc/testsuite/rust/compile/issue-3605.rs
@@ -1,0 +1,5 @@
+enum Foo<'a> {}
+
+enum Bar<'a> {
+    in_band_def_explicit_impl(Foo<'a>),
+}


### PR DESCRIPTION
num regions is based on the used arguments of regions which can be less than the substutions requirements. So lets check for that and allow anon regions to be created for them.

Fixes Rust-GCC#3605

gcc/rust/ChangeLog:

	* typecheck/rust-tyty-subst.h: check for min range

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3605.rs: New test.

