### PR TITLE
gccrs: Fix SEGV when type path resolver fails outright

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -360,6 +360,13 @@ TypeCheckType::resolve_root_path (HIR::TypePath &path, size_t *offset,
 			     seg->as_string ().c_str ());
 	      return new TyTy::ErrorType (path.get_mappings ().get_hirid ());
 	    }
+	  else if (root_tyty == nullptr)
+	    {
+	      rust_error_at (seg->get_locus (),
+			     "unknown reference for resolved name: %qs",
+			     seg->as_string ().c_str ());
+	      return new TyTy::ErrorType (path.get_mappings ().get_hirid ());
+	    }
 	  return root_tyty;
 	}
 

--- a/gcc/testsuite/rust/compile/issue-3613.rs
+++ b/gcc/testsuite/rust/compile/issue-3613.rs
@@ -1,0 +1,18 @@
+mod m1 {
+    pub enum Baz4 {
+        foo1,
+        foo2,
+    }
+}
+
+fn bar(x: m1::foo) {
+    // { dg-error "unknown reference for resolved name: .foo." "" { target *-*-* } .-1 }
+    match x {
+        m1::foo::foo1 => {}
+        // { dg-error "failed to type resolve root segment" "" { target *-*-* } .-1 }
+        m1::NodePosition::foo2 => {}
+        // { dg-error "failed to type resolve root segment" "" { target *-*-* } .-1 }
+    }
+}
+
+pub fn main() {}


### PR DESCRIPTION
When we resolve paths we resolve to Types first we walk each segment to the last module which has no type but then in the event that the child of a module is not found we have a null root_tyty which needs to be caught and turned into an ErrorType node.

Fixes Rust-GCC#3613

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-type.cc (TypeCheckType::resolve_root_path): catch nullptr root_tyty

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3613.rs: New test.

