### PR TITLE
Fix error when evaluating an enum discriminant containing arithmetic operations

### DIFF
--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -105,7 +105,9 @@ ResolvePathRef::attempt_constructor_expression_lookup (
 
   // make the ctor for the union
   HIR::Expr &discrim_expr = variant->get_discriminant ();
+  ctx->push_const_context ();
   tree discrim_expr_node = CompileExpr::Compile (discrim_expr, ctx);
+  ctx->pop_const_context ();
   tree folded_discrim_expr = fold_expr (discrim_expr_node);
   tree qualifier = folded_discrim_expr;
 

--- a/gcc/testsuite/rust/compile/enum_discriminant1.rs
+++ b/gcc/testsuite/rust/compile/enum_discriminant1.rs
@@ -1,0 +1,7 @@
+enum Foo {
+    Bar = 3 + 12,
+}
+
+fn test() -> Foo { // { dg-warning "function is never used" }
+    return Foo::Bar;
+}


### PR DESCRIPTION
Addresses https://github.com/Rust-GCC/gccrs/issues/3636
```
	* backend/rust-compile-resolve-path.cc: Evaluate the enum's discriminant in a const context

	* rust/compile/enum_discriminant1.rs: New test.
```

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`
- \[x] Added any relevant test cases to `gcc/testsuite/rust/`
