### PR TITLE
gccrs: Fix ICE when resolving lifetimes without name

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-base.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.cc
@@ -397,8 +397,6 @@ TypeCheckBase::resolve_generic_params (
 	    auto lifetime_param
 	      = static_cast<HIR::LifetimeParam &> (*generic_param);
 	    auto lifetime = lifetime_param.get_lifetime ();
-	    rust_assert (lifetime.get_lifetime_type ()
-			 == AST::Lifetime::LifetimeType::NAMED);
 	    context->get_lifetime_resolver ().insert_mapping (
 	      context->intern_lifetime (lifetime));
 	  }

--- a/gcc/testsuite/rust/compile/issue-3657.rs
+++ b/gcc/testsuite/rust/compile/issue-3657.rs
@@ -1,0 +1,8 @@
+struct Foo<'_>(&'_ u8);
+
+impl Foo<'a> {
+    // { dg-error "unresolved lifetime" "" { target *-*-* } .-1 }
+    fn x() {}
+}
+
+fn x() {}


### PR DESCRIPTION
We dont need to assert here the lifetime code already supports this case.

Fixes Rust-GCC#3657

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-base.cc: remove assertion

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3657.rs: New test.
