### PR TITLE
gccrs: Fix ICE when doing shift checks on const decl

### DIFF
--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -1074,6 +1074,12 @@ arithmetic_or_logical_expression (ArithmeticOrLogicalOperator op, tree left,
   if (left == error_mark_node || right == error_mark_node)
     return error_mark_node;
 
+  // unwrap the const decls if set
+  if (TREE_CODE (left) == CONST_DECL)
+    left = DECL_INITIAL (left);
+  if (TREE_CODE (right) == CONST_DECL)
+    right = DECL_INITIAL (right);
+
   /* We need to determine if we're doing floating point arithmetics of integer
      arithmetics. */
   bool floating_point = is_floating_point (left);

--- a/gcc/testsuite/rust/compile/issue-3665.rs
+++ b/gcc/testsuite/rust/compile/issue-3665.rs
@@ -1,0 +1,6 @@
+pub const uint_val: usize = 1;
+pub const uint_expr: usize = 1 << uint_val;
+
+pub fn test() -> usize {
+    uint_expr
+}


### PR DESCRIPTION
Const decls are just delcarations wrapping the value into the DECL_INITIAL and the shift checks we have assume no decls are involved and its just flat values. This patch simply unwraps the constant values if they exist.

Fixes Rust-GCC#3665

gcc/rust/ChangeLog:

	* rust-gcc.cc (arithmetic_or_logical_expression): unwrap const decls

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3665.rs: New test.
