### PR TITLE
Fix ICE when trying to compile enums with non-const discriminants.

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-stmt.h
+++ b/gcc/rust/resolve/rust-ast-resolve-stmt.h
@@ -235,6 +235,7 @@ public:
 	redefined_error (r);
       });
 
+    ResolveExpr::go (item.get_expr (), path, cpath);
     // Done, no fields.
   }
 

--- a/gcc/testsuite/rust/compile/enum_discriminant3.rs
+++ b/gcc/testsuite/rust/compile/enum_discriminant3.rs
@@ -1,0 +1,8 @@
+const x: isize = 1;
+// { dg-warning "unused name" "" { target *-*-* } .-1 }
+
+fn main() {
+    enum Foo {
+        Bar = x,
+    }
+}


### PR DESCRIPTION
addresses https://github.com/Rust-GCC/gccrs/issues/3635



- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`
- \[x] Added any relevant test cases to `gcc/testsuite/rust/`
