### PR TITLE
gccrs: Fix ICE when there are 2 functions named main

### DIFF
--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -663,7 +663,7 @@ get_abi (const AST::AttrVec &outer_attrs,
 
 tree
 HIRCompileBase::compile_function (
-  const std::string &fn_name, HIR::SelfParam &self_param,
+  bool is_root_item, const std::string &fn_name, HIR::SelfParam &self_param,
   std::vector<HIR::FunctionParam> &function_params,
   const HIR::FunctionQualifiers &qualifiers, HIR::Visibility &visibility,
   AST::AttrVec &outer_attrs, location_t locus, HIR::BlockExpr *function_body,
@@ -674,7 +674,7 @@ HIRCompileBase::compile_function (
     = canonical_path.get () + fntype->subst_as_string ();
 
   // we don't mangle the main fn since we haven't implemented the main shim
-  bool is_main_fn = fn_name.compare ("main") == 0;
+  bool is_main_fn = fn_name.compare ("main") == 0 && is_root_item;
   if (is_main_fn)
     {
       rust_assert (!main_identifier_node);

--- a/gcc/rust/backend/rust-compile-base.h
+++ b/gcc/rust/backend/rust-compile-base.h
@@ -102,7 +102,8 @@ protected:
 			      HIR::Expr &const_value_expr, location_t locus,
 			      location_t expr_locus);
 
-  tree compile_function (const std::string &fn_name, HIR::SelfParam &self_param,
+  tree compile_function (bool is_root_item, const std::string &fn_name,
+			 HIR::SelfParam &self_param,
 			 std::vector<HIR::FunctionParam> &function_params,
 			 const HIR::FunctionQualifiers &qualifiers,
 			 HIR::Visibility &visibility, AST::AttrVec &outer_attrs,

--- a/gcc/rust/backend/rust-compile-implitem.cc
+++ b/gcc/rust/backend/rust-compile-implitem.cc
@@ -117,7 +117,7 @@ CompileTraitItem::visit (HIR::TraitItemFunc &func)
   auto vis = HIR::Visibility (HIR::Visibility::VisType::PUBLIC);
   HIR::TraitFunctionDecl &function = func.get_decl ();
   tree fndecl
-    = compile_function (function.get_function_name ().as_string (),
+    = compile_function (false, function.get_function_name ().as_string (),
 			function.get_self (), function.get_function_params (),
 			function.get_qualifiers (), vis,
 			func.get_outer_attrs (), func.get_locus (),

--- a/gcc/rust/backend/rust-compile-implitem.h
+++ b/gcc/rust/backend/rust-compile-implitem.h
@@ -30,16 +30,10 @@ class CompileInherentImplItem : public CompileItem
 public:
   static tree Compile (HIR::ImplItem *item, Context *ctx,
 		       TyTy::BaseType *concrete = nullptr,
-		       bool is_query_mode = false,
 		       location_t ref_locus = UNDEF_LOCATION)
   {
     CompileInherentImplItem compiler (ctx, concrete, ref_locus);
     item->accept_vis (compiler);
-
-    if (is_query_mode && compiler.reference == error_mark_node)
-      rust_internal_error_at (ref_locus, "failed to compile impl item: %s",
-			      item->as_string ().c_str ());
-
     return compiler.reference;
   }
 

--- a/gcc/rust/backend/rust-compile-item.cc
+++ b/gcc/rust/backend/rust-compile-item.cc
@@ -252,8 +252,12 @@ CompileItem::visit (HIR::Function &function)
   if (function.get_qualifiers ().is_const ())
     ctx->push_const_context ();
 
+  auto lookup_root_item = ctx->get_mappings ().lookup_hir_item (
+    function.get_mappings ().get_hirid ());
+  bool is_root_item = lookup_root_item.has_value ();
   tree fndecl
-    = compile_function (function.get_function_name ().as_string (),
+    = compile_function (is_root_item,
+			function.get_function_name ().as_string (),
 			function.get_self_param (),
 			function.get_function_params (),
 			function.get_qualifiers (), function.get_visibility (),

--- a/gcc/rust/backend/rust-compile-item.h
+++ b/gcc/rust/backend/rust-compile-item.h
@@ -35,10 +35,6 @@ public:
   {
     CompileItem compiler (ctx, concrete, ref_locus);
     item->accept_vis (compiler);
-
-    if (compiler.reference == error_mark_node)
-      rust_debug ("failed to compile item: %s", item->as_string ().c_str ());
-
     return compiler.reference;
   }
 

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -286,10 +286,10 @@ HIRCompileBase::query_compile (HirId ref, TyTy::BaseType *lookup,
 	{
 	  if (!lookup->has_substitutions_defined ())
 	    return CompileInherentImplItem::Compile (resolved_item->first, ctx,
-						     nullptr, true, expr_locus);
+						     nullptr, expr_locus);
 	  else
 	    return CompileInherentImplItem::Compile (resolved_item->first, ctx,
-						     lookup, true, expr_locus);
+						     lookup, expr_locus);
 	}
       else if (auto trait_item
 	       = ctx->get_mappings ().lookup_hir_trait_item (ref))
@@ -372,11 +372,10 @@ HIRCompileBase::query_compile (HirId ref, TyTy::BaseType *lookup,
 
 	      if (!lookup->has_substitutions_defined ())
 		return CompileInherentImplItem::Compile (impl_item, ctx,
-							 nullptr, true,
-							 expr_locus);
+							 nullptr, expr_locus);
 	      else
 		return CompileInherentImplItem::Compile (impl_item, ctx, lookup,
-							 true, expr_locus);
+							 expr_locus);
 	    }
 	}
     }

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -338,7 +338,7 @@ HIRCompileBase::compute_address_for_trait_item (
 	}
 
       return CompileInherentImplItem::Compile (associated_function, ctx,
-					       lookup_fntype, true, locus);
+					       lookup_fntype, locus);
     }
 
   // we can only compile trait-items with a body

--- a/gcc/rust/typecheck/rust-hir-trait-resolve.cc
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.cc
@@ -157,7 +157,13 @@ TraitResolver::resolve_path_to_trait (const HIR::TypePath &path,
     }
 
   auto resolved_item = mappings.lookup_hir_item (hid.value ());
-  rust_assert (resolved_item.has_value ());
+  if (!resolved_item.has_value ())
+    {
+      rust_error_at (path.get_locus (),
+		     "Failed to resolve trait by looking up hir node");
+      return false;
+    }
+
   if (resolved_item.value ()->get_item_kind () != HIR::Item::ItemKind::Trait)
     {
       rich_location r (line_table, path.get_locus ());

--- a/gcc/testsuite/rust/compile/issue-3648.rs
+++ b/gcc/testsuite/rust/compile/issue-3648.rs
@@ -1,0 +1,8 @@
+struct B; // { dg-warning "struct is never constructed" }
+
+impl B {
+    fn main() {}
+    // { dg-warning "associated function is never used" "" { target *-*-* } .-1 }
+}
+
+fn main() {}


### PR DESCRIPTION
We need to setup the main_identifier_node for MAIN_DECL_P checks in the middle-end. But it is valid to have a main function/method on impl blocks. So we need to flag if this is a "root" item or not, which is one that is jsut an HIR::Function on part of the Crate::items as oppposed to a HIR::Function which is part of an HIR::ImplBlock as part of the HIR::Crate. Some small cleanups have been added here too.

Fixes Rust-GCC#3648

gcc/rust/ChangeLog:

	* backend/rust-compile-base.cc: new flag is_root_item
	* backend/rust-compile-base.h: update prototype
	* backend/rust-compile-implitem.cc (CompileTraitItem::visit): update call
	* backend/rust-compile-implitem.h: remove old debug internal error
	* backend/rust-compile-item.cc (CompileItem::visit): update call
	* backend/rust-compile-item.h: remove old debug
	* backend/rust-compile-resolve-path.cc (HIRCompileBase::query_compile): update calls
	* backend/rust-compile.cc: likewise
	* typecheck/rust-hir-trait-resolve.cc (TraitResolver::resolve_path_to_trait): remove assertion and error

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3648.rs: New test.
