### PR TITLE
gccrs: Fix ICE when hitting invalid types for generics

### DIFF
--- a/gcc/rust/resolve/rust-ast-resolve-type.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-type.cc
@@ -357,7 +357,7 @@ ResolveRelativeTypePath::go (AST::TypePath &path, NodeId &resolved_node_id)
 	{
 	  rust_error_at (segment->get_locus (), ErrorCode::E0412,
 			 "could not resolve type path %qs",
-			 segment->as_string ().c_str ());
+			 segment->get_ident_segment ().as_string ().c_str ());
 	  return false;
 	}
     }

--- a/gcc/rust/typecheck/rust-substitution-mapper.h
+++ b/gcc/rust/typecheck/rust-substitution-mapper.h
@@ -37,6 +37,8 @@ public:
 
   bool have_generic_args () const;
 
+  static bool valid_type (TyTy::BaseType *base);
+
   void visit (TyTy::FnType &type) override;
   void visit (TyTy::ADTType &type) override;
   void visit (TyTy::PlaceholderType &type) override;

--- a/gcc/testsuite/rust/compile/issue-3643.rs
+++ b/gcc/testsuite/rust/compile/issue-3643.rs
@@ -1,0 +1,4 @@
+fn foo() {
+    let x: usize<foo>;
+    // { dg-error "generic arguments are not allowed for this type .E0109." "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/compile/issue-3646.rs
+++ b/gcc/testsuite/rust/compile/issue-3646.rs
@@ -1,0 +1,7 @@
+trait Foo {
+    type T;
+    fn foo() -> Foo<main>;
+    // { dg-error "generic arguments are not allowed for this type .E0109." "" { target *-*-* } .-1 }
+}
+
+fn main() {}

--- a/gcc/testsuite/rust/compile/issue-3654.rs
+++ b/gcc/testsuite/rust/compile/issue-3654.rs
@@ -1,0 +1,3 @@
+type Meeshka = Mow<!>;
+// { dg-error "generic arguments are not allowed for this type .E0109." "" { target *-*-* } .-1 }
+type Mow = &'static fn(!) -> !;

--- a/gcc/testsuite/rust/compile/issue-3663.rs
+++ b/gcc/testsuite/rust/compile/issue-3663.rs
@@ -1,0 +1,6 @@
+pub trait TypeFn {}
+
+impl TypeFn for Output<{ 42 }> {
+    // { dg-error "could not resolve type path .Output. .E0412." "" { target *-*-* } .-1 }
+    type Output = ();
+}

--- a/gcc/testsuite/rust/compile/issue-3671.rs
+++ b/gcc/testsuite/rust/compile/issue-3671.rs
@@ -1,0 +1,2 @@
+impl Self<0> {}
+// { dg-error "could not resolve type path" "" { target *-*-* } .-1 }

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -28,4 +28,6 @@ torture/loop4.rs
 torture/loop8.rs
 torture/name_resolve1.rs
 issue-3568.rs
+issue-3663.rs
+issue-3671.rs
 # please don't delete the trailing newline


### PR DESCRIPTION
We need to check upfront if the type is valid or not. Then error with a decent message.

Fixes Rust-GCC#3643
Fixes Rust-GCC#3646
Fixes Rust-GCC#3654
Fixes Rust-GCC#3663
Fixes Rust-GCC#3671

gcc/rust/ChangeLog:

	* resolve/rust-ast-resolve-type.cc (ResolveRelativeTypePath::go): fix error msg
	* typecheck/rust-substitution-mapper.cc (SubstMapper::Resolve): add validation
	(SubstMapper::valid_type): new check
	(SubstMapper::visit): check if can resolve
	* typecheck/rust-substitution-mapper.h: new prototype

gcc/testsuite/ChangeLog:

	* rust/compile/nr2/exclude: nr2 is missing type path error
	* rust/compile/issue-3643.rs: New test.
	* rust/compile/issue-3646.rs: New test.
	* rust/compile/issue-3654.rs: New test.
	* rust/compile/issue-3663.rs: New test.
	* rust/compile/issue-3671.rs: New test.
