### PR TITLE
gccrs: Implement typecheck for zero-variant enums

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-base.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.cc
@@ -343,13 +343,27 @@ TypeCheckBase::parse_repr_options (const AST::AttrVec &attrs, location_t locus)
 	  // manually parsing the string "packed(2)" here.
 
 	  size_t oparen = inline_option.find ('(', 0);
-	  bool is_pack = false, is_align = false;
+	  bool is_pack = false, is_align = false, is_c = false,
+	       is_integer = false;
 	  unsigned char value = 1;
 
 	  if (oparen == std::string::npos)
 	    {
 	      is_pack = inline_option.compare ("packed") == 0;
 	      is_align = inline_option.compare ("align") == 0;
+	      is_c = inline_option.compare ("C") == 0;
+	      is_integer = (inline_option.compare ("isize") == 0
+			    || inline_option.compare ("i8") == 0
+			    || inline_option.compare ("i16") == 0
+			    || inline_option.compare ("i32") == 0
+			    || inline_option.compare ("i64") == 0
+			    || inline_option.compare ("i128") == 0
+			    || inline_option.compare ("usize") == 0
+			    || inline_option.compare ("u8") == 0
+			    || inline_option.compare ("u16") == 0
+			    || inline_option.compare ("u32") == 0
+			    || inline_option.compare ("u64") == 0
+			    || inline_option.compare ("u128") == 0);
 	    }
 
 	  else
@@ -369,9 +383,23 @@ TypeCheckBase::parse_repr_options (const AST::AttrVec &attrs, location_t locus)
 	    }
 
 	  if (is_pack)
-	    repr.pack = value;
+	    {
+	      repr.repr_kind = TyTy::ADTType::ReprKind::PACKED;
+	      repr.pack = value;
+	    }
 	  else if (is_align)
-	    repr.align = value;
+	    {
+	      repr.repr_kind = TyTy::ADTType::ReprKind::ALIGN;
+	      repr.align = value;
+	    }
+	  else if (is_c)
+	    {
+	      repr.repr_kind = TyTy::ADTType::ReprKind::C;
+	    }
+	  else if (is_integer)
+	    {
+	      repr.repr_kind = TyTy::ADTType::ReprKind::INT;
+	    }
 
 	  delete meta_items;
 

--- a/gcc/rust/typecheck/rust-hir-type-check-base.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.cc
@@ -298,7 +298,8 @@ TypeCheckBase::parse_repr_options (const AST::AttrVec &attrs, location_t locus)
   repr.pack = 0;
   repr.align = 0;
 
-  // FIXME handle non-integer repr types....
+  // Default repr for enums is isize, but we now check for other repr in the
+  // attributes.
   bool ok = context->lookup_builtin ("isize", &repr.repr);
   rust_assert (ok);
 

--- a/gcc/rust/typecheck/rust-hir-type-check-base.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.cc
@@ -298,7 +298,7 @@ TypeCheckBase::parse_repr_options (const AST::AttrVec &attrs, location_t locus)
   repr.pack = 0;
   repr.align = 0;
 
-  // FIXME handle repr types....
+  // FIXME handle non-integer repr types....
   bool ok = context->lookup_builtin ("isize", &repr.repr);
   rust_assert (ok);
 
@@ -343,8 +343,10 @@ TypeCheckBase::parse_repr_options (const AST::AttrVec &attrs, location_t locus)
 	  // manually parsing the string "packed(2)" here.
 
 	  size_t oparen = inline_option.find ('(', 0);
-	  bool is_pack = false, is_align = false, is_c = false,
-	       is_integer = false;
+	  bool is_pack = false;
+	  bool is_align = false;
+	  bool is_c = false;
+	  bool is_integer = false;
 	  unsigned char value = 1;
 
 	  if (oparen == std::string::npos)
@@ -399,6 +401,11 @@ TypeCheckBase::parse_repr_options (const AST::AttrVec &attrs, location_t locus)
 	  else if (is_integer)
 	    {
 	      repr.repr_kind = TyTy::ADTType::ReprKind::INT;
+	      bool ok = context->lookup_builtin (inline_option, &repr.repr);
+	      if (!ok)
+		{
+		  rust_error_at (attr.get_locus (), "Invalid repr type");
+		}
 	    }
 
 	  delete meta_items;

--- a/gcc/rust/typecheck/rust-hir-type-check-item.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.cc
@@ -355,7 +355,7 @@ TypeCheckItem::visit (HIR::Enum &enum_decl)
       variants.push_back (field_type);
     }
 
-  // Check for zero-variant enum compatibility before processing repr attribute
+  // Check for zero-variant enum compatibility
   if (enum_decl.is_zero_variant ())
     {
       if (repr.repr_kind == TyTy::ADTType::ReprKind::INT

--- a/gcc/rust/typecheck/rust-hir-type-check-item.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.cc
@@ -355,6 +355,18 @@ TypeCheckItem::visit (HIR::Enum &enum_decl)
       variants.push_back (field_type);
     }
 
+  // Check for zero-variant enum compatibility before processing repr attribute
+  if (enum_decl.is_zero_variant ())
+    {
+      if (repr.repr_kind == TyTy::ADTType::ReprKind::INT
+	  || repr.repr_kind == TyTy::ADTType::ReprKind::C)
+	{
+	  rust_error_at (enum_decl.get_locus (),
+			 "unsupported representation for zero-variant enum");
+	  return;
+	}
+    }
+
   // get the path
   tl::optional<CanonicalPath> canonical_path;
 

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -719,7 +719,6 @@ public:
     ALIGN,
     PACKED,
     // TRANSPARENT,
-    // PACKED,
     // SIMD,
     // ...
   };

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -711,12 +711,23 @@ public:
     ENUM
   };
 
+  enum ReprKind
+  {
+    RUST,
+    C,
+    INT,
+    ALIGN,
+    PACKED,
+    // TRANSPARENT,
+    // PACKED,
+    // SIMD,
+    // ...
+  };
+
   // Representation options, specified via attributes e.g. #[repr(packed)]
   struct ReprOptions
   {
-    // bool is_c;
-    // bool is_transparent;
-    //...
+    ReprKind repr_kind = ReprKind::RUST;
 
     // For align and pack: 0 = unspecified. Nonzero = byte alignment.
     // It is an error for both to be nonzero, this should be caught when

--- a/gcc/testsuite/rust/compile/issue-3530-1.rs
+++ b/gcc/testsuite/rust/compile/issue-3530-1.rs
@@ -1,0 +1,2 @@
+#[repr(i32)]
+enum NightsWatch {} // { dg-error "unsupported representation for zero-variant enum" }

--- a/gcc/testsuite/rust/compile/issue-3530-2.rs
+++ b/gcc/testsuite/rust/compile/issue-3530-2.rs
@@ -1,0 +1,2 @@
+#[repr(C)]
+enum NightsWatch {} // { dg-error "unsupported representation for zero-variant enum" }


### PR DESCRIPTION
Fixes #3530

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`
- \[x] Added any relevant test cases to `gcc/testsuite/rust/`

This quick fix is kind of an ugly one, since [parsing of `repr` types is not fully implemented yet](https://github.com/Rust-GCC/gccrs/blob/20c8539a23e0a0462e3763c3983ffb3ca9b7e709/gcc/rust/typecheck/rust-hir-type-check-base.cc#L301-L302). This merely adds a new `ReprKind` type similar to [Rust's `ReprFlags`](https://github.com/rust-lang/rust/blob/master/compiler/rustc_abi/src/lib.rs#L81-L101).

I'm open to suggestions for improvements, or any tips on fully implementing the parsing `repr` types properly.