### PR TITLE
gccrs: Fix ICE on invalid match arms

### DIFF
--- a/gcc/testsuite/rust/compile/issue-3656.rs
+++ b/gcc/testsuite/rust/compile/issue-3656.rs
@@ -1,0 +1,10 @@
+enum Foo {
+    Bar(isize),
+}
+
+fn main() {
+    match Foo::Bar(205) {
+        Foo { i } => (),
+        // { dg-error "expected struct, variant or union type, found enum .Foo. .E0574." "" { target *-*-* } .-1 }
+    }
+}


### PR DESCRIPTION
We hit assertions on empty enum or unknown variant, this catches the error and emits a new diagnostic.

Fixes Rust-GCC#3656

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-pattern.cc (TypeCheckPattern::visit): emit error

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3656.rs: New test.
