### PR TITLE
gccrs: Fix ICE for reserved lifetime name

### DIFF
--- a/gcc/rust/typecheck/rust-typecheck-context.cc
+++ b/gcc/rust/typecheck/rust-typecheck-context.cc
@@ -514,7 +514,16 @@ TypeCheckContext::lookup_lifetime (const HIR::Lifetime &lifetime) const
 {
   if (lifetime.get_lifetime_type () == AST::Lifetime::NAMED)
     {
-      rust_assert (lifetime.get_name () != "static");
+      if (lifetime.get_name () == "static")
+	{
+	  rich_location r (line_table, lifetime.get_locus ());
+	  r.add_fixit_insert_after (lifetime.get_locus (),
+				    "static is a reserved lifetime name");
+	  rust_error_at (r, ErrorCode::E0262,
+			 "invalid lifetime parameter name: %qs",
+			 lifetime.get_name ().c_str ());
+	  return tl::nullopt;
+	}
       const auto name = lifetime.get_name ();
       auto it = lifetime_name_interner.find (name);
       if (it == lifetime_name_interner.end ())

--- a/gcc/testsuite/rust/compile/issue-3647.rs
+++ b/gcc/testsuite/rust/compile/issue-3647.rs
@@ -1,0 +1,7 @@
+#![allow(dead_code)]
+type A = fn();
+
+type B = for<'static> fn();
+// { dg-error "invalid lifetime parameter name: .static. .E0262." "" { target *-*-* } .-1 }
+
+pub fn main() {}


### PR DESCRIPTION
This is a reserved name so this changes the assertion to a diagnostic.

Fixes Rust-GCC#3647

gcc/rust/ChangeLog:

	* typecheck/rust-typecheck-context.cc (TypeCheckContext::lookup_lifetime): emit error

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3647.rs: New test.
