### PR TITLE
nr2.0: Do not resolve modules this run if they are unloaded

### DIFF
--- a/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
@@ -113,7 +113,17 @@ TopLevel::visit (AST::Module &module)
   // This was copied from the old early resolver method
   // 'accumulate_escaped_macros'
   if (module.get_kind () == AST::Module::UNLOADED)
-    module.load_items ();
+    {
+      module.load_items ();
+
+      // If the module was previously unloaded, then we don't want to visit it
+      // this time around as the CfgStrip hasn't run on its inner items yet.
+      // Skip it for now, mark the visitor as dirty and try again
+
+      dirty = true;
+
+      return;
+    }
 
   DefaultResolver::visit (module);
 


### PR DESCRIPTION
Instead, mark the visitor as dirty and wait for the next round of the fixed point to take care of them. This avoids issues with module items being loaded while not being stripped yet.

gcc/rust/ChangeLog:

	* resolve/rust-toplevel-name-resolver-2.0.cc (TopLevel::visit): Return if module is unloaded.

This fixes some issues with `cfg` expansion we were getting when compiling `core` 1.49