### PR TITLE
Add basic struct pattern rebinding

### DIFF
--- a/gcc/rust/backend/rust-compile-pattern.cc
+++ b/gcc/rust/backend/rust-compile-pattern.cc
@@ -259,34 +259,16 @@ CompilePatternCheckExpr::visit (HIR::StructPattern &pattern)
 	  }
 	  break;
 
-	  case HIR::StructPatternField::ItemType::IDENT_PAT: {
-	    HIR::StructPatternFieldIdentPat &ident
-	      = static_cast<HIR::StructPatternFieldIdentPat &> (*field.get ());
+	case HIR::StructPatternField::ItemType::IDENT_PAT:
+	  // we only support rebinding patterns at the moment, which always
+	  // match - so do nothing
 
-	    size_t offs = 0;
-	    ok = variant->lookup_field (ident.get_identifier ().as_string (),
-					nullptr, &offs);
-	    rust_assert (ok);
-
-	    // we may be offsetting by + 1 here since the first field in the
-	    // record is always the discriminator
-	    offs += adt->is_enum ();
-	    tree field_expr
-	      = Backend::struct_field_expression (match_scrutinee_expr, offs,
-						  ident.get_locus ());
-
-	    tree check_expr_sub
-	      = CompilePatternCheckExpr::Compile (ident.get_pattern (),
-						  field_expr, ctx);
-	    check_expr = Backend::arithmetic_or_logical_expression (
-	      ArithmeticOrLogicalOperator::BITWISE_AND, check_expr,
-	      check_expr_sub, ident.get_pattern ().get_locus ());
-	  }
+	  // this needs to change once we actually check that the field
+	  // matches a certain value, either a literal value or a const one
 	  break;
 
-	  case HIR::StructPatternField::ItemType::IDENT: {
-	    // ident pattern always matches - do nothing
-	  }
+	case HIR::StructPatternField::ItemType::IDENT:
+	  // ident pattern always matches - do nothing
 	  break;
 	}
     }

--- a/gcc/rust/backend/rust-compile-pattern.h
+++ b/gcc/rust/backend/rust-compile-pattern.h
@@ -80,11 +80,17 @@ public:
     pattern.accept_vis (compiler);
   }
 
+  tree make_struct_access (TyTy::ADTType *adt, TyTy::VariantDef *variant,
+			   Identifier &ident, int variant_index);
+
   void handle_struct_pattern_ident (HIR::StructPatternField &pat,
 				    TyTy::ADTType *adt,
 				    TyTy::VariantDef *variant,
 				    int variant_index);
-  void handle_struct_pattern_ident_pat (HIR::StructPatternField &pat);
+  void handle_struct_pattern_ident_pat (HIR::StructPatternField &pat,
+					TyTy::ADTType *adt,
+					TyTy::VariantDef *variant,
+					int variant_index);
   void handle_struct_pattern_tuple_pat (HIR::StructPatternField &pat);
 
   void visit (HIR::StructPattern &pattern) override;

--- a/gcc/rust/backend/rust-compile-pattern.h
+++ b/gcc/rust/backend/rust-compile-pattern.h
@@ -17,7 +17,9 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-compile-base.h"
+#include "rust-hir-pattern.h"
 #include "rust-hir-visitor.h"
+#include "rust-tyty.h"
 
 namespace Rust {
 namespace Compile {
@@ -77,6 +79,13 @@ public:
     CompilePatternBindings compiler (ctx, match_scrutinee_expr);
     pattern.accept_vis (compiler);
   }
+
+  void handle_struct_pattern_ident (HIR::StructPatternField &pat,
+				    TyTy::ADTType *adt,
+				    TyTy::VariantDef *variant,
+				    int variant_index);
+  void handle_struct_pattern_ident_pat (HIR::StructPatternField &pat);
+  void handle_struct_pattern_tuple_pat (HIR::StructPatternField &pat);
 
   void visit (HIR::StructPattern &pattern) override;
   void visit (HIR::TupleStructPattern &pattern) override;

--- a/gcc/testsuite/rust/execute/torture/struct_pattern1.rs
+++ b/gcc/testsuite/rust/execute/torture/struct_pattern1.rs
@@ -1,0 +1,19 @@
+struct A {
+    // the two warnings are invalid but this should be fixed by our lint rework
+    // with this year's GSoC so ok for now
+    a: i32, // { dg-warning "never read" }
+    b: i32, // { dg-warning "never read" }
+}
+
+fn main() -> i32 {
+    let a = A { a: 15, b: 14 };
+
+    let result = match a {
+        A {
+            a: self_a,
+            b: self_b,
+        } => self_a + self_b,
+    };
+
+    result - 29
+}


### PR DESCRIPTION
This PR adds support for basic struct ident patterns, specifically in the case of rebinding struct fields to new names:

```rust
match instance {
    Foo { field_name: new_name } => { do_something(new_name) }
}
```

This is required for finish support for `derive(PartialEq)` and `derive(PartialOrd)`