### PR TITLE
gccrs: Fix ICE when checking shift's which are behind array refs

### DIFF
--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -1109,6 +1109,7 @@ arithmetic_or_logical_expression (ArithmeticOrLogicalOperator op, tree left,
       rust_error_at (location, "division by zero");
     }
   else if (op == ArithmeticOrLogicalOperator::LEFT_SHIFT
+	   && TREE_CODE (right) == INTEGER_CST
 	   && (compare_tree_int (right, TYPE_PRECISION (TREE_TYPE (ret))) >= 0))
     {
       rust_error_at (location, "left shift count >= width of type");

--- a/gcc/testsuite/rust/compile/issue-3664.rs
+++ b/gcc/testsuite/rust/compile/issue-3664.rs
@@ -1,0 +1,5 @@
+const ARR: [usize; 1] = [2];
+
+pub fn l8() {
+    let _ = 5 << ARR[0];
+}


### PR DESCRIPTION
I copied a bad form of this check from the c front-end this updates it to ensure the rhs is an INTEGER_CST and the lhs needs checked in the first place.

Fixes Rust-GCC#3664

gcc/rust/ChangeLog:

	* rust-gcc.cc (arithmetic_or_logical_expression): Ensure this is an integer

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3664.rs: New test.
