### PR TITLE
gccrs: Add check for placeholder (infer) type in return position

### DIFF
--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -137,6 +137,9 @@ public:
   void inherit_bounds (
     const std::vector<TyTy::TypeBoundPredicate> &specified_bounds);
 
+  // contains_infer checks if there is an inference variable inside the type
+  const TyTy::BaseType *contains_infer () const;
+
   // is_unit returns whether this is just a unit-struct
   bool is_unit () const;
 

--- a/gcc/testsuite/rust/compile/issue-402.rs
+++ b/gcc/testsuite/rust/compile/issue-402.rs
@@ -1,0 +1,14 @@
+#[lang = "sized"]
+pub trait Sized {}
+
+struct GenericStruct<T>(T, usize);
+
+pub fn test() -> GenericStruct<_> {
+    // { dg-error "the type placeholder ._. is not allowed within types on item signatures .E0121." "" { target *-*-* } .-1 }
+    GenericStruct(1, 2)
+}
+
+fn square(num: i32) -> _ {
+    // { dg-error "the type placeholder ._. is not allowed within types on item signatures .E0121." "" { target *-*-* } .-1 }
+    num * num
+}


### PR DESCRIPTION
It is not allowed to have a declared inference variable in the return position of a function as this may never get infered you need good points of truth.

Ideally if we get a student for GSoC 25 we will get the Default Hir Visitor so that we can grab the HIR::InferredType locus instead of using the ref location lookups.

Fixes Rust-GCC#402

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-item.cc (TypeCheckItem::visit): add diagnostic
	* typecheck/rust-tyty.cc (BaseType::contains_infer): new helper to grab first infer var
	* typecheck/rust-tyty.h: prototype

gcc/testsuite/ChangeLog:

	* rust/compile/issue-402.rs: New test.

