### PR TITLE
gccrs: Fix ICE when handling case of unknown field in HIR::FieldAccess

### DIFF
--- a/gcc/testsuite/rust/compile/issue-3581-1.rs
+++ b/gcc/testsuite/rust/compile/issue-3581-1.rs
@@ -1,0 +1,12 @@
+enum Foo {
+    Bar,
+}
+
+struct Baz;
+
+fn main() {
+    Foo::Bar.a;
+    // { dg-error "no field .a. on type .Foo. .E0609." "" { target *-*-* } .-1 }
+    Baz.a;
+    // { dg-error "no field .a. on type .Baz. .E0609." "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/compile/issue-3581-2.rs
+++ b/gcc/testsuite/rust/compile/issue-3581-2.rs
@@ -1,0 +1,9 @@
+enum A {
+    X { inner: i32 },
+    Y,
+}
+
+pub fn test() {
+    let _ = A::Y.inner;
+    // { dg-error "no field .inner. on type .A. .E0609." "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/compile/nonexistent-field.rs
+++ b/gcc/testsuite/rust/compile/nonexistent-field.rs
@@ -6,7 +6,7 @@ fn main() {
 
     let s = StructWithFields { x: 0 };
     s.foo;
-    // { dg-error "no field .foo. on type .StructWithFields.StructWithFields .x.u32... .E0609." "" { target *-*-* } .-1 }
+    // { dg-error "no field .foo. on type .StructWithFields. .E0609." "" { target *-*-* } .-1 }
 
     let numbers = (1, 2, 3);
     numbers.3;


### PR DESCRIPTION
We were wrongly adding the assertion that this must not be an enum but this is a pointless assertion we only care that there are variant in the ADT and if the field exists in the first variant.

Fixes Rust-GCC#3581

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::visit): fix bad assertion

gcc/testsuite/ChangeLog:

	* rust/compile/nonexistent-field.rs: fix error message
	* rust/compile/issue-3581.rs: New test.
