### PR TITLE
gccrs: Fix ICE in struct expressions

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-struct-field.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-struct-field.h
@@ -60,6 +60,9 @@ private:
   TyTy::BaseType *resolved_field_value_expr;
   std::set<std::string> fields_assigned;
   std::map<size_t, HIR::StructExprField *> adtFieldIndexToField;
+
+  // parent
+  HIR::Expr &parent;
 };
 
 } // namespace Resolver

--- a/gcc/testsuite/rust/compile/issue-3628.rs
+++ b/gcc/testsuite/rust/compile/issue-3628.rs
@@ -1,0 +1,10 @@
+pub enum Enum {
+    Variant1(isize),
+}
+
+impl Enum {
+    fn static_meth_enum() -> Enum {
+        Enum { x: 1 }
+        // { dg-error "expected a struct, variant or union type, found enum .Enum. .E0574." "" { target *-*-* } .-1 }
+    }
+}

--- a/gcc/testsuite/rust/compile/macros/mbe/macro-issue2983_2984.rs
+++ b/gcc/testsuite/rust/compile/macros/mbe/macro-issue2983_2984.rs
@@ -18,10 +18,9 @@ fn main() {
 
     // Error
     let _ = ReadDir {
+        // { dg-error "unknown field .end_of_stream_but_different. .E0560." "" { target *-*-* } .-1 }
         inner: 14,
         end_of_stream: false,
-        end_of_stream_but_different: false, // { dg-error "failed to resolve type for field" }
-        // { dg-error "unknown field" "" { target *-*-* } .-1 }
-        // { dg-prune-output "compilation terminated" }
+        end_of_stream_but_different: false,
     };
 }

--- a/gcc/testsuite/rust/compile/struct_init1.rs
+++ b/gcc/testsuite/rust/compile/struct_init1.rs
@@ -4,7 +4,7 @@ struct Foo {
 }
 
 fn main() {
-    let a = Foo { 0: 10.0, 1: 20.0 }; // { dg-error "failed to resolve type for field" }
-    // { dg-error "unknown field" "" { target *-*-* } .-1 }
-    // { dg-prune-output "compilation terminated" }
+    let a = Foo { 0: 10.0, 1: 20.0 };
+    // { dg-error "unknown field .0. .E0560." "" { target *-*-* } .-1 }
+    // { dg-error "unknown field .1. .E0560." "" { target *-*-* } .-2 }
 }


### PR DESCRIPTION
The error handling here was done long ago when we didnt know how to do any error handling very well. This removed bad fatal_errors and adds in some nice rich_location error diagnostics instead.

Fixes Rust-GCC#3628

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-struct-field.h: keep reference to parent expression
	* typecheck/rust-hir-type-check-struct.cc (TypeCheckStructExpr::TypeCheckStructExpr): update ctor
	(TypeCheckStructExpr::resolve): remove bad rust_fatal_errors
	(TypeCheckStructExpr::visit): cleanup errors

gcc/testsuite/ChangeLog:

	* rust/compile/macros/mbe/macro-issue2983_2984.rs: cleanup error diagnotics
	* rust/compile/struct_init1.rs: likewise
	* rust/compile/issue-3628.rs: New test.
