### PR TITLE
gccrs: Fix ICE with empty generic arguments

### DIFF
--- a/gcc/rust/ast/rust-ast-visitor.cc
+++ b/gcc/rust/ast/rust-ast-visitor.cc
@@ -108,7 +108,8 @@ DefaultASTVisitor::visit (GenericArgsBinding &binding)
 void
 DefaultASTVisitor::visit (AST::TypePathSegmentGeneric &segment)
 {
-  visit (segment.get_generic_args ());
+  if (segment.has_generic_args ())
+    visit (segment.get_generic_args ());
 }
 
 void

--- a/gcc/rust/expand/rust-expand-visitor.cc
+++ b/gcc/rust/expand/rust-expand-visitor.cc
@@ -489,7 +489,8 @@ ExpandVisitor::visit (AST::PathInExpression &path)
 void
 ExpandVisitor::visit (AST::TypePathSegmentGeneric &segment)
 {
-  expand_generic_args (segment.get_generic_args ());
+  if (segment.has_generic_args ())
+    expand_generic_args (segment.get_generic_args ());
 }
 
 void

--- a/gcc/testsuite/rust/compile/issue-3649.rs
+++ b/gcc/testsuite/rust/compile/issue-3649.rs
@@ -1,0 +1,2 @@
+struct T(Box<>);
+// { dg-error "could not resolve type path .Box. .E0412." "" { target *-*-* } .-1 }

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -22,4 +22,5 @@ issue-3568.rs
 issue-3663.rs
 issue-3671.rs
 issue-3652.rs
+issue-3649.rs
 # please don't delete the trailing newline


### PR DESCRIPTION
We have an assertion when accessing generic args if there are any which is really useful so this adds the missing guards for the case where they are specified but empty.

Fixes Rust-GCC#3649

gcc/rust/ChangeLog:

	* ast/rust-ast-visitor.cc (DefaultASTVisitor::visit): add guard
	* expand/rust-expand-visitor.cc (ExpandVisitor::visit): add guard

gcc/testsuite/ChangeLog:

	* rust/compile/nr2/exclude: nr2 is missing error for this
	* rust/compile/issue-3649.rs: New test.


