### PR TITLE
gccrs: Add test case to show issue is fixed

### DIFF
--- a/gcc/testsuite/rust/compile/issue-3711.rs
+++ b/gcc/testsuite/rust/compile/issue-3711.rs
@@ -1,0 +1,17 @@
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "fn_once"]
+pub trait FnOnce<Args> {
+    #[lang = "fn_once_output"]
+    type Output;
+
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+}
+
+fn returns_closure() -> _ {
+    // { dg-error "the type placeholder ._. is not allowed within types on item signatures .E0121." "" { target *-*-* } .-1 }
+    || 0
+}
+
+fn main() {}


### PR DESCRIPTION
This was already fixed in: bb01719f0e1 but we require fn_once lang item to be defined as we are working on libcore support still.

Fixes Rust-GCC#3711

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3711.rs: New test.
