### PR TITLE
gccrs: prealloc the initilizer vector

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -1965,8 +1965,12 @@ CompileExpr::array_copied_expr (location_t expr_locus,
   if (ctx->const_context_p ())
     {
       size_t idx = 0;
+
       std::vector<unsigned long> indexes;
       std::vector<tree> constructor;
+
+      indexes.reserve (len);
+      constructor.reserve (len);
       for (unsigned HOST_WIDE_INT i = 0; i < len; i++)
 	{
 	  constructor.push_back (translated_expr);


### PR DESCRIPTION
There are two cases when initilizing an array, this is the const context which means we need to build the array ctor, which means using lots of memory, its super inefficient because we are using a big wrapper over the GCC internals here but preallocating the vectors here causes a:

  terminate called after throwing an instance of 'std::bad_alloc'

So this is a handy error condition to rely on for this senario.

Fixes Rust-GCC#3713
Fixes Rust-GCC#3727

gcc/rust/ChangeLog:

	* backend/rust-compile-expr.cc (CompileExpr::array_copied_expr): prealloc the vector
