### PR TITLE
gccrs: Add test case to show ICE is fixed

### DIFF
--- a/gcc/testsuite/rust/compile/issue-3662.rs
+++ b/gcc/testsuite/rust/compile/issue-3662.rs
@@ -1,0 +1,8 @@
+pub fn rlib() {
+    let _ = ((-1 as i8) << 8 - 1) as f32;
+    let _ = 0u8 as char;
+    let _ = true > false;
+    let _ = true >= false;
+    let _ = true < false;
+    let _ = true >= false;
+}


### PR DESCRIPTION
Fixes Rust-GCC#3662

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3662.rs: New test.
