### PR TITLE
gccrs: Add test case to show ice is fixed

### DIFF
--- a/gcc/testsuite/rust/compile/issue-3652.rs
+++ b/gcc/testsuite/rust/compile/issue-3652.rs
@@ -1,0 +1,7 @@
+trait Foo {
+    type T;
+    fn foo() -> T<<Self as Foo>::T>;
+    // { dg-error "could not resolve type path .T. .E0412." "" { target *-*-* } .-1 }
+}
+
+fn foo() {}

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -21,4 +21,5 @@ torture/name_resolve1.rs
 issue-3568.rs
 issue-3663.rs
 issue-3671.rs
+issue-3652.rs
 # please don't delete the trailing newline


### PR DESCRIPTION
Fixes Rust-GCC#3652

gcc/testsuite/ChangeLog:

	* rust/compile/nr2/exclude: nr2 does not error on the T it should require Self::T
	* rust/compile/issue-3652.rs: New test.
