### PR TITLE
nr2.0: Improve error handling

### DIFF
--- a/gcc/rust/resolve/rust-early-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver-2.0.cc
@@ -141,6 +141,10 @@ Early::build_import_mapping (
       // be moved into the newly created import mappings
       auto path = import.to_resolve;
 
+      // used to skip the "unresolved import" error
+      // if we output other errors during resolution
+      size_t old_error_count = macro_resolve_errors.size ();
+
       switch (import.kind)
 	{
 	case TopLevel::ImportKind::Kind::Glob:
@@ -154,7 +158,7 @@ Early::build_import_mapping (
 	  break;
 	}
 
-      if (!found)
+      if (!found && old_error_count == macro_resolve_errors.size ())
 	collect_error (Error (path.get_final_segment ().get_locus (),
 			      ErrorCode::E0433, "unresolved import %qs",
 			      path.as_string ().c_str ()));

--- a/gcc/rust/resolve/rust-early-name-resolver-2.0.h
+++ b/gcc/rust/resolve/rust-early-name-resolver-2.0.h
@@ -218,7 +218,6 @@ private:
   std::vector<std::pair<Rib::Definition, Namespace>>
   resolve_path_in_all_ns (const P &path)
   {
-    const auto &segments = path.get_segments ();
     std::vector<std::pair<Rib::Definition, Namespace>> resolved;
 
     // Pair a definition with the namespace it was found in
@@ -229,12 +228,21 @@ private:
       };
     };
 
-    ctx.resolve_path (segments, Namespace::Values)
+    std::vector<Error> value_errors;
+    std::vector<Error> type_errors;
+    std::vector<Error> macro_errors;
+
+    ctx.resolve_path (path, value_errors, Namespace::Values)
       .map (pair_with_ns (Namespace::Values));
-    ctx.resolve_path (segments, Namespace::Types)
+    ctx.resolve_path (path, type_errors, Namespace::Types)
       .map (pair_with_ns (Namespace::Types));
-    ctx.resolve_path (segments, Namespace::Macros)
+    ctx.resolve_path (path, macro_errors, Namespace::Macros)
       .map (pair_with_ns (Namespace::Macros));
+
+    if (!value_errors.empty () && !type_errors.empty ()
+	&& !macro_errors.empty ())
+      for (auto &ent : value_errors)
+	collect_error (std::move (ent));
 
     return resolved;
   }

--- a/gcc/rust/resolve/rust-forever-stack.h
+++ b/gcc/rust/resolve/rust-forever-stack.h
@@ -673,7 +673,8 @@ public:
   template <typename S>
   tl::optional<Rib::Definition> resolve_path (
     const std::vector<S> &segments, bool has_opening_scope_resolution,
-    std::function<void (const S &, NodeId)> insert_segment_resolution);
+    std::function<void (const S &, NodeId)> insert_segment_resolution,
+    std::vector<Error> &collect_errors);
 
   // FIXME: Documentation
   tl::optional<Resolver::CanonicalPath> to_canonical_path (NodeId id) const;
@@ -792,13 +793,15 @@ private:
   tl::optional<SegIterator<S>> find_starting_point (
     const std::vector<S> &segments,
     std::reference_wrapper<Node> &starting_point,
-    std::function<void (const S &, NodeId)> insert_segment_resolution);
+    std::function<void (const S &, NodeId)> insert_segment_resolution,
+    std::vector<Error> &collect_errors);
 
   template <typename S>
   tl::optional<Node &> resolve_segments (
     Node &starting_point, const std::vector<S> &segments,
     SegIterator<S> iterator,
-    std::function<void (const S &, NodeId)> insert_segment_resolution);
+    std::function<void (const S &, NodeId)> insert_segment_resolution,
+    std::vector<Error> &collect_errors);
 
   tl::optional<Rib::Definition> resolve_final_segment (Node &final_node,
 						       std::string &seg_name,

--- a/gcc/rust/resolve/rust-name-resolution-context.h
+++ b/gcc/rust/resolve/rust-name-resolution-context.h
@@ -220,9 +220,10 @@ public:
   tl::optional<NodeId> lookup (NodeId usage) const;
 
   template <typename S>
-  tl::optional<Rib::Definition> resolve_path (const std::vector<S> &segments,
-					      bool has_opening_scope_resolution,
-					      Namespace ns)
+  tl::optional<Rib::Definition>
+  resolve_path (const std::vector<S> &segments,
+		bool has_opening_scope_resolution,
+		std::vector<Error> &collect_errors, Namespace ns)
   {
     std::function<void (const S &, NodeId)> insert_segment_resolution
       = [this] (const S &seg, NodeId id) {
@@ -234,60 +235,102 @@ public:
       {
       case Namespace::Values:
 	return values.resolve_path (segments, has_opening_scope_resolution,
-				    insert_segment_resolution);
+				    insert_segment_resolution, collect_errors);
       case Namespace::Types:
 	return types.resolve_path (segments, has_opening_scope_resolution,
-				   insert_segment_resolution);
+				   insert_segment_resolution, collect_errors);
       case Namespace::Macros:
 	return macros.resolve_path (segments, has_opening_scope_resolution,
-				    insert_segment_resolution);
+				    insert_segment_resolution, collect_errors);
       case Namespace::Labels:
 	return labels.resolve_path (segments, has_opening_scope_resolution,
-				    insert_segment_resolution);
+				    insert_segment_resolution, collect_errors);
       default:
 	rust_unreachable ();
       }
   }
 
   template <typename S, typename... Args>
-  tl::optional<Rib::Definition> resolve_path (const std::vector<S> &segments,
-					      bool has_opening_scope_resolution,
-					      Args... ns_args)
+  tl::optional<Rib::Definition>
+  resolve_path (const std::vector<S> &segments,
+		bool has_opening_scope_resolution,
+		tl::optional<std::vector<Error> &> collect_errors,
+		Namespace ns_first, Args... ns_args)
   {
-    std::initializer_list<Namespace> namespaces = {ns_args...};
+    std::initializer_list<Namespace> namespaces = {ns_first, ns_args...};
 
     for (auto ns : namespaces)
       {
-	if (auto ret
-	    = resolve_path (segments, has_opening_scope_resolution, ns))
+	std::vector<Error> collect_errors_inner;
+	if (auto ret = resolve_path (segments, has_opening_scope_resolution,
+				     collect_errors_inner, ns))
 	  return ret;
+	if (!collect_errors_inner.empty ())
+	  {
+	    if (collect_errors.has_value ())
+	      {
+		std::move (collect_errors_inner.begin (),
+			   collect_errors_inner.end (),
+			   std::back_inserter (collect_errors.value ()));
+	      }
+	    else
+	      {
+		for (auto &e : collect_errors_inner)
+		  e.emit ();
+	      }
+	    return tl::nullopt;
+	  }
       }
 
     return tl::nullopt;
   }
 
   template <typename... Args>
-  tl::optional<Rib::Definition> resolve_path (const AST::SimplePath &path,
-					      Args... ns_args)
+  tl::optional<Rib::Definition>
+  resolve_path (const AST::SimplePath &path,
+		tl::optional<std::vector<Error> &> collect_errors,
+		Namespace ns_first, Args... ns_args)
   {
     return resolve_path (path.get_segments (),
-			 path.has_opening_scope_resolution (), ns_args...);
+			 path.has_opening_scope_resolution (), collect_errors,
+			 ns_first, ns_args...);
   }
 
   template <typename... Args>
-  tl::optional<Rib::Definition> resolve_path (const AST::PathInExpression &path,
-					      Args... ns_args)
+  tl::optional<Rib::Definition>
+  resolve_path (const AST::PathInExpression &path,
+		tl::optional<std::vector<Error> &> collect_errors,
+		Namespace ns_first, Args... ns_args)
   {
     return resolve_path (path.get_segments (), path.opening_scope_resolution (),
-			 ns_args...);
+			 collect_errors, ns_first, ns_args...);
   }
 
   template <typename... Args>
-  tl::optional<Rib::Definition> resolve_path (const AST::TypePath &path,
-					      Args... ns_args)
+  tl::optional<Rib::Definition>
+  resolve_path (const AST::TypePath &path,
+		tl::optional<std::vector<Error> &> collect_errors,
+		Namespace ns_first, Args... ns_args)
   {
     return resolve_path (path.get_segments (),
-			 path.has_opening_scope_resolution_op (), ns_args...);
+			 path.has_opening_scope_resolution_op (),
+			 collect_errors, ns_first, ns_args...);
+  }
+
+  template <typename P, typename... Args>
+  tl::optional<Rib::Definition> resolve_path (const P &path, Namespace ns_first,
+					      Args... ns_args)
+  {
+    return resolve_path (path, tl::nullopt, ns_first, ns_args...);
+  }
+
+  template <typename P, typename... Args>
+  tl::optional<Rib::Definition>
+  resolve_path (const P &path_segments, bool has_opening_scope_resolution,
+		Namespace ns_first, Args... ns_args)
+  {
+    return resolve_path (path_segments, has_opening_scope_resolution,
+			 tl::nullopt, ns_first, ns_args...);
   }
 
 private:

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -18,7 +18,6 @@ derive-default1.rs
 derive-eq-invalid.rs
 torture/alt_patterns1.rs
 torture/name_resolve1.rs
-issue-3568.rs
 issue-3663.rs
 issue-3671.rs
 issue-3652.rs


### PR DESCRIPTION
This should allow errors produced directly or indirectly by `ForeverStack::resolve_path` to be intelligently emitted or discarded. This can be used to avoid duplicate error messages, and in the near future for better language prelude and `pub(in <path>)` handling.