### PR TITLE
Disable parallel testing for 'rust/compile/nr2/compile.exp' [PR119508]

### DIFF
--- a/gcc/testsuite/rust/compile/nr2/compile.exp
+++ b/gcc/testsuite/rust/compile/nr2/compile.exp
@@ -19,6 +19,15 @@
 # Load support procs.
 load_lib rust-dg.exp
 
+# These tests don't run runtest_file_p consistently if it
+# doesn't return the same values, so disable parallelization
+# of this *.exp file.  The first parallel runtest to reach
+# this will run all the tests serially.
+if ![gcc_parallel_test_run_p compile] {
+    return
+}
+gcc_parallel_test_enable 0
+
 # Initialize `dg'.
 dg-init
 
@@ -136,3 +145,5 @@ namespace eval rust-nr2-ns {
 
 # All done.
 dg-finish
+
+gcc_parallel_test_enable 1


### PR DESCRIPTION
..., using the standard idiom.  This '*.exp' file doesn't adhere to the parallel testing protocol as defined in 'gcc/testsuite/lib/gcc-defs.exp'.

This also restores proper behavior for '*.exp' files executing after (!) this one, which erroneously caused hundreds or even thousands of individual test cases get duplicated vs. skipped, randomly, depending on the '-jN' level.

	PR testsuite/119508
	gcc/testsuite/
	* rust/compile/nr2/compile.exp: Disable parallel testing.

(cherry picked from commit 79d2c3089f480738613b7d338d86d8be710f8158)

Resolves Rust-GCC/gccrs#3740.
