### PR TITLE
Completely duplicate path node

### DIFF
--- a/gcc/rust/expand/rust-derive-clone.cc
+++ b/gcc/rust/expand/rust-derive-clone.cc
@@ -293,8 +293,14 @@ DeriveClone::clone_enum_struct (PathInExpression variant_path,
     new ReferencePattern (std::unique_ptr<Pattern> (new StructPattern (
 			    variant_path, loc, pattern_elts)),
 			  false, false, loc));
+
+  PathInExpression new_path (variant_path.get_segments (),
+			     variant_path.get_outer_attrs (),
+			     variant_path.get_locus (),
+			     variant_path.opening_scope_resolution ());
+
   auto expr = std::unique_ptr<Expr> (
-    new StructExprStructFields (variant_path, std::move (cloned_fields), loc));
+    new StructExprStructFields (new_path, std::move (cloned_fields), loc));
 
   return builder.match_case (std::move (pattern), std::move (expr));
 }

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -6,7 +6,6 @@ pub_restricted_1.rs
 pub_restricted_2.rs
 pub_restricted_3.rs
 issue-2905-2.rs
-derive_clone_enum3.rs
 derive-default1.rs
 derive-eq-invalid.rs
 torture/alt_patterns1.rs


### PR DESCRIPTION
Both nodes had the same id, this led to a resolution conflict.

Fixes #3474