### PR TITLE
nr2.0: late: Correctly initialize funny_error member

### DIFF
--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
@@ -33,7 +33,9 @@
 namespace Rust {
 namespace Resolver2_0 {
 
-Late::Late (NameResolutionContext &ctx) : DefaultResolver (ctx) {}
+Late::Late (NameResolutionContext &ctx)
+  : DefaultResolver (ctx), funny_error (false)
+{}
 
 static NodeId
 next_node_id ()


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* resolve/rust-late-name-resolver-2.0.cc (Late::Late): False initialize the
	funny_error field.
