### PR TITLE
nr2.0: Adjust enum item visitors

### DIFF
--- a/gcc/rust/ast/rust-ast-visitor.cc
+++ b/gcc/rust/ast/rust-ast-visitor.cc
@@ -922,7 +922,7 @@ DefaultASTVisitor::visit (AST::EnumItem &item)
 void
 DefaultASTVisitor::visit (AST::EnumItemTuple &item)
 {
-  visit (reinterpret_cast<EnumItem &> (item));
+  DefaultASTVisitor::visit (reinterpret_cast<EnumItem &> (item));
   for (auto &field : item.get_tuple_fields ())
     visit (field);
 }
@@ -930,7 +930,7 @@ DefaultASTVisitor::visit (AST::EnumItemTuple &item)
 void
 DefaultASTVisitor::visit (AST::EnumItemStruct &item)
 {
-  visit (reinterpret_cast<EnumItem &> (item));
+  DefaultASTVisitor::visit (reinterpret_cast<EnumItem &> (item));
   for (auto &field : item.get_struct_fields ())
     visit (field);
 }
@@ -938,7 +938,7 @@ DefaultASTVisitor::visit (AST::EnumItemStruct &item)
 void
 DefaultASTVisitor::visit (AST::EnumItemDiscriminant &item)
 {
-  visit (reinterpret_cast<EnumItem &> (item));
+  DefaultASTVisitor::visit (reinterpret_cast<EnumItem &> (item));
   visit (item.get_expr ());
 }
 

--- a/gcc/rust/ast/rust-collect-lang-items.cc
+++ b/gcc/rust/ast/rust-collect-lang-items.cc
@@ -109,5 +109,29 @@ CollectLangItems::visit (AST::EnumItem &item)
   DefaultASTVisitor::visit (item);
 }
 
+void
+CollectLangItems::visit (AST::EnumItemTuple &item)
+{
+  maybe_add_lang_item (item);
+
+  DefaultASTVisitor::visit (item);
+}
+
+void
+CollectLangItems::visit (AST::EnumItemStruct &item)
+{
+  maybe_add_lang_item (item);
+
+  DefaultASTVisitor::visit (item);
+}
+
+void
+CollectLangItems::visit (AST::EnumItemDiscriminant &item)
+{
+  maybe_add_lang_item (item);
+
+  DefaultASTVisitor::visit (item);
+}
+
 } // namespace AST
 } // namespace Rust

--- a/gcc/rust/ast/rust-collect-lang-items.h
+++ b/gcc/rust/ast/rust-collect-lang-items.h
@@ -50,6 +50,9 @@ public:
   void visit (AST::Function &item) override;
   void visit (AST::StructStruct &item) override;
   void visit (AST::EnumItem &item) override;
+  void visit (AST::EnumItemTuple &item) override;
+  void visit (AST::EnumItemStruct &item) override;
+  void visit (AST::EnumItemDiscriminant &item) override;
 
 private:
   template <typename T> void maybe_add_lang_item (const T &item);

--- a/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
@@ -374,24 +374,32 @@ void
 TopLevel::visit (AST::EnumItem &variant)
 {
   insert_enum_variant_or_error_out (variant.get_identifier (), variant);
+
+  DefaultResolver::visit (variant);
 }
 
 void
 TopLevel::visit (AST::EnumItemTuple &variant)
 {
   insert_enum_variant_or_error_out (variant.get_identifier (), variant);
+
+  DefaultResolver::visit (variant);
 }
 
 void
 TopLevel::visit (AST::EnumItemStruct &variant)
 {
   insert_enum_variant_or_error_out (variant.get_identifier (), variant);
+
+  DefaultResolver::visit (variant);
 }
 
 void
 TopLevel::visit (AST::EnumItemDiscriminant &variant)
 {
   insert_or_error_out (variant.get_identifier (), variant, Namespace::Types);
+
+  DefaultResolver::visit (variant);
 }
 
 void


### PR DESCRIPTION
This should make the visitation of `EnumItem` instances more straightforward, as well as add some missing calls to base class visitors