### PR TITLE
gccrs: Prevent passing generic arguments to impl traits in argument position

### DIFF
--- a/gcc/rust/ast/rust-desugar-apit.cc
+++ b/gcc/rust/ast/rust-desugar-apit.cc
@@ -203,7 +203,8 @@ public:
 
     // Create the new generic parameter
     auto generic_param = std::unique_ptr<TypeParam> (
-      new TypeParam (ident, type.get_locus (), std::move (bounds)));
+      new TypeParam (ident, type.get_locus (), std::move (bounds), nullptr, {},
+		     true /*from impl trait*/));
 
     // Store the generic parameter to be added to the function signature
     implicit_generic_params.push_back (std::move (generic_param));
@@ -241,7 +242,8 @@ public:
 
     // Create the new generic parameter
     auto generic_param = std::unique_ptr<TypeParam> (
-      new TypeParam (ident, type.get_locus (), std::move (bounds)));
+      new TypeParam (ident, type.get_locus (), std::move (bounds), nullptr, {},
+		     true /*from impl trait*/));
 
     // Store the generic parameter to be added to the function signature
     implicit_generic_params.push_back (std::move (generic_param));

--- a/gcc/rust/hir/rust-ast-lower-type.cc
+++ b/gcc/rust/hir/rust-ast-lower-type.cc
@@ -620,7 +620,8 @@ ASTLowerGenericParam::visit (AST::TypeParam &param)
   translated
     = new HIR::TypeParam (mapping, param.get_type_representation (),
 			  param.get_locus (), std::move (type_param_bounds),
-			  std::move (type), param.get_outer_attrs ());
+			  std::move (type), param.get_outer_attrs (),
+			  param.from_impl_trait ());
 }
 
 HIR::TypeParamBound *

--- a/gcc/rust/hir/tree/rust-hir-item.cc
+++ b/gcc/rust/hir/tree/rust-hir-item.cc
@@ -26,16 +26,18 @@ TypeParam::TypeParam (
   Analysis::NodeMapping mappings, Identifier type_representation,
   location_t locus,
   std::vector<std::unique_ptr<TypeParamBound>> type_param_bounds,
-  tl::optional<std::unique_ptr<Type>> type, AST::AttrVec outer_attrs)
+  tl::optional<std::unique_ptr<Type>> type, AST::AttrVec outer_attrs,
+  bool was_impl_trait)
   : GenericParam (mappings), outer_attrs (std::move (outer_attrs)),
     type_representation (std::move (type_representation)),
     type_param_bounds (std::move (type_param_bounds)), type (std::move (type)),
-    locus (locus)
+    locus (locus), was_impl_trait (was_impl_trait)
 {}
 
 TypeParam::TypeParam (TypeParam const &other)
   : GenericParam (other.mappings), outer_attrs (other.outer_attrs),
-    type_representation (other.type_representation), locus (other.locus)
+    type_representation (other.type_representation), locus (other.locus),
+    was_impl_trait (other.was_impl_trait)
 {
   // guard to prevent null pointer dereference
   if (other.has_type ())
@@ -55,6 +57,7 @@ TypeParam::operator= (TypeParam const &other)
   outer_attrs = other.outer_attrs;
   locus = other.locus;
   mappings = other.mappings;
+  was_impl_trait = other.was_impl_trait;
 
   // guard to prevent null pointer dereference
   if (other.has_type ())

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -95,17 +95,11 @@ protected:
 class TypeParam : public GenericParam
 {
   AST::AttrVec outer_attrs;
-
   Identifier type_representation;
-
-  // bool has_type_param_bounds;
-  // TypeParamBounds type_param_bounds;
-  std::vector<std::unique_ptr<TypeParamBound>>
-    type_param_bounds; // inlined form
-
+  std::vector<std::unique_ptr<TypeParamBound>> type_param_bounds;
   tl::optional<std::unique_ptr<Type>> type;
-
   location_t locus;
+  bool was_impl_trait;
 
 public:
   // Returns whether the type of the type param has been specified.
@@ -121,9 +115,9 @@ public:
   TypeParam (Analysis::NodeMapping mappings, Identifier type_representation,
 	     location_t locus = UNDEF_LOCATION,
 	     std::vector<std::unique_ptr<TypeParamBound>> type_param_bounds
-	     = std::vector<std::unique_ptr<TypeParamBound>> (),
+	     = {},
 	     tl::optional<std::unique_ptr<Type>> type = tl::nullopt,
-	     AST::AttrVec outer_attrs = std::vector<AST::Attribute> ());
+	     AST::AttrVec outer_attrs = {}, bool was_impl_trait = false);
 
   // Copy constructor uses clone
   TypeParam (TypeParam const &other);
@@ -153,6 +147,8 @@ public:
   Analysis::NodeMapping get_type_mappings () const;
 
   std::vector<std::unique_ptr<TypeParamBound>> &get_type_param_bounds ();
+
+  bool from_impl_trait () const { return was_impl_trait; }
 
 protected:
   // Clone function implementation as (not pure) virtual method

--- a/gcc/rust/typecheck/rust-tyty-subst.h
+++ b/gcc/rust/typecheck/rust-tyty-subst.h
@@ -60,6 +60,7 @@ public:
   const ParamType *get_param_ty () const;
 
   HIR::TypeParam &get_generic_param ();
+  const HIR::TypeParam &get_generic_param () const;
 
   // this is used for the backend to override the HirId ref of the param to
   // what the concrete type is for the rest of the context

--- a/gcc/testsuite/rust/compile/impl_trait_generic_arg.rs
+++ b/gcc/testsuite/rust/compile/impl_trait_generic_arg.rs
@@ -1,0 +1,24 @@
+#[lang = "sized"]
+trait Sized {}
+
+trait Foo {
+    fn id(&self) -> u8;
+}
+
+struct Bar;
+
+impl Foo for Bar {
+    fn id(&self) -> u8 {
+        1
+    }
+}
+
+fn takes(val: impl Foo) -> u8 {
+    val.id()
+}
+
+fn main() {
+    let b = Bar;
+    let x = takes::<Bar>(b);
+    // { dg-error "cannot provide explicit generic arguments when .impl Trait. is used in argument position .E0632." "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -17,4 +17,5 @@ issue-3649.rs
 issue-1487.rs
 issue-2015.rs
 issue-3454.rs
+impl_trait_generic_arg.rs
 # please don't delete the trailing newline


### PR DESCRIPTION
When using impl traits in argument position (APIT), they are desugared into generics, and supplying explicit generic arguments is not allowed. This commit adds the error diagnostic E0632 for attempting to pass generic arguments to impl traits, completing the implementation of the APIT feature.

gcc/rust/ChangeLog:

	* ast/rust-desugar-apit.cc: track if this is a impl-trait generic
	* ast/rust-item.h (class TypeParam): add field to track if from impl trait
	* hir/rust-ast-lower-type.cc (ASTLowerGenericParam::visit): likewise
	* hir/tree/rust-hir-item.cc (TypeParam::TypeParam): upate hir as well
	(TypeParam::operator=): likewise
	* hir/tree/rust-hir-item.h (class TypeParam): likewise
	* typecheck/rust-tyty-subst.cc (SubstitutionParamMapping::get_generic_param): add error
	* typecheck/rust-tyty-subst.h: add const getter for the associated TypeParm

gcc/testsuite/ChangeLog:

	* rust/compile/nr2/exclude: nr2 cant handle this
	* rust/compile/impl_trait_generic_arg.rs: New test.
