### PR TITLE
Fix ICE segfault on empty static loops

### DIFF
--- a/gcc/rust/backend/rust-constexpr.cc
+++ b/gcc/rust/backend/rust-constexpr.cc
@@ -1901,6 +1901,9 @@ eval_constant_expression (const constexpr_ctx *ctx, tree t, bool lval,
 
   location_t loc = EXPR_LOCATION (t);
 
+  if (t == NULL_TREE)
+    return NULL_TREE;
+
   if (CONSTANT_CLASS_P (t))
     {
       if (TREE_OVERFLOW (t))

--- a/gcc/testsuite/rust/compile/issue-3618.rs
+++ b/gcc/testsuite/rust/compile/issue-3618.rs
@@ -1,0 +1,1 @@
+static _X: () = loop {}; // { dg-error "loop iteration count exceeds limit" }


### PR DESCRIPTION
This PR addresses #3618. With this change, the expected error of reaching the iteration limit is reported:

```
test.rs:1:17: error: ‘constexpr’ loop iteration count exceeds limit of 262144 (use ‘-fconstexpr-loop-limit=’ to increase the limit)
    1 | static _X: () = loop {};
      |                 ^~~~
```

My handling of `t` being a `NULL_TREE` may not be appropriate in `eval_constant_expression`, seeking guidance there.

Fixes #3618 