### PR TITLE
Fix test `same_field_name.rs`

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-item.cc
+++ b/gcc/rust/hir/rust-ast-lower-item.cc
@@ -217,7 +217,7 @@ ASTLoweringItem::visit (AST::StructStruct &struct_decl)
 					 field.get_outer_attrs ());
 
       if (struct_field_name_exists (fields, translated_field))
-	break;
+	continue;
 
       fields.push_back (std::move (translated_field));
     }

--- a/gcc/testsuite/rust/compile/same_field_name.rs
+++ b/gcc/testsuite/rust/compile/same_field_name.rs
@@ -1,7 +1,7 @@
 // https://doc.rust-lang.org/error_codes/E0124.html
 fn main() {
     struct Foo {
-        field1: i32, // { dg-error "field .field1. is already declared" }
+        field1: i32,
         field1: i32, // { dg-error "field .field1. is already declared" }
         field1: i32, // { dg-error "field .field1. is already declared" }
     }


### PR DESCRIPTION
As far as I can tell, this test should have been a compile test. Also, it seems like execute tests don't interact well with `dg-error` directives.