### PR TITLE
gccrs: We cant clone types as it will dup the node-id

### DIFF
--- a/gcc/rust/expand/rust-derive-default.cc
+++ b/gcc/rust/expand/rust-derive-default.cc
@@ -98,7 +98,8 @@ DeriveDefault::visit_struct (StructStruct &item)
   for (auto &field : item.get_fields ())
     {
       auto name = field.get_field_name ().as_string ();
-      auto expr = default_call (field.get_field_type ().clone_type ());
+      auto type = Builder::new_type (field.get_field_type ());
+      auto expr = default_call (std::move (type));
 
       cloned_fields.emplace_back (
 	builder.struct_expr_field (std::move (name), std::move (expr)));
@@ -119,7 +120,7 @@ DeriveDefault::visit_tuple (TupleStruct &tuple_item)
 
   for (auto &field : tuple_item.get_fields ())
     {
-      auto type = field.get_field_type ().clone_type ();
+      auto type = Builder::new_type (field.get_field_type ());
 
       defaulted_fields.emplace_back (default_call (std::move (type)));
     }

--- a/gcc/rust/expand/rust-derive-eq.cc
+++ b/gcc/rust/expand/rust-derive-eq.cc
@@ -142,7 +142,10 @@ DeriveEq::visit_tuple (TupleStruct &item)
   auto types = std::vector<std::unique_ptr<Type>> ();
 
   for (auto &field : item.get_fields ())
-    types.emplace_back (field.get_field_type ().clone_type ());
+    {
+      auto type = Builder::new_type (field.get_field_type ());
+      types.emplace_back (std::move (type));
+    }
 
   expanded = eq_impls (assert_receiver_is_total_eq_fn (std::move (types)),
 		       item.get_identifier ().as_string (),
@@ -155,7 +158,10 @@ DeriveEq::visit_struct (StructStruct &item)
   auto types = std::vector<std::unique_ptr<Type>> ();
 
   for (auto &field : item.get_fields ())
-    types.emplace_back (field.get_field_type ().clone_type ());
+    {
+      auto type = Builder::new_type (field.get_field_type ());
+      types.emplace_back (std::move (type));
+    }
 
   expanded = eq_impls (assert_receiver_is_total_eq_fn (std::move (types)),
 		       item.get_identifier ().as_string (),
@@ -179,15 +185,20 @@ DeriveEq::visit_enum (Enum &item)
 	    auto &tuple = static_cast<EnumItemTuple &> (*variant);
 
 	    for (auto &field : tuple.get_tuple_fields ())
-	      types.emplace_back (field.get_field_type ().clone_type ());
-
+	      {
+		auto type = Builder::new_type (field.get_field_type ());
+		types.emplace_back (std::move (type));
+	      }
 	    break;
 	  }
 	  case EnumItem::Kind::Struct: {
 	    auto &tuple = static_cast<EnumItemStruct &> (*variant);
 
 	    for (auto &field : tuple.get_struct_fields ())
-	      types.emplace_back (field.get_field_type ().clone_type ());
+	      {
+		auto type = Builder::new_type (field.get_field_type ());
+		types.emplace_back (std::move (type));
+	      }
 
 	    break;
 	  }
@@ -205,7 +216,10 @@ DeriveEq::visit_union (Union &item)
   auto types = std::vector<std::unique_ptr<Type>> ();
 
   for (auto &field : item.get_variants ())
-    types.emplace_back (field.get_field_type ().clone_type ());
+    {
+      auto type = Builder::new_type (field.get_field_type ());
+      types.emplace_back (std::move (type));
+    }
 
   expanded = eq_impls (assert_receiver_is_total_eq_fn (std::move (types)),
 		       item.get_identifier ().as_string (),

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -6,8 +6,6 @@ pub_restricted_1.rs
 pub_restricted_2.rs
 pub_restricted_3.rs
 issue-2905-2.rs
-derive-default1.rs
-derive-eq-invalid.rs
 torture/alt_patterns1.rs
 torture/name_resolve1.rs
 issue-3671.rs


### PR DESCRIPTION
This patch ensuers we reuse the Builder for new type to ensure we create a new type from scratch ensuring consistent new node-ids.

gcc/rust/ChangeLog:

	* expand/rust-derive-default.cc (DeriveDefault::visit_struct): use builder
	(DeriveDefault::visit_tuple): likewise
	* expand/rust-derive-eq.cc (DeriveEq::visit_tuple): likewise
	(DeriveEq::visit_struct): likewise
	(DeriveEq::visit_enum): likewise
	(DeriveEq::visit_union): likewise

gcc/testsuite/ChangeLog:

	* rust/compile/nr2/exclude: these are fixed now
