### PR TITLE
gccrs: Fix NR2 ICE in visit_attributes

### DIFF
--- a/gcc/rust/resolve/rust-early-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver-2.0.cc
@@ -350,7 +350,8 @@ Early::visit_attributes (std::vector<AST::Attribute> &attrs)
 	  auto pm_def = mappings.lookup_attribute_proc_macro_def (
 	    definition->get_node_id ());
 
-	  rust_assert (pm_def.has_value ());
+	  if (!pm_def.has_value ())
+	    return;
 
 	  mappings.insert_attribute_proc_macro_invocation (attr.get_path (),
 							   pm_def.value ());

--- a/gcc/testsuite/rust/compile/issue-3661.rs
+++ b/gcc/testsuite/rust/compile/issue-3661.rs
@@ -1,0 +1,10 @@
+pub macro m($inner_str:expr) {
+    #[m = $inner_str] 
+    // { dg-error "macro not found" "" { target *-*-* } .-1 }
+
+    struct S;
+}
+
+fn main() {
+    m!(stringify!(foo));
+}


### PR DESCRIPTION
Undefined attribute macros have no proc macro definition, which results in a failing `rust_assert`. This changes that assert to an if statement, that returns early if there is no proc macro definition. Fixes #3661.

I chose not to add an error in the if statement, because NR1 does not throw an additional error. Adding this return avoids the failing assert, and results in `error: macro not found` to be reported, exact same behavior as NR1.

Unsure if I placed the test file in the correct directory. Might be better placed in /macros.

- \[X] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[X] Read contributing guidlines
- \[X] `make check-rust` passes locally
- \[X] Run `clang-format`
- \[X] Added any relevant test cases to `gcc/testsuite/rust/`
