### PR TITLE
ast: Check before visiting a while-let's label

### DIFF
--- a/gcc/rust/ast/rust-ast-visitor.cc
+++ b/gcc/rust/ast/rust-ast-visitor.cc
@@ -594,7 +594,10 @@ DefaultASTVisitor::visit (AST::WhileLetLoopExpr &expr)
   visit_outer_attrs (expr);
   for (auto &pattern : expr.get_patterns ())
     visit (pattern);
-  visit (expr.get_loop_label ());
+
+  if (expr.has_loop_label ())
+    visit (expr.get_loop_label ());
+
   visit (expr.get_scrutinee_expr ());
   visit (expr.get_loop_block ());
 }

--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.h
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.h
@@ -42,6 +42,7 @@ public:
 
   // some more label declarations
   void visit (AST::LetStmt &) override;
+  void visit (AST::WhileLetLoopExpr &) override;
   // TODO: Do we need this?
   // void visit (AST::Method &) override;
   void visit (AST::IdentifierPattern &) override;

--- a/gcc/rust/resolve/rust-name-resolution-context.h
+++ b/gcc/rust/resolve/rust-name-resolution-context.h
@@ -198,6 +198,7 @@ enum class BindingSource
   Match,
   Let,
   IfLet,
+  WhileLet,
   For,
   /* Closure param or function param */
   Param

--- a/gcc/testsuite/rust/compile/while_let_without_label.rs
+++ b/gcc/testsuite/rust/compile/while_let_without_label.rs
@@ -1,0 +1,11 @@
+// { dg-additional-options "-frust-compile-until=lowering" }
+
+enum Foo {
+    A(i32),
+}
+
+fn main() {
+    let b = Foo::A(15);
+
+    while let Foo::A(x) = b {}
+}


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* ast/rust-ast-visitor.cc (DefaultASTVisitor::visit): Check that the WhileLet has a label
	before visiting it.

gcc/testsuite/ChangeLog:

	* rust/compile/while_let_without_label.rs: New test.
