### PR TITLE
parser: fix ICE std::out_of_range with path attrs to nonexisting path

### DIFF
--- a/gcc/rust/parse/rust-parse.cc
+++ b/gcc/rust/parse/rust-parse.cc
@@ -42,8 +42,7 @@ extract_module_path (const AST::AttrVec &inner_attrs,
     {
       rust_error_at (
 	path_attr.get_locus (),
-	// Split the format string so that -Wformat-diag does not complain...
-	"path attributes must contain a filename: '%s'", "#![path = \"file\"]");
+	"path attributes must contain a filename: %<#[path = \"file\"]%>");
       return name;
     }
 
@@ -67,8 +66,7 @@ extract_module_path (const AST::AttrVec &inner_attrs,
     {
       rust_error_at (
 	path_attr.get_locus (),
-	// Split the format string so that -Wformat-diag does not complain...
-	"path attributes must contain a filename: '%s'", "#[path = \"file\"]");
+	"path attributes must contain a filename: %<#[path = \"file\"]%>");
       return name;
     }
 
@@ -79,6 +77,15 @@ extract_module_path (const AST::AttrVec &inner_attrs,
   // In order to do this, we can simply go through the string until we find
   // a character that is not an equal sign or whitespace
   auto filename_begin = path_value.find_first_not_of ("=\t ");
+
+  // If the path consists of only whitespace, then we have an error
+  if (filename_begin == std::string::npos)
+    {
+      rust_error_at (
+	path_attr.get_locus (),
+	"path attributes must contain a filename: %<#[path = \"file\"]%>");
+      return name;
+    }
 
   auto path = path_value.substr (filename_begin);
 

--- a/gcc/testsuite/rust/compile/torture/extern_mod2.rs
+++ b/gcc/testsuite/rust/compile/torture/extern_mod2.rs
@@ -12,6 +12,12 @@ mod no_leading_equal;
 #[path       =     "modules/valid_path.rs"]
 mod extra_spaces;
 
+#[path = ""]  // { dg-error "path attributes must contain a filename" }
+mod empty_path; // { dg-error "no candidate found" }
+
+#[path = "          "]  // { dg-error "path attributes must contain a filename" }
+mod path_with_spaces; // { dg-error "no candidate found" }
+
 #[path] // { dg-error "path attributes must contain a filename" }
 mod error; // { dg-error "no candidate found" }
 


### PR DESCRIPTION
Stops an ICE from occuring when path attribute is empty

Fixes Rust-GCC#3607

gcc/rust/Changelog:
    * parse/rust-parse.cc (Rust::extract_module_path): Handle a case where the path is empty / has only whitespaces.

gcc/testsuite/Changelog:
    * rust/compile/torture/extern_mod2.rs: New tests to verify an error is thrown if the path is empty.

Signed-off by: vishruth-thimmaiah <vishruththimmaiah@gmail.com>


- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`
- \[x] Added any relevant test cases to `gcc/testsuite/rust/`
