### PR TITLE
gccrs: refactor default infer vars to be its own function

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check.h
+++ b/gcc/rust/typecheck/rust-hir-type-check.h
@@ -263,12 +263,14 @@ public:
   WARN_UNUSED_RESULT std::vector<TyTy::Region>
   regions_from_generic_args (const HIR::GenericArgs &args) const;
 
-  void compute_inference_variables (bool error);
+  void compute_inference_variables (bool emit_error);
 
   TyTy::VarianceAnalysis::CrateCtx &get_variance_analysis_ctx ();
 
 private:
   TypeCheckContext ();
+
+  bool compute_infer_var (HirId id, TyTy::BaseType *ty, bool emit_error);
 
   std::map<NodeId, HirId> node_id_refs;
   std::map<HirId, TyTy::BaseType *> resolved;


### PR DESCRIPTION
This is just a simple refactor to pull all the logic outside of the closure which makes it more readable.

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check.h: new function
	* typecheck/rust-typecheck-context.cc (TypeCheckContext::compute_inference_variables): call the new helper
	(TypeCheckContext::compute_infer_var): refactored code
