### PR TITLE
Adjust included headers in `rust-lang.cc`

### DIFF
--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -16,9 +16,8 @@
 // along with GCC; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
+#include "rust-system.h"
 #include "rust-diagnostics.h"
-#include "config.h"
-#include "system.h"
 #include "coretypes.h"
 #include "target.h"
 #include "tree.h"
@@ -66,7 +65,6 @@
  * e.g. HIR conversion.
  */
 
-#include "rust-system.h"
 #include "rust-session-manager.h"
 #include "rust-tree.h"
 


### PR DESCRIPTION
This was upstreamed as part of ea34614225d4d255e58f63206eb12178b870cb4c but never made it to our downstream repo. I've added @philberty as a co-author, since he wrote the upstream commit.

While this would effectively be included in #3761, I figured I'd split it off into a PR that could be explicitly merged in.