### PR TITLE
gccrs: Lower IdentifierPattern's to_bind to HIR

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-pattern.cc
+++ b/gcc/rust/hir/rust-ast-lower-pattern.cc
@@ -50,6 +50,11 @@ ASTLoweringPattern::visit (AST::IdentifierPattern &pattern)
 				 UNKNOWN_LOCAL_DEFID);
 
   std::unique_ptr<Pattern> to_bind;
+  if (pattern.has_pattern_to_bind ())
+    {
+      to_bind = std::unique_ptr<Pattern> (
+	ASTLoweringPattern::translate (pattern.get_pattern_to_bind ()));
+    }
   translated
     = new HIR::IdentifierPattern (mapping, pattern.get_ident (),
 				  pattern.get_locus (), pattern.get_is_ref (),

--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -2114,7 +2114,7 @@ Dump::visit (IdentifierPattern &e)
   put_field ("mut", std::to_string (e.is_mut ()));
 
   if (e.has_pattern_to_bind ())
-    put_field ("to_bind", e.get_to_bind ().as_string ());
+    visit_field ("to_bind", e.get_to_bind ());
   else
     put_field ("to_bind", "none");
 


### PR DESCRIPTION
This is part of making compilation of subpatterns (called `to_bind` in the code) of [IdentifierPattern](https://doc.rust-lang.org/reference/patterns.html#r-patterns.ident) work.

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidelines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

May be off-topic for this PR, but to those who have more experience with project, I'm currently having issues with `Resolver::TypeCheckContext` not storing the type of the lowered subpattern, which does not allow me to make changes to successfully compile the subpattern. Any advice will be appreciated!