### PR TITLE
fix: ICE when parsing unterminated raw byte strings

### DIFF
--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -1894,17 +1894,17 @@ Lexer::parse_raw_byte_string (location_t loc)
 	      break;
 	    }
 	}
+      else if (current_char.is_eof ())
+	{
+	  rust_error_at (string_begin_locus, "unended raw byte string literal");
+	  return Token::make (END_OF_FILE, get_current_location ());
+	}
       else if (current_char.value > 127)
 	{
 	  rust_error_at (get_current_location (),
 			 "character %<%s%> in raw byte string out of range",
 			 current_char.as_string ().c_str ());
 	  current_char = 0;
-	}
-      else if (current_char.is_eof ())
-	{
-	  rust_error_at (string_begin_locus, "unended raw byte string literal");
-	  return Token::make (END_OF_FILE, get_current_location ());
 	}
 
       length++;

--- a/gcc/testsuite/rust/compile/torture/unended-raw-byte-string.rs
+++ b/gcc/testsuite/rust/compile/torture/unended-raw-byte-string.rs
@@ -1,0 +1,6 @@
+// { dg-excess-errors "...." }
+fn main() {
+    // { dg-error "unended raw byte string literal" "" { target *-*-* } .+1 }
+    let s = br##"123"#
+}
+


### PR DESCRIPTION
Fixes an ICE when a raw byte string is not terminated

Fixes Rust-GCC#3731

gcc/rust/ChangeLog:

	* lex/rust-lex.cc (Lexer::parse_raw_byte_string): Fix infinite looping when a raw byte string is not terminated.

gcc/testsuite/ChangeLog:

	* rust/compile/torture/unended-raw-byte-string.rs: New test to ensure correct error message for unended raw byte string.


- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`
- \[x] Added any relevant test cases to `gcc/testsuite/rust/`