### PR TITLE
Add new function `ClosureExpr::get_definition_expr`

### DIFF
--- a/gcc/rust/ast/rust-ast-collector.cc
+++ b/gcc/rust/ast/rust-ast-collector.cc
@@ -1285,7 +1285,7 @@ TokenCollector::visit (ClosureExprInnerTyped &expr)
   visit_closure_common (expr);
   push (Rust::Token::make (RETURN_TYPE, expr.get_locus ()));
   visit (expr.get_return_type ());
-  visit (expr.get_definition_block ());
+  visit (expr.get_definition_expr ());
 }
 
 void

--- a/gcc/rust/ast/rust-ast-visitor.cc
+++ b/gcc/rust/ast/rust-ast-visitor.cc
@@ -474,7 +474,7 @@ DefaultASTVisitor::visit (AST::ClosureExprInnerTyped &expr)
   for (auto &param : expr.get_params ())
     visit (param);
   visit (expr.get_return_type ());
-  visit (expr.get_definition_block ());
+  visit (expr.get_definition_expr ());
 }
 
 void

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -2506,6 +2506,8 @@ public:
   bool get_has_move () const { return has_move; }
 
   Expr::Kind get_expr_kind () const override { return Expr::Kind::Closure; }
+
+  virtual Expr &get_definition_expr () = 0;
 };
 
 // Represents a non-type-specified closure expression AST node
@@ -2565,7 +2567,7 @@ public:
     return closure_inner == nullptr;
   }
 
-  Expr &get_definition_expr ()
+  Expr &get_definition_expr () override
   {
     rust_assert (closure_inner != nullptr);
     return *closure_inner;
@@ -2932,7 +2934,7 @@ public:
   bool is_marked_for_strip () const override { return expr == nullptr; }
 
   // TODO: is this better? Or is a "vis_block" better?
-  BlockExpr &get_definition_block ()
+  BlockExpr &get_definition_expr () override
   {
     rust_assert (expr != nullptr);
     return *expr;

--- a/gcc/rust/expand/rust-cfg-strip.cc
+++ b/gcc/rust/expand/rust-cfg-strip.cc
@@ -1190,7 +1190,7 @@ CfgStrip::visit (AST::ClosureExprInnerTyped &expr)
     rust_error_at (type.get_locus (), "cannot strip type in this position");
 
   // can't strip expression itself, but can strip sub-expressions
-  auto &definition_block = expr.get_definition_block ();
+  auto &definition_block = expr.get_definition_expr ();
   definition_block.accept_vis (*this);
   if (definition_block.is_marked_for_strip ())
     rust_error_at (definition_block.get_locus (),

--- a/gcc/rust/expand/rust-expand-visitor.cc
+++ b/gcc/rust/expand/rust-expand-visitor.cc
@@ -641,7 +641,7 @@ ExpandVisitor::visit (AST::ClosureExprInnerTyped &expr)
 
   maybe_expand_type (expr.get_return_type_ptr ());
 
-  visit (expr.get_definition_block ());
+  visit (expr.get_definition_expr ());
 }
 
 void

--- a/gcc/rust/hir/rust-ast-lower-expr.cc
+++ b/gcc/rust/hir/rust-ast-lower-expr.cc
@@ -836,7 +836,7 @@ ASTLoweringExpr::visit (AST::ClosureExprInnerTyped &expr)
 {
   HIR::Type *closure_return_type = nullptr;
   HIR::Expr *closure_expr
-    = ASTLoweringExpr::translate (expr.get_definition_block ());
+    = ASTLoweringExpr::translate (expr.get_definition_expr ());
 
   std::vector<HIR::ClosureParam> closure_params;
   for (auto &param : expr.get_params ())

--- a/gcc/rust/resolve/rust-ast-resolve-expr.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-expr.cc
@@ -779,7 +779,7 @@ ResolveExpr::visit (AST::ClosureExprInnerTyped &expr)
 
   resolver->push_closure_context (expr.get_node_id ());
 
-  ResolveExpr::go (expr.get_definition_block (), prefix, canonical_prefix);
+  ResolveExpr::go (expr.get_definition_expr (), prefix, canonical_prefix);
 
   resolver->pop_closure_context ();
 

--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
@@ -729,7 +729,7 @@ Late::visit (AST::ClosureExprInnerTyped &closure)
   ctx.bindings.exit ();
 
   visit (closure.get_return_type ());
-  visit (closure.get_definition_block ());
+  visit (closure.get_definition_expr ());
 }
 
 } // namespace Resolver2_0


### PR DESCRIPTION
I have another commit in the pipeline which depends on this and fixes test `execute/torture/closure4.rs` under name resolution 2.0