### PR TITLE
gccrs: Fix bad type canonicalization on ARRAY_TYPES

### DIFF
--- a/gcc/testsuite/rust/compile/const_generics_3.rs
+++ b/gcc/testsuite/rust/compile/const_generics_3.rs
@@ -1,4 +1,4 @@
-// { dg-additional-options "-w -frust-name-resolution-2.0" }
+// { dg-additional-options "-w -frust-name-resolution-2.0 -frust-compile-until=compilation" }
 
 #[lang = "sized"]
 trait Sized {}

--- a/gcc/testsuite/rust/compile/issue-3660.rs
+++ b/gcc/testsuite/rust/compile/issue-3660.rs
@@ -1,0 +1,3 @@
+pub static A: [u32; 2] = [1, 2];
+
+pub static B: [u8; 2] = [3, 4];


### PR DESCRIPTION
Fixes Rust-GCC#3660

gcc/rust/ChangeLog:

	* backend/rust-compile-type.cc (TyTyResolveCompile::visit): reuse GCC's build_array_type

gcc/testsuite/ChangeLog:

	* rust/compile/const_generics_3.rs:
	* rust/compile/issue-3660.rs: New test.

