### PR TITLE
nr2.0: Update IdentifierPattern's subpattern name resolution

### DIFF
--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
@@ -251,10 +251,7 @@ visit_identifier_as_pattern (NameResolutionContext &ctx,
 void
 Late::visit (AST::IdentifierPattern &identifier)
 {
-  if (identifier.has_subpattern ())
-    {
-      DefaultResolver::visit (identifier.get_subpattern ());
-    }
+  DefaultResolver::visit (identifier);
 
   visit_identifier_as_pattern (ctx, identifier.get_ident (),
 			       identifier.get_locus (),


### PR DESCRIPTION
Addresses [this comment](https://github.com/Rust-GCC/gccrs/pull/3822#discussion_r2149932447), thanks to @P-E-P for explaining the rationale for this change over meeting :)

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidelines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`