### PR TITLE
Adjust external crate lowering and type checking

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-item.h
+++ b/gcc/rust/hir/rust-ast-lower-item.h
@@ -45,6 +45,7 @@ public:
   void visit (AST::TraitImpl &impl_block) override;
   void visit (AST::ExternBlock &extern_block) override;
   void visit (AST::MacroRulesDefinition &rules_def) override;
+  void visit (AST::ExternCrate &extern_crate) override;
 
 private:
   ASTLoweringItem () : translated (nullptr) {}

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -1182,14 +1182,6 @@ Session::load_extern_crate (const std::string &crate_name, location_t locus)
   // name resolve it
   Resolver::NameResolution::Resolve (parsed_crate);
 
-  // perform hir lowering
-  std::unique_ptr<HIR::Crate> lowered
-    = HIR::ASTLowering::Resolve (parsed_crate);
-  HIR::Crate &hir = mappings.insert_hir_crate (std::move (lowered));
-
-  // perform type resolution
-  Resolver::TypeResolution::Resolve (hir);
-
   // always restore the crate_num
   mappings.set_current_crate (saved_crate_num);
 

--- a/gcc/rust/typecheck/rust-hir-type-check-item.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.h
@@ -51,9 +51,9 @@ public:
   void visit (HIR::ImplBlock &impl_block) override;
   void visit (HIR::ExternBlock &extern_block) override;
   void visit (HIR::Trait &trait_block) override;
+  void visit (HIR::ExternCrate &extern_crate) override;
 
   // nothing to do
-  void visit (HIR::ExternCrate &) override {}
   void visit (HIR::UseDeclaration &) override {}
 
 protected:


### PR DESCRIPTION
Name resolution 2.0 doesn't like crates being typechecked before the initialization of `ImmutableNameResolutionContext`