### PR TITLE
gccrs: Fix ICE when constant is missing and expression

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-item.cc
+++ b/gcc/rust/hir/rust-ast-lower-item.cc
@@ -367,7 +367,9 @@ ASTLoweringItem::visit (AST::ConstantItem &constant)
   HIR::Visibility vis = translate_visibility (constant.get_visibility ());
 
   HIR::Type *type = ASTLoweringType::translate (constant.get_type (), true);
-  HIR::Expr *expr = ASTLoweringExpr::translate (constant.get_expr ());
+  HIR::Expr *expr = nullptr;
+  if (constant.has_expr ())
+    expr = ASTLoweringExpr::translate (constant.get_expr ());
 
   auto crate_num = mappings.get_current_crate ();
   Analysis::NodeMapping mapping (crate_num, constant.get_node_id (),

--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -1926,7 +1926,8 @@ Dump::visit (ConstantItem &e)
   do_vis_item (e);
   put_field ("identifier", e.get_identifier ().as_string ());
   visit_field ("type", e.get_type ());
-  visit_field ("const_expr", e.get_expr ());
+  if (e.has_expr ())
+    visit_field ("const_expr", e.get_expr ());
   end ("ConstantItem");
 }
 

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -1797,6 +1797,8 @@ public:
     return *type;
   }
 
+  bool has_expr () const { return const_expr != nullptr; }
+
   Expr &get_expr () { return *const_expr; }
 
   Identifier get_identifier () const { return identifier; }

--- a/gcc/rust/resolve/rust-ast-resolve-item.cc
+++ b/gcc/rust/resolve/rust-ast-resolve-item.cc
@@ -453,7 +453,8 @@ ResolveItem::visit (AST::ConstantItem &constant)
   resolve_visibility (constant.get_visibility ());
 
   ResolveType::go (constant.get_type ());
-  ResolveExpr::go (constant.get_expr (), path, cpath);
+  if (constant.has_expr ())
+    ResolveExpr::go (constant.get_expr (), path, cpath);
 }
 
 void

--- a/gcc/rust/resolve/rust-ast-resolve-stmt.h
+++ b/gcc/rust/resolve/rust-ast-resolve-stmt.h
@@ -67,7 +67,8 @@ public:
       });
 
     ResolveType::go (constant.get_type ());
-    ResolveExpr::go (constant.get_expr (), prefix, canonical_prefix);
+    if (constant.has_expr ())
+      ResolveExpr::go (constant.get_expr (), prefix, canonical_prefix);
   }
 
   void visit (AST::LetStmt &stmt) override

--- a/gcc/rust/typecheck/rust-hir-type-check-stmt.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-stmt.cc
@@ -60,6 +60,12 @@ void
 TypeCheckStmt::visit (HIR::ConstantItem &constant)
 {
   TyTy::BaseType *type = TypeCheckType::Resolve (constant.get_type ());
+  if (!constant.has_expr ())
+    {
+      infered = type;
+      return;
+    }
+
   TyTy::BaseType *expr_type = TypeCheckExpr::Resolve (constant.get_expr ());
 
   infered = coercion_site (

--- a/gcc/testsuite/rust/compile/issue-3642.rs
+++ b/gcc/testsuite/rust/compile/issue-3642.rs
@@ -1,0 +1,9 @@
+#[lang = "sized"]
+trait Sized {}
+
+pub trait T<X> {
+    const D: i32 = {
+        // { dg-error "mismatched types, expected .i32. but got .()." "" { target *-*-* } .-1 }
+        const C: X;
+    };
+}

--- a/gcc/testsuite/rust/compile/nr2/exclude
+++ b/gcc/testsuite/rust/compile/nr2/exclude
@@ -4,4 +4,5 @@ issue-1487.rs
 issue-2015.rs
 issue-3454.rs
 impl_trait_generic_arg.rs
+issue-3642.rs
 # please don't delete the trailing newline


### PR DESCRIPTION
This is an invalid test case and doesnt work with rustc, we dont fully pick up the errors. Nr2 does handle this and puts out an extra good diagnostic but the old NR doesnt so for now i added this to the exclude list and then when we remove old name resolver this issue goes away.

Fixes Rust-GCC#3642

gcc/rust/ChangeLog:

	* hir/rust-ast-lower-item.cc (ASTLoweringItem::visit): check for has_expr
	* hir/rust-hir-dump.cc (Dump::visit): likewise
	* hir/tree/rust-hir-item.h: add has_expr helper
	* resolve/rust-ast-resolve-item.cc (ResolveItem::visit): check for has_expr
	* resolve/rust-ast-resolve-stmt.h: likewise
	* typecheck/rust-hir-type-check-stmt.cc (TypeCheckStmt::visit): likewise

gcc/testsuite/ChangeLog:

	* rust/compile/nr2/exclude: nr2 puts out an extra error
	* rust/compile/issue-3642.rs: New test.
