### PR TITLE
gccrs: Add test case showing RPIT working to close issue

### DIFF
--- a/gcc/testsuite/rust/execute/torture/issue-1481.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-1481.rs
@@ -1,0 +1,35 @@
+/* { dg-output "called Foo::print\\(\\)\r*" } */
+/* { dg-options "-w" } */
+
+#[lang = "sized"]
+trait Sized {}
+
+trait Printable {
+    fn print(&self);
+}
+
+struct Foo;
+
+impl Printable for Foo {
+    fn print(&self) {
+        // Simulate output
+        unsafe {
+            puts("called Foo::print()\0" as *const _ as *const i8);
+        }
+    }
+}
+
+fn get_printable() -> impl Printable {
+    Foo
+}
+
+extern "C" {
+    fn puts(s: *const i8);
+}
+
+fn main() -> i32 {
+    let p = get_printable();
+    p.print();
+
+    0
+}


### PR DESCRIPTION
Fixes Rust-GCC#1486

gcc/testsuite/ChangeLog:

	* rust/execute/torture/issue-1481.rs: New test.
