### PR TITLE
gccrs: Ensure we look at the bounds behind a reference

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -109,7 +109,8 @@ protected:
 			      TyTy::BaseType **result);
 
   HIR::PathIdentSegment resolve_possible_fn_trait_call_method_name (
-    TyTy::BaseType &receiver, TyTy::TypeBoundPredicate *associated_predicate);
+    const TyTy::BaseType &receiver,
+    TyTy::TypeBoundPredicate *associated_predicate);
 
 private:
   TypeCheckExpr ();


### PR DESCRIPTION
When type checking expressions that involve references, we need to examine the bounds of the referenced type to properly resolve traits and methods.

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-expr.cc: Look at bounds behind references.
	* typecheck/rust-hir-type-check-expr.h: Add helper method.
