### PR TITLE
gccrs: Fix silly ordering bug in trait reference resolution

### DIFF
--- a/gcc/rust/typecheck/rust-hir-trait-reference.cc
+++ b/gcc/rust/typecheck/rust-hir-trait-reference.cc
@@ -342,7 +342,15 @@ TraitReference::on_resolved ()
 {
   for (auto &item : item_refs)
     {
-      item.on_resolved ();
+      if (item.get_trait_item_type ()
+	  == TraitItemReference::TraitItemType::TYPE)
+	item.on_resolved ();
+    }
+  for (auto &item : item_refs)
+    {
+      if (item.get_trait_item_type ()
+	  != TraitItemReference::TraitItemType::TYPE)
+	item.on_resolved ();
     }
 }
 

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -549,8 +549,7 @@ TypeCheckType::resolve_segments (
       bool selfResolveOk = false;
 
       if (first_segment && tySegIsBigSelf
-	  && context->block_context ().is_in_context ()
-	  && context->block_context ().peek ().is_impl_block ())
+	  && context->block_context ().is_in_context ())
 	{
 	  TypeCheckBlockContextItem ctx = context->block_context ().peek ();
 	  TyTy::BaseType *lookup = nullptr;

--- a/gcc/testsuite/rust/compile/silly-order-bug.rs
+++ b/gcc/testsuite/rust/compile/silly-order-bug.rs
@@ -1,0 +1,8 @@
+#[lang = "sized"]
+trait Sized {}
+
+#[lang = "fn_once"]
+pub trait FnOnce<Args> {
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+    type Output;
+}


### PR DESCRIPTION
Ensure proper ordering when resolving trait references to prevent incorrect type resolution in certain contexts.

gcc/rust/ChangeLog:

	* typecheck/rust-hir-trait-reference.cc: Fix ordering bug.
	* typecheck/rust-hir-type-check-type.cc: Update call site.
	* testsuite/rust/compile/silly-order-bug.rs: New test.
