### PR TITLE
gccrs: Fix bug with non compiled const decl

### DIFF
--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -187,13 +187,18 @@ ResolvePathRef::resolve_with_node_id (
     }
 
   // Handle unit struct
+  tree resolved_item = error_mark_node;
   if (lookup->get_kind () == TyTy::TypeKind::ADT)
-    return attempt_constructor_expression_lookup (lookup, ctx, mappings,
-						  expr_locus);
+    resolved_item
+      = attempt_constructor_expression_lookup (lookup, ctx, mappings,
+					       expr_locus);
+
+  if (!error_operand_p (resolved_item))
+    return resolved_item;
 
   // let the query system figure it out
-  tree resolved_item = query_compile (ref, lookup, final_segment, mappings,
-				      expr_locus, is_qualified_path);
+  resolved_item = query_compile (ref, lookup, final_segment, mappings,
+				 expr_locus, is_qualified_path);
   if (resolved_item != error_mark_node)
     {
       TREE_USED (resolved_item) = 1;

--- a/gcc/testsuite/rust/compile/issue-3525.rs
+++ b/gcc/testsuite/rust/compile/issue-3525.rs
@@ -1,0 +1,6 @@
+// { dg-options "-w" }
+
+struct Foo(usize);
+
+const B: usize = A.0;
+const A: Foo = Foo(123);


### PR DESCRIPTION
There was a sily bug where if you reorder this test case to declare A before B this test would work but its meant to work in any order. So this fixes the bug during code gen to fall back to our query compile system if this is needed.

Fixes Rust-GCC#3525

gcc/rust/ChangeLog:

	* backend/rust-compile-resolve-path.cc: if this fails fall back to query compile

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3525.rs: New test.
