### PR TITLE
Update C++ version check in rust-lang.cc

### DIFF
--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -51,10 +51,10 @@
 // FIXME: test saving intellisense
 #include "options.h"
 
-// version check to stop compiling if c++ isn't c++11 or higher
-#if __cplusplus < 201103
+// version check to stop compiling if c++ isn't c++14 or higher
+#if __cplusplus < 201402
 #error                                                                         \
-  "GCC Rust frontend requires C++11 or higher. You can compile the g++ frontend first and then compile the Rust frontend using that."
+  "GCC Rust frontend requires C++14 or higher. You can compile the g++ frontend first and then compile the Rust frontend using that."
 #endif
 // TODO: is this best way to do it? Is it allowed? (should be)
 


### PR DESCRIPTION
I don't know if this version check is redundant, but it probably shouldn't be *this* redundant