### PR TITLE
Add getter for outer attributions

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -2698,6 +2698,8 @@ public:
   Expr &get_guard_expr () { return *guard_expr; }
 
   location_t get_locus () const { return locus; }
+
+  AST::AttrVec &get_outer_attrs () { return outer_attrs; }
 };
 
 /* A "match case" - a correlated match arm and resulting expression. Not


### PR DESCRIPTION
MatchArm has outer attributions as private member, but there was no way to get it, so I added a getter function.


```
gcc/rust/ChangeLog:

	* hir/tree/rust-hir-expr.h (MatchArm::get_outer_attrs): Add getter for outer attributions
```


- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`
