### PR TITLE
Add locus getters

### DIFF
--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -1192,6 +1192,8 @@ public:
 
   std::string as_string () const override;
 
+  location_t get_locus () const { return locus; }
+
   void accept_vis (ASTVisitor &vis) override;
 
   // TODO: this mutable getter seems really dodgy. Think up better way.
@@ -1247,6 +1249,8 @@ public:
   ArrayElemsCopied &operator= (ArrayElemsCopied &&other) = default;
 
   std::string as_string () const override;
+
+  location_t get_locus () const { return locus; }
 
   void accept_vis (ASTVisitor &vis) override;
 
@@ -1776,6 +1780,8 @@ public:
   bool is_invalid () const { return base_struct == nullptr; }
 
   std::string as_string () const;
+
+  location_t get_locus () const { return locus; }
 
   // TODO: is this better? Or is a "vis_block" better?
   Expr &get_base_struct ()

--- a/gcc/rust/ast/rust-pattern.h
+++ b/gcc/rust/ast/rust-pattern.h
@@ -948,7 +948,7 @@ public:
    * is empty). */
   bool has_struct_pattern_elems () const { return !elems.is_empty (); }
 
-  location_t get_locus () const override { return path.get_locus (); }
+  location_t get_locus () const override { return locus; }
 
   void accept_vis (ASTVisitor &vis) override;
 

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -209,6 +209,8 @@ public:
 
   std::string as_string () const override;
 
+  location_t get_locus () const { return locus; }
+
   void accept_vis (HIRFullVisitor &vis) override;
 
   Lifetime &get_lifetime () { return lifetime; }

--- a/gcc/rust/hir/tree/rust-hir-visibility.h
+++ b/gcc/rust/hir/tree/rust-hir-visibility.h
@@ -73,6 +73,8 @@ public:
   }
 
   std::string as_string () const;
+
+  location_t get_locus () const { return locus; }
 };
 } // namespace HIR
 } // namespace Rust


### PR DESCRIPTION
Missing locus getters create additional warning with clang. This PR will reduce the amount of warnings emitted by clang with clang-filter enabled.