### PR TITLE
Load modules during `CfgStrip` phase

### DIFF
--- a/gcc/rust/expand/rust-cfg-strip.cc
+++ b/gcc/rust/expand/rust-cfg-strip.cc
@@ -1765,16 +1765,17 @@ CfgStrip::visit (AST::Module &module)
       return;
     }
 
-  // A loaded module might have inner attributes
-  if (module.get_kind () == AST::Module::ModuleKind::LOADED)
+  if (module.get_kind () == AST::Module::UNLOADED)
     {
-      // strip test based on inner attrs
-      expand_cfg_attrs (module.get_inner_attrs ());
-      if (fails_cfg_with_expand (module.get_inner_attrs ()))
-	{
-	  module.mark_for_strip ();
-	  return;
-	}
+      module.load_items ();
+    }
+
+  // strip test based on inner attrs
+  expand_cfg_attrs (module.get_inner_attrs ());
+  if (fails_cfg_with_expand (module.get_inner_attrs ()))
+    {
+      module.mark_for_strip ();
+      return;
     }
 
   // strip items if required

--- a/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
@@ -101,27 +101,6 @@ TopLevel::go (AST::Crate &crate)
 void
 TopLevel::visit (AST::Module &module)
 {
-  // Parse the module's items if they haven't been expanded and the file
-  // should be parsed (i.e isn't hidden behind an untrue or impossible cfg
-  // directive
-  // TODO: make sure this is right
-  // TODO: avoid loading items if cfg attributes are present?
-  //       might not be needed if this runs after early resolution?
-  // This was copied from the old early resolver method
-  // 'accumulate_escaped_macros'
-  if (module.get_kind () == AST::Module::UNLOADED)
-    {
-      module.load_items ();
-
-      // If the module was previously unloaded, then we don't want to visit it
-      // this time around as the CfgStrip hasn't run on its inner items yet.
-      // Skip it for now, mark the visitor as dirty and try again
-
-      dirty = true;
-
-      return;
-    }
-
   DefaultResolver::visit (module);
 
   if (Analysis::Mappings::get ().lookup_ast_module (module.get_node_id ())


### PR DESCRIPTION
`TopLevel` would ignore just-loaded modules but `Early` and `ExpandVisitor` wouldn't. The latter would produce errors when it hit attributes which should have been indirectly `CfgStrip`'d away.