### PR TITLE
Remove `Late` visitor override for `StructStruct`

### DIFF
--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
@@ -617,13 +617,6 @@ Late::visit (AST::Trait &trait)
 }
 
 void
-Late::visit (AST::StructStruct &s)
-{
-  auto s_vis = [this, &s] () { AST::DefaultASTVisitor::visit (s); };
-  ctx.scoped (Rib::Kind::Item, s.get_node_id (), s_vis);
-}
-
-void
 Late::visit (AST::StructExprStruct &s)
 {
   visit_outer_attrs (s);

--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.h
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.h
@@ -66,7 +66,6 @@ public:
   void visit (AST::StructExprStruct &) override;
   void visit (AST::StructExprStructBase &) override;
   void visit (AST::StructExprStructFields &) override;
-  void visit (AST::StructStruct &) override;
   void visit (AST::GenericArgs &) override;
   void visit (AST::GenericArg &);
   void visit_closure_params (AST::ClosureExpr &) override;


### PR DESCRIPTION
`DefaultResolver` already handles `StructStruct` in a more correct fashion.