### PR TITLE
Allow the doc attribute to accept macros as arguments

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-base.cc
+++ b/gcc/rust/hir/rust-ast-lower-base.cc
@@ -805,15 +805,18 @@ void
 ASTLoweringBase::handle_doc_item_attribute (const ItemWrapper &,
 					    const AST::Attribute &attr)
 {
-  auto simple_doc_comment = attr.has_attr_input ()
-			    && attr.get_attr_input ().get_attr_input_type ()
-				 == AST::AttrInput::AttrInputType::LITERAL;
+  rust_assert (attr.has_attr_input ());
+  const AST::AttrInput &input = attr.get_attr_input ();
+  const AST::AttrInput::AttrInputType &input_type
+    = input.get_attr_input_type ();
+
+  auto simple_doc_comment
+    = input_type == AST::AttrInput::AttrInputType::LITERAL
+      || input_type == AST::AttrInput::AttrInputType::MACRO;
   if (simple_doc_comment)
     return;
 
-  const AST::AttrInput &input = attr.get_attr_input ();
-  bool is_token_tree
-    = input.get_attr_input_type () == AST::AttrInput::AttrInputType::TOKEN_TREE;
+  bool is_token_tree = input_type == AST::AttrInput::AttrInputType::TOKEN_TREE;
   rust_assert (is_token_tree);
   const auto &option = static_cast<const AST::DelimTokenTree &> (input);
   AST::AttrInputMetaItemContainer *meta_item = option.parse_to_meta_item ();

--- a/gcc/testsuite/rust/compile/issue-3545.rs
+++ b/gcc/testsuite/rust/compile/issue-3545.rs
@@ -1,0 +1,14 @@
+macro_rules! a {
+    () => { "a" }
+}
+
+macro_rules! b {
+    ($doc:expr) => {
+        #[doc = $doc]
+         struct _B;
+    }
+}
+
+b!(a!());
+
+fn main() {}


### PR DESCRIPTION
Fixes #3545

The doc attribute fails an assertion when a macro is used to provide the
documentation string. It is now updated to accept macros.

gcc/rust/ChangeLog:

	* hir/rust-ast-lower-base.cc: Allow the doc attribute to accept macros.

gcc/testsuite/ChangeLog:

    * rust/compile/issue-3545.rs: Add test for macros in doc attribute.

Signed-off-by: Andrew Chi <lgray3420@gmail.com>
