### PR TITLE
Basic SlicePattern type checking

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
@@ -563,8 +563,18 @@ TypeCheckPattern::visit (HIR::TuplePattern &pattern)
 void
 TypeCheckPattern::visit (HIR::LiteralPattern &pattern)
 {
-  infered = resolve_literal (pattern.get_mappings (), pattern.get_literal (),
-			     pattern.get_locus ());
+  TyTy::BaseType *resolved
+    = resolve_literal (pattern.get_mappings (), pattern.get_literal (),
+		       pattern.get_locus ());
+  if (resolved->get_kind () == TyTy::TypeKind::ERROR)
+    {
+      infered = resolved;
+      return;
+    }
+
+  infered = unify_site (pattern.get_mappings ().get_hirid (),
+			TyTy::TyWithLocation (parent),
+			TyTy::TyWithLocation (resolved), pattern.get_locus ());
 }
 
 void


### PR DESCRIPTION
**Edit: Resolved the previous problem.**



Type checking for LiteralPattern is also updated to resolve the following edge case:

```rust
fn main() {
    let arr = [0, 0];

    match arr {
        // Should fail as `LiteralPattern`-s in the `SlicePattern` should be type checked
        // against element type of `arr`
        [0, 0.0] => {}
        _ => {}
    }
}
```

[Link to the code in Rust Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=5664a23df0102b376f1ec74ad7d7bff1)

~~However, the draft commit causes `gccrs/gcc/testsuite/rust/compile/if_let_expr.rs` to fail, specifically `if_let_expr.rs:12:33: error: type annotations needed [E0282]`.~~

