### PR TITLE
Fix narrowing of Loan (size_t) into LoanId (uint32)

### DIFF
--- a/.github/glibcxx_ubuntu64b_log_expected_warnings
+++ b/.github/glibcxx_ubuntu64b_log_expected_warnings
@@ -1,1 +1,0 @@
-../../gcc/rust/checks/errors/borrowck/rust-borrow-checker-diagnostics.cc:145:46: warning: narrowing conversion of ‘loan’ from ‘Rust::Polonius::Loan’ {aka ‘long unsigned int’} to ‘uint32_t’ {aka ‘unsigned int’} [-Wnarrowing]

--- a/.github/log_expected_warnings
+++ b/.github/log_expected_warnings
@@ -1,1 +1,0 @@
-../../gcc/rust/checks/errors/borrowck/rust-borrow-checker-diagnostics.cc:145:46: warning: narrowing conversion of ‘loan’ from ‘Rust::Polonius::Loan’ {aka ‘long unsigned int’} to ‘uint32_t’ {aka ‘unsigned int’} [-Wnarrowing]

--- a/gcc/rust/checks/errors/borrowck/rust-bir-place.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-place.h
@@ -53,7 +53,7 @@ using Variance = TyTy::VarianceAnalysis::Variance;
 /** A unique identifier for a loan in the BIR. */
 struct LoanId
 {
-  uint32_t value;
+  size_t value;
   // some overloads for comparision
   bool operator== (const LoanId &rhs) const { return value == rhs.value; }
   bool operator!= (const LoanId &rhs) const { return !(operator== (rhs)); }


### PR DESCRIPTION
Fix narrowing:

```
  -../../gcc/rust/checks/errors/borrowck/rust-borrow-checker-diagnostics.cc:145:46:
  warning: narrowing conversion of ‘loan’ from ‘Rust::Polonius::Loan’ {aka
  ‘long unsigned int’} to ‘uint32_t’ {aka ‘unsigned int’} [-Wnarrowing]
```
