### PR TITLE
gccrs: Fix ice with invalid borrow expression

### DIFF
--- a/gcc/rust/ast/rust-ast-collector.cc
+++ b/gcc/rust/ast/rust-ast-collector.cc
@@ -870,7 +870,8 @@ TokenCollector::visit (BorrowExpr &expr)
 	push (Rust::Token::make (MUT, UNDEF_LOCATION));
     }
 
-  visit (expr.get_borrowed_expr ());
+  if (expr.has_borrow_expr ())
+    visit (expr.get_borrowed_expr ());
 }
 
 void

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -395,6 +395,8 @@ public:
     return *main_or_left_expr;
   }
 
+  bool has_borrow_expr () const { return main_or_left_expr != nullptr; }
+
   bool get_is_mut () const { return mutability == Mutability::Mut; }
 
   Mutability get_mutability () const { return mutability; }

--- a/gcc/testsuite/rust/compile/issue-3874.rs
+++ b/gcc/testsuite/rust/compile/issue-3874.rs
@@ -1,0 +1,4 @@
+fn wow(){
+    &#[serde]
+    // { dg-error "found unexpected token .#. in null denotation" "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
This is an invalid test case but we just need a guard for the missing borrow expression.

Fixes Rust-GCC#3874

gcc/rust/ChangeLog:

	* ast/rust-ast-collector.cc (TokenCollector::visit): check for missing borrow
	* ast/rust-expr.h: add helper

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3874.rs: New test.
