### PR TITLE
nr2.0: Check before visiting a for-loop's label

### DIFF
--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
@@ -142,7 +142,10 @@ Late::visit (AST::ForLoopExpr &expr)
   ctx.bindings.exit ();
 
   visit (expr.get_iterator_expr ());
-  visit (expr.get_loop_label ());
+
+  if (expr.has_loop_label ())
+    visit (expr.get_loop_label ());
+
   visit (expr.get_loop_block ());
 }
 


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* resolve/rust-late-name-resolver-2.0.cc (Late::visit): Check for a label
	before visiting it.
