### PR TITLE
gccrs: Fix bad bounds checking for PartialOrd

### DIFF
--- a/gcc/rust/typecheck/rust-hir-trait-resolve.cc
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.cc
@@ -288,7 +288,8 @@ TraitResolver::resolve_trait (HIR::Trait *trait_reference)
 
 	      auto predicate = get_predicate_from_bound (
 		b->get_path (),
-		tl::nullopt /*this will setup a PLACEHOLDER for self*/);
+		tl::nullopt /*this will setup a PLACEHOLDER for self*/,
+		BoundPolarity::RegularBound, false, true);
 	      if (predicate.is_error ())
 		return &TraitReference::error_node ();
 

--- a/gcc/rust/typecheck/rust-hir-type-bounds.h
+++ b/gcc/rust/typecheck/rust-hir-type-bounds.h
@@ -37,6 +37,10 @@ public:
 
 private:
   void scan ();
+  bool
+  process_impl_block (HirId id, HIR::ImplBlock *impl,
+		      std::vector<std::pair<HIR::TypePath *, HIR::ImplBlock *>>
+			&possible_trait_paths);
   void assemble_marker_builtins ();
   void add_trait_bound (HIR::Trait *trait);
   void assemble_builtin_candidate (LangItem::Kind item);

--- a/gcc/rust/typecheck/rust-hir-type-check-base.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.h
@@ -46,7 +46,7 @@ protected:
     HIR::TypePath &path,
     tl::optional<std::reference_wrapper<HIR::Type>> associated_self,
     BoundPolarity polarity = BoundPolarity::RegularBound,
-    bool is_qualified_type = false);
+    bool is_qualified_type = false, bool is_super_trait = false);
 
   bool check_for_unconstrained (
     const std::vector<TyTy::SubstitutionParamMapping> &params_to_constrain,

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -1866,7 +1866,7 @@ TypeCheckExpr::visit (HIR::ClosureExpr &expr)
   args.get_type_args ().push_back (std::unique_ptr<HIR::Type> (implicit_tuple));
 
   // apply the arguments
-  predicate.apply_generic_arguments (&args, false);
+  predicate.apply_generic_arguments (&args, false, false);
 
   // finally inherit the trait bound
   infered->inherit_bounds ({predicate});

--- a/gcc/rust/typecheck/rust-tyty-subst.cc
+++ b/gcc/rust/typecheck/rust-tyty-subst.cc
@@ -115,7 +115,8 @@ SubstitutionParamMapping::need_substitution () const
 
 bool
 SubstitutionParamMapping::fill_param_ty (
-  SubstitutionArgumentMappings &subst_mappings, location_t locus)
+  SubstitutionArgumentMappings &subst_mappings, location_t locus,
+  bool needs_bounds_check)
 {
   SubstitutionArg arg = SubstitutionArg::error ();
   bool ok = subst_mappings.get_argument_for_symbol (get_param_ty (), &arg);
@@ -139,8 +140,7 @@ SubstitutionParamMapping::fill_param_ty (
       rust_debug_loc (locus,
 		      "fill_param_ty bounds_compatible: param %s type %s",
 		      param->get_name ().c_str (), type.get_name ().c_str ());
-
-      if (!param->is_implicit_self_trait ())
+      if (needs_bounds_check && !param->is_implicit_self_trait ())
 	{
 	  if (!param->bounds_compatible (type, locus, true))
 	    return false;

--- a/gcc/rust/typecheck/rust-tyty-subst.h
+++ b/gcc/rust/typecheck/rust-tyty-subst.h
@@ -51,7 +51,7 @@ public:
   std::string as_string () const;
 
   bool fill_param_ty (SubstitutionArgumentMappings &subst_mappings,
-		      location_t locus);
+		      location_t locus, bool needs_bounds_check = true);
 
   SubstitutionParamMapping clone () const;
 

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -539,14 +539,15 @@ public:
 
   std::string get_name () const;
 
-  // check that this predicate is object-safe see:
+  // check that this  is object-safe see:
   // https://doc.rust-lang.org/reference/items/traits.html#object-safety
   bool is_object_safe (bool emit_error, location_t locus) const;
 
   void apply_generic_arguments (HIR::GenericArgs *generic_args,
-				bool has_associated_self);
+				bool has_associated_self, bool is_super_trait);
 
-  void apply_argument_mappings (SubstitutionArgumentMappings &arguments);
+  void apply_argument_mappings (SubstitutionArgumentMappings &arguments,
+				bool is_super_trait);
 
   bool contains_item (const std::string &search) const;
 

--- a/gcc/testsuite/rust/compile/issue-3836.rs
+++ b/gcc/testsuite/rust/compile/issue-3836.rs
@@ -1,0 +1,67 @@
+// { dg-options "-w" }
+mod core {
+    mod option {
+        pub enum Option<T> {
+            #[lang = "None"]
+            None,
+            #[lang = "Some"]
+            Some(T),
+        }
+    }
+
+    mod marker {
+        #[lang = "sized"]
+        pub trait Sized {}
+    }
+
+    mod cmp {
+        use super::marker::Sized;
+        use super::option::Option;
+
+        pub enum Ordering {
+            Less = -1,
+            Equal = 0,
+            Greater = 1,
+        }
+
+        #[lang = "eq"]
+        pub trait PartialEq<Rhs: ?Sized = Self> {
+            fn eq(&self, other: &Rhs) -> bool;
+
+            fn ne(&self, other: &Rhs) -> bool {
+                !self.eq(other)
+            }
+        }
+
+        #[lang = "partial_ord"]
+        pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
+            fn partial_cmp(&self, other: &Rhs) -> Option<Ordering>;
+        }
+    }
+}
+
+use core::cmp::{Ordering, PartialEq, PartialOrd};
+use core::marker::Sized;
+use core::option::Option;
+
+impl PartialEq for i32 {
+    fn eq(&self, other: &Self) -> bool {
+        false
+    }
+}
+
+impl PartialOrd for i32 {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Option::Some(Ordering::Equal)
+    }
+}
+
+struct Foo {
+    a: i32,
+}
+
+impl PartialEq for Foo {
+    fn eq(&self, other: &'_ Self) -> bool {
+        ::core::cmp::PartialEq::eq(&self.a, &other.a)
+    }
+}

--- a/gcc/testsuite/rust/execute/torture/basic_partial_ord1.rs
+++ b/gcc/testsuite/rust/execute/torture/basic_partial_ord1.rs
@@ -103,6 +103,19 @@ impl PartialOrd for i32 {
             Option::Some(Ordering::Equal)
         }
     }
+
+    fn lt(&self, other: &Self) -> bool {
+        *self < *other
+    }
+    fn le(&self, other: &Self) -> bool {
+        *self <= *other
+    }
+    fn ge(&self, other: &Self) -> bool {
+        *self >= *other
+    }
+    fn gt(&self, other: &Self) -> bool {
+        *self > *other
+    }
 }
 
 impl Eq for i32 {}

--- a/gcc/testsuite/rust/execute/torture/basic_partial_ord2.rs
+++ b/gcc/testsuite/rust/execute/torture/basic_partial_ord2.rs
@@ -104,6 +104,19 @@ impl PartialOrd for i32 {
             Option::Some(Ordering::Equal)
         }
     }
+
+    fn lt(&self, other: &Self) -> bool {
+        *self < *other
+    }
+    fn le(&self, other: &Self) -> bool {
+        *self <= *other
+    }
+    fn ge(&self, other: &Self) -> bool {
+        *self >= *other
+    }
+    fn gt(&self, other: &Self) -> bool {
+        *self > *other
+    }
 }
 
 impl Eq for i32 {}

--- a/gcc/testsuite/rust/execute/torture/issue-3836.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-3836.rs
@@ -1,4 +1,5 @@
-// { dg-additional-options "-w" }
+// { dg-options "-w" }
+// { dg-output "less\r*\n" }
 
 #![feature(intrinsics)]
 
@@ -381,6 +382,7 @@ impl PartialEq for i32 {
         *self == *other
     }
 }
+impl Eq for i32 {}
 
 impl PartialOrd for i32 {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
@@ -419,26 +421,12 @@ impl Ord for i32 {
     }
 }
 
-impl Eq for i32 {}
-
-#[derive(PartialEq, PartialOrd)]
-enum Foo {
-    A,
-    B(i32, i32, i32),
-    C { inner: i32, outer: i32 },
-}
+// ------------
 
 #[derive(Ord, PartialOrd, PartialEq, Eq)]
 struct Bar {
     a: i32,
-}
-
-#[derive(Ord, PartialOrd, PartialEq, Eq)]
-struct BarFull {
-    a: i32,
     b: i32,
-    c: i32,
-    d: i32,
 }
 
 extern "C" {
@@ -451,14 +439,16 @@ fn print(s: &str) {
     }
 }
 
-fn main() {
-    let a = Foo::A;
-    let b = Foo::B(15, 14, 13);
+fn main() -> i32 {
+    let x = Bar { a: 1, b: 2 };
+    let y = Bar { a: 1, b: 3 };
 
-    match a.partial_cmp(&b) {
+    match x.partial_cmp(&y) {
         Option::Some(Ordering::Less) => print("less"),
         Option::Some(Ordering::Greater) => print("greater"),
         Option::Some(Ordering::Equal) => print("equal"),
-        _ => print("uuuuh woops lol"),
+        _ => print("none"),
     }
+
+    0
 }

--- a/gcc/testsuite/rust/execute/torture/partial-ord-6.rs
+++ b/gcc/testsuite/rust/execute/torture/partial-ord-6.rs
@@ -1,4 +1,5 @@
 // { dg-additional-options "-w" }
+/* { dg-output "Foo A < B\r?\nFoo B < C\r?\nFoo C == C\r?\nBar x < y\r?\nBarFull s1 < s2\r?\n" } */
 
 #![feature(intrinsics)]
 
@@ -451,14 +452,67 @@ fn print(s: &str) {
     }
 }
 
-fn main() {
+fn main() -> i32 {
+    // Enum comparison
     let a = Foo::A;
     let b = Foo::B(15, 14, 13);
+    let c = Foo::C {
+        inner: 10,
+        outer: 20,
+    };
 
     match a.partial_cmp(&b) {
-        Option::Some(Ordering::Less) => print("less"),
-        Option::Some(Ordering::Greater) => print("greater"),
-        Option::Some(Ordering::Equal) => print("equal"),
-        _ => print("uuuuh woops lol"),
+        Option::Some(Ordering::Less) => print("Foo A < B"),
+        Option::Some(Ordering::Greater) => print("Foo A > B"),
+        Option::Some(Ordering::Equal) => print("Foo A == B"),
+        _ => print("Foo A ? B"),
     }
+
+    match b.partial_cmp(&c) {
+        Option::Some(Ordering::Less) => print("Foo B < C"),
+        Option::Some(Ordering::Greater) => print("Foo B > C"),
+        Option::Some(Ordering::Equal) => print("Foo B == C"),
+        _ => print("Foo B ? C"),
+    }
+
+    match c.partial_cmp(&c) {
+        Option::Some(Ordering::Less) => print("Foo C < C ???"),
+        Option::Some(Ordering::Greater) => print("Foo C > C ???"),
+        Option::Some(Ordering::Equal) => print("Foo C == C"),
+        _ => print("Foo C ? C"),
+    }
+
+    // Struct comparison: Bar
+    let x = Bar { a: 10 };
+    let y = Bar { a: 20 };
+
+    if x < y {
+        print("Bar x < y");
+    } else if x > y {
+        print("Bar x > y");
+    } else {
+        print("Bar x == y");
+    }
+
+    // Struct comparison: BarFull
+    let s1 = BarFull {
+        a: 1,
+        b: 2,
+        c: 3,
+        d: 4,
+    };
+    let s2 = BarFull {
+        a: 1,
+        b: 2,
+        c: 3,
+        d: 5,
+    };
+
+    match s1.cmp(&s2) {
+        Ordering::Less => print("BarFull s1 < s2"),
+        Ordering::Greater => print("BarFull s1 > s2"),
+        Ordering::Equal => print("BarFull s1 == s2"),
+    }
+
+    0
 }


### PR DESCRIPTION
This was a nasty issue to debug, the issue was very eager type bounds checking. So for example:

  pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs>

The super trait of PartialEq<Rhs> is a generic substitution and we reuse our bounds code here for normal generic bounds and generics an invalid bounds check was occuring when PartialEq<Rhs> was getting substituted becase this is a trait doing proper bounds checking is not valid here because this is telling us about the bounds in this case.

Fixes Rust-GCC#3836

gcc/rust/ChangeLog:

	* typecheck/rust-hir-trait-resolve.cc (TraitResolver::resolve_trait): track is super trait
	* typecheck/rust-hir-type-bounds.h: refactor bounds scan
	* typecheck/rust-hir-type-check-base.h: track from super trait
	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::visit): likewise
	* typecheck/rust-tyty-bounds.cc (TypeBoundsProbe::is_bound_satisfied_for_type): refactor
	(TypeBoundsProbe::scan): likewise
	(TypeBoundPredicate::apply_generic_arguments): likewise
	* typecheck/rust-tyty-subst.cc: optional bounds checking on parm subst
	* typecheck/rust-tyty-subst.h: likewise
	* typecheck/rust-tyty.h: likewise

gcc/testsuite/ChangeLog:

	* rust/compile/derive_partial_ord1.rs: this is now fully supported
	* rust/execute/torture/basic_partial_ord1.rs: add missing i32 impl
	* rust/execute/torture/basic_partial_ord2.rs: likewise
	* rust/compile/issue-3836.rs: New test.
	* rust/execute/torture/issue-3836.rs: New test.
	* rust/execute/torture/partial-ord-6.rs: New test.
