### PR TITLE
gccrs: Fix cast rules logic to try simple casts then fall back to coercions

### DIFF
--- a/gcc/rust/typecheck/rust-casts.h
+++ b/gcc/rust/typecheck/rust-casts.h
@@ -30,14 +30,16 @@ class TypeCastRules
 public:
   static TypeCoercionRules::CoercionResult resolve (location_t locus,
 						    TyTy::TyWithLocation from,
-						    TyTy::TyWithLocation to);
+						    TyTy::TyWithLocation to,
+						    bool emit_error = true);
+
+  static void emit_cast_error (location_t locus, TyTy::TyWithLocation from,
+			       TyTy::TyWithLocation to);
 
 protected:
-  TypeCoercionRules::CoercionResult check ();
+  TypeCoercionRules::CoercionResult check (bool emit_error);
   TypeCoercionRules::CoercionResult cast_rules ();
   TypeCoercionRules::CoercionResult check_ptr_ptr_cast ();
-
-  void emit_cast_error () const;
 
 protected:
   TypeCastRules (location_t locus, TyTy::TyWithLocation from,

--- a/gcc/testsuite/rust/compile/issue-2680.rs
+++ b/gcc/testsuite/rust/compile/issue-2680.rs
@@ -1,0 +1,6 @@
+// { dg-additional-options "-fdump-tree-gimple" }
+pub fn test_cast() {
+    let i = 1;
+    // { dg-final { scan-tree-dump-times {const i32 i;} 1 gimple } }
+    let _j = i as i64;
+}


### PR DESCRIPTION
This case:

    let i = 1;
    let j = i as i64;

'i' is meant to default to i32 but the inference was making both of these i64 because the code was prefering coercion logic which can end up with a default unify which causes the ?integer to unify with i64 making them both i64.

But all we need to do is allow the simple cast rules to run first then fallback to coercions but special consideration has to be made to ensure that if there are dyn objects needed then this needs a unsize coercion, but also we need to ensure the underlying types are a valid simple cast too otherwise these also need to fallback to the coercion code.

Fixes Rust-GCC#2680

gcc/rust/ChangeLog:

	* typecheck/rust-casts.cc (TypeCastRules::resolve): optional emit_error flag
	(TypeCastRules::check): try the simple cast rules then fallback to coercions
	(TypeCastRules::check_ptr_ptr_cast): ensure the underlying's
	(TypeCastRules::emit_cast_error): make this a static helper
	* typecheck/rust-casts.h: new emit_error prototype

gcc/testsuite/ChangeLog:

	* rust/compile/issue-2680.rs: New test.
