### PR TITLE
gccrs: Fix ICE when handling bad constructor

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-struct.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-struct.cc
@@ -362,7 +362,7 @@ TypeCheckStructExpr::visit (HIR::StructExprFieldIdentifier &field)
   if (!ok)
     {
       rust_error_at (field.get_locus (), "unknown field");
-      return true;
+      return false;
     }
 
   auto it = adtFieldIndexToField.find (field_index);

--- a/gcc/testsuite/rust/compile/issue-3876.rs
+++ b/gcc/testsuite/rust/compile/issue-3876.rs
@@ -1,0 +1,8 @@
+enum test {
+    A(i32),
+}
+
+fn fun(x: i32) {
+    test::A { x }
+    // { dg-error "unknown field" "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
We just had a typo returning ok true when it should have been false.

Fixes Rust-GCC#3876

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-struct.cc (TypeCheckStructExpr::visit): fix typo

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3876.rs: New test.

