### PR TITLE
gccrs: Add test case to show we emit better errors now

### DIFF
--- a/gcc/testsuite/rust/compile/issue-3144.rs
+++ b/gcc/testsuite/rust/compile/issue-3144.rs
@@ -1,0 +1,29 @@
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "copy"]
+trait Copy {}
+
+#[lang = "clone"]
+pub trait Clone {
+    fn clone(&self) -> Self;
+}
+
+impl Clone for i32 {
+    fn clone(&self) -> i32 {
+        *self
+    }
+}
+
+struct S {}
+
+#[derive(Clone, Copy)]
+// { dg-error {bounds not satisfied for S .Clone. is not satisfied .E0277.} "" { target *-*-* } .-1 }
+struct S2 {
+    a: i32,
+    s: S,
+}
+
+fn main() -> i32 {
+    0
+}


### PR DESCRIPTION
Fixes Rust-GCC#3144

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3144.rs: New test.

