### PR TITLE
Improve parsing of simple paths

### DIFF
--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -227,7 +227,7 @@ private:
 
   // Path-related
   AST::SimplePath parse_simple_path ();
-  AST::SimplePathSegment parse_simple_path_segment ();
+  AST::SimplePathSegment parse_simple_path_segment (int base_peek = 0);
   AST::TypePath parse_type_path ();
   std::unique_ptr<AST::TypePathSegment> parse_type_path_segment ();
   AST::PathIdentSegment parse_path_ident_segment ();

--- a/gcc/testsuite/rust/compile/parse_simple_path_fail_1.rs
+++ b/gcc/testsuite/rust/compile/parse_simple_path_fail_1.rs
@@ -1,0 +1,3 @@
+pub(in crate::) struct S;
+// { dg-error "expecting ... but .::. found" "" { target *-*-* } .-1 }
+// { dg-error "failed to parse item in crate" "" { target *-*-* } .-2 }

--- a/gcc/testsuite/rust/compile/parse_simple_path_fail_2.rs
+++ b/gcc/testsuite/rust/compile/parse_simple_path_fail_2.rs
@@ -1,0 +1,9 @@
+mod A {
+    struct B;
+}
+
+use A{B};
+// { dg-error "unexpected token" "" { target *-*-* } .-1 }
+// { dg-error "could not parse use tree" "" { target *-*-* } .-2 }
+// { dg-error "failed to parse item in crate" "" { target *-*-* } 10 }
+// ^^^ TODO: should the above error happen at line 10?


### PR DESCRIPTION
I noticed this earlier, while trying to reduce code duplication between `AttributeParser` and `Parser`