### PR TITLE
gccrs: Add initial support for deffered operator overload resolution

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-expr.cc
+++ b/gcc/rust/hir/tree/rust-hir-expr.cc
@@ -17,6 +17,7 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-hir-expr.h"
+#include "rust-hir-map.h"
 #include "rust-operators.h"
 #include "rust-hir-stmt.h"
 
@@ -1321,37 +1322,40 @@ AsyncBlockExpr::operator= (AsyncBlockExpr const &other)
 OperatorExprMeta::OperatorExprMeta (HIR::CompoundAssignmentExpr &expr)
   : node_mappings (expr.get_mappings ()),
     lvalue_mappings (expr.get_expr ().get_mappings ()),
-    locus (expr.get_locus ())
+    rvalue_mappings (expr.get_rhs ().get_mappings ()), locus (expr.get_locus ())
 {}
 
 OperatorExprMeta::OperatorExprMeta (HIR::ArithmeticOrLogicalExpr &expr)
   : node_mappings (expr.get_mappings ()),
     lvalue_mappings (expr.get_expr ().get_mappings ()),
-    locus (expr.get_locus ())
+    rvalue_mappings (expr.get_rhs ().get_mappings ()), locus (expr.get_locus ())
 {}
 
 OperatorExprMeta::OperatorExprMeta (HIR::NegationExpr &expr)
   : node_mappings (expr.get_mappings ()),
     lvalue_mappings (expr.get_expr ().get_mappings ()),
+    rvalue_mappings (Analysis::NodeMapping::get_error ()),
     locus (expr.get_locus ())
 {}
 
 OperatorExprMeta::OperatorExprMeta (HIR::DereferenceExpr &expr)
   : node_mappings (expr.get_mappings ()),
     lvalue_mappings (expr.get_expr ().get_mappings ()),
+    rvalue_mappings (Analysis::NodeMapping::get_error ()),
     locus (expr.get_locus ())
 {}
 
 OperatorExprMeta::OperatorExprMeta (HIR::ArrayIndexExpr &expr)
   : node_mappings (expr.get_mappings ()),
     lvalue_mappings (expr.get_array_expr ().get_mappings ()),
+    rvalue_mappings (expr.get_index_expr ().get_mappings ()),
     locus (expr.get_locus ())
 {}
 
 OperatorExprMeta::OperatorExprMeta (HIR::ComparisonExpr &expr)
   : node_mappings (expr.get_mappings ()),
     lvalue_mappings (expr.get_expr ().get_mappings ()),
-    locus (expr.get_locus ())
+    rvalue_mappings (expr.get_rhs ().get_mappings ()), locus (expr.get_locus ())
 {}
 
 InlineAsmOperand::In::In (

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -27,6 +27,7 @@
 #include "rust-hir-attrs.h"
 #include "rust-expr.h"
 #include "rust-hir-map.h"
+#include "rust-mapping-common.h"
 
 namespace Rust {
 namespace HIR {
@@ -2892,6 +2893,22 @@ public:
 
   OperatorExprMeta (HIR::ComparisonExpr &expr);
 
+  OperatorExprMeta (const OperatorExprMeta &other)
+    : node_mappings (other.node_mappings),
+      lvalue_mappings (other.lvalue_mappings),
+      rvalue_mappings (other.rvalue_mappings), locus (other.locus)
+  {}
+
+  OperatorExprMeta &operator= (const OperatorExprMeta &other)
+  {
+    node_mappings = other.node_mappings;
+    lvalue_mappings = other.lvalue_mappings;
+    rvalue_mappings = other.rvalue_mappings;
+    locus = other.locus;
+
+    return *this;
+  }
+
   const Analysis::NodeMapping &get_mappings () const { return node_mappings; }
 
   const Analysis::NodeMapping &get_lvalue_mappings () const
@@ -2899,11 +2916,22 @@ public:
     return lvalue_mappings;
   }
 
+  const Analysis::NodeMapping &get_rvalue_mappings () const
+  {
+    return rvalue_mappings;
+  }
+
+  bool has_rvalue_mappings () const
+  {
+    return rvalue_mappings.get_hirid () != UNKNOWN_HIRID;
+  }
+
   location_t get_locus () const { return locus; }
 
 private:
-  const Analysis::NodeMapping node_mappings;
-  const Analysis::NodeMapping lvalue_mappings;
+  Analysis::NodeMapping node_mappings;
+  Analysis::NodeMapping lvalue_mappings;
+  Analysis::NodeMapping rvalue_mappings;
   location_t locus;
 };
 

--- a/gcc/rust/hir/tree/rust-hir-path.h
+++ b/gcc/rust/hir/tree/rust-hir-path.h
@@ -41,11 +41,15 @@ public:
     : segment_name (std::move (segment_name))
   {}
 
-  /* TODO: insert check in constructor for this? Or is this a semantic error
-   * best handled then? */
+  PathIdentSegment (const PathIdentSegment &other)
+    : segment_name (other.segment_name)
+  {}
 
-  /* TODO: does this require visitor? pretty sure this isn't polymorphic, but
-   * not entirely sure */
+  PathIdentSegment &operator= (PathIdentSegment const &other)
+  {
+    segment_name = other.segment_name;
+    return *this;
+  }
 
   // Creates an error PathIdentSegment.
   static PathIdentSegment create_error () { return PathIdentSegment (""); }

--- a/gcc/rust/typecheck/rust-hir-trait-reference.cc
+++ b/gcc/rust/typecheck/rust-hir-trait-reference.cc
@@ -432,7 +432,13 @@ TraitReference::trait_has_generics () const
   return !trait_substs.empty ();
 }
 
-std::vector<TyTy::SubstitutionParamMapping>
+std::vector<TyTy::SubstitutionParamMapping> &
+TraitReference::get_trait_substs ()
+{
+  return trait_substs;
+}
+
+const std::vector<TyTy::SubstitutionParamMapping> &
 TraitReference::get_trait_substs () const
 {
   return trait_substs;

--- a/gcc/rust/typecheck/rust-hir-trait-reference.h
+++ b/gcc/rust/typecheck/rust-hir-trait-reference.h
@@ -224,7 +224,9 @@ public:
 
   bool trait_has_generics () const;
 
-  std::vector<TyTy::SubstitutionParamMapping> get_trait_substs () const;
+  std::vector<TyTy::SubstitutionParamMapping> &get_trait_substs ();
+
+  const std::vector<TyTy::SubstitutionParamMapping> &get_trait_substs () const;
 
   bool satisfies_bound (const TraitReference &reference) const;
 

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -31,6 +31,11 @@ class TypeCheckExpr : private TypeCheckBase, private HIR::HIRExpressionVisitor
 public:
   static TyTy::BaseType *Resolve (HIR::Expr &expr);
 
+  static TyTy::BaseType *
+  ResolveOpOverload (LangItem::Kind lang_item_type, HIR::OperatorExprMeta expr,
+		     TyTy::BaseType *lhs, TyTy::BaseType *rhs,
+		     HIR::PathIdentSegment specified_segment);
+
   void visit (HIR::TupleIndexExpr &expr) override;
   void visit (HIR::TupleExpr &expr) override;
   void visit (HIR::ReturnExpr &expr) override;

--- a/gcc/testsuite/rust/compile/issue-3916.rs
+++ b/gcc/testsuite/rust/compile/issue-3916.rs
@@ -1,0 +1,36 @@
+#![feature(rustc_attrs)]
+
+#[lang = "sized"]
+trait Sized {}
+
+#[lang = "add"]
+trait Add<Rhs = Self> {
+    type Output;
+
+    fn add(self, rhs: Rhs) -> Self::Output;
+}
+
+macro_rules! add_impl {
+    ($($t:ty)*) => ($(
+        impl Add for $t {
+            type Output = $t;
+
+            #[inline]
+            #[rustc_inherit_overflow_checks]
+            fn add(self, other: $t) -> $t { self + other }
+        }
+    )*)
+}
+
+add_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
+
+pub fn test(len: usize) -> u64 {
+    let mut i = 0;
+    let mut out = 0;
+    if i + 3 < len {
+        out = 123;
+    } else {
+        out = 456;
+    }
+    out
+}


### PR DESCRIPTION
In the test case:

```rust
  fn test (len: usize) -> u64 {
     let mut i = 0;
     let mut out = 0;
     if i + 3 < len {
        out = 123;
     }
     out
  }
```

The issue is to determine the correct type of 'i', out is simple because it hits a coercion site in the resturn position for u64. But 'i + 3', 'i' is an integer infer variable and the same for the literal '3'. So when it comes to resolving the type for the Add expression we hit the resolve the operator overload code and because of this:

```rust
  macro_rules! add_impl {
      ($($t:ty)*) => ($(
          impl Add for $t {
              type Output = $t;

              #[inline]
              #[rustc_inherit_overflow_checks]
              fn add(self, other: $t) -> $t { self + other }
          }
      )*)
  }

  add_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
```
This means the resolution for 'i + 3' is ambigious because it could be any of these Add implementations. But because we unify against the '< len' where len is defined as usize later in the resolution we determine 'i' is actually a usize. Which means if we defer the resolution of this operator overload in the ambigious case we can simply resolve it at the end.

Fixes Rust-GCC#3916

gcc/rust/ChangeLog:

	* hir/tree/rust-hir-expr.cc (OperatorExprMeta::OperatorExprMeta): track the rhs
	* hir/tree/rust-hir-expr.h: likewise
	* hir/tree/rust-hir-path.h: get rid of old comments
	* typecheck/rust-hir-trait-reference.cc (TraitReference::get_trait_substs): return references instead of copy
	* typecheck/rust-hir-trait-reference.h: update header
	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::ResolveOpOverload): write ambigious operator overloads to a table and try to resolve it at the end
	* typecheck/rust-hir-type-check-expr.h: new static helper
	* typecheck/rust-hir-type-check.h (struct DeferredOpOverload): new model to defer resolution
	* typecheck/rust-typecheck-context.cc (TypeCheckContext::lookup_operator_overload): (TypeCheckContext::compute_ambigious_op_overload): new helper (TypeCheckContext::compute_inference_variables): likewise

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3916.rs: New test.
