### PR TITLE
gccrs: Fix ICE with duplicate root item main function

### DIFF
--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -697,7 +697,8 @@ HIRCompileBase::compile_function (
     = canonical_path.get () + fntype->subst_as_string ();
 
   // we don't mangle the main fn since we haven't implemented the main shim
-  bool is_main_fn = fn_name.compare ("main") == 0 && is_root_item;
+  bool is_main_fn = fn_name.compare ("main") == 0 && is_root_item
+		    && canonical_path.size () <= 2;
   if (is_main_fn)
     {
       rust_assert (!main_identifier_node);

--- a/gcc/testsuite/rust/compile/issue-3978.rs
+++ b/gcc/testsuite/rust/compile/issue-3978.rs
@@ -1,0 +1,8 @@
+type Dimension = usize;
+
+pub fn main() {}
+
+mod m2 {
+    fn main() {}
+    // { dg-warning "function is never used" "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
Rust seems to allow duplicate HIR::Item 'main' functions but it needs to be a root item to be the true main entry point. This means we can use the canonical path to determine if this is a root one where its CrateName::main or CrateName::Module::main.

Fixes Rust-GCC#3978

gcc/rust/ChangeLog:

	* backend/rust-compile-base.cc: check the canonical path

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3978.rs: New test.
