### PR TITLE
gccrs: return error node when this fails during constexpr case

### DIFF
--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -214,7 +214,8 @@ ResolvePathRef::resolve (const HIR::PathIdentSegment &final_segment,
 {
   TyTy::BaseType *lookup = nullptr;
   bool ok = ctx->get_tyctx ()->lookup_type (mappings.get_hirid (), &lookup);
-  rust_assert (ok);
+  if (!ok)
+    return error_mark_node;
 
   // need to look up the reference for this identifier
 


### PR DESCRIPTION
Not adding the test case here we emit more errors than rustc for the error type node so its just noisy and dejagnu is being a pain.

Fixes Rust-GCC#3933

gcc/rust/ChangeLog:

	* backend/rust-compile-resolve-path.cc (ResolvePathRef::resolve): return error_mark_node
