### PR TITLE
ast: Visit block labels if they are present

### DIFF
--- a/gcc/rust/ast/rust-ast-visitor.cc
+++ b/gcc/rust/ast/rust-ast-visitor.cc
@@ -449,8 +449,13 @@ DefaultASTVisitor::visit (AST::BlockExpr &expr)
 {
   visit_outer_attrs (expr);
   visit_inner_attrs (expr);
+
+  if (expr.has_label ())
+    visit (expr.get_label ());
+
   for (auto &stmt : expr.get_statements ())
     visit (stmt);
+
   if (expr.has_tail_expr ())
     visit (expr.get_tail_expr ());
 }


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* ast/rust-ast-visitor.cc (DefaultASTVisitor::visit): Visit a block's loop label if it
	exists.
