### PR TITLE
desugar: Add desugar dispatch for all desugars

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -242,9 +242,11 @@ GRS_OBJS = \
 	rust/rust-expand-format-args.o \
 	rust/rust-lang-item.o \
 	rust/rust-collect-lang-items.o \
+	rust/rust-expression-yeast.o \
 	rust/rust-desugar-for-loops.o \
 	rust/rust-desugar-question-mark.o \
 	rust/rust-desugar-apit.o \
+	# rust/rust-desugar-try-block.o \
     $(END)
 # removed object files from here
 

--- a/gcc/rust/ast/rust-desugar-question-mark.h
+++ b/gcc/rust/ast/rust-desugar-question-mark.h
@@ -19,9 +19,7 @@
 #ifndef RUST_DESUGAR_QUESTION_MARK
 #define RUST_DESUGAR_QUESTION_MARK
 
-#include "rust-ast-visitor.h"
 #include "rust-expr.h"
-#include "rust-stmt.h"
 
 namespace Rust {
 namespace AST {
@@ -56,21 +54,15 @@ namespace AST {
 //   }
 // }
 // ```
-class DesugarQuestionMark : public DefaultASTVisitor
+class DesugarQuestionMark
 {
-  using DefaultASTVisitor::visit;
-
 public:
-  DesugarQuestionMark ();
-  void go (AST::Crate &);
+  static void go (std::unique_ptr<Expr> &ptr);
 
 private:
-  void desugar_and_replace (std::unique_ptr<Expr> &ptr);
-  std::unique_ptr<Expr> desugar (ErrorPropagationExpr &);
+  DesugarQuestionMark ();
 
-  void visit (AST::ExprStmt &) override;
-  void visit (AST::CallExpr &) override;
-  void visit (AST::LetStmt &) override;
+  std::unique_ptr<Expr> desugar (ErrorPropagationExpr &);
 };
 
 } // namespace AST

--- a/gcc/rust/ast/rust-expression-yeast.cc
+++ b/gcc/rust/ast/rust-expression-yeast.cc
@@ -1,0 +1,87 @@
+// Copyright (C) 2025 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-expression-yeast.h"
+#include "rust-ast-visitor.h"
+#include "rust-desugar-question-mark.h"
+#include "rust-ast-full.h"
+
+namespace Rust {
+namespace AST {
+
+void
+ExpressionYeast::go (AST::Crate &crate)
+{
+  DefaultASTVisitor::visit (crate);
+}
+
+void
+ExpressionYeast::dispatch (std::unique_ptr<Expr> &expr)
+{
+  switch (expr->get_expr_kind ())
+    {
+      // TODO: Handle try-blocks
+    case Expr::Kind::ErrorPropagation:
+      DesugarQuestionMark::go (expr);
+      break;
+
+    default:
+      break;
+    }
+}
+
+void
+ExpressionYeast::visit (ExprStmt &stmt)
+{
+  dispatch (stmt.get_expr_ptr ());
+
+  DefaultASTVisitor::visit (stmt);
+}
+
+void
+ExpressionYeast::visit (CallExpr &call)
+{
+  dispatch (call.get_function_expr_ptr ());
+
+  for (auto &arg : call.get_params ())
+    dispatch (arg);
+
+  DefaultASTVisitor::visit (call);
+}
+
+void
+ExpressionYeast::visit (BlockExpr &block)
+{
+  for (auto &stmt : block.get_statements ())
+    DefaultASTVisitor::visit (stmt);
+
+  if (block.has_tail_expr ())
+    dispatch (block.get_tail_expr_ptr ());
+}
+
+void
+ExpressionYeast::visit (LetStmt &stmt)
+{
+  if (stmt.has_init_expr ())
+    dispatch (stmt.get_init_expr_ptr ());
+
+  DefaultASTVisitor::visit (stmt);
+}
+
+} // namespace AST
+} // namespace Rust

--- a/gcc/rust/ast/rust-expression-yeast.h
+++ b/gcc/rust/ast/rust-expression-yeast.h
@@ -1,0 +1,51 @@
+// Copyright (C) 2025 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_EXPRESSION_YEAST
+#define RUST_EXPRESSION_YEAST
+
+#include "rust-ast-visitor.h"
+#include "rust-ast.h"
+#include "rust-desugar-question-mark.h"
+
+namespace Rust {
+namespace AST {
+
+// This visitor takes care of all the expression desugars: try-blocks,
+// error-propagation, etc.
+class ExpressionYeast : public AST::DefaultASTVisitor
+{
+  using AST::DefaultASTVisitor::visit;
+
+public:
+  void go (AST::Crate &);
+
+private:
+  // Dispatch to the proper desugar
+  void dispatch (std::unique_ptr<Expr> &expr);
+
+  void visit (AST::ExprStmt &) override;
+  void visit (AST::CallExpr &) override;
+  void visit (AST::LetStmt &) override;
+  void visit (AST::BlockExpr &) override;
+};
+
+} // namespace AST
+} // namespace Rust
+
+#endif // ! RUST_EXPRESSION_YEAST

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -22,6 +22,7 @@
 #include "rust-desugar-question-mark.h"
 #include "rust-desugar-apit.h"
 #include "rust-diagnostics.h"
+#include "rust-expression-yeast.h"
 #include "rust-hir-pattern-analysis.h"
 #include "rust-immutable-name-resolution-context.h"
 #include "rust-unsafe-checker.h"
@@ -985,8 +986,9 @@ Session::expansion (AST::Crate &crate, Resolver2_0::NameResolutionContext &ctx)
   // handle AST desugaring
   if (!saw_errors ())
     {
+      AST::ExpressionYeast ().go (crate);
+
       AST::DesugarForLoops ().go (crate);
-      AST::DesugarQuestionMark ().go (crate);
       AST::DesugarApit ().go (crate);
 
       // HACK: we may need a final TopLevel pass


### PR DESCRIPTION
Since we are doing more and more "external" desugars, as in desugars
that take a pointer and replace it with another one, rather than
modifying it from within, having an external visitor dispatch to the
proper desugar helps with code clarity.

gcc/rust/ChangeLog:

	* Make-lang.in:
	* ast/rust-desugar-question-mark.cc: Rework class
	API.
	* ast/rust-desugar-question-mark.h: Likewise.
	* ast/rust-expression-yeast.cc: New file.
	* ast/rust-expression-yeast.h: New file.
