### PR TITLE
gccrs: Implement compilation for SlicePattern matching against SliceType scrutinee

### DIFF
--- a/gcc/rust/backend/rust-compile-pattern.cc
+++ b/gcc/rust/backend/rust-compile-pattern.cc
@@ -529,7 +529,8 @@ CompilePatternCheckExpr::visit (HIR::SlicePattern &pattern)
   // pattern must either be ArrayType or SliceType, should be already confirmed
   // by type checking
   rust_assert (lookup->get_kind () == TyTy::TypeKind::ARRAY
-	       || lookup->get_kind () == TyTy::TypeKind::SLICE);
+	       || lookup->get_kind () == TyTy::TypeKind::SLICE
+	       || lookup->get_kind () == TyTy::REF);
 
   size_t array_element_index = 0;
   switch (lookup->get_kind ())
@@ -895,7 +896,8 @@ CompilePatternBindings::visit (HIR::SlicePattern &pattern)
   rust_assert (ok);
 
   rust_assert (lookup->get_kind () == TyTy::TypeKind::ARRAY
-	       || lookup->get_kind () == TyTy::TypeKind::SLICE);
+	       || lookup->get_kind () == TyTy::TypeKind::SLICE
+	       || lookup->get_kind () == TyTy::REF);
 
   size_t array_element_index = 0;
   switch (lookup->get_kind ())

--- a/gcc/rust/rust-backend.h
+++ b/gcc/rust/rust-backend.h
@@ -245,6 +245,10 @@ tree array_initializer (tree, tree, tree, tree, tree, tree *, location_t);
 // fixed-length array, not a slice.
 tree array_index_expression (tree array, tree index, location_t);
 
+// Return an expresison for SLICE[INDEX] as an l-value.  SLICE is represented
+// with a DST.
+tree slice_index_expression (tree slice, tree index, location_t);
+
 // Create an expression for a call to FN with ARGS, taking place within
 // caller CALLER.
 tree call_expression (tree fn, const std::vector<tree> &args, tree static_chain,

--- a/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
@@ -675,8 +675,21 @@ TypeCheckPattern::visit (HIR::SlicePattern &pattern)
       }
     case TyTy::SLICE:
       {
-	auto &array_ty_ty = static_cast<TyTy::SliceType &> (*parent);
-	parent_element_ty = array_ty_ty.get_element_type ();
+	auto &slice_ty_ty = static_cast<TyTy::SliceType &> (*parent);
+	parent_element_ty = slice_ty_ty.get_element_type ();
+	break;
+      }
+    case TyTy::REF:
+      {
+	auto &ref_ty_ty = static_cast<TyTy::ReferenceType &> (*parent);
+	const TyTy::SliceType *slice = nullptr;
+	if (!ref_ty_ty.is_dyn_slice_type (&slice))
+	  {
+	    rust_error_at (pattern.get_locus (), "expected %s, found slice",
+			   parent->as_string ().c_str ());
+	    return;
+	  }
+	parent_element_ty = slice->get_element_type ();
 	break;
       }
     default:

--- a/gcc/testsuite/rust/compile/match-slicepattern-slice.rs
+++ b/gcc/testsuite/rust/compile/match-slicepattern-slice.rs
@@ -1,0 +1,10 @@
+fn main() {
+    let arr = [1, 2];
+    let slice: &[i32] = &arr;
+
+    match slice {
+        [1] => {},
+        [_, 2] => {},
+        _ => {}
+    }
+}

--- a/gcc/testsuite/rust/execute/torture/match-slicepattern-slice-1.rs
+++ b/gcc/testsuite/rust/execute/torture/match-slicepattern-slice-1.rs
@@ -1,0 +1,24 @@
+// { dg-output "correct\r*" }
+extern "C" {
+    fn puts(s: *const i8);
+}
+
+fn main() -> i32 {
+    let arr = [0, 1];
+    let a: &[i32] = &arr;
+    let mut ret = 1;
+
+    match a {
+        [0, 0] => {
+            /* should not take this path */
+            unsafe { puts("wrong\0" as *const str as *const i8) }
+        },
+        [0, b] => {
+            ret -= b;
+            unsafe { puts("correct\0" as *const str as *const i8) }
+        },
+        _ => {}
+    }
+
+    ret
+}


### PR DESCRIPTION
Figured out how to use the `debug` function in `rust.gcc.cc`.

Looking for feedback on my implementation for `slice_data_index_expression`, I am unsure whether it's the best way to do so. (should I make it such that the 1st parameter is the actual slice tree and not the data field?)

Supporting rest patterns `[..]` in slice patterns will be my next task.