### PR TITLE
gccrs: 128bit integer support is limited on 32 bit platforms

### DIFF
--- a/gcc/testsuite/rust/execute/torture/sip-hasher.rs
+++ b/gcc/testsuite/rust/execute/torture/sip-hasher.rs
@@ -1,4 +1,3 @@
-// { dg-skip-if "" { *-*-* } { "-m32" } { "" } }
 // { dg-options "-w" }
 // { dg-output "Hash: 0x63d53fd2170bbb8c\r*\n" }
 #![feature(intrinsics)]
@@ -36,7 +35,7 @@ macro_rules! add_impl {
     )*)
 }
 
-add_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
+add_impl! { usize u8 u16 u32 u64 isize i8 i16 i32 i64 f32 f64 }
 
 impl<T> *const T {
     pub unsafe fn add(self, count: usize) -> Self {
@@ -83,7 +82,6 @@ impl_uint!(
     u16 = "u16",
     u32 = "u32",
     u64 = "u64",
-    u128 = "u128",
     usize = "usize"
 );
 


### PR DESCRIPTION
This is a wider gcc issue we will need to address at some point but this test runs fine under 32 bit more without the 128bit lang item for rotate here.

gcc/testsuite/ChangeLog:

	* rust/execute/torture/sip-hasher.rs: remove 128bit lang item
