### PR TITLE
Reenable test on *-*-darwin*

### DIFF
--- a/gcc/testsuite/rust/debug/chartype.rs
+++ b/gcc/testsuite/rust/debug/chartype.rs
@@ -1,5 +1,4 @@
 // { dg-do compile }
-// { dg-skip-if "see https://github.com/Rust-GCC/gccrs/pull/1632" { *-*-darwin* } }
 // { dg-options "-w -gdwarf-4 -dA" }
 // 'char' should use DW_ATE_UTF
 fn main() {


### PR DESCRIPTION
This seems to have been disabled to work around a bug in clang, back in 2022. See #1632