### PR TITLE
Fix semicolon after some namespace

### DIFF
--- a/gcc/rust/checks/errors/borrowck/rust-bir-fact-collector.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-fact-collector.h
@@ -883,7 +883,7 @@ protected: // Subset helpers.
 
     return region_end;
   }
-}; // namespace BIR
+};
 
 } // namespace BIR
 } // namespace Rust

--- a/gcc/rust/checks/errors/rust-feature.cc
+++ b/gcc/rust/checks/errors/rust-feature.cc
@@ -84,7 +84,7 @@ const std::map<std::string, Feature::Name> Feature::name_hash_map = {
   {"exclusive_range_pattern", Feature::Name::EXCLUSIVE_RANGE_PATTERN},
   {"prelude_import", Feature::Name::PRELUDE_IMPORT},
   {"min_specialization", Feature::Name::MIN_SPECIALIZATION},
-}; // namespace Rust
+};
 
 tl::optional<Feature::Name>
 Feature::as_name (const std::string &name)

--- a/gcc/rust/expand/rust-token-tree-desugar.cc
+++ b/gcc/rust/expand/rust-token-tree-desugar.cc
@@ -68,5 +68,5 @@ TokenTreeDesugar::visit (Token &tts)
     }
 }
 
-}; // namespace AST
-}; // namespace Rust
+} // namespace AST
+} // namespace Rust

--- a/gcc/rust/expand/rust-token-tree-desugar.h
+++ b/gcc/rust/expand/rust-token-tree-desugar.h
@@ -49,7 +49,7 @@ private:
   virtual void visit (Token &tts) override;
 };
 
-}; // namespace AST
-}; // namespace Rust
+} // namespace AST
+} // namespace Rust
 
 #endif //! RUST_TOKEN_TREE_DESUGAR_H

--- a/gcc/rust/util/optional.h
+++ b/gcc/rust/util/optional.h
@@ -1364,7 +1364,7 @@ public:
       this->m_has_value = false;
     }
   }
-}; // namespace tl
+};
 
 /// Compares two optional objects
 template <class T, class U>
@@ -2110,7 +2110,7 @@ public:
 
 private:
   T *m_value;
-}; // namespace tl
+};
 
 
 


### PR DESCRIPTION
Remove namespace comment after classes and structs to avoid warnings.