### PR TITLE
Fix infinite loop with missing comma

### DIFF
--- a/gcc/rust/expand/rust-macro-builtins-asm.cc
+++ b/gcc/rust/expand/rust-macro-builtins-asm.cc
@@ -937,7 +937,9 @@ parse_format_strings (InlineAsmContext inline_asm_ctx)
     {
       if (!parser.skip_token (COMMA))
 	{
-	  break;
+	  rust_error_at (parser.peek_current_token ()->get_locus (),
+			 "expected token %qs", ";");
+	  return tl::unexpected<InlineAsmParseError> (COMMITTED);
 	}
       // Ok after the comma is good, we better be parsing correctly
       // everything in here, which is formatted string in ABNF

--- a/gcc/testsuite/rust/compile/issue-4006.rs
+++ b/gcc/testsuite/rust/compile/issue-4006.rs
@@ -1,0 +1,13 @@
+#![feature(rustc_attrs)]
+
+#[rustc_builtin_macro]
+macro_rules! asm {
+    () => {};
+}
+
+pub fn main() {
+    asm!(
+        "xor eax, eax"
+        "xor eax, eax");
+    // { dg-error "expected token .;." "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
A missing comma between inline assembly templates did not throw an error and looped indefinitely.

Fixes #4006