### PR TITLE
Remove warning for unused self parameter

### DIFF
--- a/gcc/rust/checks/lints/rust-lint-unused-var.cc
+++ b/gcc/rust/checks/lints/rust-lint-unused-var.cc
@@ -31,6 +31,7 @@ check_decl (tree *t)
   tree var_name = DECL_NAME (*t);
   const char *var_name_ptr = IDENTIFIER_POINTER (var_name);
   bool starts_with_under_score = strncmp (var_name_ptr, "_", 1) == 0;
+  bool is_self = strcmp (var_name_ptr, "self") == 0;
 
   bool is_constant = TREE_CODE (*t) == CONST_DECL;
   // if (!is_constant)
@@ -43,7 +44,8 @@ check_decl (tree *t)
   //       	  starts_with_under_score ? "true" : "false", var_name_ptr);
   //   }
 
-  if (!TREE_USED (*t) && !DECL_ARTIFICIAL (*t) && !starts_with_under_score)
+  if (!TREE_USED (*t) && !DECL_ARTIFICIAL (*t) && !starts_with_under_score
+      && !is_self)
     {
       warning_at (DECL_SOURCE_LOCATION (*t),
 		  is_constant ? OPT_Wunused_const_variable_

--- a/gcc/testsuite/rust/compile/auto_traits2.rs
+++ b/gcc/testsuite/rust/compile/auto_traits2.rs
@@ -15,7 +15,7 @@ fn foo(a: &(dyn A + Send + Sync)) {
 struct S;
 
 impl A for S {
-    fn a_method(&self) {} // { dg-warning "unused name" }
+    fn a_method(&self) {}
 }
 
 fn main() {

--- a/gcc/testsuite/rust/compile/derive-debug1.rs
+++ b/gcc/testsuite/rust/compile/derive-debug1.rs
@@ -23,15 +23,15 @@ mod core {
     }
 }
 
-#[derive(Debug)] // { dg-warning "unused name" }
+#[derive(Debug)]
 // { dg-warning "stub implementation" "" { target *-*-* } .-1 }
 struct Foo { a: i32, b: i64 } // { dg-warning "is never constructed" }
 
-#[derive(Debug)] // { dg-warning "unused name" }
+#[derive(Debug)]
 // { dg-warning "stub implementation" "" { target *-*-* } .-1 }
 struct Bar(i32, i32); // { dg-warning "is never constructed" }
 
-#[derive(Debug)] // { dg-warning "unused name" }
+#[derive(Debug)]
 // { dg-warning "stub implementation" "" { target *-*-* } .-1 }
 enum Baz {
     A,

--- a/gcc/testsuite/rust/compile/derive_macro1.rs
+++ b/gcc/testsuite/rust/compile/derive_macro1.rs
@@ -7,7 +7,7 @@ pub trait Clone {
 }
 
 // This warning can be removed once we properly handle implems with #[automatically_derived]
-#[derive(Clone)] // { dg-warning "unused name .self." }
+#[derive(Clone)]
 pub struct S;
 
 fn main() {

--- a/gcc/testsuite/rust/compile/format_args_basic_expansion.rs
+++ b/gcc/testsuite/rust/compile/format_args_basic_expansion.rs
@@ -35,7 +35,6 @@ pub mod core {
 
         impl Display for i32 {
             fn fmt(&self, _: &mut Formatter) -> Result {
-                // { dg-warning "unused name .self." "" { target *-*-* } .-1 }
                 Result
             }
         }

--- a/gcc/testsuite/rust/compile/format_args_extra_comma.rs
+++ b/gcc/testsuite/rust/compile/format_args_extra_comma.rs
@@ -35,7 +35,6 @@ pub mod core {
 
         impl Display for i32 {
             fn fmt(&self, _: &mut Formatter) -> Result {
-                // { dg-warning "unused name .self." "" { target *-*-* } .-1 }
                 Result
             }
         }

--- a/gcc/testsuite/rust/compile/issue-2043.rs
+++ b/gcc/testsuite/rust/compile/issue-2043.rs
@@ -6,7 +6,6 @@ struct Foo<'a> {
 impl<'a> Foo<'a> {
     fn bar(self: &mut Foo<'a>) {}
     // { dg-warning "associated function is never used: .bar." "" { target *-*-* } .-1 }
-    // { dg-warning "unused name .self." "" { target *-*-* } .-2 }
 }
 
 fn main() {}

--- a/gcc/testsuite/rust/compile/issue-2166.rs
+++ b/gcc/testsuite/rust/compile/issue-2166.rs
@@ -11,7 +11,6 @@ impl Add for u32 {
     type Output = u32;
 
     fn add(self) -> u32 {
-        // { dg-warning "unused name" "" { target *-*-* } .-1 }
         0
     }
 }
@@ -20,7 +19,6 @@ impl<'a> Add for &'a u32 {
     type Output = u32;
 
     fn add(self) -> <u32 as Add>::Output {
-        // { dg-warning "unused name" "" { target *-*-* } .-1 }
         0
     }
 }

--- a/gcc/testsuite/rust/compile/issue-2238.rs
+++ b/gcc/testsuite/rust/compile/issue-2238.rs
@@ -10,7 +10,6 @@ fn main() {
 
     impl Bar for Foo {
         fn foo(&self) {}
-        // { dg-warning "unused name" "" { target *-*-* } .-1 }
     }
 
     let s = Foo;

--- a/gcc/testsuite/rust/compile/issue-2907.rs
+++ b/gcc/testsuite/rust/compile/issue-2907.rs
@@ -15,7 +15,6 @@ impl<B: Bar> Foo for B {
     type Ty = u32;
 
     fn foo(self) -> Self::Ty {
-        // { dg-warning "unused name" "" { target *-*-* } .-1 }
         14
     }
 }

--- a/gcc/testsuite/rust/compile/min_specialization1.rs
+++ b/gcc/testsuite/rust/compile/min_specialization1.rs
@@ -9,7 +9,7 @@ pub trait Foo {
 pub struct Bar;
 
 impl Foo for Bar {
-    default fn foo(&self) -> bool { // { dg-warning "unused" }
+    default fn foo(&self) -> bool {
         true
     }
 }

--- a/gcc/testsuite/rust/compile/name_resolution2.rs
+++ b/gcc/testsuite/rust/compile/name_resolution2.rs
@@ -4,7 +4,7 @@ pub trait Sized {}
 struct Bar;
 
 trait Foo {
-    fn bar(&self) {} // { dg-warning "unused name" }
+    fn bar(&self) {}
 }
 
 pub fn outer() {

--- a/gcc/testsuite/rust/compile/name_resolution4.rs
+++ b/gcc/testsuite/rust/compile/name_resolution4.rs
@@ -2,7 +2,7 @@
 pub trait Sized {}
 
 trait Foo {
-    fn foo(&self) {} // { dg-warning "unused name" }
+    fn foo(&self) {}
 }
 
 struct Bar;

--- a/gcc/testsuite/rust/compile/torture/generics29.rs
+++ b/gcc/testsuite/rust/compile/torture/generics29.rs
@@ -5,7 +5,6 @@ struct Foo<A, B>(A, B);
 
 impl Foo<i32, f32> {
     fn test<X>(self, a: X) -> X {
-        // { dg-warning "unused name" "" { target *-*-* } .-1 }
         a
     }
 }

--- a/gcc/testsuite/rust/compile/torture/generics30.rs
+++ b/gcc/testsuite/rust/compile/torture/generics30.rs
@@ -5,7 +5,6 @@ struct Foo<A, B>(A, B);
 
 impl<T> Foo<T, f32> {
     fn test<X>(self, a: X) -> X {
-        // { dg-warning "unused name" "" { target *-*-* } .-1 }
         a
     }
 }

--- a/gcc/testsuite/rust/compile/torture/traits3.rs
+++ b/gcc/testsuite/rust/compile/torture/traits3.rs
@@ -10,7 +10,6 @@ struct Baz;
 
 impl Foo for Baz {
     fn Bar(self) -> i32 {
-        // { dg-warning "unused name .self." "" { target *-*-* } .-1 }
         123
     }
 }

--- a/gcc/testsuite/rust/compile/torture/traits7.rs
+++ b/gcc/testsuite/rust/compile/torture/traits7.rs
@@ -13,7 +13,6 @@ impl Foo for Bar {
     // { dg-warning "unused name" "" { target *-*-* } .-1 }
 
     fn test(self) {}
-    // { dg-warning "unused name" "" { target *-*-* } .-1 }
 }
 
 fn main() {

--- a/gcc/testsuite/rust/execute/torture/impl_trait3.rs
+++ b/gcc/testsuite/rust/execute/torture/impl_trait3.rs
@@ -18,7 +18,6 @@ struct Console;
 
 impl Printer for Console {
     fn print(&self, input: impl Speak) {
-        // { dg-warning "unused name .self." "" { target *-*-* } .-1 }
         unsafe {
             let a = input.speak();
             let b = a as *const str;

--- a/gcc/testsuite/rust/execute/torture/min_specialization2.rs
+++ b/gcc/testsuite/rust/execute/torture/min_specialization2.rs
@@ -8,7 +8,7 @@ trait Foo {
 }
 
 impl<T> Foo for T {
-    default fn foo(&self) -> i32 { // { dg-warning "unused" }
+    default fn foo(&self) -> i32 {
         15
     }
 }

--- a/gcc/testsuite/rust/execute/torture/trait10.rs
+++ b/gcc/testsuite/rust/execute/torture/trait10.rs
@@ -26,7 +26,6 @@ impl Bar for Foo {
 struct S;
 impl S {
     fn dynamic_dispatch(self, t: &dyn Bar) {
-        // { dg-warning "unused name" "" { target *-*-* } .-1 }
         t.baz();
     }
 }

--- a/gcc/testsuite/rust/execute/torture/trait11.rs
+++ b/gcc/testsuite/rust/execute/torture/trait11.rs
@@ -13,7 +13,6 @@ trait FnLike<A, R> {
 struct S;
 impl<'a, T> FnLike<&'a T, &'a T> for S {
     fn call(&self, arg: &'a T) -> &'a T {
-        // { dg-warning "unused name .self." "" { target *-*-* } .-1 }
         arg
     }
 }

--- a/gcc/testsuite/rust/execute/torture/trait12.rs
+++ b/gcc/testsuite/rust/execute/torture/trait12.rs
@@ -16,7 +16,6 @@ struct Identity;
 
 impl<'a, T> FnLike<&'a T, &'a T> for Identity {
     fn call(&self, arg: &'a T) -> &'a T {
-        // { dg-warning "unused name .self." "" { target *-*-* } .-1 }
         arg
     }
 }

--- a/gcc/testsuite/rust/execute/torture/trait13.rs
+++ b/gcc/testsuite/rust/execute/torture/trait13.rs
@@ -11,7 +11,6 @@ trait Bar {
     fn baz(&self);
 
     fn qux(&self) {
-        // { dg-warning "unused name" "" { target *-*-* } .-1 }
         unsafe {
             let a = "%i\n\0";
             let b = a as *const str;

--- a/gcc/testsuite/rust/execute/torture/trait9.rs
+++ b/gcc/testsuite/rust/execute/torture/trait9.rs
@@ -13,7 +13,6 @@ trait FnLike<A, R> {
 struct S;
 impl<T> FnLike<&T, &T> for S {
     fn call(&self, arg: &T) -> &T {
-        // { dg-warning "unused name .self." "" { target *-*-* } .-1 }
         arg
     }
 }


### PR DESCRIPTION
This PR addresses https://github.com/Rust-GCC/gccrs/issues/4022

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`