### PR TITLE
Add initial support for const generics

### DIFF
--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -696,6 +696,9 @@ HIRCompileBase::compile_function (
   std::string ir_symbol_name
     = canonical_path.get () + fntype->subst_as_string ();
 
+  rust_debug_loc (locus, "--> Compiling [%s] - %s", ir_symbol_name.c_str (),
+		  fntype->get_name ().c_str ());
+
   // we don't mangle the main fn since we haven't implemented the main shim
   bool is_main_fn = fn_name.compare ("main") == 0 && is_root_item
 		    && canonical_path.size () <= 2;

--- a/gcc/rust/backend/rust-compile-intrinsic.cc
+++ b/gcc/rust/backend/rust-compile-intrinsic.cc
@@ -437,8 +437,8 @@ sizeof_handler (Context *ctx, TyTy::FnType *fntype)
   // get the template parameter type tree fn size_of<T>();
   rust_assert (fntype->get_num_substitutions () == 1);
   auto &param_mapping = fntype->get_substs ().at (0);
-  const TyTy::ParamType *param_tyty = param_mapping.get_param_ty ();
-  TyTy::BaseType *resolved_tyty = param_tyty->resolve ();
+  const auto param_tyty = param_mapping.get_param_ty ();
+  auto resolved_tyty = param_tyty->resolve ();
   tree template_parameter_type
     = TyTyResolveCompile::compile (ctx, resolved_tyty);
 
@@ -643,8 +643,8 @@ op_with_overflow_inner (Context *ctx, TyTy::FnType *fntype, tree_code op)
 
   rust_assert (fntype->get_num_substitutions () == 1);
   auto &param_mapping = fntype->get_substs ().at (0);
-  const TyTy::ParamType *param_tyty = param_mapping.get_param_ty ();
-  TyTy::BaseType *resolved_tyty = param_tyty->resolve ();
+  const auto param_tyty = param_mapping.get_param_ty ();
+  auto resolved_tyty = param_tyty->resolve ();
   tree template_parameter_type
     = TyTyResolveCompile::compile (ctx, resolved_tyty);
 
@@ -1079,8 +1079,8 @@ uninit_handler (Context *ctx, TyTy::FnType *fntype)
   // get the template parameter type tree fn uninit<T>();
   rust_assert (fntype->get_num_substitutions () == 1);
   auto &param_mapping = fntype->get_substs ().at (0);
-  const TyTy::ParamType *param_tyty = param_mapping.get_param_ty ();
-  TyTy::BaseType *resolved_tyty = param_tyty->resolve ();
+  const auto param_tyty = param_mapping.get_param_ty ();
+  auto resolved_tyty = param_tyty->resolve ();
   tree template_parameter_type
     = TyTyResolveCompile::compile (ctx, resolved_tyty);
 
@@ -1144,8 +1144,8 @@ move_val_init_handler (Context *ctx, TyTy::FnType *fntype)
   // get the template parameter type tree fn size_of<T>();
   rust_assert (fntype->get_num_substitutions () == 1);
   auto &param_mapping = fntype->get_substs ().at (0);
-  const TyTy::ParamType *param_tyty = param_mapping.get_param_ty ();
-  TyTy::BaseType *resolved_tyty = param_tyty->resolve ();
+  auto param_tyty = param_mapping.get_param_ty ();
+  auto resolved_tyty = param_tyty->resolve ();
   tree template_parameter_type
     = TyTyResolveCompile::compile (ctx, resolved_tyty);
 

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -330,7 +330,7 @@ HIRCompileBase::query_compile (HirId ref, TyTy::BaseType *lookup,
 	  auto fn = lookup->as<TyTy::FnType> ();
 	  rust_assert (fn->get_num_type_params () > 0);
 	  TyTy::SubstitutionParamMapping &self = fn->get_substs ().at (0);
-	  TyTy::ParamType *receiver = self.get_param_ty ();
+	  TyTy::BaseGeneric *receiver = self.get_param_ty ();
 	  TyTy::BaseType *r = receiver;
 	  if (!receiver->can_resolve ())
 	    {

--- a/gcc/rust/backend/rust-compile-stmt.cc
+++ b/gcc/rust/backend/rust-compile-stmt.cc
@@ -58,6 +58,9 @@ CompileStmt::visit (HIR::LetStmt &stmt)
       return;
     }
 
+  rust_debug_loc (stmt.get_locus (), "   -> LetStmt %s",
+		  ty->as_string ().c_str ());
+
   // setup var decl nodes
   fncontext fnctx = ctx->peek_fn ();
   tree fndecl = fnctx.fndecl;

--- a/gcc/rust/backend/rust-compile-type.cc
+++ b/gcc/rust/backend/rust-compile-type.cc
@@ -476,7 +476,8 @@ TyTyResolveCompile::visit (const TyTy::ArrayType &type)
 {
   tree element_type
     = TyTyResolveCompile::compile (ctx, type.get_element_type ());
-  tree folded_capacity_expr = type.get_capacity ();
+  TyTy::ConstType *const_capacity = type.get_capacity ();
+  tree folded_capacity_expr = const_capacity->get_value ();
 
   // build_index_type takes the maximum index, which is one less than
   // the length.

--- a/gcc/rust/backend/rust-compile-type.cc
+++ b/gcc/rust/backend/rust-compile-type.cc
@@ -142,6 +142,12 @@ TyTyResolveCompile::visit (const TyTy::ParamType &)
 }
 
 void
+TyTyResolveCompile::visit (const TyTy::ConstType &)
+{
+  translated = error_mark_node;
+}
+
+void
 TyTyResolveCompile::visit (const TyTy::ProjectionType &type)
 {
   translated = error_mark_node;

--- a/gcc/rust/backend/rust-compile-type.h
+++ b/gcc/rust/backend/rust-compile-type.h
@@ -50,6 +50,7 @@ public:
   void visit (const TyTy::ReferenceType &) override;
   void visit (const TyTy::PointerType &) override;
   void visit (const TyTy::ParamType &) override;
+  void visit (const TyTy::ConstType &) override;
   void visit (const TyTy::StrType &) override;
   void visit (const TyTy::NeverType &) override;
   void visit (const TyTy::PlaceholderType &) override;

--- a/gcc/rust/checks/errors/borrowck/rust-bir-fact-collector.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-fact-collector.h
@@ -824,6 +824,7 @@ protected: // Subset helpers.
       case TyTy::PLACEHOLDER:
       case TyTy::INFER:
       case TyTy::PARAM:
+      case TyTy::CONST:
       case TyTy::OPAQUE:
 	rust_unreachable ();
       }

--- a/gcc/rust/checks/errors/borrowck/rust-bir-place.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-place.h
@@ -493,6 +493,7 @@ private:
       case TyTy::PROJECTION: // TODO: DUNNO
       case TyTy::CLOSURE:    // TODO: DUNNO
       case TyTy::DYNAMIC:    // TODO: dunno
+      case TyTy::CONST:
       case TyTy::OPAQUE:
 	return false;
       }

--- a/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
+++ b/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
@@ -277,6 +277,8 @@ PrivacyReporter::check_base_type_privacy (Analysis::NodeMapping &node_mappings,
       return;
     case TyTy::OPAQUE:
       return;
+    case TyTy::CONST:
+      return;
     case TyTy::ERROR:
       return;
     }

--- a/gcc/rust/hir/tree/rust-hir-generic-param.h
+++ b/gcc/rust/hir/tree/rust-hir-generic-param.h
@@ -150,7 +150,7 @@ public:
 
   location_t get_locus () const override final { return locus; };
 
-  bool has_default_expression () { return default_expression != nullptr; }
+  bool has_default_expression () const { return default_expression != nullptr; }
 
   std::string get_name () { return name; }
   Type &get_type ()
@@ -159,6 +159,8 @@ public:
     return *type;
   }
   Expr &get_default_expression () { return *default_expression; }
+
+  const Expr &get_default_expression () const { return *default_expression; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather

--- a/gcc/rust/hir/tree/rust-hir-path.h
+++ b/gcc/rust/hir/tree/rust-hir-path.h
@@ -132,6 +132,8 @@ public:
 
   std::unique_ptr<Expr> &get_expression () { return expression; }
 
+  location_t get_locus () const { return locus; }
+
 private:
   std::unique_ptr<Expr> expression;
   location_t locus;
@@ -150,7 +152,7 @@ public:
   bool has_generic_args () const
   {
     return !(lifetime_args.empty () && type_args.empty ()
-	     && binding_args.empty ());
+	     && binding_args.empty () && const_args.empty ());
   }
 
   GenericArgs (std::vector<Lifetime> lifetime_args,

--- a/gcc/rust/typecheck/rust-hir-trait-resolve.cc
+++ b/gcc/rust/typecheck/rust-hir-trait-resolve.cc
@@ -584,8 +584,8 @@ AssociatedImplTrait::setup_associated_types (
 	}
       else
 	{
-	  TyTy::ParamType *param = p.get_param_ty ();
-	  TyTy::BaseType *resolved = param->destructure ();
+	  auto param = p.get_param_ty ();
+	  auto resolved = param->destructure ();
 	  subst_args.push_back (TyTy::SubstitutionArg (&p, resolved));
 	  param_mappings[param->get_symbol ()] = resolved->get_ref ();
 	}
@@ -613,8 +613,8 @@ AssociatedImplTrait::setup_associated_types (
       if (i == 0)
 	continue;
 
-      const TyTy::ParamType *p = arg.get_param_ty ();
-      TyTy::BaseType *r = p->resolve ();
+      const auto p = arg.get_param_ty ();
+      auto r = p->resolve ();
       if (!r->is_concrete ())
 	{
 	  r = SubstMapperInternal::Resolve (r, infer_arguments);
@@ -630,8 +630,8 @@ AssociatedImplTrait::setup_associated_types (
       if (i == 0)
 	continue;
 
-      const TyTy::ParamType *p = arg.get_param_ty ();
-      TyTy::BaseType *r = p->resolve ();
+      const auto p = arg.get_param_ty ();
+      auto r = p->resolve ();
       if (!r->is_concrete ())
 	{
 	  r = SubstMapperInternal::Resolve (r, infer_arguments);

--- a/gcc/rust/typecheck/rust-hir-type-check-base.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.cc
@@ -23,6 +23,7 @@
 #include "rust-hir-trait-resolve.h"
 #include "rust-type-util.h"
 #include "rust-attribute-values.h"
+#include "rust-tyty.h"
 
 namespace Rust {
 namespace Resolver {
@@ -486,6 +487,10 @@ TypeCheckBase::resolve_generic_params (
 
 	    context->insert_type (generic_param->get_mappings (),
 				  specified_type);
+
+	    // TODO for const generics
+	    // TyTy::SubstitutionParamMapping p (*generic_param, param_type);
+	    // substitutions.push_back (p);
 	  }
 	  break;
 
@@ -501,8 +506,7 @@ TypeCheckBase::resolve_generic_params (
 	      *generic_param, false /*resolve_trait_bounds*/);
 	    context->insert_type (generic_param->get_mappings (), param_type);
 
-	    auto &param = static_cast<HIR::TypeParam &> (*generic_param);
-	    TyTy::SubstitutionParamMapping p (param, param_type);
+	    TyTy::SubstitutionParamMapping p (*generic_param, param_type);
 	    substitutions.push_back (p);
 	  }
 	  break;
@@ -517,7 +521,10 @@ TypeCheckBase::resolve_generic_params (
 	continue;
 
       auto &type_param = static_cast<HIR::TypeParam &> (generic);
-      auto pty = subst.get_param_ty ();
+      auto bpty = subst.get_param_ty ();
+      rust_assert (bpty->get_kind () == TyTy::TypeKind::PARAM);
+      auto pty = static_cast<TyTy::ParamType *> (bpty);
+
       TypeResolveGenericParam::ApplyAnyTraitBounds (type_param, pty);
     }
 }

--- a/gcc/rust/typecheck/rust-hir-type-check-base.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.cc
@@ -512,9 +512,13 @@ TypeCheckBase::resolve_generic_params (
   // now walk them to setup any specified type param bounds
   for (auto &subst : substitutions)
     {
+      auto &generic = subst.get_generic_param ();
+      if (generic.get_kind () != HIR::GenericParam::GenericKind::TYPE)
+	continue;
+
+      auto &type_param = static_cast<HIR::TypeParam &> (generic);
       auto pty = subst.get_param_ty ();
-      TypeResolveGenericParam::ApplyAnyTraitBounds (subst.get_generic_param (),
-						    pty);
+      TypeResolveGenericParam::ApplyAnyTraitBounds (type_param, pty);
     }
 }
 

--- a/gcc/rust/typecheck/rust-hir-type-check-base.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.h
@@ -33,6 +33,7 @@ public:
   virtual ~TypeCheckBase () {}
 
   static void ResolveGenericParams (
+    const HIR::Item::ItemKind item_kind, location_t item_locus,
     const std::vector<std::unique_ptr<HIR::GenericParam>> &generic_params,
     std::vector<TyTy::SubstitutionParamMapping> &substitutions, bool is_foreign,
     ABI abi);
@@ -61,6 +62,7 @@ protected:
 						 location_t locus);
 
   void resolve_generic_params (
+    const HIR::Item::ItemKind item_kind, location_t item_locus,
     const std::vector<std::unique_ptr<HIR::GenericParam>> &generic_params,
     std::vector<TyTy::SubstitutionParamMapping> &substitutions,
     bool is_foreign = false, ABI abi = ABI::RUST);

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.cc
@@ -70,7 +70,9 @@ TypeCheckTopLevelExternItem::visit (HIR::ExternalFunctionItem &function)
   std::vector<TyTy::SubstitutionParamMapping> substitutions;
   if (function.has_generics ())
     {
-      resolve_generic_params (function.get_generic_params (), substitutions,
+      resolve_generic_params (HIR::Item::ItemKind::Function,
+			      function.get_locus (),
+			      function.get_generic_params (), substitutions,
 			      true /*is_foreign*/, parent.get_abi ());
     }
 
@@ -200,7 +202,9 @@ TypeCheckImplItem::visit (HIR::Function &function)
   auto binder_pin = context->push_lifetime_binder ();
 
   if (function.has_generics ())
-    resolve_generic_params (function.get_generic_params (), substitutions);
+    resolve_generic_params (HIR::Item::ItemKind::Function,
+			    function.get_locus (),
+			    function.get_generic_params (), substitutions);
 
   TyTy::RegionConstraints region_constraints;
   for (auto &where_clause_item : function.get_where_clause ().get_items ())
@@ -397,7 +401,8 @@ TypeCheckImplItem::visit (HIR::TypeAlias &alias)
   auto binder_pin = context->push_lifetime_binder ();
 
   if (alias.has_generics ())
-    resolve_generic_params (alias.get_generic_params (), substitutions);
+    resolve_generic_params (HIR::Item::ItemKind::TypeAlias, alias.get_locus (),
+			    alias.get_generic_params (), substitutions);
 
   TyTy::BaseType *actual_type
     = TypeCheckType::Resolve (alias.get_type_aliased ());

--- a/gcc/rust/typecheck/rust-hir-type-check-item.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.cc
@@ -20,6 +20,7 @@
 #include "optional.h"
 #include "rust-canonical-path.h"
 #include "rust-diagnostics.h"
+#include "rust-hir-item.h"
 #include "rust-hir-type-check-enumitem.h"
 #include "rust-hir-type-check-implitem.h"
 #include "rust-hir-type-check-type.h"
@@ -167,7 +168,9 @@ TypeCheckItem::visit (HIR::TupleStruct &struct_decl)
 
   std::vector<TyTy::SubstitutionParamMapping> substitutions;
   if (struct_decl.has_generics ())
-    resolve_generic_params (struct_decl.get_generic_params (), substitutions);
+    resolve_generic_params (HIR::Item::ItemKind::Struct,
+			    struct_decl.get_locus (),
+			    struct_decl.get_generic_params (), substitutions);
 
   TyTy::RegionConstraints region_constraints;
   for (auto &where_clause_item : struct_decl.get_where_clause ().get_items ())
@@ -238,7 +241,9 @@ TypeCheckItem::visit (HIR::StructStruct &struct_decl)
 
   std::vector<TyTy::SubstitutionParamMapping> substitutions;
   if (struct_decl.has_generics ())
-    resolve_generic_params (struct_decl.get_generic_params (), substitutions);
+    resolve_generic_params (HIR::Item::ItemKind::Struct,
+			    struct_decl.get_locus (),
+			    struct_decl.get_generic_params (), substitutions);
 
   TyTy::RegionConstraints region_constraints;
   for (auto &where_clause_item : struct_decl.get_where_clause ().get_items ())
@@ -304,7 +309,8 @@ TypeCheckItem::visit (HIR::Enum &enum_decl)
   auto lifetime_pin = context->push_clean_lifetime_resolver ();
   std::vector<TyTy::SubstitutionParamMapping> substitutions;
   if (enum_decl.has_generics ())
-    resolve_generic_params (enum_decl.get_generic_params (), substitutions);
+    resolve_generic_params (HIR::Item::ItemKind::Enum, enum_decl.get_locus (),
+			    enum_decl.get_generic_params (), substitutions);
 
   // Process #[repr(X)] attribute, if any
   const AST::AttrVec &attrs = enum_decl.get_outer_attrs ();
@@ -364,7 +370,8 @@ TypeCheckItem::visit (HIR::Union &union_decl)
   auto lifetime_pin = context->push_clean_lifetime_resolver ();
   std::vector<TyTy::SubstitutionParamMapping> substitutions;
   if (union_decl.has_generics ())
-    resolve_generic_params (union_decl.get_generic_params (), substitutions);
+    resolve_generic_params (HIR::Item::ItemKind::Union, union_decl.get_locus (),
+			    union_decl.get_generic_params (), substitutions);
 
   TyTy::RegionConstraints region_constraints;
   for (auto &where_clause_item : union_decl.get_where_clause ().get_items ())
@@ -512,8 +519,9 @@ TypeCheckItem::visit (HIR::Function &function)
   auto lifetime_pin = context->push_clean_lifetime_resolver ();
   std::vector<TyTy::SubstitutionParamMapping> substitutions;
   if (function.has_generics ())
-    resolve_generic_params (function.get_generic_params (),
-			    substitutions); // TODO resolve constraints
+    resolve_generic_params (HIR::Item::ItemKind::Function,
+			    function.get_locus (),
+			    function.get_generic_params (), substitutions);
 
   TyTy::RegionConstraints region_constraints;
   for (auto &where_clause_item : function.get_where_clause ().get_items ())
@@ -700,7 +708,8 @@ TypeCheckItem::resolve_impl_block_substitutions (HIR::ImplBlock &impl_block,
 {
   std::vector<TyTy::SubstitutionParamMapping> substitutions;
   if (impl_block.has_generics ())
-    resolve_generic_params (impl_block.get_generic_params (), substitutions);
+    resolve_generic_params (HIR::Item::ItemKind::Impl, impl_block.get_locus (),
+			    impl_block.get_generic_params (), substitutions);
 
   TyTy::RegionConstraints region_constraints;
   for (auto &where_clause_item : impl_block.get_where_clause ().get_items ())

--- a/gcc/rust/typecheck/rust-hir-type-check-item.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.cc
@@ -118,8 +118,8 @@ TypeCheckItem::ResolveImplBlockSelfWithInference (
 	}
       else
 	{
-	  TyTy::ParamType *param = p.get_param_ty ();
-	  TyTy::BaseType *resolved = param->destructure ();
+	  auto param = p.get_param_ty ();
+	  auto resolved = param->destructure ();
 	  args.push_back (TyTy::SubstitutionArg (&p, resolved));
 	}
     }

--- a/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
@@ -641,7 +641,8 @@ TypeCheckPattern::visit (HIR::SlicePattern &pattern)
       {
 	auto &array_ty_ty = static_cast<TyTy::ArrayType &> (*parent);
 	parent_element_ty = array_ty_ty.get_element_type ();
-	tree cap = array_ty_ty.get_capacity ();
+	auto capacity = array_ty_ty.get_capacity ();
+	tree cap = capacity->get_value ();
 	if (error_operand_p (cap))
 	  {
 	    rust_error_at (parent->get_locus (),

--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -161,7 +161,9 @@ TraitItemReference::get_type_from_fn (/*const*/ HIR::TraitItemFunc &fn) const
   HIR::TraitFunctionDecl &function = fn.get_decl ();
   if (function.has_generics ())
     {
-      TypeCheckBase::ResolveGenericParams (function.get_generic_params (),
+      TypeCheckBase::ResolveGenericParams (HIR::Item::ItemKind::Function,
+					   fn.get_locus (),
+					   function.get_generic_params (),
 					   substitutions, false /*is_foreign*/,
 					   ABI::RUST);
     }

--- a/gcc/rust/typecheck/rust-substitution-mapper.cc
+++ b/gcc/rust/typecheck/rust-substitution-mapper.cc
@@ -268,6 +268,12 @@ SubstMapperInternal::visit (TyTy::ParamType &type)
 }
 
 void
+SubstMapperInternal::visit (TyTy::ConstType &type)
+{
+  resolved = type.handle_substitions (mappings);
+}
+
+void
 SubstMapperInternal::visit (TyTy::PlaceholderType &type)
 {
   rust_assert (type.can_resolve ());

--- a/gcc/rust/typecheck/rust-substitution-mapper.h
+++ b/gcc/rust/typecheck/rust-substitution-mapper.h
@@ -61,6 +61,7 @@ public:
   void visit (TyTy::ReferenceType &) override { rust_unreachable (); }
   void visit (TyTy::PointerType &) override { rust_unreachable (); }
   void visit (TyTy::ParamType &) override { rust_unreachable (); }
+  void visit (TyTy::ConstType &) override { rust_unreachable (); }
   void visit (TyTy::StrType &) override { rust_unreachable (); }
   void visit (TyTy::NeverType &) override { rust_unreachable (); }
   void visit (TyTy::DynamicObjectType &) override { rust_unreachable (); }
@@ -92,6 +93,7 @@ public:
   void visit (TyTy::ReferenceType &type) override;
   void visit (TyTy::PointerType &type) override;
   void visit (TyTy::ParamType &type) override;
+  void visit (TyTy::ConstType &type) override;
   void visit (TyTy::PlaceholderType &type) override;
   void visit (TyTy::ProjectionType &type) override;
   void visit (TyTy::ClosureType &type) override;
@@ -145,6 +147,7 @@ public:
   void visit (TyTy::ReferenceType &) override { rust_unreachable (); }
   void visit (TyTy::PointerType &) override { rust_unreachable (); }
   void visit (TyTy::ParamType &) override { rust_unreachable (); }
+  void visit (TyTy::ConstType &) override { rust_unreachable (); }
   void visit (TyTy::StrType &) override { rust_unreachable (); }
   void visit (TyTy::NeverType &) override { rust_unreachable (); }
   void visit (TyTy::PlaceholderType &) override { rust_unreachable (); }
@@ -185,12 +188,13 @@ public:
   void visit (const TyTy::ReferenceType &) override {}
   void visit (const TyTy::PointerType &) override {}
   void visit (const TyTy::ParamType &) override {}
+  void visit (const TyTy::ConstType &) override {}
   void visit (const TyTy::StrType &) override {}
   void visit (const TyTy::NeverType &) override {}
   void visit (const TyTy::PlaceholderType &) override {}
   void visit (const TyTy::ProjectionType &) override {}
   void visit (const TyTy::DynamicObjectType &) override {}
-  void visit (const TyTy::OpaqueType &type) override {}
+  void visit (const TyTy::OpaqueType &) override {}
 
 private:
   GetUsedSubstArgs ();

--- a/gcc/rust/typecheck/rust-tyty-bounds.cc
+++ b/gcc/rust/typecheck/rust-tyty-bounds.cc
@@ -173,6 +173,7 @@ TypeBoundsProbe::assemble_marker_builtins ()
       assemble_builtin_candidate (LangItem::Kind::SIZED);
       break;
 
+    case TyTy::CONST:
     case TyTy::DYNAMIC:
     case TyTy::ERROR:
       break;

--- a/gcc/rust/typecheck/rust-tyty-bounds.cc
+++ b/gcc/rust/typecheck/rust-tyty-bounds.cc
@@ -721,7 +721,7 @@ TypeBoundPredicate::handle_substitions (
       if (sub.get_param_ty () == nullptr)
 	continue;
 
-      ParamType *p = sub.get_param_ty ();
+      auto p = sub.get_param_ty ();
       BaseType *r = p->resolve ();
       BaseType *s = Resolver::SubstMapperInternal::Resolve (r, subst_mappings);
 
@@ -851,8 +851,8 @@ TypeBoundPredicate::is_equal (const TypeBoundPredicate &other) const
       const SubstitutionParamMapping &a = substitutions.at (i);
       const SubstitutionParamMapping &b = other.substitutions.at (i);
 
-      const ParamType *ap = a.get_param_ty ();
-      const ParamType *bp = b.get_param_ty ();
+      const auto ap = a.get_param_ty ();
+      const auto bp = b.get_param_ty ();
 
       const BaseType *apd = ap->destructure ();
       const BaseType *bpd = bp->destructure ();

--- a/gcc/rust/typecheck/rust-tyty-call.h
+++ b/gcc/rust/typecheck/rust-tyty-call.h
@@ -62,6 +62,7 @@ public:
   void visit (DynamicObjectType &) override { rust_unreachable (); }
   void visit (ClosureType &type) override { rust_unreachable (); }
   void visit (OpaqueType &type) override { rust_unreachable (); }
+  void visit (ConstType &type) override { rust_unreachable (); }
 
   // tuple-structs
   void visit (ADTType &type) override;

--- a/gcc/rust/typecheck/rust-tyty-cmp.h
+++ b/gcc/rust/typecheck/rust-tyty-cmp.h
@@ -447,6 +447,22 @@ public:
       }
   }
 
+  virtual void visit (const ConstType &type) override
+  {
+    ok = false;
+    if (emit_error_flag)
+      {
+	location_t ref_locus = mappings.lookup_location (type.get_ref ());
+	location_t base_locus
+	  = mappings.lookup_location (get_base ()->get_ref ());
+	rich_location r (line_table, ref_locus);
+	r.add_range (base_locus);
+	rust_error_at (r, "expected [%s] got [%s]",
+		       get_base ()->as_string ().c_str (),
+		       type.as_string ().c_str ());
+      }
+  }
+
 protected:
   BaseCmp (const BaseType *base, bool emit_errors)
     : mappings (Analysis::Mappings::get ()),
@@ -1604,6 +1620,23 @@ private:
   const BaseType *get_base () const override { return base; }
 
   const OpaqueType *base;
+};
+
+class ConstCmp : public BaseCmp
+{
+  using Rust::TyTy::BaseCmp::visit;
+
+public:
+  ConstCmp (const ConstType *base, bool emit_errors)
+    : BaseCmp (base, emit_errors), base (base)
+  {}
+
+  // TODO
+
+private:
+  const BaseType *get_base () const override { return base; }
+
+  const ConstType *base;
 };
 
 } // namespace TyTy

--- a/gcc/rust/typecheck/rust-tyty-subst.cc
+++ b/gcc/rust/typecheck/rust-tyty-subst.cc
@@ -54,13 +54,13 @@ SubstitutionParamMapping::clone () const
 				   static_cast<ParamType *> (param->clone ()));
 }
 
-ParamType *
+BaseGeneric *
 SubstitutionParamMapping::get_param_ty ()
 {
   return param;
 }
 
-const ParamType *
+const BaseGeneric *
 SubstitutionParamMapping::get_param_ty () const
 {
   return param;
@@ -229,7 +229,7 @@ SubstitutionArg::get_param_mapping () const
   return param;
 }
 
-const ParamType *
+const BaseGeneric *
 SubstitutionArg::get_param_ty () const
 {
   return original_param;
@@ -334,11 +334,11 @@ SubstitutionArgumentMappings::is_error () const
 
 bool
 SubstitutionArgumentMappings::get_argument_for_symbol (
-  const ParamType *param_to_find, SubstitutionArg *argument) const
+  const BaseGeneric *param_to_find, SubstitutionArg *argument) const
 {
   for (const auto &mapping : mappings)
     {
-      const ParamType *p = mapping.get_param_ty ();
+      const auto *p = mapping.get_param_ty ();
       if (p->get_symbol () == param_to_find->get_symbol ())
 	{
 	  *argument = mapping;
@@ -951,7 +951,7 @@ SubstitutionRef::prepare_higher_ranked_bounds ()
 {
   for (const auto &subst : get_substs ())
     {
-      const TyTy::ParamType *pty = subst.get_param_ty ();
+      const auto pty = subst.get_param_ty ();
       for (const auto &bound : pty->get_specified_bounds ())
 	{
 	  const auto ref = bound.get ();
@@ -965,8 +965,7 @@ SubstitutionRef::monomorphize ()
 {
   for (const auto &subst : get_substs ())
     {
-      const TyTy::ParamType *pty = subst.get_param_ty ();
-
+      const auto pty = subst.get_param_ty ();
       if (!pty->can_resolve ())
 	continue;
 

--- a/gcc/rust/typecheck/rust-tyty-subst.h
+++ b/gcc/rust/typecheck/rust-tyty-subst.h
@@ -46,7 +46,7 @@ class SubstitutionArgumentMappings;
 class SubstitutionParamMapping
 {
 public:
-  SubstitutionParamMapping (HIR::GenericParam &generic, ParamType *param);
+  SubstitutionParamMapping (HIR::GenericParam &generic, BaseGeneric *param);
 
   SubstitutionParamMapping (const SubstitutionParamMapping &other);
 
@@ -81,7 +81,7 @@ public:
 
 private:
   HIR::GenericParam &generic;
-  ParamType *param;
+  BaseGeneric *param;
 };
 
 /**

--- a/gcc/rust/typecheck/rust-tyty-subst.h
+++ b/gcc/rust/typecheck/rust-tyty-subst.h
@@ -24,6 +24,7 @@
 #include "rust-hir-full-decls.h"
 #include "rust-tyty-bounds.h"
 #include "rust-tyty-region.h"
+#include "rust-ast.h"
 #include "optional.h"
 
 namespace Rust {
@@ -44,7 +45,7 @@ class SubstitutionArgumentMappings;
 class SubstitutionParamMapping
 {
 public:
-  SubstitutionParamMapping (HIR::TypeParam &generic, ParamType *param);
+  SubstitutionParamMapping (HIR::GenericParam &generic, ParamType *param);
 
   SubstitutionParamMapping (const SubstitutionParamMapping &other);
 
@@ -56,11 +57,12 @@ public:
   SubstitutionParamMapping clone () const;
 
   ParamType *get_param_ty ();
-
   const ParamType *get_param_ty () const;
 
-  HIR::TypeParam &get_generic_param ();
-  const HIR::TypeParam &get_generic_param () const;
+  HIR::GenericParam &get_generic_param ();
+  const HIR::GenericParam &get_generic_param () const;
+
+  Identifier get_type_representation () const;
 
   // this is used for the backend to override the HirId ref of the param to
   // what the concrete type is for the rest of the context
@@ -77,7 +79,7 @@ public:
   bool need_substitution () const;
 
 private:
-  HIR::TypeParam &generic;
+  HIR::GenericParam &generic;
   ParamType *param;
 };
 

--- a/gcc/rust/typecheck/rust-tyty-subst.h
+++ b/gcc/rust/typecheck/rust-tyty-subst.h
@@ -31,6 +31,7 @@ namespace Rust {
 namespace TyTy {
 
 class ParamType;
+class BaseGeneric;
 
 struct RegionConstraints
 {
@@ -56,8 +57,8 @@ public:
 
   SubstitutionParamMapping clone () const;
 
-  ParamType *get_param_ty ();
-  const ParamType *get_param_ty () const;
+  BaseGeneric *get_param_ty ();
+  const BaseGeneric *get_param_ty () const;
 
   HIR::GenericParam &get_generic_param ();
   const HIR::GenericParam &get_generic_param () const;
@@ -156,7 +157,7 @@ public:
 
   const SubstitutionParamMapping *get_param_mapping () const;
 
-  const ParamType *get_param_ty () const;
+  const BaseGeneric *get_param_ty () const;
 
   static SubstitutionArg error ();
 
@@ -168,7 +169,7 @@ public:
 
 private:
   const SubstitutionParamMapping *param;
-  const ParamType *original_param;
+  const BaseGeneric *original_param;
   BaseType *argument;
 };
 
@@ -208,7 +209,7 @@ public:
 
   bool is_error () const;
 
-  bool get_argument_for_symbol (const ParamType *param_to_find,
+  bool get_argument_for_symbol (const BaseGeneric *param_to_find,
 				SubstitutionArg *argument) const;
 
   /** Return type parameter index for symbol */

--- a/gcc/rust/typecheck/rust-tyty-util.h
+++ b/gcc/rust/typecheck/rust-tyty-util.h
@@ -25,6 +25,7 @@ namespace Rust {
 namespace TyTy {
 
 class BaseType;
+class ConstType;
 
 // this is a placeholder for types that can change like inference variables
 class TyVar
@@ -41,6 +42,9 @@ public:
   TyVar monomorphized_clone () const;
 
   static TyVar get_implicit_infer_var (location_t locus);
+
+  static TyVar get_implicit_const_infer_var (const TyTy::ConstType &const_type,
+					     location_t locus);
 
   static TyVar subst_covariant_var (TyTy::BaseType *orig,
 				    TyTy::BaseType *subst);

--- a/gcc/rust/typecheck/rust-tyty-variance-analysis-private.h
+++ b/gcc/rust/typecheck/rust-tyty-variance-analysis-private.h
@@ -170,6 +170,8 @@ public:
   }
 
   void visit (OpaqueType &type) override {}
+
+  void visit (ConstType &type) override {}
 };
 
 /** Per crate context for generic type variance analysis. */
@@ -322,7 +324,7 @@ public:
 				    Variance variance) override;
   void add_constraints_from_generic_args (HirId ref, SubstitutionRef &subst,
 					  Variance variance,
-					  bool invariant_args) override{};
+					  bool invariant_args) override {};
   void add_constrints_from_param (ParamType &param, Variance variance) override;
 
   Variance contra (Variance variance) override

--- a/gcc/rust/typecheck/rust-tyty-variance-analysis.cc
+++ b/gcc/rust/typecheck/rust-tyty-variance-analysis.cc
@@ -199,9 +199,7 @@ GenericTyPerCrateCtx::debug_print_solutions ()
 	    {
 	      if (i > solution_index)
 		result += ", ";
-	      result += param.get_generic_param ()
-			  .get_type_representation ()
-			  .as_string ();
+	      result += param.get_type_representation ().as_string ();
 	      result += "=";
 	      result += solutions[i].as_string ();
 	      i++;
@@ -239,8 +237,7 @@ GenericTyVisitorCtx::process_type (ADTType &ty)
   first_type = first_lifetime + ty.get_used_arguments ().get_regions ().size ();
 
   for (auto &param : ty.get_substs ())
-    param_names.push_back (
-      param.get_generic_param ().get_type_representation ().as_string ());
+    param_names.push_back (param.get_type_representation ().as_string ());
 
   for (const auto &variant : ty.get_variants ())
     {

--- a/gcc/rust/typecheck/rust-tyty-visitor.h
+++ b/gcc/rust/typecheck/rust-tyty-visitor.h
@@ -45,6 +45,7 @@ public:
   virtual void visit (ReferenceType &type) = 0;
   virtual void visit (PointerType &type) = 0;
   virtual void visit (ParamType &type) = 0;
+  virtual void visit (ConstType &type) = 0;
   virtual void visit (StrType &type) = 0;
   virtual void visit (NeverType &type) = 0;
   virtual void visit (PlaceholderType &type) = 0;
@@ -75,6 +76,7 @@ public:
   virtual void visit (const ReferenceType &type) = 0;
   virtual void visit (const PointerType &type) = 0;
   virtual void visit (const ParamType &type) = 0;
+  virtual void visit (const ConstType &type) = 0;
   virtual void visit (const StrType &type) = 0;
   virtual void visit (const NeverType &type) = 0;
   virtual void visit (const PlaceholderType &type) = 0;

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -1690,7 +1690,7 @@ VariantDef::clone () const
 
   auto &&discriminant_opt = has_discriminant ()
 			      ? tl::optional<std::unique_ptr<HIR::Expr>> (
-				get_discriminant ().clone_expr ())
+				  get_discriminant ().clone_expr ())
 			      : tl::nullopt;
 
   return new VariantDef (id, defid, identifier, ident, type,
@@ -1706,7 +1706,7 @@ VariantDef::monomorphized_clone () const
 
   auto discriminant_opt = has_discriminant ()
 			    ? tl::optional<std::unique_ptr<HIR::Expr>> (
-			      get_discriminant ().clone_expr ())
+				get_discriminant ().clone_expr ())
 			    : tl::nullopt;
 
   return new VariantDef (id, defid, identifier, ident, type,
@@ -1818,8 +1818,8 @@ ADTType::is_equal (const BaseType &other) const
 	  const SubstitutionParamMapping &a = substitutions.at (i);
 	  const SubstitutionParamMapping &b = other2->substitutions.at (i);
 
-	  const ParamType *aa = a.get_param_ty ();
-	  const ParamType *bb = b.get_param_ty ();
+	  const auto &aa = a.get_param_ty ();
+	  const auto &bb = b.get_param_ty ();
 	  if (!aa->is_equal (*bb))
 	    return false;
 	}
@@ -2145,8 +2145,8 @@ FnType::is_equal (const BaseType &other) const
 	  const SubstitutionParamMapping &a = get_substs ().at (i);
 	  const SubstitutionParamMapping &b = ofn.get_substs ().at (i);
 
-	  const ParamType *pa = a.get_param_ty ();
-	  const ParamType *pb = b.get_param_ty ();
+	  const auto *pa = a.get_param_ty ();
+	  const auto *pb = b.get_param_ty ();
 	  if (!pa->is_equal (*pb))
 	    return false;
 	}
@@ -3409,10 +3409,10 @@ ParamType::ParamType (std::string symbol, location_t locus, HirId ref,
 		      HIR::GenericParam &param,
 		      std::vector<TypeBoundPredicate> specified_bounds,
 		      std::set<HirId> refs)
-  : BaseType (ref, ref, KIND,
-	      {Resolver::CanonicalPath::new_seg (UNKNOWN_NODEID, symbol),
-	       locus},
-	      specified_bounds, refs),
+  : BaseGeneric (ref, ref, KIND,
+		 {Resolver::CanonicalPath::new_seg (UNKNOWN_NODEID, symbol),
+		  locus},
+		 specified_bounds, refs),
     is_trait_self (false), symbol (symbol), param (param)
 {}
 
@@ -3420,10 +3420,10 @@ ParamType::ParamType (bool is_trait_self, std::string symbol, location_t locus,
 		      HirId ref, HirId ty_ref, HIR::GenericParam &param,
 		      std::vector<TypeBoundPredicate> specified_bounds,
 		      std::set<HirId> refs)
-  : BaseType (ref, ty_ref, KIND,
-	      {Resolver::CanonicalPath::new_seg (UNKNOWN_NODEID, symbol),
-	       locus},
-	      specified_bounds, refs),
+  : BaseGeneric (ref, ty_ref, KIND,
+		 {Resolver::CanonicalPath::new_seg (UNKNOWN_NODEID, symbol),
+		  locus},
+		 specified_bounds, refs),
     is_trait_self (is_trait_self), symbol (symbol), param (param)
 {}
 

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -1820,9 +1820,7 @@ ADTType::is_equal (const BaseType &other) const
 
 	  const ParamType *aa = a.get_param_ty ();
 	  const ParamType *bb = b.get_param_ty ();
-	  BaseType *aaa = aa->resolve ();
-	  BaseType *bbb = bb->resolve ();
-	  if (!aaa->is_equal (*bbb))
+	  if (!aa->is_equal (*bb))
 	    return false;
 	}
     }
@@ -2149,7 +2147,6 @@ FnType::is_equal (const BaseType &other) const
 
 	  const ParamType *pa = a.get_param_ty ();
 	  const ParamType *pb = b.get_param_ty ();
-
 	  if (!pa->is_equal (*pb))
 	    return false;
 	}

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -57,6 +57,7 @@ enum TypeKind
   REF,
   POINTER,
   PARAM,
+  CONST,
   ARRAY,
   SLICE,
   FNDEF,
@@ -427,6 +428,59 @@ public:
 
 private:
   bool is_trait_self;
+  std::string symbol;
+  HIR::GenericParam &param;
+};
+
+class ConstType : public BaseGeneric
+{
+public:
+  static constexpr auto KIND = TypeKind::CONST;
+
+  enum ConstKind
+  {
+    Decl,
+    Value,
+    Infer,
+    Error
+  };
+
+  ConstType (ConstKind kind, std::string symbol, TyTy::BaseType *ty, tree value,
+	     std::vector<TypeBoundPredicate> specified_bounds, location_t locus,
+	     HirId ref, HirId ty_ref, HIR::GenericParam &param,
+	     std::set<HirId> refs = std::set<HirId> ());
+
+  void accept_vis (TyVisitor &vis) override;
+  void accept_vis (TyConstVisitor &vis) const override;
+
+  ConstKind get_const_kind () const { return const_kind; }
+  TyTy::BaseType *get_ty () const { return ty; }
+  tree get_value () const { return value; }
+
+  std::string as_string () const override;
+
+  bool can_eq (const BaseType *other, bool emit_errors) const override final;
+
+  BaseType *clone () const final override;
+
+  std::string get_symbol () const override final;
+
+  HIR::GenericParam &get_generic_param () override final;
+
+  bool can_resolve () const override final;
+
+  BaseType *resolve () const override final;
+
+  std::string get_name () const override final;
+
+  bool is_equal (const BaseType &other) const override;
+
+  ConstType *handle_substitions (SubstitutionArgumentMappings &mappings);
+
+private:
+  ConstKind const_kind;
+  TyTy::BaseType *ty;
+  tree value;
   std::string symbol;
   HIR::GenericParam &param;
 };

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -365,7 +365,26 @@ public:
   std::string get_name () const override final;
 };
 
-class ParamType : public BaseType
+class BaseGeneric : public BaseType
+{
+public:
+  virtual std::string get_symbol () const = 0;
+
+  virtual HIR::GenericParam &get_generic_param () = 0;
+
+  virtual bool can_resolve () const = 0;
+
+  virtual BaseType *resolve () const = 0;
+
+protected:
+  BaseGeneric (HirId ref, HirId ty_ref, TypeKind kind, RustIdent ident,
+	       std::vector<TypeBoundPredicate> specified_bounds,
+	       std::set<HirId> refs = std::set<HirId> ())
+    : BaseType (ref, ty_ref, kind, ident, specified_bounds, refs)
+  {}
+};
+
+class ParamType : public BaseGeneric
 {
 public:
   static constexpr auto KIND = TypeKind::PARAM;
@@ -389,13 +408,13 @@ public:
 
   BaseType *clone () const final override;
 
-  std::string get_symbol () const;
+  std::string get_symbol () const override final;
 
-  HIR::GenericParam &get_generic_param ();
+  HIR::GenericParam &get_generic_param () override final;
 
-  bool can_resolve () const;
+  bool can_resolve () const override final;
 
-  BaseType *resolve () const;
+  BaseType *resolve () const override final;
 
   std::string get_name () const override final;
 
@@ -523,7 +542,7 @@ public:
 
   TypeBoundPredicate (const TypeBoundPredicate &other);
 
-  virtual ~TypeBoundPredicate (){};
+  virtual ~TypeBoundPredicate () {};
 
   TypeBoundPredicate &operator= (const TypeBoundPredicate &other);
 

--- a/gcc/rust/typecheck/rust-unify.cc
+++ b/gcc/rust/typecheck/rust-unify.cc
@@ -17,6 +17,7 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-unify.h"
+#include "rust-tyty.h"
 #include "tree.h"
 
 namespace Rust {
@@ -326,6 +327,9 @@ UnifyRules::go ()
     case TyTy::OPAQUE:
       return expect_opaque (static_cast<TyTy::OpaqueType *> (ltype), rtype);
 
+    case TyTy::CONST:
+      return expect_const (static_cast<TyTy::ConstType *> (ltype), rtype);
+
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -420,6 +424,7 @@ UnifyRules::expect_inference_variable (TyTy::InferType *ltype,
     case TyTy::PROJECTION:
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
+    case TyTy::CONST:
     case TyTy::OPAQUE:
       {
 	bool is_valid = (ltype->get_infer_kind ()
@@ -546,6 +551,7 @@ UnifyRules::expect_adt (TyTy::ADTType *ltype, TyTy::BaseType *rtype)
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
     case TyTy::OPAQUE:
+    case TyTy::CONST:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -592,6 +598,7 @@ UnifyRules::expect_str (TyTy::StrType *ltype, TyTy::BaseType *rtype)
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
     case TyTy::OPAQUE:
+    case TyTy::CONST:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -663,6 +670,7 @@ UnifyRules::expect_reference (TyTy::ReferenceType *ltype, TyTy::BaseType *rtype)
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
     case TyTy::OPAQUE:
+    case TyTy::CONST:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -734,6 +742,7 @@ UnifyRules::expect_pointer (TyTy::PointerType *ltype, TyTy::BaseType *rtype)
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
     case TyTy::OPAQUE:
+    case TyTy::CONST:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -798,6 +807,7 @@ UnifyRules::expect_param (TyTy::ParamType *ltype, TyTy::BaseType *rtype)
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
     case TyTy::OPAQUE:
+    case TyTy::CONST:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -869,6 +879,7 @@ UnifyRules::expect_array (TyTy::ArrayType *ltype, TyTy::BaseType *rtype)
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
     case TyTy::OPAQUE:
+    case TyTy::CONST:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -929,6 +940,7 @@ UnifyRules::expect_slice (TyTy::SliceType *ltype, TyTy::BaseType *rtype)
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
     case TyTy::OPAQUE:
+    case TyTy::CONST:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1018,6 +1030,7 @@ UnifyRules::expect_fndef (TyTy::FnType *ltype, TyTy::BaseType *rtype)
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
     case TyTy::OPAQUE:
+    case TyTy::CONST:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1166,6 +1179,7 @@ UnifyRules::expect_fnptr (TyTy::FnPtr *ltype, TyTy::BaseType *rtype)
     case TyTy::PROJECTION:
     case TyTy::DYNAMIC:
     case TyTy::OPAQUE:
+    case TyTy::CONST:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1237,6 +1251,7 @@ UnifyRules::expect_tuple (TyTy::TupleType *ltype, TyTy::BaseType *rtype)
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
     case TyTy::OPAQUE:
+    case TyTy::CONST:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1286,6 +1301,7 @@ UnifyRules::expect_bool (TyTy::BoolType *ltype, TyTy::BaseType *rtype)
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
     case TyTy::OPAQUE:
+    case TyTy::CONST:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1335,6 +1351,7 @@ UnifyRules::expect_char (TyTy::CharType *ltype, TyTy::BaseType *rtype)
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
     case TyTy::OPAQUE:
+    case TyTy::CONST:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1392,6 +1409,7 @@ UnifyRules::expect_int (TyTy::IntType *ltype, TyTy::BaseType *rtype)
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
     case TyTy::OPAQUE:
+    case TyTy::CONST:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1449,6 +1467,7 @@ UnifyRules::expect_uint (TyTy::UintType *ltype, TyTy::BaseType *rtype)
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
     case TyTy::OPAQUE:
+    case TyTy::CONST:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1506,6 +1525,7 @@ UnifyRules::expect_float (TyTy::FloatType *ltype, TyTy::BaseType *rtype)
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
     case TyTy::OPAQUE:
+    case TyTy::CONST:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1555,6 +1575,7 @@ UnifyRules::expect_isize (TyTy::ISizeType *ltype, TyTy::BaseType *rtype)
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
     case TyTy::OPAQUE:
+    case TyTy::CONST:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1604,6 +1625,7 @@ UnifyRules::expect_usize (TyTy::USizeType *ltype, TyTy::BaseType *rtype)
     case TyTy::DYNAMIC:
     case TyTy::CLOSURE:
     case TyTy::OPAQUE:
+    case TyTy::CONST:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1676,6 +1698,7 @@ UnifyRules::expect_placeholder (TyTy::PlaceholderType *ltype,
 	return rtype->clone ();
       gcc_fallthrough ();
 
+    case TyTy::CONST:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1725,6 +1748,7 @@ UnifyRules::expect_projection (TyTy::ProjectionType *ltype,
     case TyTy::NEVER:
     case TyTy::PLACEHOLDER:
     case TyTy::OPAQUE:
+    case TyTy::CONST:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1786,6 +1810,7 @@ UnifyRules::expect_dyn (TyTy::DynamicObjectType *ltype, TyTy::BaseType *rtype)
     case TyTy::PLACEHOLDER:
     case TyTy::PROJECTION:
     case TyTy::OPAQUE:
+    case TyTy::CONST:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1857,6 +1882,7 @@ UnifyRules::expect_closure (TyTy::ClosureType *ltype, TyTy::BaseType *rtype)
     case TyTy::PROJECTION:
     case TyTy::DYNAMIC:
     case TyTy::OPAQUE:
+    case TyTy::CONST:
     case TyTy::ERROR:
       return new TyTy::ErrorType (0);
     }
@@ -1907,6 +1933,19 @@ UnifyRules::expect_opaque (TyTy::OpaqueType *ltype, TyTy::BaseType *rtype)
     }
 
   return ltype;
+}
+
+TyTy::BaseType *
+UnifyRules::expect_const (TyTy::ConstType *ltype, TyTy::BaseType *rtype)
+{
+  if (rtype->get_kind () != TyTy::TypeKind::CONST)
+    return new TyTy::ErrorType (0);
+
+  // TODO
+  // TyTy::ConstType &lhs = *ltype;
+  // TyTy::ConstType &rhs = *static_cast<TyTy::ConstType *> (rtype);
+
+  return new TyTy::ErrorType (0);
 }
 
 } // namespace Resolver

--- a/gcc/rust/typecheck/rust-unify.h
+++ b/gcc/rust/typecheck/rust-unify.h
@@ -84,6 +84,7 @@ protected:
 				  TyTy::BaseType *rtype);
   TyTy::BaseType *expect_opaque (TyTy::OpaqueType *ltype,
 				 TyTy::BaseType *rtype);
+  TyTy::BaseType *expect_const (TyTy::ConstType *ltype, TyTy::BaseType *rtype);
 
 private:
   UnifyRules (TyTy::TyWithLocation lhs, TyTy::TyWithLocation rhs,

--- a/gcc/testsuite/rust/compile/const_generics_10.rs
+++ b/gcc/testsuite/rust/compile/const_generics_10.rs
@@ -1,0 +1,32 @@
+#[lang = "sized"]
+trait Sized {}
+
+const M: usize = 4;
+
+struct Foo<T, const N: usize = 1> {
+    value: [T; N],
+}
+
+fn main() {
+    let foo = Foo::<i32> { value: [15] };
+    let foo = Foo::<i32, 2> { value: [15, 13] };
+    let foo: Foo<i32, 2> = Foo { value: [15, 13] };
+    let foo: Foo<i32, 2> = Foo::<i32, 2> { value: [15, 13] };
+    let foo: Foo<i32, { 1 + 1 }> = Foo { value: [15, 13] };
+    let foo = Foo::<i32, { 1 + 1 }> { value: [15, 13] };
+    let foo: Foo<i32, { 1 + 1 }> = Foo::<i32, { 1 + 1 }> { value: [15, 13] };
+    let foo: Foo<i32, M> = Foo::<i32, 4> {
+        value: [15, 13, 11, 9],
+    };
+
+    let invalid_foo: Foo<i32, { 1 + 1 }> = Foo::<i32, 3> { value: [15, 13] };
+    // { dg-error {mismatched types, expected ..T=i32; 3.. but got ...integer.; 2.. .E0308.} "" { target *-*-* } .-1 }
+    // { dg-error {mismatched types, expected ..T=i32; 2.. but got ..T=i32; 3.. .E0308.} "" { target *-*-* } .-2 }
+
+    let invalid_foo: Foo<i32, { 1 + 1 }> = Foo::<i32, M> { value: [15, 13] };
+    // { dg-error {mismatched types, expected ..T=i32; 4.. but got ...integer.; 2.. .E0308.} "" { target *-*-* } .-1 }
+    // { dg-error {mismatched types, expected ..T=i32; 2.. but got ..T=i32; 4.. .E0308.} "" { target *-*-* } .-2 }
+
+    let invalid_foo: Foo<i32> = Foo::<i32, 2> { value: [15, 13] };
+    // { dg-error {mismatched types, expected ..T=i32; 1.. but got ..T=i32; 2.. .E0308.} "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/compile/const_generics_11.rs
+++ b/gcc/testsuite/rust/compile/const_generics_11.rs
@@ -1,0 +1,14 @@
+// { dg-options "-w" }
+
+#[lang = "sized"]
+trait Sized {}
+
+struct Matrix<T, const ROWS: usize, const COLS: usize> {
+    data: [[T; COLS]; ROWS],
+}
+
+fn main() {
+    let _: Matrix<u8, 2, 3> = Matrix {
+        data: [[1, 2, 3], [4, 5, 6]],
+    };
+}

--- a/gcc/testsuite/rust/compile/const_generics_12.rs
+++ b/gcc/testsuite/rust/compile/const_generics_12.rs
@@ -1,0 +1,14 @@
+// { dg-options "-w" }
+
+#[lang = "sized"]
+trait Sized {}
+
+const BASE: usize = 2;
+
+struct Foo<T, const N: usize> {
+    data: [T; N],
+}
+
+fn main() {
+    let _ = Foo::<u8, { BASE + 1 * 2 }> { data: [0; 4] };
+}

--- a/gcc/testsuite/rust/compile/const_generics_13.rs
+++ b/gcc/testsuite/rust/compile/const_generics_13.rs
@@ -1,0 +1,11 @@
+#[lang = "sized"]
+trait Sized {}
+
+struct Foo<T, const N: usize> {
+    value: [T; N],
+}
+
+fn main() {
+    let foo: Foo<_, _>;
+    // { dg-error {type provided when a constant was expected .E0747.} "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/compile/const_generics_14.rs
+++ b/gcc/testsuite/rust/compile/const_generics_14.rs
@@ -1,0 +1,13 @@
+#[lang = "sized"]
+trait Sized {}
+
+type MyLen = usize;
+struct Foo<T, const N: usize> {
+    data: [T; N],
+}
+
+fn main() {
+    let _ = Foo::<u8, MyLen> { data: [1, 2, 3] };
+    // { dg-error {type provided when a constant was expected .E0747.} "" { target *-*-* } .-1 }
+    // { dg-error {expected an ADT type for constructor} "" { target *-*-* } .-2 }
+}

--- a/gcc/testsuite/rust/compile/const_generics_15.rs
+++ b/gcc/testsuite/rust/compile/const_generics_15.rs
@@ -1,0 +1,16 @@
+#[lang = "sized"]
+trait Sized {}
+
+enum Foo<const N: usize> {
+    A([u8; N]),
+}
+
+union Bar<const N: usize> {
+    a: [i32; N],
+    b: [u8; N],
+}
+
+fn main() {
+    let _ = Foo::<4>::A([1, 2, 3, 4]);
+    let _ = Bar::<4> { a: [0; 4] };
+}

--- a/gcc/testsuite/rust/compile/const_generics_16.rs
+++ b/gcc/testsuite/rust/compile/const_generics_16.rs
@@ -1,0 +1,10 @@
+#[lang = "sized"]
+trait Sized {}
+
+struct Foo<T = u8, const N: usize = 4> {
+    data: [T; N], // { dg-warning "field is never read: .data." }
+}
+
+fn main() {
+    let _x = Foo { data: [1, 2, 3, 4] };
+}

--- a/gcc/testsuite/rust/compile/const_generics_3.rs
+++ b/gcc/testsuite/rust/compile/const_generics_3.rs
@@ -1,28 +1,21 @@
-// { dg-additional-options "-w -frust-compile-until=typecheck" }
-
 #[lang = "sized"]
 trait Sized {}
 
 const M: usize = 4;
 
 struct Foo<T, const N: usize = 1> {
-    value: [T; N],
+    value: [T; N], // { dg-warning "field is never read: .value." }
 }
 
 fn main() {
-    let foo = Foo::<i32> { value: [15] };
-    let foo = Foo::<i32, 2> { value: [15, 13] };
-    let foo: Foo<i32, 2> = Foo { value: [15, 13] };
-    let foo: Foo<i32, 2> = Foo::<i32, 2> { value: [15, 13] };
-    let foo: Foo<i32, { 1 + 1 }> = Foo { value: [15, 13] };
-    let foo = Foo::<i32, { 1 + 1 }> { value: [15, 13] };
-    let foo: Foo<i32, { 1 + 1 }> = Foo::<i32, { 1 + 1 }> { value: [15, 13] };
-    let foo: Foo<i32, M> = Foo::<i32, 4> {
+    let _foo = Foo::<i32> { value: [15] };
+    let _foo = Foo::<i32, 2> { value: [15, 13] };
+    let _foo: Foo<i32, 2> = Foo { value: [15, 13] };
+    let _foo: Foo<i32, 2> = Foo::<i32, 2> { value: [15, 13] };
+    let _foo: Foo<i32, { 1 + 1 }> = Foo { value: [15, 13] };
+    let _foo = Foo::<i32, { 1 + 1 }> { value: [15, 13] };
+    let _foo: Foo<i32, { 1 + 1 }> = Foo::<i32, { 1 + 1 }> { value: [15, 13] };
+    let _foo: Foo<i32, M> = Foo::<i32, 4> {
         value: [15, 13, 11, 9],
     };
-
-    // FIXME: Add proper const typecheck errors here
-    let invalid_foo: Foo<i32, { 1 + 1 }> = Foo::<i32, 3> { value: [15, 13] };
-    let invalid_foo: Foo<i32, { 1 + 1 }> = Foo::<i32, M> { value: [15, 13] };
-    let invalid_foo: Foo<i32> = Foo::<i32, 2> { value: [15, 13] };
 }

--- a/gcc/testsuite/rust/compile/const_generics_5.rs
+++ b/gcc/testsuite/rust/compile/const_generics_5.rs
@@ -1,4 +1,3 @@
-// { dg-options "-w" }
 struct Foo<const N: usize = { 14 }>;
 
 const M: usize = 15;
@@ -8,5 +7,6 @@ fn main() {
     let _: Foo<15> = Foo;
     let _: Foo<{ M }> = Foo;
     let _: Foo<M> = Foo;
-    // let _: Foo<N> = Foo; this causes an ICE we need to do const generics
+    let _: Foo<N> = Foo;
+    // { dg-error {type provided when a constant was expected .E0747.} "" { target *-*-* } .-1 }
 }

--- a/gcc/testsuite/rust/compile/const_generics_8.rs
+++ b/gcc/testsuite/rust/compile/const_generics_8.rs
@@ -9,12 +9,13 @@ type Bipboupe<const N: i32 = 15> = Bidule;
 trait Fooable<const N: i32 = 15> {}
 
 union Bidoulepe<const N: i32 = 15> {
-    // { dg-error "default values for const generic parameters are not allowed in .union. items"  "" {target *-*-* } .-1 }
     int: i32,
     float: f32,
 }
 
-fn const_default<const N: i32 = 15>() {} // { dg-error "default values for const generic parameters are not allowed in .function. items" }
+fn const_default<const N: i32 = 15>() {} // { dg-error "default values for const generic parameters are not allowed here" }
 
 // Note - missing generic parameter - needs name resolution on const generics
-impl<const N: i32 = 15> Bidule {} // { dg-error "default values for const generic parameters are not allowed in .impl. items" }
+impl<const N: i32 = 15> Bidule {}
+// { dg-error "default values for const generic parameters are not allowed here"   "" {target *-*-* } .-1 }
+// { dg-error "unconstrained type parameter"  "" {target *-*-* } .-2 }

--- a/gcc/testsuite/rust/compile/const_generics_9.rs
+++ b/gcc/testsuite/rust/compile/const_generics_9.rs
@@ -1,0 +1,13 @@
+// { dg-options "-w" }
+
+#[lang = "sized"]
+trait Sized {}
+
+struct ArrayWrapper<T, const N: usize> {
+    data: [T; N],
+}
+
+pub fn test() -> [u8; 4] {
+    let a = ArrayWrapper { data: [1u8; 4] };
+    a.data
+}


### PR DESCRIPTION
This is a patch set so there are better comments in the commits them selves:

1. gccrs: Refactor substitution param mapping to be more abstract
2. gccrs: simplify the is_eq on ADTType
3. gccrs: Refactor the ParamType to a BaseGeneric base-type
4. gccrs: Add ConstType boiler plate to handle const generics
5. gccrs: Add initial support for const generics