### PR TITLE
gccrs: Fix ICE during const eval of const capacity

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -490,6 +490,8 @@ CompileExpr::visit (HIR::StructExprStructFields &struct_expr)
       rust_error_at (struct_expr.get_locus (), "unknown type");
       return;
     }
+  if (!tyty->is<TyTy::ADTType> ())
+    return;
 
   // it must be an ADT
   rust_assert (tyty->get_kind () == TyTy::TypeKind::ADT);

--- a/gcc/testsuite/rust/compile/issue-3960.rs
+++ b/gcc/testsuite/rust/compile/issue-3960.rs
@@ -1,0 +1,7 @@
+fn main() {
+    struct G {
+        g: (),
+    }
+    let g = [0; G { g: () }];
+    // { dg-error "mismatched types, expected .usize. but got .G. .E0308." "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
We assert that struct expressions during code-gen must be of TyTy::ADTType but we can simply just check for this and return error_mark_node to make this safe.

Fixes Rust-GCC#3960

gcc/rust/ChangeLog:

	* backend/rust-compile-expr.cc (CompileExpr::visit): check for ADTType instead of assert

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3960.rs: New test.

