### PR TITLE
gccrs: Ensure we track the const generic substitution on the param mappings

### DIFF
--- a/gcc/rust/typecheck/rust-tyty-subst.cc
+++ b/gcc/rust/typecheck/rust-tyty-subst.cc
@@ -163,8 +163,11 @@ SubstitutionParamMapping::fill_param_ty (
 
   if (type.get_kind () == TypeKind::PARAM)
     {
-      // delete param;
-      param = static_cast<ParamType *> (type.clone ());
+      param = static_cast<BaseGeneric *> (type.clone ());
+    }
+  else if (type.get_kind () == TyTy::TypeKind::CONST)
+    {
+      param = static_cast<BaseGeneric *> (type.clone ());
     }
   else if (param->get_kind () == TypeKind::PARAM)
     {

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -37,6 +37,7 @@
 #include "options.h"
 #include "rust-system.h"
 #include "tree.h"
+#include "fold-const.h"
 #include <string>
 
 namespace Rust {
@@ -3712,9 +3713,14 @@ ConstType::is_equal (const BaseType &other) const
       return false;
     }
 
-  // TODO
+  const ConstType &rhs = static_cast<const ConstType &> (other);
+  if (!get_ty ()->is_equal (*rhs.get_ty ()))
+    return false;
 
-  return false;
+  tree lv = get_value ();
+  tree rv = rhs.get_value ();
+
+  return operand_equal_p (lv, rv, 0);
 }
 
 ConstType *


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* typecheck/rust-tyty-subst.cc: track the const generic
	* typecheck/rust-tyty.cc (ConstType::is_equal): finish the is_equal

