### PR TITLE
gccrs: Remove more calls to the old TyTy::BaseType::can_eq interface

### DIFF
--- a/gcc/rust/typecheck/rust-autoderef.cc
+++ b/gcc/rust/typecheck/rust-autoderef.cc
@@ -247,7 +247,6 @@ resolve_operator_overload_fn (
 	  const TyTy::ADTType *adt = static_cast<const TyTy::ADTType *> (lhs);
 
 	  auto s = fn->get_self_type ()->get_root ();
-	  rust_assert (s->can_eq (adt, false));
 	  rust_assert (s->get_kind () == TyTy::TypeKind::ADT);
 	  const TyTy::ADTType *self_adt
 	    = static_cast<const TyTy::ADTType *> (s);

--- a/gcc/rust/typecheck/rust-coercion.cc
+++ b/gcc/rust/typecheck/rust-coercion.cc
@@ -204,8 +204,9 @@ TypeCoercionRules::coerce_unsafe_ptr (TyTy::BaseType *receiver,
 
     default:
       {
-	// FIXME this can probably turn into a unify_and
-	if (receiver->can_eq (expected, false))
+	if (types_compatable (TyTy::TyWithLocation (receiver),
+			      TyTy::TyWithLocation (expected), UNKNOWN_LOCATION,
+			      false))
 	  return CoercionResult{{}, expected->clone ()};
 
 	return CoercionResult::get_error ();
@@ -280,9 +281,6 @@ TypeCoercionRules::coerce_borrowed_pointer (TyTy::BaseType *receiver,
 
     default:
       {
-	// FIXME
-	// we might be able to replace this with a can_eq because we default
-	// back to a final unity anyway
 	rust_debug ("coerce_borrowed_pointer -- unify");
 	TyTy::BaseType *result
 	  = unify_site_and (receiver->get_ref (),

--- a/gcc/rust/typecheck/rust-hir-inherent-impl-overlap.h
+++ b/gcc/rust/typecheck/rust-hir-inherent-impl-overlap.h
@@ -79,27 +79,29 @@ public:
 	    if (query == candidate)
 	      continue;
 
-	    if (query->can_eq (candidate, false))
+	    if (!types_compatable (TyTy::TyWithLocation (query),
+				   TyTy::TyWithLocation (candidate),
+				   UNKNOWN_LOCATION, false))
+	      continue;
+
+	    // we might be in the case that we have:
+	    //
+	    // *const T vs *const [T]
+	    //
+	    // so lets use an equality check when the
+	    // candidates are both generic to be sure we dont emit a false
+	    // positive
+
+	    bool a = query->is_concrete ();
+	    bool b = candidate->is_concrete ();
+	    bool both_generic = !a && !b;
+	    if (both_generic)
 	      {
-		// we might be in the case that we have:
-		//
-		// *const T vs *const [T]
-		//
-		// so lets use an equality check when the
-		// candidates are both generic to be sure we dont emit a false
-		// positive
-
-		bool a = query->is_concrete ();
-		bool b = candidate->is_concrete ();
-		bool both_generic = !a && !b;
-		if (both_generic)
-		  {
-		    if (!query->is_equal (*candidate))
-		      continue;
-		  }
-
-		possible_collision (it->second, iy->second);
+		if (!query->is_equal (*candidate))
+		  continue;
 	      }
+
+	    possible_collision (it->second, iy->second);
 	  }
       }
   }

--- a/gcc/rust/typecheck/rust-hir-path-probe.cc
+++ b/gcc/rust/typecheck/rust-hir-path-probe.cc
@@ -137,7 +137,7 @@ PathProbeCandidate::operator< (const PathProbeCandidate &c) const
 
 // PathProbeType
 
-PathProbeType::PathProbeType (const TyTy::BaseType *receiver,
+PathProbeType::PathProbeType (TyTy::BaseType *receiver,
 			      const HIR::PathIdentSegment &query,
 			      DefId specific_trait_id)
   : TypeCheckBase (), receiver (receiver), search (query),
@@ -145,7 +145,7 @@ PathProbeType::PathProbeType (const TyTy::BaseType *receiver,
 {}
 
 std::set<PathProbeCandidate>
-PathProbeType::Probe (const TyTy::BaseType *receiver,
+PathProbeType::Probe (TyTy::BaseType *receiver,
 		      const HIR::PathIdentSegment &segment_name,
 		      bool probe_impls, bool probe_bounds,
 		      bool ignore_mandatory_trait_items,
@@ -443,7 +443,7 @@ PathProbeType::is_receiver_generic () const
 
 // PathProbImplTrait
 
-PathProbeImplTrait::PathProbeImplTrait (const TyTy::BaseType *receiver,
+PathProbeImplTrait::PathProbeImplTrait (TyTy::BaseType *receiver,
 					const HIR::PathIdentSegment &query,
 					const TraitReference *trait_reference)
   : PathProbeType (receiver, query, UNKNOWN_DEFID),
@@ -451,7 +451,7 @@ PathProbeImplTrait::PathProbeImplTrait (const TyTy::BaseType *receiver,
 {}
 
 std::set<PathProbeCandidate>
-PathProbeImplTrait::Probe (const TyTy::BaseType *receiver,
+PathProbeImplTrait::Probe (TyTy::BaseType *receiver,
 			   const HIR::PathIdentSegment &segment_name,
 			   const TraitReference *trait_reference)
 {

--- a/gcc/rust/typecheck/rust-hir-path-probe.h
+++ b/gcc/rust/typecheck/rust-hir-path-probe.h
@@ -108,9 +108,8 @@ class PathProbeType : public TypeCheckBase, public HIR::HIRImplVisitor
 {
 public:
   static std::set<PathProbeCandidate>
-  Probe (const TyTy::BaseType *receiver,
-	 const HIR::PathIdentSegment &segment_name, bool probe_impls,
-	 bool probe_bounds, bool ignore_mandatory_trait_items,
+  Probe (TyTy::BaseType *receiver, const HIR::PathIdentSegment &segment_name,
+	 bool probe_impls, bool probe_bounds, bool ignore_mandatory_trait_items,
 	 DefId specific_trait_id = UNKNOWN_DEFID);
 
   void visit (HIR::TypeAlias &alias) override;
@@ -135,8 +134,8 @@ protected:
 				    bool ignore_mandatory_trait_items);
 
 protected:
-  PathProbeType (const TyTy::BaseType *receiver,
-		 const HIR::PathIdentSegment &query, DefId specific_trait_id);
+  PathProbeType (TyTy::BaseType *receiver, const HIR::PathIdentSegment &query,
+		 DefId specific_trait_id);
 
   std::vector<std::pair<const TraitReference *, HIR::ImplBlock *>>
   union_bounds (
@@ -147,7 +146,7 @@ protected:
 
   bool is_receiver_generic () const;
 
-  const TyTy::BaseType *receiver;
+  TyTy::BaseType *receiver;
   const HIR::PathIdentSegment &search;
   std::set<PathProbeCandidate> candidates;
   HIR::ImplBlock *current_impl;
@@ -178,12 +177,11 @@ class PathProbeImplTrait : public PathProbeType
 {
 public:
   static std::set<PathProbeCandidate>
-  Probe (const TyTy::BaseType *receiver,
-	 const HIR::PathIdentSegment &segment_name,
+  Probe (TyTy::BaseType *receiver, const HIR::PathIdentSegment &segment_name,
 	 const TraitReference *trait_reference);
 
 private:
-  PathProbeImplTrait (const TyTy::BaseType *receiver,
+  PathProbeImplTrait (TyTy::BaseType *receiver,
 		      const HIR::PathIdentSegment &query,
 		      const TraitReference *trait_reference);
 

--- a/gcc/rust/typecheck/rust-hir-type-check-base.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.cc
@@ -52,10 +52,10 @@ walk_types_to_constrain (std::set<HirId> &constrained_symbols,
 {
   for (const auto &c : constraints.get_mappings ())
     {
-      const TyTy::BaseType *arg = c.get_tyty ();
+      auto arg = c.get_tyty ();
       if (arg != nullptr)
 	{
-	  const TyTy::BaseType *p = arg->get_root ();
+	  const auto p = arg->get_root ();
 	  constrained_symbols.insert (p->get_ty_ref ());
 	  if (p->has_substitutions_defined ())
 	    {
@@ -71,7 +71,7 @@ TypeCheckBase::check_for_unconstrained (
   const std::vector<TyTy::SubstitutionParamMapping> &params_to_constrain,
   const TyTy::SubstitutionArgumentMappings &constraint_a,
   const TyTy::SubstitutionArgumentMappings &constraint_b,
-  const TyTy::BaseType *reference)
+  TyTy::BaseType *reference)
 {
   bool check_result = false;
   bool check_completed

--- a/gcc/rust/typecheck/rust-hir-type-check-base.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.h
@@ -53,7 +53,7 @@ protected:
     const std::vector<TyTy::SubstitutionParamMapping> &params_to_constrain,
     const TyTy::SubstitutionArgumentMappings &constraint_a,
     const TyTy::SubstitutionArgumentMappings &constraint_b,
-    const TyTy::BaseType *reference);
+    TyTy::BaseType *reference);
 
   TyTy::BaseType *resolve_literal (const Analysis::NodeMapping &mappings,
 				   HIR::Literal &literal, location_t locus);

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -1025,7 +1025,10 @@ TypeCheckExpr::visit (HIR::ArrayIndexExpr &expr)
   bool ok = context->lookup_builtin ("usize", &size_ty);
   rust_assert (ok);
 
-  bool maybe_simple_array_access = index_expr_ty->can_eq (size_ty, false);
+  bool maybe_simple_array_access
+    = types_compatable (TyTy::TyWithLocation (index_expr_ty),
+			TyTy::TyWithLocation (size_ty), expr.get_locus (),
+			false);
   if (maybe_simple_array_access
       && direct_array_expr_ty->get_kind () == TyTy::TypeKind::ARRAY)
     {

--- a/gcc/rust/typecheck/rust-hir-type-check.h
+++ b/gcc/rust/typecheck/rust-hir-type-check.h
@@ -249,10 +249,10 @@ public:
   bool lookup_associated_type_mapping (HirId id, HirId *mapping);
 
   void insert_associated_impl_mapping (HirId trait_id,
-				       const TyTy::BaseType *impl_type,
+				       TyTy::BaseType *impl_type,
 				       HirId impl_id);
   bool lookup_associated_impl_mapping_for_self (HirId trait_id,
-						const TyTy::BaseType *self,
+						TyTy::BaseType *self,
 						HirId *mapping);
 
   void insert_autoderef_mappings (HirId id,
@@ -325,7 +325,7 @@ private:
   std::map<HirId, AssociatedImplTrait> associated_impl_traits;
 
   // trait-id -> list of < self-tyty:impl-id>
-  std::map<HirId, std::vector<std::pair<const TyTy::BaseType *, HirId>>>
+  std::map<HirId, std::vector<std::pair<TyTy::BaseType *, HirId>>>
     associated_traits_to_impls;
 
   std::map<HirId, HirId> associated_type_mappings;

--- a/gcc/rust/typecheck/rust-typecheck-context.cc
+++ b/gcc/rust/typecheck/rust-typecheck-context.cc
@@ -300,8 +300,9 @@ TypeCheckContext::lookup_associated_type_mapping (HirId id, HirId *mapping)
 }
 
 void
-TypeCheckContext::insert_associated_impl_mapping (
-  HirId trait_id, const TyTy::BaseType *impl_type, HirId impl_id)
+TypeCheckContext::insert_associated_impl_mapping (HirId trait_id,
+						  TyTy::BaseType *impl_type,
+						  HirId impl_id)
 {
   auto it = associated_traits_to_impls.find (trait_id);
   if (it == associated_traits_to_impls.end ())
@@ -313,8 +314,9 @@ TypeCheckContext::insert_associated_impl_mapping (
 }
 
 bool
-TypeCheckContext::lookup_associated_impl_mapping_for_self (
-  HirId trait_id, const TyTy::BaseType *self, HirId *mapping)
+TypeCheckContext::lookup_associated_impl_mapping_for_self (HirId trait_id,
+							   TyTy::BaseType *self,
+							   HirId *mapping)
 {
   auto it = associated_traits_to_impls.find (trait_id);
   if (it == associated_traits_to_impls.end ())
@@ -322,7 +324,9 @@ TypeCheckContext::lookup_associated_impl_mapping_for_self (
 
   for (auto &item : it->second)
     {
-      if (item.first->can_eq (self, false))
+      if (types_compatable (TyTy::TyWithLocation (item.first),
+			    TyTy::TyWithLocation (self), UNKNOWN_LOCATION,
+			    false))
 	{
 	  *mapping = item.second;
 	  return true;

--- a/gcc/rust/typecheck/rust-tyty-bounds.cc
+++ b/gcc/rust/typecheck/rust-tyty-bounds.cc
@@ -849,21 +849,19 @@ TypeBoundPredicate::is_equal (const TypeBoundPredicate &other) const
   // then match the generics applied
   for (size_t i = 0; i < get_num_substitutions (); i++)
     {
-      const SubstitutionParamMapping &a = substitutions.at (i);
-      const SubstitutionParamMapping &b = other.substitutions.at (i);
+      SubstitutionParamMapping a = substitutions.at (i);
+      SubstitutionParamMapping b = other.substitutions.at (i);
 
-      const auto ap = a.get_param_ty ();
-      const auto bp = b.get_param_ty ();
+      auto ap = a.get_param_ty ();
+      auto bp = b.get_param_ty ();
 
-      const BaseType *apd = ap->destructure ();
-      const BaseType *bpd = bp->destructure ();
+      BaseType *apd = ap->destructure ();
+      BaseType *bpd = bp->destructure ();
 
-      // FIXME use the unify_and infer inteface or try coerce
-      if (!apd->can_eq (bpd, false /*emit_errors*/))
-	{
-	  if (!bpd->can_eq (apd, false /*emit_errors*/))
-	    return false;
-	}
+      if (!Resolver::types_compatable (TyTy::TyWithLocation (apd),
+				       TyTy::TyWithLocation (bpd),
+				       UNKNOWN_LOCATION, false))
+	return false;
     }
 
   return true;

--- a/gcc/rust/typecheck/rust-tyty-subst.cc
+++ b/gcc/rust/typecheck/rust-tyty-subst.cc
@@ -231,12 +231,6 @@ SubstitutionArg::operator= (const SubstitutionArg &other)
 }
 
 BaseType *
-SubstitutionArg::get_tyty ()
-{
-  return argument;
-}
-
-const BaseType *
 SubstitutionArg::get_tyty () const
 {
   return argument;

--- a/gcc/rust/typecheck/rust-tyty-subst.h
+++ b/gcc/rust/typecheck/rust-tyty-subst.h
@@ -151,9 +151,7 @@ public:
 
   SubstitutionArg &operator= (const SubstitutionArg &other);
 
-  BaseType *get_tyty ();
-
-  const BaseType *get_tyty () const;
+  BaseType *get_tyty () const;
 
   const SubstitutionParamMapping *get_param_mapping () const;
 

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -449,11 +449,10 @@ BaseType::inherit_bounds (
     }
 }
 
-const BaseType *
-BaseType::get_root () const
+BaseType *
+BaseType::get_root ()
 {
-  // FIXME this needs to be it its own visitor class with a vector adjustments
-  const TyTy::BaseType *root = this;
+  TyTy::BaseType *root = this;
 
   if (const auto r = root->try_as<const ReferenceType> ())
     {

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -167,8 +167,7 @@ public:
 
   void debug () const;
 
-  // FIXME this will eventually go away
-  const BaseType *get_root () const;
+  BaseType *get_root ();
 
   // This will get the monomorphized type from Params, Placeholders or
   // Projections if available or error

--- a/gcc/testsuite/rust/compile/generics8.rs
+++ b/gcc/testsuite/rust/compile/generics8.rs
@@ -4,7 +4,7 @@ pub trait Sized {}
 struct Foo<A, B>(A, B);
 
 impl<T> Foo<i32, T> {
-    fn test(a: T) -> T {
+    fn test(a: T) -> T { // { dg-error "duplicate definitions with name .test." }
         a
     }
 }


### PR DESCRIPTION
This old can_eq interface was an old method to try and check if types can match up by taking into account generics but its not maintained properly and we already have a new wrapper Resolver::types_compatable (type, type, locus, emit_errors) which just calls unify_site_and infer with commit false. There are only a few places left to update.

One minor downside is that i need to remove const in some places because the unify interface is non const. Ideally we would want to avoid writing a seperate const unify anyway so i think this is not ideal but fine for us.

gcc/rust/ChangeLog:

	* typecheck/rust-autoderef.cc: remove useless assertion
	* typecheck/rust-coercion.cc (TypeCoercionRules::coerce_unsafe_ptr): refactor (TypeCoercionRules::coerce_borrowed_pointer): remove FIXME this is fine
	* typecheck/rust-hir-inherent-impl-overlap.h: use types_compatable
	* typecheck/rust-hir-path-probe.cc (PathProbeType::PathProbeType): remove const (PathProbeType::Probe): likewise (PathProbeImplTrait::PathProbeImplTrait): likewise (PathProbeImplTrait::Probe): likewise
	* typecheck/rust-hir-path-probe.h: likewise
	* typecheck/rust-hir-type-check-base.cc (walk_types_to_constrain): likewise
	* typecheck/rust-hir-type-check-base.h: likewise
	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::visit): use types_compatable
	* typecheck/rust-hir-type-check.h: remove const
	* typecheck/rust-typecheck-context.cc (TypeCheckContext::insert_associated_impl_mapping): likewise (TypeCheckContext::lookup_associated_impl_mapping_for_self): remove can_Eq
	* typecheck/rust-tyty-bounds.cc (TypeBoundPredicate::is_equal): likewise
	* typecheck/rust-tyty-subst.cc (SubstitutionArg::get_tyty): remove const version
	* typecheck/rust-tyty-subst.h: likewise
	* typecheck/rust-tyty.cc (BaseType::get_root): likewise
	* typecheck/rust-tyty.h: likewise

gcc/testsuite/ChangeLog:

	* rust/compile/generics8.rs: extra error message
