### PR TITLE
Avoid including `rust-parse-impl.h` in `rust-parse.h`

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -73,6 +73,9 @@ GRS_OBJS = \
     rust/rust-lex.o \
     rust/rust-cfg-parser.o \
     rust/rust-parse.o \
+    rust/rust-parse-impl-proc-macro.o \
+    rust/rust-parse-impl-macro.o \
+    rust/rust-parse-impl-lexer.o \
     rust/rust-ast.o \
     rust/rust-ast-formatting.o \
     rust/rust-path.o \

--- a/gcc/rust/parse/rust-parse-impl-lexer.cc
+++ b/gcc/rust/parse/rust-parse-impl-lexer.cc
@@ -1,0 +1,25 @@
+// Copyright (C) 2025 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-parse-impl.h"
+
+namespace Rust {
+
+template class Parser<Lexer>;
+
+} // namespace Rust

--- a/gcc/rust/parse/rust-parse-impl-macro.cc
+++ b/gcc/rust/parse/rust-parse-impl-macro.cc
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-parse-impl.h"
+#include "rust-macro-invoc-lexer.h"
+
+namespace Rust {
+
+template class Parser<MacroInvocLexer>;
+
+} // namespace Rust

--- a/gcc/rust/parse/rust-parse-impl-proc-macro.cc
+++ b/gcc/rust/parse/rust-parse-impl-proc-macro.cc
@@ -1,0 +1,34 @@
+// Copyright (C) 2025 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-parse-impl.h"
+#include "rust-proc-macro-invoc-lexer.h"
+
+namespace Rust {
+
+template std::unique_ptr<AST::Item>
+Parser<ProcMacroInvocLexer>::parse_item (bool);
+
+template std::unique_ptr<AST::Stmt>
+  Parser<ProcMacroInvocLexer>::parse_stmt (ParseRestrictions);
+
+// instantiate entire class (or just more functions) if necessary
+
+// template class Parser<ProcMacroInvocLexer>;
+
+} // namespace Rust

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -19,7 +19,8 @@
 /* Template implementation for Rust::Parser. Previously in rust-parse.cc (before
  * Parser was template). Separated from rust-parse.h for readability. */
 
-/* DO NOT INCLUDE ANYWHERE - this is automatically included with rust-parse.h
+/* DO NOT INCLUDE ANYWHERE - this is automatically included
+ *   by rust-parse-impl-*.cc
  * This is also the reason why there are no include guards. */
 
 #include "expected.h"
@@ -3372,7 +3373,8 @@ Parser<ManagedTokenSource>::parse_lifetime_params (EndTokenPred is_end_token)
 
 /* Parses lifetime generic parameters (objects). Will also consume any
  * trailing comma. No extra checks for end token.
- * TODO: is this best solution? implements most of the same algorithm. */
+ * TODO: is this best solution? implements most of the same algorithm.
+ * TODO: seems to be unused, remove? */
 template <typename ManagedTokenSource>
 std::vector<AST::LifetimeParam>
 Parser<ManagedTokenSource>::parse_lifetime_params_objs ()
@@ -3390,7 +3392,7 @@ Parser<ManagedTokenSource>::parse_lifetime_params_objs ()
 	  break;
 	}
 
-      lifetime_params.push_back (std::move (lifetime_param));
+      lifetime_params.push_back (std::move (lifetime_param.value ()));
 
       if (lexer.peek_token ()->get_id () != COMMA)
 	break;
@@ -11920,11 +11922,12 @@ Parser<ManagedTokenSource>::parse_struct_expr_field ()
 }
 
 // "Unexpected token" panic mode - flags gcc error at unexpected token
+// TODO: seems to be unused, remove?
 template <typename ManagedTokenSource>
 void
 Parser<ManagedTokenSource>::unexpected_token (const_TokenPtr t)
 {
-  Error error (t->get_locus (), "unexpected token %qs\n",
+  Error error (t->get_locus (), "unexpected token %qs",
 	       t->get_token_description ());
   add_error (std::move (error));
 }

--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -797,7 +797,4 @@ bool is_match_compatible (const AST::MacroMatch &last_match,
 			  const AST::MacroMatch &current_match);
 } // namespace Rust
 
-// as now template, include implementations of all methods
-#include "rust-parse-impl.h"
-
 #endif // RUST_PARSE_H


### PR DESCRIPTION
This should reduce incremental compile times when modifying `rust-parse-impl.h` and not `rust-parse.h`