### PR TITLE
Fix object copying issue causing pointer inconsistency

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-implitem.cc
+++ b/gcc/rust/hir/rust-ast-lower-implitem.cc
@@ -275,7 +275,7 @@ ASTLowerTraitItem::visit (AST::Function &func)
       auto hir_param
 	= HIR::FunctionParam (mapping, std::move (translated_pattern),
 			      std::move (translated_type), param.get_locus ());
-      function_params.push_back (hir_param);
+      function_params.push_back (std::move (hir_param));
     }
 
   HIR::TraitFunctionDecl decl (func.get_function_name (),


### PR DESCRIPTION
# Problem Summary
This PR fixes an issue where an object was unintentionally copied instead of moved, causing inconsistencies in object state and pointer references. Specifically, the copy constructor was invoked, resulting in a duplicated object where internal pointers or identifiers became misaligned. The original object was left in an outdated state, and any pointers referring to it could point to the wrong memory.

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`

