### PR TITLE
Exclude some inline assembly test

### DIFF
--- a/gcc/testsuite/rust/execute/inline_asm_inout_ident.rs
+++ b/gcc/testsuite/rust/execute/inline_asm_inout_ident.rs
@@ -1,3 +1,4 @@
+/* { dg-do run { target x86_64*-*-* } } */
 /* { dg-output "Value is: 5\r*\n" } */
 #![feature(rustc_attrs)]
 

--- a/gcc/testsuite/rust/execute/inline_asm_inout_var.rs
+++ b/gcc/testsuite/rust/execute/inline_asm_inout_var.rs
@@ -1,3 +1,4 @@
+/* { dg-do run { target x86_64*-*-* } } */
 /* { dg-output "Value is: 5\r*\n" } */
 #![feature(rustc_attrs)]
 


### PR DESCRIPTION
Those test are failing on the macos CI runner. (expected)