### PR TITLE
gccrs: Fix ICE on exclusive_range_pattern lowering

### DIFF
--- a/gcc/rust/backend/rust-compile-pattern.cc
+++ b/gcc/rust/backend/rust-compile-pattern.cc
@@ -158,13 +158,15 @@ CompilePatternCheckExpr::visit (HIR::RangePattern &pattern)
 					    pattern.get_mappings (),
 					    pattern.get_locus (), ctx);
 
+  ComparisonOperator upper_cmp = pattern.is_inclusive_range ()
+				   ? ComparisonOperator::LESS_OR_EQUAL
+				   : ComparisonOperator::LESS_THAN;
   tree check_lower
     = Backend::comparison_expression (ComparisonOperator::GREATER_OR_EQUAL,
 				      match_scrutinee_expr, lower,
 				      pattern.get_locus ());
   tree check_upper
-    = Backend::comparison_expression (ComparisonOperator::LESS_OR_EQUAL,
-				      match_scrutinee_expr, upper,
+    = Backend::comparison_expression (upper_cmp, match_scrutinee_expr, upper,
 				      pattern.get_locus ());
   check_expr = Backend::arithmetic_or_logical_expression (
     ArithmeticOrLogicalOperator::BITWISE_AND, check_lower, check_upper,

--- a/gcc/rust/hir/rust-ast-lower-pattern.cc
+++ b/gcc/rust/hir/rust-ast-lower-pattern.cc
@@ -268,8 +268,6 @@ ASTLoweringPattern::visit (AST::LiteralPattern &pattern)
 void
 ASTLoweringPattern::visit (AST::RangePattern &pattern)
 {
-  if (pattern.get_range_kind () == AST::RangeKind::EXCLUDED)
-    rust_unreachable (); // Not supported yet
   auto upper_bound = lower_range_pattern_bound (pattern.get_upper_bound ());
   auto lower_bound = lower_range_pattern_bound (pattern.get_lower_bound ());
 
@@ -278,9 +276,11 @@ ASTLoweringPattern::visit (AST::RangePattern &pattern)
 				 mappings.get_next_hir_id (crate_num),
 				 UNKNOWN_LOCAL_DEFID);
 
-  translated
-    = new HIR::RangePattern (mapping, std::move (lower_bound),
-			     std::move (upper_bound), pattern.get_locus ());
+  bool is_inclusive = (pattern.get_range_kind () == AST::RangeKind::INCLUDED);
+
+  translated = new HIR::RangePattern (mapping, std::move (lower_bound),
+				      std::move (upper_bound),
+				      pattern.get_locus (), is_inclusive);
 }
 
 void

--- a/gcc/rust/hir/tree/rust-hir-pattern.h
+++ b/gcc/rust/hir/tree/rust-hir-pattern.h
@@ -350,6 +350,7 @@ class RangePattern : public Pattern
   /* location only stored to avoid a dereference - lower pattern should give
    * correct location so maybe change in future */
   location_t locus;
+  bool is_inclusive;
   Analysis::NodeMapping mappings;
 
 public:
@@ -359,10 +360,10 @@ public:
   RangePattern (Analysis::NodeMapping mappings,
 		std::unique_ptr<RangePatternBound> lower,
 		std::unique_ptr<RangePatternBound> upper, location_t locus,
-		bool has_ellipsis_syntax = false)
+		bool is_inclusive, bool has_ellipsis_syntax = false)
     : lower (std::move (lower)), upper (std::move (upper)),
       has_ellipsis_syntax (has_ellipsis_syntax), locus (locus),
-      mappings (mappings)
+      is_inclusive (is_inclusive), mappings (mappings)
   {}
 
   // Copy constructor with clone
@@ -370,7 +371,7 @@ public:
     : lower (other.lower->clone_range_pattern_bound ()),
       upper (other.upper->clone_range_pattern_bound ()),
       has_ellipsis_syntax (other.has_ellipsis_syntax), locus (other.locus),
-      mappings (other.mappings)
+      is_inclusive (other.is_inclusive), mappings (other.mappings)
   {}
 
   // Overloaded assignment operator to clone
@@ -380,6 +381,7 @@ public:
     upper = other.upper->clone_range_pattern_bound ();
     has_ellipsis_syntax = other.has_ellipsis_syntax;
     locus = other.locus;
+    is_inclusive = other.is_inclusive;
     mappings = other.mappings;
 
     return *this;
@@ -395,6 +397,7 @@ public:
   void accept_vis (HIRPatternVisitor &vis) override;
 
   bool get_has_ellipsis_syntax () { return has_ellipsis_syntax; };
+  bool is_inclusive_range () const { return is_inclusive; }
 
   const Analysis::NodeMapping &get_mappings () const override final
   {

--- a/gcc/testsuite/rust/compile/issue-3928.rs
+++ b/gcc/testsuite/rust/compile/issue-3928.rs
@@ -1,0 +1,12 @@
+// { dg-do compile }
+// { dg-options "-fsyntax-only" }
+
+#![feature(exclusive_range_pattern)]
+
+fn Foo() {
+    let x = 1u32;
+
+    match x {
+        3..-1 => 4,
+    };
+}


### PR DESCRIPTION
Fixes #3928 
Add support to AST lowering of exclusive range pattern.

gcc/rust/ChangeLog:

        * backend/rust-compile-pattern.cc (CompilePatternCheckExpr::visit):
        Check upper compare operator.
        * hir/rust-ast-lower-pattern.cc (ASTLoweringPattern::visit):
        Handle lowering of exclusive range pattern.
        * hir/tree/rust-hir-pattern.h (class RangePattern):
        Add support for exclusive ranges in HIR representation.

gcc/testsuite/ChangeLog:

        * rust/compile/issue-3928.rs: New test.