### PR TITLE
Detect failure to match an `ident` metavariable

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -1053,6 +1053,7 @@ Parser<ManagedTokenSource>::parse_identifier_or_keyword_token ()
     }
   else
     {
+      add_error (Error (t->get_locus (), "expected keyword or identifier"));
       return nullptr;
     }
 }

--- a/gcc/testsuite/rust/compile/macros/mbe/macro-issue4054.rs
+++ b/gcc/testsuite/rust/compile/macros/mbe/macro-issue4054.rs
@@ -1,0 +1,14 @@
+#[allow(path_statements)]
+
+macro_rules! array_impl_default {
+    {$t:ident} => {
+        $t;
+        array_impl_default!{}
+    };
+    {} => {}
+}
+
+pub fn foo() {
+    let x = 12;
+    array_impl_default! {x}
+}


### PR DESCRIPTION
Fixes Rust-GCC#4054