### PR TITLE
gccrs: Implement rest pattern support for slice patterns

### DIFF
--- a/gcc/rust/checks/errors/borrowck/rust-bir-builder-pattern.cc
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-builder-pattern.cc
@@ -70,11 +70,34 @@ PatternBindingBuilder::visit (HIR::SlicePattern &pattern)
     return ty->as<TyTy::SliceType> ()->get_element_type ();
   });
 
-  // Regions are unchnaged.
+  // Regions are unchanged.
 
-  for (auto &item : pattern.get_items ())
+  switch (pattern.get_items ().get_item_type ())
     {
-      item->accept_vis (*this);
+    case HIR::SlicePatternItems::NO_REST:
+      {
+	auto &items
+	  = static_cast<HIR::SlicePatternItemsNoRest &> (pattern.get_items ());
+	for (auto &member : items.get_patterns ())
+	  {
+	    member->accept_vis (*this);
+	  }
+	break;
+      }
+    case HIR::SlicePatternItems::HAS_REST:
+      {
+	auto &items
+	  = static_cast<HIR::SlicePatternItemsHasRest &> (pattern.get_items ());
+	for (auto &member : items.get_lower_patterns ())
+	  {
+	    member->accept_vis (*this);
+	  }
+	for (auto &member : items.get_upper_patterns ())
+	  {
+	    member->accept_vis (*this);
+	  }
+	break;
+      }
     }
 }
 

--- a/gcc/rust/checks/errors/borrowck/rust-bir-builder-struct.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-builder-struct.h
@@ -246,6 +246,14 @@ protected:
     rust_unreachable ();
   }
   void visit (HIR::TuplePattern &pattern) override { rust_unreachable (); }
+  void visit (HIR::SlicePatternItemsNoRest &tuple_items) override
+  {
+    rust_unreachable ();
+  }
+  void visit (HIR::SlicePatternItemsHasRest &tuple_items) override
+  {
+    rust_unreachable ();
+  }
   void visit (HIR::SlicePattern &pattern) override { rust_unreachable (); }
   void visit (HIR::AltPattern &pattern) override { rust_unreachable (); }
   void visit (HIR::EmptyStmt &stmt) override { rust_unreachable (); }

--- a/gcc/rust/checks/errors/borrowck/rust-function-collector.h
+++ b/gcc/rust/checks/errors/borrowck/rust-function-collector.h
@@ -176,6 +176,8 @@ public:
   void visit (HIR::TuplePatternItemsNoRest &tuple_items) override {}
   void visit (HIR::TuplePatternItemsHasRest &tuple_items) override {}
   void visit (HIR::TuplePattern &pattern) override {}
+  void visit (HIR::SlicePatternItemsNoRest &tuple_items) override {}
+  void visit (HIR::SlicePatternItemsHasRest &tuple_items) override {}
   void visit (HIR::SlicePattern &pattern) override {}
   void visit (HIR::AltPattern &pattern) override {}
   void visit (HIR::EmptyStmt &stmt) override {}

--- a/gcc/rust/checks/errors/rust-const-checker.cc
+++ b/gcc/rust/checks/errors/rust-const-checker.cc
@@ -837,6 +837,14 @@ ConstChecker::visit (TuplePattern &)
 {}
 
 void
+ConstChecker::visit (SlicePatternItemsNoRest &)
+{}
+
+void
+ConstChecker::visit (SlicePatternItemsHasRest &)
+{}
+
+void
 ConstChecker::visit (SlicePattern &)
 {}
 

--- a/gcc/rust/checks/errors/rust-const-checker.h
+++ b/gcc/rust/checks/errors/rust-const-checker.h
@@ -186,6 +186,8 @@ private:
   virtual void visit (TuplePatternItemsNoRest &tuple_items) override;
   virtual void visit (TuplePatternItemsHasRest &tuple_items) override;
   virtual void visit (TuplePattern &pattern) override;
+  virtual void visit (SlicePatternItemsNoRest &items) override;
+  virtual void visit (SlicePatternItemsHasRest &items) override;
   virtual void visit (SlicePattern &pattern) override;
   virtual void visit (AltPattern &pattern) override;
   virtual void visit (EmptyStmt &stmt) override;

--- a/gcc/rust/checks/errors/rust-hir-pattern-analysis.cc
+++ b/gcc/rust/checks/errors/rust-hir-pattern-analysis.cc
@@ -664,6 +664,14 @@ PatternChecker::visit (TuplePattern &)
 {}
 
 void
+PatternChecker::visit (SlicePatternItemsNoRest &)
+{}
+
+void
+PatternChecker::visit (SlicePatternItemsHasRest &)
+{}
+
+void
 PatternChecker::visit (SlicePattern &)
 {}
 

--- a/gcc/rust/checks/errors/rust-hir-pattern-analysis.h
+++ b/gcc/rust/checks/errors/rust-hir-pattern-analysis.h
@@ -159,6 +159,8 @@ private:
   virtual void visit (TuplePatternItemsNoRest &tuple_items) override;
   virtual void visit (TuplePatternItemsHasRest &tuple_items) override;
   virtual void visit (TuplePattern &pattern) override;
+  virtual void visit (SlicePatternItemsNoRest &items) override;
+  virtual void visit (SlicePatternItemsHasRest &items) override;
   virtual void visit (SlicePattern &pattern) override;
   virtual void visit (AltPattern &pattern) override;
   virtual void visit (EmptyStmt &stmt) override;

--- a/gcc/rust/checks/errors/rust-unsafe-checker.cc
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.cc
@@ -950,6 +950,14 @@ UnsafeChecker::visit (TuplePattern &)
 {}
 
 void
+UnsafeChecker::visit (SlicePatternItemsNoRest &)
+{}
+
+void
+UnsafeChecker::visit (SlicePatternItemsHasRest &)
+{}
+
+void
 UnsafeChecker::visit (SlicePattern &)
 {}
 

--- a/gcc/rust/checks/errors/rust-unsafe-checker.h
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.h
@@ -167,6 +167,8 @@ private:
   virtual void visit (TuplePatternItemsNoRest &tuple_items) override;
   virtual void visit (TuplePatternItemsHasRest &tuple_items) override;
   virtual void visit (TuplePattern &pattern) override;
+  virtual void visit (SlicePatternItemsNoRest &items) override;
+  virtual void visit (SlicePatternItemsHasRest &items) override;
   virtual void visit (SlicePattern &pattern) override;
   virtual void visit (AltPattern &pattern) override;
   virtual void visit (EmptyStmt &stmt) override;

--- a/gcc/rust/hir/rust-ast-lower-base.cc
+++ b/gcc/rust/hir/rust-ast-lower-base.cc
@@ -906,6 +906,41 @@ ASTLoweringBase::lower_tuple_pattern_ranged (
 				       std::move (upper_patterns)));
 }
 
+std::unique_ptr<HIR::SlicePatternItems>
+ASTLoweringBase::lower_slice_pattern_no_rest (
+  AST::SlicePatternItemsNoRest &pattern)
+{
+  std::vector<std::unique_ptr<HIR::Pattern>> patterns;
+  patterns.reserve (pattern.get_patterns ().size ());
+  for (auto &p : pattern.get_patterns ())
+    patterns.emplace_back (ASTLoweringPattern::translate (*p));
+
+  return std::unique_ptr<HIR::SlicePatternItems> (
+    new HIR::SlicePatternItemsNoRest (std::move (patterns)));
+}
+
+std::unique_ptr<HIR::SlicePatternItems>
+ASTLoweringBase::lower_slice_pattern_has_rest (
+  AST::SlicePatternItemsHasRest &pattern)
+{
+  std::vector<std::unique_ptr<HIR::Pattern>> lower_patterns;
+  lower_patterns.reserve (pattern.get_lower_patterns ().size ());
+  std::vector<std::unique_ptr<HIR::Pattern>> upper_patterns;
+  upper_patterns.reserve (pattern.get_upper_patterns ().size ());
+
+  for (auto &p : pattern.get_lower_patterns ())
+    lower_patterns.emplace_back (
+      std::unique_ptr<HIR::Pattern> (ASTLoweringPattern::translate (*p)));
+
+  for (auto &p : pattern.get_upper_patterns ())
+    upper_patterns.emplace_back (
+      std::unique_ptr<HIR::Pattern> (ASTLoweringPattern::translate (*p)));
+
+  return std::unique_ptr<HIR::SlicePatternItems> (
+    new HIR::SlicePatternItemsHasRest (std::move (lower_patterns),
+				       std::move (upper_patterns)));
+}
+
 std::unique_ptr<HIR::RangePatternBound>
 ASTLoweringBase::lower_range_pattern_bound (AST::RangePatternBound &bound)
 {

--- a/gcc/rust/hir/rust-ast-lower-base.h
+++ b/gcc/rust/hir/rust-ast-lower-base.h
@@ -322,6 +322,12 @@ protected:
   std::unique_ptr<TuplePatternItems>
   lower_tuple_pattern_ranged (AST::TuplePatternItemsRanged &pattern);
 
+  std::unique_ptr<SlicePatternItems>
+  lower_slice_pattern_no_rest (AST::SlicePatternItemsNoRest &pattern);
+
+  std::unique_ptr<SlicePatternItems>
+  lower_slice_pattern_has_rest (AST::SlicePatternItemsHasRest &pattern);
+
   std::unique_ptr<HIR::RangePatternBound>
   lower_range_pattern_bound (AST::RangePatternBound &bound);
 

--- a/gcc/rust/hir/rust-ast-lower-pattern.cc
+++ b/gcc/rust/hir/rust-ast-lower-pattern.cc
@@ -322,23 +322,22 @@ ASTLoweringPattern::visit (AST::ReferencePattern &pattern)
 void
 ASTLoweringPattern::visit (AST::SlicePattern &pattern)
 {
-  std::vector<std::unique_ptr<HIR::Pattern>> items;
+  std::unique_ptr<HIR::SlicePatternItems> items;
 
   switch (pattern.get_items ().get_pattern_type ())
     {
     case AST::SlicePatternItems::SlicePatternItemType::NO_REST:
       {
-	AST::SlicePatternItemsNoRest &ref
+	auto &ref
 	  = static_cast<AST::SlicePatternItemsNoRest &> (pattern.get_items ());
-	for (auto &p : ref.get_patterns ())
-	  items.emplace_back (ASTLoweringPattern::translate (*p));
+	items = ASTLoweringBase::lower_slice_pattern_no_rest (ref);
       }
       break;
     case AST::SlicePatternItems::SlicePatternItemType::HAS_REST:
       {
-	rust_error_at (pattern.get_locus (),
-		       "lowering of slice patterns with rest elements are not "
-		       "supported yet");
+	auto &ref
+	  = static_cast<AST::SlicePatternItemsHasRest &> (pattern.get_items ());
+	items = ASTLoweringBase::lower_slice_pattern_has_rest (ref);
       }
       break;
     }

--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -2363,11 +2363,28 @@ Dump::visit (TuplePattern &e)
 }
 
 void
+Dump::visit (SlicePatternItemsNoRest &e)
+{
+  begin ("SlicePatternItemsNoRest");
+  visit_collection ("patterns", e.get_patterns ());
+  end ("SlicePatternItemsNoRest");
+}
+
+void
+Dump::visit (SlicePatternItemsHasRest &e)
+{
+  begin ("SlicePatternItemsHasRest");
+  visit_collection ("lower_patterns", e.get_lower_patterns ());
+  visit_collection ("upper_patterns", e.get_upper_patterns ());
+  end ("SlicePatternItemsHasRest");
+}
+
+void
 Dump::visit (SlicePattern &e)
 {
   begin ("SlicePattern");
   do_mappings (e.get_mappings ());
-  visit_collection ("items", e.get_items ());
+  visit_field ("items", e.get_items ());
   end ("SlicePattern");
 }
 

--- a/gcc/rust/hir/rust-hir-dump.h
+++ b/gcc/rust/hir/rust-hir-dump.h
@@ -230,7 +230,11 @@ private:
   virtual void visit (TuplePatternItemsNoRest &) override;
   virtual void visit (TuplePatternItemsHasRest &) override;
   virtual void visit (TuplePattern &) override;
+
+  virtual void visit (SlicePatternItemsNoRest &) override;
+  virtual void visit (SlicePatternItemsHasRest &) override;
   virtual void visit (SlicePattern &) override;
+
   virtual void visit (AltPattern &) override;
 
   virtual void visit (EmptyStmt &) override;

--- a/gcc/rust/hir/tree/rust-hir-full-decls.h
+++ b/gcc/rust/hir/tree/rust-hir-full-decls.h
@@ -206,6 +206,8 @@ class TuplePatternItems;
 class TuplePatternItemsNoRest;
 class TuplePatternItemsHasRest;
 class TuplePattern;
+class SlicePatternItemsNoRest;
+class SlicePatternItemsHasRest;
 class SlicePattern;
 class AltPattern;
 

--- a/gcc/rust/hir/tree/rust-hir-visitor.cc
+++ b/gcc/rust/hir/tree/rust-hir-visitor.cc
@@ -1068,10 +1068,25 @@ DefaultHIRVisitor::walk (TuplePattern &pattern)
 }
 
 void
+DefaultHIRVisitor::walk (SlicePatternItemsNoRest &items)
+{
+  for (auto &pattern : items.get_patterns ())
+    pattern->accept_vis (*this);
+}
+
+void
+DefaultHIRVisitor::walk (SlicePatternItemsHasRest &items)
+{
+  for (auto &lower : items.get_lower_patterns ())
+    lower->accept_vis (*this);
+  for (auto &upper : items.get_upper_patterns ())
+    upper->accept_vis (*this);
+}
+
+void
 DefaultHIRVisitor::walk (SlicePattern &pattern)
 {
-  for (auto &item : pattern.get_items ())
-    item->accept_vis (*this);
+  pattern.get_items ().accept_vis (*this);
 }
 
 void

--- a/gcc/rust/hir/tree/rust-hir-visitor.h
+++ b/gcc/rust/hir/tree/rust-hir-visitor.h
@@ -138,6 +138,8 @@ public:
   virtual void visit (TuplePatternItemsNoRest &tuple_items) = 0;
   virtual void visit (TuplePatternItemsHasRest &tuple_items) = 0;
   virtual void visit (TuplePattern &pattern) = 0;
+  virtual void visit (SlicePatternItemsNoRest &items) = 0;
+  virtual void visit (SlicePatternItemsHasRest &items) = 0;
   virtual void visit (SlicePattern &pattern) = 0;
   virtual void visit (AltPattern &pattern) = 0;
   virtual void visit (EmptyStmt &stmt) = 0;
@@ -311,6 +313,8 @@ public:
   virtual void visit (TuplePatternItemsNoRest &node) override { walk (node); }
   virtual void visit (TuplePatternItemsHasRest &node) override { walk (node); }
   virtual void visit (TuplePattern &node) override { walk (node); }
+  virtual void visit (SlicePatternItemsNoRest &node) override { walk (node); }
+  virtual void visit (SlicePatternItemsHasRest &node) override { walk (node); }
   virtual void visit (SlicePattern &node) override { walk (node); }
   virtual void visit (AltPattern &node) override { walk (node); }
   virtual void visit (EmptyStmt &node) override { walk (node); }
@@ -444,6 +448,8 @@ protected:
   virtual void walk (TuplePatternItemsNoRest &) final;
   virtual void walk (TuplePatternItemsHasRest &) final;
   virtual void walk (TuplePattern &) final;
+  virtual void walk (SlicePatternItemsNoRest &) final;
+  virtual void walk (SlicePatternItemsHasRest &) final;
   virtual void walk (SlicePattern &) final;
   virtual void walk (AltPattern &) final;
   virtual void walk (EmptyStmt &) final;
@@ -593,6 +599,9 @@ public:
   virtual void visit (TuplePatternItemsNoRest &) override {}
   virtual void visit (TuplePatternItemsHasRest &) override {}
   virtual void visit (TuplePattern &) override {}
+
+  virtual void visit (SlicePatternItemsNoRest &) override {}
+  virtual void visit (SlicePatternItemsHasRest &) override {}
   virtual void visit (SlicePattern &) override {}
   virtual void visit (AltPattern &) override {}
 

--- a/gcc/rust/hir/tree/rust-hir.cc
+++ b/gcc/rust/hir/tree/rust-hir.cc
@@ -2386,16 +2386,56 @@ RangePatternBoundLiteral::as_string () const
 }
 
 std::string
-SlicePattern::as_string () const
+SlicePatternItemsNoRest::as_string () const
 {
-  std::string str ("SlicePattern: ");
+  std::string str;
 
-  for (const auto &pattern : items)
+  for (const auto &pattern : patterns)
     {
       str += "\n " + pattern->as_string ();
     }
 
   return str;
+}
+
+std::string
+SlicePatternItemsHasRest::as_string () const
+{
+  std::string str;
+
+  str += "\n Lower patterns: ";
+  if (lower_patterns.empty ())
+    {
+      str += "none";
+    }
+  else
+    {
+      for (const auto &lower : lower_patterns)
+	{
+	  str += "\n  " + lower->as_string ();
+	}
+    }
+
+  str += "\n Upper patterns: ";
+  if (upper_patterns.empty ())
+    {
+      str += "none";
+    }
+  else
+    {
+      for (const auto &upper : upper_patterns)
+	{
+	  str += "\n  " + upper->as_string ();
+	}
+    }
+
+  return str;
+}
+
+std::string
+SlicePattern::as_string () const
+{
+  return "SlicePattern: " + items->as_string ();
 }
 
 std::string
@@ -4501,6 +4541,18 @@ TuplePatternItemsHasRest::accept_vis (HIRFullVisitor &vis)
 
 void
 TuplePattern::accept_vis (HIRFullVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+void
+SlicePatternItemsNoRest::accept_vis (HIRFullVisitor &vis)
+{
+  vis.visit (*this);
+}
+
+void
+SlicePatternItemsHasRest::accept_vis (HIRFullVisitor &vis)
 {
   vis.visit (*this);
 }

--- a/gcc/testsuite/rust/compile/slice_rest_pattern.rs
+++ b/gcc/testsuite/rust/compile/slice_rest_pattern.rs
@@ -1,5 +1,4 @@
-// { dg-options "-fsyntax-only" }
-fn foo(a: &[u32]) {
+pub fn foo(a: &[u32]) {
     match a {
         [first, ..] => {}
         [.., last] => {}

--- a/gcc/testsuite/rust/execute/torture/match-slicepattern-array-2.rs
+++ b/gcc/testsuite/rust/execute/torture/match-slicepattern-array-2.rs
@@ -1,0 +1,27 @@
+// { dg-output "correct\r*" }
+extern "C" {
+    fn puts(s: *const i8);
+}
+
+fn main() -> i32 {
+    let a = [0, 4, 5, 6, 1];
+    let mut ret = 1;
+
+    match a {
+        [1, .., b] => {
+            /* should not take this path */
+            unsafe { puts("wrong\0" as *const str as *const i8) }
+        }
+        [0, .., 0] => {
+            /* should not take this path */
+            unsafe { puts("wrong\0" as *const str as *const i8) }
+        },
+        [0, .., b] => {
+            ret -= b;
+            unsafe { puts("correct\0" as *const str as *const i8) }
+        },
+        _ => {}
+    }
+
+    ret
+}

--- a/gcc/testsuite/rust/execute/torture/match-slicepattern-slice-2.rs
+++ b/gcc/testsuite/rust/execute/torture/match-slicepattern-slice-2.rs
@@ -1,0 +1,28 @@
+// { dg-output "correct\r*" }
+extern "C" {
+    fn puts(s: *const i8);
+}
+
+fn main() -> i32 {
+    let arr = [0, 4, 5, 6, 1];
+    let a: &[i32] = &arr;
+    let mut ret = 1;
+
+    match a {
+        [1, .., b] => {
+            /* should not take this path */
+            unsafe { puts("wrong\0" as *const str as *const i8) }
+        }
+        [0, .., 0] => {
+            /* should not take this path */
+            unsafe { puts("wrong\0" as *const str as *const i8) }
+        },
+        [0, .., b] => {
+            ret -= b;
+            unsafe { puts("correct\0" as *const str as *const i8) }
+        },
+        _ => {}
+    }
+
+    ret
+}


### PR DESCRIPTION
My meatiest PR to this repo so far. I'm ready to be grilled for my code style (especially in `rust-compile-pattern.cc`).

Similar to my changes made to the AST for rest-pattern-in-slice-pattern support, the main change is adding `SlicePatternItemsNoRest` and `SlicePatternItemsHasRest` classes which hold patterns for `HIR::SlicePattern`. The changes made to `rust-compile-pattern.cc` is also quite significant due to having 4 different cases to handle (array parent + no rest, array parent + has rest, slice parent + no rest, slice parent + has rest) - reviewers should focus more on that file, since other changes are mainly cascading changes stemmed from the introduction of new classes.