### PR TITLE
Allow `format_args!` with a macro as first argument

### DIFF
--- a/gcc/rust/ast/rust-ast-visitor.cc
+++ b/gcc/rust/ast/rust-ast-visitor.cc
@@ -1500,9 +1500,12 @@ DefaultASTVisitor::visit (AST::BareFunctionType &type)
 }
 
 void
-DefaultASTVisitor::visit (AST::FormatArgs &)
+DefaultASTVisitor::visit (AST::FormatArgs &fmt)
 {
   // FIXME: Do we have anything to do? any subnodes to visit? Probably, right?
+  auto &fmt_arg = fmt.get_template_arg ();
+  if (fmt_arg.has_expr ())
+    visit (fmt_arg.get_expr ());
 }
 
 void

--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -5025,8 +5025,6 @@ FormatArgs::set_outer_attrs (std::vector<Attribute>)
 Expr *
 FormatArgs::clone_expr_impl () const
 {
-  std::cerr << "[ARTHUR] cloning FormatArgs! " << std::endl;
-
   return new FormatArgs (*this);
 }
 

--- a/gcc/rust/ast/rust-fmt.cc
+++ b/gcc/rust/ast/rust-fmt.cc
@@ -32,41 +32,11 @@ Pieces
 Pieces::collect (const std::string &to_parse, bool append_newline,
 		 ffi::ParseMode parse_mode)
 {
-  auto handle
-    = ffi::collect_pieces (to_parse.c_str (), append_newline, parse_mode);
-
-  // this performs multiple copies, can we avoid them maybe?
-  // TODO: Instead of just creating a vec of, basically, `ffi::Piece`s, we
-  // should transform them into the proper C++ type which we can work with. so
-  // transform all the strings into C++ strings? all the Option<T> into
-  // tl::optional<T>?
-  auto pieces_vector = std::vector<ffi::Piece> (handle.piece_slice.base_ptr,
-						handle.piece_slice.base_ptr
-						  + handle.piece_slice.len);
-
-  return Pieces (handle, std::move (pieces_vector));
+  Pieces ret (to_parse, ffi::FFIVec<ffi::Piece> ());
+  ret.data->second = ffi::collect_pieces (ffi::RustHamster (ret.data->first),
+					  append_newline, parse_mode);
+  return ret;
 }
-
-Pieces::~Pieces () { ffi::destroy_pieces (handle); }
-
-Pieces::Pieces (const Pieces &other) : pieces_vector (other.pieces_vector)
-{
-  handle = ffi::clone_pieces (other.handle);
-}
-
-Pieces &
-Pieces::operator= (const Pieces &other)
-{
-  handle = ffi::clone_pieces (other.handle);
-  pieces_vector = other.pieces_vector;
-
-  return *this;
-}
-
-Pieces::Pieces (Pieces &&other)
-  : pieces_vector (std::move (other.pieces_vector)),
-    handle (clone_pieces (other.handle))
-{}
 
 } // namespace Fmt
 } // namespace Rust

--- a/gcc/rust/expand/rust-expand-format-args.h
+++ b/gcc/rust/expand/rust-expand-format-args.h
@@ -19,15 +19,20 @@
 #ifndef RUST_EXPAND_FORMAT_ARGS_H
 #define RUST_EXPAND_FORMAT_ARGS_H
 
-#include "optional.h"
+#include "rust-system.h"
 #include "rust-ast-fragment.h"
+#include "optional.h"
 
 namespace Rust {
+
+// forward declare
+class ExpandVisitor;
+struct MacroExpander;
+
 namespace Fmt {
 
-tl::optional<AST::Fragment>
-expand_format_args (AST::FormatArgs &fmt,
-		    std::vector<std::unique_ptr<AST::Token>> &&tokens);
+void expand_format_args (ExpandVisitor &expand_visitor, MacroExpander &expander,
+			 AST::FormatArgs &fmt);
 
 } // namespace Fmt
 } // namespace Rust

--- a/gcc/rust/expand/rust-expand-visitor.cc
+++ b/gcc/rust/expand/rust-expand-visitor.cc
@@ -23,6 +23,7 @@
 #include "rust-ast.h"
 #include "rust-type.h"
 #include "rust-derive.h"
+#include "rust-expand-format-args.h"
 
 namespace Rust {
 
@@ -1059,6 +1060,21 @@ ExpandVisitor::visit (AST::SelfParam &param)
    * lifetime? */
   if (param.has_type ())
     maybe_expand_type (param.get_type_ptr ());
+}
+
+void
+ExpandVisitor::visit (AST::FormatArgs &fmt)
+{
+  if (macro_invoc_expect_id != fmt.get_node_id ())
+    {
+      rust_internal_error_at (fmt.get_locus (),
+			      "attempting to expand FormatArgs node with id %d "
+			      "into position with node id %d",
+			      (int) fmt.get_node_id (),
+			      (int) macro_invoc_expect_id);
+    }
+
+  Fmt::expand_format_args (*this, expander, fmt);
 }
 
 template <typename T>

--- a/gcc/rust/expand/rust-expand-visitor.h
+++ b/gcc/rust/expand/rust-expand-visitor.h
@@ -22,6 +22,7 @@
 #include "rust-ast-visitor.h"
 #include "rust-macro-expand.h"
 #include "rust-proc-macro.h"
+#include "rust-ast-full-decls.h"
 
 namespace Rust {
 
@@ -283,6 +284,9 @@ public:
   void visit (AST::BareFunctionType &type) override;
   void visit (AST::FunctionParam &type) override;
   void visit (AST::SelfParam &type) override;
+
+  // expand these if possible
+  void visit (AST::FormatArgs &fmt) override;
 
   template <typename T>
   void expand_inner_attribute (T &item, AST::SimplePath &Path);

--- a/gcc/rust/expand/rust-macro-builtins-asm.cc
+++ b/gcc/rust/expand/rust-macro-builtins-asm.cc
@@ -787,12 +787,12 @@ expand_inline_asm_strings (InlineAsmContext inline_asm_ctx)
 
       auto pieces = Fmt::Pieces::collect (template_str.symbol, false,
 					  Fmt::ffi::ParseMode::InlineAsm);
-      auto pieces_vec = pieces.get_pieces ();
+      auto &pieces_vec = pieces.get_pieces ();
 
       std::string transformed_template_str = "";
       for (size_t i = 0; i < pieces_vec.size (); i++)
 	{
-	  auto piece = pieces_vec[i];
+	  auto &piece = pieces_vec[i];
 	  if (piece.tag == Fmt::ffi::Piece::Tag::String)
 	    {
 	      transformed_template_str += piece.string._0.to_string ();

--- a/gcc/rust/expand/rust-macro-builtins-format-args.cc
+++ b/gcc/rust/expand/rust-macro-builtins-format-args.cc
@@ -24,7 +24,7 @@ namespace Rust {
 
 struct FormatArgsInput
 {
-  std::string format_str;
+  std::unique_ptr<AST::Expr> format_expr;
   AST::FormatArguments args;
   // bool is_literal?
 };
@@ -48,27 +48,9 @@ format_args_parse_arguments (AST::MacroInvocData &invoc)
 
   auto args = AST::FormatArguments ();
   auto last_token_id = macro_end_token (invoc.get_delim_tok_tree (), parser);
-  std::unique_ptr<AST::Expr> format_expr = nullptr;
 
-  // TODO: Handle the case where we're not parsing a string literal (macro
-  // invocation for e.g.)
-  switch (parser.peek_current_token ()->get_id ())
-    {
-    case STRING_LITERAL:
-    case RAW_STRING_LITERAL:
-      format_expr = parser.parse_literal_expr ();
-    default:
-      // do nothing
-      ;
-    }
-
+  auto format_expr = parser.parse_expr ();
   rust_assert (format_expr);
-
-  // TODO(Arthur): Clean this up - if we haven't parsed a string literal but a
-  // macro invocation, what do we do here? return a tl::unexpected?
-  auto format_str = static_cast<AST::LiteralExpr &> (*format_expr)
-		      .get_literal ()
-		      .as_string ();
 
   // TODO: Allow implicit captures ONLY if the the first arg is a string literal
   // and not a macro invocation
@@ -126,7 +108,7 @@ format_args_parse_arguments (AST::MacroInvocData &invoc)
       // we need to skip commas, don't we?
     }
 
-  return FormatArgsInput{std::move (format_str), std::move (args)};
+  return FormatArgsInput{std::move (format_expr), std::move (args)};
 }
 
 tl::optional<AST::Fragment>
@@ -144,67 +126,12 @@ MacroBuiltin::format_args_handler (location_t invoc_locus,
       return tl::nullopt;
     }
 
-  // TODO(Arthur): We need to handle this
-  // // if it is not a literal, it's an eager macro invocation - return it
-  // if (!fmt_expr->is_literal ())
-  //   {
-  //     auto token_tree = invoc.get_delim_tok_tree ();
-  //     return AST::Fragment ({AST::SingleASTNode (std::move (fmt_expr))},
-  // 	    token_tree.to_token_stream ());
-  //   }
+  auto node = AST::SingleASTNode (std::make_unique<AST::FormatArgs> (
+    invoc_locus, AST::FormatArgsPieces (std::move (input->format_expr), nl),
+    std::move (input->args)));
 
-  // TODO(Arthur): Handle this as well - raw strings are special for the
-  // format_args parser auto fmt_str = static_cast<AST::LiteralExpr &>
-  // (*fmt_arg.get ()); Switch on the format string to know if the string is raw
-  // or cooked switch (fmt_str.get_lit_type ())
-  //   {
-  //   // case AST::Literal::RAW_STRING:
-  //   case AST::Literal::STRING:
-  //     break;
-  //   case AST::Literal::CHAR:
-  //   case AST::Literal::BYTE:
-  //   case AST::Literal::BYTE_STRING:
-  //   case AST::Literal::INT:
-  //   case AST::Literal::FLOAT:
-  //   case AST::Literal::BOOL:
-  //   case AST::Literal::ERROR:
-  //     rust_unreachable ();
-  //   }
-
-  bool append_newline = nl == AST::FormatArgs::Newline::Yes;
-
-  auto fmt_str = std::move (input->format_str);
-  if (append_newline)
-    fmt_str += '\n';
-
-  auto pieces = Fmt::Pieces::collect (fmt_str, append_newline,
-				      Fmt::ffi::ParseMode::Format);
-
-  // TODO:
-  // do the transformation into an AST::FormatArgs node
-  // return that
-  // expand it during lowering
-
-  // TODO: we now need to take care of creating `unfinished_literal`? this is
-  // for creating the `template`
-
-  auto fmt_args_node = AST::FormatArgs (invoc_locus, std::move (pieces),
-					std::move (input->args));
-
-  auto expanded
-    = Fmt::expand_format_args (fmt_args_node,
-			       invoc.get_delim_tok_tree ().to_token_stream ());
-
-  if (!expanded.has_value ())
-    return AST::Fragment::create_error ();
-
-  return *expanded;
-
-  // auto node = std::unique_ptr<AST::Expr> (fmt_args_node);
-  // auto single_node = AST::SingleASTNode (std::move (node));
-
-  // return AST::Fragment ({std::move (single_node)},
-  // 	invoc.get_delim_tok_tree ().to_token_stream ());
+  return AST::Fragment ({std::move (node)},
+			invoc.get_delim_tok_tree ().to_token_stream ());
 }
 
 } // namespace Rust

--- a/gcc/testsuite/rust/compile/format_args_concat.rs
+++ b/gcc/testsuite/rust/compile/format_args_concat.rs
@@ -1,0 +1,51 @@
+#![feature(rustc_attrs)]
+
+#[rustc_builtin_macro]
+macro_rules! format_args {
+    () => {};
+}
+
+#[rustc_builtin_macro]
+macro_rules! concat {
+    () => {};
+}
+
+#[lang = "sized"]
+trait Sized {}
+
+pub mod core {
+    pub mod fmt {
+        pub struct Formatter;
+        pub struct Result;
+
+        pub struct Arguments<'a>;
+
+        impl<'a> Arguments<'a> {
+            pub fn new_v1(_: &'a [&'static str], _: &'a [ArgumentV1<'a>]) -> Arguments<'a> {
+                Arguments
+            }
+        }
+
+        pub struct ArgumentV1<'a>;
+
+        impl<'a> ArgumentV1<'a> {
+            pub fn new<'b, T>(_: &'b T, _: fn(&T, &mut Formatter) -> Result) -> ArgumentV1 {
+                ArgumentV1
+            }
+        }
+
+        pub trait Display {
+            fn fmt(&self, _: &mut Formatter) -> Result;
+        }
+
+        impl Display for i32 {
+            fn fmt(&self, _: &mut Formatter) -> Result {
+                Result
+            }
+        }
+    }
+}
+
+fn main() {
+    let _formatted = format_args!(concat!("hello ", "{}"), 15);
+}

--- a/libgrust/libformat_parser/src/lib.rs
+++ b/libgrust/libformat_parser/src/lib.rs
@@ -1,35 +1,12 @@
 //! FFI interface for `rustc_format_parser`
 
+use std::alloc::Layout;
+
 // what's the plan? Have a function return something that can be constructed into a vector?
 // or an iterator?
 
-use std::ffi::CStr;
-
 trait IntoFFI<T> {
     fn into_ffi(self) -> T;
-}
-
-impl<T> IntoFFI<*const T> for Option<T>
-where
-    T: Sized,
-{
-    fn into_ffi(self) -> *const T {
-        match self.as_ref() {
-            None => std::ptr::null(),
-            Some(r) => r as *const T,
-        }
-    }
-}
-
-// Extension trait to provide `String::leak` which did not exist in Rust 1.49
-pub trait StringLeakExt {
-    fn leak<'a>(self) -> &'a mut str;
-}
-
-impl StringLeakExt for String {
-    fn leak<'a>(self) -> &'a mut str {
-        Box::leak(self.into_boxed_str())
-    }
 }
 
 // FIXME: Make an ffi module in a separate file
@@ -37,20 +14,184 @@ impl StringLeakExt for String {
 // FIXME: How to encode the Option type? As a pointer? Option<T> -> Option<&T> -> *const T could work maybe?
 pub mod ffi {
     use super::IntoFFI;
+    use std::marker::PhantomData;
+    use std::mem::MaybeUninit;
+
+    #[repr(C)]
+    pub struct FFIVec<T> {
+        data: *mut T,
+        len: usize,
+        cap: usize
+    }
+
+    impl<T> IntoFFI<FFIVec<T>> for Vec<T> {
+        fn into_ffi(mut self) -> FFIVec<T> {
+            let ret = FFIVec {
+                data: self.as_mut_ptr(),
+                len: self.len(),
+                cap: self.capacity()
+            };
+            self.leak();
+            ret
+        }
+    }
+
+    impl<T> Drop for FFIVec<T> {
+        fn drop(&mut self) {
+            unsafe {
+                Vec::from_raw_parts(self.data, self.len, self.cap);
+            }
+        }
+    }
+
+    impl<T> FFIVec<T> {
+        fn with_vec_ref<R, F: for<'a> FnOnce(&'a Vec<T>) -> R>(
+            &self, f: F
+        ) -> R {
+            let v = unsafe {
+                Vec::from_raw_parts(self.data, self.len, self.cap)
+            };
+            let ret = f(&v);
+            v.leak();
+            ret
+        }
+
+        // currently unused
+        // may be nice to have later, though
+        #[allow(unused)]
+        fn with_vec_mut_ref<R, F: for<'a> FnOnce(&'a mut Vec<T>) -> R>(
+            &mut self, f: F
+        ) -> R {
+            let mut v = unsafe {
+                Vec::from_raw_parts(self.data, self.len, self.cap)
+            };
+            let ret = f(&mut v);
+            self.data = v.as_mut_ptr();
+            self.len = v.len();
+            self.cap = v.capacity();
+            v.leak();
+            ret
+        }
+    }
+
+    impl<T> Clone for FFIVec<T>
+    where
+        T: Clone
+    {
+        fn clone(&self) -> FFIVec<T> {
+            self.with_vec_ref(|v| v.clone().into_ffi())
+        }
+    }
+
+    #[repr(C)]
+    pub struct FFIOpt<T> {
+        val: MaybeUninit<T>,
+        is_some: bool
+    }
+
+    impl<T> Clone for FFIOpt<T>
+    where
+        T: Clone
+    {
+        fn clone(&self) -> Self {
+            match self.get_opt_ref() {
+                Some(r) => FFIOpt::new_val(r.clone()),
+                None => FFIOpt::new_none()
+            }
+        }
+    }
+
+    impl<T> PartialEq for FFIOpt<T>
+    where
+        T: PartialEq
+    {
+        fn eq(&self, other: &Self) -> bool {
+            match (self.get_opt_ref(), other.get_opt_ref()) {
+                (Some(a), Some(b)) => a.eq(b),
+                _ => false
+            }
+        }
+    }
+
+    impl<T> Eq for FFIOpt<T>
+    where
+        T: Eq
+    {}
+
+    impl<T> Drop for FFIOpt<T>
+    {
+        fn drop(&mut self) {
+            if self.is_some {
+                unsafe { std::ptr::drop_in_place(self.val.as_mut_ptr()) }
+            }
+        }
+    }
+
+    impl<T> IntoFFI<FFIOpt<T>> for Option<T> {
+        fn into_ffi(self) -> FFIOpt<T> {
+            match self {
+                Some(v) => FFIOpt::new_val(v),
+                None => FFIOpt::new_none()
+            }
+        }
+    }
+
+    impl<T> FFIOpt<T> {
+        pub fn new_val(v: T) -> Self {
+            FFIOpt {
+                val: MaybeUninit::new(v),
+                is_some: true
+            }
+        }
+
+        pub fn new_none() -> Self {
+            FFIOpt {
+                val: MaybeUninit::uninit(),
+                is_some: false
+            }
+        }
+
+        pub fn get_opt_ref(&self) -> Option<&T> {
+            if self.is_some {
+                Some(unsafe {&*self.val.as_ptr()})
+            } else {
+                None
+            }
+        }
+
+        pub fn get_opt_ref_mut(&mut self) -> Option<&mut T> {
+            if self.is_some {
+                Some(unsafe {&mut *self.val.as_mut_ptr()})
+            } else {
+                None
+            }
+        }
+    }
 
     // FIXME: We need to ensure we deal with memory properly - whether it's owned by the C++ side or the Rust side
     #[derive(Copy, Clone, PartialEq, Eq, Debug)]
     #[repr(C)]
-    pub struct RustHamster {
+    pub struct RustHamster<'a> {
         ptr: *const u8,
         len: usize,
+        phantom: PhantomData<&'a u8>
     }
 
-    impl<'a> From<&'a str> for RustHamster {
-        fn from(s: &'a str) -> RustHamster {
+    impl<'a> IntoFFI<RustHamster<'a>> for &'a str {
+        fn into_ffi(self) -> RustHamster<'a> {
             RustHamster {
-                ptr: s.as_ptr(),
-                len: s.len(),
+                ptr: self.as_ptr(),
+                len: self.len(),
+                phantom: PhantomData,
+            }
+        }
+    }
+
+    impl<'a> RustHamster<'a> {
+        pub fn as_str(&self) -> &'a str {
+            unsafe {
+                let slice: &'a [u8] = std::slice::from_raw_parts(self.ptr, self.len);
+                std::str::from_utf8_unchecked(slice)
             }
         }
     }
@@ -101,11 +242,11 @@ pub mod ffi {
 
     /// A piece is a portion of the format string which represents the next part
     /// to emit. These are emitted as a stream by the `Parser` class.
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Clone)]
     #[repr(C)]
     pub enum Piece<'a> {
         /// A literal string which should directly be emitted
-        String(RustHamster),
+        String(RustHamster<'a>),
         /// This describes that formatting should process the next argument (as
         /// specified inside) for emission.
         // do we need a pointer here? we're doing big cloning anyway
@@ -113,7 +254,7 @@ pub mod ffi {
     }
 
     /// Representation of an argument specification.
-    #[derive(Copy, Clone, Debug, PartialEq)]
+    #[derive(Clone)]
     #[repr(C)]
     pub struct Argument<'a> {
         /// Where to find this argument
@@ -126,37 +267,37 @@ pub mod ffi {
     }
 
     /// Specification for the formatting of an argument in the format string.
-    #[derive(Copy, Clone, Debug, PartialEq)]
+    #[derive(Clone)]
     #[repr(C)]
     pub struct FormatSpec<'a> {
         /// Optionally specified character to fill alignment with.
-        pub fill: Option<char>,
+        pub fill: FFIOpt<char>,
         /// Span of the optionally specified fill character.
-        pub fill_span: *const InnerSpan,
+        pub fill_span: FFIOpt<InnerSpan>,
         /// Optionally specified alignment.
         pub align: Alignment,
         /// The `+` or `-` flag.
-        pub sign: *const Sign,
+        pub sign: FFIOpt<Sign>,
         /// The `#` flag.
         pub alternate: bool,
         /// The `0` flag.
         pub zero_pad: bool,
         /// The `x` or `X` flag. (Only for `Debug`.)
-        pub debug_hex: *const DebugHex,
+        pub debug_hex: FFIOpt<DebugHex>,
         /// The integer precision to use.
         pub precision: Count<'a>,
         /// The span of the precision formatting flag (for diagnostics).
-        pub precision_span: *const InnerSpan,
+        pub precision_span: FFIOpt<InnerSpan>,
         /// The string width requested for the resulting format.
         pub width: Count<'a>,
         /// The span of the width formatting flag (for diagnostics).
-        pub width_span: *const InnerSpan,
+        pub width_span: FFIOpt<InnerSpan>,
         /// The descriptor string representing the name of the format desired for
         /// this argument, this can be empty or any number of characters, although
         /// it is required to be one word.
-        pub ty: &'a str,
+        pub ty: RustHamster<'a>,
         /// The span of the descriptor string (for diagnostics).
-        pub ty_span: *const InnerSpan,
+        pub ty_span: FFIOpt<InnerSpan>,
     }
 
     /// Enum describing where an argument for a format can be located.
@@ -168,7 +309,7 @@ pub mod ffi {
         /// The argument is located at a specific index given in the format,
         ArgumentIs(usize),
         /// The argument has a name.
-        ArgumentNamed(&'a str),
+        ArgumentNamed(RustHamster<'a>),
     }
 
     /// Enum of alignments which are supported.
@@ -213,7 +354,7 @@ pub mod ffi {
         /// The count is specified explicitly.
         CountIs(usize),
         /// The count is specified by the argument with the given name.
-        CountIsName(&'a str, InnerSpan),
+        CountIsName(RustHamster<'a>, InnerSpan),
         /// The count is specified by the argument at the given index.
         CountIsParam(usize),
         /// The count is specified by a star (like in `{:.*}`) that refers to the argument at the given index.
@@ -225,7 +366,7 @@ pub mod ffi {
     impl<'a> From<generic_format_parser::Piece<'a>> for Piece<'a> {
         fn from(old: generic_format_parser::Piece<'a>) -> Self {
             match old {
-                generic_format_parser::Piece::String(x) => Piece::String(x.into()),
+                generic_format_parser::Piece::String(x) => Piece::String(x.into_ffi()),
                 generic_format_parser::Piece::NextArgument(x) => {
                     // FIXME: This is problematic - if we do this, then we probably run into the issue that the Box
                     // is freed at the end of the call to collect_pieces. if we just .leak() it, then we have
@@ -259,7 +400,7 @@ pub mod ffi {
                 }
                 generic_format_parser::Position::ArgumentIs(x) => Position::ArgumentIs(x.into()),
                 generic_format_parser::Position::ArgumentNamed(x) => {
-                    Position::ArgumentNamed(x.into())
+                    Position::ArgumentNamed(x.into_ffi())
                 }
             }
         }
@@ -277,7 +418,7 @@ pub mod ffi {
     impl<'a> From<generic_format_parser::FormatSpec<'a>> for FormatSpec<'a> {
         fn from(old: generic_format_parser::FormatSpec<'a>) -> Self {
             FormatSpec {
-                fill: old.fill,
+                fill: old.fill.into_ffi(),
                 fill_span: old.fill_span.map(Into::into).into_ffi(),
                 align: old.align.into(),
                 sign: old.sign.map(Into::into).into_ffi(),
@@ -288,7 +429,7 @@ pub mod ffi {
                 precision_span: old.precision_span.map(Into::into).into_ffi(),
                 width: old.width.into(),
                 width_span: old.width_span.map(Into::into).into_ffi(),
-                ty: old.ty,
+                ty: old.ty.into_ffi(),
                 ty_span: old.ty_span.map(Into::into).into_ffi(),
             }
         }
@@ -307,7 +448,7 @@ pub mod ffi {
         fn from(old: generic_format_parser::Count<'a>) -> Self {
             match old {
                 generic_format_parser::Count::CountIs(x) => Count::CountIs(x),
-                generic_format_parser::Count::CountIsName(x, y) => Count::CountIsName(x, y.into()),
+                generic_format_parser::Count::CountIsName(x, y) => Count::CountIsName(x.into_ffi(), y.into()),
                 generic_format_parser::Count::CountIsParam(x) => Count::CountIsParam(x),
                 generic_format_parser::Count::CountIsStar(x) => Count::CountIsStar(x),
                 generic_format_parser::Count::CountImplied => Count::CountImplied,
@@ -357,100 +498,66 @@ pub mod rust {
 }
 
 // TODO: Should we instead make an FFIVector struct?
-#[repr(C)]
-pub struct PieceSlice {
-    base_ptr: *mut ffi::Piece<'static /* FIXME: That's wrong */>,
-    len: usize,
-    cap: usize,
-}
-
-#[repr(C)]
-// FIXME: we should probably use FFIString here
-pub struct RustString {
-    ptr: *const u8,
-    len: usize,
-    cap: usize,
-}
-
-#[repr(C)]
-pub struct FormatArgsHandle(PieceSlice, RustString);
+type PieceVec<'a> = ffi::FFIVec<ffi::Piece<'a>>;
 
 #[no_mangle]
-pub extern "C" fn collect_pieces(
-    input: *const libc::c_char,
+pub extern "C" fn collect_pieces<'a>(
+    input: ffi::RustHamster<'a>,
     append_newline: bool,
     parse_mode: crate::ffi::ParseMode,
-) -> FormatArgsHandle {
-    // FIXME: Add comment
-    let str = unsafe { CStr::from_ptr(input) };
-    let str = str.to_str().unwrap().to_owned();
-
-    // we are never going to free this string here (we leak it later on), so we can extend its lifetime
-    // to send it across an FFI boundary.
-    // FIXME: Is that correct?
-    let s = &str;
-    let s = unsafe { std::mem::transmute::<&'_ str, &'static str>(s) };
-
+) -> PieceVec<'a> {
     // FIXME: No unwrap
     let pieces: Vec<ffi::Piece<'_>> =
-        rust::collect_pieces(s, None, None, append_newline, parse_mode)
+        rust::collect_pieces(input.as_str(), None, None, append_newline, parse_mode)
             .into_iter()
             .map(Into::into)
             .collect();
 
-    let piece_slice = PieceSlice {
-        len: pieces.len(),
-        cap: pieces.capacity(),
-        base_ptr: pieces.leak().as_mut_ptr(),
-    };
-    let rust_string = RustString {
-        len: str.len(),
-        cap: str.capacity(),
-        ptr: str.leak().as_ptr(),
-    };
-
-    FormatArgsHandle(piece_slice, rust_string)
+    pieces.into_ffi()
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn destroy_pieces(FormatArgsHandle(piece_slice, s): FormatArgsHandle) {
-    let PieceSlice { base_ptr, len, cap } = piece_slice;
-    drop(Vec::from_raw_parts(base_ptr, len, cap));
+pub extern "C" fn clone_pieces<'a, 'b>(
+    piece_vec: &'a PieceVec<'b>
+) -> PieceVec<'b> {
+    piece_vec.clone()
+}
 
-    let RustString { ptr, len, cap } = s;
-    drop(String::from_raw_parts(ptr as *mut u8, len, cap));
+// we need Layout::repeat
+// function signature is a bit different, so call it repeat_x
+trait LayoutExt {
+    fn repeat_x(&self, n: usize) -> Layout;
+}
+
+impl LayoutExt for Layout {
+    fn repeat_x(&self, n: usize) -> Layout {
+        let elem = self.pad_to_align();
+        let total_size = elem.size().checked_mul(n).unwrap();
+        Layout::from_size_align(total_size, elem.align()).unwrap()
+    }
 }
 
 #[no_mangle]
-pub extern "C" fn clone_pieces(
-    FormatArgsHandle(piece_slice, s): &FormatArgsHandle,
-) -> FormatArgsHandle {
-    let PieceSlice { base_ptr, len, cap } = *piece_slice;
+pub unsafe extern "C" fn rust_ffi_alloc(
+    count: usize, elem_size: usize, align: usize
+) -> *mut u8 {
+    unsafe {
+        std::alloc::alloc(
+            Layout::from_size_align_unchecked(elem_size, align)
+                .repeat_x(count)
+        )
+    }
+}
 
-    let v = unsafe { Vec::from_raw_parts(base_ptr, len, cap) };
-    let cloned_v = v.clone();
-
-    // FIXME: Add documentation
-    v.leak();
-
-    let piece_slice = PieceSlice {
-        len: cloned_v.len(),
-        cap: cloned_v.capacity(),
-        base_ptr: cloned_v.leak().as_mut_ptr(),
-    };
-
-    let RustString { ptr, len, cap } = *s;
-    let s = unsafe { String::from_raw_parts(ptr as *mut u8, len, cap) };
-    let cloned_s = s.clone();
-
-    // FIXME: Documentation
-    s.leak();
-
-    let rust_string = RustString {
-        len: cloned_s.len(),
-        cap: cloned_s.capacity(),
-        ptr: cloned_s.leak().as_ptr(),
-    };
-
-    FormatArgsHandle(piece_slice, rust_string)
+#[no_mangle]
+pub unsafe extern "C" fn rust_ffi_dealloc(
+    data: *mut u8, count: usize, elem_size: usize, align: usize
+) {
+    unsafe {
+        std::alloc::dealloc(
+            data,
+            Layout::from_size_align_unchecked(elem_size, align)
+                .repeat_x(count)
+        )
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/Rust-GCC/gccrs/issues/3896. `FormatArgsPieces` isn't great, but I don't see a better alternative for now.