### PR TITLE
Remove `#[simd_test]` support

### DIFF
--- a/gcc/rust/util/rust-attribute-values.h
+++ b/gcc/rust/util/rust-attribute-values.h
@@ -88,8 +88,6 @@ public:
 
   static constexpr auto &TEST = "test";
 
-  static constexpr auto &SIMD_TEST = "simd_test";
-
   static constexpr auto &RUSTC_ARGS_REQUIRED_CONST
     = "rustc_args_required_const";
 };

--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -125,8 +125,7 @@ static const BuiltinAttrDefinition __definitions[]
      {Attrs::NON_EXHAUSTIVE, TYPE_CHECK},
      {Attrs::RUSTFMT, EXTERNAL},
 
-     {Attrs::TEST, CODE_GENERATION},
-     {Attrs::SIMD_TEST, CODE_GENERATION}};
+     {Attrs::TEST, CODE_GENERATION}};
 
 BuiltinAttributeMappings *
 BuiltinAttributeMappings::get ()


### PR DESCRIPTION
This attribute is a procedural macro defined by the crate `simd-test-macro`, not a built-in macro.