### PR TITLE
Fix copy construction and assignment of `Pieces`

### DIFF
--- a/gcc/rust/ast/rust-fmt.cc
+++ b/gcc/rust/ast/rust-fmt.cc
@@ -49,24 +49,26 @@ Pieces::collect (const std::string &to_parse, bool append_newline,
 
 Pieces::~Pieces () { ffi::destroy_pieces (handle); }
 
-Pieces::Pieces (const Pieces &other) : pieces_vector (other.pieces_vector)
+Pieces::Pieces (const Pieces &other) : handle (ffi::clone_pieces (other.handle))
 {
-  handle = ffi::clone_pieces (other.handle);
+  // reconstruct
+  pieces_vector = std::vector<ffi::Piece> (handle.piece_slice.base_ptr,
+					   handle.piece_slice.base_ptr
+					     + handle.piece_slice.len);
 }
 
 Pieces &
 Pieces::operator= (const Pieces &other)
 {
   handle = ffi::clone_pieces (other.handle);
-  pieces_vector = other.pieces_vector;
+
+  // reconstruct
+  pieces_vector = std::vector<ffi::Piece> (handle.piece_slice.base_ptr,
+					   handle.piece_slice.base_ptr
+					     + handle.piece_slice.len);
 
   return *this;
 }
-
-Pieces::Pieces (Pieces &&other)
-  : pieces_vector (std::move (other.pieces_vector)),
-    handle (clone_pieces (other.handle))
-{}
 
 } // namespace Fmt
 } // namespace Rust

--- a/gcc/rust/ast/rust-fmt.h
+++ b/gcc/rust/ast/rust-fmt.h
@@ -286,8 +286,6 @@ struct Pieces
   Pieces (const Pieces &other);
   Pieces &operator= (const Pieces &other);
 
-  Pieces (Pieces &&other);
-
   const std::vector<ffi::Piece> &get_pieces () const { return pieces_vector; }
 
   // {


### PR DESCRIPTION
Pointers stored in `Pieces::pieces_vector` refer to objects with lifetimes tied to `Pieces::handle`. This commit also removes the move constructor for Pieces, as it's equivalent to the copy constructor.