### PR TITLE
Finish up subpattern codegen support for identifier patterns

### DIFF
--- a/gcc/rust/backend/rust-compile-pattern.cc
+++ b/gcc/rust/backend/rust-compile-pattern.cc
@@ -992,6 +992,11 @@ CompilePatternLet::visit (HIR::IdentifierPattern &pattern)
     }
   else
     {
+      if (pattern.has_subpattern ())
+	{
+	  CompilePatternLet::Compile (&pattern.get_subpattern (), init_expr, ty,
+				      rval_locus, ctx);
+	}
       auto s = Backend::init_statement (fnctx.fndecl, var, init_expr);
       ctx->add_statement (s);
     }

--- a/gcc/rust/backend/rust-compile-var-decl.h
+++ b/gcc/rust/backend/rust-compile-var-decl.h
@@ -64,6 +64,15 @@ public:
     ctx->insert_var_decl (stmt_id, var);
 
     vars.push_back (var);
+
+    if (pattern.has_subpattern ())
+      {
+	auto subpattern_vars
+	  = CompileVarDecl::compile (fndecl, translated_type,
+				     &pattern.get_subpattern (), ctx);
+	vars.insert (vars.end (), subpattern_vars.begin (),
+		     subpattern_vars.end ());
+      }
   }
 
   void visit (HIR::TuplePattern &pattern) override

--- a/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
@@ -814,6 +814,11 @@ ClosureParamInfer::visit (HIR::WildcardPattern &pattern)
 void
 ClosureParamInfer::visit (HIR::IdentifierPattern &pattern)
 {
+  if (pattern.has_subpattern ())
+    {
+      ClosureParamInfer::Resolve (pattern.get_subpattern ());
+    }
+
   HirId id = pattern.get_mappings ().get_hirid ();
   infered = new TyTy::InferType (id, TyTy::InferType::InferTypeKind::GENERAL,
 				 TyTy::InferType::TypeHint::Default (),

--- a/gcc/testsuite/rust/execute/torture/let-identifierpattern-subpattern.rs
+++ b/gcc/testsuite/rust/execute/torture/let-identifierpattern-subpattern.rs
@@ -1,0 +1,11 @@
+fn main() -> i32 {
+    let foo @ (bar, _, _) = (0, 2, 3);
+    let mut ret = 1;
+
+    match foo {
+        (0, 2, 3) => { ret = bar },
+        _ => {}
+    }
+
+    ret
+}


### PR DESCRIPTION
Implements `let` statement binding support for identifier patterns' subpatterns, together with closure param bindings as well (albeit untested because of #4071)
