### PR TITLE
Handle patterns in macro expansion

### DIFF
--- a/gcc/rust/ast/rust-ast-fragment.cc
+++ b/gcc/rust/ast/rust-ast-fragment.cc
@@ -116,6 +116,12 @@ Fragment::is_type_fragment () const
   return is_single_fragment_of_kind (SingleASTNode::Kind::Type);
 }
 
+bool
+Fragment::is_pattern_fragment () const
+{
+  return is_single_fragment_of_kind (SingleASTNode::Kind::Pattern);
+}
+
 std::unique_ptr<Expr>
 Fragment::take_expression_fragment ()
 {
@@ -128,6 +134,13 @@ Fragment::take_type_fragment ()
 {
   assert_single_fragment (SingleASTNode::Kind::Type);
   return nodes[0].take_type ();
+}
+
+std::unique_ptr<Pattern>
+Fragment::take_pattern_fragment ()
+{
+  assert_single_fragment (SingleASTNode::Kind::Pattern);
+  return nodes[0].take_pattern ();
 }
 
 void
@@ -159,6 +172,7 @@ Fragment::assert_single_fragment (SingleASTNode::Kind expected) const
     {SingleASTNode::Kind::Expr, "expr"},
     {SingleASTNode::Kind::Stmt, "stmt"},
     {SingleASTNode::Kind::Extern, "extern"},
+    {SingleASTNode::Kind::Pattern, "pattern"},
   };
 
   auto actual = nodes[0].get_kind ();

--- a/gcc/rust/ast/rust-ast-fragment.cc
+++ b/gcc/rust/ast/rust-ast-fragment.cc
@@ -107,26 +107,26 @@ Fragment::should_expand () const
 bool
 Fragment::is_expression_fragment () const
 {
-  return is_single_fragment_of_kind (SingleASTNode::NodeType::EXPRESSION);
+  return is_single_fragment_of_kind (SingleASTNode::Kind::Expr);
 }
 
 bool
 Fragment::is_type_fragment () const
 {
-  return is_single_fragment_of_kind (SingleASTNode::NodeType::TYPE);
+  return is_single_fragment_of_kind (SingleASTNode::Kind::Type);
 }
 
 std::unique_ptr<Expr>
 Fragment::take_expression_fragment ()
 {
-  assert_single_fragment (SingleASTNode::NodeType::EXPRESSION);
+  assert_single_fragment (SingleASTNode::Kind::Expr);
   return nodes[0].take_expr ();
 }
 
 std::unique_ptr<Type>
 Fragment::take_type_fragment ()
 {
-  assert_single_fragment (SingleASTNode::NodeType::TYPE);
+  assert_single_fragment (SingleASTNode::Kind::Type);
   return nodes[0].take_type ();
 }
 
@@ -144,21 +144,21 @@ Fragment::is_single_fragment () const
 }
 
 bool
-Fragment::is_single_fragment_of_kind (SingleASTNode::NodeType expected) const
+Fragment::is_single_fragment_of_kind (SingleASTNode::Kind expected) const
 {
   return is_single_fragment () && nodes[0].get_kind () == expected;
 }
 
 void
-Fragment::assert_single_fragment (SingleASTNode::NodeType expected) const
+Fragment::assert_single_fragment (SingleASTNode::Kind expected) const
 {
-  static const std::map<SingleASTNode::NodeType, const char *> str_map = {
-    {SingleASTNode::NodeType::ASSOC_ITEM, "associated item"},
-    {SingleASTNode::NodeType::ITEM, "item"},
-    {SingleASTNode::NodeType::TYPE, "type"},
-    {SingleASTNode::NodeType::EXPRESSION, "expr"},
-    {SingleASTNode::NodeType::STMT, "stmt"},
-    {SingleASTNode::NodeType::EXTERN, "extern"},
+  static const std::map<SingleASTNode::Kind, const char *> str_map = {
+    {SingleASTNode::Kind::Assoc, "associated item"},
+    {SingleASTNode::Kind::Item, "item"},
+    {SingleASTNode::Kind::Type, "type"},
+    {SingleASTNode::Kind::Expr, "expr"},
+    {SingleASTNode::Kind::Stmt, "stmt"},
+    {SingleASTNode::Kind::Extern, "extern"},
   };
 
   auto actual = nodes[0].get_kind ();

--- a/gcc/rust/ast/rust-ast-fragment.h
+++ b/gcc/rust/ast/rust-ast-fragment.h
@@ -86,9 +86,11 @@ public:
 
   bool is_expression_fragment () const;
   bool is_type_fragment () const;
+  bool is_pattern_fragment () const;
 
   std::unique_ptr<Expr> take_expression_fragment ();
   std::unique_ptr<Type> take_type_fragment ();
+  std::unique_ptr<Pattern> take_pattern_fragment ();
 
   void accept_vis (ASTVisitor &vis);
 

--- a/gcc/rust/ast/rust-ast-fragment.h
+++ b/gcc/rust/ast/rust-ast-fragment.h
@@ -119,8 +119,8 @@ private:
    * one Node will be extracted from the `nodes` vector
    */
   bool is_single_fragment () const;
-  bool is_single_fragment_of_kind (SingleASTNode::NodeType expected) const;
-  void assert_single_fragment (SingleASTNode::NodeType expected) const;
+  bool is_single_fragment_of_kind (SingleASTNode::Kind expected) const;
+  void assert_single_fragment (SingleASTNode::Kind expected) const;
 };
 
 enum class InvocKind

--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -48,27 +48,27 @@ SingleASTNode::SingleASTNode (SingleASTNode const &other)
   kind = other.kind;
   switch (kind)
     {
-    case EXPRESSION:
+    case Kind::Expr:
       expr = other.expr->clone_expr ();
       break;
 
-    case ITEM:
+    case Kind::Item:
       item = other.item->clone_item ();
       break;
 
-    case STMT:
+    case Kind::Stmt:
       stmt = other.stmt->clone_stmt ();
       break;
 
-    case EXTERN:
+    case Kind::Extern:
       external_item = other.external_item->clone_external_item ();
       break;
 
-    case ASSOC_ITEM:
+    case Kind::Assoc:
       assoc_item = other.assoc_item->clone_associated_item ();
       break;
 
-    case TYPE:
+    case Kind::Type:
       type = other.type->clone_type ();
       break;
     }
@@ -80,27 +80,27 @@ SingleASTNode::operator= (SingleASTNode const &other)
   kind = other.kind;
   switch (kind)
     {
-    case EXPRESSION:
+    case Kind::Expr:
       expr = other.expr->clone_expr ();
       break;
 
-    case ITEM:
+    case Kind::Item:
       item = other.item->clone_item ();
       break;
 
-    case STMT:
+    case Kind::Stmt:
       stmt = other.stmt->clone_stmt ();
       break;
 
-    case EXTERN:
+    case Kind::Extern:
       external_item = other.external_item->clone_external_item ();
       break;
 
-    case ASSOC_ITEM:
+    case Kind::Assoc:
       assoc_item = other.assoc_item->clone_associated_item ();
       break;
 
-    case TYPE:
+    case Kind::Type:
       type = other.type->clone_type ();
       break;
     }
@@ -112,27 +112,27 @@ SingleASTNode::accept_vis (ASTVisitor &vis)
 {
   switch (kind)
     {
-    case EXPRESSION:
+    case Kind::Expr:
       expr->accept_vis (vis);
       break;
 
-    case ITEM:
+    case Kind::Item:
       item->accept_vis (vis);
       break;
 
-    case STMT:
+    case Kind::Stmt:
       stmt->accept_vis (vis);
       break;
 
-    case EXTERN:
+    case Kind::Extern:
       external_item->accept_vis (vis);
       break;
 
-    case ASSOC_ITEM:
+    case Kind::Assoc:
       assoc_item->accept_vis (vis);
       break;
 
-    case TYPE:
+    case Kind::Type:
       type->accept_vis (vis);
       break;
     }
@@ -143,17 +143,17 @@ SingleASTNode::is_error ()
 {
   switch (kind)
     {
-    case EXPRESSION:
+    case Kind::Expr:
       return expr == nullptr;
-    case ITEM:
+    case Kind::Item:
       return item == nullptr;
-    case STMT:
+    case Kind::Stmt:
       return stmt == nullptr;
-    case EXTERN:
+    case Kind::Extern:
       return external_item == nullptr;
-    case ASSOC_ITEM:
+    case Kind::Assoc:
       return assoc_item == nullptr;
-    case TYPE:
+    case Kind::Type:
       return type == nullptr;
     }
 
@@ -166,17 +166,17 @@ SingleASTNode::as_string () const
 {
   switch (kind)
     {
-    case EXPRESSION:
+    case Kind::Expr:
       return "Expr: " + expr->as_string ();
-    case ITEM:
+    case Kind::Item:
       return "Item: " + item->as_string ();
-    case STMT:
+    case Kind::Stmt:
       return "Stmt: " + stmt->as_string ();
-    case EXTERN:
+    case Kind::Extern:
       return "External Item: " + external_item->as_string ();
-    case ASSOC_ITEM:
+    case Kind::Assoc:
       return "Associated Item: " + assoc_item->as_string ();
-    case TYPE:
+    case Kind::Type:
       return "Type: " + type->as_string ();
     }
 

--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -71,6 +71,10 @@ SingleASTNode::SingleASTNode (SingleASTNode const &other)
     case Kind::Type:
       type = other.type->clone_type ();
       break;
+
+    case Kind::Pattern:
+      pattern = other.pattern->clone_pattern ();
+      break;
     }
 }
 
@@ -102,6 +106,10 @@ SingleASTNode::operator= (SingleASTNode const &other)
 
     case Kind::Type:
       type = other.type->clone_type ();
+      break;
+
+    case Kind::Pattern:
+      pattern = other.pattern->clone_pattern ();
       break;
     }
   return *this;
@@ -135,6 +143,10 @@ SingleASTNode::accept_vis (ASTVisitor &vis)
     case Kind::Type:
       type->accept_vis (vis);
       break;
+
+    case Kind::Pattern:
+      pattern->accept_vis (vis);
+      break;
     }
 }
 
@@ -155,6 +167,8 @@ SingleASTNode::is_error ()
       return assoc_item == nullptr;
     case Kind::Type:
       return type == nullptr;
+    case Kind::Pattern:
+      return pattern == nullptr;
     }
 
   rust_unreachable ();
@@ -178,6 +192,8 @@ SingleASTNode::as_string () const
       return "Associated Item: " + assoc_item->as_string ();
     case Kind::Type:
       return "Type: " + type->as_string ();
+    case Kind::Pattern:
+      return "Pattern: " + pattern->as_string ();
     }
 
   rust_unreachable ();

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -1957,18 +1957,18 @@ public:
 class SingleASTNode : public Visitable
 {
 public:
-  enum NodeType
+  enum class Kind
   {
-    EXPRESSION,
-    ITEM,
-    STMT,
-    EXTERN,
-    ASSOC_ITEM,
-    TYPE,
+    Expr,
+    Item,
+    Stmt,
+    Extern,
+    Assoc,
+    Type,
   };
 
 private:
-  NodeType kind;
+  Kind kind;
 
   // FIXME make this a union
   std::unique_ptr<Expr> expr;
@@ -1980,27 +1980,27 @@ private:
 
 public:
   SingleASTNode (std::unique_ptr<Expr> expr)
-    : kind (EXPRESSION), expr (std::move (expr))
+    : kind (Kind::Expr), expr (std::move (expr))
   {}
 
   SingleASTNode (std::unique_ptr<Item> item)
-    : kind (ITEM), item (std::move (item))
+    : kind (Kind::Item), item (std::move (item))
   {}
 
   SingleASTNode (std::unique_ptr<Stmt> stmt)
-    : kind (STMT), stmt (std::move (stmt))
+    : kind (Kind::Stmt), stmt (std::move (stmt))
   {}
 
   SingleASTNode (std::unique_ptr<ExternalItem> item)
-    : kind (EXTERN), external_item (std::move (item))
+    : kind (Kind::Extern), external_item (std::move (item))
   {}
 
   SingleASTNode (std::unique_ptr<AssociatedItem> item)
-    : kind (ASSOC_ITEM), assoc_item (std::move (item))
+    : kind (Kind::Assoc), assoc_item (std::move (item))
   {}
 
   SingleASTNode (std::unique_ptr<Type> type)
-    : kind (TYPE), type (std::move (type))
+    : kind (Kind::Type), type (std::move (type))
   {}
 
   SingleASTNode (SingleASTNode const &other);
@@ -2010,23 +2010,23 @@ public:
   SingleASTNode (SingleASTNode &&other) = default;
   SingleASTNode &operator= (SingleASTNode &&other) = default;
 
-  NodeType get_kind () const { return kind; }
+  Kind get_kind () const { return kind; }
 
   std::unique_ptr<Expr> &get_expr ()
   {
-    rust_assert (kind == EXPRESSION);
+    rust_assert (kind == Kind::Expr);
     return expr;
   }
 
   std::unique_ptr<Item> &get_item ()
   {
-    rust_assert (kind == ITEM);
+    rust_assert (kind == Kind::Item);
     return item;
   }
 
   std::unique_ptr<Stmt> &get_stmt ()
   {
-    rust_assert (kind == STMT);
+    rust_assert (kind == Kind::Stmt);
     return stmt;
   }
 

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -1965,6 +1965,7 @@ public:
     Extern,
     Assoc,
     Type,
+    Pattern,
   };
 
 private:
@@ -1977,6 +1978,7 @@ private:
   std::unique_ptr<ExternalItem> external_item;
   std::unique_ptr<AssociatedItem> assoc_item;
   std::unique_ptr<Type> type;
+  std::unique_ptr<Pattern> pattern;
 
 public:
   SingleASTNode (std::unique_ptr<Expr> expr)
@@ -2001,6 +2003,10 @@ public:
 
   SingleASTNode (std::unique_ptr<Type> type)
     : kind (Kind::Type), type (std::move (type))
+  {}
+
+  SingleASTNode (std::unique_ptr<Pattern> pattern)
+    : kind (Kind::Pattern), pattern (std::move (pattern))
   {}
 
   SingleASTNode (SingleASTNode const &other);
@@ -2069,6 +2075,12 @@ public:
   {
     rust_assert (!is_error ());
     return std::move (type);
+  }
+
+  std::unique_ptr<Pattern> take_pattern ()
+  {
+    rust_assert (!is_error ());
+    return std::move (pattern);
   }
 
   void accept_vis (ASTVisitor &vis) override;

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -2480,6 +2480,12 @@ public:
     return *pattern;
   }
 
+  std::unique_ptr<Pattern> &get_pattern_ptr ()
+  {
+    rust_assert (pattern != nullptr);
+    return pattern;
+  }
+
   Type &get_type ()
   {
     rust_assert (has_type_given ());

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -631,6 +631,12 @@ public:
     return *param_name;
   }
 
+  std::unique_ptr<Pattern> &get_pattern_ptr ()
+  {
+    rust_assert (param_name != nullptr);
+    return param_name;
+  }
+
   const Pattern &get_pattern () const
   {
     rust_assert (param_name != nullptr);
@@ -712,6 +718,12 @@ public:
   {
     rust_assert (param_name != nullptr);
     return *param_name;
+  }
+
+  std::unique_ptr<Pattern> &get_pattern_ptr ()
+  {
+    rust_assert (param_name != nullptr);
+    return param_name;
   }
 
   bool has_name () const { return param_name != nullptr; }

--- a/gcc/rust/ast/rust-pattern.h
+++ b/gcc/rust/ast/rust-pattern.h
@@ -1509,6 +1509,12 @@ public:
     return *pattern_in_parens;
   }
 
+  std::unique_ptr<Pattern> &get_pattern_in_parens_ptr ()
+  {
+    rust_assert (pattern_in_parens != nullptr);
+    return pattern_in_parens;
+  }
+
   NodeId get_node_id () const override { return node_id; }
 
   Pattern::Kind get_pattern_kind () override { return Pattern::Kind::Grouped; }

--- a/gcc/rust/ast/rust-stmt.h
+++ b/gcc/rust/ast/rust-stmt.h
@@ -201,6 +201,12 @@ public:
     return *variables_pattern;
   }
 
+  std::unique_ptr<Pattern> &get_pattern_ptr ()
+  {
+    rust_assert (variables_pattern != nullptr);
+    return variables_pattern;
+  }
+
   Type &get_type ()
   {
     rust_assert (has_type ());

--- a/gcc/rust/expand/rust-expand-visitor.h
+++ b/gcc/rust/expand/rust-expand-visitor.h
@@ -20,6 +20,7 @@
 #define RUST_EXPAND_VISITOR_H
 
 #include "rust-ast-visitor.h"
+#include "rust-item.h"
 #include "rust-macro-expand.h"
 #include "rust-proc-macro.h"
 
@@ -45,17 +46,14 @@ public:
 
   using AST::DefaultASTVisitor::visit;
 
-  /*
-     Maybe expand a macro invocation in lieu of an expression
-     expr : Core guidelines R33, this function reseat the pointer.
-  */
-  void maybe_expand_expr (std::unique_ptr<AST::Expr> &expr);
-
-  /*
-     Maybe expand a macro invocation in lieu of a type
-     type : Core guidelines R33, this function reseat the pointer.
+  /**
+   * Maybe expand a macro invocation in lieu of an expression, type or pattern.
+   *
+   * @ptr Core guidelines R33, this function reseats the pointer.
    */
-  void maybe_expand_type (std::unique_ptr<AST::Type> &type);
+  void maybe_expand_expr (std::unique_ptr<AST::Expr> &ptr);
+  void maybe_expand_type (std::unique_ptr<AST::Type> &ptr);
+  void maybe_expand_pattern (std::unique_ptr<AST::Pattern> &ptr);
 
   /**
    * Expand all macro invocations in lieu of types within a vector of struct
@@ -232,6 +230,7 @@ public:
   void visit (AST::IfLetExpr &expr) override;
   void visit (AST::IfLetExprConseqElse &expr) override;
   void visit (AST::MatchExpr &expr) override;
+  void visit (AST::TupleExpr &expr) override;
   void visit (AST::TypeParam &param) override;
   void visit (AST::LifetimeWhereClauseItem &) override;
   void visit (AST::TypeBoundWhereClauseItem &item) override;
@@ -269,12 +268,20 @@ public:
   void visit (AST::MetaListNameValueStr &) override;
   void visit (AST::StructPatternFieldIdent &field) override;
   void visit (AST::GroupedPattern &pattern) override;
+  void visit (AST::SlicePatternItemsNoRest &items) override;
+  void visit (AST::SlicePatternItemsHasRest &items) override;
+  void visit (AST::AltPattern &pattern) override;
+  void visit (AST::TupleStructItemsNoRange &tuple_items) override;
+  void visit (AST::TupleStructItemsRange &tuple_items) override;
+  void visit (AST::TuplePatternItemsMultiple &tuple_items) override;
+  void visit (AST::TuplePatternItemsRanged &tuple_items) override;
 
   void visit (AST::LetStmt &stmt) override;
   void visit (AST::ExprStmt &stmt) override;
 
   void visit (AST::BareFunctionType &type) override;
-  void visit (AST::FunctionParam &type) override;
+  void visit (AST::FunctionParam &param) override;
+  void visit (AST::VariadicParam &param) override;
   void visit (AST::SelfParam &type) override;
 
   template <typename T>

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -291,6 +291,7 @@ struct MacroExpander
     TRAIT,
     IMPL,
     TRAIT_IMPL,
+    PATTERN,
   };
 
   ExpansionCfg cfg;

--- a/gcc/testsuite/rust/compile/issue-3726.rs
+++ b/gcc/testsuite/rust/compile/issue-3726.rs
@@ -1,0 +1,17 @@
+pub enum TypeCtor {
+    Slice,
+    Array,
+}
+pub struct ApplicationTy(TypeCtor);
+
+macro_rules! ty_app {
+    ($ctor:pat) => {
+        ApplicationTy($ctor)
+    };
+}
+
+pub fn foo(ty: ApplicationTy) {
+    match ty {
+        ty_app!(TypeCtor::Array) => {}
+    }
+}

--- a/gcc/testsuite/rust/compile/issue-3898.rs
+++ b/gcc/testsuite/rust/compile/issue-3898.rs
@@ -1,0 +1,112 @@
+// { dg-additional-options "-frust-compile-until=lowering" }
+
+#[lang = "sized"]
+trait Sized {}
+
+enum Result<T, E> {
+    Ok(T),
+    Err(E),
+}
+
+use Result::{Err, Ok};
+
+struct Utf8Error;
+
+const CONT_MASK: u8 = 15;
+const TAG_CONT_U8: u8 = 15;
+
+#[inline(always)]
+pub fn run_utf8_validation(v: &[u8]) -> Result<(), Utf8Error> {
+    let mut index = 0;
+    let len = 64;
+
+    let usize_bytes = 8;
+    let ascii_block_size = 2 * usize_bytes;
+    let blocks_end = if len >= ascii_block_size {
+        len - ascii_block_size + 1
+    } else {
+        0
+    };
+
+    while index < len {
+        let old_offset = index;
+        macro_rules! err {
+            ($error_len: expr) => {
+                return Err(Utf8Error)
+            };
+        }
+
+        macro_rules! next {
+            () => {{
+                index += 1;
+                // we needed data, but there was none: error!
+                if index >= len {
+                    err!(None)
+                }
+                v[index]
+            }};
+        }
+
+        let first = v[index];
+        if first >= 128 {
+            let w = 15;
+            // 2-byte encoding is for codepoints  \u{0080} to  \u{07ff}
+            //        first  C2 80        last DF BF
+            // 3-byte encoding is for codepoints  \u{0800} to  \u{ffff}
+            //        first  E0 A0 80     last EF BF BF
+            //   excluding surrogates codepoints  \u{d800} to  \u{dfff}
+            //               ED A0 80 to       ED BF BF
+            // 4-byte encoding is for codepoints \u{1000}0 to \u{10ff}ff
+            //        first  F0 90 80 80  last F4 8F BF BF
+            //
+            // Use the UTF-8 syntax from the RFC
+            //
+            // https://tools.ietf.org/html/rfc3629
+            // UTF8-1      = %x00-7F
+            // UTF8-2      = %xC2-DF UTF8-tail
+            // UTF8-3      = %xE0 %xA0-BF UTF8-tail / %xE1-EC 2( UTF8-tail ) /
+            //               %xED %x80-9F UTF8-tail / %xEE-EF 2( UTF8-tail )
+            // UTF8-4      = %xF0 %x90-BF 2( UTF8-tail ) / %xF1-F3 3( UTF8-tail ) /
+            //               %xF4 %x80-8F 2( UTF8-tail )
+            match w {
+                2 => {
+                    if next!() & !CONT_MASK != TAG_CONT_U8 {
+                        err!(Some(1))
+                    }
+                }
+                3 => {
+                    match (first, next!()) {
+                        (0xE0, 0xA0..=0xBF)
+                        | (0xE1..=0xEC, 0x80..=0xBF)
+                        | (0xED, 0x80..=0x9F)
+                        | (0xEE..=0xEF, 0x80..=0xBF) => {}
+                        _ => err!(Some(1)),
+                    }
+                    if next!() & !CONT_MASK != TAG_CONT_U8 {
+                        err!(Some(2))
+                    }
+                }
+                4 => {
+                    match (first, next!()) {
+                        (0xF0, 0x90..=0xBF) | (0xF1..=0xF3, 0x80..=0xBF) | (0xF4, 0x80..=0x8F) => {}
+                        _ => err!(Some(1)),
+                    }
+                    if next!() & !CONT_MASK != TAG_CONT_U8 {
+                        err!(Some(2))
+                    }
+                    if next!() & !CONT_MASK != TAG_CONT_U8 {
+                        err!(Some(3))
+                    }
+                }
+                _ => err!(Some(1)),
+            }
+            index += 1;
+        } else {
+            index += 1;
+        }
+    }
+
+    Ok(())
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #3898
Fixes #3726

- **ast: Cleanup SingleASTNode::NodeType**
- **expand: Add handling for macro expansion in pattern context**

This should be reworked with a proper `ExternalVisitor` or `ReseatVisitor` or something.
