### PR TITLE
gccrs: fix ICE by skipping invalid (non-FNDEF) candidates

### DIFF
--- a/gcc/testsuite/rust/compile/issue-3958.rs
+++ b/gcc/testsuite/rust/compile/issue-3958.rs
@@ -1,0 +1,11 @@
+// { dg-options "-fsyntax-only" }
+trait A {
+    fn a(&self) -> <Self as A>::X;
+}
+
+impl A for u32 {}
+
+fn main() {
+    let a: u32 = 0;
+    let b: u32 = a.a();
+}


### PR DESCRIPTION
Fixes #3958 
gcc/rust/ChangeLog:

	* typecheck/rust-hir-dot-operator.cc (MethodResolver::Select): 
	(MethodResolver::try_select_predicate_candidates): 
	Skip invalid candidates and skip asserts with early-continue.

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3958.rs: New test.
