### PR TITLE
nr1.0: Remove support in expansion phase

### DIFF
--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -27,9 +27,11 @@
 #include "rust-macro.h"
 #include "rust-parse.h"
 #include "rust-cfg-strip.h"
-#include "rust-early-name-resolver.h"
 #include "rust-proc-macro.h"
 #include "rust-token-tree-desugar.h"
+
+// flag_assume_builtin_offset_of
+#include "options.h"
 
 namespace Rust {
 
@@ -335,9 +337,6 @@ MacroExpander::expand_invoc (AST::MacroInvocation &invoc,
 void
 MacroExpander::expand_crate ()
 {
-  NodeId scope_node_id = crate.get_node_id ();
-  resolver->get_macro_scope ().push (scope_node_id);
-
   /* fill macro/decorator map from init list? not sure where init list comes
    * from? */
 

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -27,8 +27,6 @@
 #include "rust-ast.h"
 #include "rust-macro.h"
 #include "rust-hir-map.h"
-#include "rust-early-name-resolver.h"
-#include "rust-name-resolver.h"
 #include "rust-macro-invoc-lexer.h"
 #include "rust-proc-macro-invoc-lexer.h"
 #include "rust-token-converter.h"
@@ -301,8 +299,7 @@ struct MacroExpander
     : cfg (cfg), crate (crate), session (session),
       sub_stack (SubstitutionScope ()),
       expanded_fragment (AST::Fragment::create_error ()),
-      has_changed_flag (false), resolver (Resolver::Resolver::get ()),
-      mappings (Analysis::Mappings::get ())
+      has_changed_flag (false), mappings (Analysis::Mappings::get ())
   {}
 
   ~MacroExpander () = default;
@@ -514,7 +511,6 @@ private:
   tl::optional<AST::MacroInvocation &> last_invoc;
 
 public:
-  Resolver::Resolver *resolver;
   Analysis::Mappings &mappings;
 };
 


### PR DESCRIPTION
Removing this usage of the `nr1.0` resolver, without replacing it with a usage of the `nr2.0` resolver, seems alright, although I'm not 100% sure about it.