### PR TITLE
nr2.0: Add extra check when resolving identifier patterns

### DIFF
--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
@@ -206,6 +206,17 @@ Late::visit (AST::IdentifierPattern &identifier)
 {
   DefaultResolver::visit (identifier);
 
+  // We need to check if the Identifier resolves to a variant or empty struct
+  auto path = AST::SimplePath (identifier.get_ident ());
+
+  if (auto resolved = ctx.resolve_path (path, Namespace::Types))
+    {
+      ctx.map_usage (Usage (identifier.get_node_id ()),
+		     Definition (resolved->definition.get_node_id ()),
+		     resolved->ns);
+      return;
+    }
+
   visit_identifier_as_pattern (ctx, identifier.get_ident (),
 			       identifier.get_locus (),
 			       identifier.get_node_id (),

--- a/gcc/testsuite/rust/compile/issue-4116.rs
+++ b/gcc/testsuite/rust/compile/issue-4116.rs
@@ -1,0 +1,16 @@
+enum Foo {
+    Relaxed,
+    SeqCst,
+    StressedOut,
+}
+
+use Foo::{Relaxed, SeqCst, StressedOut};
+
+fn main() {
+    let a = (Relaxed, Relaxed);
+
+    match a {
+        (Relaxed, Relaxed) => {}
+        _ => {}
+    }
+}


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* resolve/rust-late-name-resolver-2.0.cc (Late::visit): Check if an identifier pattern
	can be resolved in the types namespace before visiting it as an identifier proper.

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4116.rs: New test.

Fixes #4116
