### PR TITLE
gccrs: Fix segv when handling invalid array capacities

### DIFF
--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -322,7 +322,13 @@ public:
 
   void push_loop_context (Bvariable *var) { loop_value_stack.push_back (var); }
 
-  Bvariable *peek_loop_context () { return loop_value_stack.back (); }
+  bool have_loop_context () const { return !loop_value_stack.empty (); }
+
+  Bvariable *peek_loop_context ()
+  {
+    rust_assert (!loop_value_stack.empty ());
+    return loop_value_stack.back ();
+  }
 
   Bvariable *pop_loop_context ()
   {
@@ -336,7 +342,11 @@ public:
     loop_begin_labels.push_back (label);
   }
 
-  tree peek_loop_begin_label () { return loop_begin_labels.back (); }
+  tree peek_loop_begin_label ()
+  {
+    rust_assert (!loop_begin_labels.empty ());
+    return loop_begin_labels.back ();
+  }
 
   tree pop_loop_begin_label ()
   {

--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -891,6 +891,10 @@ CompileExpr::visit (HIR::BreakExpr &expr)
 void
 CompileExpr::visit (HIR::ContinueExpr &expr)
 {
+  translated = error_mark_node;
+  if (!ctx->have_loop_context ())
+    return;
+
   tree label = ctx->peek_loop_begin_label ();
   if (expr.has_label ())
     {
@@ -2000,13 +2004,11 @@ CompileExpr::array_copied_expr (location_t expr_locus,
       return error_mark_node;
     }
 
-  ctx->push_const_context ();
-  tree capacity_expr = CompileExpr::Compile (elems.get_num_copies_expr (), ctx);
-  ctx->pop_const_context ();
-
+  auto capacity_tyty = array_tyty.get_capacity ();
+  tree capacity_expr = capacity_tyty->get_value ();
   if (!TREE_CONSTANT (capacity_expr))
     {
-      rust_error_at (expr_locus, "non const num copies %qT", array_type);
+      rust_error_at (expr_locus, "non const num copies %qT", capacity_expr);
       return error_mark_node;
     }
 

--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -828,6 +828,10 @@ CompileExpr::visit (HIR::BreakExpr &expr)
     {
       tree compiled_expr = CompileExpr::Compile (expr.get_expr (), ctx);
 
+      translated = error_mark_node;
+      if (!ctx->have_loop_context ())
+	return;
+
       Bvariable *loop_result_holder = ctx->peek_loop_context ();
       tree result_reference
 	= Backend::var_expression (loop_result_holder,

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -1090,6 +1090,8 @@ TypeCheckExpr::visit (HIR::ArrayExpr &expr)
 
 	auto capacity_expr_ty
 	  = TypeCheckExpr::Resolve (elems.get_num_copies_expr ());
+	if (capacity_expr_ty->is<TyTy::ErrorType> ())
+	  return;
 
 	context->insert_type (elems.get_num_copies_expr ().get_mappings (),
 			      expected_ty);

--- a/gcc/testsuite/rust/compile/issue-3965-1.rs
+++ b/gcc/testsuite/rust/compile/issue-3965-1.rs
@@ -1,0 +1,4 @@
+fn main() {
+    [(); { continue }];
+    // { dg-error ".continue. outside of a loop .E0268." "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/compile/issue-3965-2.rs
+++ b/gcc/testsuite/rust/compile/issue-3965-2.rs
@@ -1,0 +1,7 @@
+fn main() {
+    loop { continue }
+
+    [(); {while true {break}; 0}];
+
+    [(); {while true {break}; 0}];
+}

--- a/gcc/testsuite/rust/compile/issue-3969.rs
+++ b/gcc/testsuite/rust/compile/issue-3969.rs
@@ -1,0 +1,30 @@
+#[lang = "sized"]
+pub trait Sized {
+    // Empty.
+}
+
+#[lang = "fn_once"]
+pub trait FnOnce<Args> {
+    #[lang = "fn_once_output"]
+    type Output;
+
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+}
+
+fn main() {
+    [(); {
+        while true {
+            // { dg-error ".constexpr. loop iteration count exceeds limit" "" { target *-*-* } .-1 }
+            break 9;
+            // { dg-error "can only .break. with a value inside a .loop. block .E0571." "" { target *-*-* } .-1 }
+        }
+        51
+    }];
+
+    while true {
+        break (|| {
+            // { dg-error "can only .break. with a value inside a .loop. block .E0571." "" { target *-*-* } .-1 }
+            let while_true = 9;
+        });
+    }
+}


### PR DESCRIPTION
We need to catch the error node for the array capacity and return early. Otherwise we try to const evaluate something thats just silly. Also when compiling array expressions we can simply reuse the array capacity expression we already have cons folded.

Fixes Rust-GCC#3965
Fixes Rust-GCC#3969

gcc/rust/ChangeLog:

	* backend/rust-compile-context.h: add assertions for context peeks
	* backend/rust-compile-expr.cc (CompileExpr::visit): check for valid loop context
	(CompileExpr::array_copied_expr): just reuse array tyty capacity value
	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::visit): catch error

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3965-1.rs: New test.
	* rust/compile/issue-3965-2.rs: New test.
