### PR TITLE
gccrs: Remove the template parameter so clang format stops barfing this

### DIFF
--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -1661,8 +1661,7 @@ VariantDef::clone () const
     cloned_fields.push_back ((StructFieldType *) f->clone ());
 
   auto &&discriminant_opt = has_discriminant ()
-			      ? tl::optional<std::unique_ptr<HIR::Expr>> (
-				get_discriminant ().clone_expr ())
+			      ? tl::optional (get_discriminant ().clone_expr ())
 			      : tl::nullopt;
 
   return new VariantDef (id, defid, identifier, ident, type,
@@ -1677,8 +1676,7 @@ VariantDef::monomorphized_clone () const
     cloned_fields.push_back ((StructFieldType *) f->monomorphized_clone ());
 
   auto discriminant_opt = has_discriminant ()
-			    ? tl::optional<std::unique_ptr<HIR::Expr>> (
-			      get_discriminant ().clone_expr ())
+			    ? tl::optional (get_discriminant ().clone_expr ())
 			    : tl::nullopt;
 
   return new VariantDef (id, defid, identifier, ident, type,


### PR DESCRIPTION
Change this formatting, so clang format stops formatting this wierd for me.

gcc/rust/ChangeLog:

	* typecheck/rust-tyty.cc (VariantDef::clone): remove template param
	(VariantDef::monomorphized_clone): likewise