### PR TITLE
gccrs: Revert "gccrs: Remove the template parameter

### DIFF
--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -1661,7 +1661,8 @@ VariantDef::clone () const
     cloned_fields.push_back ((StructFieldType *) f->clone ());
 
   auto &&discriminant_opt = has_discriminant ()
-			      ? tl::optional (get_discriminant ().clone_expr ())
+			      ? tl::optional<std::unique_ptr<HIR::Expr>> (
+				get_discriminant ().clone_expr ())
 			      : tl::nullopt;
 
   return new VariantDef (id, defid, identifier, ident, type,
@@ -1676,7 +1677,8 @@ VariantDef::monomorphized_clone () const
     cloned_fields.push_back ((StructFieldType *) f->monomorphized_clone ());
 
   auto discriminant_opt = has_discriminant ()
-			    ? tl::optional (get_discriminant ().clone_expr ())
+			    ? tl::optional<std::unique_ptr<HIR::Expr>> (
+			      get_discriminant ().clone_expr ())
 			    : tl::nullopt;
 
   return new VariantDef (id, defid, identifier, ident, type,


### PR DESCRIPTION
This reverts commit a50fb38f36506e02139f3ff9343e099c2f5508d7 as it breaks gcc5 bootstrap.

gcc/rust/ChangeLog:

	* typecheck/rust-tyty.cc (VariantDef::clone): revert
	(VariantDef::monomorphized_clone): likewise

