### PR TITLE
gccrs: Revert "nr1.0: Remove support in expansion phase"

### DIFF
--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -27,11 +27,9 @@
 #include "rust-macro.h"
 #include "rust-parse.h"
 #include "rust-cfg-strip.h"
+#include "rust-early-name-resolver.h"
 #include "rust-proc-macro.h"
 #include "rust-token-tree-desugar.h"
-
-// flag_assume_builtin_offset_of
-#include "options.h"
 
 namespace Rust {
 
@@ -337,6 +335,9 @@ MacroExpander::expand_invoc (AST::MacroInvocation &invoc,
 void
 MacroExpander::expand_crate ()
 {
+  NodeId scope_node_id = crate.get_node_id ();
+  resolver->get_macro_scope ().push (scope_node_id);
+
   /* fill macro/decorator map from init list? not sure where init list comes
    * from? */
 

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -27,6 +27,8 @@
 #include "rust-ast.h"
 #include "rust-macro.h"
 #include "rust-hir-map.h"
+#include "rust-early-name-resolver.h"
+#include "rust-name-resolver.h"
 #include "rust-macro-invoc-lexer.h"
 #include "rust-proc-macro-invoc-lexer.h"
 #include "rust-token-converter.h"
@@ -299,7 +301,8 @@ struct MacroExpander
     : cfg (cfg), crate (crate), session (session),
       sub_stack (SubstitutionScope ()),
       expanded_fragment (AST::Fragment::create_error ()),
-      has_changed_flag (false), mappings (Analysis::Mappings::get ())
+      has_changed_flag (false), resolver (Resolver::Resolver::get ()),
+      mappings (Analysis::Mappings::get ())
   {}
 
   ~MacroExpander () = default;
@@ -511,6 +514,7 @@ private:
   tl::optional<AST::MacroInvocation &> last_invoc;
 
 public:
+  Resolver::Resolver *resolver;
   Analysis::Mappings &mappings;
 };
 


### PR DESCRIPTION
This reverts commit 3e527693cfae6b41c841d6f09a601d2e6d1b2964.

gcc/rust/ChangeLog:

	* expand/rust-macro-expand.cc (MacroExpander::expand_crate): revert
	* expand/rust-macro-expand.h (struct MacroExpander): likewise

