### PR TITLE
gccrs: Fix ICE with invalid const expression

### DIFF
--- a/gcc/testsuite/rust/compile/issue-4139.rs
+++ b/gcc/testsuite/rust/compile/issue-4139.rs
@@ -1,0 +1,7 @@
+// { dg-skip-if "" { *-*-* } { "-m32" } { "" } }
+const X: i32 = const {
+    let a = 0x736f6d6570736575;
+    // { dg-error "integer overflows the respective type" "" { target *-*-* } .-1 }
+    let b = 14;
+    a + b
+};


### PR DESCRIPTION
This patch handles the overflowed var expression in the const block, so that we error properly in the const expr code. It was missing some stuff from the c++ implementation in how this should be handled properly.

Fixes Rust-GCC#4139

gcc/rust/ChangeLog:

	* backend/rust-constexpr.cc (struct constexpr_global_ctx): port over c++ helpers
	(decl_really_constant_value): likewise
	(eval_constant_expression): likewise
	(non_const_var_error): likewise

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4139.rs: New test.
