### PR TITLE
gccrs: Fix ICE handling division by zero in const eval

### DIFF
--- a/gcc/testsuite/rust/compile/issue-2394.rs
+++ b/gcc/testsuite/rust/compile/issue-2394.rs
@@ -1,5 +1,6 @@
 const A: i32 = (1 / 0);
 // { dg-error "division by zero" "" { target *-*-* } .-1 }
+// { dg-error "is not a constant expression" "" { target *-*-* } .-2 }
 
 fn main() {
     let a = 1 / 0;

--- a/gcc/testsuite/rust/compile/issue-4146.rs
+++ b/gcc/testsuite/rust/compile/issue-4146.rs
@@ -1,0 +1,3 @@
+const _NISIZE_DIV_P: &isize = &(1isize / 0);
+// { dg-error "division by zero" "" { target *-*-* } .-1 }
+// { dg-error "is not a constant expression" "" { target *-*-* } .-2 }


### PR DESCRIPTION
This pulls over more constexpr support from C++ front-end.

Fixes Rust-GCC#4146

gcc/rust/ChangeLog:

	* backend/rust-constexpr.cc (eval_constant_expression): port over missing bits
	(eval_store_expression): likewise
	(eval_call_expression): likewise
	(eval_binary_expression): likewise
	(eval_bit_field_ref): likewise
	(eval_check_shift_p): likewise
	(fold_pointer_plus_expression): likewise
	(maybe_fold_addr_pointer_plus): likewise
	(fold_expr): likewise
	(union_active_member): likewise
	(fold_indirect_ref_1): likewise
	(rs_fold_indirect_ref): likewise
	(rs_eval_indirect_ref): likewise
	(eval_logical_expression): likewise
	(eval_vector_conditional_expression): likewise
	(eval_bare_aggregate): likewise
	(cxx_eval_trinary_expression): likewise
	(eval_and_check_array_index): likewise
	(eval_array_reference): likewise
	(eval_component_reference): likewise
	(rs_bind_parameters_in_call): likewise
	(eval_builtin_function_call): likewise
	(constexpr_fn_retval): likewise
	(verify_constant): likewise
	(get_array_or_vector_nelts): likewise
	(eval_conditional_expression): likewise
	(eval_switch_expr): likewise
	(eval_unary_expression): likewise
	(cxx_eval_outermost_constant_expr): likewise
	(potential_constant_expression_1): likewise

gcc/testsuite/ChangeLog:

	* rust/compile/issue-2394.rs: Update test case
	* rust/compile/issue-4146.rs: New test.
