### PR TITLE
gccrs: Fix ICE for invalid const capacity expression handling

### DIFF
--- a/gcc/testsuite/rust/compile/issue-4168.rs
+++ b/gcc/testsuite/rust/compile/issue-4168.rs
@@ -1,0 +1,7 @@
+const fn add(x: usize, y: usize) -> i32 {
+    add + y
+    // { dg-error "cannot apply operator .+. to types fn .x usize,y usize,. -> i32 and usize" "" { target *-*-* } .-1 }
+}
+const ARR: [i32; add(1, 2)] = [5, 6, 1];
+// { dg-error "mismatched types, expected .usize. but got .i32. .E0308." "" { target *-*-* } .-1 }
+// { dg-error "mismatched types" "" { target *-*-* } .-2 }


### PR DESCRIPTION
When we have an invalid capacity expression we can't try to then also const fold it as GCC will assert on invalid conversions.

Fixes Rust-GCC#4168

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-type.cc (TypeCheckType::visit): check for invalid capacity

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4168.rs: New test.
