### PR TITLE
gccrs: fnptr types can hold onto generic params so it needs to handle substs

### DIFF
--- a/gcc/rust/typecheck/rust-substitution-mapper.cc
+++ b/gcc/rust/typecheck/rust-substitution-mapper.cc
@@ -310,15 +310,15 @@ SubstMapperInternal::visit (TyTy::SliceType &type)
 {
   resolved = type.handle_substitions (mappings);
 }
+void
+SubstMapperInternal::visit (TyTy::FnPtr &type)
+{
+  resolved = type.handle_substitions (mappings);
+}
 
 // nothing to do for these
 void
 SubstMapperInternal::visit (TyTy::InferType &type)
-{
-  resolved = type.clone ();
-}
-void
-SubstMapperInternal::visit (TyTy::FnPtr &type)
 {
   resolved = type.clone ();
 }

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -1101,6 +1101,8 @@ public:
 
   Unsafety get_unsafety () const { return unsafety; }
 
+  FnPtr *handle_substitions (SubstitutionArgumentMappings &mappings);
+
 private:
   std::vector<TyVar> params;
   TyVar result_type;

--- a/gcc/testsuite/rust/compile/issue-4090-1.rs
+++ b/gcc/testsuite/rust/compile/issue-4090-1.rs
@@ -1,0 +1,68 @@
+mod core {
+    mod marker {
+        #[lang = "sized"]
+        pub trait Sized {}
+
+        #[lang = "phantom_data"]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        pub struct PhantomData<T: ?Sized>;
+
+        #[unstable(feature = "structural_match", issue = "31434")]
+        #[lang = "structural_teq"]
+        pub trait StructuralEq {
+            // Empty.
+        }
+
+        #[unstable(feature = "structural_match", issue = "31434")]
+        #[lang = "structural_peq"]
+        pub trait StructuralPartialEq {
+            // Empty.
+        }
+    }
+
+    pub mod cmp {
+        use super::marker::Sized;
+
+        #[lang = "eq"]
+        pub trait PartialEq<Rhs: ?Sized = Self> {
+            fn eq(&self, other: &Rhs) -> bool;
+
+            fn ne(&self, other: &Rhs) -> bool {
+                !self.eq(other)
+            }
+        }
+
+        pub trait Eq: PartialEq<Self> {
+            fn assert_receiver_is_total_eq(&self) {}
+        }
+    }
+
+    pub mod ptr {
+
+        use super::cmp::{Eq, PartialEq};
+
+        macro_rules! fnptr_impls_safety_abi {
+            ($FnTy: ty, $($Arg: ident),*) => {
+                #[stable(feature = "fnptr_impls", since = "1.4.0")]
+                impl<Ret, $($Arg),*> PartialEq for $FnTy {
+                    #[inline]
+                    fn eq(&self, other: &Self) -> bool {
+                        *self as usize == *other as usize
+                    }
+                }
+
+                #[stable(feature = "fnptr_impls", since = "1.4.0")]
+                impl<Ret, $($Arg),*> Eq for $FnTy {}
+
+            }
+        }
+
+        fnptr_impls_safety_abi! { extern "Rust" fn() -> Ret, }
+    }
+}
+
+#[derive(PartialEq, Eq)]
+struct AllowedBelow {
+    // { dg-warning "struct is never constructed" "" { target *-*-* } .-1 }
+    f: fn(),
+}

--- a/gcc/testsuite/rust/compile/issue-4090-2.rs
+++ b/gcc/testsuite/rust/compile/issue-4090-2.rs
@@ -1,0 +1,71 @@
+mod core {
+    mod marker {
+        #[lang = "sized"]
+        pub trait Sized {}
+
+        #[lang = "phantom_data"]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        pub struct PhantomData<T: ?Sized>;
+
+        #[unstable(feature = "structural_match", issue = "31434")]
+        #[lang = "structural_teq"]
+        pub trait StructuralEq {
+            // Empty.
+        }
+
+        #[unstable(feature = "structural_match", issue = "31434")]
+        #[lang = "structural_peq"]
+        pub trait StructuralPartialEq {
+            // Empty.
+        }
+    }
+
+    pub mod cmp {
+        use super::marker::Sized;
+
+        #[lang = "eq"]
+        pub trait PartialEq<Rhs: ?Sized = Self> {
+            fn eq(&self, other: &Rhs) -> bool;
+
+            fn ne(&self, other: &Rhs) -> bool {
+                !self.eq(other)
+            }
+        }
+
+        pub trait Eq: PartialEq<Self> {
+            fn assert_receiver_is_total_eq(&self) {}
+        }
+    }
+
+    pub mod ptr {
+
+        use super::cmp::{Eq, PartialEq};
+
+        macro_rules! fnptr_impls_safety_abi {
+            ($FnTy: ty, $($Arg: ident),*) => {
+                #[stable(feature = "fnptr_impls", since = "1.4.0")]
+                impl<Ret, $($Arg),*> PartialEq for $FnTy {
+                    #[inline]
+                    fn eq(&self, other: &Self) -> bool {
+                        *self as usize == *other as usize
+                    }
+                }
+
+                #[stable(feature = "fnptr_impls", since = "1.4.0")]
+                impl<Ret, $($Arg),*> Eq for $FnTy {}
+
+            }
+        }
+
+        fnptr_impls_safety_abi! { extern "Rust" fn() -> Ret, }
+        fnptr_impls_safety_abi! { extern "C" fn() -> Ret, }
+        fnptr_impls_safety_abi! { unsafe extern "Rust" fn() -> Ret, }
+        fnptr_impls_safety_abi! { unsafe extern "C" fn() -> Ret, }
+    }
+}
+
+#[derive(PartialEq, Eq)]
+struct AllowedBelow {
+    // { dg-warning "struct is never constructed" "" { target *-*-* } .-1 }
+    f: fn(),
+}


### PR DESCRIPTION
This patch adds support to recursively walk fnptr types to do generic substitutions.

Fixes #4090

gcc/rust/ChangeLog:

	* typecheck/rust-substitution-mapper.cc (SubstMapperInternal::visit): handle fnptr
	* typecheck/rust-tyty.cc (FnPtr::handle_substitions): new
	* typecheck/rust-tyty.h: likewise

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4090-1.rs: New test.
	* rust/compile/issue-4090-2.rs: New test.
