### PR TITLE
gccrs: Fix ICE on copied array expressions

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -1096,11 +1096,13 @@ TypeCheckExpr::visit (HIR::ArrayExpr &expr)
 	context->insert_type (elems.get_num_copies_expr ().get_mappings (),
 			      expected_ty);
 
-	unify_site (
+	auto result = unify_site (
 	  expr.get_mappings ().get_hirid (), TyTy::TyWithLocation (expected_ty),
 	  TyTy::TyWithLocation (capacity_expr_ty,
 				elems.get_num_copies_expr ().get_locus ()),
 	  expr.get_locus ());
+	if (result->is<TyTy::ErrorType> ())
+	  return;
 
 	capacity_expr = &elems.get_num_copies_expr ();
 	capacity_type = expected_ty;

--- a/gcc/testsuite/rust/compile/issue-4165.rs
+++ b/gcc/testsuite/rust/compile/issue-4165.rs
@@ -1,0 +1,12 @@
+const N: usize = 2;
+const ARR: [i32; N] = [42; X];
+// { dg-error {cannot find value .X. in this scope \[E0425\]} "" { target *-*-* } .-1 }
+// { dg-error {mismatched types, expected .\[i32; 2]. but got .<tyty::error>. \[E0308\]} "" { target *-*-* } .-2 }
+// { dg-error {mismatched types, expected .usize. but got .bool. \[E0308\]} "" { target *-*-* } .-3 }
+const X: bool = (N[0] == 99) && (ARR[0] == 0);
+// { dg-error {the type .usize. cannot be indexed by .<integer>. \[E0277\]} "" { target *-*-* } .-1 }
+// { dg-error {mismatched types, expected .<tyty::error>. but got .<integer>. \[E0308\]} "" { target *-*-* } .-2 }
+
+fn main() {
+    let _ = X;
+}


### PR DESCRIPTION
We need to check for errors on the number of copies expression before trying to const fold it otherwise it will just fail in the const evaluator.

Fixes Rust-GCC#4165

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::visit): check for error

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4165.rs: New test.
