### PR TITLE
gccrs: Add error diag for self params on plain functions

### DIFF
--- a/gcc/testsuite/rust/compile/issue-3592.rs
+++ b/gcc/testsuite/rust/compile/issue-3592.rs
@@ -1,0 +1,7 @@
+pub trait X {
+    fn x() {
+        fn f(&mut self) {}
+        // { dg-error ".self. parameter is only allowed in associated functions" "" { target *-*-* } .-1 }
+        f();
+    }
+}


### PR DESCRIPTION
self params dont have a type unless used within impl blocks. Rustc as far as I can tell in this senario generics a synthetic param of type Self in this senario so that it keeps consistent error diagnostic for number of parameters but the logic for what the parameter typpe should be seems unclear.

Fixes Rust-GCC#3592

gcc/rust/ChangeLog:

	* hir/rust-ast-lower-item.cc (ASTLoweringItem::visit): add error diagnostic

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3592.rs: New test.
