### PR TITLE
gccrs: Fix ICE where we expect a num enum variant

### DIFF
--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -97,8 +97,11 @@ ResolvePathRef::attempt_constructor_expression_lookup (
 
   // this can only be for discriminant variants the others are built up
   // using call-expr or struct-init
-  rust_assert (variant->get_variant_type ()
-	       == TyTy::VariantDef::VariantType::NUM);
+  if (variant->get_variant_type () != TyTy::VariantDef::VariantType::NUM)
+    {
+      rust_error_at (expr_locus, "variant expected constructor call");
+      return error_mark_node;
+    }
 
   // we need the actual gcc type
   tree compiled_adt_type = TyTyResolveCompile::compile (ctx, adt);

--- a/gcc/testsuite/rust/compile/issue-3538.rs
+++ b/gcc/testsuite/rust/compile/issue-3538.rs
@@ -1,0 +1,9 @@
+enum A {
+    Value(()),
+}
+
+fn main() {
+    let a = A::Value(());
+    a == A::Value;
+    // { dg-error "variant expected constructor call" "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
This changes the assertion into a valid error diagnostic.

Fixes Rust-GCC#3538

gcc/rust/ChangeLog:

	* backend/rust-compile-resolve-path.cc: add error diag

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3538.rs: New test.

