### PR TITLE
gccrs: Refactor TyTy::ConstType into separate types

### DIFF
--- a/gcc/rust/backend/rust-compile-type.h
+++ b/gcc/rust/backend/rust-compile-type.h
@@ -50,7 +50,10 @@ public:
   void visit (const TyTy::ReferenceType &) override;
   void visit (const TyTy::PointerType &) override;
   void visit (const TyTy::ParamType &) override;
-  void visit (const TyTy::ConstType &) override;
+  void visit (const TyTy::ConstParamType &) override;
+  void visit (const TyTy::ConstValueType &) override;
+  void visit (const TyTy::ConstInferType &) override;
+  void visit (const TyTy::ConstErrorType &) override;
   void visit (const TyTy::StrType &) override;
   void visit (const TyTy::NeverType &) override;
   void visit (const TyTy::PlaceholderType &) override;

--- a/gcc/rust/typecheck/rust-hir-type-check-base.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.cc
@@ -367,17 +367,17 @@ TypeCheckBase::resolve_literal (const Analysis::NodeMapping &expr_mappings,
 	tree capacity = Compile::HIRCompileBase::query_compile_const_expr (
 	  ctx, expected_ty, *literal_capacity);
 
-	TyTy::ConstType *capacity_expr
-	  = new TyTy::ConstType (TyTy::ConstType::ConstKind::Value, "",
-				 expected_ty, capacity, {},
-				 literal_capacity->get_locus (),
-				 literal_capacity->get_mappings ().get_hirid (),
-				 literal_capacity->get_mappings ().get_hirid (),
-				 {});
+	HirId capacity_expr_id = literal_capacity->get_mappings ().get_hirid ();
+	auto capacity_expr
+	  = new TyTy::ConstValueType (capacity, expected_ty, capacity_expr_id,
+				      capacity_expr_id);
+	context->insert_type (literal_capacity->get_mappings (),
+			      capacity_expr->as_base_type ());
 
-	TyTy::ArrayType *array
-	  = new TyTy::ArrayType (array_mapping.get_hirid (), locus,
-				 capacity_expr, TyTy::TyVar (u8->get_ref ()));
+	TyTy::ArrayType *array = new TyTy::ArrayType (
+	  array_mapping.get_hirid (), locus,
+	  TyTy::TyVar (capacity_expr->as_base_type ()->get_ty_ref ()),
+	  TyTy::TyVar (u8->get_ref ()));
 	context->insert_type (array_mapping, array);
 
 	infered = new TyTy::ReferenceType (expr_mappings.get_hirid (),
@@ -597,22 +597,21 @@ TypeCheckBase::resolve_generic_params (
 		  = Compile::HIRCompileBase::query_compile_const_expr (
 		    ctx, specified_type, expr);
 
-		TyTy::ConstType *default_const_decl
-		  = new TyTy::ConstType (TyTy::ConstType::ConstKind::Value,
-					 param.get_name (), specified_type,
-					 default_value, {}, param.get_locus (),
-					 expr.get_mappings ().get_hirid (),
-					 expr.get_mappings ().get_hirid (), {});
+		auto default_const_decl
+		  = new TyTy::ConstValueType (default_value, specified_type,
+					      expr.get_mappings ().get_hirid (),
+					      expr.get_mappings ().get_hirid (),
+					      {});
 
 		context->insert_type (expr.get_mappings (), default_const_decl);
 	      }
 
-	    TyTy::ConstType *const_decl
-	      = new TyTy::ConstType (TyTy::ConstType::ConstKind::Decl,
-				     param.get_name (), specified_type,
-				     error_mark_node, {}, param.get_locus (),
-				     param.get_mappings ().get_hirid (),
-				     param.get_mappings ().get_hirid (), {});
+	    TyTy::BaseGeneric *const_decl
+	      = new TyTy::ConstParamType (param.get_name (), param.get_locus (),
+					  specified_type,
+					  param.get_mappings ().get_hirid (),
+					  param.get_mappings ().get_hirid (),
+					  {});
 
 	    context->insert_type (generic_param->get_mappings (), const_decl);
 	    TyTy::SubstitutionParamMapping p (*generic_param, const_decl);

--- a/gcc/rust/typecheck/rust-substitution-mapper.cc
+++ b/gcc/rust/typecheck/rust-substitution-mapper.cc
@@ -268,9 +268,27 @@ SubstMapperInternal::visit (TyTy::ParamType &type)
 }
 
 void
-SubstMapperInternal::visit (TyTy::ConstType &type)
+SubstMapperInternal::visit (TyTy::ConstParamType &type)
 {
   resolved = type.handle_substitions (mappings);
+}
+
+void
+SubstMapperInternal::visit (TyTy::ConstValueType &type)
+{
+  resolved = type.clone ();
+}
+
+void
+SubstMapperInternal::visit (TyTy::ConstInferType &type)
+{
+  resolved = type.clone ();
+}
+
+void
+SubstMapperInternal::visit (TyTy::ConstErrorType &type)
+{
+  resolved = type.clone ();
 }
 
 void

--- a/gcc/rust/typecheck/rust-substitution-mapper.h
+++ b/gcc/rust/typecheck/rust-substitution-mapper.h
@@ -61,7 +61,10 @@ public:
   void visit (TyTy::ReferenceType &) override { rust_unreachable (); }
   void visit (TyTy::PointerType &) override { rust_unreachable (); }
   void visit (TyTy::ParamType &) override { rust_unreachable (); }
-  void visit (TyTy::ConstType &) override { rust_unreachable (); }
+  void visit (TyTy::ConstParamType &) override { rust_unreachable (); }
+  void visit (TyTy::ConstValueType &) override { rust_unreachable (); }
+  void visit (TyTy::ConstInferType &) override { rust_unreachable (); }
+  void visit (TyTy::ConstErrorType &) override { rust_unreachable (); }
   void visit (TyTy::StrType &) override { rust_unreachable (); }
   void visit (TyTy::NeverType &) override { rust_unreachable (); }
   void visit (TyTy::DynamicObjectType &) override { rust_unreachable (); }
@@ -93,7 +96,10 @@ public:
   void visit (TyTy::ReferenceType &type) override;
   void visit (TyTy::PointerType &type) override;
   void visit (TyTy::ParamType &type) override;
-  void visit (TyTy::ConstType &type) override;
+  void visit (TyTy::ConstParamType &type) override;
+  void visit (TyTy::ConstValueType &type) override;
+  void visit (TyTy::ConstInferType &type) override;
+  void visit (TyTy::ConstErrorType &type) override;
   void visit (TyTy::PlaceholderType &type) override;
   void visit (TyTy::ProjectionType &type) override;
   void visit (TyTy::ClosureType &type) override;
@@ -147,13 +153,16 @@ public:
   void visit (TyTy::ReferenceType &) override { rust_unreachable (); }
   void visit (TyTy::PointerType &) override { rust_unreachable (); }
   void visit (TyTy::ParamType &) override { rust_unreachable (); }
-  void visit (TyTy::ConstType &) override { rust_unreachable (); }
+  void visit (TyTy::ConstParamType &) override { rust_unreachable (); }
+  void visit (TyTy::ConstValueType &) override { rust_unreachable (); }
+  void visit (TyTy::ConstInferType &) override { rust_unreachable (); }
+  void visit (TyTy::ConstErrorType &) override { rust_unreachable (); }
   void visit (TyTy::StrType &) override { rust_unreachable (); }
   void visit (TyTy::NeverType &) override { rust_unreachable (); }
   void visit (TyTy::PlaceholderType &) override { rust_unreachable (); }
   void visit (TyTy::ProjectionType &) override { rust_unreachable (); }
   void visit (TyTy::DynamicObjectType &) override { rust_unreachable (); }
-  void visit (TyTy::OpaqueType &type) override { rust_unreachable (); }
+  void visit (TyTy::OpaqueType &) override { rust_unreachable (); }
 
 private:
   SubstMapperFromExisting (TyTy::BaseType *concrete, TyTy::BaseType *receiver);
@@ -188,7 +197,10 @@ public:
   void visit (const TyTy::ReferenceType &) override {}
   void visit (const TyTy::PointerType &) override {}
   void visit (const TyTy::ParamType &) override {}
-  void visit (const TyTy::ConstType &) override {}
+  void visit (const TyTy::ConstParamType &) override {}
+  void visit (const TyTy::ConstValueType &) override {}
+  void visit (const TyTy::ConstInferType &) override {}
+  void visit (const TyTy::ConstErrorType &) override {}
   void visit (const TyTy::StrType &) override {}
   void visit (const TyTy::NeverType &) override {}
   void visit (const TyTy::PlaceholderType &) override {}

--- a/gcc/rust/typecheck/rust-type-util.cc
+++ b/gcc/rust/typecheck/rust-type-util.cc
@@ -231,7 +231,8 @@ unify_site_and (HirId id, TyTy::TyWithLocation lhs, TyTy::TyWithLocation rhs,
 
 	  // remove the inference variable
 	  context.clear_type (i.infer);
-	  delete i.infer;
+	  // FIXME: Don't delete - result might point to this
+	  // delete i.infer;
 	}
     }
   return result;

--- a/gcc/rust/typecheck/rust-tyty-call.h
+++ b/gcc/rust/typecheck/rust-tyty-call.h
@@ -60,9 +60,12 @@ public:
   void visit (PlaceholderType &) override { rust_unreachable (); }
   void visit (ProjectionType &) override { rust_unreachable (); }
   void visit (DynamicObjectType &) override { rust_unreachable (); }
-  void visit (ClosureType &type) override { rust_unreachable (); }
-  void visit (OpaqueType &type) override { rust_unreachable (); }
-  void visit (ConstType &type) override { rust_unreachable (); }
+  void visit (ClosureType &) override { rust_unreachable (); }
+  void visit (OpaqueType &) override { rust_unreachable (); }
+  void visit (ConstParamType &) override { rust_unreachable (); }
+  void visit (ConstValueType &) override { rust_unreachable (); }
+  void visit (ConstInferType &) override { rust_unreachable (); }
+  void visit (ConstErrorType &) override { rust_unreachable (); }
 
   // tuple-structs
   void visit (ADTType &type) override;

--- a/gcc/rust/typecheck/rust-tyty-util.cc
+++ b/gcc/rust/typecheck/rust-tyty-util.cc
@@ -60,17 +60,14 @@ TyVar::get_implicit_infer_var (location_t locus)
 }
 
 TyVar
-TyVar::get_implicit_const_infer_var (const ConstType &const_type,
-				     location_t locus)
+TyVar::get_implicit_const_infer_var (location_t locus)
 {
   auto &mappings = Analysis::Mappings::get ();
   auto context = Resolver::TypeCheckContext::get ();
 
+  TyVar ty_infer = get_implicit_infer_var (locus);
   HirId next = mappings.get_next_hir_id ();
-  auto infer
-    = new ConstType (ConstType::ConstKind::Infer, const_type.get_symbol (),
-		     const_type.get_ty (), error_mark_node,
-		     const_type.get_specified_bounds (), locus, next, next, {});
+  auto infer = new ConstInferType (ty_infer.get_tyty (), next, next, {});
 
   context->insert_implicit_type (infer->get_ref (), infer);
   mappings.insert_location (infer->get_ref (), locus);

--- a/gcc/rust/typecheck/rust-tyty-util.h
+++ b/gcc/rust/typecheck/rust-tyty-util.h
@@ -43,8 +43,7 @@ public:
 
   static TyVar get_implicit_infer_var (location_t locus);
 
-  static TyVar get_implicit_const_infer_var (const TyTy::ConstType &const_type,
-					     location_t locus);
+  static TyVar get_implicit_const_infer_var (location_t locus);
 
   static TyVar subst_covariant_var (TyTy::BaseType *orig,
 				    TyTy::BaseType *subst);

--- a/gcc/rust/typecheck/rust-tyty-variance-analysis-private.h
+++ b/gcc/rust/typecheck/rust-tyty-variance-analysis-private.h
@@ -175,7 +175,10 @@ public:
 
   void visit (OpaqueType &type) override {}
 
-  void visit (ConstType &type) override {}
+  void visit (TyTy::ConstParamType &) override {}
+  void visit (TyTy::ConstValueType &) override {}
+  void visit (TyTy::ConstInferType &) override {}
+  void visit (TyTy::ConstErrorType &) override {}
 };
 
 /** Per crate context for generic type variance analysis. */

--- a/gcc/rust/typecheck/rust-tyty-visitor.h
+++ b/gcc/rust/typecheck/rust-tyty-visitor.h
@@ -45,7 +45,10 @@ public:
   virtual void visit (ReferenceType &type) = 0;
   virtual void visit (PointerType &type) = 0;
   virtual void visit (ParamType &type) = 0;
-  virtual void visit (ConstType &type) = 0;
+  virtual void visit (ConstParamType &type) = 0;
+  virtual void visit (ConstValueType &type) = 0;
+  virtual void visit (ConstInferType &type) = 0;
+  virtual void visit (ConstErrorType &type) = 0;
   virtual void visit (StrType &type) = 0;
   virtual void visit (NeverType &type) = 0;
   virtual void visit (PlaceholderType &type) = 0;
@@ -76,7 +79,10 @@ public:
   virtual void visit (const ReferenceType &type) = 0;
   virtual void visit (const PointerType &type) = 0;
   virtual void visit (const ParamType &type) = 0;
-  virtual void visit (const ConstType &type) = 0;
+  virtual void visit (const ConstParamType &type) = 0;
+  virtual void visit (const ConstValueType &type) = 0;
+  virtual void visit (const ConstInferType &type) = 0;
+  virtual void visit (const ConstErrorType &type) = 0;
   virtual void visit (const StrType &type) = 0;
   virtual void visit (const NeverType &type) = 0;
   virtual void visit (const PlaceholderType &type) = 0;

--- a/gcc/rust/typecheck/rust-unify.h
+++ b/gcc/rust/typecheck/rust-unify.h
@@ -95,7 +95,8 @@ protected:
 				  TyTy::BaseType *rtype);
   TyTy::BaseType *expect_opaque (TyTy::OpaqueType *ltype,
 				 TyTy::BaseType *rtype);
-  TyTy::BaseType *expect_const (TyTy::ConstType *ltype, TyTy::BaseType *rtype);
+  TyTy::BaseType *expect_const (TyTy::BaseConstType *ltype,
+				TyTy::BaseType *rtype);
 
 private:
   UnifyRules (TyTy::TyWithLocation lhs, TyTy::TyWithLocation rhs,


### PR DESCRIPTION
This patch refactors the const generic type system to follow the same pattern as regular type parameters. The monolithic ConstType is split into four distinct types:

  ConstParamType (generic parameter placeholder)
  ConstValueType (resolved constant value)
  ConstInferType (inference variable)
  ConstErrorType (error sentinel)

gcc/rust/ChangeLog:

	* backend/rust-compile-expr.cc (CompileExpr::array_copied_expr): refactor to new classes
	* backend/rust-compile-pattern.cc (CompilePatternCheckExpr::visit): likewise
	(CompilePatternBindings::visit): likewise
	* backend/rust-compile-type.cc (TyTyResolveCompile::visit): likewise
	* backend/rust-compile-type.h: likewise
	* typecheck/rust-hir-type-check-base.cc (TypeCheckBase::resolve_literal): likewise
	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::visit): likewise
	* typecheck/rust-hir-type-check-pattern.cc (TypeCheckPattern::visit): likewise
	* typecheck/rust-hir-type-check-type.cc (TypeCheckType::visit): likewise
	* typecheck/rust-substitution-mapper.cc (SubstMapperInternal::visit): likewise
	* typecheck/rust-substitution-mapper.h: likewise
	* typecheck/rust-tyty-call.h: likewise
	* typecheck/rust-tyty-subst.cc (SubstitutionParamMapping::clone): likewise
	(SubstitutionRef::infer_substitions): likewise
	* typecheck/rust-tyty-util.cc (TyVar::get_implicit_const_infer_var): likewise
	* typecheck/rust-tyty-util.h: likewise
	* typecheck/rust-tyty-variance-analysis-private.h: likewise
	* typecheck/rust-tyty-visitor.h: likewise
	* typecheck/rust-tyty.cc (BaseType::destructure): likewise
	(BaseType::monomorphized_clone): likewise
	(BaseType::is_concrete): likewise
	(VariantDef::clone): likewise
	(VariantDef::monomorphized_clone): likewise
	(ArrayType::as_string): likewise
	(ArrayType::get_capacity): likewise
	(ArrayType::handle_substitions): likewise
	(generate_tree_str): likewise
	(ConstType::ConstType): likewise
	(ConstParamType::ConstParamType): likewise
	(ConstType::accept_vis): likewise
	(ConstParamType::const_kind): likewise
	(ConstParamType::get_symbol): likewise
	(ConstParamType::can_resolve): likewise
	(ConstParamType::resolve): likewise
	(ConstParamType::accept_vis): likewise
	(ConstType::set_value): likewise
	(ConstType::as_string): likewise
	(ConstParamType::as_string): likewise
	(ConstType::clone): likewise
	(ConstParamType::clone): likewise
	(ConstType::get_symbol): likewise
	(ConstParamType::get_name): likewise
	(ConstType::can_resolve): likewise
	(ConstParamType::is_equal): likewise
	(ConstType::resolve): likewise
	(ConstValueType::ConstValueType): likewise
	(ConstValueType::const_kind): likewise
	(ConstValueType::accept_vis): likewise
	(ConstValueType::as_string): likewise
	(ConstValueType::clone): likewise
	(ConstValueType::get_name): likewise
	(ConstValueType::is_equal): likewise
	(ConstValueType::get_value): likewise
	(ConstInferType::ConstInferType): likewise
	(ConstInferType::const_kind): likewise
	(ConstInferType::accept_vis): likewise
	(ConstType::get_name): likewise
	(ConstInferType::as_string): likewise
	(ConstInferType::clone): likewise
	(ConstInferType::get_name): likewise
	(ConstType::is_equal): likewise
	(ConstInferType::is_equal): likewise
	(ConstErrorType::ConstErrorType): likewise
	(ConstErrorType::const_kind): likewise
	(ConstType::handle_substitions): likewise
	(ConstErrorType::accept_vis): likewise
	(ConstErrorType::as_string): likewise
	(ConstErrorType::clone): likewise
	(ConstErrorType::get_name): likewise
	(ConstErrorType::is_equal): likewise
	* typecheck/rust-tyty.h (class BaseConstType): likewise
	(class ConstType): likewise
	(class ConstParamType): likewise
	(class ConstValueType): likewise
	(class ConstInferType): likewise
	(class ConstErrorType): likewise
	* typecheck/rust-unify.cc (UnifyRules::commit): likewise
	(UnifyRules::go): likewise
	(UnifyRules::expect_array): likewise
	(UnifyRules::expect_const): likewise
	* typecheck/rust-unify.h: likewise

