### PR TITLE
gccrs: fix ICE in TyVar constructor

### DIFF
--- a/gcc/testsuite/rust/compile/issue-3556.rs
+++ b/gcc/testsuite/rust/compile/issue-3556.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let ref mut a @ (ref mut b,);
+    // { dg-error "expected T\\?, found tuple" "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
fix #3556 
The changes ensure that type lookup failures no longer trigger assertions and instead safely return implicit inference variables. 
If further support for this pattern is needed, I'm happy to discuss possible approaches further!

gcc/rust/ChangeLog:

        * typecheck/rust-tyty-util.cc (TyVar::TyVar):
        (TyVar::get_tyty):
        (TyVar::clone):
        (TyVar::monomorphized_clone):

gcc/testsuite/ChangeLog:

        * rust/compile/issue-3556.rs: New test.
