### PR TITLE
gccrs: Emit error when tuple-indexing on non-tuples

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -126,7 +126,13 @@ TypeCheckExpr::visit (HIR::TupleIndexExpr &expr)
     }
 
   TyTy::ADTType *adt = static_cast<TyTy::ADTType *> (resolved);
-  rust_assert (!adt->is_enum ());
+  if (!adt->is_tuple_struct ())
+    {
+      rust_error_at (expr.get_locus (),
+		     "expected tuple or tuple struct, found %qs",
+		     adt->get_name ().c_str ());
+      return;
+    }
   rust_assert (adt->number_of_variants () == 1);
 
   TyTy::VariantDef *variant = adt->get_variants ().at (0);

--- a/gcc/testsuite/rust/compile/tuple_index_on_non_tuple.rs
+++ b/gcc/testsuite/rust/compile/tuple_index_on_non_tuple.rs
@@ -1,0 +1,15 @@
+enum E {
+    V(usize),
+}
+
+struct S {
+    field: i32,
+}
+
+fn main() {
+    let e = E::V(0);
+    let _ = e.0; // { dg-error "expected tuple or tuple struct, found 'E'" }
+
+    let s = S { field: 0 };
+    let _ = s.0; // { dg-error "expected tuple or tuple struct, found 'S'" }
+}


### PR DESCRIPTION
Fixes #3927 

This PR fixes type checking on tuple indexing expressions by properly emitting errors when the tuple operand of the expression is not tuple-like instead of an assertion that was causing the reported panic. Although not reported by the issue, I also found that the previous code allowed tuple indexing on structs, so I added a test case to assert such expressions also cause compilations to fail with an appropriate error message.

In addition, I fixed the clang-format version to use in CONTRIBUTING.md. Let me know if the commit should be in a separate PR since it's irrelevant to #3927.