### PR TITLE
gccrs: fix ICE on missing pattern in while loop

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -8206,7 +8206,14 @@ Parser<ManagedTokenSource>::parse_while_let_loop_expr (
   // parse predicate patterns
   std::vector<std::unique_ptr<AST::Pattern>> predicate_patterns
     = parse_match_arm_patterns (EQUAL);
-  // TODO: have to ensure that there is at least 1 pattern?
+  // ensure that there is at least 1 pattern
+  if (predicate_patterns.empty ())
+    {
+      Error error (lexer.peek_token ()->get_locus (),
+		   "should be at least 1 pattern");
+      add_error (std::move (error));
+      return nullptr;
+    }
 
   if (!skip_token (EQUAL))
     {

--- a/gcc/testsuite/rust/compile/issue-4162.rs
+++ b/gcc/testsuite/rust/compile/issue-4162.rs
@@ -1,0 +1,9 @@
+pub fn main() {
+    while let  = 5
+    // { dg-error "should be at least 1 pattern" "" { target *-*-* } .-1 }
+    // { dg-error "failed to parse statement or expression in block expression" "" { target *-*-* } .-2 }
+    // { dg-error "unrecognised token .=. for start of item" "" { target *-*-* } .-3 }
+    // { dg-error "failed to parse item in crate" "" { target *-*-* } .-4 }
+    {}
+}
+


### PR DESCRIPTION
Adds a proper check for missing patterns in while expressions.

Fixes Rust-GCC#4162
	
gcc/rust/ChangeLog:
    
        * parse/rust-parse-impl.h(Parser<ManagedTokenSource>::parse_while_let_loop_expr):
        Add check for missing pattern.
    
gcc/testsuite/ChangeLog:
```     * rust/compile/issue-4162.rs: New test.```
    
Signed-off-by: Lucas Ly Ba <lucas.ly-ba@outlook.com>