### PR TITLE
gccrs: add error check if derive has wrong item

### DIFF
--- a/gcc/rust/expand/rust-derive.cc
+++ b/gcc/rust/expand/rust-derive.cc
@@ -25,6 +25,7 @@
 #include "rust-derive-ord.h"
 #include "rust-derive-partial-eq.h"
 #include "rust-derive-hash.h"
+#include "rust-system.h"
 
 namespace Rust {
 namespace AST {
@@ -38,6 +39,16 @@ DeriveVisitor::derive (Item &item, const Attribute &attr,
 		       BuiltinMacro to_derive)
 {
   auto loc = attr.get_locus ();
+
+  using Kind = AST::Item::Kind;
+  auto item_kind = item.get_item_kind ();
+  if (item_kind != Kind::Enum && item_kind != Kind::Struct
+      && item_kind != Kind::Union)
+    {
+      rust_error_at (loc,
+		     "derive may only be applied to structs, enums and unions");
+      return {};
+    }
 
   switch (to_derive)
     {

--- a/gcc/testsuite/rust/compile/issue-3971.rs
+++ b/gcc/testsuite/rust/compile/issue-3971.rs
@@ -1,0 +1,11 @@
+#[lang = "copy"]
+trait Copy {}
+
+// since the macro expansion fails, the current nameres fixpoint error is emitted - just accept it for now
+#[derive(Copy)]
+// { dg-error "derive may only be applied to structs, enums and unions" "" { target *-*-* } .-1 }
+// { dg-excess-errors "could not resolve trait" }
+
+pub fn check_ge(a: i32, b: i32) -> bool {
+    a >= b
+}


### PR DESCRIPTION
Derive may only be applied to structs, enums and unions.

Fixes Rust-GCC#3971

gcc/rust/ChangeLog:

	* expand/rust-expand-visitor.cc(ExpandVisitor::expand_inner_items): Added check and error.

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3971.rs: New test.

Signed-off-by: Lucas Ly Ba <lucas.ly-ba@outlook.com>