### PR TITLE
gccrs: fix parser error on parenthesised types

### DIFF
--- a/gcc/rust/ast/rust-path.cc
+++ b/gcc/rust/ast/rust-path.cc
@@ -290,6 +290,11 @@ TypePath::make_debug_string () const
 TraitBound *
 TypePath::to_trait_bound (bool in_parens) const
 {
+  // If already in parentheses, don't convert to trait bound
+  // This ensures (TypePath) stays as ParenthesisedType in the parser
+  if (in_parens)
+    return nullptr;
+
   return new TraitBound (TypePath (*this), get_locus (), in_parens);
 }
 

--- a/gcc/rust/hir/tree/rust-hir-type.cc
+++ b/gcc/rust/hir/tree/rust-hir-type.cc
@@ -101,8 +101,13 @@ ParenthesisedType::operator= (ParenthesisedType const &other)
 }
 
 std::unique_ptr<TraitBound>
-ParenthesisedType::to_trait_bound (bool in_parens ATTRIBUTE_UNUSED) const
+ParenthesisedType::to_trait_bound (bool in_parens) const
 {
+  /* If already in parentheses, don't convert - should stay as
+   * ParenthesisedType */
+  if (in_parens)
+    return nullptr;
+
   /* NOTE: obviously it is unknown whether the internal type is a trait bound
    * due to polymorphism, so just let the internal type handle it. As
    * parenthesised type, it must be in parentheses. */

--- a/gcc/rust/hir/tree/rust-hir.cc
+++ b/gcc/rust/hir/tree/rust-hir.cc
@@ -2798,6 +2798,11 @@ Expr::as_string () const
 std::unique_ptr<TraitBound>
 TypePath::to_trait_bound (bool in_parens) const
 {
+  // If already in parentheses, don't convert to trait bound
+  // This ensures (TypePath) stays as ParenthesisedType in the parser
+  if (in_parens)
+    return nullptr;
+
   // create clone FIXME is this required? or is copy constructor automatically
   // called?
   TypePath copy (*this);

--- a/gcc/testsuite/rust/compile/issue-4148.rs
+++ b/gcc/testsuite/rust/compile/issue-4148.rs
@@ -1,5 +1,3 @@
-// { dg-excess-errors "warnings" }
-
 // TODO: all `xfail` conditions should be changed to `target` once the ICE in #4148 is resolved
 
 pub fn ret_parens(x: i32) -> i32 {


### PR DESCRIPTION
Do not cast parenthesised types to TraitBound types

Fixes #4148

gcc/rust/ChangeLog:

	* parse/rust-parse-impl.h (Parser::parse_paren_prefixed_type):

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4148.rs:

Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[ ] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[ ] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[ ] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---

*Please write a comment explaining your change. This is the message
that will be part of the merge commit.
