### PR TITLE
gccrs: fix segfault on exported macro

### DIFF
--- a/gcc/rust/metadata/rust-export-metadata.cc
+++ b/gcc/rust/metadata/rust-export-metadata.cc
@@ -23,6 +23,7 @@
 #include "rust-ast-dump.h"
 #include "rust-abi.h"
 #include "rust-item.h"
+#include "rust-macro.h"
 #include "rust-object-export.h"
 
 #include "md5.h"
@@ -111,14 +112,12 @@ ExportContext::emit_function (const HIR::Function &fn)
 }
 
 void
-ExportContext::emit_macro (NodeId macro)
+ExportContext::emit_macro (AST::MacroRulesDefinition &macro)
 {
   std::stringstream oss;
   AST::Dump dumper (oss);
 
-  AST::Item *item = mappings.lookup_ast_item (macro).value ();
-
-  dumper.go (*item);
+  dumper.go (macro);
 
   public_interface_buffer += oss.str ();
 }
@@ -195,7 +194,7 @@ PublicInterface::gather_export_data ()
 	vis_item.accept_vis (visitor);
     }
 
-  for (const auto &macro : mappings.get_exported_macros ())
+  for (auto &macro : mappings.get_exported_macros ())
     context.emit_macro (macro);
 }
 

--- a/gcc/rust/metadata/rust-export-metadata.h
+++ b/gcc/rust/metadata/rust-export-metadata.h
@@ -48,7 +48,7 @@ public:
    * directly refer to them using their NodeId. There's no need to keep an HIR
    * node for them.
    */
-  void emit_macro (NodeId macro);
+  void emit_macro (AST::MacroRulesDefinition &macro);
 
   const std::string &get_interface_buffer () const;
 

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -925,10 +925,10 @@ Mappings::lookup_macro_invocation (AST::MacroInvocation &invoc)
 void
 Mappings::insert_exported_macro (AST::MacroRulesDefinition &def)
 {
-  exportedMacros.emplace_back (def.get_node_id ());
+  exportedMacros.emplace_back (def);
 }
 
-std::vector<NodeId> &
+std::vector<AST::MacroRulesDefinition>
 Mappings::get_exported_macros ()
 {
   return exportedMacros;

--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -279,7 +279,7 @@ public:
   lookup_macro_invocation (AST::MacroInvocation &invoc);
 
   void insert_exported_macro (AST::MacroRulesDefinition &def);
-  std::vector<NodeId> &get_exported_macros ();
+  std::vector<AST::MacroRulesDefinition> get_exported_macros ();
 
   void insert_derive_proc_macros (CrateNum num,
 				  std::vector<CustomDeriveProcMacro> macros);
@@ -408,7 +408,7 @@ private:
   std::map<NodeId, std::pair<AST::MacroRulesDefinition *, CrateNum>>
     macroMappings;
   std::map<NodeId, AST::MacroRulesDefinition *> macroInvocations;
-  std::vector<NodeId> exportedMacros;
+  std::vector<AST::MacroRulesDefinition> exportedMacros;
 
   // Procedural macros
   std::map<CrateNum, std::vector<CustomDeriveProcMacro>>

--- a/gcc/testsuite/rust/compile/issue-3617.rs
+++ b/gcc/testsuite/rust/compile/issue-3617.rs
@@ -1,0 +1,14 @@
+macro_rules! quote_tokens {
+    () => {
+        #[macro_export]
+        macro_rules! inner {
+                    () => {
+                        $crate::
+                    }
+                }
+    };
+}
+
+pub fn main() {
+    quote_tokens!();
+}


### PR DESCRIPTION
An imbricated exported macro leads to a segfault.

Fixes Rust-GCC#3617

gcc/rust/ChangeLog:

	* metadata/rust-export-metadata.cc (ExportContext::emit_macro): Change method argument NodeId to AST::MacroRulesDefinition.
	* metadata/rust-export-metadata.h: Likewise.
	* util/rust-hir-map.cc (Mappings::insert_exported_macro): Insert AST::MacroRulesDefinition instead of NodeId.
	* util/rust-hir-map.h: Change methods declarations of exported macros.

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3617.rs: New test.

Signed-off-by: Lucas Ly Ba <lucas.ly-ba@outlook.fr>
