### PR TITLE
gccrs: Fix ICE in no input file

### DIFF
--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -285,6 +285,10 @@ grs_langhook_post_options (const char **pfilename ATTRIBUTE_UNUSED)
 {
   // can be used to override other options if required
 
+  // check for input file
+  if (!*pfilename && num_in_fnames == 0)
+    *pfilename = "-";
+
   // satisfies an assert in init_excess_precision in toplev.cc
   if (flag_excess_precision /*_cmdline*/ == EXCESS_PRECISION_DEFAULT)
     flag_excess_precision /*_cmdline*/ = EXCESS_PRECISION_STANDARD;

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -464,6 +464,12 @@ Session::handle_excluded_node (std::string arg)
 void
 Session::handle_input_files (int num_files, const char **files)
 {
+  static const char *stdin_file[] = {"-"};
+  if (num_files == 0)
+    {
+      files = stdin_file;
+      num_files = 1;
+    }
   if (num_files != 1)
     rust_fatal_error (UNDEF_LOCATION,
 		      "only one file may be specified on the command line");


### PR DESCRIPTION
Fixes #3523

### Problem Description

Invoking the `crab1` front-end without an input source file currently results in an Internal Compiler Error (ICE) due to a segmentation fault. This was caused by two different code paths attempting to process a `NULL` filename pointer.

### Solution

This patch fixes both crash scenarios by making the Rust front-end gracefully default to reading from standard input (`stdin`), aligning its behavior with other GCC front-ends.

1.  **`Session::handle_input_files`** (in `gcc/rust/rust-session-manager.cc`) is updated to handle the `num_files == 0` case by setting the filename to `"-"` (stdin).
2.  **`grs_langhook_post_options`** (in `gcc/rust/rust-lang.cc`) is updated to check for cases where flags are present but no positional file is given, also setting the filename pointer to `"-"` to prevent the original crash in `init_asm_output`.

### Testing

The fix was verified by testing the two scenarios that previously caused a crash. Both now correctly default to `stdin` and exit gracefully without a segfault.

**1. Running `./gcc/crab1` with no arguments:**
(Shows the experimental compiler warning and exits safely)
<img width="1549" height="359" alt="image" src="https://github.com/user-attachments/assets/da796d2e-efe3-4160-be1b-d566fd72cf90" />



**2. Running `./gcc/crab1` with flags but no file:**
(Correctly defaults to stdin and waits for input)
<img width="1545" height="466" alt="image" src="https://github.com/user-attachments/assets/bd8d904e-5591-4d19-92d0-83d84e7e6eef" />
<img width="1543" height="274" alt="image" src="https://github.com/user-attachments/assets/c57a5599-7d04-4f22-83bc-d7135c005fe1" />


Regression testing by compiling a file normally (e.g., `gccrs test.rs`) was also performed and passed, confirming the fix does not break existing functionality. A full `make check-rust` also passes locally.