### PR TITLE
gccrs: Fix ICE on enum in tuple struct pattern

### DIFF
--- a/gcc/testsuite/rust/compile/match-tuplestructpattern-non-variant.rs
+++ b/gcc/testsuite/rust/compile/match-tuplestructpattern-non-variant.rs
@@ -1,0 +1,20 @@
+enum Empty {}
+enum NonEmpty {
+    Foo(i32),
+}
+
+fn f(e: Empty) {
+    match e { 
+        Empty(0) => {} // { dg-error "expected tuple struct or tuple variant, found enum 'Empty'" }
+    }
+
+    match e {
+        Empty(Empty(..)) => {} // { dg-error "expected tuple struct or tuple variant, found enum 'Empty'" }
+    }
+}
+
+fn g(e: NonEmpty) {
+    match e {
+        NonEmpty(0) => {} // { dg-error "expected tuple struct or tuple variant, found enum 'NonEmpty'" }
+    }
+}


### PR DESCRIPTION
This PR fixes an ICE during typeckecking tuple struct patterns. When the type of a tuple struct pattern's path is resolved to an enum, the path is expected to refer to an enum variant in a correct Rust program. However, it may refer to the enum itself, in which case we should emit an error.

Note that while #3917 reported that the given code had run into an ICE during AST lowering, it currently causes an ICE in typecheck at the same location as #3918. This PR therefore resolves both issues.

Fixes #3917
Fixes #3918
Fixes #3926
