### PR TITLE
gccrs: Fix ICE with non-trailing const defaults

### DIFF
--- a/gcc/testsuite/rust/compile/const_generics_17.rs
+++ b/gcc/testsuite/rust/compile/const_generics_17.rs
@@ -1,0 +1,3 @@
+struct Foo<const N: u32 = 1, const O: bool>; // { dg-error "invalid order for generic parameters: generic parameters with a default must be trailing" }
+
+impl<const N: u32> Foo<N> {}

--- a/gcc/testsuite/rust/compile/generics14.rs
+++ b/gcc/testsuite/rust/compile/generics14.rs
@@ -1,0 +1,1 @@
+struct Foo<const N: i32, 'a>; // { dg-error "invalid order for generic parameters: lifetime parameters must be declared prior to type and const parameters" }


### PR DESCRIPTION
When a const generic with a default value is not trailing, emit an error.

Closes #4220

Godbolt: https://godbolt.org/z/exzMx7aKx

gcc/rust/ChangeLog:

	* parse/rust-parse-impl.h (Parser::parse_generic_params): Emit an error when const generics with a default value is not trailing.

gcc/testsuite/ChangeLog:

	* rust/compile/const_generics_17.rs: New test.
	* rust/compile/generics14.rs: New test.

Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`
- \[x] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---

*Please write a comment explaining your change. This is the message
that will be part of the merge commit.
