### PR TITLE
gccrs: Add support for binding const generic values to paths

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-item.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.cc
@@ -112,17 +112,27 @@ TypeCheckItem::ResolveImplBlockSelfWithInference (
   std::vector<TyTy::SubstitutionArg> args;
   for (auto &p : substitutions)
     {
-      if (p.needs_substitution ())
+      auto param = p.get_param_ty ();
+      if (!p.needs_substitution ())
 	{
-	  TyTy::TyVar infer_var = TyTy::TyVar::get_implicit_infer_var (locus);
-	  args.emplace_back (&p, infer_var.get_tyty ());
+	  auto resolved = param->destructure ();
+	  args.emplace_back (&p, resolved);
+
+	  continue;
+	}
+
+      TyTy::BaseType *argument = nullptr;
+      if (param->get_kind () == TyTy::TypeKind::CONST)
+	{
+	  auto i = TyTy::TyVar::get_implicit_const_infer_var (locus);
+	  argument = i.get_tyty ();
 	}
       else
 	{
-	  auto param = p.get_param_ty ();
-	  auto resolved = param->destructure ();
-	  args.emplace_back (&p, resolved);
+	  auto i = TyTy::TyVar::get_implicit_infer_var (locus);
+	  argument = i.get_tyty ();
 	}
+      args.emplace_back (&p, argument);
     }
 
   // create argument mappings

--- a/gcc/rust/typecheck/rust-type-util.cc
+++ b/gcc/rust/typecheck/rust-type-util.cc
@@ -221,13 +221,13 @@ unify_site_and (HirId id, TyTy::TyWithLocation lhs, TyTy::TyWithLocation rhs,
     }
   else if (cleanup)
     {
-      // FIXME
-      // reset the get_next_hir_id
-
       for (auto &i : infers)
 	{
-	  i.param->set_ref (i.pref);
-	  i.param->set_ty_ref (i.ptyref);
+	  if (i.param != nullptr)
+	    {
+	      i.param->set_ref (i.pref);
+	      i.param->set_ty_ref (i.ptyref);
+	    }
 
 	  // remove the inference variable
 	  context.clear_type (i.infer);

--- a/gcc/rust/typecheck/rust-tyty-util.cc
+++ b/gcc/rust/typecheck/rust-tyty-util.cc
@@ -62,14 +62,15 @@ TyVar::get_implicit_infer_var (location_t locus)
 }
 
 TyVar
-TyVar::get_implicit_const_infer_var (location_t locus)
+TyVar::get_implicit_const_infer_var (location_t locus, TyVar *implicit_type)
 {
   auto &mappings = Analysis::Mappings::get ();
   auto context = Resolver::TypeCheckContext::get ();
 
-  TyVar ty_infer = get_implicit_infer_var (locus);
+  TyVar it = (implicit_type != nullptr) ? *implicit_type
+					: get_implicit_infer_var (locus);
   HirId next = mappings.get_next_hir_id ();
-  auto infer = new ConstInferType (ty_infer.get_tyty (), next, next, {});
+  auto infer = new ConstInferType (it.get_tyty (), next, next, {});
 
   context->insert_implicit_type (infer->get_ref (), infer);
   mappings.insert_location (infer->get_ref (), locus);

--- a/gcc/rust/typecheck/rust-tyty-util.h
+++ b/gcc/rust/typecheck/rust-tyty-util.h
@@ -43,7 +43,8 @@ public:
 
   static TyVar get_implicit_infer_var (location_t locus);
 
-  static TyVar get_implicit_const_infer_var (location_t locus);
+  static TyVar get_implicit_const_infer_var (location_t locus,
+					     TyVar *implicit_type = nullptr);
 
   static TyVar subst_covariant_var (TyTy::BaseType *orig,
 				    TyTy::BaseType *subst);

--- a/gcc/rust/typecheck/rust-unify.h
+++ b/gcc/rust/typecheck/rust-unify.h
@@ -30,15 +30,15 @@ class UnifyRules
 public:
   struct InferenceSite
   {
-    InferenceSite (HirId pref, HirId ptyref, TyTy::ParamType *param,
-		   TyTy::InferType *infer)
+    InferenceSite (HirId pref, HirId ptyref, TyTy::BaseGeneric *param,
+		   TyTy::BaseType *infer)
       : pref (pref), ptyref (ptyref), param (param), infer (infer)
     {}
 
     HirId pref;
     HirId ptyref;
-    TyTy::ParamType *param;
-    TyTy::InferType *infer;
+    TyTy::BaseGeneric *param;
+    TyTy::BaseType *infer;
   };
   struct CommitSite
   {

--- a/gcc/testsuite/rust/execute/torture/const-generics-2.rs
+++ b/gcc/testsuite/rust/execute/torture/const-generics-2.rs
@@ -1,0 +1,20 @@
+#[lang = "sized"]
+trait Sized {}
+
+trait Magic {
+    fn magic(&self) -> usize;
+}
+
+struct Foo<const N: usize>;
+
+impl<const N: usize> Magic for Foo<N> {
+    fn magic(&self) -> usize {
+        N
+    }
+}
+
+fn main() -> i32 {
+    let f = Foo::<7> {};
+    let n = f.magic();
+    n as i32 - 7
+}


### PR DESCRIPTION
Const generics bind values which can be accessed like a normal path but the difference is that they can be true expression values not just type paths. This patch adds support to resolving a method inference which passes a generic value into the method and fixes some missed bugs along the way. The tricky part was that there is a case where in the return position of a method returning a const param type vs the type of the method there is a special case in the unify rules so that we unify the specified type of the const param type not the const param itself.

gcc/rust/ChangeLog:

	* backend/rust-compile-resolve-path.cc: handle const param values
	* typecheck/rust-hir-type-check-item.cc: generate const infer vars when required
	* typecheck/rust-type-util.cc (unify_site_and): handle a null param cleanup
	* typecheck/rust-tyty-util.cc (TyVar::get_implicit_const_infer_var): helper interface
	* typecheck/rust-tyty-util.h: update header prototypes
	* typecheck/rust-tyty.cc (BaseType::is_concrete): correctly handle const types
	(ConstParamType::get_name): emit the specified type
	(ConstParamType::is_equal): fix recursion loop
	* typecheck/rust-unify.cc (UnifyRules::go): const infer vars need cleanup too
	* typecheck/rust-unify.h: support base generics

gcc/testsuite/ChangeLog:

	* rust/execute/torture/const-generics-2.rs: New test.
