### PR TITLE
README: Fedora: Add `gcc`, `gcc-c++`, `cargo`, and `awk`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ apt install build-essential libgmp3-dev libmpfr-dev libmpc-dev flex bison auto
 Fetch dependencies for Fedora:
 
 ```bash
-$ dnf install autoconf automake dejagnu flex bison glibc-devel.{x86_64,i686} gmp-devel libmpc-devel mpfr-devel
+$ dnf install autoconf automake dejagnu flex bison glibc-devel.{x86_64,i686} gmp-devel libmpc-devel mpfr-devel gcc gcc-c++ cargo awk
 ```
 
 Clone the repository


### PR DESCRIPTION
Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[ ] `make check-rust` passes locally (N/A)
- \[ ] Run `clang-format` (N/A)
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/` (N/A)

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---

This commit adds dependencies needed for `../gccrs/configure --prefix=$HOME/gccrs-install --disable-bootstrap --enable-multilib --enable-languages=rust` (from the README) in a fresh `FedoraLinux-43` WSL. Most are also needed in a `fedora` container (the exception is `awk`; it's present in the container but not WSL).

In other words, this commit fixes the following `configure` errors (truncated and combined):

```
configure: error: no acceptable C compiler found in $PATH
configure: error: *** A compiler with support for C++14 language features is required.
configure: error: cargo is required to build rust
./config.status: line 1194: awk: command not found
```

The goal is to eventually package `gccrs` in Copr (Fedora's AUR). Finding all the dependencies is a first step.

Signed-off-by: Osama Albahrani \<osalbahr@gmail.com\>