### PR TITLE
warning: Fix `warning: spurious leading punctuation sequence`

### DIFF
--- a/gcc/text-art/style.cc
+++ b/gcc/text-art/style.cc
@@ -146,7 +146,7 @@ style::color::print_sgr (pretty_printer *pp,
 	  pp_string (pp, "38");
 	else
 	  pp_string (pp, "48");
-	pp_printf (pp, ";5;%i", (int)u.m_8bit);
+	pp_printf (pp, "5;%i", (int)u.m_8bit);
       }
       break;
     case kind::BITS_24:
@@ -156,7 +156,7 @@ style::color::print_sgr (pretty_printer *pp,
 	  pp_string (pp, "38");
 	else
 	  pp_string (pp, "48");
-	pp_printf (pp, ";2;%i;%i;%i",
+	pp_printf (pp, "2;%i;%i;%i",
 		   (int)u.m_24bit.r,
 		   (int)u.m_24bit.g,
 		   (int)u.m_24bit.b);


### PR DESCRIPTION
Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[ ] `make check-rust` passes locally (N/A)
- \[x] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/` (N/A)

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---

Fix the following warning:

```c
../../gccrs/gcc/text-art/style.cc:149:25: warning: spurious leading punctuation sequence ';' in format [-Wformat-diag]
  149 |         pp_printf (pp, ";5;%i", (int)u.m_8bit);
      |                         ^
../../gccrs/gcc/text-art/style.cc:159:25: warning: spurious leading punctuation sequence ';' in format [-Wformat-diag]
  159 |         pp_printf (pp, ";2;%i;%i;%i",
      |                         ^
```

Signed-off-by: Osama Albahrani \<osalbahr@gmail.com\>