### PR TITLE
gccrs: fix segfault with empty cfg attribute

### DIFF
--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -4179,10 +4179,11 @@ Attribute::check_cfg_predicate (const Session &session) const
 
   auto &meta_item = static_cast<AttrInputMetaItemContainer &> (*attr_input);
   if (meta_item.get_items ().empty ()
-      && string_path == Values::Attributes::CFG_ATTR)
+      && (string_path == Values::Attributes::CFG
+	  || string_path == Values::Attributes::CFG_ATTR))
     {
-      rust_error_at (path.get_locus (),
-		     "malformed %<cfg_attr%> attribute input");
+      rust_error_at (path.get_locus (), "malformed %<%s%> attribute input",
+		     string_path.c_str ());
       return false;
     }
   return meta_item.get_items ().front ()->check_cfg_predicate (session);

--- a/gcc/testsuite/rust/compile/issue-4261.rs
+++ b/gcc/testsuite/rust/compile/issue-4261.rs
@@ -1,0 +1,3 @@
+#[cfg()]
+// { dg-error "malformed .cfg. attribute input" "" { target *-*-* } .-1 }
+fn a() {}


### PR DESCRIPTION
Fixes Rust-GCC#4261
gcc/rust/ChangeLog:

	* ast/rust-ast.cc (Attribute::check_cfg_predicate): add cfg path in condition

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4261.rs: New test.

