### PR TITLE
gccrs: fix cfg attribute without parentheses error

### DIFF
--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -4163,16 +4163,10 @@ Attribute::check_cfg_predicate (const Session &session) const
   auto string_path = path.as_string ();
   /* assume that cfg predicate actually can exist, i.e. attribute has cfg or
    * cfg_attr path */
-  if (!has_attr_input ()
-      || (string_path != Values::Attributes::CFG
-	  && string_path != Values::Attributes::CFG_ATTR))
+  if (!has_attr_input ())
     {
-      // DEBUG message
-      rust_debug (
-	"tried to check cfg predicate on attr that either has no input "
-	"or invalid path. attr: '%s'",
-	as_string ().c_str ());
-
+      rust_error_at (path.get_locus (), "%qs is not followed by parentheses",
+		     string_path.c_str ());
       return false;
     }
 
@@ -4181,9 +4175,7 @@ Attribute::check_cfg_predicate (const Session &session) const
     return false;
 
   auto &meta_item = static_cast<AttrInputMetaItemContainer &> (*attr_input);
-  if (meta_item.get_items ().empty ()
-      && (string_path == Values::Attributes::CFG
-	  || string_path == Values::Attributes::CFG_ATTR))
+  if (meta_item.get_items ().empty ())
     {
       rust_error_at (path.get_locus (), "malformed %<%s%> attribute input",
 		     string_path.c_str ());

--- a/gcc/testsuite/rust/compile/issue-4262.rs
+++ b/gcc/testsuite/rust/compile/issue-4262.rs
@@ -1,0 +1,3 @@
+#[cfg]
+// { dg-error ".cfg. is not followed by parentheses" "" { target *-*-* } .-1 }
+fn a() {}


### PR DESCRIPTION
Fixes Rust-GCC#4262
gcc/rust/ChangeLog:
    
        * ast/rust-ast.cc (Attribute::check_cfg_predicate): Make error when attribute has no input.
    
gcc/testsuite/ChangeLog:
    
        * rust/compile/issue-4262.rs: New test.
