### PR TITLE
gccrs: fix cfg attribute error with literal predicate

### DIFF
--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -3834,6 +3834,9 @@ MetaItemLitExpr::check_cfg_predicate (const Session &) const
 {
   /* as far as I can tell, a literal expr can never be a valid cfg body, so
    * false */
+  rust_error_at (this->get_locus (), "'%s' predicate key cannot be a literal",
+		 this->as_string ().c_str ());
+
   return false;
 }
 

--- a/gcc/testsuite/rust/compile/issue-4222.rs
+++ b/gcc/testsuite/rust/compile/issue-4222.rs
@@ -1,0 +1,3 @@
+#![cfg(false)]
+// { dg-error ".false. predicate key cannot be a literal" "" { target *-*-* } .-1 }
+fn a() {}


### PR DESCRIPTION
Fixes Rust-GCC#4222
gcc/rust/ChangeLog:

	* ast/rust-ast.cc (MetaItemLitExpr::check_cfg_predicate): Make error.

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4222.rs: New test.


