### PR TITLE
gccrs: fix error multiple cfg predicates

### DIFF
--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -4185,6 +4185,14 @@ Attribute::check_cfg_predicate (const Session &session) const
 		     "malformed %<cfg_attr%> attribute input");
       return false;
     }
+
+  if (string_path == Values::Attributes::CFG
+      && meta_item.get_items ().size () != 1)
+    {
+      rust_error_at (path.get_locus (), "multiple %qs predicates are specified",
+		     path.as_string ().c_str ());
+      return false;
+    }
   return meta_item.get_items ().front ()->check_cfg_predicate (session);
 }
 

--- a/gcc/testsuite/rust/compile/issue-4267.rs
+++ b/gcc/testsuite/rust/compile/issue-4267.rs
@@ -1,0 +1,3 @@
+#[cfg(a,a)]
+// { dg-error "multiple .cfg. predicates are specified" "" { target *-*-* } .-1 }
+fn a(){}


### PR DESCRIPTION
Fixes Rust-GCC#4267
gcc/rust/ChangeLog:

	* ast/rust-ast.cc (Attribute::check_cfg_predicate): Make error.

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4267.rs: New test.

