### PR TITLE
gccrs:fix ICE with continue/break/return in while condition

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -1541,18 +1541,25 @@ void
 TypeCheckExpr::visit (HIR::WhileLoopExpr &expr)
 {
   context->push_new_while_loop_context (expr.get_mappings ().get_hirid ());
-
-  TypeCheckExpr::Resolve (expr.get_predicate_expr ());
+  TyTy::BaseType *predicate_type
+    = TypeCheckExpr::Resolve (expr.get_predicate_expr ());
+  if (predicate_type->get_kind () != TyTy::TypeKind::BOOL
+      && predicate_type->get_kind () != TyTy::TypeKind::NEVER)
+    {
+      rust_error_at (expr.get_predicate_expr ().get_locus (),
+		     "expected boolean expression in %<while%> condition");
+      context->pop_loop_context ();
+      return;
+    }
   TyTy::BaseType *block_expr = TypeCheckExpr::Resolve (expr.get_loop_block ());
-
   if (!block_expr->is_unit ())
     {
       rust_error_at (expr.get_loop_block ().get_locus (),
 		     "expected %<()%> got %s",
 		     block_expr->as_string ().c_str ());
+      context->pop_loop_context ();
       return;
     }
-
   context->pop_loop_context ();
   infered = TyTy::TupleType::get_unit_type ();
 }
@@ -1602,7 +1609,6 @@ TypeCheckExpr::visit (HIR::ContinueExpr &expr)
 		     "%<continue%> outside of a loop");
       return;
     }
-
   infered = new TyTy::NeverType (expr.get_mappings ().get_hirid ());
 }
 

--- a/gcc/testsuite/rust/compile/issue-3977.rs
+++ b/gcc/testsuite/rust/compile/issue-3977.rs
@@ -1,0 +1,65 @@
+// Test for issue #3977 - ICE with continue/break/return in while condition
+
+fn diverge() -> ! {
+    loop {}
+}
+
+fn test_continue() {
+    loop {
+        while continue {}
+    }
+}
+
+fn test_break() {      
+    loop {
+        while break {}
+    }
+}
+
+fn test_return() {
+    loop {
+        while return {}
+    }
+}
+
+fn test_labeled_break() {
+    'outer: loop {
+        loop {
+            while break 'outer {}
+        }
+    }
+}
+
+fn test_labeled_continue() {
+    'outer: loop {
+        loop {
+            while continue 'outer {}
+        }
+    }
+}
+
+fn test_complex_if_else() {
+    loop {
+        while if true { continue } else { break } {}
+    }
+}
+
+fn foo() {
+    while diverge() {
+        break
+    }
+    let _x = 5;
+}
+
+fn main() {
+    // Just reference them so they're "used"
+    if false {
+        test_continue();
+        test_break();
+        test_return();
+        test_labeled_break();
+        test_labeled_continue();
+        test_complex_if_else();
+        foo();
+    }
+}


### PR DESCRIPTION
Fixes ICE when continue/break/return/loop are used as while conditions.

Fixes #3977

The predicate expression must be evaluated before type checking to ensure side effects occur even when the predicate has `Never` type. This prevents skipping function calls, panics, or other side effects in diverging predicates.

### Proof of fix using `-fdump-tree-gimple`

As requested, here is the GIMPLE dump for the test case `while loop {} {}`. It confirms that the infinite loop side-effect is preserved correctly:

```c
__attribute__((cdecl))
struct () test::main ()
{
  struct () D.107;

  <D.101>:
  <D.103>:
  {
    <D.104>:
    {
      <D.102>:
      goto <D.102>; // Side-effect correctly preserved
      if (0 != 0) goto <D.105>; else goto <D.106>;
      <D.106>:
      {

      }
    }
    goto <D.104>;
    <D.105>:
  }
  goto <D.103>;
  return D.107;
}
```
Here is a checklist to help you with your PR.

- \[ ] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[ ] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[ ] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---

*Please write a comment explaining your change. This is the message
that will be part of the merge commit.
