### PR TITLE
gccrs: fix segfault on empty doc attribute

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-base.cc
+++ b/gcc/rust/hir/rust-ast-lower-base.cc
@@ -820,9 +820,17 @@ void
 ASTLoweringBase::handle_doc_item_attribute (const ItemWrapper &,
 					    const AST::Attribute &attr)
 {
-  auto simple_doc_comment = attr.has_attr_input ()
-			    && attr.get_attr_input ().get_attr_input_type ()
-				 == AST::AttrInput::AttrInputType::LITERAL;
+  if (!attr.has_attr_input ())
+    {
+      rust_error_at (attr.get_locus (),
+		     "attribute must be of the form %qs or %qs",
+		     "#[doc(hidden|inline|...)]", "#[doc = string]");
+      return;
+    }
+
+  auto simple_doc_comment = attr.get_attr_input ().get_attr_input_type ()
+			    == AST::AttrInput::AttrInputType::LITERAL;
+
   if (simple_doc_comment)
     return;
 

--- a/gcc/testsuite/rust/compile/issue-4226.rs
+++ b/gcc/testsuite/rust/compile/issue-4226.rs
@@ -1,0 +1,3 @@
+#[doc]
+// { dg-error "attribute must be of the form ...doc.hidden.inline....... or ...doc = string.." "" { target *-*-* } .-1 }
+pub fn a(){}


### PR DESCRIPTION
Fixes Rust-GCC#4266
gcc/rust/ChangeLog:

	* hir/rust-ast-lower-base.cc (ASTLoweringBase::handle_doc_item_attribute): Make error.

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4226.rs: New test.

