### PR TITLE
gccrs: Support generic constant impl items

### DIFF
--- a/gcc/rust/backend/rust-compile-item.cc
+++ b/gcc/rust/backend/rust-compile-item.cc
@@ -109,6 +109,17 @@ CompileItem::visit (HIR::ConstantItem &constant)
   // canonical path
   Resolver::CanonicalPath canonical_path
     = nr_ctx.to_canonical_path (mappings.get_nodeid ());
+  if (constant_type->is<const TyTy::FnType> ())
+    {
+      if (concrete == nullptr)
+	return;
+
+      rust_assert (concrete->get_kind () == TyTy::TypeKind::FNDEF);
+      TyTy::FnType *concrete_fnty = static_cast<TyTy::FnType *> (concrete);
+
+      concrete_fnty->override_context ();
+      constant_type = expr_type = concrete_fnty->get_return_type ();
+    }
 
   ctx->push_const_context ();
   tree const_expr

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -1050,6 +1050,7 @@ public:
   static const uint8_t FNTYPE_IS_METHOD_FLAG = 0x01;
   static const uint8_t FNTYPE_IS_EXTERN_FLAG = 0x02;
   static const uint8_t FNTYPE_IS_VARADIC_FLAG = 0X04;
+  static const uint8_t FNTYPE_IS_SYN_CONST_FLAG = 0X08;
 
   FnType (HirId ref, DefId id, std::string identifier, RustIdent ident,
 	  uint8_t flags, ABI abi, std::vector<FnParam> params, BaseType *type,
@@ -1110,6 +1111,11 @@ public:
   bool is_extern () const { return (flags & FNTYPE_IS_EXTERN_FLAG) != 0; }
 
   bool is_variadic () const { return (flags & FNTYPE_IS_VARADIC_FLAG) != 0; }
+
+  bool is_syn_constant () const
+  {
+    return (flags & FNTYPE_IS_SYN_CONST_FLAG) != 0;
+  }
 
   DefId get_id () const { return id; }
 

--- a/gcc/testsuite/rust/execute/torture/const-generics-5.rs
+++ b/gcc/testsuite/rust/execute/torture/const-generics-5.rs
@@ -1,0 +1,13 @@
+#[lang = "sized"]
+trait Sized {}
+
+struct Foo<const N: usize>;
+
+impl<const N: usize> Foo<N> {
+    const VALUE: usize = N;
+}
+
+fn main() -> i32 {
+    let val = Foo::<7>::VALUE;
+    val as i32 - 7
+}

--- a/gcc/testsuite/rust/execute/torture/const-generics-6.rs
+++ b/gcc/testsuite/rust/execute/torture/const-generics-6.rs
@@ -1,0 +1,15 @@
+#[lang = "sized"]
+trait Sized {}
+
+struct Foo<const N: usize>;
+
+impl<const N: usize> Foo<N> {
+    const VALUE: usize = N;
+    const SQUARE: usize = N * N;
+}
+
+fn main() -> i32 {
+    let a = Foo::<5>::VALUE; // 5
+    let b = Foo::<5>::SQUARE; // 25
+    (a + b) as i32 - 30
+}

--- a/gcc/testsuite/rust/execute/torture/const-generics-7.rs
+++ b/gcc/testsuite/rust/execute/torture/const-generics-7.rs
@@ -1,0 +1,22 @@
+#![feature(intrinsics)]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+mod mem {
+    extern "rust-intrinsic" {
+        #[rustc_const_stable(feature = "const_size_of", since = "1.40.0")]
+        pub fn size_of<T>() -> usize;
+    }
+}
+
+struct Foo<T>;
+
+impl<T> Foo<T> {
+    const MAGIC: usize = mem::size_of::<T>();
+}
+
+fn main() -> i32 {
+    let sz = Foo::<u16>::MAGIC;
+    sz as i32 - 2
+}


### PR DESCRIPTION
Impl items can have constants defined which could in turn be generic this was not supported by gccrs and missed. So for example:
```rust
  impl<T> Foo<T> {
    const MAGIC: usize = mem::size_of::<T>();
  }
```
This is a normal type parameter but in order to setup the generics we need to create a synthetic TyTy::FnType so we can bind the parent's impl generics to the type system and it just works like any other generic item at that point. Then for example we have:
```rust
  impl<const N: usize> Foo<N> {
    const VALUE: usize = N;
  }
```
Again we consistently bind the this const generic parameter the same way so the lazy evaluation of the generic can take place.

gcc/rust/ChangeLog:

	* backend/rust-compile-item.cc (CompileItem::visit): support the synthetic function consts
	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::Resolve): likewise
	* typecheck/rust-hir-type-check-implitem.cc (TypeCheckImplItem::visit): create the synth
	* typecheck/rust-tyty.h: new flag for synthetic constant

gcc/testsuite/ChangeLog:

	* rust/execute/torture/const-generics-5.rs: New test.
	* rust/execute/torture/const-generics-6.rs: New test.
	* rust/execute/torture/const-generics-7.rs: New test.
