### PR TITLE
gccrs: fmt: Skip warnings in Fmt class due to unused devirt method [PR122498]

### DIFF
--- a/gcc/rust/ast/rust-fmt.h
+++ b/gcc/rust/ast/rust-fmt.h
@@ -22,6 +22,10 @@
 #include "rust-system.h"
 #include "optional.h"
 
+// PR122498 "rust-enabled bootstrap is broken after r16-4897"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Warray-bounds"
+
 namespace Rust {
 namespace Fmt {
 
@@ -428,5 +432,8 @@ private:
 
 } // namespace Fmt
 } // namespace Rust
+
+// PR122498 "rust-enabled bootstrap is broken after r16-4897"
+#pragma GCC diagnostic push
 
 #endif // !RUST_FMT_H


### PR DESCRIPTION
Since this warning is not easily fixable, avoid it for now and wait for the underlying issue to be resolved.

gcc/rust/ChangeLog:

	PR rust/122498
	* ast/rust-fmt.h: Add -Warray-bounds pragma to avoid the issue during bootstraps

@tschwinge I moved the pragma location directly to the offending file and added you as co-author. Let me know if you want any changes!