### PR TITLE
gccrs: Fix `compile_float_literal` not compiling negatives properly

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -1712,6 +1712,8 @@ CompileExpr::compile_float_literal (const HIR::LiteralExpr &expr,
       rust_error_at (expr.get_locus (), "bad number in literal");
       return error_mark_node;
     }
+  if (expr.is_negative ())
+    mpfr_neg (fval, fval, MPFR_RNDN);
 
   // taken from:
   // see go/gofrontend/expressions.cc:check_float_type

--- a/gcc/rust/backend/rust-compile-pattern.cc
+++ b/gcc/rust/backend/rust-compile-pattern.cc
@@ -170,9 +170,9 @@ CompilePatternCheckExpr::visit (HIR::RangePattern &pattern)
   bool error_E0579 = false;
   if (TREE_CODE (upper) == REAL_CST)
     {
-      REAL_VALUE_TYPE upper_r = TREE_REAL_CST (upper);
-      REAL_VALUE_TYPE lower_r = TREE_REAL_CST (lower);
-      if (real_compare (GE_EXPR, &lower_r, &upper_r))
+      const REAL_VALUE_TYPE *upper_r = TREE_REAL_CST_PTR (upper);
+      const REAL_VALUE_TYPE *lower_r = TREE_REAL_CST_PTR (lower);
+      if (real_compare (GE_EXPR, lower_r, upper_r))
 	error_E0579 = true;
     }
   else if (TREE_CODE (upper) == INTEGER_CST)

--- a/gcc/testsuite/rust/compile/e0579-neg-float-fail.rs
+++ b/gcc/testsuite/rust/compile/e0579-neg-float-fail.rs
@@ -1,0 +1,9 @@
+#![feature(exclusive_range_pattern)]
+
+fn main() {
+    let x = 1.0;
+
+    match x { // { dg-message "sorry, unimplemented: match on floating-point types is not yet supported" }
+        -1.0f32..-1.2f32 => 2, // { dg-error "lower range bound must be less than upper .E0579." }
+    };
+}

--- a/gcc/testsuite/rust/compile/e0579-neg-float.rs
+++ b/gcc/testsuite/rust/compile/e0579-neg-float.rs
@@ -1,0 +1,9 @@
+#![feature(exclusive_range_pattern)]
+
+fn main() {
+    let x = 1.0;
+
+    match x { // { dg-message "sorry, unimplemented: match on floating-point types is not yet supported" }
+        -1.2f32..-1.0f32 => 2,
+    };
+}


### PR DESCRIPTION
Follow up from my comment in an earlier PR: https://github.com/Rust-GCC/gccrs/pull/4243#discussion_r2464306007

> Anyways, `1.0f32..1.2f32` compiles properly and does not trigger E0579 but ` -1.2f32..-1.0f32` triggers E0579... not sure what went wrong here :/

This is a *very, very subtle* bug that took me quite a while to debug, I'm very surprised none of our tests were able to catch `compile_float_literal` compiling negatives wrongly.

Edit for more context:

Previously, using `-1.2f32..-1.0f32` as a pattern match arm throws E0579 "lower range bound must be less than upper", which is incorrect because -1.2 < -1.0. Meanwhile, `-1.0f32..-1.2f32` does not throw that error, which is also incorrect. This is due to `compile_float_literal` not taking `is_negative()` into account during code gen, so this PR aims to fix that.