### PR TITLE
Use tl::expected in the parser to avoid error state

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -477,37 +477,20 @@ private:
   SimplePath in_path;
   location_t locus;
 
-  // should this store location info?
-
-public:
-  // Creates a Visibility - TODO make constructor protected or private?
   Visibility (VisType vis_type, SimplePath in_path, location_t locus)
     : vis_type (vis_type), in_path (std::move (in_path)), locus (locus)
   {}
 
+public:
   VisType get_vis_type () const { return vis_type; }
 
-  // Returns whether visibility is in an error state.
-  bool is_error () const
-  {
-    return vis_type == PUB_IN_PATH && in_path.is_empty ();
-  }
-
   // Returns whether a visibility has a path
-  bool has_path () const { return !is_error () && vis_type >= PUB_CRATE; }
+  bool has_path () const { return vis_type >= PUB_CRATE; }
 
   // Returns whether visibility is public or not.
-  bool is_public () const { return vis_type != PRIV && !is_error (); }
+  bool is_public () const { return vis_type != PRIV; }
 
   location_t get_locus () const { return locus; }
-
-  // empty?
-  // Creates an error visibility.
-  static Visibility create_error ()
-  {
-    return Visibility (PUB_IN_PATH, SimplePath::create_empty (),
-		       UNDEF_LOCATION);
-  }
 
   // Unique pointer custom clone function
   /*std::unique_ptr<Visibility> clone_visibility() const {

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -814,7 +814,7 @@ public:
   // Loaded module constructor, with items
   Module (Identifier name, location_t locus,
 	  std::vector<std::unique_ptr<Item>> items,
-	  Visibility visibility = Visibility::create_error (),
+	  Visibility visibility = Visibility::create_private (),
 	  Unsafety safety = Unsafety::Normal,
 	  std::vector<Attribute> inner_attrs = std::vector<Attribute> (),
 	  std::vector<Attribute> outer_attrs = std::vector<Attribute> ())
@@ -1743,7 +1743,7 @@ public:
   bool has_outer_attributes () const { return !outer_attrs.empty (); }
 
   // Returns whether struct field has a non-private (non-default) visibility.
-  bool has_visibility () const { return !visibility.is_error (); }
+  bool has_visibility () const { return true; }
 
   StructField (Identifier field_name, std::unique_ptr<Type> field_type,
 	       Visibility vis, location_t locus,
@@ -1797,8 +1797,8 @@ public:
   // Creates an error state struct field.
   static StructField create_error ()
   {
-    return StructField (std::string (""), nullptr, Visibility::create_error (),
-			UNDEF_LOCATION);
+    return StructField (std::string (""), nullptr,
+			Visibility::create_private (), UNDEF_LOCATION);
   }
 
   std::string as_string () const;
@@ -1902,7 +1902,7 @@ public:
 
   /* Returns whether tuple field has a non-default visibility (i.e. a public
    * one) */
-  bool has_visibility () const { return !visibility.is_error (); }
+  bool has_visibility () const { return true; }
 
   // Complete constructor
   TupleField (std::unique_ptr<Type> field_type, Visibility vis,
@@ -1952,7 +1952,7 @@ public:
   // Creates an error state tuple field.
   static TupleField create_error ()
   {
-    return TupleField (nullptr, Visibility::create_error (), UNDEF_LOCATION);
+    return TupleField (nullptr, Visibility::create_private (), UNDEF_LOCATION);
   }
 
   std::string as_string () const;
@@ -3389,7 +3389,7 @@ public:
   bool has_outer_attrs () const { return !outer_attrs.empty (); }
 
   // Returns whether item has non-default visibility.
-  bool has_visibility () const { return !visibility.is_error (); }
+  bool has_visibility () const { return true; }
 
   location_t get_locus () const { return locus; }
 
@@ -3481,7 +3481,7 @@ public:
   bool has_outer_attrs () const { return !outer_attrs.empty (); }
 
   // Returns whether item has non-default visibility.
-  bool has_visibility () const { return !visibility.is_error (); }
+  bool has_visibility () const { return true; }
 
   location_t get_locus () const { return locus; }
 

--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -529,7 +529,7 @@ public:
     return std::make_unique<MacroRulesDefinition> (
       MacroRulesDefinition (rule_name, delim_type, rules, outer_attrs, locus,
 			    AST::MacroRulesDefinition::MacroKind::MBE,
-			    AST::Visibility::create_error ()));
+			    AST::Visibility::create_private ()));
   }
 
   static std::unique_ptr<MacroRulesDefinition>

--- a/gcc/rust/expand/rust-macro-builtins-include.cc
+++ b/gcc/rust/expand/rust-macro-builtins-include.cc
@@ -248,7 +248,8 @@ MacroBuiltin::include_handler (location_t invoc_locus,
   std::vector<std::unique_ptr<AST::Item>> parsed_items{};
 
   if (is_semicoloned)
-    parsed_items = parser.parse_items ();
+    parsed_items = parser.parse_items ().value_or (
+      std::vector<std::unique_ptr<AST::Item>>{});
   else
     parsed_expr = parser.parse_expr ();
 

--- a/gcc/rust/expand/rust-macro-builtins-offset-of.cc
+++ b/gcc/rust/expand/rust-macro-builtins-offset-of.cc
@@ -56,7 +56,7 @@ MacroBuiltin::offset_of_handler (location_t invoc_locus,
   parser.skip_token (COMMA);
 
   auto field_tok = parser.parse_identifier_or_keyword_token ();
-  auto invalid_field = !field_tok || !field_tok->should_have_str ();
+  auto invalid_field = !field_tok || !field_tok.value ()->should_have_str ();
 
   if (invalid_field)
     rust_error_at (invoc_locus, "could not parse field argument for %qs",
@@ -65,7 +65,7 @@ MacroBuiltin::offset_of_handler (location_t invoc_locus,
   if (!type || invalid_field)
     return tl::nullopt;
 
-  auto field = Identifier (field_tok->get_str ());
+  auto field = Identifier (field_tok.value ()->get_str ());
 
   // FIXME: Do we need to do anything to handle the optional comma at the end?
   parser.maybe_skip_token (COMMA);

--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -858,7 +858,9 @@ transcribe_many_items (Parser<MacroInvocLexer> &parser, TokenId &delimiter)
 {
   return parse_many (parser, delimiter, [&parser] () {
     auto item = parser.parse_item (true);
-    return AST::SingleASTNode (std::move (item));
+    if (!item)
+      return AST::SingleASTNode (std::unique_ptr<AST::Item> (nullptr));
+    return AST::SingleASTNode (std::move (item.value ()));
   });
 }
 
@@ -1191,9 +1193,9 @@ MacroExpander::parse_proc_macro_output (ProcMacro::TokenStream ts)
       while (lex.peek_token ()->get_id () != END_OF_FILE)
 	{
 	  auto result = parser.parse_item (false);
-	  if (result == nullptr)
+	  if (!result)
 	    break;
-	  nodes.emplace_back (std::move (result));
+	  nodes.emplace_back (std::move (result.value ()));
 	}
       break;
     case ContextType::STMT:

--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -38,8 +38,6 @@ translate_visibility (const AST::Visibility &vis)
   // the AST vis is an error?
   // FIXME: We need to add a `create_private()` static function to the
   // AST::Visibility class and use it when the vis is empty in the parser...
-  if (vis.is_error ())
-    return Visibility::create_error ();
 
   switch (vis.get_vis_type ())
     {
@@ -57,7 +55,7 @@ translate_visibility (const AST::Visibility &vis)
       break;
     }
 
-  return Visibility::create_error ();
+  rust_unreachable ();
 }
 
 ASTLowering::ASTLowering (AST::Crate &astCrate) : astCrate (astCrate) {}

--- a/gcc/rust/parse/rust-parse-error.h
+++ b/gcc/rust/parse/rust-parse-error.h
@@ -1,0 +1,326 @@
+// Copyright (C) 2025 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_PARSE_ERROR_H
+#define RUST_PARSE_ERROR_H
+
+#include "expected.h"
+#include "rust-ast.h"
+#include "rust-parse-utils.h"
+
+namespace Rust {
+namespace Parse {
+namespace Error {
+
+struct Attribute
+{
+  static tl::expected<AST::Attribute, Attribute> make_malformed ()
+  {
+    return tl::unexpected<Attribute> (Attribute (Kind::MALFORMED));
+  }
+
+  static tl::expected<AST::Attribute, Attribute> make_malformed_body ()
+  {
+    return tl::unexpected<Attribute> (Attribute (Kind::MALFORMED_BODY));
+  }
+
+  static tl::expected<AST::Attribute, Attribute> make_unexpected_inner ()
+  {
+    return tl::unexpected<Attribute> (Attribute (Kind::UNEXPECTED_INNER));
+  }
+
+  enum class Kind
+  {
+    MALFORMED,
+    MALFORMED_BODY,
+    UNEXPECTED_INNER,
+  } kind;
+
+private:
+  Attribute (Kind kind) : kind (kind) {}
+};
+
+struct SimplePath
+{
+  static tl::expected<AST::SimplePath, SimplePath> make_malformed ()
+  {
+    return tl::unexpected<SimplePath> (SimplePath (Kind::MALFORMED));
+  }
+
+  enum class Kind
+  {
+    MALFORMED,
+  } kind;
+
+private:
+  SimplePath (Kind kind) : kind (kind) {}
+};
+
+struct AttributeBody
+{
+  static tl::expected<Parse::AttributeBody, AttributeBody> make_invalid_path ()
+  {
+    return tl::unexpected<AttributeBody> (AttributeBody (Kind::INVALID_PATH));
+  }
+
+  static tl::expected<Parse::AttributeBody, AttributeBody>
+  make_invalid_attrinput ()
+  {
+    return tl::unexpected<AttributeBody> (
+      AttributeBody (Kind::INVALID_ATTRINPUT));
+  }
+
+  enum class Kind
+  {
+    INVALID_PATH,
+    INVALID_ATTRINPUT,
+  } kind;
+
+private:
+  AttributeBody (Kind kind) : kind (kind) {}
+};
+
+struct SimplePathSegment
+{
+  static tl::expected<AST::SimplePathSegment, SimplePathSegment>
+  make_invalid_token_or_path_end ()
+  {
+    return tl::unexpected<SimplePathSegment> (
+      SimplePathSegment (Kind::INVALID_SIMPLE_PATH_TOKEN));
+  }
+
+  enum class Kind
+  {
+    /* Invalid token found whilst parsing a simple path segment, could be an
+       error or the end of the path */
+    INVALID_SIMPLE_PATH_TOKEN,
+  } kind;
+
+private:
+  SimplePathSegment (Kind kind) : kind (kind) {}
+};
+
+struct PathIdentSegment
+{
+  static tl::expected<AST::PathIdentSegment, PathIdentSegment>
+  make_invalid_token ()
+  {
+    return tl::unexpected<PathIdentSegment> (
+      PathIdentSegment (Kind::INVALID_PATH_IDENT_TOKEN));
+  }
+
+  enum class Kind
+  {
+    INVALID_PATH_IDENT_TOKEN,
+  } kind;
+
+private:
+  PathIdentSegment (Kind kind) : kind (kind) {}
+};
+
+struct AttrInput
+{
+  static tl::expected<std::unique_ptr<AST::AttrInput>, AttrInput>
+  make_malformed ()
+  {
+    return tl::unexpected<AttrInput> (AttrInput (Kind::MALFORMED));
+  }
+
+  static tl::expected<std::unique_ptr<AST::AttrInput>, AttrInput>
+  make_bad_macro_invocation ()
+  {
+    return tl::unexpected<AttrInput> (AttrInput (Kind::BAD_MACRO_INVOCATION));
+  }
+
+  static tl::expected<std::unique_ptr<AST::AttrInput>, AttrInput>
+  make_missing_attrinput ()
+  {
+    return tl::unexpected<AttrInput> (AttrInput (Kind::MISSING));
+  }
+
+  static tl::expected<std::unique_ptr<AST::AttrInput>, AttrInput>
+  make_bad_token_tree ()
+  {
+    return tl::unexpected<AttrInput> (AttrInput (Kind::BAD_TOKEN_TREE));
+  }
+
+  enum class Kind
+  {
+    MALFORMED,
+    BAD_MACRO_INVOCATION,
+    BAD_TOKEN_TREE,
+    // Not an hard error in some context
+    MISSING,
+  } kind;
+
+private:
+  AttrInput (Kind kind) : kind (kind) {}
+};
+
+struct DelimTokenTree
+{
+  static tl::expected<AST::DelimTokenTree, DelimTokenTree>
+  make_expected_delimiter ()
+  {
+    return tl::unexpected<DelimTokenTree> (
+      DelimTokenTree (Kind::EXPECTED_DELIMITER));
+  }
+
+  static tl::expected<AST::DelimTokenTree, DelimTokenTree>
+  make_invalid_token_tree ()
+  {
+    return tl::unexpected<DelimTokenTree> (
+      DelimTokenTree (Kind::INVALID_TOKEN_TREE));
+  }
+
+  static tl::expected<AST::DelimTokenTree, DelimTokenTree>
+  make_mismatched_delimiters ()
+  {
+    return tl::unexpected<DelimTokenTree> (
+      DelimTokenTree (Kind::INVALID_TOKEN_TREE));
+  }
+
+  enum class Kind
+  {
+    EXPECTED_DELIMITER,
+    INVALID_TOKEN_TREE,
+    MISMATCHED_DELIMITERS,
+  } kind;
+
+private:
+  DelimTokenTree (Kind kind) : kind (kind) {}
+};
+
+struct Token
+{
+  static tl::expected<std::unique_ptr<AST::Token>, Token> make_malformed ()
+  {
+    return tl::unexpected<Token> (Token (Kind::MALFORMED));
+  }
+
+  enum class Kind
+  {
+    MALFORMED,
+  } kind;
+
+private:
+  Token (Kind kind) : kind (kind) {}
+};
+
+struct TokenTree
+{
+  static tl::expected<std::unique_ptr<AST::TokenTree>, TokenTree>
+  make_malformed ()
+  {
+    return tl::unexpected<TokenTree> (TokenTree (Kind::MALFORMED));
+  }
+
+  static tl::expected<std::unique_ptr<AST::TokenTree>, TokenTree>
+  make_malformed_delimited_token_tree ()
+  {
+    return tl::unexpected<TokenTree> (
+      TokenTree (Kind::MALFORMED_DELIMITED_TOKEN_TREE));
+  }
+
+  enum class Kind
+  {
+    MALFORMED,
+    MALFORMED_DELIMITED_TOKEN_TREE,
+  } kind;
+
+private:
+  TokenTree (Kind kind) : kind (kind) {}
+};
+
+struct Item
+{
+  static tl::expected<std::unique_ptr<AST::Item>, Item> make_end_of_file ()
+  {
+    return tl::unexpected<Item> (Item (Kind::END_OF_FILE));
+  }
+
+  static tl::expected<std::unique_ptr<AST::Item>, Item> make_malformed ()
+  {
+    return tl::unexpected<Item> (Item (Kind::MALFORMED));
+  }
+
+  enum class Kind
+  {
+    END_OF_FILE,
+    MALFORMED,
+  } kind;
+
+private:
+  Item (Kind kind) : kind (kind) {}
+};
+
+struct Items
+{
+  static tl::expected<std::vector<std::unique_ptr<AST::Item>>, Items>
+  make_malformed (std::vector<std::unique_ptr<AST::Item>> items)
+  {
+    return tl::unexpected<Items> (Items (Kind::MALFORMED, std::move (items)));
+  }
+
+  enum class Kind
+  {
+    MALFORMED,
+  } kind;
+
+  Items (Items const &) = delete;
+  Items &operator= (Items const &) = delete;
+
+  Items (Items &&items) = default;
+  Items &operator= (Items &&) = default;
+
+  // Should we do anything with valid items ?
+  std::vector<std::unique_ptr<AST::Item>> items;
+
+private:
+  Items (Kind kind, std::vector<std::unique_ptr<AST::Item>> items)
+    : kind (kind), items (std::move (items))
+  {}
+};
+
+struct Visibility
+{
+  static tl::expected<AST::Visibility, Visibility> make_malformed ()
+  {
+    return tl::unexpected<Visibility> (Visibility (Kind::MALFORMED));
+  }
+
+  static tl::expected<AST::Visibility, Visibility> make_missing_path ()
+  {
+    return tl::unexpected<Visibility> (Visibility (Kind::MISSING_PATH));
+  }
+
+  enum class Kind
+  {
+    MISSING_PATH,
+    MALFORMED,
+  } kind;
+
+private:
+  Visibility (Kind kind) : kind (kind) {}
+};
+
+} // namespace Error
+} // namespace Parse
+} // namespace Rust
+
+#endif /* !RUST_PARSE_ERROR_H */

--- a/gcc/rust/parse/rust-parse-impl-proc-macro.cc
+++ b/gcc/rust/parse/rust-parse-impl-proc-macro.cc
@@ -21,7 +21,7 @@
 
 namespace Rust {
 
-template std::unique_ptr<AST::Item>
+template tl::expected<std::unique_ptr<AST::Item>, Parse::Error::Item>
 Parser<ProcMacroInvocLexer>::parse_item (bool);
 
 template std::unique_ptr<AST::Stmt>

--- a/gcc/rust/parse/rust-parse-utils.h
+++ b/gcc/rust/parse/rust-parse-utils.h
@@ -1,0 +1,73 @@
+
+// Copyright (C) 2025 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_PARSE_UTILS_H
+#define RUST_PARSE_UTILS_H
+
+#include "rust-ast.h"
+
+namespace Rust {
+namespace Parse {
+/* Utility structure to return members of an attribute body, was initially a
+ * tuple but tuples are ugly*/
+struct AttributeBody
+{
+  AST::SimplePath path;
+  std::unique_ptr<AST::AttrInput> input;
+  location_t locus;
+};
+
+namespace Utils {
+
+/* Returns true if the token id matches the delimiter type. Note that this only
+ * operates for END delimiter tokens. */
+inline bool
+token_id_matches_delims (TokenId token_id, AST::DelimType delim_type)
+{
+  return ((token_id == RIGHT_PAREN && delim_type == AST::PARENS)
+	  || (token_id == RIGHT_SQUARE && delim_type == AST::SQUARE)
+	  || (token_id == RIGHT_CURLY && delim_type == AST::CURLY));
+}
+
+/* Determines whether token is a valid simple path segment. This does not
+ * include scope resolution operators. */
+inline bool
+is_simple_path_segment (TokenId id)
+{
+  switch (id)
+    {
+    case IDENTIFIER:
+    case SUPER:
+    case SELF:
+    case CRATE:
+      return true;
+    case DOLLAR_SIGN:
+      // assume that dollar sign leads to $crate
+      return true;
+    default:
+      return false;
+    }
+}
+
+} // namespace Utils
+
+} // namespace Parse
+} // namespace Rust
+
+#endif /* !RUST_PARSE_UTILS_H */

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -873,7 +873,7 @@ Session::injection (AST::Crate &crate)
 
       // create "extern crate" item with the name
       std::unique_ptr<AST::ExternCrate> extern_crate (
-	new AST::ExternCrate (*it, AST::Visibility::create_error (),
+	new AST::ExternCrate (*it, AST::Visibility::create_private (),
 			      {std::move (attr)}, UNKNOWN_LOCATION));
 
       // insert at beginning

--- a/gcc/testsuite/rust/compile/macros/mbe/macro-issue3608.rs
+++ b/gcc/testsuite/rust/compile/macros/mbe/macro-issue3608.rs
@@ -6,5 +6,3 @@ impl Bar for
 
 
 fn main() { )// { dg-error "unexpected closing delimiter .\\)." }
-             // { dg-error "unexpected token .end of file. - expecting closing delimiter .\}. .for a delimited token tree." "" { target *-*-* } .+2 }
-             // { dg-error "unexpected token .end of file. - expecting closing delimiter .\\). .for a macro invocation semi." "" { target *-*-* } .+1 }


### PR DESCRIPTION
We made heavy use of error state within some AST node and it was the source of multiple errors, and caused confusion with (null) pointers. This commit removes some error state usage within our parser in an attempt to remove those error states later.