### PR TITLE
Implement unused mut lint

### DIFF
--- a/gcc/rust/checks/lints/unused/rust-unused-checker.cc
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.cc
@@ -76,6 +76,12 @@ UnusedChecker::visit (HIR::IdentifierPattern &pattern)
     rust_warning_at (pattern.get_locus (), OPT_Wunused_variable,
 		     "unused variable %qs",
 		     pattern.get_identifier ().as_string ().c_str ());
+
+  if (pattern.is_mut () && !unused_context.is_mut_used (id)
+      && var_name != Values::Keywords::SELF && var_name[0] != '_')
+    rust_warning_at (pattern.get_locus (), OPT_Wunused_variable,
+		     "unused mut %qs",
+		     pattern.get_identifier ().as_string ().c_str ());
 }
 void
 
@@ -92,5 +98,24 @@ UnusedChecker::visit (HIR::AssignmentExpr &expr)
     rust_warning_at (lhs.get_locus (), OPT_Wunused_variable,
 		     "unused assignment %qs", var_name.c_str ());
 }
+
+void
+UnusedChecker::visit (HIR::StructPatternFieldIdent &pattern)
+{
+  std::string var_name = pattern.get_identifier ().as_string ();
+  auto id = pattern.get_mappings ().get_hirid ();
+  if (!unused_context.is_variable_used (id)
+      && var_name != Values::Keywords::SELF && var_name[0] != '_')
+    rust_warning_at (pattern.get_locus (), OPT_Wunused_variable,
+		     "unused variable %qs",
+		     pattern.get_identifier ().as_string ().c_str ());
+
+  if (pattern.is_mut () && !unused_context.is_mut_used (id)
+      && var_name != Values::Keywords::SELF && var_name[0] != '_')
+    rust_warning_at (pattern.get_locus (), OPT_Wunused_variable,
+		     "unused mut %qs",
+		     pattern.get_identifier ().as_string ().c_str ());
+}
+
 } // namespace Analysis
 } // namespace Rust

--- a/gcc/rust/checks/lints/unused/rust-unused-checker.h
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.h
@@ -42,6 +42,7 @@ private:
   virtual void visit (HIR::StaticItem &item) override;
   virtual void visit (HIR::IdentifierPattern &identifier) override;
   virtual void visit (HIR::AssignmentExpr &identifier) override;
+  virtual void visit (HIR::StructPatternFieldIdent &identifier) override;
 };
 } // namespace Analysis
 } // namespace Rust

--- a/gcc/rust/checks/lints/unused/rust-unused-collector.cc
+++ b/gcc/rust/checks/lints/unused/rust-unused-collector.cc
@@ -58,14 +58,34 @@ UnusedCollector::visit (HIR::StructExprFieldIdentifier &ident)
   mark_path_used (ident);
   walk (ident);
 }
+
 void
 UnusedCollector::visit (HIR::AssignmentExpr &expr)
 {
   auto def_id = get_def_id (expr.get_lhs ());
   HirId id = expr.get_lhs ().get_mappings ().get_hirid ();
+  unused_context.remove_mut (def_id);
   unused_context.add_assign (def_id, id);
   visit_outer_attrs (expr);
   expr.get_rhs ().accept_vis (*this);
+}
+
+void
+UnusedCollector::visit (HIR::IdentifierPattern &pattern)
+{
+  if (pattern.is_mut ())
+    unused_context.add_mut (pattern.get_mappings ().get_hirid ());
+
+  walk (pattern);
+}
+
+void
+UnusedCollector::visit (HIR::StructPatternFieldIdent &pattern)
+{
+  if (pattern.is_mut ())
+    unused_context.add_mut (pattern.get_mappings ().get_hirid ());
+
+  walk (pattern);
 }
 
 } // namespace Analysis

--- a/gcc/rust/checks/lints/unused/rust-unused-collector.h
+++ b/gcc/rust/checks/lints/unused/rust-unused-collector.h
@@ -38,10 +38,18 @@ private:
   UnusedContext &unused_context;
 
   using HIR::DefaultHIRVisitor::visit;
+
+  // Unused var
   virtual void visit (HIR::PathInExpression &expr) override;
   virtual void visit (HIR::StructExprFieldIdentifier &ident) override;
   virtual void visit (HIR::QualifiedPathInExpression &expr) override;
+
+  // Unused assignments
   virtual void visit (HIR::AssignmentExpr &expr) override;
+
+  // Unused mut
+  virtual void visit (HIR::IdentifierPattern &pattern) override;
+  virtual void visit (HIR::StructPatternFieldIdent &pattern) override;
 
   template <typename T> HirId get_def_id (T &path_expr)
   {

--- a/gcc/rust/checks/lints/unused/rust-unused-context.cc
+++ b/gcc/rust/checks/lints/unused/rust-unused-context.cc
@@ -46,12 +46,31 @@ UnusedContext::remove_assign (HirId id_def)
   if (assigned_vars.find (id_def) != assigned_vars.end ())
     assigned_vars[id_def].pop_back ();
 }
+
 bool
 UnusedContext::is_variable_assigned (HirId id_def, HirId id)
 {
   auto assigned_vec = assigned_vars[id_def];
   return std::find (assigned_vec.begin (), assigned_vec.end (), id)
 	 != assigned_vec.end ();
+}
+
+void
+UnusedContext::add_mut (HirId id)
+{
+  mutable_vars.emplace (id);
+}
+
+void
+UnusedContext::remove_mut (HirId id)
+{
+  mutable_vars.erase (id);
+}
+
+bool
+UnusedContext::is_mut_used (HirId id) const
+{
+  return mutable_vars.find (id) == mutable_vars.end ();
 }
 
 std::string

--- a/gcc/rust/checks/lints/unused/rust-unused-context.h
+++ b/gcc/rust/checks/lints/unused/rust-unused-context.h
@@ -24,16 +24,24 @@ namespace Analysis {
 class UnusedContext
 {
 public:
+  // Unused var
   void add_variable (HirId id);
   bool is_variable_used (HirId id) const;
+
+  // Assigned var
   void add_assign (HirId id_def, HirId id);
   void remove_assign (HirId id_def);
   bool is_variable_assigned (HirId id_def, HirId id);
 
+  // Mutable var
+  void add_mut (HirId id);
+  void remove_mut (HirId id);
+  bool is_mut_used (HirId id) const;
   std::string as_string () const;
 
 private:
   std::unordered_set<HirId> used_vars;
+  std::unordered_set<HirId> mutable_vars;
   std::map<HirId, std::vector<HirId>> assigned_vars;
 };
 

--- a/gcc/testsuite/rust/compile/unused-mut-identifier_0.rs
+++ b/gcc/testsuite/rust/compile/unused-mut-identifier_0.rs
@@ -1,0 +1,6 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+pub fn a() ->i32 {
+    let mut x = 2;
+// { dg-warning "unused mut .x." "" { target *-*-* } .-1 }
+    return x
+}

--- a/gcc/testsuite/rust/compile/unused-mut-struct-field_0.rs
+++ b/gcc/testsuite/rust/compile/unused-mut-struct-field_0.rs
@@ -1,0 +1,17 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+struct Point { x: i32, y: i32 }
+// { dg-warning "field is never read: .x." "" { target *-*-* } .-1 }
+// { dg-warning "field is never read: .y." "" { target *-*-* } .-2 }
+
+pub fn main() -> (i32, i32){
+    let p = Point { x: 1, y: 2 };
+
+    match p {
+        Point { mut x, mut y } => {
+// { dg-warning "unused mut .x." "" { target *-*-* } .-1 }
+// { dg-warning "unused mut .y." "" { target *-*-* } .-2 }
+            return (x,y)
+        }
+    }
+}
+


### PR DESCRIPTION
This PR implements unused mut lint, it uses the hir default visitor and visit IdentifierPattern and StructPatternFieldIdent, to add to a map of mutable vars in the lint unused context.


Requires https://github.com/Rust-GCC/gccrs/pull/4285