### PR TITLE
gccrs: Add support for initial generic associated types

### DIFF
--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -3050,6 +3050,18 @@ TraitItemType::as_string () const
 
   str += "\ntype " + name.as_string ();
 
+  if (has_generics ())
+    {
+      str += "<";
+      for (size_t i = 0; i < generic_params.size (); i++)
+	{
+	  if (i > 0)
+	    str += ", ";
+	  str += generic_params[i]->as_string ();
+	}
+      str += ">";
+    }
+
   str += "\n Type param bounds: ";
   if (!has_type_param_bounds ())
     {

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -1891,7 +1891,6 @@ public:
   {
     parsed_items = std::move (new_items);
   }
-  // TODO: mutable getter seems kinda dodgy
   std::vector<std::unique_ptr<MetaItemInner>> &get_meta_items ()
   {
     return parsed_items;

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -2726,21 +2726,28 @@ class TraitItemType : public TraitItem
 
   Identifier name;
 
+  // Generic parameters for GATs (Generic Associated Types)
+  std::vector<std::unique_ptr<GenericParam>> generic_params;
+
   // bool has_type_param_bounds;
   // TypeParamBounds type_param_bounds;
   std::vector<std::unique_ptr<TypeParamBound>>
     type_param_bounds; // inlined form
 
 public:
+  bool has_generics () const { return !generic_params.empty (); }
+
   // Returns whether trait item type has type param bounds.
   bool has_type_param_bounds () const { return !type_param_bounds.empty (); }
 
   TraitItemType (Identifier name,
+		 std::vector<std::unique_ptr<GenericParam>> generic_params,
 		 std::vector<std::unique_ptr<TypeParamBound>> type_param_bounds,
 		 std::vector<Attribute> outer_attrs, Visibility vis,
 		 location_t locus)
     : TraitItem (vis, locus), outer_attrs (std::move (outer_attrs)),
-      name (std::move (name)), type_param_bounds (std::move (type_param_bounds))
+      name (std::move (name)), generic_params (std::move (generic_params)),
+      type_param_bounds (std::move (type_param_bounds))
   {}
 
   // Copy constructor with vector clone
@@ -2749,6 +2756,9 @@ public:
       name (other.name)
   {
     node_id = other.node_id;
+    generic_params.reserve (other.generic_params.size ());
+    for (const auto &e : other.generic_params)
+      generic_params.push_back (e->clone_generic_param ());
     type_param_bounds.reserve (other.type_param_bounds.size ());
     for (const auto &e : other.type_param_bounds)
       type_param_bounds.push_back (e->clone_type_param_bound ());
@@ -2763,6 +2773,9 @@ public:
     locus = other.locus;
     node_id = other.node_id;
 
+    generic_params.reserve (other.generic_params.size ());
+    for (const auto &e : other.generic_params)
+      generic_params.push_back (e->clone_generic_param ());
     type_param_bounds.reserve (other.type_param_bounds.size ());
     for (const auto &e : other.type_param_bounds)
       type_param_bounds.push_back (e->clone_type_param_bound ());
@@ -2786,7 +2799,15 @@ public:
   std::vector<Attribute> &get_outer_attrs () { return outer_attrs; }
   const std::vector<Attribute> &get_outer_attrs () const { return outer_attrs; }
 
-  // TODO: mutable getter seems kinda dodgy
+  std::vector<std::unique_ptr<GenericParam>> &get_generic_params ()
+  {
+    return generic_params;
+  }
+  const std::vector<std::unique_ptr<GenericParam>> &get_generic_params () const
+  {
+    return generic_params;
+  }
+
   std::vector<std::unique_ptr<TypeParamBound>> &get_type_param_bounds ()
   {
     return type_param_bounds;

--- a/gcc/rust/ast/rust-type.h
+++ b/gcc/rust/ast/rust-type.h
@@ -177,7 +177,6 @@ public:
 
   void accept_vis (ASTVisitor &vis) override;
 
-  // TODO: mutable getter seems kinda dodgy
   std::vector<std::unique_ptr<TypeParamBound> > &get_type_param_bounds ()
   {
     return type_param_bounds;
@@ -250,7 +249,6 @@ public:
 
   bool is_dyn () const { return has_dyn; }
 
-  // TODO: mutable getter seems kinda dodgy
   std::vector<std::unique_ptr<TypeParamBound> > &get_type_param_bounds ()
   {
     return type_param_bounds;
@@ -463,7 +461,6 @@ public:
 
   void accept_vis (ASTVisitor &vis) override;
 
-  // TODO: mutable getter seems kinda dodgy
   std::vector<std::unique_ptr<Type> > &get_elems () { return elems; }
   const std::vector<std::unique_ptr<Type> > &get_elems () const
   {

--- a/gcc/rust/hir/tree/rust-hir-item.cc
+++ b/gcc/rust/hir/tree/rust-hir-item.cc
@@ -716,17 +716,21 @@ TraitItemConst::operator= (TraitItemConst const &other)
 
 TraitItemType::TraitItemType (
   Analysis::NodeMapping mappings, Identifier name,
+  std::vector<std::unique_ptr<GenericParam>> generic_params,
   std::vector<std::unique_ptr<TypeParamBound>> type_param_bounds,
   AST::AttrVec outer_attrs, location_t locus)
   : TraitItem (mappings), outer_attrs (std::move (outer_attrs)),
-    name (std::move (name)), type_param_bounds (std::move (type_param_bounds)),
-    locus (locus)
+    name (std::move (name)), generic_params (std::move (generic_params)),
+    type_param_bounds (std::move (type_param_bounds)), locus (locus)
 {}
 
 TraitItemType::TraitItemType (TraitItemType const &other)
   : TraitItem (other.mappings), outer_attrs (other.outer_attrs),
     name (other.name), locus (other.locus)
 {
+  generic_params.reserve (other.generic_params.size ());
+  for (const auto &e : other.generic_params)
+    generic_params.push_back (e->clone_generic_param ());
   type_param_bounds.reserve (other.type_param_bounds.size ());
   for (const auto &e : other.type_param_bounds)
     type_param_bounds.push_back (e->clone_type_param_bound ());
@@ -741,6 +745,9 @@ TraitItemType::operator= (TraitItemType const &other)
   locus = other.locus;
   mappings = other.mappings;
 
+  generic_params.reserve (other.generic_params.size ());
+  for (const auto &e : other.generic_params)
+    generic_params.push_back (e->clone_generic_param ());
   type_param_bounds.reserve (other.type_param_bounds.size ());
   for (const auto &e : other.type_param_bounds)
     type_param_bounds.push_back (e->clone_type_param_bound ());

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -2121,15 +2121,20 @@ class TraitItemType : public TraitItem
   AST::AttrVec outer_attrs;
 
   Identifier name;
+  // Generic parameters for GATs (Generic Associated Types)
+  std::vector<std::unique_ptr<GenericParam>> generic_params;
   std::vector<std::unique_ptr<TypeParamBound>>
     type_param_bounds; // inlined form
   location_t locus;
 
 public:
+  bool has_generics () const { return !generic_params.empty (); }
+
   // Returns whether trait item type has type param bounds.
   bool has_type_param_bounds () const { return !type_param_bounds.empty (); }
 
   TraitItemType (Analysis::NodeMapping mappings, Identifier name,
+		 std::vector<std::unique_ptr<GenericParam>> generic_params,
 		 std::vector<std::unique_ptr<TypeParamBound>> type_param_bounds,
 		 AST::AttrVec outer_attrs, location_t locus);
 
@@ -2151,6 +2156,15 @@ public:
   void accept_vis (HIRTraitItemVisitor &vis) override;
 
   Identifier get_name () const { return name; }
+
+  std::vector<std::unique_ptr<GenericParam>> &get_generic_params ()
+  {
+    return generic_params;
+  }
+  const std::vector<std::unique_ptr<GenericParam>> &get_generic_params () const
+  {
+    return generic_params;
+  }
 
   std::vector<std::unique_ptr<TypeParamBound>> &get_type_param_bounds ()
   {

--- a/gcc/rust/hir/tree/rust-hir.cc
+++ b/gcc/rust/hir/tree/rust-hir.cc
@@ -3582,6 +3582,18 @@ TraitItemType::as_string () const
 
   str += "\ntype " + name.as_string ();
 
+  if (has_generics ())
+    {
+      str += "<";
+      for (size_t i = 0; i < generic_params.size (); i++)
+	{
+	  if (i > 0)
+	    str += ", ";
+	  str += generic_params[i]->as_string ();
+	}
+      str += ">";
+    }
+
   str += "\n Type param bounds: ";
   if (!has_type_param_bounds ())
     {

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -5221,6 +5221,13 @@ Parser<ManagedTokenSource>::parse_trait_type (AST::AttrVec outer_attrs,
 
   Identifier ident{ident_tok};
 
+  // Parse optional generic parameters for GATs (Generic Associated Types)
+  std::vector<std::unique_ptr<AST::GenericParam>> generic_params;
+  if (lexer.peek_token ()->get_id () == LEFT_ANGLE)
+    {
+      generic_params = parse_generic_params_in_angles ();
+    }
+
   std::vector<std::unique_ptr<AST::TypeParamBound>> bounds;
 
   // parse optional colon
@@ -5241,8 +5248,9 @@ Parser<ManagedTokenSource>::parse_trait_type (AST::AttrVec outer_attrs,
     }
 
   return std::unique_ptr<AST::TraitItemType> (
-    new AST::TraitItemType (std::move (ident), std::move (bounds),
-			    std::move (outer_attrs), vis, locus));
+    new AST::TraitItemType (std::move (ident), std::move (generic_params),
+			    std::move (bounds), std::move (outer_attrs), vis,
+			    locus));
 }
 
 // Parses a constant trait item.

--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.cc
@@ -519,6 +519,12 @@ TypeCheckImplItemWithTrait::visit (HIR::ConstantItem &constant)
 void
 TypeCheckImplItemWithTrait::visit (HIR::TypeAlias &type)
 {
+  auto binder_pin = context->push_lifetime_binder ();
+
+  if (type.has_generics ())
+    resolve_generic_params (HIR::Item::ItemKind::TypeAlias, type.get_locus (),
+			    type.get_generic_params (), substitutions);
+
   // normal resolution of the item
   TyTy::BaseType *lookup
     = TypeCheckImplItem::Resolve (parent, type, self, substitutions);

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -890,7 +890,7 @@ BaseType::is_concrete () const
 bool
 BaseType::has_substitutions_defined () const
 {
-  const TyTy::BaseType *x = destructure ();
+  const auto x = this;
   switch (x->get_kind ())
     {
     case INFER:

--- a/gcc/testsuite/rust/compile/gat1.rs
+++ b/gcc/testsuite/rust/compile/gat1.rs
@@ -1,0 +1,4 @@
+trait Foo {
+    type Bar<T>;
+    type Baz<'a>;
+}

--- a/gcc/testsuite/rust/execute/torture/gat1.rs
+++ b/gcc/testsuite/rust/execute/torture/gat1.rs
@@ -1,0 +1,18 @@
+#[lang = "sized"]
+trait Sized {}
+
+pub struct MyBuf;
+
+trait Foo {
+    type Bar<T>: Sized;
+}
+
+impl Foo for MyBuf {
+    type Bar<T> = T;
+}
+
+type A = <MyBuf as Foo>::Bar<u32>;
+fn main() -> i32 {
+    let a: A = 1;
+    a as i32 - 1
+}


### PR DESCRIPTION
NOTE: Gat's are not finished this is just a starting point

This patch is the initial part in supporting generic associated types. In rust we have trait item types that get implemented for example:
```
  trait Foo<T> {
    type Bar
  }

  impl<T> Foo for T {
    type Bar = T
  }
```
The trait position uses a Ty::Placeholder which is just a thing that gets set for lazy evaluation to the impl type alias which is actually a Ty::Projection see:

  0798add3d3c1bf4b20ecc1b4fa1047ba4ba19759

For more info the projection type needs to hold onto generics in order to properly support generic types this GAT's support extends this all the way to the placeholder which still needs to be done.

Fixes Rust-GCC#4276

gcc/rust/ChangeLog:

	* ast/rust-ast.cc (TraitItemType::as_string): add generic params
	* ast/rust-ast.h: remove old comment
	* ast/rust-item.h: add generic params to associated type
	* ast/rust-type.h: remove old comment
	* hir/rust-ast-lower-implitem.cc (ASTLowerTraitItem::visit): hir lowering for gat's
	* hir/tree/rust-hir-item.cc (TraitItemType::TraitItemType): gat's on TraitItemType
	(TraitItemType::operator=): preserve generic params
	* hir/tree/rust-hir-item.h: likewise
	* hir/tree/rust-hir.cc (TraitItemType::as_string): likewise
	* parse/rust-parse-impl.h (Parser::parse_trait_type): hit the < and parse params
	* typecheck/rust-hir-type-check-implitem.cc (TypeCheckImplItemWithTrait::visit): typecheck
	* typecheck/rust-tyty.cc (BaseType::has_substitutions_defined): dont destructure

gcc/testsuite/ChangeLog:

	* rust/compile/gat1.rs: New test.
	* rust/execute/torture/gat1.rs: New test.

*Please write a comment explaining your change. This is the message
that will be part of the merge commit.
