### PR TITLE
Refactor dead code lint 

### DIFF
--- a/gcc/rust/checks/lints/rust-lint-scan-deadcode.h
+++ b/gcc/rust/checks/lints/rust-lint-scan-deadcode.h
@@ -19,6 +19,7 @@
 #ifndef RUST_HIR_SCAN_DEADCODE
 #define RUST_HIR_SCAN_DEADCODE
 
+#include "options.h"
 #include "rust-hir-full-decls.h"
 #include "rust-hir-map.h"
 #include "rust-lint-marklive.h"
@@ -134,6 +135,34 @@ public:
   {
     for (auto &item : mod.get_items ())
       item->accept_vis (*this);
+  }
+
+  void visit (HIR::ConstantItem &item) override
+  {
+    if (!flag_unused_check_2_0)
+      return;
+    std::string var_name = item.get_identifier ().as_string ();
+    bool starts_with_under_score = var_name.at (0) == '_';
+    HirId hirId = item.get_mappings ().get_hirid ();
+    if (should_warn (hirId) && !item.get_visibility ().is_public ()
+	&& !starts_with_under_score)
+      rust_warning_at (item.get_locus (), OPT_Wunused_variable,
+		       "deadcode const item %qs",
+		       item.get_identifier ().as_string ().c_str ());
+  }
+
+  void visit (HIR::StaticItem &item) override
+  {
+    if (!flag_unused_check_2_0)
+      return;
+    std::string var_name = item.get_identifier ().as_string ();
+    bool starts_with_under_score = var_name.at (0) == '_';
+    HirId hirId = item.get_mappings ().get_hirid ();
+    if (should_warn (hirId) && !item.get_visibility ().is_public ()
+	&& !starts_with_under_score)
+      rust_warning_at (item.get_locus (), OPT_Wunused_variable,
+		       "deadcode static item %qs",
+		       item.get_identifier ().as_string ().c_str ());
   }
 
 private:

--- a/gcc/rust/checks/lints/unused/rust-unused-checker.cc
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.cc
@@ -55,14 +55,6 @@ void
 UnusedChecker::visit (HIR::ConstantItem &item)
 {
   std::string var_name = item.get_identifier ().as_string ();
-  auto id = item.get_mappings ().get_hirid ();
-  if (!unused_context.is_variable_used (id) && var_name[0] != '_')
-    rust_warning_at (item.get_locus (), OPT_Wunused_variable,
-		     "unused variable %qs",
-		     item.get_identifier ().as_string ().c_str ());
-
-  // The unused_visibilities lint: a visibility qualifier on a `const _` item
-  // has no effect.
   if (var_name == "_" && item.get_visibility ().is_public ())
     rust_warning_at (item.get_locus (), OPT_Wunused_variable,
 		     "visibility qualifier on a %<const _%> item is unused");
@@ -72,12 +64,6 @@ void
 UnusedChecker::visit (HIR::StaticItem &item)
 {
   std::string var_name = item.get_identifier ().as_string ();
-  auto id = item.get_mappings ().get_hirid ();
-  if (!unused_context.is_variable_used (id) && var_name[0] != '_')
-    rust_warning_at (item.get_locus (), OPT_Wunused_variable,
-		     "unused variable %qs",
-		     item.get_identifier ().as_string ().c_str ());
-
   if (!std::all_of (var_name.begin (), var_name.end (), [] (unsigned char c) {
 	return ISUPPER (c) || ISDIGIT (c) || c == '_';
       }))

--- a/gcc/testsuite/rust/compile/const_item_0.rs
+++ b/gcc/testsuite/rust/compile/const_item_0.rs
@@ -1,0 +1,6 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+#![feature(no_core)]
+#![no_core]
+
+const A: usize = 1;
+// { dg-warning "deadcode const item .A." "" { target *-*-* } .-1 }

--- a/gcc/testsuite/rust/compile/static-mut-refs_0.rs
+++ b/gcc/testsuite/rust/compile/static-mut-refs_0.rs
@@ -5,7 +5,7 @@
 #[lang = "sized"]
 pub trait Sized {}
 
-static mut S: i32 = 0;
+pub static mut S: i32 = 0;
 
 pub unsafe fn f() {
     let _y = &S;

--- a/gcc/testsuite/rust/compile/static_item_0.rs
+++ b/gcc/testsuite/rust/compile/static_item_0.rs
@@ -3,4 +3,4 @@
 #![no_core]
 
 static TEST: usize = 1;
-// { dg-warning "unused variable .TEST." "" { target *-*-* } .-1 }
+// { dg-warning "deadcode static item .TEST." "" { target *-*-* } .-1 }


### PR DESCRIPTION
This patch is simple, it only moves the check of unused static items and unused const items into the dead-code scan visitor.
    