### PR TITLE
Remove match arm pattern vector to single pattern

### DIFF
--- a/gcc/rust/ast/rust-ast-builder.cc
+++ b/gcc/rust/ast/rust-ast-builder.cc
@@ -484,10 +484,7 @@ Builder::match (std::unique_ptr<Expr> &&scrutinee,
 MatchArm
 Builder::match_arm (std::unique_ptr<Pattern> &&pattern)
 {
-  auto patterns = std::vector<std::unique_ptr<Pattern>> ();
-  patterns.emplace_back (std::move (pattern));
-
-  return MatchArm (std::move (patterns), loc);
+  return MatchArm (std::move (pattern), loc);
 }
 
 MatchCase

--- a/gcc/rust/ast/rust-ast-collector.cc
+++ b/gcc/rust/ast/rust-ast-collector.cc
@@ -1617,11 +1617,7 @@ TokenCollector::visit (WhileLetLoopExpr &expr)
     visit_loop_common (expr);
     push (Rust::Token::make (WHILE, expr.get_locus ()));
     push (Rust::Token::make (LET, UNDEF_LOCATION));
-    // TODO: The reference mention only one Pattern
-    for (auto &item : expr.get_patterns ())
-      {
-	visit (item);
-      }
+    visit (expr.get_pattern ());
     push (Rust::Token::make (EQUAL, UNDEF_LOCATION));
     visit (expr.get_scrutinee_expr ());
     visit (expr.get_loop_block ());
@@ -1669,10 +1665,7 @@ TokenCollector::visit (IfLetExpr &expr)
   describe_node (std::string ("IfLetExpr"), [this, &expr] () {
     push (Rust::Token::make (IF, expr.get_locus ()));
     push (Rust::Token::make (LET, UNDEF_LOCATION));
-    for (auto &pattern : expr.get_patterns ())
-      {
-	visit (pattern);
-      }
+    visit (expr.get_pattern ());
     push (Rust::Token::make (EQUAL, UNDEF_LOCATION));
     visit (expr.get_value_expr ());
     visit (expr.get_if_block ());
@@ -1695,10 +1688,7 @@ TokenCollector::visit (MatchArm &arm)
 {
   describe_node (std::string ("MatchArm"), [this, &arm] () {
     visit_items_as_lines (arm.get_outer_attrs ());
-    for (auto &pattern : arm.get_patterns ())
-      {
-	visit (pattern);
-      }
+    visit (arm.get_pattern ());
     if (arm.has_match_arm_guard ())
       {
 	push (Rust::Token::make (IF, UNDEF_LOCATION));

--- a/gcc/rust/ast/rust-ast-pointer-visitor.cc
+++ b/gcc/rust/ast/rust-ast-pointer-visitor.cc
@@ -587,8 +587,7 @@ void
 PointerVisitor::visit (AST::WhileLetLoopExpr &expr)
 {
   visit_outer_attrs (expr);
-  for (auto &pattern : expr.get_patterns ())
-    reseat (pattern);
+  reseat (expr.get_pattern ());
 
   if (expr.has_loop_label ())
     visit (expr.get_loop_label ());
@@ -627,8 +626,7 @@ void
 PointerVisitor::visit (AST::IfLetExpr &expr)
 {
   visit_outer_attrs (expr);
-  for (auto &pattern : expr.get_patterns ())
-    reseat (pattern);
+  reseat (expr.get_pattern ());
   reseat (expr.get_value_expr_ptr ());
   visit (expr.get_if_block ());
 }
@@ -644,8 +642,7 @@ void
 PointerVisitor::visit (AST::MatchArm &arm)
 {
   visit_outer_attrs (arm);
-  for (auto &pattern : arm.get_patterns ())
-    reseat (pattern);
+  reseat (arm.get_pattern ());
   if (arm.has_match_arm_guard ())
     reseat (arm.get_guard_expr_ptr ());
 }

--- a/gcc/rust/ast/rust-ast-visitor.cc
+++ b/gcc/rust/ast/rust-ast-visitor.cc
@@ -607,8 +607,7 @@ void
 DefaultASTVisitor::visit (AST::WhileLetLoopExpr &expr)
 {
   visit_outer_attrs (expr);
-  for (auto &pattern : expr.get_patterns ())
-    visit (pattern);
+  visit (expr.get_pattern ());
 
   if (expr.has_loop_label ())
     visit (expr.get_loop_label ());
@@ -647,8 +646,7 @@ void
 DefaultASTVisitor::visit (AST::IfLetExpr &expr)
 {
   visit_outer_attrs (expr);
-  for (auto &pattern : expr.get_patterns ())
-    visit (pattern);
+  visit (expr.get_pattern ());
   visit (expr.get_value_expr ());
   visit (expr.get_if_block ());
 }
@@ -664,8 +662,7 @@ void
 DefaultASTVisitor::visit (AST::MatchArm &arm)
 {
   visit_outer_attrs (arm);
-  for (auto &pattern : arm.get_patterns ())
-    visit (pattern);
+  visit (arm.get_pattern ());
   if (arm.has_match_arm_guard ())
     visit (arm.get_guard_expr ());
 }

--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -1943,14 +1943,13 @@ IfLetExpr::as_string () const
   str += append_attributes (outer_attrs, OUTER);
 
   str += "\n Condition match arm patterns: ";
-  if (match_arm_patterns.empty ())
+  if (match_arm_pattern == nullptr)
     {
       str += "none";
     }
   else
     {
-      for (const auto &pattern : match_arm_patterns)
-	str += "\n  " + pattern->as_string ();
+      str += "\n  " + match_arm_pattern->as_string ();
     }
 
   str += "\n Scrutinee expr: " + value->as_string ();
@@ -2167,14 +2166,13 @@ WhileLetLoopExpr::as_string () const
     str += get_loop_label ().as_string ();
 
   str += "\n Match arm patterns: ";
-  if (match_arm_patterns.empty ())
+  if (match_arm_pattern == nullptr)
     {
       str += "none";
     }
   else
     {
-      for (const auto &pattern : match_arm_patterns)
-	str += "\n  " + pattern->as_string ();
+      str += "\n  " + match_arm_pattern->as_string ();
     }
 
   str += "\n Scrutinee expr: " + scrutinee->as_string ();
@@ -2253,14 +2251,13 @@ MatchArm::as_string () const
   std::string str = append_attributes (outer_attrs, OUTER);
 
   str += "\nPatterns: ";
-  if (match_arm_patterns.empty ())
+  if (match_arm_pattern == nullptr)
     {
       str += "none";
     }
   else
     {
-      for (const auto &pattern : match_arm_patterns)
-	str += "\n " + pattern->as_string ();
+      str += "\n " + match_arm_pattern->as_string ();
     }
 
   str += "\nGuard expr: ";

--- a/gcc/rust/ast/rust-desugar-question-mark.cc
+++ b/gcc/rust/ast/rust-desugar-question-mark.cc
@@ -39,11 +39,7 @@ MatchArm
 make_match_arm (std::unique_ptr<Pattern> &&pattern)
 {
   auto loc = pattern->get_locus ();
-
-  auto patterns = std::vector<std::unique_ptr<Pattern>> ();
-  patterns.emplace_back (std::move (pattern));
-
-  return MatchArm (std::move (patterns), loc);
+  return MatchArm (std::move (pattern), loc);
 }
 
 MatchCase

--- a/gcc/rust/ast/rust-desugar-while-let.cc
+++ b/gcc/rust/ast/rust-desugar-while-let.cc
@@ -53,9 +53,9 @@ DesugarWhileLet::DesugarCtx::make_continue_arm (
 std::unique_ptr<Expr>
 DesugarWhileLet::desugar (WhileLetLoopExpr &expr)
 {
-  rust_assert (expr.get_patterns ().size () == 1);
+  rust_assert (expr.get_pattern () != nullptr);
 
-  auto pattern = expr.get_patterns ()[0]->clone_pattern ();
+  auto pattern = expr.get_pattern ()->clone_pattern ();
   auto body = expr.get_loop_block ().clone_block_expr ();
   auto scrutinee = expr.get_scrutinee_expr ().clone_expr ();
 

--- a/gcc/rust/checks/errors/rust-hir-pattern-analysis.cc
+++ b/gcc/rust/checks/errors/rust-hir-pattern-analysis.cc
@@ -1463,10 +1463,10 @@ static MatchArm
 lower_arm (Resolver::TypeCheckContext *ctx, HIR::MatchCase &arm,
 	   TyTy::BaseType *scrutinee_ty)
 {
-  rust_assert (arm.get_arm ().get_patterns ().size () > 0);
+  rust_assert (arm.get_arm ().get_pattern () != nullptr);
 
   DeconstructedPat pat
-    = lower_pattern (ctx, *arm.get_arm ().get_patterns ().at (0), scrutinee_ty);
+    = lower_pattern (ctx, *arm.get_arm ().get_pattern (), scrutinee_ty);
   return MatchArm (pat, arm.get_arm ().has_match_arm_guard ());
 }
 

--- a/gcc/rust/expand/rust-cfg-strip.cc
+++ b/gcc/rust/expand/rust-cfg-strip.cc
@@ -1434,10 +1434,9 @@ CfgStrip::visit (AST::WhileLetLoopExpr &expr)
 
   AST::DefaultASTVisitor::visit (expr);
 
-  for (auto &pattern : expr.get_patterns ())
-    if (pattern->is_marked_for_strip ())
-      rust_error_at (pattern->get_locus (),
-		     "cannot strip pattern in this position");
+  if (expr.get_pattern ()->is_marked_for_strip ())
+    rust_error_at (expr.get_pattern ()->get_locus (),
+		   "cannot strip pattern in this position");
 
   // can't strip scrutinee expr itself, but can strip sub-expressions
   auto &scrutinee_expr = expr.get_scrutinee_expr ();
@@ -1564,10 +1563,9 @@ CfgStrip::visit (AST::IfLetExpr &expr)
 
   AST::DefaultASTVisitor::visit (expr);
 
-  for (auto &pattern : expr.get_patterns ())
-    if (pattern->is_marked_for_strip ())
-      rust_error_at (pattern->get_locus (),
-		     "cannot strip pattern in this position");
+  if (expr.get_pattern ()->is_marked_for_strip ())
+    rust_error_at (expr.get_pattern ()->get_locus (),
+		   "cannot strip pattern in this position");
 
   // can't strip value expr itself, but can strip sub-expressions
   auto &value_expr = expr.get_value_expr ();
@@ -1596,10 +1594,9 @@ CfgStrip::visit (AST::IfLetExprConseqElse &expr)
 
   AST::DefaultASTVisitor::visit (expr);
 
-  for (auto &pattern : expr.get_patterns ())
-    if (pattern->is_marked_for_strip ())
-      rust_error_at (pattern->get_locus (),
-		     "cannot strip pattern in this position");
+  if (expr.get_pattern ()->is_marked_for_strip ())
+    rust_error_at (expr.get_pattern ()->get_locus (),
+		   "cannot strip pattern in this position");
 
   // can't strip value expr itself, but can strip sub-expressions
   auto &value_expr = expr.get_value_expr ();
@@ -1666,10 +1663,9 @@ CfgStrip::visit (AST::MatchExpr &expr)
 	  continue;
 	}
 
-      for (auto &pattern : match_arm.get_patterns ())
-	if (pattern->is_marked_for_strip ())
-	  rust_error_at (pattern->get_locus (),
-			 "cannot strip pattern in this position");
+      if (match_arm.get_pattern ()->is_marked_for_strip ())
+	rust_error_at (match_arm.get_pattern ()->get_locus (),
+		       "cannot strip pattern in this position");
 
       /* assuming that guard expression cannot be stripped as
        * strictly speaking you would have to strip the whole guard to

--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -366,7 +366,7 @@ Dump::do_matcharm (MatchArm &e)
   begin ("MatchArm");
   // FIXME Can't remember how to handle that. Let's see later.
   // do_outer_attrs(e);
-  visit_collection ("match_arm_patterns", e.get_patterns ());
+  visit_field ("match_arm_pattern", e.get_pattern ());
   if (e.has_match_arm_guard ())
     visit_field ("guard_expr", e.get_guard_expr ());
   end ("MatchArm");
@@ -1461,7 +1461,7 @@ Dump::visit (WhileLetLoopExpr &e)
   begin ("WhileLetLoopExpr");
   do_baseloopexpr (e);
 
-  visit_collection ("match_arm_patterns", e.get_patterns ());
+  visit_field ("match_arm_patterns", e.get_pattern ());
 
   visit_field ("condition", e.get_cond ());
 

--- a/gcc/rust/hir/tree/rust-hir-expr.cc
+++ b/gcc/rust/hir/tree/rust-hir-expr.cc
@@ -76,7 +76,6 @@ OperatorExpr::operator= (OperatorExpr const &other)
   ExprWithoutBlock::operator= (other);
   main_or_left_expr = other.main_or_left_expr->clone_expr ();
   locus = other.locus;
-  // outer_attrs = other.outer_attrs;
 
   return *this;
 }
@@ -130,7 +129,6 @@ ArithmeticOrLogicalExpr &
 ArithmeticOrLogicalExpr::operator= (ArithmeticOrLogicalExpr const &other)
 {
   OperatorExpr::operator= (other);
-  // main_or_left_expr = other.main_or_left_expr->clone_expr();
   right_expr = other.right_expr->clone_expr ();
   expr_type = other.expr_type;
 
@@ -155,10 +153,8 @@ ComparisonExpr &
 ComparisonExpr::operator= (ComparisonExpr const &other)
 {
   OperatorExpr::operator= (other);
-  // main_or_left_expr = other.main_or_left_expr->clone_expr();
   right_expr = other.right_expr->clone_expr ();
   expr_type = other.expr_type;
-  // outer_attrs = other.outer_attrs;
 
   return *this;
 }
@@ -181,7 +177,6 @@ LazyBooleanExpr &
 LazyBooleanExpr::operator= (LazyBooleanExpr const &other)
 {
   OperatorExpr::operator= (other);
-  // main_or_left_expr = other.main_or_left_expr->clone_expr();
   right_expr = other.right_expr->clone_expr ();
   expr_type = other.expr_type;
 
@@ -206,7 +201,6 @@ TypeCastExpr &
 TypeCastExpr::operator= (TypeCastExpr const &other)
 {
   OperatorExpr::operator= (other);
-  // main_or_left_expr = other.main_or_left_expr->clone_expr();
   type_to_convert_to = other.type_to_convert_to->clone_type ();
 
   return *this;
@@ -229,9 +223,7 @@ AssignmentExpr &
 AssignmentExpr::operator= (AssignmentExpr const &other)
 {
   OperatorExpr::operator= (other);
-  // main_or_left_expr = other.main_or_left_expr->clone_expr();
   right_expr = other.right_expr->clone_expr ();
-  // outer_attrs = other.outer_attrs;
 
   return *this;
 }
@@ -254,10 +246,8 @@ CompoundAssignmentExpr &
 CompoundAssignmentExpr::operator= (CompoundAssignmentExpr const &other)
 {
   OperatorExpr::operator= (other);
-  // main_or_left_expr = other.main_or_left_expr->clone_expr();
   right_expr = other.right_expr->clone_expr ();
   expr_type = other.expr_type;
-  // outer_attrs = other.outer_attrs;
 
   return *this;
 }
@@ -283,7 +273,6 @@ GroupedExpr::operator= (GroupedExpr const &other)
   inner_attrs = other.inner_attrs;
   expr_in_parens = other.expr_in_parens->clone_expr ();
   locus = other.locus;
-  // outer_attrs = other.outer_attrs;
 
   return *this;
 }
@@ -357,7 +346,6 @@ ArrayExpr::operator= (ArrayExpr const &other)
   if (other.has_array_elems ())
     internal_elements = other.internal_elements->clone_array_elems ();
   locus = other.locus;
-  // outer_attrs = other.outer_attrs;
 
   return *this;
 }
@@ -382,7 +370,6 @@ ArrayIndexExpr::operator= (ArrayIndexExpr const &other)
   ExprWithoutBlock::operator= (other);
   array_expr = other.array_expr->clone_expr ();
   index_expr = other.index_expr->clone_expr ();
-  // outer_attrs = other.outer_attrs;
   locus = other.locus;
 
   return *this;
@@ -607,8 +594,6 @@ CallExpr::operator= (CallExpr const &other)
   ExprWithoutBlock::operator= (other);
   function = other.function->clone_expr ();
   locus = other.locus;
-  // params = other.params;
-  // outer_attrs = other.outer_attrs;
 
   params.reserve (other.params.size ());
   for (const auto &e : other.params)
@@ -642,8 +627,6 @@ MethodCallExpr::operator= (MethodCallExpr const &other)
   receiver = other.receiver->clone_expr ();
   method_name = other.method_name;
   locus = other.locus;
-  // params = other.params;
-  // outer_attrs = other.outer_attrs;
 
   params.reserve (other.params.size ());
   for (const auto &e : other.params)
@@ -673,7 +656,6 @@ FieldAccessExpr::operator= (FieldAccessExpr const &other)
   receiver = other.receiver->clone_expr ();
   field = other.field;
   locus = other.locus;
-  // outer_attrs = other.outer_attrs;
 
   return *this;
 }
@@ -778,14 +760,12 @@ BlockExpr &
 BlockExpr::operator= (BlockExpr const &other)
 {
   ExprWithBlock::operator= (other);
-  // statements = other.statements;
   expr = other.expr->clone_expr ();
   inner_attrs = other.inner_attrs;
   start_locus = other.end_locus;
   end_locus = other.end_locus;
-  // outer_attrs = other.outer_attrs;
-
   statements.reserve (other.statements.size ());
+
   for (const auto &e : other.statements)
     statements.push_back (e->clone_stmt ());
 
@@ -878,7 +858,6 @@ BreakExpr::operator= (BreakExpr const &other)
   label = other.label;
   break_expr = other.break_expr->clone_expr ();
   locus = other.locus;
-  // outer_attrs = other.outer_attrs;
 
   return *this;
 }
@@ -1014,7 +993,6 @@ ReturnExpr::operator= (ReturnExpr const &other)
   ExprWithoutBlock::operator= (other);
   return_expr = other.return_expr->clone_expr ();
   locus = other.locus;
-  // outer_attrs = other.outer_attrs;
 
   return *this;
 }
@@ -1037,7 +1015,6 @@ UnsafeBlockExpr::operator= (UnsafeBlockExpr const &other)
   ExprWithBlock::operator= (other);
   expr = other.expr->clone_block_expr ();
   locus = other.locus;
-  // outer_attrs = other.outer_attrs;
 
   return *this;
 }
@@ -1064,7 +1041,6 @@ BaseLoopExpr::operator= (BaseLoopExpr const &other)
   loop_block = other.loop_block->clone_block_expr ();
   loop_label = other.loop_label;
   locus = other.locus;
-  // outer_attrs = other.outer_attrs;
 
   return *this;
 }
@@ -1097,48 +1073,34 @@ WhileLoopExpr::operator= (WhileLoopExpr const &other)
 {
   BaseLoopExpr::operator= (other);
   condition = other.condition->clone_expr ();
-  // loop_block = other.loop_block->clone_block_expr();
-  // loop_label = other.loop_label;
-  // outer_attrs = other.outer_attrs;
-
   return *this;
 }
 
-WhileLetLoopExpr::WhileLetLoopExpr (
-  Analysis::NodeMapping mappings,
-  std::vector<std::unique_ptr<Pattern>> match_arm_patterns,
-  std::unique_ptr<Expr> condition, std::unique_ptr<BlockExpr> loop_block,
-  location_t locus, tl::optional<LoopLabel> loop_label,
-  AST::AttrVec outer_attribs)
+WhileLetLoopExpr::WhileLetLoopExpr (Analysis::NodeMapping mappings,
+				    std::unique_ptr<Pattern> match_arm_pattern,
+				    std::unique_ptr<Expr> condition,
+				    std::unique_ptr<BlockExpr> loop_block,
+				    location_t locus,
+				    tl::optional<LoopLabel> loop_label,
+				    AST::AttrVec outer_attribs)
   : BaseLoopExpr (std::move (mappings), std::move (loop_block), locus,
 		  std::move (loop_label), std::move (outer_attribs)),
-    match_arm_patterns (std::move (match_arm_patterns)),
+    match_arm_pattern (std::move (match_arm_pattern)),
     condition (std::move (condition))
 {}
 
 WhileLetLoopExpr::WhileLetLoopExpr (WhileLetLoopExpr const &other)
   : BaseLoopExpr (other),
-    /*match_arm_patterns(other.match_arm_patterns),*/ condition (
-      other.condition->clone_expr ())
-{
-  match_arm_patterns.reserve (other.match_arm_patterns.size ());
-  for (const auto &e : other.match_arm_patterns)
-    match_arm_patterns.push_back (e->clone_pattern ());
-}
+    match_arm_pattern (other.match_arm_pattern->clone_pattern ()),
+    condition (other.condition->clone_expr ())
+{}
 
 WhileLetLoopExpr &
 WhileLetLoopExpr::operator= (WhileLetLoopExpr const &other)
 {
   BaseLoopExpr::operator= (other);
-  // match_arm_patterns = other.match_arm_patterns;
   condition = other.condition->clone_expr ();
-  // loop_block = other.loop_block->clone_block_expr();
-  // loop_label = other.loop_label;
-  // outer_attrs = other.outer_attrs;
-
-  match_arm_patterns.reserve (other.match_arm_patterns.size ());
-  for (const auto &e : other.match_arm_patterns)
-    match_arm_patterns.push_back (e->clone_pattern ());
+  match_arm_pattern = other.match_arm_pattern->clone_pattern ();
 
   return *this;
 }
@@ -1191,11 +1153,11 @@ IfExprConseqElse::operator= (IfExprConseqElse const &other)
   return *this;
 }
 
-MatchArm::MatchArm (std::vector<std::unique_ptr<Pattern>> match_arm_patterns,
+MatchArm::MatchArm (std::unique_ptr<Pattern> match_arm_pattern,
 		    location_t locus, std::unique_ptr<Expr> guard_expr,
 		    AST::AttrVec outer_attrs)
   : outer_attrs (std::move (outer_attrs)),
-    match_arm_patterns (std::move (match_arm_patterns)),
+    match_arm_pattern (std::move (match_arm_pattern)),
     guard_expr (std::move (guard_expr)), locus (locus)
 {}
 
@@ -1205,9 +1167,7 @@ MatchArm::MatchArm (MatchArm const &other) : outer_attrs (other.outer_attrs)
   if (other.guard_expr != nullptr)
     guard_expr = other.guard_expr->clone_expr ();
 
-  match_arm_patterns.reserve (other.match_arm_patterns.size ());
-  for (const auto &e : other.match_arm_patterns)
-    match_arm_patterns.push_back (e->clone_pattern ());
+  match_arm_pattern = other.match_arm_pattern->clone_pattern ();
 
   locus = other.locus;
 }
@@ -1220,10 +1180,7 @@ MatchArm::operator= (MatchArm const &other)
   if (other.guard_expr != nullptr)
     guard_expr = other.guard_expr->clone_expr ();
 
-  match_arm_patterns.clear ();
-  match_arm_patterns.reserve (other.match_arm_patterns.size ());
-  for (const auto &e : other.match_arm_patterns)
-    match_arm_patterns.push_back (e->clone_pattern ());
+  match_arm_pattern = other.match_arm_pattern->clone_pattern ();
 
   return *this;
 }
@@ -1275,7 +1232,6 @@ MatchExpr::operator= (MatchExpr const &other)
   branch_value = other.branch_value->clone_expr ();
   inner_attrs = other.inner_attrs;
   match_arms = other.match_arms;
-  // outer_attrs = other.outer_attrs;
   locus = other.locus;
 
   /*match_arms.reserve (other.match_arms.size ());

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -2498,7 +2498,7 @@ protected:
 class WhileLetLoopExpr : public BaseLoopExpr
 {
   // MatchArmPatterns patterns;
-  std::vector<std::unique_ptr<Pattern>> match_arm_patterns; // inlined
+  std::unique_ptr<Pattern> match_arm_pattern; // inlined
   std::unique_ptr<Expr> condition;
 
 public:
@@ -2506,7 +2506,7 @@ public:
 
   // Constructor with a loop label
   WhileLetLoopExpr (Analysis::NodeMapping mappings,
-		    std::vector<std::unique_ptr<Pattern>> match_arm_patterns,
+		    std::unique_ptr<Pattern> match_arm_pattern,
 		    std::unique_ptr<Expr> condition,
 		    std::unique_ptr<BlockExpr> loop_block, location_t locus,
 		    tl::optional<LoopLabel> loop_label,
@@ -2526,10 +2526,7 @@ public:
   void accept_vis (HIRExpressionVisitor &vis) override;
 
   Expr &get_cond () { return *condition; }
-  std::vector<std::unique_ptr<Pattern>> &get_patterns ()
-  {
-    return match_arm_patterns;
-  }
+  std::unique_ptr<Pattern> &get_pattern () { return match_arm_pattern; }
 
 protected:
   /* Use covariance to implement clone function as returning this object rather
@@ -2671,7 +2668,7 @@ struct MatchArm
 {
 private:
   AST::AttrVec outer_attrs;
-  std::vector<std::unique_ptr<Pattern>> match_arm_patterns;
+  std::unique_ptr<Pattern> match_arm_pattern;
   std::unique_ptr<Expr> guard_expr;
   location_t locus;
 
@@ -2680,8 +2677,8 @@ public:
   bool has_match_arm_guard () const { return guard_expr != nullptr; }
 
   // Constructor for match arm with a guard expression
-  MatchArm (std::vector<std::unique_ptr<Pattern>> match_arm_patterns,
-	    location_t locus, std::unique_ptr<Expr> guard_expr = nullptr,
+  MatchArm (std::unique_ptr<Pattern> match_arm_pattern, location_t locus,
+	    std::unique_ptr<Expr> guard_expr = nullptr,
 	    AST::AttrVec outer_attrs = AST::AttrVec ());
 
   // Copy constructor with clone
@@ -2697,21 +2694,18 @@ public:
   MatchArm &operator= (MatchArm &&other) = default;
 
   // Returns whether match arm is in an error state.
-  bool is_error () const { return match_arm_patterns.empty (); }
+  bool is_error () const { return match_arm_pattern == nullptr; }
 
   // Creates a match arm in an error state.
   static MatchArm create_error ()
   {
     location_t locus = UNDEF_LOCATION;
-    return MatchArm (std::vector<std::unique_ptr<Pattern>> (), locus);
+    return MatchArm (nullptr, locus);
   }
 
   std::string to_string () const;
 
-  std::vector<std::unique_ptr<Pattern>> &get_patterns ()
-  {
-    return match_arm_patterns;
-  }
+  std::unique_ptr<Pattern> &get_pattern () { return match_arm_pattern; }
 
   Expr &get_guard_expr () { return *guard_expr; }
 

--- a/gcc/rust/hir/tree/rust-hir-visitor.cc
+++ b/gcc/rust/hir/tree/rust-hir-visitor.cc
@@ -479,8 +479,7 @@ void
 DefaultHIRVisitor::walk (WhileLetLoopExpr &expr)
 {
   visit_outer_attrs (expr);
-  for (auto &pattern : expr.get_patterns ())
-    pattern->accept_vis (*this);
+  expr.get_pattern ()->accept_vis (*this);
   if (expr.has_loop_label ())
     visit_loop_label (expr.get_loop_label ());
   expr.get_cond ().accept_vis (*this);
@@ -506,8 +505,7 @@ void
 DefaultHIRVisitor::visit_match_arm (MatchArm &arm)
 {
   // visit_outer_attrs (arm);
-  for (auto &pattern : arm.get_patterns ())
-    pattern->accept_vis (*this);
+  arm.get_pattern ()->accept_vis (*this);
   if (arm.has_match_arm_guard ())
     arm.get_guard_expr ().accept_vis (*this);
 }

--- a/gcc/rust/hir/tree/rust-hir.cc
+++ b/gcc/rust/hir/tree/rust-hir.cc
@@ -1775,16 +1775,13 @@ WhileLetLoopExpr::to_string () const
     }
 
   str += "\n Match arm patterns: ";
-  if (match_arm_patterns.empty ())
+  if (match_arm_pattern == nullptr)
     {
       str += "none";
     }
   else
     {
-      for (const auto &pattern : match_arm_patterns)
-	{
-	  str += "\n  " + pattern->to_string ();
-	}
+      str += "\n  " + match_arm_pattern->to_string ();
     }
 
   str += "\n Scrutinee expr: " + condition->to_string ();
@@ -1898,17 +1895,10 @@ MatchArm::to_string () const
     }
 
   str += "\nPatterns: ";
-  if (match_arm_patterns.empty ())
-    {
-      str += "none";
-    }
+  if (match_arm_pattern == nullptr)
+    str += "none";
   else
-    {
-      for (const auto &pattern : match_arm_patterns)
-	{
-	  str += "\n " + pattern->to_string ();
-	}
-    }
+    str += "\n " + match_arm_pattern->to_string ();
 
   str += "\nGuard expr: ";
   if (!has_match_arm_guard ())

--- a/gcc/rust/parse/rust-parse-impl-expr.hxx
+++ b/gcc/rust/parse/rust-parse-impl-expr.hxx
@@ -687,9 +687,9 @@ Parser<ManagedTokenSource>::parse_if_let_expr (AST::AttrVec outer_attrs,
   lexer.skip_token ();
 
   // parse match arm patterns (which are required)
-  std::vector<std::unique_ptr<AST::Pattern>> match_arm_patterns
-    = parse_match_arm_patterns (EQUAL);
-  if (match_arm_patterns.empty ())
+  std::unique_ptr<AST::Pattern> match_arm_pattern
+    = parse_match_arm_pattern (EQUAL);
+  if (match_arm_pattern == nullptr)
     {
       Error error (
 	lexer.peek_token ()->get_locus (),
@@ -740,7 +740,7 @@ Parser<ManagedTokenSource>::parse_if_let_expr (AST::AttrVec outer_attrs,
     {
       // single selection - end of if let expression
       return std::unique_ptr<AST::IfLetExpr> (
-	new AST::IfLetExpr (std::move (match_arm_patterns),
+	new AST::IfLetExpr (std::move (match_arm_pattern),
 			    std::move (scrutinee_expr), std::move (if_let_body),
 			    std::move (outer_attrs), locus));
     }
@@ -772,7 +772,7 @@ Parser<ManagedTokenSource>::parse_if_let_expr (AST::AttrVec outer_attrs,
 	      }
 
 	    return std::unique_ptr<AST::IfLetExprConseqElse> (
-	      new AST::IfLetExprConseqElse (std::move (match_arm_patterns),
+	      new AST::IfLetExprConseqElse (std::move (match_arm_pattern),
 					    std::move (scrutinee_expr),
 					    std::move (if_let_body),
 					    std::move (else_body),
@@ -800,7 +800,7 @@ Parser<ManagedTokenSource>::parse_if_let_expr (AST::AttrVec outer_attrs,
 
 		return std::unique_ptr<AST::IfLetExprConseqElse> (
 		  new AST::IfLetExprConseqElse (
-		    std::move (match_arm_patterns), std::move (scrutinee_expr),
+		    std::move (match_arm_pattern), std::move (scrutinee_expr),
 		    std::move (if_let_body), std::move (if_let_expr),
 		    std::move (outer_attrs), locus));
 	      }
@@ -821,7 +821,7 @@ Parser<ManagedTokenSource>::parse_if_let_expr (AST::AttrVec outer_attrs,
 
 		return std::unique_ptr<AST::IfLetExprConseqElse> (
 		  new AST::IfLetExprConseqElse (
-		    std::move (match_arm_patterns), std::move (scrutinee_expr),
+		    std::move (match_arm_pattern), std::move (scrutinee_expr),
 		    std::move (if_let_body), std::move (if_expr),
 		    std::move (outer_attrs), locus));
 	      }
@@ -983,10 +983,10 @@ Parser<ManagedTokenSource>::parse_while_let_loop_expr (
   lexer.skip_token ();
 
   // parse predicate patterns
-  std::vector<std::unique_ptr<AST::Pattern>> predicate_patterns
-    = parse_match_arm_patterns (EQUAL);
+  std::unique_ptr<AST::Pattern> predicate_pattern
+    = parse_match_arm_pattern (EQUAL);
   // ensure that there is at least 1 pattern
-  if (predicate_patterns.empty ())
+  if (predicate_pattern == nullptr)
     {
       Error error (lexer.peek_token ()->get_locus (),
 		   "should be at least 1 pattern");
@@ -1030,8 +1030,8 @@ Parser<ManagedTokenSource>::parse_while_let_loop_expr (
     }
 
   return std::unique_ptr<AST::WhileLetLoopExpr> (new AST::WhileLetLoopExpr (
-    std::move (predicate_patterns), std::move (predicate_expr),
-    std::move (body), locus, std::move (label), std::move (outer_attrs)));
+    std::move (predicate_pattern), std::move (predicate_expr), std::move (body),
+    locus, std::move (label), std::move (outer_attrs)));
 }
 
 /* Parses a "for" iterative loop. Label is not parsed and should be parsed via

--- a/gcc/rust/parse/rust-parse.h
+++ b/gcc/rust/parse/rust-parse.h
@@ -748,8 +748,7 @@ private:
   parse_match_expr (AST::AttrVec outer_attrs = AST::AttrVec (),
 		    location_t pratt_parsed_loc = UNKNOWN_LOCATION);
   AST::MatchArm parse_match_arm ();
-  std::vector<std::unique_ptr<AST::Pattern>>
-  parse_match_arm_patterns (TokenId end_token_id);
+  std::unique_ptr<AST::Pattern> parse_match_arm_pattern (TokenId end_token_id);
   std::unique_ptr<AST::Expr> parse_labelled_loop_expr (const_TokenPtr tok,
 						       AST::AttrVec outer_attrs
 						       = AST::AttrVec ());

--- a/gcc/rust/resolve/rust-default-resolver.cc
+++ b/gcc/rust/resolve/rust-default-resolver.cc
@@ -91,8 +91,7 @@ DefaultResolver::visit (AST::ForLoopExpr &expr)
 void
 DefaultResolver::visit_if_let_patterns (AST::IfLetExpr &expr)
 {
-  for (auto &pattern : expr.get_patterns ())
-    visit (pattern);
+  visit (expr.get_pattern ());
 }
 
 void

--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
@@ -93,8 +93,7 @@ Late::visit (AST::MatchArm &arm)
 
   ctx.bindings.enter (BindingSource::Match);
 
-  for (auto &pattern : arm.get_patterns ())
-    visit (pattern);
+  visit (arm.get_pattern ());
 
   ctx.bindings.exit ();
 
@@ -153,8 +152,7 @@ Late::visit (AST::WhileLetLoopExpr &while_let)
 
   ctx.bindings.enter (BindingSource::WhileLet);
 
-  for (auto &pattern : while_let.get_patterns ())
-    visit (pattern);
+  visit (while_let.get_pattern ());
 
   ctx.bindings.exit ();
 

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -1744,27 +1744,25 @@ TypeCheckExpr::visit (HIR::MatchExpr &expr)
     {
       // lets check the arms
       HIR::MatchArm &kase_arm = kase.get_arm ();
-      for (auto &pattern : kase_arm.get_patterns ())
+      auto &pattern = kase_arm.get_pattern ();
+      TyTy::BaseType *kase_arm_ty
+	= TypeCheckPattern::Resolve (*pattern, scrutinee_tyty);
+      if (kase_arm_ty->get_kind () == TyTy ::TypeKind::ERROR)
 	{
-	  TyTy::BaseType *kase_arm_ty
-	    = TypeCheckPattern::Resolve (*pattern, scrutinee_tyty);
-	  if (kase_arm_ty->get_kind () == TyTy ::TypeKind::ERROR)
-	    {
-	      saw_error = true;
-	      continue;
-	    }
+	  saw_error = true;
+	  continue;
+	}
 
-	  TyTy::BaseType *checked_kase = unify_site (
-	    expr.get_mappings ().get_hirid (),
-	    TyTy::TyWithLocation (scrutinee_tyty,
-				  expr.get_scrutinee_expr ().get_locus ()),
-	    TyTy::TyWithLocation (kase_arm_ty, pattern->get_locus ()),
-	    expr.get_locus ());
-	  if (checked_kase->get_kind () == TyTy::TypeKind::ERROR)
-	    {
-	      saw_error = true;
-	      continue;
-	    }
+      TyTy::BaseType *checked_kase = unify_site (
+	expr.get_mappings ().get_hirid (),
+	TyTy::TyWithLocation (scrutinee_tyty,
+			      expr.get_scrutinee_expr ().get_locus ()),
+	TyTy::TyWithLocation (kase_arm_ty, pattern->get_locus ()),
+	expr.get_locus ());
+      if (checked_kase->get_kind () == TyTy::TypeKind::ERROR)
+	{
+	  saw_error = true;
+	  continue;
 	}
 
       // check the kase type


### PR DESCRIPTION
This patch refactors all uses of vector patterns since a vector of patterns would be considered as an alt pattern, a vector is considered useless.