### PR TITLE
ci: refactor ccpp workflow

### DIFF
--- a/.github/actions/build-gcc/action.yml
+++ b/.github/actions/build-gcc/action.yml
@@ -1,0 +1,191 @@
+name: 'Build GCC'
+description: 'Builds GCC with Rust enabled'
+inputs:
+  extra-configure-env:
+    description: 'Extra env for configure'
+    default: ''
+
+  run-test-flags:
+    description: 'Args for RUNTESTFLAGS'
+    required: true
+
+  rustc-version:
+    description: 'rustc version to install'
+    default: "1.72.0"
+
+  use-old-gcc:
+    description: 'Version to use for old GCC'
+    default: ''
+
+  bootstrap:
+    description: 'Set to true to bootstrap the compiler'
+    default: false
+
+  warning-file:
+    description: 'If set, checks compile log for extra warnings compared to provided file'
+    default: ''
+
+  extra-configure-args:
+    description: 'Extra configure args to use for ./configure step'
+    default: ''
+
+  glibc-assertion:
+    description: 'Enable GLIBC_ASSERTION for extra runtime checks'
+    default: false
+
+  enable-multilib:
+    description: 'Enable multilib'
+    default: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install dependencies
+      run: |
+          sudo apt-get update;
+          sudo apt-get install -y \
+                  automake \
+                  autoconf \
+                  libtool \
+                  autogen \
+                  bison \
+                  flex \
+                  libgmp3-dev \
+                  libmpfr-dev \
+                  libmpc-dev \
+                  build-essential \
+                  gcc-multilib \
+                  g++-multilib \
+                  dejagnu;
+      shell: bash
+
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: ${{ inputs.rustc-version }}
+
+    - name: Make Source Read-Only
+      run: chmod -R a-w ./*
+      shell: bash
+
+    - name: Restore cached old gcc ${{ inputs.use-old-gcc }}
+      if: inputs.use-old-gcc != ''
+      id: restore-gcc5
+      uses: actions/cache/restore@v4
+      with:
+        key: ce-tar-gcc-${{ inputs.use-old-gcc }}
+        path: ~/gcc-${{ inputs.use-old-gcc }}/
+
+    - name: Download and install gcc ${{ inputs.use-old-gcc }}
+      if: steps.restore-gcc5.outputs.cache-hit != 'true' && inputs.use-old-gcc != ''
+      shell: bash
+      run: |
+        curl "https://s3.amazonaws.com/compiler-explorer/opt/gcc-${{ inputs.use-old-gcc }}.tar.xz" -o /tmp/gcc.tar.xz;
+        cd ~;
+        tar xvf /tmp/gcc.tar.xz
+
+    - name: Store gcc ${{ inputs.use-old-gcc }} to cache
+      id: cache-gcc5
+      if: always() && steps.restore-gcc5.outputs.cache-hit != 'true' && inputs.use-old-gcc != ''
+      uses: actions/cache/save@v4
+      with:
+        key: ce-tar-gcc-${{ inputs.use-old-gcc }}
+        path: ~/gcc-${{ inputs.use-old-gcc }}/
+
+    - name: Configure GCC
+      shell: bash
+      run: |
+           mkdir -p gccrs-build;
+           cd gccrs-build;
+           if [ -n "${{ inputs.use-old-gcc }}" ]; then
+              echo "Adjusting PATH for old gcc"
+              export PATH=$HOME/gcc-${{ inputs.use-old-gcc }}/bin:$PATH
+           fi
+
+           if ${{ inputs.glibc-assertion }}; then
+              echo "Enabling GLIBCXX assertions"
+              export CXXFLAGS="$CXXFLAGS -D_GLIBCXX_ASSERTIONS"
+           fi
+
+           if ${{ inputs.enable-multilib }}; then
+              echo "Enabling multilib"
+              MULTILIB_FLG=--enable-multilib
+           else
+              echo "Disabling multilib"
+              MULTILIB_FLG=--disable-multilib
+           fi
+
+           if ${{ inputs.bootstrap }}; then
+              echo "Enabling bootstrap"
+              BOOTSTRAP_FLG=--enable-bootstrap
+           else
+              echo "Disabling bootstrap"
+              BOOTSTRAP_FLG=--disable-bootstrap
+           fi
+
+           if [ -n "${{ inputs.extra-configure-args }}" ]; then
+              EXTRA_CONFIGURE_ARGS="${{ inputs.extra-configure-args }}"
+              echo "Using extra configure args: $EXTRA_CONFIGURE_ARGS"
+           else
+              EXTRA_CONFIGURE_ARGS=""
+           fi
+
+           ../configure \
+               --enable-languages=rust \
+               $BOOTSTRAP_FLG \
+               $MULTILIB_FLG \
+               $EXTRA_CONFIGURE_ARGS
+
+    - name: Build GCC
+      shell: bash
+      run: |
+           cd gccrs-build; \
+
+           if [ -n "${{ inputs.use-old-gcc }}" ]; then
+              export PATH=$HOME/gcc-${{ inputs.use-old-gcc }}/bin:$PATH
+           fi
+
+           # Build without network access
+           unshare --net --ipc -r /bin/bash -c "\
+              make -Otarget -j $(nproc) 2>&1 | \
+                tee log; exit \${PIPESTATUS[0]}"
+           wc -l log
+
+    - name: Check for new warnings
+      if: inputs.warning-file != ''
+      shell: bash
+      run: |
+           cd gccrs-build
+           echo "Before"
+           if grep 'warning: ' log | grep rust | sort > log_warnings; then
+             echo yes
+           else
+             echo no
+           fi
+
+           echo "After"
+
+           if diff -U0 ../.github/${{ inputs.warning-file }} log_warnings; then
+               echo "No new warnings found"
+           else
+               echo 'See <https://github.com/Rust-GCC/gccrs/pull/1026>.'
+               exit 1
+           fi >&2
+
+    - name: Run Tests
+      shell: bash
+      run: |
+           cd gccrs-build; \
+           make check-rust RUNTESTFLAGS="${{ inputs.run-test-flags }}"
+
+    - name: Check regressions
+      shell: bash
+      run: |
+           cd gccrs-build
+           if grep -e "unexpected" -e "unresolved" -e "ERROR:" gcc/testsuite/rust/rust.sum;
+           then
+              echo "::error title=Regression test failed::some tests are not correct"
+              perl -n ../.github/emit_test_errors.pl < gcc/testsuite/rust/rust.sum
+              exit 1
+            else
+              exit 0
+            fi

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -6,451 +6,90 @@ on:
       - trying
       - staging
   pull_request:
-    branches: [ master ]
+    branches: [master]
   merge_group:
 
 env:
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+  # Force locale, in particular for reproducible results re '.github/log_expected_warnings' (see below).
+  LC_ALL: C.UTF-8
 
 jobs:
   build-and-check-ubuntu-64bit:
-
-    env:
-      # Force locale, in particular for reproducible results re '.github/log_expected_warnings' (see below).
-      LC_ALL: C.UTF-8
-
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Install Deps
-      run: |
-          sudo apt-get update;
-          sudo apt-get install -y \
-                  automake \
-                  autoconf \
-                  libtool \
-                  autogen \
-                  bison \
-                  flex \
-                  libgmp3-dev \
-                  libmpfr-dev \
-                  libmpc-dev \
-                  build-essential \
-                  gcc-multilib \
-                  g++-multilib \
-                  dejagnu;
-          # install Rust directly using rustup
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.72.0;
-
-    - name: Make Source Read-Only
-      run: chmod -R a-w ./*
-
-    - name: Configure
-      run: |
-           mkdir -p gccrs-build;
-           cd gccrs-build;
-           ../configure \
-               --enable-languages=rust \
-               --disable-bootstrap \
-               --enable-multilib
-
-    - name: Build
-      shell: bash
-      run: |
-           cd gccrs-build; \
-           # Add cargo to our path quickly
-           . "$HOME/.cargo/env"; \
-           # Build without network access
-           unshare --net --ipc -r /bin/bash -c "make -Otarget -j $(nproc) 2>&1 | tee log ; exit \${PIPESTATUS[0]}"
-
-    - name: Check for new warnings
-      run: |
-           cd gccrs-build
-           < log grep 'warning: ' | grep rust | sort > log_warnings
-           if diff -U0 ../.github/log_expected_warnings log_warnings; then
-               :
-           else
-               echo 'See <https://github.com/Rust-GCC/gccrs/pull/1026>.'
-               exit 1
-           fi >&2
-
-    - name: Run Tests
-      run: |
-           cd gccrs-build; \
-           make check-rust RUNTESTFLAGS="--target_board=unix\{-m64}"
-    - name: Archive check-rust results
-      uses: actions/upload-artifact@v4
-      with:
-        name: check-rust-logs-ubuntu-64
-        path: |
-          gccrs-build/gcc/testsuite/rust/
-    - name: Check regressions
-      run: |
-           cd gccrs-build; \
-           if grep -e "unexpected" -e "unresolved" -e "ERROR:" gcc/testsuite/rust/rust.sum;\
-           then \
-              echo "::error title=Regression test failed::some tests are not correct"; \
-              perl -n ../.github/emit_test_errors.pl < gcc/testsuite/rust/rust.sum; \
-              exit 1; \
-            else \
-              exit 0; \
-            fi
+      - id: build-and-test
+        uses: ./.github/actions/build-gcc
+        with:
+          extra-configure-env: ''
+          run-test-flags: '--target_board=unix\{-m64}'
+          warning-file: 'log_expected_warnings'
+          enable-multilib: false
 
   build-and-check-ubuntu-64bit-glibcxx:
-
-    env:
-      # Force locale, in particular for reproducible results re '.github/log_expected_warnings' (see below).
-      LC_ALL: C.UTF-8
-
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Install Deps
-      run: |
-          sudo apt-get update;
-          sudo apt-get install -y \
-                  automake \
-                  autoconf \
-                  libtool \
-                  autogen \
-                  bison \
-                  flex \
-                  libgmp3-dev \
-                  libmpfr-dev \
-                  libmpc-dev \
-                  build-essential \
-                  gcc-multilib \
-                  g++-multilib \
-                  dejagnu;
-          # install Rust directly using rustup
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.72.0;
+      - id: build-and-test
+        uses: ./.github/actions/build-gcc
+        with:
+          extra-configure-env: ''
+          run-test-flags: '--target_board=unix\{-m64}'
+          warning-file: 'glibcxx_ubuntu64b_log_expected_warnings'
+          glibc-assertion: true
+          enable-multilib: false
+          bootstrap: false
 
-    - name: Make Source Read-Only
-      run: chmod -R a-w ./*
-
-    - name: Configure
-      run: |
-           mkdir -p gccrs-build;
-           cd gccrs-build;
-           export CXXFLAGS="$CXXFLAGS -D_GLIBCXX_ASSERTIONS"
-           ../configure \
-               --enable-languages=rust \
-               --disable-bootstrap \
-               --enable-multilib
-
-    - name: Build
-      shell: bash
-      run: |
-           cd gccrs-build; \
-           # Add cargo to our path quickly
-           . "$HOME/.cargo/env";
-           make -Otarget -j $(nproc) 2>&1 | tee log
-
-    - name: Check for new warnings
-      run: |
-           cd gccrs-build
-           < log grep 'warning: ' | grep rust | sort > log_warnings
-           if diff -U0 ../.github/glibcxx_ubuntu64b_log_expected_warnings log_warnings; then
-               :
-           else
-               echo 'See <https://github.com/Rust-GCC/gccrs/pull/1026>.'
-               exit 1
-           fi >&2
-
-    - name: Run Tests
-      run: |
-           cd gccrs-build; \
-           make check-rust RUNTESTFLAGS="--target_board=unix\{-m64}"
-    - name: Archive check-rust results
-      uses: actions/upload-artifact@v4
-      with:
-        name: check-rust-logs-ubuntu-64-glibcxx
-        path: |
-          gccrs-build/gcc/testsuite/rust/
-    - name: Check regressions
-      run: |
-           cd gccrs-build; \
-           if grep -e "unexpected" -e "unresolved" -e "ERROR:" gcc/testsuite/rust/rust.sum;\
-           then \
-              echo "::error title=Regression test failed::some tests are not correct"; \
-              perl -n ../.github/emit_test_errors.pl < gcc/testsuite/rust/rust.sum; \
-              exit 1; \
-            else \
-              exit 0; \
-            fi
-
+  # This is redundant with 64bit as we are doing multilib. Should build once and test both.
   build-and-check-ubuntu-32bit:
-
-    env:
-      # Force locale, in particular for reproducible results re '.github/log_expected_warnings' (see below).
-      LC_ALL: C.UTF-8
-
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Install Deps
-      run: |
-          sudo apt-get update;
-          sudo apt-get install -y \
-                  automake \
-                  autoconf \
-                  libtool \
-                  autogen \
-                  bison \
-                  flex \
-                  libgmp3-dev \
-                  libmpfr-dev \
-                  libmpc-dev \
-                  build-essential \
-                  gcc-multilib \
-                  g++-multilib \
-                  dejagnu;
-          # install Rust directly using rustup
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.72.0;
-
-    - name: Make Source Read-Only
-      run: chmod -R a-w ./*
-
-    - name: Configure
-      run: |
-           mkdir -p gccrs-build;
-           cd gccrs-build;
-           ../configure \
-               --enable-languages=rust \
-               --disable-bootstrap \
-               --enable-multilib
-
-    - name: Build
-      shell: bash
-      run: |
-           cd gccrs-build; \
-           # Add cargo to our path quickly
-           . "$HOME/.cargo/env";
-           make -Otarget -j $(nproc) 2>&1 | tee log
-
-    - name: Check for new warnings
-      run: |
-           cd gccrs-build
-           < log grep 'warning: ' | grep rust | sort > log_warnings
-           if diff -U0 ../.github/log_expected_warnings log_warnings; then
-               :
-           else
-               echo 'See <https://github.com/Rust-GCC/gccrs/pull/1026>.'
-               exit 1
-           fi >&2
-
-    - name: Run Tests
-      run: |
-           cd gccrs-build; \
-           make check-rust RUNTESTFLAGS="--target_board=unix\{-m32}"
-    - name: Archive check-rust results
-      uses: actions/upload-artifact@v4
-      with:
-        name: check-rust-logs-ubuntu-32
-        path: |
-          gccrs-build/gcc/testsuite/rust/
-    - name: Check regressions
-      run: |
-           cd gccrs-build; \
-           if grep -e "unexpected" -e "unresolved" -e "ERROR:" gcc/testsuite/rust/rust.sum;\
-           then \
-              echo "::error title=Regression test failed::some tests are not correct"; \
-              perl -n ../.github/emit_test_errors.pl < gcc/testsuite/rust/rust.sum; \
-              exit 1; \
-            else \
-              exit 0; \
-            fi
+      - id: build-and-test
+        uses: ./.github/actions/build-gcc
+        with:
+          extra-configure-env: ''
+          run-test-flags: '--target_board=unix\{-m32}'
+          warning-file: 'log_expected_warnings'
+          glibc-assertion: true
+          enable-multilib: true
+          bootstrap: false
 
   build-and-check-gcc-5:
-
     runs-on: ubuntu-22.04
-    env:
-      # otherwise we hang when installing tzdata
-      DEBIAN_FRONTEND: noninteractive
+
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Install Deps
-      run: |
-          sudo apt-get update;
-          sudo apt-get install -y \
-                  curl \
-                  automake \
-                  autoconf \
-                  libtool \
-                  autogen \
-                  bison \
-                  flex \
-                  libc6-dev \
-                  libc6-dev-i386 \
-                  libgmp3-dev \
-                  libmpfr-dev \
-                  libmpc-dev \
-                  build-essential \
-                  dejagnu;
-          # install Rust directly using rustup
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.72.0;
-
-    - name: Restore cached gcc-5.4
-      id: restore-gcc5
-      uses: actions/cache/restore@v4
-      with:
-        key: ce-tar-gcc-5
-        path: ~/gcc-5.4.0/
-
-    - name: Download and install gcc5.4
-      if: ${{ steps.restore-gcc5.outputs.cache-hit != 'true' }}
-      run: |
-        curl "https://s3.amazonaws.com/compiler-explorer/opt/gcc-5.4.0.tar.xz" -o /tmp/gcc.tar.xz;
-        cd ~;
-        tar xvf /tmp/gcc.tar.xz
-
-    - name: Store gcc-5.4 to cache
-      id: cache-gcc5
-      if: always() && steps.restore-gcc5.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
-      with:
-        key: ce-tar-gcc-5
-        path: ~/gcc-5.4.0/
-
-    - name: Make Source Read-Only
-      run: chmod -R a-w ./*
-
-    - name: Configure
-      run: |
-           mkdir -p gccrs-build;
-           cd gccrs-build;
-
-           # Add cargo to our path quickly
-           . "$HOME/.cargo/env";
-
-           PATH=$HOME/gcc-5.4.0/bin:$PATH \
-             ../configure \
-                 --enable-languages=rust \
-                 --disable-bootstrap \
-                 --enable-multilib
-
-    - name: Build
-      shell: bash
-      run: |
-           # Add cargo to our path quickly
-           . "$HOME/.cargo/env";
-           PATH=$HOME/gcc-5.4.0/bin:$PATH \
-             make -C gccrs-build -j $(nproc)
-
-    - name: Run Tests
-      run: |
-           cd gccrs-build; \
-           PATH=$HOME/gcc-5.4.0/bin:$PATH \
-             make check-rust RUNTESTFLAGS="--target_board=unix\{-m32,-m64}"
-
-    - name: Archive check-rust results
-      uses: actions/upload-artifact@v4
-      with:
-        name: check-rust-logs-5
-        path: |
-          gccrs-build/gcc/testsuite/rust/
-
-    - name: Check regressions
-      run: |
-           cd gccrs-build; \
-           if grep -e "unexpected" -e "unresolved" -e "ERROR:" gcc/testsuite/rust/rust.sum;\
-           then \
-              echo "::error title=Regression test failed::some tests are not correct"; \
-              exit 1; \
-            else \
-              exit 0; \
-            fi
+      - id: build-and-test
+        uses: ./.github/actions/build-gcc
+        with:
+          extra-configure-env: ''
+          run-test-flags: '--target_board=unix\{-m32,-m64}'
+          glibc-assertion: false
+          use-old-gcc: '5.4.0'
+          enable-multilib: true
+          bootstrap: false
 
   build-and-check-asan:
-
-    env:
-      # Force locale, in particular for reproducible results re '.github/log_expected_warnings' (see below).
-      LC_ALL: C.UTF-8
-
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Install Deps
-      run: |
-          sudo apt-get update;
-          sudo apt-get install -y \
-                  automake \
-                  autoconf \
-                  libtool \
-                  autogen \
-                  bison \
-                  flex \
-                  libgmp3-dev \
-                  libmpfr-dev \
-                  libmpc-dev \
-                  build-essential \
-                  gcc-multilib \
-                  g++-multilib \
-                  dejagnu;
-          # install Rust directly using rustup
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.72.0;
-
-    - name: Make Source Read-Only
-      run: chmod -R a-w ./*
-
-    - name: Configure
-      run: |
-           mkdir -p gccrs-build;
-           cd gccrs-build;
-           ../configure \
-                   --enable-languages=rust \
-                   --disable-bootstrap \
-                   --enable-multilib \
-                   --with-build-config=../.github/no-bootstrap-asan
-
-    - name: Build
-      shell: bash
-      run: |
-           cd gccrs-build; \
-           # Add cargo to our path quickly
-           . "$HOME/.cargo/env";
-           make -Otarget -j $(nproc) 2>&1 | tee log
-
-# Skip warnings check
-#    - name: Check for new warnings
-#      run: |
-#           cd gccrs-build
-#           < log grep 'warning: ' | sort > log_warnings
-#           if diff -U0 ../.github/log_expected_warnings log_warnings; then
-#               :
-#           else
-#               echo 'See <https://github.com/Rust-GCC/gccrs/pull/1026>.'
-#               exit 1
-#           fi >&2
-
-    - name: Run Tests
-      run: |
-           cd gccrs-build; \
-           ASAN_OPTIONS=detect_leaks=0:use_odr_indicator=1 \
-           make check-rust RUNTESTFLAGS="--target_board=unix\{-m64}"
-    - name: Archive check-rust results
-      uses: actions/upload-artifact@v4
-      with:
-        name: check-rust-logs-asan
-        path: |
-          gccrs-build/gcc/testsuite/rust/
-    - name: Check regressions
-      run: |
-           cd gccrs-build; \
-           if grep -e "unexpected" -e "unresolved" -e "ERROR:" gcc/testsuite/rust/rust.sum;\
-           then \
-              echo "::error title=Regression test failed::some tests are not correct"; \
-              perl -n ../.github/emit_test_errors.pl < gcc/testsuite/rust/rust.sum; \
-              exit 1; \
-            else \
-              exit 0; \
-            fi
+      - id: build-and-test
+        uses: ./.github/actions/build-gcc
+        with:
+          extra-configure-env: ''
+          run-test-flags: '--target_board=unix\{-m64}'
+          glibc-assertion: false
+          enable-multilib: true
+          extra-configure-args: "--with-build-config=../.github/no-bootstrap-asan"
+          bootstrap: false


### PR DESCRIPTION
Use dtolnay/rust-toolchain action to install rustc toolchain.
Use a composite action for the various build/check on ubuntu.

More cleanup possible (the 32/64bits builds could be simplified and only
build 1 compiler and split the checks)
