### PR TITLE
WIP: Handle identifier after for inside impl

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -5418,7 +5418,7 @@ Parser<ManagedTokenSource>::parse_impl (AST::Visibility vis,
   else
     {
       // type path must both be valid and next token is for, so trait impl
-      if (!skip_token (FOR))
+      if (!skip_token (FOR) || !skip_token (IDENTIFIER))
 	{
 	  skip_after_next_block ();
 	  return nullptr;


### PR DESCRIPTION
Thank you for making Rust GCC better!

Adds 

Here is a checklist to help you with your PR.

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[x] Run `clang-format`
- \[x] Added any relevant test cases to `gcc/testsuite/rust/`

Note: Currently several test cases are failing.
This still doesn't fix Rust-GCC#3608
