### PR TITLE
ci: add pull-request URL in commit emails

### DIFF
--- a/.github/workflows/send-emails.yml
+++ b/.github/workflows/send-emails.yml
@@ -220,7 +220,24 @@ jobs:
              echo ""
 
              cp /tmp/description.txt "/tmp/tmp_descr.txt"
-             echo "Commit on github: https://github.com/rust-GCC/gccrs/commit/$SHA1" >> "/tmp/tmp_descr.txt"
+             echo "Commit on github: https://github.com/${{ github.repository }}/commit/$SHA1" >> /tmp/tmp_descr.txt
+
+             if gh api "repos/${{ github.repository }}/commits/$SHA1/pulls" | \
+                  jq '.[].html_url' > /tmp/tmp_pr_links.txt;
+             then
+               if [ -s /tmp/tmp_pr_links.txt ]; then
+                 echo -e "\nThe commit has been mentionned in the following pull-request(s):" >> /tmp/tmp_descr.txt
+
+                 tr -d '"' < /tmp/tmp_pr_links.txt | \
+                   sed 's/^/ - /'  >> /tmp/tmp_descr.txt
+               else
+                 echo "The commit is not linked to any pull-request" >> /tmp/tmp_descr.txt
+               fi
+             else
+               echo "There was an error fetching data from github API for getting PR for commit" | tee -a "$GITHUB_STEP_SUMMARY"
+             fi
+
+             echo >> /tmp/tmp_descr.txt
 
              # insert the github header right after the '---'.
              sed '/^---$/ r /tmp/tmp_descr.txt' -i "$f"


### PR DESCRIPTION
Use github API through `gh` to get the related pull-request URL and add them in the comment section of the emails.

Example content it creates:

```
This change was merged into the gccrs repository and is posted here for
upstream visibility and potential drive-by review, as requested by GCC
release managers. 
Each commit email contains a link to its details on github from where you can
find the Pull-Request and associated discussions. 


Commit on github: https://github.com/dkm/gccrs/commit/a4b3fa2b28a59930e9ee8a690845739bf70f3a2f
                                                                           
The commit has been mentionned in the following pull-request(s): 
 - https://github.com/dkm/gccrs/pull/105

 gcc/rust/lang-specs.h | 2 ++
 1 file changed, 2 insertions(+)
```