### PR TITLE
Remove non-leaf parsing failure error

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -431,10 +431,6 @@ Parser<ManagedTokenSource>::parse_items ()
       std::unique_ptr<AST::Item> item = parse_item (false);
       if (item == nullptr)
 	{
-	  Error error (lexer.peek_token ()->get_locus (),
-		       "failed to parse item in crate");
-	  add_error (std::move (error));
-
 	  // TODO: should all items be cleared?
 	  items = std::vector<std::unique_ptr<AST::Item>> ();
 	  break;

--- a/gcc/testsuite/rust/compile/braced_macro_arm.rs
+++ b/gcc/testsuite/rust/compile/braced_macro_arm.rs
@@ -12,7 +12,6 @@ fn h(c: bool) {
         false => ()
         // { dg-error "exprwithoutblock requires comma after match case expression in match arm \\(if not final case\\)" "" { target *-*-* } .-1 }
         // { dg-error "unrecognised token .false. for start of item" "" { target *-*-* } .-2 }
-        // { dg-error "failed to parse item in crate" "" { target *-*-* } .-3 }
     };
 }
 

--- a/gcc/testsuite/rust/compile/decl_macro6.rs
+++ b/gcc/testsuite/rust/compile/decl_macro6.rs
@@ -2,4 +2,3 @@
 macro m {}
 // { dg-error "unexpected token .\}. - expecting delimiters .for a macro matcher." "" { target *-*-* } .-1 }
 // { dg-error "required first macro rule in declarative macro definition could not be parsed" "" { target *-*-* } .-2 }
-// { dg-error "failed to parse item in crate" "" { target *-*-* } .-3 }

--- a/gcc/testsuite/rust/compile/decl_macro7.rs
+++ b/gcc/testsuite/rust/compile/decl_macro7.rs
@@ -1,4 +1,3 @@
 #![feature(decl_macro)]
 pub macro hello() [ "Hello" ]
 // { dg-error "only braces can be used for a macro transcriber in declarative macro definition" "" { target *-*-* } .-1 }
-// { dg-error "failed to parse item in crate" }

--- a/gcc/testsuite/rust/compile/extern_type_item_missing_semi.rs
+++ b/gcc/testsuite/rust/compile/extern_type_item_missing_semi.rs
@@ -4,4 +4,3 @@ extern "C" {
     type F;
     type E // { dg-error "failed to parse" }
 } // { dg-error "expecting" }
-// { dg-error "failed to parse item in crate" ""  { target *-*-* } .-1 }

--- a/gcc/testsuite/rust/compile/issue-2187.rs
+++ b/gcc/testsuite/rust/compile/issue-2187.rs
@@ -8,4 +8,3 @@ const D: &'static str = "
 ";
 ERROR_TIME
 // { dg-error "unrecognised token" "" { target *-*-* } .-1 }
-// { dg-error "failed to parse item in crate" "" { target *-*-* } .-2 }

--- a/gcc/testsuite/rust/compile/issue-407-2.rs
+++ b/gcc/testsuite/rust/compile/issue-407-2.rs
@@ -10,7 +10,6 @@ pub fn loopy()  {
             // { dg-error {failed to parse if body block expression in if expression} "" { target *-*-* } .-2 }
             // { dg-error {could not parse loop body in \(infinite\) loop expression} "" { target *-*-* } .-3 }
             // { dg-error {unrecognised token 'integer literal' for start of item} "" { target *-*-* } .-4 }
-            // { dg-error {failed to parse item in crate} "" { target *-*-* } .-5 }
         } else {
             break;
         }

--- a/gcc/testsuite/rust/compile/issue-407.rs
+++ b/gcc/testsuite/rust/compile/issue-407.rs
@@ -4,5 +4,4 @@ fn test()  {
     a + = 1; // { dg-error "found unexpected token '=' in null denotation" }
     // { dg-error {failed to parse statement or expression in block expression} "" { target *-*-* } .-1 }
     // { dg-error {unrecognised token 'integer literal' for start of item} "" { target *-*-* } .-2 }
-    // { dg-error {failed to parse item in crate} "" { target *-*-* } .-3 }
 }

--- a/gcc/testsuite/rust/compile/issue-4162.rs
+++ b/gcc/testsuite/rust/compile/issue-4162.rs
@@ -3,7 +3,6 @@ pub fn main() {
     // { dg-error "should be at least 1 pattern" "" { target *-*-* } .-1 }
     // { dg-error "failed to parse statement or expression in block expression" "" { target *-*-* } .-2 }
     // { dg-error "unrecognised token .=. for start of item" "" { target *-*-* } .-3 }
-    // { dg-error "failed to parse item in crate" "" { target *-*-* } .-4 }
     {}
 }
 

--- a/gcc/testsuite/rust/compile/issue-867.rs
+++ b/gcc/testsuite/rust/compile/issue-867.rs
@@ -3,6 +3,5 @@ fn main() {
     let a = _ + 123; // { dg-error "use of '_' is not allowed on the right-side of an assignment" }
                      // { dg-error {failed to parse expression in let statement} "" { target *-*-* } .-1  }
                      // { dg-error {failed to parse statement or expression in block expression} "" { target *-*-* } .-2 }
-                     // { dg-error {unrecognised token '\}' for start of item} "" { target *-*-* } .+2 }
-                     // { dg-error {failed to parse item in crate} "" { target *-*-* } .+1 }
+                     // { dg-error {unrecognised token '\}' for start of item} "" { target *-*-* } .+1 }
 }

--- a/gcc/testsuite/rust/compile/macros/mbe/macro-issue1053-2.rs
+++ b/gcc/testsuite/rust/compile/macros/mbe/macro-issue1053-2.rs
@@ -1,5 +1,4 @@
 macro_rules! m {
     ($e:expr $(forbidden)*) => {{}}; // { dg-error "token .identifier. is not allowed after .expr. fragment" }
                                      // { dg-error "required first macro rule in macro rules definition could not be parsed" "" { target *-*-* } .-1 }
-                                     // { dg-error "failed to parse item in crate" "" { target *-*-* } .-2 }
 }

--- a/gcc/testsuite/rust/compile/macros/mbe/macro-issue1395-2.rs
+++ b/gcc/testsuite/rust/compile/macros/mbe/macro-issue1395-2.rs
@@ -2,6 +2,5 @@
 
 macro_rules! try {
     // { dg-error "expecting .identifier. but .try. found" "" { target *-*-* } .-1 }
-    // { dg-error "failed to parse item in crate" "" { target *-*-* } .-2 }
     () => {};
 }

--- a/gcc/testsuite/rust/compile/macros/mbe/macro-issue3608.rs
+++ b/gcc/testsuite/rust/compile/macros/mbe/macro-issue3608.rs
@@ -7,6 +7,5 @@ impl Bar for
 
 fn main() { )// { dg-error "unexpected closing delimiter .\\). - token tree requires either paired delimiters or non-delimiter tokens" }
              // { dg-error "failed to parse token tree in delimited token tree - found .\\)." "" { target *-*-* } .-1 }
-             // { dg-error "unexpected token .end of file. - expecting closing delimiter .\}. .for a delimited token tree." "" { target *-*-* } .+3 }
-             // { dg-error "unexpected token .end of file. - expecting closing delimiter .\\). .for a macro invocation semi." "" { target *-*-* } .+2 }
-             // { dg-error "failed to parse item in crate" "" { target *-*-* } .+1 }
+             // { dg-error "unexpected token .end of file. - expecting closing delimiter .\}. .for a delimited token tree." "" { target *-*-* } .+2 }
+             // { dg-error "unexpected token .end of file. - expecting closing delimiter .\\). .for a macro invocation semi." "" { target *-*-* } .+1 }

--- a/gcc/testsuite/rust/compile/macros/mbe/macro27.rs
+++ b/gcc/testsuite/rust/compile/macros/mbe/macro27.rs
@@ -2,7 +2,6 @@ macro_rules! m {
     ($a:expr tok) => {
         // { dg-error "token .identifier. is not allowed after .expr. fragment" "" { target *-*-* } .-1 }
         // { dg-error "required first macro rule in macro rules definition could not be parsed" "" { target *-*-* } .-2 }
-        // { dg-error "failed to parse item in crate" "" { target *-*-* } .-3 }
         $a
     };
 }

--- a/gcc/testsuite/rust/compile/macros/mbe/macro28.rs
+++ b/gcc/testsuite/rust/compile/macros/mbe/macro28.rs
@@ -2,7 +2,6 @@ macro_rules! m {
     ($a:expr $(tok $es:expr)*) => {
         // { dg-error "token .identifier. is not allowed after .expr. fragment" "" { target *-*-* } .-1 }
         // { dg-error "required first macro rule in macro rules definition could not be parsed" "" { target *-*-* } .-2 }
-        // { dg-error "failed to parse item in crate" "" { target *-*-* } .-3 }
         $a
     };
 }

--- a/gcc/testsuite/rust/compile/macros/mbe/macro29.rs
+++ b/gcc/testsuite/rust/compile/macros/mbe/macro29.rs
@@ -2,7 +2,6 @@ macro_rules! m {
     ($($es:expr)* tok) => {
         // { dg-error "token .identifier. is not allowed after .expr. fragment" "" { target *-*-* } .-1 }
         // { dg-error "required first macro rule in macro rules definition could not be parsed" "" { target *-*-* } .-2 }
-        // { dg-error "failed to parse item in crate" "" { target *-*-* } .-3 }
         $a
     };
 }

--- a/gcc/testsuite/rust/compile/macros/mbe/macro30.rs
+++ b/gcc/testsuite/rust/compile/macros/mbe/macro30.rs
@@ -2,7 +2,6 @@ macro_rules! m {
     ($e:expr $f:expr) => {
         // { dg-error "fragment is not allowed after .expr. fragment" "" { target *-*-* } .-1 }
         // { dg-error "required first macro rule in macro rules definition could not be parsed" "" { target *-*-* } .-2 }
-        // { dg-error "failed to parse item in crate" "" { target *-*-* } .-3 }
         $e
     };
 }

--- a/gcc/testsuite/rust/compile/macros/mbe/macro31.rs
+++ b/gcc/testsuite/rust/compile/macros/mbe/macro31.rs
@@ -2,7 +2,6 @@ macro_rules! m {
     ($($e:expr)* $($f:expr)*) => {
         // { dg-error "fragment is not allowed after .expr. fragment" "" { target *-*-* } .-1 }
         // { dg-error "required first macro rule in macro rules definition could not be parsed" "" { target *-*-* } .-2 }
-        // { dg-error "failed to parse item in crate" "" { target *-*-* } .-3 }
         $e
     };
 }

--- a/gcc/testsuite/rust/compile/macros/mbe/macro33.rs
+++ b/gcc/testsuite/rust/compile/macros/mbe/macro33.rs
@@ -1,5 +1,4 @@
 macro_rules! forbidden_frag {
     ($t:ty $not_block:ident) => {{}}; // { dg-error "fragment specifier .ident. is not allowed after .ty. fragments" }
                                       // { dg-error "required first macro rule in macro rules definition could not be parsed" "" { target *-*-* } .-1 }
-                                      // { dg-error "failed to parse item in crate" "" { target *-*-* } .-2 }
 }

--- a/gcc/testsuite/rust/compile/macros/mbe/macro35.rs
+++ b/gcc/testsuite/rust/compile/macros/mbe/macro35.rs
@@ -3,5 +3,4 @@ macro_rules! inside_matcher {
                                  // { dg-error "failed to parse macro matcher" "" { target *-*-* } .-1 }
                                  // { dg-error "failed to parse macro match" "" { target *-*-* } .-2 }
                                  // { dg-error "required first macro rule" "" { target *-*-* } .-3 }
-                                 // { dg-error "failed to parse item in crate" "" { target *-*-* } .-4 }
 }

--- a/gcc/testsuite/rust/compile/macros/mbe/macro37.rs
+++ b/gcc/testsuite/rust/compile/macros/mbe/macro37.rs
@@ -1,5 +1,4 @@
 macro_rules! invalid_after_zeroable {
     ($e:expr $(,)* forbidden) => {{}}; // { dg-error "token .identifier. is not allowed after .expr. fragment" }
                                        // { dg-error "required first macro rule" "" { target *-*-* } .-1 }
-                                       // { dg-error "failed to parse item in crate" "" { target *-*-* } .-2 }
 }

--- a/gcc/testsuite/rust/compile/macros/mbe/macro38.rs
+++ b/gcc/testsuite/rust/compile/macros/mbe/macro38.rs
@@ -1,5 +1,4 @@
 macro_rules! invalid_after_zeroable_multi {
     ($e:expr $(,)? $(;)* $(=>)? forbidden) => {{}}; // { dg-error "token .identifier. is not allowed after .expr. fragment" }
                                                     // { dg-error "required first macro rule" "" { target *-*-* } .-1 }
-                                                    // { dg-error "failed to parse item in crate" "" { target *-*-* } .-2 }
 }

--- a/gcc/testsuite/rust/compile/macros/mbe/macro39.rs
+++ b/gcc/testsuite/rust/compile/macros/mbe/macro39.rs
@@ -1,5 +1,4 @@
 macro_rules! m {
     ($e:expr (, parenthesis_forbidden)) => {{}}; // { dg-error "token .\\(. at start of matcher is not allowed after .expr. fragment" }
                                                  // { dg-error "required first macro rule" "" { target *-*-* } .-1 }
-                                                 // { dg-error "failed to parse item in crate" "" { target *-*-* } .-2 }
 }

--- a/gcc/testsuite/rust/compile/macros/mbe/macro48.rs
+++ b/gcc/testsuite/rust/compile/macros/mbe/macro48.rs
@@ -1,8 +1,7 @@
 // Check that "priv" is not in the follow set of :vis.
 
-// { dg-error "token .priv. is not allowed after .vis. fragment" "#359" { target *-*-* } .+4 }
-// { dg-error "required first macro rule in macro rules definition could not be parsed" "" { target *-*-* } .+3 }
-// { dg-error "failed to parse item in crate" "" { target *-*-* } .+2 }
+// { dg-error "token .priv. is not allowed after .vis. fragment" "#359" { target *-*-* } .+3 }
+// { dg-error "required first macro rule in macro rules definition could not be parsed" "" { target *-*-* } .+2 }
 macro_rules! my_mac {
     ($v:vis priv) => {
         $v struct Foo(i32);

--- a/gcc/testsuite/rust/compile/parse_invalid_specialization.rs
+++ b/gcc/testsuite/rust/compile/parse_invalid_specialization.rs
@@ -1,4 +1,3 @@
 default fn f() {
     // { dg-error ".default. is only allowed on items within .impl. blocks" "" { target *-*-* } .-1 }
-    // { dg-error "failed to parse item in crate" "" { target *-*-* } .-2 }
 }

--- a/gcc/testsuite/rust/compile/parse_simple_path_fail_1.rs
+++ b/gcc/testsuite/rust/compile/parse_simple_path_fail_1.rs
@@ -1,3 +1,2 @@
 pub(in crate::) struct S;
 // { dg-error "expecting ... but .::. found" "" { target *-*-* } .-1 }
-// { dg-error "failed to parse item in crate" "" { target *-*-* } .-2 }

--- a/gcc/testsuite/rust/compile/parse_simple_path_fail_2.rs
+++ b/gcc/testsuite/rust/compile/parse_simple_path_fail_2.rs
@@ -5,5 +5,3 @@ mod A {
 use A{B};
 // { dg-error "unexpected token" "" { target *-*-* } .-1 }
 // { dg-error "could not parse use tree" "" { target *-*-* } .-2 }
-// { dg-error "failed to parse item in crate" "" { target *-*-* } 10 }
-// ^^^ TODO: should the above error happen at line 10?

--- a/gcc/testsuite/rust/compile/raw-byte-string-loc.rs
+++ b/gcc/testsuite/rust/compile/raw-byte-string-loc.rs
@@ -3,4 +3,3 @@ const X: &'static u8 = br#"12
 
 BREAK
 // { dg-error "unrecognised token" "" { target *-*-* } .-1 }
-// { dg-error "failed to parse item" "" { target *-*-* } .-2 }

--- a/gcc/testsuite/rust/compile/raw-string-loc.rs
+++ b/gcc/testsuite/rust/compile/raw-string-loc.rs
@@ -3,4 +3,3 @@ const X: &'static str = r#"12
 
 BREAK
 // { dg-error "unrecognised token" "" { target *-*-* } .-1 }
-// { dg-error "failed to parse item" "" { target *-*-* } .-2 }

--- a/gcc/testsuite/rust/compile/self_const_ptr.rs
+++ b/gcc/testsuite/rust/compile/self_const_ptr.rs
@@ -4,5 +4,4 @@ impl MyStruct {
     pub fn do_something(*const self) {}
     // { dg-error "cannot pass .self. by raw pointer" "" { target *-*-* } .-1 }
     // { dg-error "failed to parse inherent impl item in inherent impl" "" { target *-*-* } .-2 }
-    // { dg-error "failed to parse item in crate" "" { target *-*-* } .-3 }
 }

--- a/gcc/testsuite/rust/compile/self_mut_ptr.rs
+++ b/gcc/testsuite/rust/compile/self_mut_ptr.rs
@@ -4,5 +4,4 @@ impl MyStruct {
     pub fn do_something(*mut self) {}
     // { dg-error "cannot pass .self. by raw pointer" "" { target *-*-* } .-1 }
     // { dg-error "failed to parse inherent impl item in inherent impl" "" { target *-*-* } .-2 }
-    // { dg-error "failed to parse item in crate" "" { target *-*-* } .-3 }
 }

--- a/gcc/testsuite/rust/compile/self_ptr.rs
+++ b/gcc/testsuite/rust/compile/self_ptr.rs
@@ -4,5 +4,4 @@ impl MyStruct {
     pub fn do_something(*self) {}
     // { dg-error "cannot pass .self. by raw pointer" "" { target *-*-* } .-1 }
     // { dg-error "failed to parse inherent impl item in inherent impl" "" { target *-*-* } .-2 }
-    // { dg-error "failed to parse item in crate" "" { target *-*-* } .-3 }
 }

--- a/gcc/testsuite/rust/compile/static_var1.rs
+++ b/gcc/testsuite/rust/compile/static_var1.rs
@@ -1,5 +1,5 @@
 static x = 3; // { dg-error "expecting ':' but '=' found" }
 
-fn main() {// { dg-error "failed to parse item in crate" }
+fn main() {
     let y = x +1;
 }

--- a/gcc/testsuite/rust/compile/torture/identifier-missing-impl-1.rs
+++ b/gcc/testsuite/rust/compile/torture/identifier-missing-impl-1.rs
@@ -4,7 +4,6 @@ impl I {
     fn () {
         // { dg-error {expecting 'identifier' but '\(' found} "" { target *-*-* } .-1 }
         // { dg-error {failed to parse inherent impl item in inherent impl} "" { target *-*-* } .-2 }
-        // { dg-error {failed to parse item in crate} "" { target *-*-* } .-3 }
     }
 }
 


### PR DESCRIPTION
Error messages within GCCRS are unclear, mainly because we're emitting up to five error messages for the same error. This PR aims to bring that number down and keep only leaf errors unless the higher context is required.