### PR TITLE
Handle IDENTIFIER at parse_bare_function_type(

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -9678,6 +9678,18 @@ Parser<ManagedTokenSource>::parse_bare_function_type (
   if (!skip_token (FN_KW))
     return nullptr;
 
+  // bare functions don't have identifiers
+  auto t = lexer.peek_token ();
+  if (t->get_id () == IDENTIFIER)
+    {
+      Error error (t->get_locus (),
+		   "unexpected token %qs - expected bare function",
+		   t->get_token_description ());
+      add_error (std::move (error));
+
+      return nullptr;
+    }
+
   if (!skip_token (LEFT_PAREN))
     return nullptr;
 
@@ -9686,7 +9698,7 @@ Parser<ManagedTokenSource>::parse_bare_function_type (
   bool is_variadic = false;
   AST::AttrVec variadic_attrs;
 
-  const_TokenPtr t = lexer.peek_token ();
+  t = lexer.peek_token ();
   while (t->get_id () != RIGHT_PAREN)
     {
       AST::AttrVec temp_attrs = parse_outer_attributes ();

--- a/gcc/testsuite/rust/compile/invalid_impl_for.rs
+++ b/gcc/testsuite/rust/compile/invalid_impl_for.rs
@@ -1,0 +1,4 @@
+impl Foo for
+fn main() {// { dg-error "unexpected token .identifier. - expected bare function" }
+// { dg-error "could not parse type in trait impl" "" { target *-*-* } .-1 }
+}// { dg-error "failed to parse item in crate" "" { target *-*-* } .+1 }


### PR DESCRIPTION
- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`
- \[x] Added any relevant test cases to `gcc/testsuite/rust/`

This is useful when compiling:
```
impl Foo for
fn my_function() {
//do something
}
```

