### PR TITLE
Fixes PR 122886: Initialize uninit boolean

### DIFF
--- a/gcc/rust/backend/rust-constexpr.cc
+++ b/gcc/rust/backend/rust-constexpr.cc
@@ -3137,7 +3137,7 @@ eval_binary_expression (const constexpr_ctx *ctx, tree t, bool lval,
 	{
 	  tree lmem = PTRMEM_CST_MEMBER (lhs);
 	  tree rmem = PTRMEM_CST_MEMBER (rhs);
-	  bool eq;
+	  bool eq = false;
 	  if (TREE_CODE (lmem) == TREE_CODE (rmem)
 	      && TREE_CODE (lmem) == FIELD_DECL
 	      && TREE_CODE (DECL_CONTEXT (lmem)) == UNION_TYPE


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* backend/rust-constexpr.cc (eval_binary_expression): Set initial value equality value to false.

Fixes https://gcc.gnu.org/bugzilla/show_bug.cgi?id=122886