### PR TITLE
Correct spelling of 'mentionned'

### DIFF
--- a/.github/workflows/send-emails.yml
+++ b/.github/workflows/send-emails.yml
@@ -226,7 +226,7 @@ jobs:
                   jq '.[].html_url' > /tmp/tmp_pr_links.txt;
              then
                if [ -s /tmp/tmp_pr_links.txt ]; then
-                 echo -e "\nThe commit has been mentionned in the following pull-request(s):" >> /tmp/tmp_descr.txt
+                 echo -e "\nThe commit has been mentioned in the following pull-request(s):" >> /tmp/tmp_descr.txt
 
                  tr -d '"' < /tmp/tmp_pr_links.txt | \
                    sed 's/^/ - /'  >> /tmp/tmp_descr.txt


### PR DESCRIPTION
https://github.com/Rust-GCC/gccrs/pull/4306 added a GH action to push GH PRs into emails, however, it looks like this:

```
The commit has been mentionned in the following pull-request(s): 
 - https://github.com/dkm/gccrs/pull/105
```

Notice: the incorrect spelling of "mentionned".

This PR corrects that.