### PR TITLE
gccrs: Fix comment typos in rust-macro-expand.h

### DIFF
--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -358,7 +358,7 @@ struct MacroExpander
    *
    * @param parser Parser to use for matching
    * @param rep Repetition to try and match
-   * @param match_amount Reference in which to store the ammount of succesful
+   * @param match_amount Reference in which to store the amount of successful
    * and valid matches
    *
    * @param lo_bound Lower bound of the matcher. When specified, the matcher


### PR DESCRIPTION
gcc/rust/ChangeLog:
    
[pretend there's a tab here]* expand/rust-macro-expand.h: Fix typos in comment.
