### PR TITLE
Remove non-leaf error message in delimited tt

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -978,16 +978,7 @@ Parser<ManagedTokenSource>::parse_delim_token_tree ()
       std::unique_ptr<AST::TokenTree> tok_tree = parse_token_tree ();
 
       if (tok_tree == nullptr)
-	{
-	  // TODO: is this error handling appropriate?
-	  Error error (
-	    t->get_locus (),
-	    "failed to parse token tree in delimited token tree - found %qs",
-	    t->get_token_description ());
-	  add_error (std::move (error));
-
-	  return AST::DelimTokenTree::create_empty ();
-	}
+	return AST::DelimTokenTree::create_empty ();
 
       token_trees_in_tree.push_back (std::move (tok_tree));
 
@@ -1075,11 +1066,12 @@ Parser<ManagedTokenSource>::parse_token_tree ()
     case RIGHT_SQUARE:
     case RIGHT_CURLY:
       // error - should not be called when this a token
-      add_error (
-	Error (t->get_locus (),
-	       "unexpected closing delimiter %qs - token tree requires "
-	       "either paired delimiters or non-delimiter tokens",
-	       t->get_token_description ()));
+      add_error (Error (t->get_locus (), "unexpected closing delimiter %qs",
+			t->get_token_description ()));
+
+      add_error (Error (Error::Kind::Hint, t->get_locus (),
+			"token tree requires either paired delimiters or "
+			"non-delimiter tokens"));
 
       lexer.skip_token ();
       return nullptr;

--- a/gcc/testsuite/rust/compile/macros/mbe/macro-issue3608.rs
+++ b/gcc/testsuite/rust/compile/macros/mbe/macro-issue3608.rs
@@ -5,7 +5,6 @@ struct Baz {
 impl Bar for
 
 
-fn main() { )// { dg-error "unexpected closing delimiter .\\). - token tree requires either paired delimiters or non-delimiter tokens" }
-             // { dg-error "failed to parse token tree in delimited token tree - found .\\)." "" { target *-*-* } .-1 }
+fn main() { )// { dg-error "unexpected closing delimiter .\\)." }
              // { dg-error "unexpected token .end of file. - expecting closing delimiter .\}. .for a delimited token tree." "" { target *-*-* } .+2 }
              // { dg-error "unexpected token .end of file. - expecting closing delimiter .\\). .for a macro invocation semi." "" { target *-*-* } .+1 }


### PR DESCRIPTION
Delimited token tree parsing already emit an error in a leaf location, this error is redundant.