### PR TITLE
Add check for token at parse_bare_function_type

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -9643,7 +9643,7 @@ Parser<ManagedTokenSource>::parse_bare_function_type (
     return nullptr;
 
   auto t = lexer.peek_token ();
-  if (t->get_id () == IDENTIFIER)
+  if (t->get_id () != LEFT_PAREN)
     {
       Error error (t->get_locus (),
 		   "unexpected token %qs - expected bare function",

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -9653,9 +9653,6 @@ Parser<ManagedTokenSource>::parse_bare_function_type (
       return nullptr;
     }
 
-  if (!skip_token (LEFT_PAREN))
-    return nullptr;
-
   // parse function params, if they exist
   std::vector<AST::MaybeNamedParam> params;
   bool is_variadic = false;

--- a/gcc/rust/parse/rust-parse-impl.h
+++ b/gcc/rust/parse/rust-parse-impl.h
@@ -9642,6 +9642,17 @@ Parser<ManagedTokenSource>::parse_bare_function_type (
   if (!skip_token (FN_KW))
     return nullptr;
 
+  auto t = lexer.peek_token ();
+  if (t->get_id () == IDENTIFIER)
+    {
+      Error error (t->get_locus (),
+		   "unexpected token %qs - expected bare function",
+		   t->get_token_description ());
+      add_error (std::move (error));
+
+      return nullptr;
+    }
+
   if (!skip_token (LEFT_PAREN))
     return nullptr;
 
@@ -9650,7 +9661,7 @@ Parser<ManagedTokenSource>::parse_bare_function_type (
   bool is_variadic = false;
   AST::AttrVec variadic_attrs;
 
-  const_TokenPtr t = lexer.peek_token ();
+  t = lexer.peek_token ();
   while (t->get_id () != RIGHT_PAREN)
     {
       AST::AttrVec temp_attrs = parse_outer_attributes ();

--- a/gcc/testsuite/rust/compile/invalid_impl_for.rs
+++ b/gcc/testsuite/rust/compile/invalid_impl_for.rs
@@ -1,4 +1,4 @@
 impl Foo for
-fn main() {// { dg-error "unexpected token .identifier. - expected bare function" }
+fn main() {// { dg-error "unexpected token ..*. - expected bare function" }
 // { dg-error "could not parse type in trait impl" "" { target *-*-* } .-1 }
 }

--- a/gcc/testsuite/rust/compile/invalid_impl_for.rs
+++ b/gcc/testsuite/rust/compile/invalid_impl_for.rs
@@ -1,0 +1,4 @@
+impl Foo for
+fn main() {// { dg-error "unexpected token .identifier. - expected bare function" }
+// { dg-error "could not parse type in trait impl" "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/compile/invalid_impl_for.rs
+++ b/gcc/testsuite/rust/compile/invalid_impl_for.rs
@@ -1,4 +1,4 @@
 impl Foo for
-fn main() {// { dg-error "unexpected token ..*. - expected bare function" }
+fn main() {// { dg-error "unexpected token .* - expected bare function" }
 // { dg-error "could not parse type in trait impl" "" { target *-*-* } .-1 }
 }


### PR DESCRIPTION
previously the compiler emmited:

> expecting ‘(’ but ‘identifier’ found

now it emmits:

> unexpected token 'identifier' - expected bare function

code example:
```
impl Foo for
fn my_function() {
//do something
}
```