### PR TITLE
Add missing test for lang item feature gate

### DIFF
--- a/gcc/testsuite/rust/compile/lang_feature_gate.rs
+++ b/gcc/testsuite/rust/compile/lang_feature_gate.rs
@@ -1,0 +1,2 @@
+#[lang = "sized"] // { dg-error "lang items are subject to change. add .#!.feature.lang_items... to the crate attributes to enable" }
+pub trait Sized {}


### PR DESCRIPTION
We recently modified all tests with lang items to add the lang feature gate switch but we did not introduce any test to check that a proper error message is printed when this switch is not used.

gcc/testsuite/ChangeLog:

	* rust/compile/lang_feature_gate.rs: New test.