### PR TITLE
Use the path location for MetaItemPathExpr

### DIFF
--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -294,15 +294,7 @@ public:
     return MetaItem::ItemKind::PathExpr;
   }
 
-  // There are two Locations in MetaItemPathExpr (path and expr),
-  //  we have no idea use which of them, just simply return UNKNOWN_LOCATION
-  //  now.
-  // Maybe we will figure out when we really need the location in the future.
-  location_t get_locus () const override
-  {
-    rust_unreachable ();
-    return UNKNOWN_LOCATION;
-  }
+  location_t get_locus () const override { return path.get_locus (); }
 
   void accept_vis (ASTVisitor &vis) override;
 

--- a/gcc/testsuite/rust/compile/issue-4301.rs
+++ b/gcc/testsuite/rust/compile/issue-4301.rs
@@ -1,0 +1,3 @@
+#![feature(unused_variables, server = b"\0")]
+// { dg-error {unknown feature .server = .} "" { target *-*-* } .-1 }
+// { dg-error {unknown feature .unused_variables.} "" { target *-*-* } .-2 }


### PR DESCRIPTION
Previously we aborted when querying the location on a MetaItemPathExpr, the location should start on the path and continue over the expr but we do not support that kind of location range yet.

Fixes #4301 