### PR TITLE
gccrs: refactor string methods in HIR

### DIFF
--- a/gcc/rust/backend/rust-compile-implitem.h
+++ b/gcc/rust/backend/rust-compile-implitem.h
@@ -56,7 +56,7 @@ public:
 
     if (is_query_mode && compiler.reference == error_mark_node)
       rust_internal_error_at (ref_locus, "failed to compile trait item: %s",
-			      item->as_string ().c_str ());
+			      item->to_string ().c_str ());
 
     return compiler.reference;
   }

--- a/gcc/rust/backend/rust-compile-type.cc
+++ b/gcc/rust/backend/rust-compile-type.cc
@@ -244,7 +244,7 @@ TyTyResolveCompile::visit (const TyTy::FnType &type)
       auto compiled_param_type
 	= TyTyResolveCompile::compile (ctx, param_tyty, trait_object_mode);
 
-      parameters.emplace_back (param_pair.get_pattern ().as_string (),
+      parameters.emplace_back (param_pair.get_pattern ().to_string (),
 			       compiled_param_type,
 			       ctx->get_mappings ().lookup_location (
 				 param_tyty->get_ref ()));

--- a/gcc/rust/checks/errors/rust-readonly-check.cc
+++ b/gcc/rust/checks/errors/rust-readonly-check.cc
@@ -121,7 +121,7 @@ ReadonlyChecker::check_variable (IdentifierPattern *pattern,
   auto hir_id = pattern->get_mappings ().get_hirid ();
   if (already_assigned_variables.count (hir_id) > 0)
     rust_error_at (assigned_loc, "assignment of read-only variable '%s'",
-		   pattern->as_string ().c_str ());
+		   pattern->to_string ().c_str ());
   already_assigned_variables.insert (hir_id);
 }
 

--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -298,7 +298,7 @@ Dump::do_vis_item (VisItem &e)
   do_item (e);
   std::string str = "none";
   if (e.has_visibility ())
-    str = e.get_visibility ().as_string ();
+    str = e.get_visibility ().to_string ();
   put_field ("visibility", str);
 }
 
@@ -326,7 +326,7 @@ Dump::do_pathpattern (PathPattern &e)
   std::string str = "";
 
   for (const auto &segment : e.get_segments ())
-    str += segment.as_string () + ", ";
+    str += segment.to_string () + ", ";
 
   put_field ("segments", str);
 }
@@ -399,7 +399,7 @@ Dump::do_typepathsegment (TypePathSegment &e)
   if (e.is_lang_item ())
     put_field ("ident_segment", LangItem::PrettyString (e.get_lang_item ()));
   else
-    put_field ("ident_segment", e.get_ident_segment ().as_string ());
+    put_field ("ident_segment", e.get_ident_segment ().to_string ());
 }
 
 void
@@ -474,7 +474,7 @@ Dump::do_baseloopexpr (BaseLoopExpr &e)
   if (!e.has_loop_label ())
     put_field ("label", "none");
   else
-    put_field ("label", e.get_loop_label ().as_string ());
+    put_field ("label", e.get_loop_label ().to_string ());
 
   visit_field ("loop_block", e.get_loop_block ());
 }
@@ -489,7 +489,7 @@ Dump::do_struct (Struct &e)
   if (!e.has_where_clause ())
     put_field ("where_clause", "none");
   else
-    put_field ("where clause", e.get_where_clause ().as_string ());
+    put_field ("where clause", e.get_where_clause ().to_string ());
 }
 
 void
@@ -522,7 +522,7 @@ void
 Dump::do_traitfunctiondecl (TraitFunctionDecl &e)
 {
   begin ("TraitFunctionDecl");
-  put_field ("qualifiers", e.get_qualifiers ().as_string ());
+  put_field ("qualifiers", e.get_qualifiers ().to_string ());
   put_field ("function_name", e.get_function_name ().as_string ());
   visit_collection ("generic_params", e.get_generic_params ());
 
@@ -542,12 +542,12 @@ Dump::do_traitfunctiondecl (TraitFunctionDecl &e)
     put_field ("return_type", "none");
 
   if (e.has_where_clause ())
-    put_field ("where_clause", e.get_where_clause ().as_string ());
+    put_field ("where_clause", e.get_where_clause ().to_string ());
   else
     put_field ("where_clause", "none");
 
   if (e.is_method ())
-    put_field ("self", e.get_self_unchecked ().as_string ());
+    put_field ("self", e.get_self_unchecked ().to_string ());
 
   end ("TraitFunctionDecl");
 }
@@ -562,7 +562,7 @@ Dump::do_externalitem (ExternalItem &e)
 
   std::string str = "none";
   if (e.has_visibility ())
-    str = e.get_visibility ().as_string ();
+    str = e.get_visibility ().to_string ();
   put_field ("visibility", str);
   put_field ("item_name", e.get_item_name ().as_string ());
 }
@@ -606,7 +606,7 @@ Dump::do_tuplefield (TupleField &e)
 
   std::string str = "none";
   if (e.has_visibility ())
-    str = e.get_visibility ().as_string ();
+    str = e.get_visibility ().to_string ();
   put_field ("visibility", str);
 
   visit_field ("field_type", e.get_field_type ());
@@ -621,7 +621,7 @@ Dump::do_structfield (StructField &e)
 
   std::string str = "none";
   if (e.has_visibility ())
-    str = e.get_visibility ().as_string ();
+    str = e.get_visibility ().to_string ();
   put_field ("visibility", str);
   put_field ("field_name", e.get_field_name ().as_string ());
   visit_field ("field_type", e.get_field_type ());
@@ -721,7 +721,7 @@ void
 Dump::visit (LifetimeParam &lifetimeparam)
 {
   begin ("Lifetimeparam");
-  put (lifetimeparam.as_string ());
+  put (lifetimeparam.to_debug_string ());
   end ("Lifetimeparam");
 }
 
@@ -1191,7 +1191,7 @@ Dump::visit (StructExprStructFields &e)
   if (!e.has_struct_base ())
     put_field ("struct_base", "none");
   else
-    put_field ("struct_base", e.get_struct_base ().as_string ());
+    put_field ("struct_base", e.get_struct_base ().to_string ());
 
   end ("StructExprStructFields");
 }
@@ -1202,7 +1202,7 @@ Dump::visit (StructExprStructBase &e)
   begin ("StructExprStructBase");
   do_structexprstruct (e);
 
-  put_field ("struct_base", e.get_struct_base ().as_string ());
+  put_field ("struct_base", e.get_struct_base ().to_string ());
 
   end ("StructExprStructBase");
 }
@@ -1226,7 +1226,7 @@ Dump::visit (MethodCallExpr &e)
   do_expr (e);
 
   visit_field ("receiver", e.get_receiver ());
-  put_field ("method_name", e.get_method_name ().as_string ());
+  put_field ("method_name", e.get_method_name ().to_string ());
   visit_collection ("params", e.get_arguments ());
 
   end ("MethodCallExpr");
@@ -1286,7 +1286,7 @@ Dump::visit (BlockExpr &e)
   put_field ("tail_reachable", std::to_string (e.is_tail_reachable ()));
 
   if (e.has_label ())
-    put_field ("label", e.get_label ().as_string ());
+    put_field ("label", e.get_label ().to_string ());
 
   visit_collection ("statements", e.get_statements ());
 
@@ -1327,7 +1327,7 @@ Dump::visit (ContinueExpr &e)
   begin ("ContinueExpr");
 
   if (e.has_label ())
-    put_field ("label", e.get_label ().as_string ());
+    put_field ("label", e.get_label ().to_string ());
   else
     put_field ("label", "none");
 
@@ -1341,7 +1341,7 @@ Dump::visit (BreakExpr &e)
   std::string str ("break ");
 
   if (e.has_label ())
-    put_field ("label", e.get_label ().as_string ());
+    put_field ("label", e.get_label ().to_string ());
   else
     put_field ("label", "none");
 
@@ -1610,7 +1610,7 @@ Dump::visit (OffsetOf &e)
 {
   begin ("OffsetOf");
 
-  put_field ("type", e.get_type ().as_string ());
+  put_field ("type", e.get_type ().to_debug_string ());
   put_field ("field", e.get_field ());
 
   end ("OffsetOf");
@@ -1778,7 +1778,7 @@ Dump::visit (Function &e)
   begin ("Function");
   do_vis_item (e);
 
-  put_field ("function_qualifiers", e.get_qualifiers ().as_string ());
+  put_field ("function_qualifiers", e.get_qualifiers ().to_string ());
 
   visit_collection ("generic_params", e.get_generic_params ());
 
@@ -1802,11 +1802,11 @@ Dump::visit (Function &e)
   if (!e.has_where_clause ())
     put_field ("where_clause", "none");
   else
-    put_field ("where clause", e.get_where_clause ().as_string ());
+    put_field ("where clause", e.get_where_clause ().to_string ());
 
   visit_field ("function_body", e.get_definition ());
   if (e.is_method ())
-    put_field ("self", e.get_self_param_unchecked ().as_string ());
+    put_field ("self", e.get_self_param_unchecked ().to_string ());
 
   end ("Function");
 }
@@ -1825,9 +1825,9 @@ Dump::visit (TypeAlias &e)
   if (!e.has_where_clause ())
     put_field ("where_clause", "none");
   else
-    put_field ("where clause", e.get_where_clause ().as_string ());
+    put_field ("where clause", e.get_where_clause ().to_string ());
 
-  put_field ("type", e.get_type_aliased ().as_string ());
+  put_field ("type", e.get_type_aliased ().to_debug_string ());
 
   end ("TypeAlias");
 }
@@ -1951,7 +1951,7 @@ Dump::visit (Enum &e)
 
   std::string str = "none";
   if (e.has_where_clause ())
-    str = e.get_where_clause ().as_string ();
+    str = e.get_where_clause ().to_string ();
   put_field ("where clause", str);
 
   visit_collection ("items", e.get_variants ());
@@ -1969,7 +1969,7 @@ Dump::visit (Union &e)
 
   std::string str;
   if (e.has_where_clause ())
-    str = e.get_where_clause ().as_string ();
+    str = e.get_where_clause ().to_string ();
   else
     str = "none";
   put_field ("where clause", str);
@@ -1989,7 +1989,7 @@ Dump::visit (Union &e)
 
 	  std::string str = "none";
 	  if (elt.has_visibility ())
-	    str = elt.get_visibility ().as_string ();
+	    str = elt.get_visibility ().to_string ();
 	  put_field ("visibility", str);
 	  put_field ("field_name", elt.get_field_name ().as_string ());
 	  visit_field ("field_type", elt.get_field_type ());
@@ -2077,7 +2077,7 @@ Dump::visit (Trait &e)
 
   std::string str;
   if (e.has_where_clause ())
-    str = e.get_where_clause ().as_string ();
+    str = e.get_where_clause ().to_string ();
   else
     str = "none";
   put_field ("where clause", str);
@@ -2099,7 +2099,7 @@ Dump::visit (ImplBlock &e)
 
   std::string str;
   if (e.has_where_clause ())
-    str = e.get_where_clause ().as_string ();
+    str = e.get_where_clause ().to_string ();
   else
     str = "none";
   put_field ("where clause", str);
@@ -2122,7 +2122,7 @@ Dump::visit (ExternalStaticItem &e)
 
   std::string str = "none";
   if (e.has_visibility ())
-    str = e.get_visibility ().as_string ();
+    str = e.get_visibility ().to_string ();
   put_field ("visibility", str);
   //
 
@@ -2225,7 +2225,7 @@ void
 Dump::visit (RangePatternBoundPath &e)
 {
   begin ("RangePatternBoundPath");
-  put_field ("path", e.get_path ().as_string ());
+  put_field ("path", e.get_path ().to_string ());
   end ("RangePatternBoundPath");
 }
 
@@ -2242,8 +2242,8 @@ Dump::visit (RangePattern &e)
 {
   begin ("RangePattern");
   do_mappings (e.get_mappings ());
-  put_field ("lower", e.get_lower_bound ().as_string ());
-  put_field ("upper", e.get_upper_bound ().as_string ());
+  put_field ("lower", e.get_lower_bound ().to_string ());
+  put_field ("upper", e.get_upper_bound ().to_string ());
   put_field ("has_ellipsis_syntax",
 	     std::to_string (e.get_has_ellipsis_syntax ()));
   end ("RangePattern");
@@ -2255,7 +2255,7 @@ Dump::visit (ReferencePattern &e)
   begin ("ReferencePattern");
   do_mappings (e.get_mappings ());
   put_field ("mut", std::to_string (e.is_mut ()));
-  put_field ("pattern", e.get_referenced_pattern ().as_string ());
+  put_field ("pattern", e.get_referenced_pattern ().to_debug_string ());
   end ("ReferencePattern");
 }
 
@@ -2267,7 +2267,7 @@ Dump::visit (StructPatternFieldTuplePat &e)
   auto oa = e.get_outer_attrs ();
   do_outer_attrs (oa);
   put_field ("index", std::to_string (e.get_index ()));
-  put_field ("tuple_pattern", e.get_tuple_pattern ().as_string ());
+  put_field ("tuple_pattern", e.get_tuple_pattern ().to_string ());
   end ("StructPatternFieldTuplePat");
 }
 
@@ -2301,7 +2301,7 @@ Dump::visit (StructPattern &e)
   begin ("StructPattern");
 
   visit_field ("path", e.get_path ());
-  put_field ("elems", e.get_struct_pattern_elems ().as_string ());
+  put_field ("elems", e.get_struct_pattern_elems ().to_string ());
 
   end ("StructPattern");
 }
@@ -2329,7 +2329,7 @@ Dump::visit (TupleStructPattern &e)
   begin ("TupleStructPattern");
   do_mappings (e.get_mappings ());
 
-  put_field ("path", e.get_path ().as_string ());
+  put_field ("path", e.get_path ().to_string ());
 
   visit_field ("items", e.get_items ());
 
@@ -2476,7 +2476,7 @@ Dump::visit (ParenthesisedType &e)
 {
   begin ("ParenthesisedType");
   do_type (e);
-  put_field ("type_in_parens", e.get_type_in_parens ().as_string ());
+  put_field ("type_in_parens", e.get_type_in_parens ().to_debug_string ());
   end ("ParenthesisedType");
 }
 
@@ -2503,7 +2503,7 @@ Dump::visit (RawPointerType &e)
   begin ("RawPointerType");
   do_type (e);
   put_field ("mut", Rust::enum_to_str (e.get_mut ()));
-  put_field ("type", e.get_type ().as_string ());
+  put_field ("type", e.get_type ().to_debug_string ());
   end ("RawPointerType");
 }
 
@@ -2512,9 +2512,9 @@ Dump::visit (ReferenceType &e)
 {
   begin ("ReferenceType");
   do_type (e);
-  put_field ("lifetime", e.get_lifetime ().as_string ());
+  put_field ("lifetime", e.get_lifetime ().to_string ());
   put_field ("mut", enum_to_str (e.get_mut ()));
-  put_field ("type", e.get_base_type ().as_string ());
+  put_field ("type", e.get_base_type ().to_debug_string ());
   end ("ReferenceType");
 }
 
@@ -2553,7 +2553,7 @@ Dump::visit (BareFunctionType &e)
 
   visit_collection ("for_lifetimes", e.get_for_lifetimes ());
 
-  put_field ("function_qualifiers", e.get_function_qualifiers ().as_string ());
+  put_field ("function_qualifiers", e.get_function_qualifiers ().to_string ());
 
   if (e.get_function_params ().empty ())
     {

--- a/gcc/rust/hir/tree/rust-hir-bound-abstract.h
+++ b/gcc/rust/hir/tree/rust-hir-bound-abstract.h
@@ -46,7 +46,7 @@ public:
     return std::unique_ptr<TypeParamBound> (clone_type_param_bound_impl ());
   }
 
-  virtual std::string as_string () const = 0;
+  virtual std::string to_string () const = 0;
 
   virtual Analysis::NodeMapping get_mappings () const = 0;
 

--- a/gcc/rust/hir/tree/rust-hir-bound.h
+++ b/gcc/rust/hir/tree/rust-hir-bound.h
@@ -44,7 +44,7 @@ public:
   {}
 
   // Returns true if the lifetime is in an error state.
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
 

--- a/gcc/rust/hir/tree/rust-hir-expr-abstract.h
+++ b/gcc/rust/hir/tree/rust-hir-expr-abstract.h
@@ -88,7 +88,12 @@ public:
   }
 
   // TODO: make pure virtual if move out outer attributes to derived classes
-  virtual std::string as_string () const;
+  virtual std::string to_string () const;
+
+  std::string to_debug_string () const
+  {
+    return to_string () + mappings.as_string ();
+  }
 
   virtual ~Expr () {}
 

--- a/gcc/rust/hir/tree/rust-hir-expr.cc
+++ b/gcc/rust/hir/tree/rust-hir-expr.cc
@@ -1545,9 +1545,9 @@ OffsetOf::clone_expr_without_block_impl () const
 }
 
 std::string
-OffsetOf::as_string () const
+OffsetOf::to_string () const
 {
-  return "OffsetOf(" + type->as_string () + ", " + field.as_string () + ")";
+  return "OffsetOf(" + type->to_string () + ", " + field.as_string () + ")";
 }
 
 void

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -43,7 +43,7 @@ class LoopLabel /*: public Node*/
   Analysis::NodeMapping mappings;
 
 public:
-  std::string as_string () const;
+  std::string to_string () const;
 
   LoopLabel (Analysis::NodeMapping mapping, Lifetime loop_label,
 	     location_t locus);
@@ -93,11 +93,7 @@ class LiteralExpr : public ExprWithoutBlock
   bool negative_number = false;
 
 public:
-  std::string as_string () const override
-  {
-    return "( " + literal.as_string () + " (" + get_mappings ().as_string ()
-	   + "))";
-  }
+  std::string to_string () const override { return literal.as_string (); }
 
   Literal::LitType get_lit_type () const { return literal.get_lit_type (); }
 
@@ -202,7 +198,7 @@ class BorrowExpr : public OperatorExpr
   bool raw;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   BorrowExpr (Analysis::NodeMapping mappings,
 	      std::unique_ptr<Expr> borrow_lvalue, Mutability mut, bool raw,
@@ -235,7 +231,7 @@ protected:
 class DereferenceExpr : public OperatorExpr
 {
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Constructor calls OperatorExpr's protected constructor
   DereferenceExpr (Analysis::NodeMapping mappings,
@@ -265,7 +261,7 @@ protected:
 class ErrorPropagationExpr : public OperatorExpr
 {
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Constructor calls OperatorExpr's protected constructor
   ErrorPropagationExpr (Analysis::NodeMapping mappings,
@@ -304,7 +300,7 @@ private:
   ExprType expr_type;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   ExprType get_expr_type () const { return expr_type; }
 
@@ -345,7 +341,7 @@ private:
   std::unique_ptr<Expr> right_expr;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   ExprType get_expr_type () const { return expr_type; }
 
@@ -407,7 +403,7 @@ private:
   std::unique_ptr<Expr> right_expr;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   ExprType get_expr_type () const { return expr_type; }
 
@@ -483,7 +479,7 @@ public:
   LazyBooleanExpr (LazyBooleanExpr &&other) = default;
   LazyBooleanExpr &operator= (LazyBooleanExpr &&other) = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   ExprType get_expr_type () const { return expr_type; }
 
@@ -516,7 +512,7 @@ class TypeCastExpr : public OperatorExpr
 
   // Note: only certain type casts allowed, outlined in reference
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Constructor requires calling protected constructor of OperatorExpr
   TypeCastExpr (Analysis::NodeMapping mappings,
@@ -564,7 +560,7 @@ class AssignmentExpr : public OperatorExpr
   std::unique_ptr<Expr> right_expr;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Call OperatorExpr constructor to initialise left_expr
   AssignmentExpr (Analysis::NodeMapping mappings,
@@ -618,7 +614,7 @@ private:
   std::unique_ptr<Expr> right_expr;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   ExprType get_expr_type () const { return expr_type; }
 
@@ -668,7 +664,7 @@ class GroupedExpr : public ExprWithoutBlock, public WithInnerAttrs
   location_t locus;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   GroupedExpr (Analysis::NodeMapping mappings,
 	       std::unique_ptr<Expr> parenthesised_expr,
@@ -734,7 +730,7 @@ public:
     return std::unique_ptr<ArrayElems> (clone_array_elems_impl ());
   }
 
-  virtual std::string as_string () const = 0;
+  virtual std::string to_string () const = 0;
 
   virtual void accept_vis (HIRFullVisitor &vis) = 0;
 
@@ -770,7 +766,7 @@ public:
   ArrayElemsValues (ArrayElemsValues &&other) = default;
   ArrayElemsValues &operator= (ArrayElemsValues &&other) = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
 
@@ -812,7 +808,7 @@ public:
   ArrayElemsCopied (ArrayElemsCopied &&other) = default;
   ArrayElemsCopied &operator= (ArrayElemsCopied &&other) = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
 
@@ -840,7 +836,7 @@ class ArrayExpr : public ExprWithoutBlock, public WithInnerAttrs
   location_t locus;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Returns whether array expr has array elems or if it is just empty.
   bool has_array_elems () const { return internal_elements != nullptr; }
@@ -894,7 +890,7 @@ class ArrayIndexExpr : public ExprWithoutBlock
   location_t locus;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   ArrayIndexExpr (Analysis::NodeMapping mappings,
 		  std::unique_ptr<Expr> array_expr,
@@ -949,7 +945,7 @@ class TupleExpr : public ExprWithoutBlock, public WithInnerAttrs
   location_t locus;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   TupleExpr (Analysis::NodeMapping mappings,
 	     std::vector<std::unique_ptr<Expr>> tuple_elements,
@@ -1007,7 +1003,7 @@ class TupleIndexExpr : public ExprWithoutBlock
   location_t locus;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   TupleIndex get_tuple_index () const { return tuple_index; }
 
@@ -1066,7 +1062,7 @@ protected:
 public:
   PathInExpression &get_struct_name () { return struct_name; }
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   ExprType get_expression_type () const override final
   {
@@ -1080,7 +1076,7 @@ class StructExprStruct : public StructExpr, public WithInnerAttrs
   location_t locus;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Constructor has to call protected constructor of base class
   StructExprStruct (Analysis::NodeMapping mappings,
@@ -1138,7 +1134,7 @@ public:
   // Returns whether StructBase is in error state
   bool is_invalid () const { return base_struct == nullptr; }
 
-  std::string as_string () const;
+  std::string to_string () const;
 
   Expr &get_base () { return *base_struct; }
 };
@@ -1163,7 +1159,7 @@ public:
     return std::unique_ptr<StructExprField> (clone_struct_expr_field_impl ());
   }
 
-  virtual std::string as_string () const = 0;
+  virtual std::string to_string () const = 0;
 
   virtual void accept_vis (HIRFullVisitor &vis) = 0;
   virtual void accept_vis (HIRExpressionVisitor &vis) = 0;
@@ -1195,7 +1191,7 @@ public:
   StructExprFieldIdentifier (Analysis::NodeMapping mapping,
 			     Identifier field_identifier, location_t locus);
 
-  std::string as_string () const override { return field_name.as_string (); }
+  std::string to_string () const override { return field_name.as_string (); }
 
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRExpressionVisitor &vis) override;
@@ -1237,7 +1233,7 @@ protected:
   StructExprFieldWithVal &operator= (StructExprFieldWithVal &&other) = default;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   Expr &get_value () { return *value; }
 };
@@ -1255,7 +1251,7 @@ public:
 				  std::unique_ptr<Expr> field_value,
 				  location_t locus);
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRExpressionVisitor &vis) override;
@@ -1289,7 +1285,7 @@ public:
 			     std::unique_ptr<Expr> field_value,
 			     location_t locus);
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   TupleIndex get_tuple_index () const { return index; };
 
@@ -1322,7 +1318,7 @@ public:
   // is set when type checking
   int union_index = -1;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   bool has_struct_base () const { return struct_base.has_value (); }
 
@@ -1420,7 +1416,7 @@ class CallExpr : public ExprWithoutBlock
   location_t locus;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   CallExpr (Analysis::NodeMapping mappings, std::unique_ptr<Expr> function_expr,
 	    std::vector<std::unique_ptr<Expr>> function_params,
@@ -1483,7 +1479,7 @@ class MethodCallExpr : public ExprWithoutBlock
   location_t locus;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   MethodCallExpr (Analysis::NodeMapping mappings,
 		  std::unique_ptr<Expr> call_receiver,
@@ -1552,7 +1548,7 @@ class FieldAccessExpr : public ExprWithoutBlock
   location_t locus;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   FieldAccessExpr (Analysis::NodeMapping mappings,
 		   std::unique_ptr<Expr> field_access_receiver,
@@ -1629,7 +1625,7 @@ public:
   ClosureParam (ClosureParam &&other) = default;
   ClosureParam &operator= (ClosureParam &&other) = default;
 
-  std::string as_string () const;
+  std::string to_string () const;
 
   const std::vector<AST::Attribute> &get_outer_attrs () const
   {
@@ -1671,7 +1667,7 @@ public:
   ClosureExpr (ClosureExpr &&other) = default;
   ClosureExpr &operator= (ClosureExpr &&other) = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   location_t get_locus () const override final { return locus; }
 
@@ -1721,7 +1717,7 @@ public:
   location_t start_locus;
   location_t end_locus;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   AST::AttrVec get_inner_attrs () const { return inner_attrs; }
 
@@ -1819,7 +1815,7 @@ public:
   AnonConst (const AnonConst &other);
   AnonConst operator= (const AnonConst &other);
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRExpressionVisitor &vis) override;
@@ -1868,7 +1864,7 @@ public:
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRExpressionVisitor &vis) override;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   ExprType get_expression_type () const final override
   {
@@ -1896,7 +1892,7 @@ class ContinueExpr : public ExprWithoutBlock
   location_t locus;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Returns true if the continue expr has a label.
   bool has_label () const { return label.has_value (); }
@@ -1947,7 +1943,7 @@ class BreakExpr : public ExprWithoutBlock
   location_t locus;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Returns whether the break expression has a label or not.
   bool has_label () const { return label.has_value (); }
@@ -2026,7 +2022,7 @@ class RangeFromToExpr : public RangeExpr
   std::unique_ptr<Expr> to;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   RangeFromToExpr (Analysis::NodeMapping mappings,
 		   std::unique_ptr<Expr> range_from,
@@ -2071,7 +2067,7 @@ class RangeFromExpr : public RangeExpr
   std::unique_ptr<Expr> from;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   RangeFromExpr (Analysis::NodeMapping mappings,
 		 std::unique_ptr<Expr> range_from, location_t locus);
@@ -2114,7 +2110,7 @@ class RangeToExpr : public RangeExpr
   std::unique_ptr<Expr> to;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // outer attributes not allowed
   RangeToExpr (Analysis::NodeMapping mappings, std::unique_ptr<Expr> range_to,
@@ -2156,7 +2152,7 @@ protected:
 class RangeFullExpr : public RangeExpr
 {
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   RangeFullExpr (Analysis::NodeMapping mappings, location_t locus);
   // outer attributes not allowed
@@ -2188,7 +2184,7 @@ class RangeFromToInclExpr : public RangeExpr
   std::unique_ptr<Expr> to;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   RangeFromToInclExpr (Analysis::NodeMapping mappings,
 		       std::unique_ptr<Expr> range_from,
@@ -2234,7 +2230,7 @@ class RangeToInclExpr : public RangeExpr
   std::unique_ptr<Expr> to;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   RangeToInclExpr (Analysis::NodeMapping mappings,
 		   std::unique_ptr<Expr> range_to, location_t locus);
@@ -2279,7 +2275,7 @@ public:
 
   location_t locus;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   /* Returns whether the object has an expression returned (i.e. not void return
    * type). */
@@ -2337,7 +2333,7 @@ class UnsafeBlockExpr : public ExprWithBlock
   location_t locus;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   UnsafeBlockExpr (Analysis::NodeMapping mappings,
 		   std::unique_ptr<BlockExpr> block_expr,
@@ -2428,7 +2424,7 @@ public:
 class LoopExpr : public BaseLoopExpr
 {
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Constructor for LoopExpr
   LoopExpr (Analysis::NodeMapping mappings,
@@ -2458,7 +2454,7 @@ class WhileLoopExpr : public BaseLoopExpr
   std::unique_ptr<Expr> condition;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Constructor for while loop with loop label
   WhileLoopExpr (Analysis::NodeMapping mappings,
@@ -2506,7 +2502,7 @@ class WhileLetLoopExpr : public BaseLoopExpr
   std::unique_ptr<Expr> condition;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Constructor with a loop label
   WhileLetLoopExpr (Analysis::NodeMapping mappings,
@@ -2560,7 +2556,7 @@ class IfExpr : public ExprWithBlock
   location_t locus;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   IfExpr (Analysis::NodeMapping mappings, std::unique_ptr<Expr> condition,
 	  std::unique_ptr<BlockExpr> if_block, location_t locus);
@@ -2621,7 +2617,7 @@ class IfExprConseqElse : public IfExpr
   std::unique_ptr<ExprWithBlock> else_block;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   IfExprConseqElse (Analysis::NodeMapping mappings,
 		    std::unique_ptr<Expr> condition,
@@ -2710,7 +2706,7 @@ public:
     return MatchArm (std::vector<std::unique_ptr<Pattern>> (), locus);
   }
 
-  std::string as_string () const;
+  std::string to_string () const;
 
   std::vector<std::unique_ptr<Pattern>> &get_patterns ()
   {
@@ -2746,7 +2742,8 @@ public:
 
   ~MatchCase () = default;
 
-  std::string as_string () const;
+  std::string to_string () const;
+  std::string to_debug_string () const;
 
   Analysis::NodeMapping get_mappings () const { return mappings; }
 
@@ -2762,7 +2759,7 @@ class MatchExpr : public ExprWithBlock, public WithInnerAttrs
   location_t locus;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   bool has_match_arms () const { return !match_arms.empty (); }
 
@@ -2829,7 +2826,7 @@ public:
   AwaitExpr (AwaitExpr &&other) = default;
   AwaitExpr &operator= (AwaitExpr &&other) = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   location_t get_locus () const override final { return locus; }
 
@@ -2874,7 +2871,7 @@ public:
   AsyncBlockExpr (AsyncBlockExpr &&other) = default;
   AsyncBlockExpr &operator= (AsyncBlockExpr &&other) = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   location_t get_locus () const override final { return locus; }
 
@@ -3185,7 +3182,7 @@ public:
 
   void accept_vis (HIRFullVisitor &vis) override;
 
-  std::string as_string () const override { return "InlineAsm HIR Node"; }
+  std::string to_string () const override { return "InlineAsm HIR Node"; }
 
   location_t get_locus () const override { return locus; }
 
@@ -3253,7 +3250,7 @@ public:
   OffsetOf &operator= (const OffsetOf &other);
 
   ExprWithoutBlock *clone_expr_without_block_impl () const override;
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRExpressionVisitor &vis) override;
   void accept_vis (HIRFullVisitor &vis) override;

--- a/gcc/rust/hir/tree/rust-hir-generic-param.cc
+++ b/gcc/rust/hir/tree/rust-hir-generic-param.cc
@@ -54,6 +54,61 @@ LifetimeParam::operator= (LifetimeParam const &other)
   return *this;
 }
 
+std::string
+LifetimeParam::to_debug_string () const
+{
+  std::string result = "LifetimeParam";
+  result += "\nOuter attributes: ";
+  if (outer_attrs.empty ())
+    {
+      result += "\nnone";
+    }
+  else
+    {
+      for (const auto &attr : outer_attrs)
+	{
+	  result += "\n" + attr.as_string ();
+	}
+    }
+  result += lifetime.to_string ();
+  if (!lifetime_bounds.empty ())
+    {
+      result += ": ";
+      for (size_t i = 0; i < lifetime_bounds.size (); ++i)
+	{
+	  if (i > 0)
+	    result += " + ";
+	  result += lifetime_bounds[i].to_string ();
+	}
+    }
+  return result;
+}
+
+std::string
+LifetimeParam::to_string () const
+{
+  std::string result;
+  if (!outer_attrs.empty ())
+    {
+      for (const auto &attr : outer_attrs)
+	{
+	  result += attr.as_string () + "\n";
+	}
+    }
+  result += lifetime.to_string ();
+  if (!lifetime_bounds.empty ())
+    {
+      result += ": ";
+      for (size_t i = 0; i < lifetime_bounds.size (); ++i)
+	{
+	  if (i > 0)
+	    result += " + ";
+	  result += lifetime_bounds[i].to_string ();
+	}
+    }
+  return result;
+}
+
 ConstGenericParam::ConstGenericParam (std::string name,
 				      std::unique_ptr<Type> type,
 				      std::unique_ptr<Expr> default_expression,
@@ -77,12 +132,40 @@ ConstGenericParam::ConstGenericParam (const ConstGenericParam &other)
 }
 
 std::string
-ConstGenericParam::as_string () const
+ConstGenericParam::to_debug_string () const
 {
-  auto result = "ConstGenericParam: " + name + " : " + type->as_string ();
+  std::string result = "ConstGenericParam:\n";
+  result += "Outer attributes: ";
+  if (outer_attrs.empty ())
+    {
+      result += "\nnone";
+    }
+  else
+    {
+      for (const auto &attr : outer_attrs)
+	{
+	  result += "\n" + attr.as_string ();
+	}
+    }
+  result += "\nconst " + name + ": " + type->to_string ();
 
   if (default_expression)
-    result += " = " + default_expression->as_string ();
+    result += " = " + default_expression->to_string ();
+
+  return result;
+}
+
+std::string
+ConstGenericParam::to_string () const
+{
+  std::string result;
+  if (!outer_attrs.empty ())
+    for (const auto &attr : outer_attrs)
+      result += attr.as_string () + "\n";
+  result = "const " + name + ": " + type->to_string ();
+
+  if (default_expression)
+    result += " = " + default_expression->to_string ();
 
   return result;
 }

--- a/gcc/rust/hir/tree/rust-hir-generic-param.h
+++ b/gcc/rust/hir/tree/rust-hir-generic-param.h
@@ -51,7 +51,9 @@ public:
     return std::unique_ptr<GenericParam> (clone_generic_param_impl ());
   }
 
-  virtual std::string as_string () const = 0;
+  virtual std::string to_debug_string () const = 0;
+
+  virtual std::string to_string () const = 0;
 
   virtual location_t get_locus () const = 0;
 
@@ -116,7 +118,9 @@ public:
   LifetimeParam (LifetimeParam &&other) = default;
   LifetimeParam &operator= (LifetimeParam &&other) = default;
 
-  std::string as_string () const override;
+  std::string to_debug_string () const override;
+
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
 
@@ -144,7 +148,9 @@ public:
 
   AST::AttrVec &get_outer_attrs () override { return outer_attrs; }
 
-  std::string as_string () const override final;
+  std::string to_debug_string () const override final;
+
+  std::string to_string () const override final;
 
   void accept_vis (HIRFullVisitor &vis) override final;
 

--- a/gcc/rust/hir/tree/rust-hir-item.h
+++ b/gcc/rust/hir/tree/rust-hir-item.h
@@ -65,7 +65,7 @@ public:
 
   BaseKind get_hir_kind () override { return Node::BaseKind::ITEM; }
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   /* Adds crate names to the vector passed by reference, if it can
    * (polymorphism). */
@@ -130,7 +130,9 @@ public:
 
   TypeParam &operator= (TypeParam &&other) = default;
 
-  std::string as_string () const override;
+  std::string to_debug_string () const override;
+
+  std::string to_string () const override;
 
   location_t get_locus () const override final { return locus; }
 
@@ -177,7 +179,7 @@ public:
     return std::unique_ptr<WhereClauseItem> (clone_where_clause_item_impl ());
   }
 
-  virtual std::string as_string () const = 0;
+  virtual std::string to_string () const = 0;
 
   virtual void accept_vis (HIRFullVisitor &vis) = 0;
 
@@ -207,7 +209,7 @@ public:
       mappings (std::move (mappings))
   {}
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   location_t get_locus () const { return locus; }
 
@@ -270,7 +272,7 @@ public:
 
   location_t get_locus () const { return locus; }
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
 
@@ -342,7 +344,7 @@ public:
   // Returns whether the WhereClause has no items.
   bool is_empty () const { return where_clause_items.empty (); }
 
-  std::string as_string () const;
+  std::string to_string () const;
 
   std::vector<std::unique_ptr<WhereClauseItem>> &get_items ()
   {
@@ -406,7 +408,7 @@ public:
 
   Lifetime &get_lifetime () { return lifetime.value (); }
 
-  std::string as_string () const;
+  std::string to_string () const;
 
   location_t get_locus () const { return locus; }
 
@@ -444,7 +446,7 @@ public:
       unsafety (unsafety), has_extern (has_extern), abi (abi)
   {}
 
-  std::string as_string () const;
+  std::string to_string () const;
 
   Const get_const_status () const { return const_status; }
 
@@ -479,7 +481,7 @@ public:
   FunctionParam (FunctionParam &&other) = default;
   FunctionParam &operator= (FunctionParam &&other) = default;
 
-  std::string as_string () const;
+  std::string to_string () const;
 
   location_t get_locus () const { return locus; }
 
@@ -531,7 +533,7 @@ public:
   Visibility &get_visibility () { return visibility; }
   const Visibility &get_visibility () const { return visibility; }
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 };
 
 // Rust module item - abstract base class
@@ -543,7 +545,7 @@ class Module : public VisItem, public WithInnerAttrs
   std::vector<std::unique_ptr<Item>> items;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Returns whether the module has items in its body.
   bool has_items () const { return !items.empty (); }
@@ -609,7 +611,7 @@ class ExternCrate : public VisItem
       "extern crate foo"
       "extern crate std as cool_std"  */
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Returns whether extern crate declaration has an as clause.
   bool has_as_clause () const { return !as_clause_name.empty (); }
@@ -673,7 +675,7 @@ public:
     return std::unique_ptr<UseTree> (clone_use_tree_impl ());
   }
 
-  virtual std::string as_string () const = 0;
+  virtual std::string to_string () const = 0;
 
   location_t get_locus () const { return locus; }
 
@@ -720,7 +722,7 @@ public:
   PathType get_glob_type () { return glob_type; }
   AST::SimplePath get_path () { return path; };
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
 
@@ -801,7 +803,7 @@ public:
   // Returns whether has inner tree elements.
   bool has_trees () const { return !trees.empty (); }
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
 
@@ -856,7 +858,7 @@ public:
   // Returns whether has identifier (or, rather, is allowed to).
   bool has_identifier () const { return bind_type == IDENTIFIER; }
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
 
@@ -880,7 +882,7 @@ class UseDeclaration : public VisItem
   location_t locus;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   UseDeclaration (Analysis::NodeMapping mappings,
 		  std::unique_ptr<UseTree> use_tree, Visibility visibility,
@@ -962,7 +964,7 @@ class Function : public VisItem, public ImplItem
   Defaultness defaultness;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Returns whether function has generic parameters.
   bool has_generics () const { return !generic_params.empty (); }
@@ -1091,7 +1093,7 @@ class TypeAlias : public VisItem, public ImplItem
   location_t locus;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Returns whether type alias has generic parameters.
   bool has_generics () const { return !generic_params.empty (); }
@@ -1175,7 +1177,7 @@ protected:
 class Struct : public VisItem
 {
 protected:
-  // protected to enable access by derived classes - allows better as_string
+  // protected to enable access by derived classes - allows better to_string
   Identifier struct_name;
 
   // bool has_generics;
@@ -1287,7 +1289,7 @@ public:
   StructField (StructField &&other) = default;
   StructField &operator= (StructField &&other) = default;
 
-  std::string as_string () const;
+  std::string to_string () const;
 
   Identifier get_field_name () const { return field_name; }
 
@@ -1307,7 +1309,7 @@ public:
   std::vector<StructField> fields;
   bool is_unit;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Mega-constructor with all possible fields
   StructStruct (Analysis::NodeMapping mappings, std::vector<StructField> fields,
@@ -1403,7 +1405,7 @@ public:
   // Returns whether tuple field is in an error state.
   bool is_error () const { return field_type == nullptr; }
 
-  std::string as_string () const;
+  std::string to_string () const;
 
   Analysis::NodeMapping get_mappings () const { return mappings; }
 
@@ -1421,7 +1423,7 @@ class TupleStruct : public Struct
   std::vector<TupleField> fields;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Mega-constructor with all possible fields
   TupleStruct (Analysis::NodeMapping mappings, std::vector<TupleField> fields,
@@ -1481,7 +1483,7 @@ public:
     return std::unique_ptr<EnumItem> (clone_item_impl ());
   }
 
-  virtual std::string as_string () const override;
+  virtual std::string to_string () const override;
   virtual EnumItemKind get_enum_item_kind () const { return Named; };
 
   // not pure virtual as not abstract
@@ -1518,7 +1520,7 @@ public:
 		 std::vector<TupleField> tuple_fields, AST::AttrVec outer_attrs,
 		 location_t locus);
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRStmtVisitor &vis) override;
@@ -1552,7 +1554,7 @@ public:
 		  std::vector<StructField> struct_fields,
 		  AST::AttrVec outer_attrs, location_t locus);
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRStmtVisitor &vis) override;
@@ -1592,7 +1594,7 @@ public:
     return EnumItemKind::Discriminant;
   }
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRStmtVisitor &vis) override;
@@ -1629,7 +1631,7 @@ class Enum : public VisItem
   location_t locus;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Returns whether "enum" has generic parameters.
   bool has_generics () const { return !generic_params.empty (); }
@@ -1710,7 +1712,7 @@ class Union : public VisItem
   location_t locus;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Returns whether union has generic params.
   bool has_generics () const { return !generic_params.empty (); }
@@ -1766,7 +1768,7 @@ class ConstantItem : public VisItem, public ImplItem
   location_t locus;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   ConstantItem (Analysis::NodeMapping mappings, Identifier ident,
 		Visibility vis, std::unique_ptr<Type> type,
@@ -1852,7 +1854,7 @@ class StaticItem : public VisItem
   location_t locus;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   StaticItem (Analysis::NodeMapping mappings, Identifier name, Mutability mut,
 	      std::unique_ptr<Type> type, std::unique_ptr<Expr> expr,
@@ -1934,7 +1936,7 @@ public:
   TraitFunctionDecl (TraitFunctionDecl &&other) = default;
   TraitFunctionDecl &operator= (TraitFunctionDecl &&other) = default;
 
-  std::string as_string () const;
+  std::string to_string () const;
 
   // Returns whether function decl has generic parameters.
   bool has_generics () const { return !generic_params.empty (); }
@@ -1998,7 +2000,7 @@ public:
   TraitItemFunc (TraitItemFunc &&other) = default;
   TraitItemFunc &operator= (TraitItemFunc &&other) = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   location_t get_locus () const { return locus; }
 
@@ -2064,7 +2066,7 @@ public:
   TraitItemConst (TraitItemConst &&other) = default;
   TraitItemConst &operator= (TraitItemConst &&other) = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   location_t get_locus () const { return locus; }
 
@@ -2148,7 +2150,7 @@ public:
   TraitItemType (TraitItemType &&other) = default;
   TraitItemType &operator= (TraitItemType &&other) = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   location_t get_locus () const { return locus; }
 
@@ -2209,7 +2211,7 @@ class Trait : public VisItem
   location_t locus;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Returns whether trait has generic parameters.
   bool has_generics () const { return !generic_params.empty (); }
@@ -2313,7 +2315,7 @@ public:
   ImplBlock (ImplBlock &&other) = default;
   ImplBlock &operator= (ImplBlock &&other) = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Returns whether inherent impl block has inherent impl items.
   bool has_impl_items () const { return !impl_items.empty (); }
@@ -2405,7 +2407,12 @@ public:
     return std::unique_ptr<ExternalItem> (clone_external_item_impl ());
   }
 
-  virtual std::string as_string () const;
+  virtual std::string to_string () const;
+
+  std::string to_debug_string () const
+  {
+    return to_string () + mappings.as_string ();
+  }
 
   location_t get_locus () const { return locus; }
 
@@ -2459,7 +2466,7 @@ public:
   ExternalStaticItem (ExternalStaticItem &&other) = default;
   ExternalStaticItem &operator= (ExternalStaticItem &&other) = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRExternalItemVisitor &vis) override;
@@ -2507,7 +2514,7 @@ public:
   NamedFunctionParam (NamedFunctionParam &&other) = default;
   NamedFunctionParam &operator= (NamedFunctionParam &&other) = default;
 
-  std::string as_string () const;
+  std::string to_string () const;
 
   Identifier get_param_name () const { return name; }
 
@@ -2569,7 +2576,7 @@ public:
   ExternalFunctionItem (ExternalFunctionItem &&other) = default;
   ExternalFunctionItem &operator= (ExternalFunctionItem &&other) = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRExternalItemVisitor &vis) override;
@@ -2611,7 +2618,7 @@ public:
   ExternalTypeItem &operator= (ExternalTypeItem &&other) = default;
   ExternalTypeItem &operator= (ExternalTypeItem const &other) = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRExternalItemVisitor &vis) override;
@@ -2635,7 +2642,7 @@ class ExternBlock : public VisItem, public WithInnerAttrs
   location_t locus;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Returns whether extern block has extern items.
   bool has_extern_items () const { return !extern_items.empty (); }

--- a/gcc/rust/hir/tree/rust-hir-path.cc
+++ b/gcc/rust/hir/tree/rust-hir-path.cc
@@ -168,7 +168,9 @@ PathInExpression::is_self () const
   if (!is_single_segment ())
     return false;
 
-  return get_final_segment ().get_segment ().as_string ().compare ("self") == 0;
+  return get_final_segment ().get_segment ().to_string ().compare (
+	   Rust::Values::Keywords::SELF)
+	 == 0;
 }
 
 TypePathSegment::TypePathSegment (Analysis::NodeMapping mappings,

--- a/gcc/rust/hir/tree/rust-hir-path.h
+++ b/gcc/rust/hir/tree/rust-hir-path.h
@@ -57,7 +57,7 @@ public:
   // Returns whether PathIdentSegment is in an error state.
   bool is_error () const { return segment_name.empty (); }
 
-  std::string as_string () const { return segment_name; }
+  std::string to_string () const { return segment_name; }
 };
 
 // A binding of an identifier to a type used in generic arguments in paths
@@ -99,7 +99,7 @@ public:
   GenericArgsBinding (GenericArgsBinding &&other) = default;
   GenericArgsBinding &operator= (GenericArgsBinding &&other) = default;
 
-  std::string as_string () const;
+  std::string to_string () const;
 
   Identifier &get_identifier () { return identifier; }
   const Identifier &get_identifier () const { return identifier; }
@@ -180,7 +180,7 @@ public:
 
   bool is_empty () const;
 
-  std::string as_string () const;
+  std::string to_string () const;
 
   std::vector<Lifetime> &get_lifetime_args () { return lifetime_args; }
   const std::vector<Lifetime> &get_lifetime_args () const
@@ -220,7 +220,7 @@ public:
   PathExprSegment (PathExprSegment &&other) = default;
   PathExprSegment &operator= (PathExprSegment &&other) = default;
 
-  std::string as_string () const;
+  std::string to_string () const;
 
   location_t get_locus () const { return locus; }
 
@@ -280,7 +280,7 @@ public:
     return segments.size () == 1;
   }
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void iterate_path_segments (std::function<bool (PathExprSegment &)> cb);
 
@@ -339,7 +339,7 @@ class PathInExpression : public PathPattern, public PathExpr
   location_t locus;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Constructor
   PathInExpression (Analysis::NodeMapping mappings,
@@ -459,10 +459,10 @@ public:
   TypePathSegment (Analysis::NodeMapping mappings, std::string segment_name,
 		   bool has_separating_scope_resolution, location_t locus);
 
-  virtual std::string as_string () const
+  virtual std::string to_string () const
   {
     if (ident_segment)
-      return ident_segment->as_string ();
+      return ident_segment->to_string ();
 
     return LangItem::PrettyString (*lang_item);
   }
@@ -536,7 +536,7 @@ public:
 			  std::vector<ConstGenericArg> const_args,
 			  location_t locus);
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
 
@@ -583,7 +583,7 @@ public:
   TypePathFunction (TypePathFunction &&other) = default;
   TypePathFunction &operator= (TypePathFunction &&other) = default;
 
-  std::string as_string () const;
+  std::string to_string () const;
 
   const std::vector<std::unique_ptr<Type> > &get_params () const
   {
@@ -613,7 +613,7 @@ public:
 			   bool has_separating_scope_resolution,
 			   TypePathFunction function_path, location_t locus);
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   bool is_ident_only () const override { return false; }
 
@@ -683,7 +683,7 @@ public:
   TypePath (TypePath &&other) = default;
   TypePath &operator= (TypePath &&other) = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   /* Converts TypePath to SimplePath if possible (i.e. no generic or function
    * arguments). Otherwise returns an empty SimplePath. */
@@ -733,7 +733,7 @@ public:
   // Returns whether the qualified path type has a rebind as clause.
   bool has_as_clause () const { return trait != nullptr; }
 
-  std::string as_string () const;
+  std::string to_string () const;
 
   location_t get_locus () const { return locus; }
 
@@ -767,7 +767,7 @@ class QualifiedPathInExpression : public PathPattern, public PathExpr
   location_t locus;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   QualifiedPathInExpression (Analysis::NodeMapping mappings,
 			     QualifiedPathType qual_path_type,
@@ -855,7 +855,7 @@ public:
   QualifiedPathInType (QualifiedPathInType &&other) = default;
   QualifiedPathInType &operator= (QualifiedPathInType &&other) = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRTypeVisitor &vis) override;

--- a/gcc/rust/hir/tree/rust-hir-pattern-abstract.h
+++ b/gcc/rust/hir/tree/rust-hir-pattern-abstract.h
@@ -61,7 +61,12 @@ public:
 
   virtual ~Pattern () {}
 
-  virtual std::string as_string () const = 0;
+  virtual std::string to_string () const = 0;
+
+  std::string to_debug_string () const
+  {
+    return to_string () + get_mappings ().as_string ();
+  }
 
   virtual void accept_vis (HIRPatternVisitor &vis) = 0;
 

--- a/gcc/rust/hir/tree/rust-hir-pattern.h
+++ b/gcc/rust/hir/tree/rust-hir-pattern.h
@@ -35,7 +35,7 @@ class LiteralPattern : public Pattern
   bool has_minus;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Constructor for a literal pattern
   LiteralPattern (Analysis::NodeMapping mappings, Literal lit, location_t locus)
@@ -95,7 +95,7 @@ class IdentifierPattern : public Pattern
   Analysis::NodeMapping mappings;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Returns whether the IdentifierPattern has a pattern to bind.
   bool has_subpattern () const { return subpattern != nullptr; }
@@ -176,7 +176,7 @@ class WildcardPattern : public Pattern
   Analysis::NodeMapping mappings;
 
 public:
-  std::string as_string () const override { return std::string (1, '_'); }
+  std::string to_string () const override { return "_"; }
 
   WildcardPattern (Analysis::NodeMapping mappings, location_t locus)
     : locus (locus), mappings (mappings)
@@ -226,7 +226,7 @@ public:
       clone_range_pattern_bound_impl ());
   }
 
-  virtual std::string as_string () const = 0;
+  virtual std::string to_string () const = 0;
 
   virtual void accept_vis (HIRFullVisitor &vis) = 0;
 
@@ -256,7 +256,7 @@ public:
     : literal (literal), has_minus (has_minus), locus (locus)
   {}
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   location_t get_locus () const { return locus; }
 
@@ -290,7 +290,7 @@ class RangePatternBoundPath : public RangePatternBound
 public:
   RangePatternBoundPath (PathInExpression path) : path (std::move (path)) {}
 
-  std::string as_string () const override { return path.as_string (); }
+  std::string to_string () const override { return path.to_string (); }
 
   location_t get_locus () const { return path.get_locus (); }
 
@@ -326,7 +326,7 @@ public:
     : path (std::move (path))
   {}
 
-  std::string as_string () const override { return path.as_string (); }
+  std::string to_string () const override { return path.to_string (); }
 
   location_t get_locus () const { return path.get_locus (); }
 
@@ -364,7 +364,7 @@ class RangePattern : public Pattern
   Analysis::NodeMapping mappings;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Constructor
   RangePattern (Analysis::NodeMapping mappings,
@@ -441,7 +441,7 @@ class ReferencePattern : public Pattern
   Analysis::NodeMapping mappings;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   ReferencePattern (Analysis::NodeMapping mappings,
 		    std::unique_ptr<Pattern> pattern, Mutability reference_mut,
@@ -525,7 +525,7 @@ public:
       clone_struct_pattern_field_impl ());
   }
 
-  virtual std::string as_string () const;
+  virtual std::string to_string () const;
   virtual void accept_vis (HIRFullVisitor &vis) = 0;
   virtual ItemType get_item_type () const = 0;
 
@@ -581,7 +581,7 @@ public:
   StructPatternFieldTuplePat &operator= (StructPatternFieldTuplePat &&other)
     = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
 
@@ -636,7 +636,7 @@ public:
   StructPatternFieldIdentPat &operator= (StructPatternFieldIdentPat &&other)
     = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
 
@@ -670,7 +670,7 @@ public:
       has_ref (is_ref), mut (mut), ident (std::move (ident))
   {}
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   bool is_mut () const { return mut == Mutability::Mut; }
 
@@ -748,7 +748,7 @@ public:
       std::vector<std::unique_ptr<StructPatternField>> ());
   }
 
-  std::string as_string () const;
+  std::string to_string () const;
 
   std::vector<std::unique_ptr<StructPatternField>> &get_struct_pattern_fields ()
   {
@@ -764,7 +764,7 @@ class StructPattern : public Pattern
   Analysis::NodeMapping mappings;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   StructPattern (Analysis::NodeMapping mappings, PathInExpression struct_path,
 		 StructPatternElements elems)
@@ -824,7 +824,7 @@ public:
 
   virtual ItemType get_item_type () const = 0;
 
-  virtual std::string as_string () const = 0;
+  virtual std::string to_string () const = 0;
 
 protected:
   // pure virtual clone implementation
@@ -879,7 +879,7 @@ public:
   TupleStructItemsNoRest (TupleStructItemsNoRest &&other) = default;
   TupleStructItemsNoRest &operator= (TupleStructItemsNoRest &&other) = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
 
@@ -947,7 +947,7 @@ public:
   TupleStructItemsHasRest &operator= (TupleStructItemsHasRest &&other)
     = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
 
@@ -992,7 +992,7 @@ class TupleStructPattern : public Pattern
    * data */
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   TupleStructPattern (Analysis::NodeMapping mappings,
 		      PathInExpression tuple_struct_path,
@@ -1098,7 +1098,7 @@ public:
   TuplePatternItemsNoRest &operator= (TuplePatternItemsNoRest &&other)
     = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
 
@@ -1167,7 +1167,7 @@ public:
   TuplePatternItemsHasRest &operator= (TuplePatternItemsHasRest &&other)
     = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
 
@@ -1208,7 +1208,7 @@ class TuplePattern : public Pattern
   Analysis::NodeMapping mappings;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   // Returns true if the tuple pattern has items
   bool has_tuple_pattern_items () const { return items != nullptr; }
@@ -1310,7 +1310,7 @@ public:
   SlicePatternItemsNoRest &operator= (SlicePatternItemsNoRest &&other)
     = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
 
@@ -1379,7 +1379,7 @@ public:
   SlicePatternItemsHasRest &operator= (SlicePatternItemsHasRest &&other)
     = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
 
@@ -1420,7 +1420,7 @@ class SlicePattern : public Pattern
   Analysis::NodeMapping mappings;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   SlicePattern (Analysis::NodeMapping mappings,
 		std::unique_ptr<SlicePatternItems> items, location_t locus)
@@ -1482,7 +1482,7 @@ class AltPattern : public Pattern
   Analysis::NodeMapping mappings;
 
 public:
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   AltPattern (Analysis::NodeMapping mappings,
 	      std::vector<std::unique_ptr<Pattern>> alts, location_t locus)

--- a/gcc/rust/hir/tree/rust-hir-stmt.h
+++ b/gcc/rust/hir/tree/rust-hir-stmt.h
@@ -43,7 +43,12 @@ public:
 
   virtual ~Stmt () {}
 
-  virtual std::string as_string () const = 0;
+  virtual std::string to_string () const = 0;
+
+  std::string to_debug_string () const
+  {
+    return to_string () + mappings.as_string ();
+  }
 
   virtual void accept_vis (HIRStmtVisitor &vis) = 0;
 
@@ -70,7 +75,7 @@ class EmptyStmt : public Stmt
   location_t locus;
 
 public:
-  std::string as_string () const override { return std::string (1, ';'); }
+  std::string to_string () const override { return ";"; }
 
   EmptyStmt (Analysis::NodeMapping mappings, location_t locus)
     : Stmt (std::move (mappings)), locus (locus)
@@ -117,7 +122,7 @@ public:
   // Returns whether let statement has a diverging else expression.
   bool has_else_expr () const { return else_expr.has_value (); }
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   LetStmt (Analysis::NodeMapping mappings,
 	   std::unique_ptr<Pattern> variables_pattern,
@@ -207,7 +212,7 @@ public:
   ExprStmt (Analysis::NodeMapping mappings, std::unique_ptr<Expr> expr,
 	    location_t locus);
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   location_t get_locus () const override final { return locus; }
 

--- a/gcc/rust/hir/tree/rust-hir-trait-bound.h
+++ b/gcc/rust/hir/tree/rust-hir-trait-bound.h
@@ -51,7 +51,9 @@ public:
       type_path (std::move (type_path)), locus (locus), mappings (mapping)
   {}
 
-  std::string as_string () const override;
+  std::string to_string () const override;
+
+  std::string to_debug_string () const;
 
   location_t get_locus () const override final { return locus; }
 

--- a/gcc/rust/hir/tree/rust-hir-type-abstract.h
+++ b/gcc/rust/hir/tree/rust-hir-type-abstract.h
@@ -45,7 +45,12 @@ public:
 
   BaseKind get_hir_kind () override final { return TYPE; }
 
-  virtual std::string as_string () const = 0;
+  virtual std::string to_string () const = 0;
+
+  std::string to_debug_string () const
+  {
+    return to_string () + mappings.as_string ();
+  }
 
   /* HACK: convert to trait bound. Virtual method overriden by classes that
    * enable this. */

--- a/gcc/rust/hir/tree/rust-hir-type.h
+++ b/gcc/rust/hir/tree/rust-hir-type.h
@@ -57,7 +57,7 @@ public:
   ImplTraitType (ImplTraitType &&other) = default;
   ImplTraitType &operator= (ImplTraitType &&other) = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
   std::vector<std::unique_ptr<TypeParamBound>> &get_type_param_bounds ()
   {
     return type_param_bounds;
@@ -96,7 +96,7 @@ public:
   TraitObjectType (TraitObjectType &&other) = default;
   TraitObjectType &operator= (TraitObjectType &&other) = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
   bool get_has_dyn () { return has_dyn; }
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRTypeVisitor &vis) override;
@@ -150,9 +150,9 @@ public:
   ParenthesisedType (ParenthesisedType &&other) = default;
   ParenthesisedType &operator= (ParenthesisedType &&other) = default;
 
-  std::string as_string () const override
+  std::string to_string () const override
   {
-    return "(" + type_in_parens->as_string () + ")";
+    return "(" + type_in_parens->to_string () + ")";
   }
 
   // Creates a trait bound (clone of this one's trait bound) - HACK
@@ -187,7 +187,7 @@ public:
   TupleType (TupleType &&other) = default;
   TupleType &operator= (TupleType &&other) = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRTypeVisitor &vis) override;
@@ -228,7 +228,7 @@ protected:
 public:
   NeverType (Analysis::NodeMapping mappings, location_t locus);
 
-  std::string as_string () const override { return "! (never type)"; }
+  std::string to_string () const override { return "! (never type)"; }
 
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRTypeVisitor &vis) override;
@@ -256,7 +256,7 @@ public:
   RawPointerType (RawPointerType &&other) = default;
   RawPointerType &operator= (RawPointerType &&other) = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRTypeVisitor &vis) override;
@@ -318,7 +318,7 @@ public:
   ReferenceType (ReferenceType &&other) = default;
   ReferenceType &operator= (ReferenceType &&other) = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRTypeVisitor &vis) override;
@@ -367,7 +367,7 @@ public:
   ArrayType (ArrayType &&other) = default;
   ArrayType &operator= (ArrayType &&other) = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRTypeVisitor &vis) override;
@@ -410,7 +410,7 @@ public:
   SliceType (SliceType &&other) = default;
   SliceType &operator= (SliceType &&other) = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRTypeVisitor &vis) override;
@@ -453,7 +453,7 @@ protected:
 public:
   InferredType (Analysis::NodeMapping mappings, location_t locus);
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRTypeVisitor &vis) override;
@@ -494,7 +494,7 @@ public:
   MaybeNamedParam (MaybeNamedParam &&other) = default;
   MaybeNamedParam &operator= (MaybeNamedParam &&other) = default;
 
-  std::string as_string () const;
+  std::string to_string () const;
 
   // Returns whether the param is in an error state.
   bool is_error () const { return param_type == nullptr; }
@@ -553,7 +553,7 @@ public:
   BareFunctionType (BareFunctionType &&other) = default;
   BareFunctionType &operator= (BareFunctionType &&other) = default;
 
-  std::string as_string () const override;
+  std::string to_string () const override;
 
   void accept_vis (HIRFullVisitor &vis) override;
   void accept_vis (HIRTypeVisitor &vis) override;

--- a/gcc/rust/hir/tree/rust-hir-visibility.h
+++ b/gcc/rust/hir/tree/rust-hir-visibility.h
@@ -72,7 +72,7 @@ public:
     return path;
   }
 
-  std::string as_string () const;
+  std::string to_string () const;
 
   location_t get_locus () const { return locus; }
 };

--- a/gcc/rust/hir/tree/rust-hir.cc
+++ b/gcc/rust/hir/tree/rust-hir.cc
@@ -99,7 +99,7 @@ Crate::operator= (Crate const &other)
 }
 
 std::string
-Crate::as_string () const
+Crate::to_debug_string () const
 {
   std::string str ("HIR::Crate: ");
 
@@ -137,15 +137,30 @@ Crate::as_string () const
 	      return "nullptr_POINTER_MARK";
 	    }
 
-	  str += "\n  " + item->as_string ();
+	  str += "\n  " + item->to_string ();
 	}
     }
 
-  return str + "\n::" + get_mappings ().as_string () + "\n";
+  return str;
 }
 
 std::string
-Visibility::as_string () const
+Crate::to_string () const
+{
+  std::string str;
+  if (!inner_attrs.empty ())
+    for (const auto &attr : inner_attrs)
+      str += attr.as_string () + "\n";
+
+  if (!items.empty ())
+    for (const auto &item : items)
+      str += item->to_string () + "\n";
+
+  return str;
+}
+
+std::string
+Visibility::to_string () const
 {
   switch (vis_type)
     {
@@ -163,14 +178,14 @@ Visibility::as_string () const
 
 // Creates a string that reflects the visibility stored.
 std::string
-VisItem::as_string () const
+VisItem::to_string () const
 {
   // FIXME: can't do formatting on string to make identation occur.
-  std::string str = Item::as_string ();
+  std::string str = Item::to_string ();
 
   if (has_visibility ())
     {
-      str = visibility.as_string () + " ";
+      str = visibility.to_string () + " ";
     }
 
   return str;
@@ -178,7 +193,7 @@ VisItem::as_string () const
 
 // Creates a string that reflects the outer attributes stored.
 std::string
-Item::as_string () const
+Item::to_string () const
 {
   std::string str;
 
@@ -194,10 +209,10 @@ Item::as_string () const
 }
 
 std::string
-Module::as_string () const
+Module::to_string () const
 {
   // get module string for "[vis] mod [name]"
-  std::string str = VisItem::as_string () + "mod " + module_name.as_string ();
+  std::string str = VisItem::to_string () + "mod " + module_name.as_string ();
 
   // inner attributes
   str += "\n inner attributes: ";
@@ -233,7 +248,7 @@ Module::as_string () const
 	      return "nullptr_POINTER_MARK";
 	    }
 
-	  str += "\n  " + item->as_string ();
+	  str += "\n  " + item->to_string ();
 	}
     }
 
@@ -279,9 +294,9 @@ Item::item_kind_string (Item::ItemKind kind)
 }
 
 std::string
-StaticItem::as_string () const
+StaticItem::to_string () const
 {
-  std::string str = VisItem::as_string ();
+  std::string str = VisItem::to_string ();
 
   str += indent_spaces (stay) + "static";
 
@@ -299,7 +314,7 @@ StaticItem::as_string () const
 		  "pointer type in static item.");
       return "nullptr_POINTER_MARK";
     }
-  str += "\n" + indent_spaces (stay) + "Type: " + type->as_string ();
+  str += "\n" + indent_spaces (stay) + "Type: " + type->to_string ();
 
   // DEBUG: null pointer check
   if (expr == nullptr)
@@ -308,15 +323,15 @@ StaticItem::as_string () const
 		  "pointer expr in static item.");
       return "nullptr_POINTER_MARK";
     }
-  str += "\n" + indent_spaces (stay) + "Expression: " + expr->as_string ();
+  str += "\n" + indent_spaces (stay) + "Expression: " + expr->to_string ();
 
   return str + "\n";
 }
 
 std::string
-ExternCrate::as_string () const
+ExternCrate::to_string () const
 {
-  std::string str = VisItem::as_string ();
+  std::string str = VisItem::to_string ();
 
   str += "extern crate " + referenced_crate;
 
@@ -329,9 +344,9 @@ ExternCrate::as_string () const
 }
 
 std::string
-TupleStruct::as_string () const
+TupleStruct::to_string () const
 {
-  std::string str = VisItem::as_string ();
+  std::string str = VisItem::to_string ();
 
   str += "struct " + struct_name.as_string ();
 
@@ -354,7 +369,7 @@ TupleStruct::as_string () const
 	      return "nullptr_POINTER_MARK";
 	    }
 
-	  str += "\n  " + param->as_string ();
+	  str += "\n  " + param->to_string ();
 	}
     }
 
@@ -368,14 +383,14 @@ TupleStruct::as_string () const
     {
       for (const auto &field : fields)
 	{
-	  str += "\n  " + field.as_string ();
+	  str += "\n  " + field.to_string ();
 	}
     }
 
   str += "\n Where clause: ";
   if (has_where_clause ())
     {
-      str += where_clause.as_string ();
+      str += where_clause.to_string ();
     }
   else
     {
@@ -386,9 +401,9 @@ TupleStruct::as_string () const
 }
 
 std::string
-ConstantItem::as_string () const
+ConstantItem::to_string () const
 {
-  std::string str = VisItem::as_string ();
+  std::string str = VisItem::to_string ();
 
   str += "const " + identifier.as_string ();
 
@@ -399,7 +414,7 @@ ConstantItem::as_string () const
 		  "pointer type in const item.");
       return "nullptr_POINTER_MARK";
     }
-  str += "\n  Type: " + type->as_string ();
+  str += "\n  Type: " + type->to_string ();
 
   // DEBUG: null pointer check
   if (const_expr == nullptr)
@@ -408,15 +423,15 @@ ConstantItem::as_string () const
 		  "pointer expr in const item.");
       return "nullptr_POINTER_MARK";
     }
-  str += "\n  Expression: " + const_expr->as_string ();
+  str += "\n  Expression: " + const_expr->to_string ();
 
   return str + "\n";
 }
 
 std::string
-ImplBlock::as_string () const
+ImplBlock::to_string () const
 {
-  std::string str = VisItem::as_string ();
+  std::string str = VisItem::to_string ();
 
   str += "impl ";
 
@@ -439,16 +454,16 @@ ImplBlock::as_string () const
 	      return "nullptr_POINTER_MARK";
 	    }
 
-	  str += "\n  " + param->as_string ();
+	  str += "\n  " + param->to_string ();
 	}
     }
 
-  str += "\n Type: " + impl_type->as_string ();
+  str += "\n Type: " + impl_type->to_string ();
 
   str += "\n Where clause: ";
   if (has_where_clause ())
     {
-      str += where_clause.as_string ();
+      str += where_clause.to_string ();
     }
   else
     {
@@ -480,7 +495,7 @@ ImplBlock::as_string () const
     {
       for (const auto &item : impl_items)
 	{
-	  str += "\n  " + item->as_string ();
+	  str += "\n  " + item->to_string ();
 	}
     }
 
@@ -488,9 +503,9 @@ ImplBlock::as_string () const
 }
 
 std::string
-StructStruct::as_string () const
+StructStruct::to_string () const
 {
-  std::string str = VisItem::as_string ();
+  std::string str = VisItem::to_string ();
 
   str += "struct " + struct_name.as_string ();
 
@@ -513,14 +528,14 @@ StructStruct::as_string () const
 	      return "nullptr_POINTER_MARK";
 	    }
 
-	  str += "\n  " + param->as_string ();
+	  str += "\n  " + param->to_string ();
 	}
     }
 
   str += "\n Where clause: ";
   if (has_where_clause ())
     {
-      str += where_clause.as_string ();
+      str += where_clause.to_string ();
     }
   else
     {
@@ -541,18 +556,18 @@ StructStruct::as_string () const
     {
       for (const auto &field : fields)
 	{
-	  str += "\n  - " + field.as_string ();
+	  str += "\n  - " + field.to_string ();
 	}
       str += "\n";
     }
 
-  return str + "::" + get_mappings ().as_string () + "\n";
+  return str;
 }
 
 std::string
-UseDeclaration::as_string () const
+UseDeclaration::to_string () const
 {
-  std::string str = VisItem::as_string ();
+  std::string str = VisItem::to_string ();
 
   // DEBUG: null pointer check
   if (use_tree == nullptr)
@@ -563,13 +578,13 @@ UseDeclaration::as_string () const
       return "nullptr_POINTER_MARK";
     }
 
-  str += "use " + use_tree->as_string ();
+  str += "use " + use_tree->to_string ();
 
   return str;
 }
 
 std::string
-UseTreeGlob::as_string () const
+UseTreeGlob::to_string () const
 {
   switch (glob_type)
     {
@@ -590,7 +605,7 @@ UseTreeGlob::as_string () const
 }
 
 std::string
-UseTreeList::as_string () const
+UseTreeList::to_string () const
 {
   std::string path_str;
   switch (path_type)
@@ -626,7 +641,7 @@ UseTreeList::as_string () const
 
       for (; i != e; i++)
 	{
-	  path_str += (*i)->as_string ();
+	  path_str += (*i)->to_string ();
 	  if (e != i + 1)
 	    path_str += ", ";
 	}
@@ -640,7 +655,7 @@ UseTreeList::as_string () const
 }
 
 std::string
-UseTreeRebind::as_string () const
+UseTreeRebind::to_string () const
 {
   std::string path_str = path.as_string ();
 
@@ -664,9 +679,9 @@ UseTreeRebind::as_string () const
 }
 
 std::string
-Enum::as_string () const
+Enum::to_string () const
 {
-  std::string str = VisItem::as_string ();
+  std::string str = VisItem::to_string ();
   str += enum_name.as_string ();
 
   // generic params
@@ -688,14 +703,14 @@ Enum::as_string () const
 	      return "nullptr_POINTER_MARK";
 	    }
 
-	  str += "\n  " + param->as_string ();
+	  str += "\n  " + param->to_string ();
 	}
     }
 
   str += "\n Where clause: ";
   if (has_where_clause ())
     {
-      str += where_clause.as_string ();
+      str += where_clause.to_string ();
     }
   else
     {
@@ -721,7 +736,7 @@ Enum::as_string () const
 	      return "nullptr_POINTER_MARK";
 	    }
 
-	  str += "\n  " + item->as_string ();
+	  str += "\n  " + item->to_string ();
 	}
     }
 
@@ -729,9 +744,9 @@ Enum::as_string () const
 }
 
 std::string
-Trait::as_string () const
+Trait::to_string () const
 {
-  std::string str = VisItem::as_string ();
+  std::string str = VisItem::to_string ();
 
   if (unsafety == Unsafety::Unsafe)
     {
@@ -759,7 +774,7 @@ Trait::as_string () const
 	      return "nullptr_POINTER_MARK";
 	    }
 
-	  str += "\n  " + param->as_string ();
+	  str += "\n  " + param->to_string ();
 	}
     }
 
@@ -781,7 +796,7 @@ Trait::as_string () const
 	      return "nullptr_POINTER_MARK";
 	    }
 
-	  str += "\n  " + bound->as_string ();
+	  str += "\n  " + bound->to_string ();
 	}
     }
 
@@ -792,7 +807,7 @@ Trait::as_string () const
     }
   else
     {
-      str += where_clause.as_string ();
+      str += where_clause.to_string ();
     }
 
   str += "\n Trait items: ";
@@ -813,7 +828,7 @@ Trait::as_string () const
 	      return "nullptr_POINTER_MARK";
 	    }
 
-	  str += "\n  " + item->as_string ();
+	  str += "\n  " + item->to_string ();
 	}
     }
 
@@ -821,9 +836,9 @@ Trait::as_string () const
 }
 
 std::string
-Union::as_string () const
+Union::to_string () const
 {
-  std::string str = VisItem::as_string ();
+  std::string str = VisItem::to_string ();
 
   str += "union " + union_name.as_string ();
 
@@ -846,14 +861,14 @@ Union::as_string () const
 	      return "nullptr_POINTER_MARK";
 	    }
 
-	  str += "\n  " + param->as_string ();
+	  str += "\n  " + param->to_string ();
 	}
     }
 
   str += "\n Where clause: ";
   if (has_where_clause ())
     {
-      str += where_clause.as_string ();
+      str += where_clause.to_string ();
     }
   else
     {
@@ -870,7 +885,7 @@ Union::as_string () const
     {
       for (const auto &field : variants)
 	{
-	  str += "\n  " + field.as_string ();
+	  str += "\n  " + field.to_string ();
 	}
     }
 
@@ -878,10 +893,10 @@ Union::as_string () const
 }
 
 std::string
-Function::as_string () const
+Function::to_string () const
 {
-  std::string str = VisItem::as_string () + "\n";
-  std::string qstr = qualifiers.as_string ();
+  std::string str = VisItem::to_string () + "\n";
+  std::string qstr = qualifiers.to_string ();
   if ("" != qstr)
     str += qstr + " ";
 
@@ -896,7 +911,7 @@ Function::as_string () const
 	  return "nullptr_POINTER_MARK";
 	}
 
-      str += return_type->as_string () + " ";
+      str += return_type->to_string () + " ";
     }
   else
     {
@@ -922,7 +937,7 @@ Function::as_string () const
 
       for (; i != e; i++)
 	{
-	  str += (*i)->as_string ();
+	  str += (*i)->to_string ();
 	  if (e != i + 1)
 	    str += ", ";
 	}
@@ -936,7 +951,7 @@ Function::as_string () const
       str += "(";
       for (; i != e; i++)
 	{
-	  str += (*i).as_string ();
+	  str += (*i).to_string ();
 	  if (e != i + 1)
 	    str += ", ";
 	}
@@ -949,7 +964,7 @@ Function::as_string () const
 
   if (has_where_clause ())
     {
-      str += " where " + where_clause.as_string ();
+      str += " where " + where_clause.to_string ();
     }
 
   str += "\n";
@@ -962,12 +977,11 @@ Function::as_string () const
 	"body in function.");
       return "nullptr_POINTER_MARK";
     }
-  return str + function_body->as_string () + "::" + get_mappings ().as_string ()
-	 + "\n";
+  return str + function_body->to_string ();
 }
 
 std::string
-WhereClause::as_string () const
+WhereClause::to_string () const
 {
   // just print where clause items, don't mention "where" or "where clause"
   std::string str;
@@ -980,7 +994,7 @@ WhereClause::as_string () const
     {
       for (const auto &item : where_clause_items)
 	{
-	  str += "\n  " + item->as_string ();
+	  str += "\n  " + item->to_string ();
 	}
     }
 
@@ -988,12 +1002,12 @@ WhereClause::as_string () const
 }
 
 std::string
-BlockExpr::as_string () const
+BlockExpr::to_string () const
 {
   std::string istr = indent_spaces (enter);
   std::string str = istr + "BlockExpr:\n" + istr;
   // get outer attributes
-  str += "{\n" + indent_spaces (stay) + Expr::as_string ();
+  str += "{\n" + indent_spaces (stay) + Expr::to_string ();
 
   // inner attributes
   str += "\n" + indent_spaces (stay) + "inner attributes: ";
@@ -1030,7 +1044,7 @@ BlockExpr::as_string () const
 	      return "nullptr_POINTER_MARK";
 	    }
 
-	  str += "\n" + indent_spaces (stay) + stmt->as_string ();
+	  str += "\n" + indent_spaces (stay) + stmt->to_string ();
 	}
     }
 
@@ -1042,7 +1056,7 @@ BlockExpr::as_string () const
     }
   else
     {
-      str += "\n" + expr->as_string ();
+      str += "\n" + expr->to_string ();
     }
 
   str += "\n" + indent_spaces (out) + "}";
@@ -1050,13 +1064,13 @@ BlockExpr::as_string () const
 }
 
 std::string
-AnonConst::as_string () const
+AnonConst::to_string () const
 {
   std::string istr = indent_spaces (enter);
   std::string str = istr + "AnonConst:\n" + istr;
 
   if (expr.has_value ())
-    str += get_inner_expr ().as_string ();
+    str += get_inner_expr ().to_string ();
   else
     str += "_";
 
@@ -1066,13 +1080,13 @@ AnonConst::as_string () const
 }
 
 std::string
-ConstBlock::as_string () const
+ConstBlock::to_string () const
 {
   std::string istr = indent_spaces (enter);
 
   std::string str = istr + "ConstBlock:\n" + istr;
 
-  str += get_const_expr ().as_string ();
+  str += get_const_expr ().to_string ();
 
   str += "\n" + indent_spaces (out);
 
@@ -1080,9 +1094,9 @@ ConstBlock::as_string () const
 }
 
 std::string
-TypeAlias::as_string () const
+TypeAlias::to_string () const
 {
-  std::string str = VisItem::as_string ();
+  std::string str = VisItem::to_string ();
 
   str += " " + new_type_name.as_string ();
 
@@ -1099,7 +1113,7 @@ TypeAlias::as_string () const
 
       for (; i != e; i++)
 	{
-	  str += (*i)->as_string ();
+	  str += (*i)->to_string ();
 	  if (e != i + 1)
 	    str += ", ";
 	}
@@ -1112,18 +1126,18 @@ TypeAlias::as_string () const
     }
   else
     {
-      str += where_clause.as_string ();
+      str += where_clause.to_string ();
     }
 
-  str += "\n Type: " + existing_type->as_string ();
+  str += "\n Type: " + existing_type->to_string ();
 
   return str;
 }
 
 std::string
-ExternBlock::as_string () const
+ExternBlock::to_string () const
 {
-  std::string str = VisItem::as_string ();
+  std::string str = VisItem::to_string ();
 
   str += "extern ";
   str += "\"" + get_string_from_abi (abi) + "\" ";
@@ -1153,7 +1167,7 @@ ExternBlock::as_string () const
     {
       for (const auto &item : extern_items)
 	{
-	  str += "\n  " + item->as_string ();
+	  str += "\n  " + item->to_string ();
 	}
     }
 
@@ -1161,7 +1175,7 @@ ExternBlock::as_string () const
 }
 
 std::string
-PathInExpression::as_string () const
+PathInExpression::to_string () const
 {
   std::string str;
 
@@ -1170,11 +1184,11 @@ PathInExpression::as_string () const
       str = "::";
     }
 
-  return str + PathPattern::as_string () + "::" + get_mappings ().as_string ();
+  return str + PathPattern::to_string ();
 }
 
 std::string
-ExprStmt::as_string () const
+ExprStmt::to_string () const
 {
   std::string str = indent_spaces (enter) + "ExprStmt:\n";
 
@@ -1185,7 +1199,7 @@ ExprStmt::as_string () const
   else
     {
       indent_spaces (enter);
-      str += expr->as_string ();
+      str += expr->to_string ();
       indent_spaces (out);
     }
 
@@ -1194,20 +1208,20 @@ ExprStmt::as_string () const
 }
 
 std::string
-ClosureParam::as_string () const
+ClosureParam::to_string () const
 {
-  std::string str (pattern->as_string ());
+  std::string str (pattern->to_string ());
 
   if (has_type_given ())
     {
-      str += " : " + type->as_string ();
+      str += " : " + type->to_string ();
     }
 
   return str;
 }
 
 std::string
-ClosureExpr::as_string () const
+ClosureExpr::to_string () const
 {
   std::string str ("ClosureExpr:\n Has move: ");
   if (has_move)
@@ -1228,20 +1242,20 @@ ClosureExpr::as_string () const
     {
       for (const auto &param : params)
 	{
-	  str += "\n  " + param.as_string ();
+	  str += "\n  " + param.to_string ();
 	}
     }
 
   str += "\n Return type: "
-	 + (has_return_type () ? return_type->as_string () : "none");
+	 + (has_return_type () ? return_type->to_string () : "none");
 
-  str += "\n Body: " + expr->as_string ();
+  str += "\n Body: " + expr->to_string ();
 
   return str;
 }
 
 std::string
-PathPattern::as_string () const
+PathPattern::to_string () const
 {
   if (is_lang_item ())
     return LangItem::PrettyString (*lang_item);
@@ -1250,7 +1264,7 @@ PathPattern::as_string () const
 
   for (const auto &segment : segments)
     {
-      str += segment.as_string () + "::";
+      str += segment.to_string () + "::";
     }
 
   // basically a hack - remove last two characters of string (remove final ::)
@@ -1260,27 +1274,27 @@ PathPattern::as_string () const
 }
 
 std::string
-QualifiedPathType::as_string () const
+QualifiedPathType::to_string () const
 {
   std::string str ("<");
-  str += type->as_string ();
+  str += type->to_string ();
 
   if (has_as_clause ())
     {
-      str += " as " + trait->as_string ();
+      str += " as " + trait->to_string ();
     }
 
   return str + ">";
 }
 
 std::string
-QualifiedPathInExpression::as_string () const
+QualifiedPathInExpression::to_string () const
 {
-  return path_type.as_string () + "::" + PathPattern::as_string ();
+  return path_type.to_string () + "::" + PathPattern::to_string ();
 }
 
 std::string
-BorrowExpr::as_string () const
+BorrowExpr::to_string () const
 {
   std::string str ("&");
 
@@ -1289,26 +1303,26 @@ BorrowExpr::as_string () const
       str += "mut ";
     }
 
-  str += main_or_left_expr->as_string ();
+  str += main_or_left_expr->to_string ();
 
   return str;
 }
 
 std::string
-ReturnExpr::as_string () const
+ReturnExpr::to_string () const
 {
   std::string str ("return ");
 
   if (has_return_expr ())
     {
-      str += return_expr->as_string ();
+      str += return_expr->to_string ();
     }
 
-  return str + "::" + get_mappings ().as_string ();
+  return str;
 }
 
 std::string
-GroupedExpr::as_string () const
+GroupedExpr::to_string () const
 {
   std::string str ("Grouped expr:");
 
@@ -1328,32 +1342,32 @@ GroupedExpr::as_string () const
 	}
     }
 
-  str += "\n Expr in parens: " + expr_in_parens->as_string ();
+  str += "\n Expr in parens: " + expr_in_parens->to_string ();
 
   return str;
 }
 
 std::string
-RangeToExpr::as_string () const
+RangeToExpr::to_string () const
 {
-  return ".." + to->as_string ();
+  return ".." + to->to_string ();
 }
 
 std::string
-ContinueExpr::as_string () const
+ContinueExpr::to_string () const
 {
   std::string str ("continue ");
 
   if (has_label ())
     {
-      str += get_label ().as_string ();
+      str += get_label ().to_string ();
     }
 
   return str;
 }
 
 std::string
-NegationExpr::as_string () const
+NegationExpr::to_string () const
 {
   std::string str;
 
@@ -1369,34 +1383,33 @@ NegationExpr::as_string () const
       return "ERROR_MARK_STRING - negation expr";
     }
 
-  str += main_or_left_expr->as_string ();
+  str += main_or_left_expr->to_string ();
 
   return str;
 }
 
 std::string
-RangeFromExpr::as_string () const
+RangeFromExpr::to_string () const
 {
-  return from->as_string () + "..";
+  return from->to_string () + "..";
 }
 
 std::string
-RangeFullExpr::as_string () const
+RangeFullExpr::to_string () const
 {
   return "..";
 }
 
 std::string
-ArrayIndexExpr::as_string () const
+ArrayIndexExpr::to_string () const
 {
-  return array_expr->as_string () + "[" + index_expr->as_string () + "]";
+  return array_expr->to_string () + "[" + index_expr->to_string () + "]";
 }
 
 std::string
-AssignmentExpr::as_string () const
+AssignmentExpr::to_string () const
 {
-  return main_or_left_expr->as_string () + " = " + right_expr->as_string ()
-	 + "::" + get_mappings ().as_string ();
+  return main_or_left_expr->to_string () + " = " + right_expr->to_string ();
 }
 
 std::string
@@ -1449,7 +1462,7 @@ CompoundAssignmentExpr::get_operator_str () const
 }
 
 std::string
-CompoundAssignmentExpr::as_string () const
+CompoundAssignmentExpr::to_string () const
 {
   std::string str ("CompoundAssignmentExpr: ");
   std::string operator_str = get_operator_str ();
@@ -1459,8 +1472,8 @@ CompoundAssignmentExpr::as_string () const
     }
   else
     {
-      str += "\n left: " + main_or_left_expr->as_string ();
-      str += "\n right: " + right_expr->as_string ();
+      str += "\n left: " + main_or_left_expr->to_string ();
+      str += "\n right: " + right_expr->to_string ();
       str += "\n operator: " + operator_str;
     }
 
@@ -1468,23 +1481,23 @@ CompoundAssignmentExpr::as_string () const
 }
 
 std::string
-AsyncBlockExpr::as_string () const
+AsyncBlockExpr::to_string () const
 {
   std::string str = "AsyncBlockExpr: ";
 
   // get outer attributes
-  str += "\n " + Expr::as_string ();
+  str += "\n " + Expr::to_string ();
 
   str += "\n Has move: ";
   str += has_move ? "true" : "false";
 
-  return str + "\n" + block_expr->as_string ();
+  return str + "\n" + block_expr->to_string ();
 }
 
 std::string
-ComparisonExpr::as_string () const
+ComparisonExpr::to_string () const
 {
-  std::string str (main_or_left_expr->as_string ());
+  std::string str (main_or_left_expr->to_string ());
 
   switch (expr_type)
     {
@@ -1510,21 +1523,21 @@ ComparisonExpr::as_string () const
       return "ERROR_MARK_STRING - comparison expr";
     }
 
-  str += right_expr->as_string ();
+  str += right_expr->to_string ();
 
   return str;
 }
 
 std::string
-MethodCallExpr::as_string () const
+MethodCallExpr::to_string () const
 {
   std::string str ("MethodCallExpr: \n Object (receiver) expr: ");
 
-  str += receiver->as_string ();
+  str += receiver->to_string ();
 
   str += "\n Method path segment: \n";
 
-  str += method_name.as_string ();
+  str += method_name.to_string ();
 
   str += "\n Call params:";
   if (params.empty ())
@@ -1540,7 +1553,7 @@ MethodCallExpr::as_string () const
 	      return "ERROR_MARK_STRING - method call expr param is null";
 	    }
 
-	  str += "\n  " + param->as_string ();
+	  str += "\n  " + param->to_string ();
 	}
     }
 
@@ -1548,27 +1561,27 @@ MethodCallExpr::as_string () const
 }
 
 std::string
-TupleIndexExpr::as_string () const
+TupleIndexExpr::to_string () const
 {
-  return tuple_expr->as_string () + "." + std::to_string (tuple_index);
+  return tuple_expr->to_string () + "." + std::to_string (tuple_index);
 }
 
 std::string
-DereferenceExpr::as_string () const
+DereferenceExpr::to_string () const
 {
-  return "*" + main_or_left_expr->as_string ();
+  return "*" + main_or_left_expr->to_string ();
 }
 
 std::string
-FieldAccessExpr::as_string () const
+FieldAccessExpr::to_string () const
 {
-  return receiver->as_string () + "." + field.as_string ();
+  return receiver->to_string () + "." + field.as_string ();
 }
 
 std::string
-LazyBooleanExpr::as_string () const
+LazyBooleanExpr::to_string () const
 {
-  std::string str (main_or_left_expr->as_string ());
+  std::string str (main_or_left_expr->to_string ());
 
   switch (expr_type)
     {
@@ -1582,68 +1595,68 @@ LazyBooleanExpr::as_string () const
       return "ERROR_MARK_STRING - lazy boolean expr out of bounds";
     }
 
-  str += right_expr->as_string ();
+  str += right_expr->to_string ();
 
   return str;
 }
 
 std::string
-RangeFromToExpr::as_string () const
+RangeFromToExpr::to_string () const
 {
-  return from->as_string () + ".." + to->as_string ();
+  return from->to_string () + ".." + to->to_string ();
 }
 
 std::string
-RangeToInclExpr::as_string () const
+RangeToInclExpr::to_string () const
 {
-  return "..=" + to->as_string ();
+  return "..=" + to->to_string ();
 }
 
 std::string
-UnsafeBlockExpr::as_string () const
+UnsafeBlockExpr::to_string () const
 {
   std::string istr = indent_spaces (enter);
   std::string str = istr + "UnsafeBlockExpr:";
   str += istr + "{";
 
   // get outer attributes
-  str += "\n" + indent_spaces (stay) + Expr::as_string ();
+  str += "\n" + indent_spaces (stay) + Expr::to_string ();
 
-  return str + "\n" + indent_spaces (out) + "}\n" + expr->as_string ();
+  return str + "\n" + indent_spaces (out) + "}\n" + expr->to_string ();
 }
 
 std::string
-IfExpr::as_string () const
+IfExpr::to_string () const
 {
   std::string str ("IfExpr: ");
 
-  str += "\n Condition expr: " + condition->as_string ();
+  str += "\n Condition expr: " + condition->to_string ();
 
-  str += "\n If block expr: " + if_block->as_string ();
-
-  return str;
-}
-
-std::string
-IfExprConseqElse::as_string () const
-{
-  std::string str = IfExpr::as_string ();
-
-  str += "\n Else expr: " + else_block->as_string ();
+  str += "\n If block expr: " + if_block->to_string ();
 
   return str;
 }
 
 std::string
-RangeFromToInclExpr::as_string () const
+IfExprConseqElse::to_string () const
 {
-  return from->as_string () + "..=" + to->as_string ();
+  std::string str = IfExpr::to_string ();
+
+  str += "\n Else expr: " + else_block->to_string ();
+
+  return str;
 }
 
 std::string
-ErrorPropagationExpr::as_string () const
+RangeFromToInclExpr::to_string () const
 {
-  return main_or_left_expr->as_string () + "?";
+  return from->to_string () + "..=" + to->to_string ();
+}
+
+std::string
+ErrorPropagationExpr::to_string () const
+{
+  return main_or_left_expr->to_string () + "?";
 }
 
 std::string
@@ -1694,19 +1707,19 @@ ArithmeticOrLogicalExpr::get_operator_str () const
 }
 
 std::string
-ArithmeticOrLogicalExpr::as_string () const
+ArithmeticOrLogicalExpr::to_string () const
 {
-  std::string str = main_or_left_expr->as_string () + " ";
+  std::string str = main_or_left_expr->to_string () + " ";
   str += get_operator_str () + " ";
-  str += right_expr->as_string ();
+  str += right_expr->to_string ();
 
-  return "( " + str + " (" + get_mappings ().as_string () + "))";
+  return "( " + str + " )";
 }
 
 std::string
-CallExpr::as_string () const
+CallExpr::to_string () const
 {
-  std::string str = function->as_string () + "(";
+  std::string str = function->to_string () + "(";
   if (!has_params ())
     str += "none";
   else
@@ -1718,14 +1731,14 @@ CallExpr::as_string () const
 	      return "ERROR_MARK_STRING - call expr param is null";
 	    }
 
-	  str += param->as_string () + ",";
+	  str += param->to_string () + ",";
 	}
     }
-  return str + ")" + "::" + get_mappings ().as_string ();
+  return str + ")";
 }
 
 std::string
-WhileLoopExpr::as_string () const
+WhileLoopExpr::to_string () const
 {
   std::string str ("WhileLoopExpr: ");
 
@@ -1736,18 +1749,18 @@ WhileLoopExpr::as_string () const
     }
   else
     {
-      str += get_loop_label ().as_string ();
+      str += get_loop_label ().to_string ();
     }
 
-  str += "\n Conditional expr: " + condition->as_string ();
+  str += "\n Conditional expr: " + condition->to_string ();
 
-  str += "\n Loop block: " + loop_block->as_string ();
+  str += "\n Loop block: " + loop_block->to_string ();
 
   return str;
 }
 
 std::string
-WhileLetLoopExpr::as_string () const
+WhileLetLoopExpr::to_string () const
 {
   std::string str ("WhileLetLoopExpr: ");
 
@@ -1758,7 +1771,7 @@ WhileLetLoopExpr::as_string () const
     }
   else
     {
-      str += get_loop_label ().as_string ();
+      str += get_loop_label ().to_string ();
     }
 
   str += "\n Match arm patterns: ";
@@ -1770,19 +1783,19 @@ WhileLetLoopExpr::as_string () const
     {
       for (const auto &pattern : match_arm_patterns)
 	{
-	  str += "\n  " + pattern->as_string ();
+	  str += "\n  " + pattern->to_string ();
 	}
     }
 
-  str += "\n Scrutinee expr: " + condition->as_string ();
+  str += "\n Scrutinee expr: " + condition->to_string ();
 
-  str += "\n Loop block: " + loop_block->as_string ();
+  str += "\n Loop block: " + loop_block->to_string ();
 
   return str;
 }
 
 std::string
-LoopExpr::as_string () const
+LoopExpr::to_string () const
 {
   std::string str ("LoopExpr: (infinite loop)");
 
@@ -1793,16 +1806,16 @@ LoopExpr::as_string () const
     }
   else
     {
-      str += get_loop_label ().as_string ();
+      str += get_loop_label ().to_string ();
     }
 
-  str += "\n Loop block: " + loop_block->as_string ();
+  str += "\n Loop block: " + loop_block->to_string ();
 
   return str;
 }
 
 std::string
-ArrayExpr::as_string () const
+ArrayExpr::to_string () const
 {
   std::string str ("ArrayExpr:");
 
@@ -1829,44 +1842,44 @@ ArrayExpr::as_string () const
     }
   else
     {
-      str += internal_elements->as_string ();
+      str += internal_elements->to_string ();
     }
 
   return str;
 }
 
 std::string
-AwaitExpr::as_string () const
+AwaitExpr::to_string () const
 {
-  return awaited_expr->as_string () + ".await";
+  return awaited_expr->to_string () + ".await";
 }
 
 std::string
-BreakExpr::as_string () const
+BreakExpr::to_string () const
 {
   std::string str ("break ");
 
   if (has_label ())
     {
-      str += get_label ().as_string () + " ";
+      str += get_label ().to_string () + " ";
     }
 
   if (has_break_expr ())
     {
-      str += break_expr->as_string ();
+      str += break_expr->to_string ();
     }
 
   return str;
 }
 
 std::string
-LoopLabel::as_string () const
+LoopLabel::to_string () const
 {
-  return label.as_string () + ": (label) ";
+  return label.to_string () + ": (label) ";
 }
 
 std::string
-MatchArm::as_string () const
+MatchArm::to_string () const
 {
   // outer attributes
   std::string str = "Outer attributes: ";
@@ -1893,7 +1906,7 @@ MatchArm::as_string () const
     {
       for (const auto &pattern : match_arm_patterns)
 	{
-	  str += "\n " + pattern->as_string ();
+	  str += "\n " + pattern->to_string ();
 	}
     }
 
@@ -1904,49 +1917,58 @@ MatchArm::as_string () const
     }
   else
     {
-      str += guard_expr->as_string ();
+      str += guard_expr->to_string ();
     }
 
   return str;
 }
 
 std::string
-MatchCase::as_string () const
+MatchCase::to_debug_string () const
 {
   std::string str ("MatchCase: (match arm) ");
 
-  str += "\n Match arm matcher: \n" + arm.as_string ();
-  str += "\n Expr: " + expr->as_string ();
-
-  return str;
-}
-
-/*std::string
-MatchCaseBlockExpr::as_string () const
-{
-  std::string str = MatchCase::as_string ();
-
-  str += "\n Block expr: " + block_expr->as_string ();
+  str += "\n Match arm matcher: \n" + arm.to_string ();
+  str += "\n Expr: " + expr->to_string ();
 
   return str;
 }
 
 std::string
-MatchCaseExpr::as_string () const
+MatchCase::to_string () const
 {
-  std::string str = MatchCase::as_string ();
+  std::string str = arm.to_string ();
+  str += " => ";
+  str += expr ? expr->to_string () : "null";
+  return str;
+}
 
-  str += "\n Expr: " + expr->as_string ();
+/*std::string
+MatchCaseBlockExpr::to_string () const
+{
+  std::string str = MatchCase::to_string ();
+
+  str += "\n Block expr: " + block_expr->to_string ();
+
+  return str;
+}
+
+std::string
+MatchCaseExpr::to_string () const
+{
+  std::string str = MatchCase::to_string ();
+
+  str += "\n Expr: " + expr->to_string ();
 
   return str;
 }*/
 
 std::string
-MatchExpr::as_string () const
+MatchExpr::to_string () const
 {
   std::string str ("MatchExpr:");
 
-  str += "\n Scrutinee expr: " + branch_value->as_string ();
+  str += "\n Scrutinee expr: " + branch_value->to_string ();
 
   // inner attributes
   str += "\n inner attributes: ";
@@ -1973,14 +1995,14 @@ MatchExpr::as_string () const
   else
     {
       for (const auto &arm : match_arms)
-	str += "\n  " + arm.as_string ();
+	str += "\n  " + arm.to_string ();
     }
 
   return str;
 }
 
 std::string
-TupleExpr::as_string () const
+TupleExpr::to_string () const
 {
   std::string str ("TupleExpr:");
 
@@ -2009,7 +2031,7 @@ TupleExpr::as_string () const
     {
       for (const auto &elem : tuple_elems)
 	{
-	  str += "\n  " + elem->as_string ();
+	  str += "\n  " + elem->to_string ();
 	}
     }
 
@@ -2017,13 +2039,13 @@ TupleExpr::as_string () const
 }
 
 std::string
-FunctionParam::as_string () const
+FunctionParam::to_string () const
 {
-  return param_name->as_string () + " : " + type->as_string ();
+  return param_name->to_string () + " : " + type->to_string ();
 }
 
 std::string
-FunctionQualifiers::as_string () const
+FunctionQualifiers::to_string () const
 {
   std::string str;
 
@@ -2044,7 +2066,7 @@ FunctionQualifiers::as_string () const
 }
 
 std::string
-TraitBound::as_string () const
+TraitBound::to_debug_string () const
 {
   std::string str ("TraitBound:");
 
@@ -2069,69 +2091,56 @@ TraitBound::as_string () const
     {
       for (const auto &lifetime : for_lifetimes)
 	{
-	  str += "\n  " + lifetime.as_string ();
+	  str += "\n  " + lifetime.to_string ();
 	}
     }
 
-  str += "\n Type path: " + type_path.as_string ();
+  str += "\n Type path: " + type_path.to_string ();
 
   return str;
 }
 
 std::string
-LifetimeParam::as_string () const
+TraitBound::to_string () const
 {
-  std::string str ("LifetimeParam: ");
-
-  str += "\n Outer attributes: ";
-  if (outer_attrs.empty ())
+  std::string str;
+  switch (polarity)
     {
-      str += "none";
-    }
-  else
-    {
-      /* note that this does not print them with "outer attribute" syntax -
-       * just the body */
-      for (const auto &attr : outer_attrs)
-	{
-	  str += "\n " + attr.as_string ();
-	}
+    case RegularBound:
+      break;
+    case NegativeBound:
+      str += "!";
+      break;
+    case AntiBound:
+      str += "?";
+      break;
     }
 
-  str += "\n Lifetime: " + lifetime.as_string ();
+  if (has_for_lifetimes ())
+    for (const auto &lifetime : for_lifetimes)
+      str += "\n  " + lifetime.to_string ();
 
-  str += "\n Lifetime bounds: ";
-  if (!has_lifetime_bounds ())
-    {
-      str += "none";
-    }
-  else
-    {
-      for (const auto &bound : lifetime_bounds)
-	{
-	  str += "\n  " + bound.as_string ();
-	}
-    }
+  str += "\n" + type_path.to_string ();
 
   return str;
 }
 
 std::string
-QualifiedPathInType::as_string () const
+QualifiedPathInType::to_string () const
 {
-  std::string str = path_type.as_string ();
+  std::string str = path_type.to_string ();
 
-  str += "::" + associated_segment->as_string ();
+  str += "::" + associated_segment->to_string ();
   for (const auto &segment : segments)
     {
-      str += "::" + segment->as_string ();
+      str += "::" + segment->to_string ();
     }
 
   return str;
 }
 
 std::string
-Lifetime::as_string () const
+Lifetime::to_string () const
 {
   switch (lifetime_type)
     {
@@ -2147,7 +2156,7 @@ Lifetime::as_string () const
 }
 
 std::string
-TypePath::as_string () const
+TypePath::to_string () const
 {
   std::string str;
 
@@ -2158,7 +2167,7 @@ TypePath::as_string () const
 
   for (const auto &segment : segments)
     {
-      str += segment->as_string () + "::";
+      str += segment->to_string () + "::";
     }
 
   // kinda hack - remove last 2 '::' characters
@@ -2168,14 +2177,14 @@ TypePath::as_string () const
 }
 
 std::string
-TypeParam::as_string () const
+TypeParam::to_debug_string () const
 {
   std::string str ("TypeParam: ");
 
   str += "\n Outer attributes: ";
   if (outer_attrs.empty ())
     {
-      str += "none";
+      str += "\nnone";
     }
   else
     {
@@ -2198,7 +2207,7 @@ TypeParam::as_string () const
     {
       for (const auto &bound : type_param_bounds)
 	{
-	  str += "\n  " + bound->as_string ();
+	  str += "\n  " + bound->to_string ();
 	}
     }
 
@@ -2209,8 +2218,39 @@ TypeParam::as_string () const
     }
   else
     {
-      str += type.value ()->as_string ();
+      str += type.value ()->to_string ();
     }
+
+  return str;
+}
+
+std::string
+TypeParam::to_string () const
+{
+  std::string str;
+  if (!outer_attrs.empty ())
+    {
+      for (const auto &attr : outer_attrs)
+	{
+	  str += attr.as_string () + "\n";
+	}
+    }
+
+  str += type_representation.as_string ();
+
+  if (!has_type_param_bounds ())
+    {
+      str += ": ";
+      for (size_t i = 0; i < type_param_bounds.size (); ++i)
+	{
+	  if (i > 0)
+	    str += " + ";
+	  str += type_param_bounds[i]->to_string ();
+	}
+    }
+
+  if (has_type ())
+    str += ": " + type.value ()->to_string ();
 
   return str;
 }
@@ -2232,13 +2272,13 @@ PathPattern::convert_to_simple_path (bool with_opening_scope_resolution) const
   for (const auto &segment : segments)
     {
       // return empty path if doesn't meet simple path segment requirements
-      if (segment.has_generic_args () || segment.as_string () == "Self")
+      if (segment.has_generic_args () || segment.to_string () == "Self")
 	{
 	  return AST::SimplePath::create_empty ();
 	}
 
       // create segment and add to vector
-      std::string segment_str = segment.as_string ();
+      std::string segment_str = segment.to_string ();
       simple_segments.emplace_back (std::move (segment_str),
 				    segment.get_locus ());
     }
@@ -2274,13 +2314,13 @@ TypePath::as_simple_path () const
     {
       // return empty path if doesn't meet simple path segment requirements
       if (segment == nullptr || segment->is_error ()
-	  || !segment->is_ident_only () || segment->as_string () == "Self")
+	  || !segment->is_ident_only () || segment->to_string () == "Self")
 	{
 	  return AST::SimplePath::create_empty ();
 	}
 
       // create segment and add to vector
-      std::string segment_str = segment->as_string ();
+      std::string segment_str = segment->to_string ();
       simple_segments.emplace_back (std::move (segment_str),
 				    segment->get_locus ());
     }
@@ -2290,19 +2330,19 @@ TypePath::as_simple_path () const
 }
 
 std::string
-PathExprSegment::as_string () const
+PathExprSegment::to_string () const
 {
-  std::string ident_str = segment_name.as_string ();
+  std::string ident_str = segment_name.to_string ();
   if (has_generic_args ())
     {
-      ident_str += "::<" + generic_args.as_string () + ">";
+      ident_str += "::<" + generic_args.to_string () + ">";
     }
 
   return ident_str;
 }
 
 std::string
-GenericArgs::as_string () const
+GenericArgs::to_string () const
 {
   std::string args;
 
@@ -2314,7 +2354,7 @@ GenericArgs::as_string () const
 
       for (; i != e; i++)
 	{
-	  args += (*i).as_string ();
+	  args += (*i).to_string ();
 	  if (e != i + 1)
 	    args += ", ";
 	}
@@ -2328,7 +2368,7 @@ GenericArgs::as_string () const
 
       for (; i != e; i++)
 	{
-	  args += (*i)->as_string ();
+	  args += (*i)->to_string ();
 	  if (e != i + 1)
 	    args += ", ";
 	}
@@ -2342,7 +2382,7 @@ GenericArgs::as_string () const
 
       for (; i != e; i++)
 	{
-	  args += (*i).as_string ();
+	  args += (*i).to_string ();
 	  if (e != i + 1)
 	    args += ", ";
 	}
@@ -2352,26 +2392,26 @@ GenericArgs::as_string () const
 }
 
 std::string
-GenericArgsBinding::as_string () const
+GenericArgsBinding::to_string () const
 {
-  return identifier.as_string () + " = " + type->as_string ();
+  return identifier.as_string () + " = " + type->to_string ();
 }
 
 std::string
-RangePattern::as_string () const
+RangePattern::to_string () const
 {
   if (has_ellipsis_syntax)
     {
-      return lower->as_string () + "..." + upper->as_string ();
+      return lower->to_string () + "..." + upper->to_string ();
     }
   else
     {
-      return lower->as_string () + "..=" + upper->as_string ();
+      return lower->to_string () + "..=" + upper->to_string ();
     }
 }
 
 std::string
-RangePatternBoundLiteral::as_string () const
+RangePatternBoundLiteral::to_string () const
 {
   std::string str;
 
@@ -2386,20 +2426,20 @@ RangePatternBoundLiteral::as_string () const
 }
 
 std::string
-SlicePatternItemsNoRest::as_string () const
+SlicePatternItemsNoRest::to_string () const
 {
   std::string str;
 
   for (const auto &pattern : patterns)
     {
-      str += "\n " + pattern->as_string ();
+      str += "\n " + pattern->to_string ();
     }
 
   return str;
 }
 
 std::string
-SlicePatternItemsHasRest::as_string () const
+SlicePatternItemsHasRest::to_string () const
 {
   std::string str;
 
@@ -2412,7 +2452,7 @@ SlicePatternItemsHasRest::as_string () const
     {
       for (const auto &lower : lower_patterns)
 	{
-	  str += "\n  " + lower->as_string ();
+	  str += "\n  " + lower->to_string ();
 	}
     }
 
@@ -2425,7 +2465,7 @@ SlicePatternItemsHasRest::as_string () const
     {
       for (const auto &upper : upper_patterns)
 	{
-	  str += "\n  " + upper->as_string ();
+	  str += "\n  " + upper->to_string ();
 	}
     }
 
@@ -2433,39 +2473,39 @@ SlicePatternItemsHasRest::as_string () const
 }
 
 std::string
-SlicePattern::as_string () const
+SlicePattern::to_string () const
 {
-  return "SlicePattern: " + items->as_string ();
+  return "SlicePattern: " + items->to_string ();
 }
 
 std::string
-AltPattern::as_string () const
+AltPattern::to_string () const
 {
   std::string str ("AltPattern: ");
 
   for (const auto &pattern : alts)
     {
-      str += "\n " + pattern->as_string ();
+      str += "\n " + pattern->to_string ();
     }
 
   return str;
 }
 
 std::string
-TuplePatternItemsNoRest::as_string () const
+TuplePatternItemsNoRest::to_string () const
 {
   std::string str;
 
   for (const auto &pattern : patterns)
     {
-      str += "\n " + pattern->as_string ();
+      str += "\n " + pattern->to_string ();
     }
 
   return str;
 }
 
 std::string
-TuplePatternItemsHasRest::as_string () const
+TuplePatternItemsHasRest::to_string () const
 {
   std::string str;
 
@@ -2478,7 +2518,7 @@ TuplePatternItemsHasRest::as_string () const
     {
       for (const auto &lower : lower_patterns)
 	{
-	  str += "\n  " + lower->as_string ();
+	  str += "\n  " + lower->to_string ();
 	}
     }
 
@@ -2491,7 +2531,7 @@ TuplePatternItemsHasRest::as_string () const
     {
       for (const auto &upper : upper_patterns)
 	{
-	  str += "\n  " + upper->as_string ();
+	  str += "\n  " + upper->to_string ();
 	}
     }
 
@@ -2499,13 +2539,13 @@ TuplePatternItemsHasRest::as_string () const
 }
 
 std::string
-TuplePattern::as_string () const
+TuplePattern::to_string () const
 {
-  return "TuplePattern: " + items->as_string ();
+  return items->to_string ();
 }
 
 std::string
-StructPatternField::as_string () const
+StructPatternField::to_string () const
 {
   // outer attributes
   std::string str ("Outer attributes: ");
@@ -2540,15 +2580,13 @@ StructPatternField::as_string () const
       break;
     }
 
-  str += "\n   mapping: " + mappings.as_string ();
-
   return str;
 }
 
 std::string
-StructPatternFieldIdent::as_string () const
+StructPatternFieldIdent::to_string () const
 {
-  std::string str = StructPatternField::as_string ();
+  std::string str = StructPatternField::to_string ();
 
   str += "\n";
 
@@ -2568,31 +2606,31 @@ StructPatternFieldIdent::as_string () const
 }
 
 std::string
-StructPatternFieldTuplePat::as_string () const
+StructPatternFieldTuplePat::to_string () const
 {
-  std::string str = StructPatternField::as_string ();
+  std::string str = StructPatternField::to_string ();
 
   str += "\n";
 
-  str += std::to_string (index) + " : " + tuple_pattern->as_string ();
+  str += std::to_string (index) + " : " + tuple_pattern->to_string ();
 
   return str;
 }
 
 std::string
-StructPatternFieldIdentPat::as_string () const
+StructPatternFieldIdentPat::to_string () const
 {
-  std::string str = StructPatternField::as_string ();
+  std::string str = StructPatternField::to_string ();
 
   str += "\n";
 
-  str += ident.as_string () + " : " + ident_pattern->as_string ();
+  str += ident.as_string () + " : " + ident_pattern->to_string ();
 
   return str;
 }
 
 std::string
-StructPatternElements::as_string () const
+StructPatternElements::to_string () const
 {
   std::string str ("\n  Fields: ");
 
@@ -2604,7 +2642,7 @@ StructPatternElements::as_string () const
     {
       for (const auto &field : fields)
 	{
-	  str += "\n   " + field->as_string ();
+	  str += "\n   " + field->to_string ();
 	}
     }
 
@@ -2612,11 +2650,11 @@ StructPatternElements::as_string () const
 }
 
 std::string
-StructPattern::as_string () const
+StructPattern::to_string () const
 {
   std::string str ("StructPattern: \n Path: ");
 
-  str += path.as_string ();
+  str += path.to_string ();
 
   str += "\n Struct pattern elems: ";
   if (!has_struct_pattern_elems ())
@@ -2625,20 +2663,20 @@ StructPattern::as_string () const
     }
   else
     {
-      str += elems.as_string ();
+      str += elems.to_string ();
     }
 
   return str;
 }
 
 std::string
-LiteralPattern::as_string () const
+LiteralPattern::to_string () const
 {
   return (has_minus ? "-" : "") + lit.as_string ();
 }
 
 std::string
-ReferencePattern::as_string () const
+ReferencePattern::to_string () const
 {
   std::string str ("&");
 
@@ -2647,13 +2685,13 @@ ReferencePattern::as_string () const
       str += "mut ";
     }
 
-  str += pattern->as_string ();
+  str += pattern->to_string ();
 
   return str;
 }
 
 std::string
-IdentifierPattern::as_string () const
+IdentifierPattern::to_string () const
 {
   std::string str;
 
@@ -2671,27 +2709,27 @@ IdentifierPattern::as_string () const
 
   if (has_subpattern ())
     {
-      str += " @ " + subpattern->as_string ();
+      str += " @ " + subpattern->to_string ();
     }
 
   return str;
 }
 
 std::string
-TupleStructItemsNoRest::as_string () const
+TupleStructItemsNoRest::to_string () const
 {
   std::string str;
 
   for (const auto &pattern : patterns)
     {
-      str += "\n  " + pattern->as_string ();
+      str += "\n  " + pattern->to_string ();
     }
 
   return str;
 }
 
 std::string
-TupleStructItemsHasRest::as_string () const
+TupleStructItemsHasRest::to_string () const
 {
   std::string str ("\n  Lower patterns: ");
 
@@ -2703,7 +2741,7 @@ TupleStructItemsHasRest::as_string () const
     {
       for (const auto &lower : lower_patterns)
 	{
-	  str += "\n   " + lower->as_string ();
+	  str += "\n   " + lower->to_string ();
 	}
     }
 
@@ -2716,7 +2754,7 @@ TupleStructItemsHasRest::as_string () const
     {
       for (const auto &upper : upper_patterns)
 	{
-	  str += "\n   " + upper->as_string ();
+	  str += "\n   " + upper->to_string ();
 	}
     }
 
@@ -2724,19 +2762,19 @@ TupleStructItemsHasRest::as_string () const
 }
 
 std::string
-TupleStructPattern::as_string () const
+TupleStructPattern::to_string () const
 {
   std::string str ("TupleStructPattern: \n Path: ");
 
-  str += path.as_string ();
+  str += path.to_string ();
 
-  str += "\n Tuple struct items: " + items->as_string ();
+  str += "\n Tuple struct items: " + items->to_string ();
 
   return str;
 }
 
 std::string
-LetStmt::as_string () const
+LetStmt::to_string () const
 {
   // outer attributes
   std::string str = "Outer attributes: ";
@@ -2756,16 +2794,16 @@ LetStmt::as_string () const
       indent_spaces (out);
     }
 
-  str += "\n" + indent_spaces (stay) + "let " + variables_pattern->as_string ();
+  str += "\n" + indent_spaces (stay) + "let " + variables_pattern->to_string ();
 
   if (has_type ())
     {
-      str += " : " + get_type ().as_string ();
+      str += " : " + get_type ().to_string ();
     }
 
   if (has_init_expr ())
     {
-      str += " = " + get_init_expr ().as_string ();
+      str += " = " + get_init_expr ().to_string ();
     }
 
   return str;
@@ -2773,7 +2811,7 @@ LetStmt::as_string () const
 
 // Used to get outer attributes for expressions.
 std::string
-Expr::as_string () const
+Expr::to_string () const
 {
   // outer attributes
   std::string str = "outer attributes: ";
@@ -2806,20 +2844,20 @@ TypePath::to_trait_bound (bool in_parens) const
 }
 
 std::string
-InferredType::as_string () const
+InferredType::to_string () const
 {
-  return "_ (inferred) " + get_mappings ().as_string ();
+  return "_ (inferred)";
 }
 
 std::string
-TypeCastExpr::as_string () const
+TypeCastExpr::to_string () const
 {
-  return main_or_left_expr->as_string () + " as "
-	 + type_to_convert_to->as_string ();
+  return main_or_left_expr->to_string () + " as "
+	 + type_to_convert_to->to_string ();
 }
 
 std::string
-ImplTraitType::as_string () const
+ImplTraitType::to_string () const
 {
   std::string str ("ImplTraitType: \n TypeParamBounds: ");
 
@@ -2831,7 +2869,7 @@ ImplTraitType::as_string () const
     {
       for (const auto &bound : type_param_bounds)
 	{
-	  str += "\n  " + bound->as_string ();
+	  str += "\n  " + bound->to_string ();
 	}
     }
 
@@ -2839,13 +2877,13 @@ ImplTraitType::as_string () const
 }
 
 std::string
-ReferenceType::as_string () const
+ReferenceType::to_string () const
 {
   std::string str ("&");
 
   if (has_lifetime ())
     {
-      str += get_lifetime ().as_string () + " ";
+      str += get_lifetime ().to_string () + " ";
     }
 
   if (is_mut ())
@@ -2853,20 +2891,20 @@ ReferenceType::as_string () const
       str += "mut ";
     }
 
-  str += type->as_string ();
+  str += type->to_string ();
 
   return str;
 }
 
 std::string
-RawPointerType::as_string () const
+RawPointerType::to_string () const
 {
   return std::string ("*") + (is_mut () ? "mut " : "const ")
-	 + type->as_string ();
+	 + type->to_string ();
 }
 
 std::string
-TraitObjectType::as_string () const
+TraitObjectType::to_string () const
 {
   std::string str ("TraitObjectType: \n Has dyn dispatch: ");
 
@@ -2888,7 +2926,7 @@ TraitObjectType::as_string () const
     {
       for (const auto &bound : type_param_bounds)
 	{
-	  str += "\n  " + bound->as_string ();
+	  str += "\n  " + bound->to_string ();
 	}
     }
 
@@ -2896,7 +2934,7 @@ TraitObjectType::as_string () const
 }
 
 std::string
-BareFunctionType::as_string () const
+BareFunctionType::to_string () const
 {
   std::string str ("BareFunctionType: \n For lifetimes: ");
 
@@ -2908,11 +2946,11 @@ BareFunctionType::as_string () const
     {
       for (const auto &for_lifetime : for_lifetimes)
 	{
-	  str += "\n  " + for_lifetime.as_string ();
+	  str += "\n  " + for_lifetime.to_string ();
 	}
     }
 
-  str += "\n Qualifiers: " + function_qualifiers.as_string ();
+  str += "\n Qualifiers: " + function_qualifiers.to_string ();
 
   str += "\n Params: ";
   if (params.empty ())
@@ -2923,7 +2961,7 @@ BareFunctionType::as_string () const
     {
       for (const auto &param : params)
 	{
-	  str += "\n  " + param.as_string ();
+	  str += "\n  " + param.to_string ();
 	}
     }
 
@@ -2944,20 +2982,20 @@ BareFunctionType::as_string () const
     }
   else
     {
-      str += return_type->as_string ();
+      str += return_type->to_string ();
     }
 
   return str;
 }
 
 std::string
-TypePathSegmentGeneric::as_string () const
+TypePathSegmentGeneric::to_string () const
 {
-  return TypePathSegment::as_string () + "<" + generic_args.as_string () + ">";
+  return TypePathSegment::to_string () + "<" + generic_args.to_string () + ">";
 }
 
 std::string
-TypePathFunction::as_string () const
+TypePathFunction::to_string () const
 {
   std::string str ("(");
 
@@ -2968,7 +3006,7 @@ TypePathFunction::as_string () const
 
       for (; i != e; i++)
 	{
-	  str += (*i)->as_string ();
+	  str += (*i)->to_string ();
 	  if (e != i + 1)
 	    str += ", ";
 	}
@@ -2978,32 +3016,32 @@ TypePathFunction::as_string () const
 
   if (has_return_type ())
     {
-      str += " -> " + return_type->as_string ();
+      str += " -> " + return_type->to_string ();
     }
 
   return str;
 }
 
 std::string
-TypePathSegmentFunction::as_string () const
+TypePathSegmentFunction::to_string () const
 {
-  return TypePathSegment::as_string () + function_path.as_string ();
+  return TypePathSegment::to_string () + function_path.to_string ();
 }
 
 std::string
-ArrayType::as_string () const
+ArrayType::to_string () const
 {
-  return "[" + elem_type->as_string () + "; " + size->as_string () + "]";
+  return "[" + elem_type->to_string () + "; " + size->to_string () + "]";
 }
 
 std::string
-SliceType::as_string () const
+SliceType::to_string () const
 {
-  return "[" + elem_type->as_string () + "]";
+  return "[" + elem_type->to_string () + "]";
 }
 
 std::string
-TupleType::as_string () const
+TupleType::to_string () const
 {
   std::string str ("(");
 
@@ -3014,7 +3052,7 @@ TupleType::as_string () const
 
       for (; i != e; i++)
 	{
-	  str += (*i)->as_string ();
+	  str += (*i)->to_string ();
 	  if (e != i + 1)
 	    str += ", ";
 	}
@@ -3026,25 +3064,25 @@ TupleType::as_string () const
 }
 
 std::string
-StructExpr::as_string () const
+StructExpr::to_string () const
 {
-  std::string str = ExprWithoutBlock::as_string ();
+  std::string str = ExprWithoutBlock::to_string ();
   indent_spaces (enter);
   str += "\n" + indent_spaces (stay) + "StructExpr:";
   indent_spaces (enter);
   str += "\n" + indent_spaces (stay) + "PathInExpr:\n";
-  str += indent_spaces (stay) + struct_name.as_string ();
+  str += indent_spaces (stay) + struct_name.to_string ();
   indent_spaces (out);
   indent_spaces (out);
   return str;
 }
 
 std::string
-StructExprStruct::as_string () const
+StructExprStruct::to_string () const
 {
   std::string str ("StructExprStruct (or subclass): ");
 
-  str += "\n Path: " + struct_name.as_string ();
+  str += "\n Path: " + struct_name.to_string ();
 
   // inner attributes
   str += "\n inner attributes: ";
@@ -3066,11 +3104,11 @@ StructExprStruct::as_string () const
 }
 
 std::string
-StructBase::as_string () const
+StructBase::to_string () const
 {
   if (base_struct != nullptr)
     {
-      return base_struct->as_string ();
+      return base_struct->to_string ();
     }
   else
     {
@@ -3079,28 +3117,28 @@ StructBase::as_string () const
 }
 
 std::string
-StructExprFieldWithVal::as_string () const
+StructExprFieldWithVal::to_string () const
 {
   // used to get value string
-  return value->as_string ();
+  return value->to_string ();
 }
 
 std::string
-StructExprFieldIdentifierValue::as_string () const
+StructExprFieldIdentifierValue::to_string () const
 {
-  return field_name.as_string () + " : " + StructExprFieldWithVal::as_string ();
+  return field_name.as_string () + " : " + StructExprFieldWithVal::to_string ();
 }
 
 std::string
-StructExprFieldIndexValue::as_string () const
+StructExprFieldIndexValue::to_string () const
 {
-  return std::to_string (index) + " : " + StructExprFieldWithVal::as_string ();
+  return std::to_string (index) + " : " + StructExprFieldWithVal::to_string ();
 }
 
 std::string
-StructExprStructFields::as_string () const
+StructExprStructFields::to_string () const
 {
-  std::string str = StructExprStruct::as_string ();
+  std::string str = StructExprStruct::to_string ();
 
   str += "\n Fields: ";
   if (fields.empty ())
@@ -3111,7 +3149,7 @@ StructExprStructFields::as_string () const
     {
       for (const auto &field : fields)
 	{
-	  str += "\n  " + field->as_string ();
+	  str += "\n  " + field->to_string ();
 	}
     }
 
@@ -3122,16 +3160,16 @@ StructExprStructFields::as_string () const
     }
   else
     {
-      str += (*struct_base)->as_string ();
+      str += (*struct_base)->to_string ();
     }
 
   return str;
 }
 
 std::string
-EnumItem::as_string () const
+EnumItem::to_string () const
 {
-  std::string str = Item::as_string ();
+  std::string str = Item::to_string ();
   str += variant_name.as_string ();
   str += " ";
   switch (get_enum_item_kind ())
@@ -3154,9 +3192,9 @@ EnumItem::as_string () const
 }
 
 std::string
-EnumItemTuple::as_string () const
+EnumItemTuple::to_string () const
 {
-  std::string str = EnumItem::as_string ();
+  std::string str = EnumItem::to_string ();
 
   // add tuple opening parens
   str += "(";
@@ -3169,7 +3207,7 @@ EnumItemTuple::as_string () const
 
       for (; i != e; i++)
 	{
-	  str += (*i).as_string ();
+	  str += (*i).to_string ();
 	  if (e != i + 1)
 	    str += ", ";
 	}
@@ -3182,7 +3220,7 @@ EnumItemTuple::as_string () const
 }
 
 std::string
-TupleField::as_string () const
+TupleField::to_string () const
 {
   // outer attributes
   std::string str = "outer attributes: ";
@@ -3202,18 +3240,18 @@ TupleField::as_string () const
 
   if (has_visibility ())
     {
-      str += "\n" + visibility.as_string ();
+      str += "\n" + visibility.to_string ();
     }
 
-  str += " " + field_type->as_string ();
+  str += " " + field_type->to_string ();
 
   return str;
 }
 
 std::string
-EnumItemStruct::as_string () const
+EnumItemStruct::to_string () const
 {
-  std::string str = EnumItem::as_string ();
+  std::string str = EnumItem::to_string ();
 
   // add struct opening parens
   str += "{";
@@ -3226,7 +3264,7 @@ EnumItemStruct::as_string () const
 
       for (; i != e; i++)
 	{
-	  str += (*i).as_string ();
+	  str += (*i).to_string ();
 	  if (e != i + 1)
 	    str += ", ";
 	}
@@ -3239,7 +3277,7 @@ EnumItemStruct::as_string () const
 }
 
 std::string
-StructField::as_string () const
+StructField::to_string () const
 {
   // outer attributes
   std::string str = "outer attributes: ";
@@ -3259,27 +3297,27 @@ StructField::as_string () const
 
   if (has_visibility ())
     {
-      str += "\n" + visibility.as_string ();
+      str += "\n" + visibility.to_string ();
     }
 
-  str += " " + field_name.as_string () + " : " + field_type->as_string ();
+  str += " " + field_name.as_string () + " : " + field_type->to_string ();
 
   return str;
 }
 
 std::string
-EnumItemDiscriminant::as_string () const
+EnumItemDiscriminant::to_string () const
 {
-  std::string str = EnumItem::as_string ();
+  std::string str = EnumItem::to_string ();
 
   // add equal and expression
-  str += " = " + expression->as_string ();
+  str += " = " + expression->to_string ();
 
   return str;
 }
 
 std::string
-ExternalItem::as_string () const
+ExternalItem::to_string () const
 {
   // outer attributes
   std::string str = "outer attributes: ";
@@ -3298,15 +3336,15 @@ ExternalItem::as_string () const
     }
 
   // start visibility on new line and with a space
-  str += "\n" + visibility.as_string () + " ";
+  str += "\n" + visibility.to_string () + " ";
 
   return str;
 }
 
 std::string
-ExternalStaticItem::as_string () const
+ExternalStaticItem::to_string () const
 {
-  std::string str = ExternalItem::as_string ();
+  std::string str = ExternalItem::to_string ();
 
   str += "static ";
 
@@ -3319,15 +3357,15 @@ ExternalStaticItem::as_string () const
   str += get_item_name ().as_string ();
 
   // add type on new line
-  str += "\n Type: " + item_type->as_string ();
+  str += "\n Type: " + item_type->to_string ();
 
   return str;
 }
 
 std::string
-ExternalFunctionItem::as_string () const
+ExternalFunctionItem::to_string () const
 {
-  std::string str = ExternalItem::as_string ();
+  std::string str = ExternalItem::to_string ();
 
   str += "fn ";
 
@@ -3353,7 +3391,7 @@ ExternalFunctionItem::as_string () const
 	      return "nullptr_POINTER_MARK";
 	    }
 
-	  str += "\n  " + param->as_string ();
+	  str += "\n  " + param->to_string ();
 	}
     }
 
@@ -3367,7 +3405,7 @@ ExternalFunctionItem::as_string () const
     {
       for (const auto &param : function_params)
 	{
-	  str += "\n  " + param.as_string ();
+	  str += "\n  " + param.to_string ();
 	}
       if (has_variadics)
 	{
@@ -3377,13 +3415,13 @@ ExternalFunctionItem::as_string () const
 
   // add type on new line)
   str += "\n (return) Type: "
-	 + (has_return_type () ? return_type->as_string () : "()");
+	 + (has_return_type () ? return_type->to_string () : "()");
 
   // where clause
   str += "\n Where clause: ";
   if (has_where_clause ())
     {
-      str += where_clause.as_string ();
+      str += where_clause.to_string ();
     }
   else
     {
@@ -3394,9 +3432,9 @@ ExternalFunctionItem::as_string () const
 }
 
 std::string
-ExternalTypeItem::as_string () const
+ExternalTypeItem::to_string () const
 {
-  std::string str = ExternalItem::as_string ();
+  std::string str = ExternalItem::to_string ();
 
   str += "type ";
 
@@ -3407,16 +3445,16 @@ ExternalTypeItem::as_string () const
 }
 
 std::string
-NamedFunctionParam::as_string () const
+NamedFunctionParam::to_string () const
 {
   std::string str = name.as_string ();
 
-  str += "\n Type: " + param_type->as_string ();
+  str += "\n Type: " + param_type->to_string ();
 
   return str;
 }
 
-/*std::string TraitItem::as_string() const {
+/*std::string TraitItem::to_string() const {
     // outer attributes
     std::string str = "outer attributes: ";
     if (outer_attrs.empty()) {
@@ -3424,7 +3462,7 @@ NamedFunctionParam::as_string () const
     } else {
 	// note that this does not print them with "outer attribute" syntax -
 just the body for (const auto& attr : outer_attrs) { str += "\n  " +
-attr.as_string();
+attr.to_string();
 	}
     }
 
@@ -3432,7 +3470,7 @@ attr.as_string();
 }*/
 
 std::string
-TraitItemFunc::as_string () const
+TraitItemFunc::to_string () const
 {
   std::string str = "outer attributes: ";
   if (outer_attrs.empty ())
@@ -3449,12 +3487,12 @@ TraitItemFunc::as_string () const
 	}
     }
 
-  str += "\n" + decl.as_string ();
+  str += "\n" + decl.to_string ();
 
   str += "\n Definition (block expr): ";
   if (has_definition ())
     {
-      str += block_expr->as_string ();
+      str += block_expr->to_string ();
     }
   else
     {
@@ -3465,10 +3503,10 @@ TraitItemFunc::as_string () const
 }
 
 std::string
-TraitFunctionDecl::as_string () const
+TraitFunctionDecl::to_string () const
 {
   std::string str
-    = qualifiers.as_string () + "fn " + function_name.as_string ();
+    = qualifiers.to_string () + "fn " + function_name.as_string ();
 
   // generic params
   str += "\n Generic params: ";
@@ -3489,21 +3527,21 @@ TraitFunctionDecl::as_string () const
 	      return "nullptr_POINTER_MARK";
 	    }
 
-	  str += "\n  " + param->as_string ();
+	  str += "\n  " + param->to_string ();
 	}
     }
 
   str += "\n Function params: ";
   if (is_method ())
     {
-      str += get_self_unchecked ().as_string () + (has_params () ? ", " : "");
+      str += get_self_unchecked ().to_string () + (has_params () ? ", " : "");
     }
 
   if (has_params ())
     {
       for (const auto &param : function_params)
 	{
-	  str += "\n  " + param.as_string ();
+	  str += "\n  " + param.to_string ();
 	}
     }
   else if (!is_method ())
@@ -3514,7 +3552,7 @@ TraitFunctionDecl::as_string () const
   str += "\n Return type: ";
   if (has_return_type ())
     {
-      str += return_type->as_string ();
+      str += return_type->to_string ();
     }
   else
     {
@@ -3524,7 +3562,7 @@ TraitFunctionDecl::as_string () const
   str += "\n Where clause: ";
   if (has_where_clause ())
     {
-      str += where_clause.as_string ();
+      str += where_clause.to_string ();
     }
   else
     {
@@ -3535,7 +3573,7 @@ TraitFunctionDecl::as_string () const
 }
 
 std::string
-TraitItemConst::as_string () const
+TraitItemConst::to_string () const
 {
   std::string str = "outer attributes: ";
   if (outer_attrs.empty ())
@@ -3552,18 +3590,18 @@ TraitItemConst::as_string () const
 	}
     }
 
-  str += "\nconst " + name.as_string () + " : " + type->as_string ();
+  str += "\nconst " + name.as_string () + " : " + type->to_string ();
 
   if (has_expression ())
     {
-      str += " = " + expr->as_string ();
+      str += " = " + expr->to_string ();
     }
 
   return str;
 }
 
 std::string
-TraitItemType::as_string () const
+TraitItemType::to_string () const
 {
   std::string str = "outer attributes: ";
   if (outer_attrs.empty ())
@@ -3589,7 +3627,7 @@ TraitItemType::as_string () const
 	{
 	  if (i > 0)
 	    str += ", ";
-	  str += generic_params[i]->as_string ();
+	  str += generic_params[i]->to_string ();
 	}
       str += ">";
     }
@@ -3612,7 +3650,7 @@ TraitItemType::as_string () const
 	      return "nullptr_POINTER_MARK";
 	    }
 
-	  str += "\n  " + bound->as_string ();
+	  str += "\n  " + bound->to_string ();
 	}
     }
 
@@ -3620,7 +3658,7 @@ TraitItemType::as_string () const
 }
 
 std::string
-SelfParam::as_string () const
+SelfParam::to_string () const
 {
   if (has_type ())
     {
@@ -3634,14 +3672,14 @@ SelfParam::as_string () const
 
       str += "self : ";
 
-      str += type->as_string ();
+      str += type->to_string ();
 
       return str;
     }
   else if (has_lifetime ())
     {
       // ref and lifetime
-      std::string str = "&" + get_lifetime ().as_string () + " ";
+      std::string str = "&" + get_lifetime ().to_string () + " ";
 
       if (is_mut ())
 	{
@@ -3683,30 +3721,30 @@ SelfParam::as_string () const
 }
 
 std::string
-ArrayElemsCopied::as_string () const
+ArrayElemsCopied::to_string () const
 {
-  return elem_to_copy->as_string () + "; " + num_copies->as_string ();
+  return elem_to_copy->to_string () + "; " + num_copies->to_string ();
 }
 
 std::string
-LifetimeWhereClauseItem::as_string () const
+LifetimeWhereClauseItem::to_string () const
 {
   std::string str ("Lifetime: ");
 
-  str += lifetime.as_string ();
+  str += lifetime.to_string ();
 
   str += "\nLifetime bounds: ";
 
   for (const auto &bound : lifetime_bounds)
     {
-      str += "\n " + bound.as_string ();
+      str += "\n " + bound.to_string ();
     }
 
   return str;
 }
 
 std::string
-TypeBoundWhereClauseItem::as_string () const
+TypeBoundWhereClauseItem::to_string () const
 {
   std::string str ("For lifetimes: ");
 
@@ -3718,11 +3756,11 @@ TypeBoundWhereClauseItem::as_string () const
     {
       for (const auto &for_lifetime : for_lifetimes)
 	{
-	  str += "\n " + for_lifetime.as_string ();
+	  str += "\n " + for_lifetime.to_string ();
 	}
     }
 
-  str += "\nType: " + bound_type->as_string ();
+  str += "\nType: " + bound_type->to_string ();
 
   str += "\nType param bounds bounds: ";
 
@@ -3734,14 +3772,14 @@ TypeBoundWhereClauseItem::as_string () const
 	  return "nullptr_POINTER_MARK - type param bounds";
 	}
 
-      str += "\n " + bound->as_string ();
+      str += "\n " + bound->to_string ();
     }
 
   return str;
 }
 
 std::string
-ArrayElemsValues::as_string () const
+ArrayElemsValues::to_string () const
 {
   std::string str;
 
@@ -3755,14 +3793,14 @@ ArrayElemsValues::as_string () const
 	  return "nullptr_POINTER_MARK";
 	}
 
-      str += "\n  " + expr->as_string ();
+      str += "\n  " + expr->to_string ();
     }
 
   return str;
 }
 
 std::string
-MaybeNamedParam::as_string () const
+MaybeNamedParam::to_string () const
 {
   std::string str;
 
@@ -3780,7 +3818,7 @@ MaybeNamedParam::as_string () const
       return "ERROR_MARK_STRING - maybe named param unrecognised param kind";
     }
 
-  str += param_type->as_string ();
+  str += param_type->to_string ();
 
   return str;
 }

--- a/gcc/rust/hir/tree/rust-hir.h
+++ b/gcc/rust/hir/tree/rust-hir.h
@@ -69,7 +69,12 @@ public:
     return std::unique_ptr<TraitItem> (clone_trait_item_impl ());
   }
 
-  virtual std::string as_string () const = 0;
+  virtual std::string to_string () const = 0;
+
+  std::string to_debug_string () const
+  {
+    return to_string () + mappings.as_string ();
+  }
 
   virtual void accept_vis (HIRTraitItemVisitor &vis) = 0;
 
@@ -106,7 +111,12 @@ public:
     return std::unique_ptr<ImplItem> (clone_inherent_impl_item_impl ());
   }
 
-  virtual std::string as_string () const = 0;
+  virtual std::string to_string () const = 0;
+
+  std::string to_debug_string () const
+  {
+    return to_string () + get_impl_mappings ().as_string ();
+  }
 
   virtual void accept_vis (HIRImplVisitor &vis) = 0;
   virtual void accept_vis (HIRStmtVisitor &vis) = 0;
@@ -152,7 +162,9 @@ public:
   Crate &operator= (Crate &&other) = default;
 
   // Get crate representation as string (e.g. for debugging).
-  std::string as_string () const;
+  std::string to_string () const;
+
+  std::string to_debug_string () const;
 
   const Analysis::NodeMapping &get_mappings () const { return mappings; }
   std::vector<std::unique_ptr<Item>> &get_items () { return items; }

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -1130,7 +1130,7 @@ Session::dump_hir (HIR::Crate &crate) const
       return;
     }
 
-  out << crate.as_string ();
+  out << crate.to_string ();
   out.close ();
 }
 

--- a/gcc/rust/typecheck/rust-hir-dot-operator.cc
+++ b/gcc/rust/typecheck/rust-hir-dot-operator.cc
@@ -131,7 +131,7 @@ MethodResolver::assemble_inherent_impl_candidates (
 	return true;
 
       bool name_matches = func->get_function_name ().as_string ().compare (
-			    segment_name.as_string ())
+			    segment_name.to_string ())
 			  == 0;
       if (!name_matches)
 	return true;
@@ -215,7 +215,7 @@ MethodResolver::assemble_trait_impl_candidates (
 	  continue;
 
 	bool name_matches = func->get_function_name ().as_string ().compare (
-			      segment_name.as_string ())
+			      segment_name.to_string ())
 			    == 0;
 	if (!name_matches)
 	  continue;
@@ -271,7 +271,7 @@ MethodResolver::assemble_trait_impl_candidates (
     rust_assert (!trait_ref->is_error ());
 
     auto item_ref
-      = trait_ref->lookup_trait_item (segment_name.as_string (),
+      = trait_ref->lookup_trait_item (segment_name.to_string (),
 				      TraitItemReference::TraitItemType::FN);
     if (item_ref->is_error ())
       return true;
@@ -424,7 +424,7 @@ MethodResolver::select (TyTy::BaseType &receiver)
 {
   rust_debug ("MethodResolver::select reciever=[%s] path=[%s]",
 	      receiver.debug_str ().c_str (),
-	      segment_name.as_string ().c_str ());
+	      segment_name.to_string ().c_str ());
 
   // Assemble candidates
   std::vector<impl_item_candidate> inherent_impl_fns
@@ -472,7 +472,7 @@ MethodResolver::get_predicate_items (
   for (auto &bound : specified_bounds)
     {
       tl::optional<TyTy::TypeBoundPredicateItem> lookup
-	= bound.lookup_associated_item (segment_name.as_string ());
+	= bound.lookup_associated_item (segment_name.to_string ());
       if (!lookup.has_value ())
 	continue;
 

--- a/gcc/rust/typecheck/rust-hir-path-probe.cc
+++ b/gcc/rust/typecheck/rust-hir-path-probe.cc
@@ -208,7 +208,7 @@ void
 PathProbeType::visit (HIR::TypeAlias &alias)
 {
   Identifier name = alias.get_new_type_name ();
-  if (search.as_string ().compare (name.as_string ()) == 0)
+  if (search.to_string ().compare (name.as_string ()) == 0)
     {
       HirId tyid = alias.get_mappings ().get_hirid ();
       TyTy::BaseType *ty = nullptr;
@@ -228,7 +228,7 @@ void
 PathProbeType::visit (HIR::ConstantItem &constant)
 {
   Identifier name = constant.get_identifier ();
-  if (search.as_string ().compare (name.as_string ()) == 0)
+  if (search.to_string ().compare (name.as_string ()) == 0)
     {
       HirId tyid = constant.get_mappings ().get_hirid ();
       TyTy::BaseType *ty = nullptr;
@@ -248,7 +248,7 @@ void
 PathProbeType::visit (HIR::Function &function)
 {
   Identifier name = function.get_function_name ();
-  if (search.as_string ().compare (name.as_string ()) == 0)
+  if (search.to_string ().compare (name.as_string ()) == 0)
     {
       HirId tyid = function.get_mappings ().get_hirid ();
       TyTy::BaseType *ty = nullptr;
@@ -271,7 +271,7 @@ PathProbeType::process_enum_item_for_candiates (const TyTy::ADTType *adt)
     return;
 
   TyTy::VariantDef *v;
-  if (!adt->lookup_variant (search.as_string (), &v))
+  if (!adt->lookup_variant (search.to_string (), &v))
     return;
 
   PathProbeCandidate::EnumItemCandidate enum_item_candidate{adt, v};
@@ -317,7 +317,7 @@ PathProbeType::process_associated_trait_for_candidates (
   bool ignore_mandatory_trait_items)
 {
   const TraitItemReference *trait_item_ref = nullptr;
-  if (!trait_ref->lookup_trait_item (search.as_string (), &trait_item_ref))
+  if (!trait_ref->lookup_trait_item (search.to_string (), &trait_item_ref))
     return;
 
   bool trait_item_needs_implementation = !trait_item_ref->is_optional ();
@@ -367,7 +367,7 @@ PathProbeType::process_predicate_for_candidates (
   const TraitReference *trait_ref = predicate.get ();
 
   tl::optional<TyTy::TypeBoundPredicateItem> item
-    = predicate.lookup_associated_item (search.as_string ());
+    = predicate.lookup_associated_item (search.to_string ());
   if (!item.has_value ())
     return;
 

--- a/gcc/rust/typecheck/rust-hir-path-probe.h
+++ b/gcc/rust/typecheck/rust-hir-path-probe.h
@@ -164,12 +164,12 @@ public:
     for (auto &c : candidates)
       r.add_range (c.locus);
 
-    std::string rich_msg = "multiple " + query.as_string () + " found";
+    std::string rich_msg = "multiple " + query.to_string () + " found";
     r.add_fixit_replace (rich_msg.c_str ());
 
     rust_error_at (r, ErrorCode::E0034,
 		   "multiple applicable items in scope for: %qs",
-		   query.as_string ().c_str ());
+		   query.to_string ().c_str ());
   }
 };
 

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -1293,7 +1293,7 @@ emit_ambiguous_resolution_error (HIR::MethodCallExpr &expr,
 {
   rich_location r (line_table, expr.get_method_name ().get_locus ());
   std::string rich_msg = "multiple "
-			 + expr.get_method_name ().get_segment ().as_string ()
+			 + expr.get_method_name ().get_segment ().to_string ()
 			 + " found";
 
   // We have to filter out default candidates
@@ -1304,7 +1304,7 @@ emit_ambiguous_resolution_error (HIR::MethodCallExpr &expr,
   r.add_fixit_replace (rich_msg.c_str ());
 
   rust_error_at (r, ErrorCode::E0592, "duplicate definitions with name %qs",
-		 expr.get_method_name ().get_segment ().as_string ().c_str ());
+		 expr.get_method_name ().get_segment ().to_string ().c_str ());
 }
 
 // We are allowed to have multiple candidates if they are all specializable
@@ -1380,7 +1380,7 @@ TypeCheckExpr::visit (HIR::MethodCallExpr &expr)
       rust_error_at (
 	richloc, ErrorCode::E0599,
 	"no method named %qs found in the current scope",
-	expr.get_method_name ().get_segment ().as_string ().c_str ());
+	expr.get_method_name ().get_segment ().to_string ().c_str ());
       return;
     }
 
@@ -2253,7 +2253,7 @@ TypeCheckExpr::resolve_fn_trait_call (HIR::CallExpr &expr,
 
       rust_error_at (
 	r, "multiple candidates found for function trait method call %qs",
-	method_name.as_string ().c_str ());
+	method_name.to_string ().c_str ());
       return false;
     }
 

--- a/gcc/rust/typecheck/rust-hir-type-check-path.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-path.cc
@@ -78,7 +78,7 @@ TypeCheckExpr::visit (HIR::QualifiedPathInExpression &expr)
   HIR::PathExprSegment &item_seg = expr.get_segments ().at (0);
   HIR::PathIdentSegment item_seg_identifier = item_seg.get_segment ();
   tl::optional<TyTy::TypeBoundPredicateItem> item
-    = specified_bound.lookup_associated_item (item_seg_identifier.as_string ());
+    = specified_bound.lookup_associated_item (item_seg_identifier.to_string ());
   if (!item.has_value ())
     {
       rust_error_at (item_seg.get_locus (), "unknown associated item");
@@ -99,7 +99,7 @@ TypeCheckExpr::visit (HIR::QualifiedPathInExpression &expr)
 	   associated_impl_trait->get_impl_block ()->get_impl_items ())
 	{
 	  bool found = i->get_impl_item_name ().compare (
-			 item_seg_identifier.as_string ())
+			 item_seg_identifier.to_string ())
 		       == 0;
 	  if (found)
 	    {
@@ -284,7 +284,7 @@ TypeCheckExpr::resolve_root_path (HIR::PathInExpression &expr, size_t *offset,
 	  rust_error_at (seg.get_locus (), "456 reverse lookup failure");
 	  rust_debug_loc (seg.get_locus (),
 			  "failure with [%s] mappings [%s] ref_node_id [%u]",
-			  seg.as_string ().c_str (),
+			  seg.to_string ().c_str (),
 			  seg.get_mappings ().as_string ().c_str (),
 			  ref_node_id);
 
@@ -296,7 +296,7 @@ TypeCheckExpr::resolve_root_path (HIR::PathInExpression &expr, size_t *offset,
       auto seg_is_crate = mappings.is_local_hirid_crate (ref);
       auto seg_is_pattern = mappings.lookup_hir_pattern (ref).has_value ();
       auto seg_is_self = is_root && !have_more_segments
-			 && seg.get_segment ().as_string () == "self";
+			 && seg.get_segment ().to_string () == "self";
       if (seg_is_module || seg_is_crate)
 	{
 	  // A::B::C::this_is_a_module::D::E::F

--- a/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-pattern.cc
@@ -19,6 +19,7 @@
 #include "rust-hir-type-check-pattern.h"
 #include "rust-hir-pattern.h"
 #include "rust-hir-type-check-expr.h"
+#include "rust-token.h"
 #include "rust-type-util.h"
 #include "rust-immutable-name-resolution-context.h"
 #include "rust-tyty.h"
@@ -90,7 +91,7 @@ TypeCheckPattern::visit (HIR::PathInExpression &pattern)
 	      for (size_t i = 0; i < pattern.get_segments ().size (); i++)
 		{
 		  HIR::PathExprSegment &seg = pattern.get_segments ().at (i);
-		  path_buf += seg.as_string ();
+		  path_buf += seg.to_string ();
 		  if (i != pattern.get_segments ().size () - 1)
 		    path_buf += "::";
 		}
@@ -543,7 +544,7 @@ TypeCheckPattern::visit (HIR::StructPattern &pattern)
 		auto first_elem
 		  = struct_pattern_elems.get_struct_pattern_fields ()
 		      .at (0)
-		      ->as_string ();
+		      ->to_string ();
 		rust_error_at (pattern.get_locus (),
 			       "%qs cannot be used in union patterns",
 			       first_elem.c_str ());

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -138,7 +138,7 @@ TypeCheckType::visit (HIR::TupleType &tuple)
 void
 TypeCheckType::visit (HIR::TypePath &path)
 {
-  rust_debug ("{ARTHUR}: Path visited: %s", path.as_string ().c_str ());
+  rust_debug ("{ARTHUR}: Path visited: %s", path.to_string ().c_str ());
 
   // this can happen so we need to look up the root then resolve the
   // remaining segments if possible
@@ -215,11 +215,11 @@ TypeCheckType::visit (HIR::QualifiedPathInType &path)
   HIR::TypePathSegment &item_seg = path.get_associated_segment ();
   HIR::PathIdentSegment item_seg_identifier = item_seg.get_ident_segment ();
   tl::optional<TyTy::TypeBoundPredicateItem> item
-    = specified_bound.lookup_associated_item (item_seg_identifier.as_string ());
+    = specified_bound.lookup_associated_item (item_seg_identifier.to_string ());
   if (!item.has_value ())
     {
       std::string item_seg_ident_name, rich_msg;
-      item_seg_ident_name = qual_path_type.get_trait ().as_string ();
+      item_seg_ident_name = qual_path_type.get_trait ().to_string ();
       rich_msg = "not found in `" + item_seg_ident_name + "`";
 
       rich_location richloc (line_table, item_seg.get_locus ());
@@ -227,7 +227,7 @@ TypeCheckType::visit (HIR::QualifiedPathInType &path)
 
       rust_error_at (richloc, ErrorCode::E0576,
 		     "cannot find associated type %qs in trait %qs",
-		     item_seg_identifier.as_string ().c_str (),
+		     item_seg_identifier.to_string ().c_str (),
 		     item_seg_ident_name.c_str ());
       return;
     }
@@ -251,7 +251,7 @@ TypeCheckType::visit (HIR::QualifiedPathInType &path)
 	       associated_impl_trait->get_impl_block ()->get_impl_items ())
 	    {
 	      bool found = i->get_impl_item_name ().compare (
-			     item_seg_identifier.as_string ())
+			     item_seg_identifier.to_string ())
 			   == 0;
 	      if (found)
 		{
@@ -359,20 +359,20 @@ TypeCheckType::resolve_root_path (HIR::TypePath &path, size_t *offset,
 	    {
 	      rust_error_at (seg->get_locus (),
 			     "unknown reference for resolved name: %qs",
-			     seg->as_string ().c_str ());
+			     seg->to_string ().c_str ());
 	      return new TyTy::ErrorType (path.get_mappings ().get_hirid ());
 	    }
 	  else if (root_tyty == nullptr)
 	    {
 	      rust_error_at (seg->get_locus (),
 			     "unknown reference for resolved name: %qs",
-			     seg->as_string ().c_str ());
+			     seg->to_string ().c_str ());
 	      return new TyTy::ErrorType (path.get_mappings ().get_hirid ());
 	    }
 	  return root_tyty;
 	}
 
-      if (seg->is_ident_only () && seg->as_string () == "Self")
+      if (seg->is_ident_only () && seg->to_string () == "Self")
 	*wasBigSelf = true;
 
       // node back to HIR
@@ -385,7 +385,7 @@ TypeCheckType::resolve_root_path (HIR::TypePath &path, size_t *offset,
 	      rust_debug_loc (
 		seg->get_locus (),
 		"failure with [%s] mappings [%s] ref_node_id [%u]",
-		seg->as_string ().c_str (),
+		seg->to_string ().c_str (),
 		seg->get_mappings ().as_string ().c_str (), ref_node_id);
 
 	      return new TyTy::ErrorType (path.get_mappings ().get_hirid ());
@@ -423,7 +423,7 @@ TypeCheckType::resolve_root_path (HIR::TypePath &path, size_t *offset,
 	    {
 	      rust_error_at (seg->get_locus (),
 			     "failed to resolve type path segment: %qs",
-			     seg->as_string ().c_str ());
+			     seg->to_string ().c_str ());
 	      return new TyTy::ErrorType (path.get_mappings ().get_hirid ());
 	    }
 
@@ -556,7 +556,7 @@ TypeCheckType::resolve_segments (
 	  TypeCheckBlockContextItem ctx = context->block_context ().peek ();
 	  TyTy::BaseType *lookup = nullptr;
 	  selfResolveOk
-	    = resolve_associated_type (seg->as_string (), ctx, &lookup);
+	    = resolve_associated_type (seg->to_string (), ctx, &lookup);
 	  if (selfResolveOk)
 	    {
 	      prev_segment = tyseg;
@@ -1120,7 +1120,7 @@ ResolveWhereClauseItem::visit (HIR::TypeBoundWhereClauseItem &item)
       // FIXME
       rust_error_at (UNDEF_LOCATION,
 		     "Failed to lookup type reference for node: %s",
-		     binding_type_path.as_string ().c_str ());
+		     binding_type_path.to_string ().c_str ());
       return;
     }
 
@@ -1133,7 +1133,7 @@ ResolveWhereClauseItem::visit (HIR::TypeBoundWhereClauseItem &item)
 	{
 	  rust_error_at (mappings.lookup_location (*hid),
 			 "Failed to resolve where-clause binding type: %s",
-			 binding_type_path.as_string ().c_str ());
+			 binding_type_path.to_string ().c_str ());
 	  return;
 	}
 

--- a/gcc/rust/typecheck/rust-tyty-bounds.cc
+++ b/gcc/rust/typecheck/rust-tyty-bounds.cc
@@ -883,14 +883,14 @@ TypeBoundPredicate::validate_type_implements_super_traits (
 	    = "required by this bound in: " + ptref.get_name ();
 	  std::string fixit2 = "the trait " + sptref.get_name ()
 			       + " is not implemented for "
-			       + impl_type.as_string ();
+			       + impl_type.to_string ();
 
 	  rich_location r (line_table, trait.get_locus ());
 	  r.add_fixit_insert_after (super.get_locus (), fixit1.c_str ());
 	  r.add_fixit_insert_after (trait.get_locus (), fixit2.c_str ());
 	  rust_error_at (r, ErrorCode::E0277,
 			 "the trait bound %<%s: %s%> is not satisfied",
-			 impl_type.as_string ().c_str (),
+			 impl_type.to_string ().c_str (),
 			 sptref.get_name ().c_str ());
 
 	  return false;

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -1653,7 +1653,7 @@ VariantDef::as_string () const
 {
   if (type == VariantType::NUM)
     return identifier
-	   + (has_discriminant () ? " = " + get_discriminant ().as_string ()
+	   + (has_discriminant () ? " = " + get_discriminant ().to_string ()
 				  : "");
 
   std::string buffer;
@@ -2099,7 +2099,7 @@ FnType::as_string () const
     {
       auto &pattern = param.get_pattern ();
       auto ty = param.get_type ();
-      params_str += pattern.as_string () + " " + ty->as_string ();
+      params_str += pattern.to_string () + " " + ty->as_string ();
       params_str += ",";
     }
 


### PR DESCRIPTION
This patch changes as_string methods in HIR to to_string, we also create a to_debug_string method at the parent class of every HIR nodes.

gcc/rust/ChangeLog:

	* backend/rust-compile-implitem.h: Change as_string to to_string.
	* backend/rust-compile-type.cc (TyTyResolveCompile::visit): Likewise.
	* checks/errors/rust-readonly-check.cc (ReadonlyChecker::check_variable): Likewise.
	* hir/rust-hir-dump.cc (Dump::do_vis_item): Likewise.
	(Dump::do_pathpattern): Likewise.
	(Dump::do_typepathsegment): Likewise.
	(Dump::do_baseloopexpr): Likewise.
	(Dump::do_struct): Likewise.
	(Dump::do_traitfunctiondecl): Likewise.
	(Dump::do_externalitem): Likewise.
	(Dump::do_tuplefield): Likewise.
	(Dump::do_structfield): Likewise.
	(Dump::visit): Likewise.
	* hir/tree/rust-hir-bound-abstract.h: Likewise.
	* hir/tree/rust-hir-bound.h: Likewise.
	* hir/tree/rust-hir-expr-abstract.h: Likewise.
	* hir/tree/rust-hir-expr.cc (OffsetOf::as_string): Likewise.
	(OffsetOf::to_string): Likewise.
	* hir/tree/rust-hir-expr.h: Likewise.
	* hir/tree/rust-hir-generic-param.cc (ConstGenericParam::as_string): Likewise.
	(ConstGenericParam::to_string): Likewise.
	* hir/tree/rust-hir-generic-param.h: Likewise.
	* hir/tree/rust-hir-item.h: Likewise.
	* hir/tree/rust-hir-path.cc (PathInExpression::is_self): Likewise.
	* hir/tree/rust-hir-path.h: Likewise.
	* hir/tree/rust-hir-pattern-abstract.h: Likewise.
	* hir/tree/rust-hir-pattern.h: Likewise.
	* hir/tree/rust-hir-stmt.h: Likewise.
	* hir/tree/rust-hir-trait-bound.h: Likewise.
	* hir/tree/rust-hir-type-abstract.h: Likewise.
	* hir/tree/rust-hir-type.h: Likewise.
	* hir/tree/rust-hir-visibility.h: Likewise.
	* hir/tree/rust-hir.cc (Crate::as_string): Likewise.
	(Crate::to_string): Likewise.
	(Visibility::as_string): Likewise.
	(Visibility::to_string): Likewise.
	(VisItem::as_string): Likewise.
	(VisItem::to_string): Likewise.
	(Item::as_string): Likewise.
	(Item::to_string): Likewise.
	(Module::as_string): Likewise.
	(Module::to_string): Likewise.
	(StaticItem::as_string): Likewise.
	(StaticItem::to_string): Likewise.
	(ExternCrate::as_string): Likewise.
	(ExternCrate::to_string): Likewise.
	(TupleStruct::as_string): Likewise.
	(TupleStruct::to_string): Likewise.
	(ConstantItem::as_string): Likewise.
	(ConstantItem::to_string): Likewise.
	(ImplBlock::as_string): Likewise.
	(ImplBlock::to_string): Likewise.
	(StructStruct::as_string): Likewise.
	(StructStruct::to_string): Likewise.
	(UseDeclaration::as_string): Likewise.
	(UseDeclaration::to_string): Likewise.
	(UseTreeGlob::as_string): Likewise.
	(UseTreeGlob::to_string): Likewise.
	(UseTreeList::as_string): Likewise.
	(UseTreeList::to_string): Likewise.
	(UseTreeRebind::as_string): Likewise.
	(UseTreeRebind::to_string): Likewise.
	(Enum::as_string): Likewise.
	(Enum::to_string): Likewise.
	(Trait::as_string): Likewise.
	(Trait::to_string): Likewise.
	(Union::as_string): Likewise.
	(Union::to_string): Likewise.
	(Function::as_string): Likewise.
	(Function::to_string): Likewise.
	(WhereClause::as_string): Likewise.
	(WhereClause::to_string): Likewise.
	(BlockExpr::as_string): Likewise.
	(BlockExpr::to_string): Likewise.
	(AnonConst::as_string): Likewise.
	(AnonConst::to_string): Likewise.
	(ConstBlock::as_string): Likewise.
	(ConstBlock::to_string): Likewise.
	(TypeAlias::as_string): Likewise.
	(TypeAlias::to_string): Likewise.
	(ExternBlock::as_string): Likewise.
	(ExternBlock::to_string): Likewise.
	(PathInExpression::as_string): Likewise.
	(PathInExpression::to_string): Likewise.
	(ExprStmt::as_string): Likewise.
	(ExprStmt::to_string): Likewise.
	(ClosureParam::as_string): Likewise.
	(ClosureParam::to_string): Likewise.
	(ClosureExpr::as_string): Likewise.
	(ClosureExpr::to_string): Likewise.
	(PathPattern::as_string): Likewise.
	(PathPattern::to_string): Likewise.
	(QualifiedPathType::as_string): Likewise.
	(QualifiedPathType::to_string): Likewise.
	(QualifiedPathInExpression::as_string): Likewise.
	(QualifiedPathInExpression::to_string): Likewise.
	(BorrowExpr::as_string): Likewise.
	(BorrowExpr::to_string): Likewise.
	(ReturnExpr::as_string): Likewise.
	(ReturnExpr::to_string): Likewise.
	(GroupedExpr::as_string): Likewise.
	(GroupedExpr::to_string): Likewise.
	(RangeToExpr::as_string): Likewise.
	(RangeToExpr::to_string): Likewise.
	(ContinueExpr::as_string): Likewise.
	(ContinueExpr::to_string): Likewise.
	(NegationExpr::as_string): Likewise.
	(NegationExpr::to_string): Likewise.
	(RangeFromExpr::as_string): Likewise.
	(RangeFromExpr::to_string): Likewise.
	(RangeFullExpr::as_string): Likewise.
	(RangeFullExpr::to_string): Likewise.
	(ArrayIndexExpr::as_string): Likewise.
	(ArrayIndexExpr::to_string): Likewise.
	(AssignmentExpr::as_string): Likewise.
	(AssignmentExpr::to_string): Likewise.
	(CompoundAssignmentExpr::as_string): Likewise.
	(CompoundAssignmentExpr::to_string): Likewise.
	(AsyncBlockExpr::as_string): Likewise.
	(AsyncBlockExpr::to_string): Likewise.
	(ComparisonExpr::as_string): Likewise.
	(ComparisonExpr::to_string): Likewise.
	(MethodCallExpr::as_string): Likewise.
	(MethodCallExpr::to_string): Likewise.
	(TupleIndexExpr::as_string): Likewise.
	(TupleIndexExpr::to_string): Likewise.
	(DereferenceExpr::as_string): Likewise.
	(DereferenceExpr::to_string): Likewise.
	(FieldAccessExpr::as_string): Likewise.
	(FieldAccessExpr::to_string): Likewise.
	(LazyBooleanExpr::as_string): Likewise.
	(LazyBooleanExpr::to_string): Likewise.
	(RangeFromToExpr::as_string): Likewise.
	(RangeFromToExpr::to_string): Likewise.
	(RangeToInclExpr::as_string): Likewise.
	(RangeToInclExpr::to_string): Likewise.
	(UnsafeBlockExpr::as_string): Likewise.
	(UnsafeBlockExpr::to_string): Likewise.
	(IfExpr::as_string): Likewise.
	(IfExpr::to_string): Likewise.
	(IfExprConseqElse::as_string): Likewise.
	(IfExprConseqElse::to_string): Likewise.
	(RangeFromToInclExpr::as_string): Likewise.
	(RangeFromToInclExpr::to_string): Likewise.
	(ErrorPropagationExpr::as_string): Likewise.
	(ErrorPropagationExpr::to_string): Likewise.
	(ArithmeticOrLogicalExpr::as_string): Likewise.
	(ArithmeticOrLogicalExpr::to_string): Likewise.
	(CallExpr::as_string): Likewise.
	(CallExpr::to_string): Likewise.
	(WhileLoopExpr::as_string): Likewise.
	(WhileLoopExpr::to_string): Likewise.
	(WhileLetLoopExpr::as_string): Likewise.
	(WhileLetLoopExpr::to_string): Likewise.
	(LoopExpr::as_string): Likewise.
	(LoopExpr::to_string): Likewise.
	(ArrayExpr::as_string): Likewise.
	(ArrayExpr::to_string): Likewise.
	(AwaitExpr::as_string): Likewise.
	(AwaitExpr::to_string): Likewise.
	(BreakExpr::as_string): Likewise.
	(BreakExpr::to_string): Likewise.
	(LoopLabel::as_string): Likewise.
	(LoopLabel::to_string): Likewise.
	(MatchArm::as_string): Likewise.
	(MatchArm::to_string): Likewise.
	(MatchCase::as_string): Likewise.
	(MatchCase::to_string): Likewise.
	(MatchCaseBlockExpr::as_string): Likewise.
	(MatchCaseBlockExpr::to_string): Likewise.
	(MatchCaseExpr::as_string): Likewise.
	(MatchCaseExpr::to_string): Likewise.
	(MatchExpr::as_string): Likewise.
	(MatchExpr::to_string): Likewise.
	(TupleExpr::as_string): Likewise.
	(TupleExpr::to_string): Likewise.
	(FunctionParam::as_string): Likewise.
	(FunctionParam::to_string): Likewise.
	(FunctionQualifiers::as_string): Likewise.
	(FunctionQualifiers::to_string): Likewise.
	(TraitBound::as_string): Likewise.
	(TraitBound::to_string): Likewise.
	(LifetimeParam::as_string): Likewise.
	(LifetimeParam::to_string): Likewise.
	(QualifiedPathInType::as_string): Likewise.
	(QualifiedPathInType::to_string): Likewise.
	(Lifetime::as_string): Likewise.
	(Lifetime::to_string): Likewise.
	(TypePath::as_string): Likewise.
	(TypePath::to_string): Likewise.
	(TypeParam::as_string): Likewise.
	(TypeParam::to_string): Likewise.
	(PathPattern::convert_to_simple_path): Likewise.
	(TypePath::as_simple_path): Likewise.
	(PathExprSegment::as_string): Likewise.
	(PathExprSegment::to_string): Likewise.
	(GenericArgs::as_string): Likewise.
	(GenericArgs::to_string): Likewise.
	(GenericArgsBinding::as_string): Likewise.
	(GenericArgsBinding::to_string): Likewise.
	(RangePattern::as_string): Likewise.
	(RangePattern::to_string): Likewise.
	(RangePatternBoundLiteral::as_string): Likewise.
	(RangePatternBoundLiteral::to_string): Likewise.
	(SlicePatternItemsNoRest::as_string): Likewise.
	(SlicePatternItemsNoRest::to_string): Likewise.
	(SlicePatternItemsHasRest::as_string): Likewise.
	(SlicePatternItemsHasRest::to_string): Likewise.
	(SlicePattern::as_string): Likewise.
	(SlicePattern::to_string): Likewise.
	(AltPattern::as_string): Likewise.
	(AltPattern::to_string): Likewise.
	(TuplePatternItemsNoRest::as_string): Likewise.
	(TuplePatternItemsNoRest::to_string): Likewise.
	(TuplePatternItemsHasRest::as_string): Likewise.
	(TuplePatternItemsHasRest::to_string): Likewise.
	(TuplePattern::as_string): Likewise.
	(TuplePattern::to_string): Likewise.
	(StructPatternField::as_string): Likewise.
	(StructPatternField::to_string): Likewise.
	(StructPatternFieldIdent::as_string): Likewise.
	(StructPatternFieldIdent::to_string): Likewise.
	(StructPatternFieldTuplePat::as_string): Likewise.
	(StructPatternFieldTuplePat::to_string): Likewise.
	(StructPatternFieldIdentPat::as_string): Likewise.
	(StructPatternFieldIdentPat::to_string): Likewise.
	(StructPatternElements::as_string): Likewise.
	(StructPatternElements::to_string): Likewise.
	(StructPattern::as_string): Likewise.
	(StructPattern::to_string): Likewise.
	(LiteralPattern::as_string): Likewise.
	(LiteralPattern::to_string): Likewise.
	(ReferencePattern::as_string): Likewise.
	(ReferencePattern::to_string): Likewise.
	(IdentifierPattern::as_string): Likewise.
	(IdentifierPattern::to_string): Likewise.
	(TupleStructItemsNoRest::as_string): Likewise.
	(TupleStructItemsNoRest::to_string): Likewise.
	(TupleStructItemsHasRest::as_string): Likewise.
	(TupleStructItemsHasRest::to_string): Likewise.
	(TupleStructPattern::as_string): Likewise.
	(TupleStructPattern::to_string): Likewise.
	(LetStmt::as_string): Likewise.
	(LetStmt::to_string): Likewise.
	(Expr::as_string): Likewise.
	(Expr::to_string): Likewise.
	(InferredType::as_string): Likewise.
	(InferredType::to_string): Likewise.
	(TypeCastExpr::as_string): Likewise.
	(TypeCastExpr::to_string): Likewise.
	(ImplTraitType::as_string): Likewise.
	(ImplTraitType::to_string): Likewise.
	(ReferenceType::as_string): Likewise.
	(ReferenceType::to_string): Likewise.
	(RawPointerType::as_string): Likewise.
	(RawPointerType::to_string): Likewise.
	(TraitObjectType::as_string): Likewise.
	(TraitObjectType::to_string): Likewise.
	(BareFunctionType::as_string): Likewise.
	(BareFunctionType::to_string): Likewise.
	(TypePathSegmentGeneric::as_string): Likewise.
	(TypePathSegmentGeneric::to_string): Likewise.
	(TypePathFunction::as_string): Likewise.
	(TypePathFunction::to_string): Likewise.
	(TypePathSegmentFunction::as_string): Likewise.
	(TypePathSegmentFunction::to_string): Likewise.
	(ArrayType::as_string): Likewise.
	(ArrayType::to_string): Likewise.
	(SliceType::as_string): Likewise.
	(SliceType::to_string): Likewise.
	(TupleType::as_string): Likewise.
	(TupleType::to_string): Likewise.
	(StructExpr::as_string): Likewise.
	(StructExpr::to_string): Likewise.
	(StructExprStruct::as_string): Likewise.
	(StructExprStruct::to_string): Likewise.
	(StructBase::as_string): Likewise.
	(StructBase::to_string): Likewise.
	(StructExprFieldWithVal::as_string): Likewise.
	(StructExprFieldWithVal::to_string): Likewise.
	(StructExprFieldIdentifierValue::as_string): Likewise.
	(StructExprFieldIdentifierValue::to_string): Likewise.
	(StructExprFieldIndexValue::as_string): Likewise.
	(StructExprFieldIndexValue::to_string): Likewise.
	(StructExprStructFields::as_string): Likewise.
	(StructExprStructFields::to_string): Likewise.
	(EnumItem::as_string): Likewise.
	(EnumItem::to_string): Likewise.
	(EnumItemTuple::as_string): Likewise.
	(EnumItemTuple::to_string): Likewise.
	(TupleField::as_string): Likewise.
	(TupleField::to_string): Likewise.
	(EnumItemStruct::as_string): Likewise.
	(EnumItemStruct::to_string): Likewise.
	(StructField::as_string): Likewise.
	(StructField::to_string): Likewise.
	(EnumItemDiscriminant::as_string): Likewise.
	(EnumItemDiscriminant::to_string): Likewise.
	(ExternalItem::as_string): Likewise.
	(ExternalItem::to_string): Likewise.
	(ExternalStaticItem::as_string): Likewise.
	(ExternalStaticItem::to_string): Likewise.
	(ExternalFunctionItem::as_string): Likewise.
	(ExternalFunctionItem::to_string): Likewise.
	(ExternalTypeItem::as_string): Likewise.
	(ExternalTypeItem::to_string): Likewise.
	(NamedFunctionParam::as_string): Likewise.
	(NamedFunctionParam::to_string): Likewise.
	(attr.as_string): Likewise.
	(attr.to_string): Likewise.
	(TraitItemFunc::as_string): Likewise.
	(TraitItemFunc::to_string): Likewise.
	(TraitFunctionDecl::as_string): Likewise.
	(TraitFunctionDecl::to_string): Likewise.
	(TraitItemConst::as_string): Likewise.
	(TraitItemConst::to_string): Likewise.
	(TraitItemType::as_string): Likewise.
	(TraitItemType::to_string): Likewise.
	(SelfParam::as_string): Likewise.
	(SelfParam::to_string): Likewise.
	(ArrayElemsCopied::as_string): Likewise.
	(ArrayElemsCopied::to_string): Likewise.
	(LifetimeWhereClauseItem::as_string): Likewise.
	(LifetimeWhereClauseItem::to_string): Likewise.
	(TypeBoundWhereClauseItem::as_string): Likewise.
	(TypeBoundWhereClauseItem::to_string): Likewise.
	(ArrayElemsValues::as_string): Likewise.
	(ArrayElemsValues::to_string): Likewise.
	(MaybeNamedParam::as_string): Likewise.
	(MaybeNamedParam::to_string): Likewise.
	* hir/tree/rust-hir.h: Likewise.
	* rust-session-manager.cc (Session::dump_hir): Likewise.
	* typecheck/rust-hir-dot-operator.cc (MethodResolver::select): Likewise.
	* typecheck/rust-hir-path-probe.cc (PathProbeType::visit): Likewise.
	(PathProbeType::process_enum_item_for_candiates): Likewise.
	* typecheck/rust-hir-path-probe.h: Likewise.
	* typecheck/rust-hir-type-check-expr.cc (emit_ambiguous_resolution_error): Likewise.
	(TypeCheckExpr::visit): Likewise.
	(TypeCheckExpr::resolve_fn_trait_call): Likewise.
	* typecheck/rust-hir-type-check-path.cc (TypeCheckExpr::visit): Likewise.
	(TypeCheckExpr::resolve_root_path): Likewise.
	* typecheck/rust-hir-type-check-pattern.cc (TypeCheckPattern::visit): Likewise.
	* typecheck/rust-hir-type-check-type.cc (TypeCheckType::visit): Likewise.
	(TypeCheckType::resolve_root_path): Likewise.
	(ResolveWhereClauseItem::visit): Likewise.
	* typecheck/rust-tyty-bounds.cc: Likewise.
	* typecheck/rust-tyty.cc (VariantDef::as_string): Likewise.
	(FnType::as_string): Likewise.

Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[ ] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[ ] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[ ] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---

*Please write a comment explaining your change. This is the message
that will be part of the merge commit.
