### PR TITLE
gccrs: avoid ICE on generic const expressions in path resolution

### DIFF
--- a/gcc/rust/ChangeLog
+++ b/gcc/rust/ChangeLog
@@ -1,3 +1,9 @@
+2025-12-27  Jayant Chauhan  <0001jayant@gmail.com>
+
+	* backend/rust-compile-resolve-path.cc
+	(resolve_with_node_id): Reject non-value generic const
+	expressions and emit a diagnostic instead of ICE.
+
 2025-12-17  Pierre-Emmanuel Patry  <pierre-emmanuel.patry@embecosm.com>
 
 	* parse/rust-parse-impl-lexer.cc: Fix included file name.

--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -193,10 +193,19 @@ ResolvePathRef::resolve_with_node_id (
       auto d = lookup->destructure ();
       rust_assert (d->get_kind () == TyTy::TypeKind::CONST);
       auto c = d->as_const_type ();
-      rust_assert (c->const_kind () == TyTy::BaseConstType::ConstKind::Value);
+
+      if (c->const_kind () != TyTy::BaseConstType::ConstKind::Value)
+        {
+          rust_error_at (
+            expr_locus,
+            "cannot evaluate constant expression with  generic parameters");
+          return error_mark_node;
+        }
+
       auto val = static_cast<TyTy::ConstValueType *> (c);
       return val->get_value ();
     }
+
 
   // Handle unit struct
   tree resolved_item = error_mark_node;

--- a/gcc/testsuite/rust/compile/const-generic-ice-4302.rs
+++ b/gcc/testsuite/rust/compile/const-generic-ice-4302.rs
@@ -1,0 +1,8 @@
+//@compile-flags: -frust-incomplete-and-experimental-compiler-do-not-use
+// ICE regression test: PR #4302
+
+pub struct Foo<const N: usize>;
+
+pub fn foo<const N: usize>() -> Foo<{ N + 1 }> {
+    Foo
+}


### PR DESCRIPTION
Fixes #4302

ResolvePathRef::resolve_with_node_id previously assumed that all CONST
types were concrete values and asserted otherwise. Generic const expressions
such as { N + 1 } are symbolic and cannot be evaluated prior to
monomorphization, which resulted in an internal compiler error (ICE).

This change rejects non-value const kinds gracefully and emits a diagnostic
instead of aborting the compiler.

Testsuite

gcc/testsuite/rust/compile/const-generic-ice-4302.rs: New test.

Checklist

 Developer Certificate of Origin (DCO) sign-off included

 Contributing guidelines read

 make check-rust passes locally

 clang-format run on modified files

 Relevant test case added to gcc/testsuite/rust/