### PR TITLE
gccrs: Fix empty struct constructors causing ICE during type checking

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -499,7 +499,25 @@ CompileExpr::visit (HIR::StructExprStruct &struct_expr)
       return;
     }
 
-  rust_assert (tyty->is_unit ());
+  TyTy::ADTType *adt = static_cast<TyTy::ADTType *> (tyty);
+  TyTy::VariantDef *variant = nullptr;
+  if (adt->is_enum ())
+    {
+      // unwrap variant and ensure that it can be resolved
+      HirId variant_id;
+      bool ok = ctx->get_tyctx ()->lookup_variant_definition (
+	struct_expr.get_struct_name ().get_mappings ().get_hirid (),
+	&variant_id);
+      rust_assert (ok);
+
+      ok = adt->lookup_variant_by_id (variant_id, &variant);
+      rust_assert (ok);
+    }
+  else
+    {
+      rust_assert (tyty->is_unit ());
+    }
+
   translated = unit_expression (struct_expr.get_locus ());
 }
 

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -1604,7 +1604,6 @@ VariantDef::get_field_at_index (size_t index)
 std::vector<StructFieldType *> &
 VariantDef::get_fields ()
 {
-  rust_assert (type != NUM);
   return fields;
 }
 

--- a/gcc/testsuite/rust/compile/issue-4163-2.rs
+++ b/gcc/testsuite/rust/compile/issue-4163-2.rs
@@ -1,0 +1,10 @@
+enum Enum {
+    NotEmpty {x: i32},
+    Struct {},
+    Tuple (),
+}
+
+fn main() {
+    Enum::Struct {};
+    Enum::Tuple {};
+}

--- a/gcc/testsuite/rust/compile/issue-4163.rs
+++ b/gcc/testsuite/rust/compile/issue-4163.rs
@@ -1,0 +1,9 @@
+enum Enum {
+    Unit,
+    Tuple(i32),
+    Struct { x: i32 },
+}
+
+fn main() {
+    Enum::Unit {};
+}


### PR DESCRIPTION
Fixes #4163.

