### PR TITLE
core: Add -frust-compile-core flag

### DIFF
--- a/gcc/rust/ast/rust-ast-builder.cc
+++ b/gcc/rust/ast/rust-ast-builder.cc
@@ -541,7 +541,8 @@ std::unique_ptr<Stmt>
 Builder::discriminant_value (std::string binding_name, std::string instance)
 {
   auto intrinsic = ptrify (
-    path_in_expression ({"core", "intrinsics", "discriminant_value"}, true));
+    path_in_expression ({get_path_start (), "intrinsics", "discriminant_value"},
+			true));
 
   return let (identifier_pattern (binding_name), nullptr,
 	      call (std::move (intrinsic), identifier (instance)));

--- a/gcc/rust/ast/rust-ast-builder.h
+++ b/gcc/rust/ast/rust-ast-builder.h
@@ -24,7 +24,7 @@
 #include "rust-ast.h"
 #include "rust-item.h"
 #include "rust-operators.h"
-#include <initializer_list>
+#include "options.h"
 
 namespace Rust {
 namespace AST {
@@ -332,10 +332,19 @@ public:
   /* Location of the generated AST nodes */
   location_t loc;
 
+  const char *get_path_start () const
+  {
+    if (flag_compile_core)
+      return "crate";
+    else
+      return "core";
+  }
+
 private:
-  /* Some constexpr helpers for some of the builders */
-  static constexpr std::initializer_list<const char *> discriminant_value_path
-    = {"core", "intrinsics", "discriminant_value"};
+  // /* Some constexpr helpers for some of the builders */
+  // static constexpr std::initializer_list<const char *>
+  // discriminant_value_path
+  //   = {"core", "intrinsics", "discriminant_value"};
 };
 
 } // namespace AST

--- a/gcc/rust/expand/rust-derive-debug.cc
+++ b/gcc/rust/expand/rust-derive-debug.cc
@@ -54,11 +54,11 @@ DeriveDebug::stub_debug_fn ()
 
   auto self = builder.self_ref_param ();
 
-  auto return_type
-    = ptrify (builder.type_path ({"core", "fmt", "Result"}, true));
+  auto return_type = ptrify (
+    builder.type_path ({builder.get_path_start (), "fmt", "Result"}, true));
 
-  auto mut_fmt_type_inner
-    = ptrify (builder.type_path ({"core", "fmt", "Formatter"}, true));
+  auto mut_fmt_type_inner = ptrify (
+    builder.type_path ({builder.get_path_start (), "fmt", "Formatter"}, true));
 
   auto mut_fmt_type
     = builder.reference_type (std::move (mut_fmt_type_inner), true);
@@ -81,7 +81,8 @@ DeriveDebug::stub_derive_impl (
 {
   auto trait_items = vec (stub_debug_fn ());
 
-  auto debug = builder.type_path ({"core", "fmt", "Debug"}, true);
+  auto debug
+    = builder.type_path ({builder.get_path_start (), "fmt", "Debug"}, true);
   auto generics
     = setup_impl_generics (name, type_generics, builder.trait_bound (debug));
 

--- a/gcc/rust/expand/rust-derive-default.cc
+++ b/gcc/rust/expand/rust-derive-default.cc
@@ -42,7 +42,9 @@ DeriveDefault::go (Item &item)
 std::unique_ptr<Expr>
 DeriveDefault::default_call (std::unique_ptr<Type> &&type)
 {
-  auto default_trait = builder.type_path ({"core", "default", "Default"}, true);
+  auto default_trait
+    = builder.type_path ({builder.get_path_start (), "default", "Default"},
+			 true);
 
   auto default_fn
     = builder.qualified_path_in_expression (std::move (type), default_trait,
@@ -69,7 +71,9 @@ DeriveDefault::default_impl (
   std::unique_ptr<AssociatedItem> &&default_fn, std::string name,
   const std::vector<std::unique_ptr<GenericParam>> &type_generics)
 {
-  auto default_path = builder.type_path ({"core", "default", "Default"}, true);
+  auto default_path
+    = builder.type_path ({builder.get_path_start (), "default", "Default"},
+			 true);
 
   auto trait_items = vec (std::move (default_fn));
 

--- a/gcc/rust/expand/rust-derive-eq.cc
+++ b/gcc/rust/expand/rust-derive-eq.cc
@@ -30,7 +30,7 @@ namespace AST {
 static TypePath
 get_eq_trait_path (Builder &builder)
 {
-  return builder.type_path ({"core", "cmp", "Eq"}, true);
+  return builder.type_path ({builder.get_path_start (), "cmp", "Eq"}, true);
 }
 
 DeriveEq::DeriveEq (location_t loc) : DeriveVisitor (loc) {}

--- a/gcc/rust/expand/rust-derive-hash.cc
+++ b/gcc/rust/expand/rust-derive-hash.cc
@@ -41,8 +41,9 @@ DeriveHash::go (Item &item)
 std::unique_ptr<Expr>
 DeriveHash::hash_call (std::unique_ptr<Expr> &&value)
 {
-  auto hash
-    = builder.path_in_expression ({"core", "hash", "Hash", "hash"}, true);
+  auto hash = builder.path_in_expression ({builder.get_path_start (), "hash",
+					   "Hash", "hash"},
+					  true);
 
   return builder.call (ptrify (hash),
 		       vec (std::move (value),
@@ -63,8 +64,8 @@ DeriveHash::hash_fn (std::unique_ptr<BlockExpr> &&block)
 						    true));
 
   auto params = vec (builder.self_ref_param (), std::move (state_param));
-  auto bounds = vec (
-    builder.trait_bound (builder.type_path ({"core", "hash", "Hasher"}, true)));
+  auto bounds = vec (builder.trait_bound (
+    builder.type_path ({builder.get_path_start (), "hash", "Hasher"}, true)));
   auto generics = vec (
     builder.generic_type_param (DeriveHash::state_type, std::move (bounds)));
 
@@ -77,7 +78,8 @@ DeriveHash::hash_impl (
   std::unique_ptr<AssociatedItem> &&hash_fn, std::string name,
   const std::vector<std::unique_ptr<GenericParam>> &type_generics)
 {
-  auto hash_path = builder.type_path ({"core", "hash", "Hash"}, true);
+  auto hash_path
+    = builder.type_path ({builder.get_path_start (), "hash", "Hash"}, true);
 
   auto trait_items = vec (std::move (hash_fn));
 

--- a/gcc/rust/expand/rust-derive-ord.cc
+++ b/gcc/rust/expand/rust-derive-ord.cc
@@ -43,7 +43,7 @@ DeriveOrd::cmp_call (std::unique_ptr<Expr> &&self_expr,
 		     std::unique_ptr<Expr> &&other_expr)
 {
   auto cmp_fn_path = builder.path_in_expression (
-    {"core", "cmp", trait (ordering), fn (ordering)}, true);
+    {builder.get_path_start (), "cmp", trait (ordering), fn (ordering)}, true);
 
   return builder.call (ptrify (cmp_fn_path),
 		       vec (builder.ref (std::move (self_expr)),
@@ -58,10 +58,11 @@ DeriveOrd::cmp_impl (
   auto fn = cmp_fn (std::move (fn_block), type_name);
 
   auto trait = ordering == Ordering::Partial ? "PartialOrd" : "Ord";
-  auto trait_path = builder.type_path ({"core", "cmp", trait}, true);
+  auto trait_path
+    = builder.type_path ({builder.get_path_start (), "cmp", trait}, true);
 
-  auto trait_bound
-    = builder.trait_bound (builder.type_path ({"core", "cmp", trait}, true));
+  auto trait_bound = builder.trait_bound (
+    builder.type_path ({builder.get_path_start (), "cmp", trait}, true));
 
   auto trait_items = vec (std::move (fn));
 
@@ -78,7 +79,8 @@ std::unique_ptr<AssociatedItem>
 DeriveOrd::cmp_fn (std::unique_ptr<BlockExpr> &&block, Identifier type_name)
 {
   // Ordering
-  auto return_type = builder.type_path ({"core", "cmp", "Ordering"}, true);
+  auto return_type
+    = builder.type_path ({builder.get_path_start (), "cmp", "Ordering"}, true);
 
   // In the case of PartialOrd, we return an Option<Ordering>
   if (ordering == Ordering::Partial)
@@ -87,7 +89,7 @@ DeriveOrd::cmp_fn (std::unique_ptr<BlockExpr> &&block, Identifier type_name)
 
       auto generic_seg = builder.type_path_segment_generic (
 	"Option", GenericArgs ({}, {generic}, {}, loc));
-      auto core = builder.type_path_segment ("core");
+      auto core = builder.type_path_segment (builder.get_path_start ());
       auto option = builder.type_path_segment ("option");
 
       return_type
@@ -112,8 +114,8 @@ DeriveOrd::cmp_fn (std::unique_ptr<BlockExpr> &&block, Identifier type_name)
 std::unique_ptr<Pattern>
 DeriveOrd::make_equal ()
 {
-  std::unique_ptr<Pattern> equal = ptrify (
-    builder.path_in_expression ({"core", "cmp", "Ordering", "Equal"}, true));
+  std::unique_ptr<Pattern> equal = ptrify (builder.path_in_expression (
+    {builder.get_path_start (), "cmp", "Ordering", "Equal"}, true));
 
   // We need to wrap the pattern in Option::Some if we are doing partial
   // ordering
@@ -147,9 +149,8 @@ DeriveOrd::recursive_match (std::vector<SelfOther> &&members)
 {
   if (members.empty ())
     {
-      std::unique_ptr<Expr> value = ptrify (
-	builder.path_in_expression ({"core", "cmp", "Ordering", "Equal"},
-				    true));
+      std::unique_ptr<Expr> value = ptrify (builder.path_in_expression (
+	{builder.get_path_start (), "cmp", "Ordering", "Equal"}, true));
 
       if (ordering == Ordering::Partial)
 	value = builder.call (ptrify (builder.path_in_expression (

--- a/gcc/rust/expand/rust-expand-format-args.cc
+++ b/gcc/rust/expand/rust-expand-format-args.cc
@@ -35,11 +35,13 @@ static std::unique_ptr<AST::Expr>
 format_arg (const AST::Builder &builder, std::unique_ptr<AST::Expr> &&to_format,
 	    const std::string &trait)
 {
-  auto formatter_fn = std::unique_ptr<AST::Expr> (new AST::PathInExpression (
-    builder.path_in_expression ({"core", "fmt", trait, "fmt"})));
+  auto formatter_fn = std::unique_ptr<AST::Expr> (
+    new AST::PathInExpression (builder.path_in_expression (
+      {builder.get_path_start (), "fmt", trait, "fmt"})));
 
-  auto path = std::unique_ptr<AST::Expr> (new AST::PathInExpression (
-    builder.path_in_expression ({"core", "fmt", "ArgumentV1", "new"})));
+  auto path = std::unique_ptr<AST::Expr> (
+    new AST::PathInExpression (builder.path_in_expression (
+      {builder.get_path_start (), "fmt", "ArgumentV1", "new"})));
 
   auto args = std::vector<std::unique_ptr<AST::Expr>> ();
   args.emplace_back (std::move (to_format));
@@ -122,8 +124,9 @@ expand_format_args (AST::FormatArgs &fmt,
   auto pieces = builder.ref (builder.array (std::move (static_pieces)));
   auto args_slice = builder.ref (builder.array (std::move (args_array)));
 
-  auto final_path = std::make_unique<AST::PathInExpression> (
-    builder.path_in_expression ({"core", "fmt", "Arguments", "new_v1"}));
+  auto final_path
+    = std::make_unique<AST::PathInExpression> (builder.path_in_expression (
+      {builder.get_path_start (), "fmt", "Arguments", "new_v1"}));
   auto final_args = std::vector<std::unique_ptr<AST::Expr>> ();
   final_args.emplace_back (std::move (pieces));
   final_args.emplace_back (std::move (args_slice));

--- a/gcc/rust/lang.opt
+++ b/gcc/rust/lang.opt
@@ -237,4 +237,8 @@ frust-unused-check-2.0
 Rust Var(flag_unused_check_2_0)
 Use the new unused variable check implementation.
 
+frust-compile-core
+Rust Var(flag_compile_core)
+Tell the compiler that we are currently compiling the core library
+
 ; This comment is to ensure we retain the blank line above.


### PR DESCRIPTION
Add a specific flag for compiling core which changes compiler generated paths. This is important for derives, and especially for core, where we want to implement crate::marker::Copy rather than core::marker::Copy.

gcc/rust/ChangeLog:

	* lang.opt: Add -frust-compile-core option.
	* ast/rust-ast-builder.h: Add get_path_start method which depends on -frust-compile-core
	* ast/rust-ast-builder.cc (Builder::discriminant_value): Use it.
	* expand/rust-derive-debug.cc (DeriveDebug::stub_debug_fn): Likewise.
	* expand/rust-derive-default.cc (DeriveDefault::default_call): Likewise.
	* expand/rust-derive-eq.cc (DeriveEq::assert_param_is_eq): Likewise.
	* expand/rust-derive-hash.cc (DeriveHash::hash_call): Likewise. (DeriveHash::hash_fn): Likewise.
	* expand/rust-derive-ord.cc (DeriveOrd::cmp_call): Likewise. (DeriveOrd::cmp_fn): Likewise. (DeriveOrd::make_equal): Likewise. (DeriveOrd::recursive_match): Likewise.
	* expand/rust-expand-format-args.cc (format_arg): Likewise. (expand_format_args): Likewise.
