### PR TITLE
nr: Add better error to unresolved attribute macro

### DIFF
--- a/gcc/rust/resolve/rust-early-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver-2.0.cc
@@ -356,7 +356,8 @@ Early::visit_attributes (std::vector<AST::Attribute> &attrs)
 	      // FIXME: Change to proper error message
 	      collect_error (
 		Error (attr.get_locus (),
-		       "could not resolve attribute macro invocation"));
+		       "could not resolve attribute macro invocation %qs",
+		       name.c_str ()));
 	      return;
 	    }
 	  auto pm_def = mappings.lookup_attribute_proc_macro_def (


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* resolve/rust-early-name-resolver-2.0.cc (Early::visit_attributes): Explicit the name of the attribute macro that hasn't been found.