### PR TITLE
gccrs: Fix rogue macro error during lowering on expansion failure

### DIFF
--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -327,7 +327,14 @@ MacroExpander::expand_invoc (AST::MacroInvocation &invoc,
   else
     fragment
       = expand_decl_macro (invoc.get_locus (), invoc_data, *rdef, semicolon);
-
+  // fix: if the expansion is failing, we must replace the marco with an empty
+  // error or node
+  // makes sure that it doesn't panic on Rouge macro (it -> Lowering Phase)
+  // added the parsing errors in gcc/testsuite/rust/compile/issue-4213.rs
+  if (fragment.is_error ())
+    {
+      fragment = AST::Fragment::create_empty ();
+    }
   set_expanded_fragment (std::move (fragment));
 }
 

--- a/gcc/testsuite/rust/compile/issue-4213.rs
+++ b/gcc/testsuite/rust/compile/issue-4213.rs
@@ -1,0 +1,34 @@
+// Test for issue #4213 - rogue macro detected during Lowering.
+
+macro_rules! inner {
+    () => {
+        $crate::    // { dg-error "could not parse path expression segment" }
+    };
+}
+
+macro_rules! multi_arm {
+    (a) => { $crate:: };     // { dg-error "could not parse path expression segment" }
+    (b) => { () };
+}
+
+macro_rules! another_macro {
+    () => { $crate:: }      // { dg-error "could not parse path expression segment" }
+}
+macro_rules! generic_macro {
+    ($t:ty) => {
+        $crate::            // { dg-error "could not parse path expression segment" }
+    };
+}
+
+macro_rules! empty_case {
+    () => {};
+}
+
+pub fn main() {
+    let _ = inner!();
+    let _ = multi_arm!(a);
+    let _ = multi_arm!(b);
+    let _ = another_macro!();
+    let _ = generic_macro!(i32);
+    empty_case!();
+}


### PR DESCRIPTION
When a macro expansion fails (e.g. due to a parsing error like invalid syntax in the macro body), the expander previously returned an error fragment but did not update the AST. This left the original macro invocation in place, which subsequently caused an ICE (rogue macro detected) during the lowering phase.

This patch updates `expand_invoc` to replace the macro invocation with an empty fragment if expansion fails, ensuring the compiler can proceed (or exit gracefully) without crashing.

Fixes #4213

gcc/rust/ChangeLog:

	* expand/rust-macro-expand.cc (MacroExpander::expand_invoc): Handle error fragments by replacing them with empty fragments.

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4213.rs: New test.

Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[ ] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[ ] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[ ] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---

*Please write a comment explaining your change. This is the message
that will be part of the merge commit.
