### PR TITLE
util/attributes: Fix/target feature malformed 4233 

### DIFF
--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -864,6 +864,17 @@ AttributeChecker::visit (AST::Function &fun)
 	{
 	  check_crate_type (name, attribute);
 	}
+      else if (result.name == Attrs::TARGET_FEATURE)
+	{
+	  if (!attribute.has_attr_input ())
+	    {
+	      rust_error_at (attribute.get_locus (),
+			     "malformed %<target_feature%> attribute input");
+	      rust_inform (attribute.get_locus (),
+			   "must be of the form: %<#[target_feature(enable = "
+			   "\"name\")]%>");
+	    }
+	}
       else if (result.name == "no_mangle")
 	check_no_mangle_function (attribute, fun);
 

--- a/gcc/testsuite/rust/compile/target_feature-malformed-4233.rs
+++ b/gcc/testsuite/rust/compile/target_feature-malformed-4233.rs
@@ -1,0 +1,6 @@
+// { dg-options "-w" }
+// Test for issue #4233 - malformed #[target_feature] attribute input
+
+#[target_feature] // { dg-error "malformed .target_feature. attribute input" }
+unsafe fn foo_sse() {} 
+// { dg-note "must be of the form" "" { target *-*-* } .-2 }


### PR DESCRIPTION
Fixes #4233 


Emit a diagnostic when `#[target_feature]` is used without arguments,
matching rustc behavior.

- Add testsuite case asserting the diagnostic
- Validate attribute input in AttributeChec