### PR TITLE
Add wrapper class for automatic node cloning

### DIFF
--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -26,6 +26,7 @@
 #include "rust-location.h"
 #include "rust-diagnostics.h"
 #include "rust-keyword-values.h"
+#include "rust-cloneable.h"
 
 namespace Rust {
 // TODO: remove typedefs and make actual types for these
@@ -2115,6 +2116,19 @@ public:
 };
 
 } // namespace AST
+
+template <> struct CloneableDelegate<std::unique_ptr<AST::Pattern>>
+{
+  static std::unique_ptr<AST::Pattern>
+  clone (const std::unique_ptr<AST::Pattern> &other)
+  {
+    if (other == nullptr)
+      return nullptr;
+    else
+      return other->clone_pattern ();
+  }
+};
+
 } // namespace Rust
 
 namespace std {

--- a/gcc/rust/ast/rust-pattern.cc
+++ b/gcc/rust/ast/rust-pattern.cc
@@ -66,7 +66,7 @@ IdentifierPattern::as_string () const
   str += variable_ident.as_string ();
 
   if (has_subpattern ())
-    str += " @ " + subpattern->as_string ();
+    str += " @ " + subpattern.get ()->as_string ();
 
   return str;
 }
@@ -91,11 +91,11 @@ RangePattern::as_string () const
   switch (range_kind)
     {
     case RangeKind::EXCLUDED:
-      return lower->as_string () + ".." + upper->as_string ();
+      return lower.get ()->as_string () + ".." + upper.get ()->as_string ();
     case RangeKind::INCLUDED:
-      return lower->as_string () + "..=" + upper->as_string ();
+      return lower.get ()->as_string () + "..=" + upper.get ()->as_string ();
     case RangeKind::ELLIPSIS:
-      return lower->as_string () + "..." + upper->as_string ();
+      return lower.get ()->as_string () + "..." + upper.get ()->as_string ();
     default:
       rust_unreachable ();
     }
@@ -113,7 +113,7 @@ ReferencePattern::as_string () const
   if (is_mut)
     str += "mut ";
 
-  str += pattern->as_string ();
+  str += pattern.get ()->as_string ();
 
   return str;
 }
@@ -135,7 +135,7 @@ StructPatternFieldTuplePat::as_string () const
 
   str += "\n";
 
-  str += std::to_string (index) + " : " + tuple_pattern->as_string ();
+  str += std::to_string (index) + " : " + tuple_pattern.get ()->as_string ();
 
   return str;
 }
@@ -148,7 +148,7 @@ StructPatternFieldIdentPat::as_string () const
 
   str += "\n";
 
-  str += ident.as_string () + " : " + ident_pattern->as_string ();
+  str += ident.as_string () + " : " + ident_pattern.get ()->as_string ();
 
   return str;
 }
@@ -182,7 +182,7 @@ StructPatternElements::as_string () const
     }
   else
     {
-      for (const auto &field : fields)
+      for (const auto &field : fields.get ())
 	str += "\n   " + field->as_string ();
     }
 
@@ -216,7 +216,7 @@ TupleStructItemsNoRest::as_string () const
 {
   std::string str;
 
-  for (const auto &pattern : patterns)
+  for (const auto &pattern : patterns.get ())
     str += "\n  " + pattern->as_string ();
 
   return str;
@@ -227,24 +227,24 @@ TupleStructItemsHasRest::as_string () const
 {
   std::string str ("\n  Lower patterns: ");
 
-  if (lower_patterns.empty ())
+  if (lower_patterns.get ().empty ())
     {
       str += "none";
     }
   else
     {
-      for (const auto &lower : lower_patterns)
+      for (const auto &lower : lower_patterns.get ())
 	str += "\n   " + lower->as_string ();
     }
 
   str += "\n  Upper patterns: ";
-  if (upper_patterns.empty ())
+  if (upper_patterns.get ().empty ())
     {
       str += "none";
     }
   else
     {
-      for (const auto &upper : upper_patterns)
+      for (const auto &upper : upper_patterns.get ())
 	str += "\n   " + upper->as_string ();
     }
 
@@ -258,7 +258,7 @@ TupleStructPattern::as_string () const
 
   str += path.as_string ();
 
-  str += "\n Tuple struct items: " + items->as_string ();
+  str += "\n Tuple struct items: " + items.get ()->as_string ();
 
   return str;
 }
@@ -268,7 +268,7 @@ TuplePatternItemsNoRest::as_string () const
 {
   std::string str;
 
-  for (const auto &pattern : patterns)
+  for (const auto &pattern : patterns.get ())
     str += "\n " + pattern->as_string ();
 
   return str;
@@ -280,24 +280,24 @@ TuplePatternItemsHasRest::as_string () const
   std::string str;
 
   str += "\n Lower patterns: ";
-  if (lower_patterns.empty ())
+  if (lower_patterns.get ().empty ())
     {
       str += "none";
     }
   else
     {
-      for (const auto &lower : lower_patterns)
+      for (const auto &lower : lower_patterns.get ())
 	str += "\n  " + lower->as_string ();
     }
 
   str += "\n Upper patterns: ";
-  if (upper_patterns.empty ())
+  if (upper_patterns.get ().empty ())
     {
       str += "none";
     }
   else
     {
-      for (const auto &upper : upper_patterns)
+      for (const auto &upper : upper_patterns.get ())
 	str += "\n  " + upper->as_string ();
     }
 
@@ -307,7 +307,7 @@ TuplePatternItemsHasRest::as_string () const
 std::string
 TuplePattern::as_string () const
 {
-  return "TuplePattern: " + items->as_string ();
+  return "TuplePattern: " + items.get ()->as_string ();
 }
 
 std::string
@@ -331,7 +331,7 @@ SlicePatternItemsNoRest::as_string () const
 {
   std::string str;
 
-  for (const auto &pattern : patterns)
+  for (const auto &pattern : patterns.get ())
     str += "\n " + pattern->as_string ();
 
   return str;
@@ -343,24 +343,24 @@ SlicePatternItemsHasRest::as_string () const
   std::string str;
 
   str += "\n Lower patterns: ";
-  if (lower_patterns.empty ())
+  if (lower_patterns.get ().empty ())
     {
       str += "none";
     }
   else
     {
-      for (const auto &lower : lower_patterns)
+      for (const auto &lower : lower_patterns.get ())
 	str += "\n  " + lower->as_string ();
     }
 
   str += "\n Upper patterns: ";
-  if (upper_patterns.empty ())
+  if (upper_patterns.get ().empty ())
     {
       str += "none";
     }
   else
     {
-      for (const auto &upper : upper_patterns)
+      for (const auto &upper : upper_patterns.get ())
 	str += "\n  " + upper->as_string ();
     }
 
@@ -370,7 +370,7 @@ SlicePatternItemsHasRest::as_string () const
 std::string
 SlicePattern::as_string () const
 {
-  return "SlicePattern: " + items->as_string ();
+  return "SlicePattern: " + items.get ()->as_string ();
 }
 
 std::string
@@ -378,7 +378,7 @@ AltPattern::as_string () const
 {
   std::string str ("AltPattern: ");
 
-  for (const auto &pattern : alts)
+  for (const auto &pattern : alts.get ())
     str += "\n " + pattern->as_string ();
 
   return str;

--- a/gcc/rust/util/rust-cloneable.h
+++ b/gcc/rust/util/rust-cloneable.h
@@ -1,0 +1,85 @@
+// Copyright (C) 2026 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_CLONEABLE
+#define RUST_CLONEABLE
+
+#include "rust-system.h"
+
+namespace Rust {
+
+// used to automatically copy cloneable types
+
+template <typename T> struct CloneableDelegate
+{
+};
+
+template <typename T> class Cloneable
+{
+public:
+  template <typename... Args>
+  Cloneable (Args &&...args) : inner (std::forward<Args> (args)...)
+  {}
+
+  Cloneable (const Cloneable &other)
+    : Cloneable (CloneableDelegate<T>::clone (other.inner))
+  {}
+
+  template <typename Arg> Cloneable &operator= (Arg &&arg)
+  {
+    inner = std::forward<Arg> (arg);
+    return *this;
+  }
+
+  Cloneable &operator= (const Cloneable &other)
+  {
+    inner = CloneableDelegate<T>::clone (other.inner);
+    return *this;
+  }
+
+  Cloneable (Cloneable &&) = default;
+  Cloneable &operator= (Cloneable &&) = default;
+
+  T &get () { return inner; }
+  const T &get () const { return inner; }
+
+  bool operator== (decltype (nullptr)) const { return inner == nullptr; }
+
+  bool operator!= (decltype (nullptr)) const { return inner != nullptr; }
+
+private:
+  T inner;
+};
+
+// general specializations
+
+template <typename T> struct CloneableDelegate<std::vector<T>>
+{
+  static std::vector<T> clone (const std::vector<T> &other)
+  {
+    std::vector<T> ret;
+    ret.reserve (other.size ());
+    for (auto &ent : other)
+      ret.push_back (CloneableDelegate<T>::clone (ent));
+    return ret;
+  }
+};
+
+} // namespace Rust
+
+#endif // RUST_CLONEABLE


### PR DESCRIPTION
This patch adds a wrapper class called `Cloneable`, which can be used to automatically perform polymorphic copying. This should greatly reduce the need for error-prone user defined copy constructors and assignment operators.

As a demonstration/first step, this patch also uses Cloneable to simplify the pattern nodes described in `ast/rust-pattern.h`.