### PR TITLE
util/attributes: error on malformed #[link_name] input

### DIFF
--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -866,6 +866,17 @@ AttributeChecker::visit (AST::Function &fun)
 	}
       else if (result.name == "no_mangle")
 	check_no_mangle_function (attribute, fun);
+
+      else if (result.name == Attrs::LINK_NAME)
+	{
+	  if (!attribute.has_attr_input ())
+	    {
+	      rust_error_at (attribute.get_locus (),
+			     "malformed %<link_name%> attribute input");
+	      rust_inform (attribute.get_locus (),
+			   "must be of the form: %<#[link_name = \"name\"]%>");
+	    }
+	}
     }
   if (fun.has_body ())
     fun.get_definition ().value ()->accept_vis (*this);

--- a/gcc/testsuite/rust/compile/link_name-malformed.rs
+++ b/gcc/testsuite/rust/compile/link_name-malformed.rs
@@ -1,0 +1,5 @@
+// { dg-options "-w" }
+#[link_name] // { dg-error "malformed .link_name. attribute input" }
+fn foo() {}
+
+// { dg-note "must be of the form" "" { target *-*-* } .-3 }


### PR DESCRIPTION
Emit a diagnostic when #[link_name] is used without arguments, matching rustc behavior. This prevents silent acceptance of empty attributes and provides a helpful diagnostic that shows the expected form.

Fixes Rust-GCC#4228

gcc/rust/ChangeLog:

	* util/rust-attributes.cc: Emit diagnostic.

gcc/testsuite/ChangeLog:

	* rust/compile/link_name-malformed.rs: New test.
