### PR TITLE
util/attributes: error on malformed #[no_mangle] input

### DIFF
--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -464,7 +464,6 @@ AttributeChecker::check_attribute (const AST::Attribute &attribute)
   else if (result.name == Attrs::DEPRECATED)
     check_deprecated_attribute (attribute);
 }
-
 void
 AttributeChecker::check_attributes (const AST::AttrVec &attributes)
 {
@@ -865,8 +864,17 @@ AttributeChecker::visit (AST::Function &fun)
 	  check_crate_type (name, attribute);
 	}
       else if (result.name == "no_mangle")
-	check_no_mangle_function (attribute, fun);
-
+	{
+	  if (attribute.has_attr_input ())
+	    {
+	      rust_error_at (attribute.get_locus (),
+			     "malformed %<no_mangle%> attribute input");
+	      rust_inform (attribute.get_locus (),
+			   "must be of the form: %<#[no_mangle]%>");
+	    }
+	  else
+	    check_no_mangle_function (attribute, fun);
+	}
       else if (result.name == Attrs::LINK_NAME)
 	{
 	  if (!attribute.has_attr_input ())

--- a/gcc/testsuite/rust/compile/no_mangle-malformed.rs
+++ b/gcc/testsuite/rust/compile/no_mangle-malformed.rs
@@ -1,0 +1,4 @@
+// { dg-options "-w" }
+#[no_mangle(foo)] // { dg-error "malformed .no_mangle. attribute input" }
+fn foo() {}
+// { dg-note "must be of the form" "" { target *-*-* } .-2 }


### PR DESCRIPTION
util/attributes: error on malformed #[no_mangle] input

Emit a diagnostic when #[no_mangle] is used with arguments,
matching rustc behavior. The no_mangle attribute is a word
attribute and should not accept any input values.

Fixes Rust-GCC#4230

gcc/rust/ChangeLog:

	* util/rust-attributes.cc (AttributeChecker::check_attributes): Emit diagnostic.

gcc/testsuite/ChangeLog:

	* rust/compile/no_mangle-malformed.rs: New test.

Signed-off-by: Jayant Chauhan <0001jayant@gmail.com>
