### PR TITLE
util/attributes: Error on #[repr] applied to functions

### DIFF
--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -912,6 +912,12 @@ AttributeChecker::visit (AST::Function &fun)
 	{
 	  check_link_section_attribute (attribute);
 	}
+      else if (result.name == Attrs::REPR)
+	{
+	  rust_error_at (
+	    attribute.get_locus (),
+	    "attribute should be applied to a struct, enum, or union");
+	}
     }
 
   if (fun.has_body ())

--- a/gcc/testsuite/rust/compile/issue-4232.rs
+++ b/gcc/testsuite/rust/compile/issue-4232.rs
@@ -1,0 +1,3 @@
+// { dg-options "-w" }
+#[repr(C)] // { dg-error "attribute should be applied to a struct, enum, or union" }
+fn a() {}


### PR DESCRIPTION
The #[repr] attribute is only valid for structs, enums, and unions. Applying it to a function is invalid and should result in an error. This patch adds a check in the attribute visitor to reject #[repr] on functions, matching rustc behavior.

Fixes Rust-GCC#4232

gcc/rust/ChangeLog:

	* util/rust-attributes.cc: Emit error for #[repr] on functions.

gcc/testsuite/ChangeLog:

	* rust/compile/repr_on_function.rs: New test.
