### PR TITLE
util/attributes: Check that #[target_feature] is only used on unsafe …

### DIFF
--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -885,6 +885,13 @@ AttributeChecker::visit (AST::Function &fun)
 			   "must be of the form: %<#[target_feature(enable = "
 			   "\"name\")]%>");
 	    }
+	  else if (!fun.get_qualifiers ().is_unsafe ())
+	    {
+	      rust_error_at (
+		attribute.get_locus (),
+		"the %<#[target_feature]%> attribute can only be applied "
+		"to %<unsafe%> functions");
+	    }
 	}
       else if (result.name == "no_mangle")
 	{

--- a/gcc/testsuite/rust/compile/issue-4234.rs
+++ b/gcc/testsuite/rust/compile/issue-4234.rs
@@ -1,0 +1,3 @@
+// { dg-options "-w" }
+#[target_feature(sse)] // { dg-error "attribute can only be applied" }
+fn foo() {}

--- a/gcc/testsuite/rust/compile/unsafe11.rs
+++ b/gcc/testsuite/rust/compile/unsafe11.rs
@@ -1,8 +1,9 @@
 #[target_feature(sse)]
-fn foo() {
+unsafe fn foo() {
     let a: usize = 0;
 }
 
 fn main() {
-    foo() // { dg-error "requires unsafe function or block" }
+    foo(); // { dg-error "requires unsafe function or block" }
+    unsafe { foo(); }
 }


### PR DESCRIPTION
The #[target_feature] attribute allows code generation that may not be supported by the runtime hardware, making it inherently unsafe. This patch adds a check to ensure it is only applied to functions declared as 'unsafe', matching rustc behavior (E0658).

Fixes Rust-GCC#4234

gcc/rust/ChangeLog:

	* util/rust-attributes.cc: Error if target_feature is on safe function.

gcc/testsuite/ChangeLog:

	* rust/compile/target_feature-unsafe.rs: New test.
