### PR TITLE
util/attributes: error on malformed #[link_section] input

### DIFF
--- a/gcc/testsuite/rust/compile/link_section-malformed.rs
+++ b/gcc/testsuite/rust/compile/link_section-malformed.rs
@@ -1,0 +1,5 @@
+// { dg-options "-w" }
+#[link_section] // { dg-error "malformed .link_section. attribute input" }
+pub static VAR1: u32 = 1;
+
+// { dg-note "must be of the form" "" { target *-*-* } .-3 }


### PR DESCRIPTION
Emit a diagnostic when #[link_section] is used without arguments, matching rustc behavior. This prevents silent acceptance of empty attributes and provides a helpful diagnostic that shows the expected form.

Fixes Rust-GCC#4229

gcc/rust/ChangeLog:

	* util/rust-attributes.cc: Emit diagnostic for malformed link_section.

gcc/testsuite/ChangeLog:

	* rust/compile/link_section-malformed.rs: New test.
