### PR TITLE
util/attributes: Error on malformed lint attributes

### DIFF
--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -465,6 +465,18 @@ check_export_name_attribute (const AST::Attribute &attribute)
     }
 }
 
+static void
+check_lint_attribute (const AST::Attribute &attribute, const char *name)
+{
+  if (!attribute.has_attr_input ())
+    {
+      rust_error_at (attribute.get_locus (), "malformed %qs attribute input",
+		     name);
+      rust_inform (attribute.get_locus (),
+		   "must be of the form: %<#[%s(lint1, lint2, ...)]%>", name);
+    }
+}
+
 void
 AttributeChecker::check_attribute (const AST::Attribute &attribute)
 {
@@ -928,6 +940,11 @@ AttributeChecker::visit (AST::Function &fun)
       else if (result.name == Attrs::EXPORT_NAME)
 	{
 	  check_export_name_attribute (attribute);
+	}
+      else if (result.name == Attrs::ALLOW || result.name == "deny"
+	       || result.name == "warn" || result.name == "forbid")
+	{
+	  check_lint_attribute (attribute, name);
 	}
       else if (result.name == Attrs::LINK_NAME)
 	{

--- a/gcc/testsuite/rust/compile/issue-4225.rs
+++ b/gcc/testsuite/rust/compile/issue-4225.rs
@@ -1,0 +1,10 @@
+#![feature(no_core)]
+#![no_core]
+// { dg-options "-w" }
+
+#[allow] // { dg-error "malformed .allow. attribute input" }
+fn foo() {}
+// { dg-note "must be of the form" "" { target *-*-* } .-2 }
+
+#[allow(dead_code)] // This is a correctly formed attribute
+fn bar() {}


### PR DESCRIPTION
The lint attributes (allow, deny, warn, forbid) require arguments specifying which lints to affect. Using them without arguments (e.g. #[allow]) is invalid. This patch adds validation to reject empty lint attributes.

Fixes Rust-GCC#4225

gcc/rust/ChangeLog:

	* util/rust-attributes.cc: Check for empty lint attributes.

gcc/testsuite/ChangeLog:

	* rust/compile/allow-malformed.rs: New test.