### PR TITLE
expand: Add error check if derive has wrong item

### DIFF
--- a/gcc/testsuite/rust/compile/issue-3875.rs
+++ b/gcc/testsuite/rust/compile/issue-3875.rs
@@ -1,0 +1,28 @@
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![feature(lang_items)]
+#![no_core]
+// { dg-options "-w" }
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "clone"]
+pub trait Clone: Sized {
+    fn clone(&self) -> Self;
+}
+
+#[lang = "copy"]
+pub trait Copy: Clone {}
+
+#[derive(Clone)] // { dg-error "derive may only be applied to structs, enums and unions" }
+fn foo() {}
+
+#[derive(Clone)] // { dg-error "derive may only be applied to structs, enums and unions" }
+trait Bar {}
+
+// Valid test: Derive Copy and Clone on a unit struct
+#[derive(Copy, Clone)]
+struct TupleStruct;
+
+// { dg-prune-output "could not resolve" }


### PR DESCRIPTION
The DeriveVisitor previously dispatched calls to specific handlers (like DeriveClone) without validating the input item type. This caused internal compiler errors (ICEs) when users attempted to derive traits on invalid items like functions or traits, as the handlers assumed the input was a struct, enum, or union.

This patch adds a validation predicate  to the DeriveVisitor to reject invalid items gracefully with a diagnostic error before dispatching.

Fixes Rust-GCC#3875

gcc/rust/ChangeLog:

	* expand/rust-derive.h: Add validate_item prototype.
	* expand/rust-derive.cc (DeriveVisitor::derive): Use visitor validation.
	(DeriveVisitor::validate_item): New function to check item kind.

gcc/testsuite/ChangeLog:

	* rust/compile/derive-on-invalid-item.rs: New test.

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidlines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`
- \[x] Added any relevant test cases to `gcc/testsuite/rust/`

