### PR TITLE
gccrs: add redundant semicolon lint

### DIFF
--- a/gcc/rust/checks/lints/unused/rust-unused-checker.cc
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.cc
@@ -117,5 +117,12 @@ UnusedChecker::visit (HIR::StructPatternFieldIdent &pattern)
 		     pattern.get_identifier ().as_string ().c_str ());
 }
 
+void
+UnusedChecker::visit (HIR::EmptyStmt &stmt)
+{
+  rust_warning_at (stmt.get_locus (), OPT_Wunused_variable,
+		   "unnecessary trailing semicolons");
+}
+
 } // namespace Analysis
 } // namespace Rust

--- a/gcc/rust/checks/lints/unused/rust-unused-checker.h
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.h
@@ -43,6 +43,7 @@ private:
   virtual void visit (HIR::IdentifierPattern &identifier) override;
   virtual void visit (HIR::AssignmentExpr &identifier) override;
   virtual void visit (HIR::StructPatternFieldIdent &identifier) override;
+  virtual void visit (HIR::EmptyStmt &stmt) override;
 };
 } // namespace Analysis
 } // namespace Rust

--- a/gcc/testsuite/rust/compile/redundant-semicolons_0.rs
+++ b/gcc/testsuite/rust/compile/redundant-semicolons_0.rs
@@ -1,0 +1,10 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+
+pub fn foo() -> i32 
+{
+    let a = 32;;
+// { dg-warning "unnecessary trailing semicolons" "" { target *-*-* } .-1 }
+    return a
+}
+
+


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* checks/lints/unused/rust-unused-checker.cc (UnusedChecker::visit): Emit warning in empty statement visitor.
	* checks/lints/unused/rust-unused-checker.h: Likewise.

gcc/testsuite/ChangeLog:

	* rust/compile/redundant-semicolons_0.rs: New test.