### PR TITLE
gccrs: Fix ICE in insert_associated_trait_impl due to recursion

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check.h
+++ b/gcc/rust/typecheck/rust-hir-type-check.h
@@ -235,7 +235,7 @@ public:
   void insert_trait_reference (DefId id, TraitReference &&ref);
   bool lookup_trait_reference (DefId id, TraitReference **ref);
 
-  void insert_associated_trait_impl (HirId id,
+  bool insert_associated_trait_impl (HirId id,
 				     AssociatedImplTrait &&associated);
   bool lookup_associated_trait_impl (HirId id,
 				     AssociatedImplTrait **associated);

--- a/gcc/rust/typecheck/rust-typecheck-context.cc
+++ b/gcc/rust/typecheck/rust-typecheck-context.cc
@@ -248,13 +248,17 @@ TypeCheckContext::lookup_trait_reference (DefId id, TraitReference **ref)
   return true;
 }
 
-void
+bool
 TypeCheckContext::insert_associated_trait_impl (
   HirId id, AssociatedImplTrait &&associated)
 {
-  rust_assert (associated_impl_traits.find (id)
-	       == associated_impl_traits.end ());
+  auto it = associated_impl_traits.find (id);
+  if (it != associated_impl_traits.end ())
+    {
+      return false;
+    }
   associated_impl_traits.emplace (id, std::move (associated));
+  return true;
 }
 
 bool

--- a/gcc/testsuite/rust/compile/issue-4166.rs
+++ b/gcc/testsuite/rust/compile/issue-4166.rs
@@ -1,0 +1,19 @@
+
+pub trait Foo {
+    type Bar;
+    fn foo(bar: Self::bar); // { dg-error "failed to resolve path segment using an impl Probe" }
+}
+
+pub struct FooImpl;
+
+const foo_impl: () = {
+    impl Foo for FooImpl {
+        type Bar = ();
+        fn foo(_bar: Self::Bar) { // { dg-error "method .foo. has an incompatible type|mismatched types" }
+            // This is the recursive reference that used to cause the ICE
+            let () = foo_impl; 
+        }
+    }
+};
+
+fn main() {}


### PR DESCRIPTION
This patch fixes an Internal Compiler Error (ICE) that occurred when handling recursive const blocks containing trait implementations. Previously, the compiler asserted that an associated trait implementation ID must not already exist in the context. However, recursive definitions could trigger a second visit to the same implementation, causing the assertion to fail.

We now check if the ID exists and return early if it does, allowing the compiler to handle the recursion gracefully and emit standard error messages instead of crashing.

Fixes #4166

gcc/rust/ChangeLog:

	* typecheck/rust-typecheck-context.cc (insert_associated_trait_impl): Remove assertion and add check for existing ID to prevent ICE.

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4166.rs: New test.

Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[ ] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[ ] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[ ] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---

*Please write a comment explaining your change. This is the message
that will be part of the merge commit.
