### PR TITLE
gccrs: add non camel case types lint

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -203,6 +203,7 @@ GRS_OBJS = \
     rust/rust-const-checker.o \
     rust/rust-lint-marklive.o \
     rust/rust-lint-unused-var.o \
+    rust/rust-lint-naming.o \
     rust/rust-unused-checker.o \
     rust/rust-unused-collector.o \
     rust/rust-unused-context.o \

--- a/gcc/rust/checks/lints/rust-lint-naming.cc
+++ b/gcc/rust/checks/lints/rust-lint-naming.cc
@@ -1,0 +1,82 @@
+// Copyright (C) 2026 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-lint-naming.h"
+#include "options.h"
+
+namespace Rust {
+namespace Analysis {
+
+static bool
+is_camel_case (Identifier identifier)
+{
+  auto s = identifier.as_string ();
+  return ISUPPER (s.front ())
+	 && std::all_of (s.begin (), s.end (),
+			 [] (unsigned char c) { return ISALNUM (c); });
+}
+
+void
+NamingConventionCheck::go (HIR::Crate &crate)
+{
+  for (auto &item : crate.get_items ())
+    item->accept_vis (*this);
+}
+
+void
+NamingConventionCheck::visit (HIR::Trait &trait)
+{
+  if (!is_camel_case (trait.get_name ()))
+    rust_warning_at (trait.get_locus (), OPT_Wunused,
+		     "trait %qs should have an upper camel case name",
+		     trait.get_name ().as_string ().c_str ());
+  walk (trait);
+}
+
+void
+NamingConventionCheck::visit (HIR::StructStruct &strct)
+{
+  if (!is_camel_case (strct.get_identifier ()))
+    rust_warning_at (strct.get_locus (), OPT_Wunused,
+		     "struct %qs should have an upper camel case name",
+		     strct.get_identifier ().as_string ().c_str ());
+  walk (strct);
+}
+
+void
+NamingConventionCheck::visit (HIR::TupleStruct &strct)
+{
+  if (!is_camel_case (strct.get_identifier ()))
+    rust_warning_at (strct.get_locus (), OPT_Wunused,
+		     "struct %qs should have an upper camel case name",
+		     strct.get_identifier ().as_string ().c_str ());
+  walk (strct);
+}
+
+void
+NamingConventionCheck::visit (HIR::Enum &enm)
+{
+  if (!is_camel_case (enm.get_identifier ()))
+    rust_warning_at (enm.get_locus (), OPT_Wunused,
+		     "enum %qs should have an upper camel case name",
+		     enm.get_identifier ().as_string ().c_str ());
+  walk (enm);
+}
+
+} // namespace Analysis
+} // namespace Rust

--- a/gcc/rust/checks/lints/rust-lint-naming.h
+++ b/gcc/rust/checks/lints/rust-lint-naming.h
@@ -1,0 +1,41 @@
+// Copyright (C) 2026 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_LINT_NAMING_H
+#define RUST_LINT_NAMING_H
+
+#include "rust-hir-item.h"
+#include "rust-hir-visitor.h"
+
+namespace Rust {
+namespace Analysis {
+class NamingConventionCheck : public HIR::DefaultHIRVisitor
+{
+public:
+  void go (HIR::Crate &crate);
+
+  using HIR::DefaultHIRVisitor::visit;
+  virtual void visit (HIR::Trait &trait) override;
+  virtual void visit (HIR::StructStruct &strct) override;
+  virtual void visit (HIR::TupleStruct &strct) override;
+  virtual void visit (HIR::Enum &enm) override;
+};
+} // namespace Analysis
+} // namespace Rust
+
+#endif // RUST_LINT_NAMING_H

--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -136,6 +136,8 @@ grs_langhook_init_options_struct (struct gcc_options *opts)
 
   /* We need to warn on unused variables by default */
   opts->x_warn_unused_variable = 1;
+  /* Experimental lints under -frust-unused-check-2.0 warn by default */
+  opts->x_warn_unused = 1;
   /* For const variables too */
   opts->x_warn_unused_const_variable = 1;
   /* And finally unused result for #[must_use] */

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -41,6 +41,7 @@
 #include "rust-lint-scan-deadcode.h"
 #include "rust-lint-unused-var.h"
 #include "rust-unused-checker.h"
+#include "rust-lint-naming.h"
 #include "rust-readonly-check.h"
 #include "rust-hir-dump.h"
 #include "rust-ast-dump.h"
@@ -861,7 +862,10 @@ Session::compile_crate (const char *filename)
       Analysis::ScanDeadcode::Scan (hir);
 
       if (flag_unused_check_2_0)
-	Analysis::UnusedChecker ().go (hir);
+	{
+	  Analysis::UnusedChecker ().go (hir);
+	  Analysis::NamingConventionCheck ().go (hir);
+	}
       else
 	Analysis::UnusedVariables::Lint (*ctx);
 

--- a/gcc/testsuite/rust/compile/non-camel-case-types_0.rs
+++ b/gcc/testsuite/rust/compile/non-camel-case-types_0.rs
@@ -1,0 +1,13 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+#![feature(no_core)]
+#![no_core]
+
+struct my_struct; // { dg-warning "struct is never constructed: .my.struct." }
+// { dg-warning "struct .my.struct. should have an upper camel case name" "" { target *-*-* } .-1 }
+
+enum my_enum {}
+// { dg-warning "enum .my.enum. should have an upper camel case name" "" { target *-*-* } .-1 }
+
+trait my_trait {}
+// { dg-warning "trait .my.trait. should have an upper camel case name" "" { target *-*-* } .-1 }
+


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* checks/lints/unused/rust-unused-checker.cc (is_camel_case): Add warning for struct, enum, and trait. (UnusedChecker::visit): New.
	* checks/lints/unused/rust-unused-checker.h: New.

gcc/testsuite/ChangeLog:

	* rust/compile/non-camel-case-types_0.rs: New test.

Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[ ] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[ ] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[ ] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---

*Please write a comment explaining your change. This is the message
that will be part of the merge commit.
