### PR TITLE
gccrs: add non snake case lint

### DIFF
--- a/gcc/rust/checks/lints/unused/rust-unused-checker.cc
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.cc
@@ -18,6 +18,7 @@
 
 #include "rust-unused-checker.h"
 #include "rust-hir-expr.h"
+#include "rust-hir-generic-param.h"
 #include "rust-hir-item.h"
 
 #include "options.h"
@@ -37,6 +38,15 @@ UnusedChecker::go (HIR::Crate &crate)
   collector.go (crate);
   for (auto &item : crate.get_items ())
     item->accept_vis (*this);
+}
+
+bool
+is_snake_case (Identifier identifier)
+{
+  auto s = identifier.as_string ();
+  return std::all_of (s.begin (), s.end (), [] (unsigned char c) {
+    return ISLOWER (c) || ISDIGIT (c) || c == '_';
+  });
 }
 
 void
@@ -82,6 +92,11 @@ UnusedChecker::visit (HIR::IdentifierPattern &pattern)
     rust_warning_at (pattern.get_locus (), OPT_Wunused_variable,
 		     "unused mut %qs",
 		     pattern.get_identifier ().as_string ().c_str ());
+
+  if (!is_snake_case (pattern.get_identifier ()))
+    rust_warning_at (pattern.get_locus (), OPT_Wunused_variable,
+		     "variable %qs should have a snake case name",
+		     var_name.c_str ());
 }
 void
 
@@ -122,6 +137,36 @@ UnusedChecker::visit (HIR::EmptyStmt &stmt)
 {
   rust_warning_at (stmt.get_locus (), OPT_Wunused_variable,
 		   "unnecessary trailing semicolons");
+}
+
+void
+UnusedChecker::visit (HIR::Function &fct)
+{
+  if (!is_snake_case (fct.get_function_name ()))
+    rust_warning_at (fct.get_locus (), OPT_Wunused_variable,
+		     "function %qs should have a snake case name",
+		     fct.get_function_name ().as_string ().c_str ());
+  walk (fct);
+}
+
+void
+UnusedChecker::visit (HIR::Module &mod)
+{
+  if (!is_snake_case (mod.get_module_name ()))
+    rust_warning_at (mod.get_locus (), OPT_Wunused_variable,
+		     "module %qs should have a snake case name",
+		     mod.get_module_name ().as_string ().c_str ());
+  walk (mod);
+}
+
+void
+UnusedChecker::visit (HIR::LifetimeParam &lft)
+{
+  if (!is_snake_case (lft.get_lifetime ().get_name ()))
+    rust_warning_at (lft.get_locus (), OPT_Wunused_variable,
+		     "lifetime %qs should have a snake case name",
+		     lft.get_lifetime ().get_name ().c_str ());
+  walk (lft);
 }
 
 void

--- a/gcc/rust/checks/lints/unused/rust-unused-checker.h
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.h
@@ -17,6 +17,7 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-hir-expr.h"
+#include "rust-hir-generic-param.h"
 #include "rust-hir-item.h"
 #include "rust-hir-pattern.h"
 #include "rust-hir-visitor.h"
@@ -44,6 +45,9 @@ private:
   virtual void visit (HIR::AssignmentExpr &identifier) override;
   virtual void visit (HIR::StructPatternFieldIdent &identifier) override;
   virtual void visit (HIR::EmptyStmt &stmt) override;
+  virtual void visit (HIR::Function &fct) override;
+  virtual void visit (HIR::Module &mod) override;
+  virtual void visit (HIR::LifetimeParam &lft) override;
   virtual void visit_loop_label (HIR::LoopLabel &label) override;
 };
 } // namespace Analysis

--- a/gcc/testsuite/rust/compile/non-snake-case_0.rs
+++ b/gcc/testsuite/rust/compile/non-snake-case_0.rs
@@ -1,0 +1,16 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+
+pub fn MyFunction() {
+// { dg-warning "function .MyFunction. should have a snake case name" "" { target *-*-* } .-1 }
+    let _MyVar = 2;
+// { dg-warning "variable ._MyVar. should have a snake case name" "" { target *-*-* } .-1 }
+}
+
+pub fn foo<'MyLifetime>(x: &'MyLifetime i32) -> &'MyLifetime i32 {
+// { dg-warning "lifetime .MyLifetime. should have a snake case name" "" { target *-*-* } .-1 }
+    x
+}
+
+mod MyModule {}
+// { dg-warning "module .MyModule. should have a snake case name" "" { target *-*-* } .-1 }
+


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* checks/lints/unused/rust-unused-checker.cc (is_snake_case): Add warning for variables, methods, functions, lifetime parameters and modules. (UnusedChecker::visit): New.
	* checks/lints/unused/rust-unused-checker.h: New.

gcc/testsuite/ChangeLog:

	* rust/compile/non-snake-case_0.rs: New test.

Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[ ] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[ ] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[ ] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---

*Please write a comment explaining your change. This is the message
that will be part of the merge commit.
