### PR TITLE
gccrs: add non upper case globals lint

### DIFF
--- a/gcc/rust/checks/lints/unused/rust-unused-checker.cc
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.cc
@@ -59,6 +59,13 @@ UnusedChecker::visit (HIR::StaticItem &item)
     rust_warning_at (item.get_locus (), OPT_Wunused_variable,
 		     "unused variable %qs",
 		     item.get_identifier ().as_string ().c_str ());
+
+  if (!std::all_of (var_name.begin (), var_name.end (), [] (unsigned char c) {
+	return ISUPPER (c) || ISDIGIT (c) || c == '_';
+      }))
+    rust_warning_at (item.get_locus (), OPT_Wunused_variable,
+		     "static variable %qs should have an upper case name",
+		     var_name.c_str ());
 }
 
 void

--- a/gcc/testsuite/rust/compile/non-upper-case-globals_0.rs
+++ b/gcc/testsuite/rust/compile/non-upper-case-globals_0.rs
@@ -1,0 +1,4 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+
+static _my_static : i32 = 0;
+// { dg-warning "static variable ._my_static. should have an upper case name" "" { target *-*-* } .-1 }


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* checks/lints/unused/rust-unused-checker.cc (UnusedChecker::visit): Add warning for static variables.

gcc/testsuite/ChangeLog:

	* rust/compile/non-upper-case-globals_0.rs: New test.

Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[ ] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[ ] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[ ] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---

*Please write a comment explaining your change. This is the message
that will be part of the merge commit.
