### PR TITLE
gccrs: Emit error when borrowing immutable variable as mutable

### DIFF
--- a/gcc/testsuite/rust/compile/issue-4289.rs
+++ b/gcc/testsuite/rust/compile/issue-4289.rs
@@ -1,0 +1,19 @@
+// { dg-options "-frust-incomplete-and-experimental-compiler-do-not-use" }
+#![feature(no_core)]
+#![feature(lang_items)]
+#![no_core]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+pub fn a() {
+    let v = 10;
+    let ref mut r = v; // { dg-error "cannot borrow immutable local variable as mutable" }
+}
+
+pub fn b() {
+    let mut v2 = 10;
+    let ref mut r2 = v2; // Should compile fine
+}
+
+fn main() {}


### PR DESCRIPTION
gccrs: Emit error when borrowing immutable variable as mutable

Fixes #4289

Rust rules strictly forbid creating a mutable reference ('&mut T') to an
immutable binding. Previously, the compiler failed to validate the
mutability of the source variable when using a 'ref mut' pattern.
This patch adds verification logic to TypeCheckStmt to check the
mutability status of the variable definition.

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-stmt.cc (TypeCheckStmt::visit):
	Add check to ensure 'ref mut' patterns bind to mutable variables.

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4289.rs: New test.

Signed-off-by: Jayant Chauhan <0001jayant@gmail.com>