### PR TITLE
util/attributes: error on malformed #[export_name] input

### DIFF
--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -446,6 +446,25 @@ check_link_section_attribute (const AST::Attribute &attribute)
     }
 }
 
+static void
+check_export_name_attribute (const AST::Attribute &attribute)
+{
+  if (!attribute.has_attr_input ())
+    {
+      rust_error_at (attribute.get_locus (),
+		     "malformed %<export_name%> attribute input");
+      rust_inform (attribute.get_locus (),
+		   "must be of the form: %<#[export_name = \"name\"]%>");
+      return;
+    }
+
+  if (!Attributes::extract_string_literal (attribute))
+    {
+      rust_error_at (attribute.get_locus (),
+		     "attribute must be a string literal");
+    }
+}
+
 void
 AttributeChecker::check_attribute (const AST::Attribute &attribute)
 {
@@ -905,6 +924,10 @@ AttributeChecker::visit (AST::Function &fun)
 	    }
 	  else
 	    check_no_mangle_function (attribute, fun);
+	}
+      else if (result.name == Attrs::EXPORT_NAME)
+	{
+	  check_export_name_attribute (attribute);
 	}
       else if (result.name == Attrs::LINK_NAME)
 	{

--- a/gcc/testsuite/rust/compile/issue-4387.rs
+++ b/gcc/testsuite/rust/compile/issue-4387.rs
@@ -1,0 +1,11 @@
+#[export_name] // { dg-error "malformed" }
+fn foo() {}
+
+#[export_name(123)] // { dg-error "attribute must be a string literal" }
+fn bar() {}
+
+#[export_name = 123] // { dg-error "attribute must be a string literal" }
+fn baz() {}
+
+#[export_name = "valid"]
+fn qux() {}


### PR DESCRIPTION
Emit a diagnostic when #[export_name] is used without arguments or with invalid arguments (non-string literals). This prevents silent failures or backend crashes when lowering the attribute to GIMPLE, ensuring the attribute follows the expected form: #[export_name = name].

Fixes Rust-GCC#4387

gcc/rust/ChangeLog:

	* util/rust-attributes.cc (check_export_name_attribute): New helper.
	(AttributeChecker::visit): Check export_name on functions.

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4387.rs: New test.