### PR TITLE
gccrs: replace unreachable with sorry_at

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-expr.cc
+++ b/gcc/rust/hir/rust-ast-lower-expr.cc
@@ -192,8 +192,8 @@ ASTLoweringExpr::visit (AST::QualifiedPathInExpression &expr)
 void
 ASTLoweringExpr::visit (AST::BoxExpr &expr)
 {
-  // Not implemented
-  rust_unreachable ();
+  rust_sorry_at (expr.get_locus (),
+		 "box expression syntax is not supported yet");
 }
 
 void


### PR DESCRIPTION
Do not throw an ICE whit unimplemented `box`.

