### PR TITLE
derive: Implement make_qualified_call helper

### DIFF
--- a/gcc/rust/ast/rust-ast-builder.cc
+++ b/gcc/rust/ast/rust-ast-builder.cc
@@ -737,5 +737,15 @@ Builder::new_generic_args (GenericArgs &args)
 		      std::move (binding_args), locus);
 }
 
+std::unique_ptr<Expr>
+Builder::qualified_call (std::vector<std::string> &&segments,
+			 std::vector<std::unique_ptr<Expr>> &&args) const
+{
+  auto path = std::unique_ptr<Expr> (
+    new PathInExpression (path_in_expression (std::move (segments))));
+
+  return call (std::move (path), std::move (args));
+}
+
 } // namespace AST
 } // namespace Rust

--- a/gcc/rust/ast/rust-ast-builder.h
+++ b/gcc/rust/ast/rust-ast-builder.h
@@ -169,6 +169,10 @@ public:
 				std::vector<PathExprSegment> &&segments
 				= {}) const;
 
+  std::unique_ptr<Expr>
+  qualified_call (std::vector<std::string> &&segments,
+		  std::vector<std::unique_ptr<Expr>> &&args) const;
+
   /* Self parameter for a function definition (`&self`) */
   std::unique_ptr<Param> self_ref_param (bool mutability = false) const;
   /* A regular named function parameter for a definition (`a: type`) */

--- a/gcc/rust/expand/rust-derive-clone.cc
+++ b/gcc/rust/expand/rust-derive-clone.cc
@@ -42,13 +42,10 @@ DeriveClone::clone_call (std::unique_ptr<Expr> &&to_clone)
 
   // Not sure how to call it properly in the meantime...
 
-  auto path = std::unique_ptr<Expr> (
-    new PathInExpression (builder.path_in_expression ({"Clone", "clone"})));
-
   auto args = std::vector<std::unique_ptr<Expr>> ();
   args.emplace_back (std::move (to_clone));
 
-  return builder.call (std::move (path), std::move (args));
+  return builder.qualified_call ({"Clone", "clone"}, std::move (args));
 }
 
 /**
@@ -103,8 +100,6 @@ DeriveClone::clone_impl (
 			     std::move (trait_items),
 			     std::move (generics.impl));
 }
-
-// TODO: Create new `make_qualified_call` helper function
 
 DeriveClone::DeriveClone (location_t loc)
   : DeriveVisitor (loc), expanded (nullptr)


### PR DESCRIPTION
This patch implements the make_qualified_call helper function as requested by the TODO in rust-derive-clone.cc. It refactors DeriveClone::clone_call to use this new helper, simplifying the construction of qualified paths for function calls.

Fixes Rust-GCC#4393

gcc/rust/ChangeLog:

	* ast/rust-derive-clone.cc (make_qualified_call): New helper function.
	(DeriveClone::clone_call): Use make_qualified_call.