### PR TITLE
derive: Factor out Eq trait path generation

### DIFF
--- a/gcc/rust/expand/rust-derive-eq.cc
+++ b/gcc/rust/expand/rust-derive-eq.cc
@@ -27,6 +27,12 @@
 namespace Rust {
 namespace AST {
 
+static TypePath
+get_eq_trait_path (Builder &builder)
+{
+  return builder.type_path ({"core", "cmp", "Eq"}, true);
+}
+
 DeriveEq::DeriveEq (location_t loc) : DeriveVisitor (loc) {}
 
 std::vector<std::unique_ptr<AST::Item>>
@@ -61,7 +67,7 @@ std::unique_ptr<Stmt>
 DeriveEq::assert_param_is_eq ()
 {
   auto eq_bound = std::unique_ptr<TypeParamBound> (
-    new TraitBound (builder.type_path ({"core", "cmp", "Eq"}, true), loc));
+    new TraitBound (get_eq_trait_path (builder), loc));
 
   auto sized_bound = std::unique_ptr<TypeParamBound> (
     new TraitBound (builder.type_path (LangItem::Kind::SIZED), loc, false,
@@ -113,9 +119,8 @@ DeriveEq::eq_impls (
   const std::vector<std::unique_ptr<GenericParam>> &type_generics)
 {
   // We create two copies of the type-path to avoid duplicate NodeIds
-  auto eq = builder.type_path ({"core", "cmp", "Eq"}, true);
-  auto eq_bound
-    = builder.trait_bound (builder.type_path ({"core", "cmp", "Eq"}, true));
+  auto eq = get_eq_trait_path (builder);
+  auto eq_bound = builder.trait_bound (get_eq_trait_path (builder));
 
   auto steq = builder.type_path (LangItem::Kind::STRUCTURAL_TEQ);
 


### PR DESCRIPTION
This patch introduces a local helper  in DeriveEq. This removes the duplication of the hardcoded path {core, cmp, Eq} used in both  and .

gcc/rust/ChangeLog:

	* expand/rust-derive-eq.cc (get_eq_trait_path): New helper.
	(DeriveEq::assert_param_is_eq): Use helper.
	(DeriveEq::eq_impls): Use helper.