### PR TITLE
expand: Refactor field expansion and add documentation

### DIFF
--- a/gcc/rust/expand/rust-expand-visitor.cc
+++ b/gcc/rust/expand/rust-expand-visitor.cc
@@ -404,22 +404,16 @@ ExpandVisitor::maybe_expand_pattern (std::unique_ptr<AST::Pattern> &pattern)
     pattern = final_fragment.take_pattern_fragment ();
 }
 
-// FIXME: Can this be refactored into a `scoped` method? Which takes a
-// ContextType as parameter and a lambda? And maybe just an std::vector<T>&?
 void
 ExpandVisitor::expand_struct_fields (std::vector<AST::StructField> &fields)
 {
-  for (auto &field : fields)
-    {
-      maybe_expand_type (field.get_field_type_ptr ());
-    }
+  expand_fields (fields);
 }
 
 void
 ExpandVisitor::expand_tuple_fields (std::vector<AST::TupleField> &fields)
 {
-  for (auto &field : fields)
-    maybe_expand_type (field.get_field_type_ptr ());
+  expand_fields (fields);
 }
 
 // FIXME: This can definitely be refactored with the method above

--- a/gcc/rust/expand/rust-expand-visitor.h
+++ b/gcc/rust/expand/rust-expand-visitor.h
@@ -105,7 +105,10 @@ public:
    */
   void expand_qualified_path_type (AST::QualifiedPathType &path_type);
 
-  // FIXME: Add documentation
+  /**
+   * Expand all macro invocations in lieu of types within a list of closure
+   * parameters
+   */
   void expand_closure_params (std::vector<AST::ClosureParam> &params);
   void expand_where_clause (AST::WhereClause &where_clause);
 
@@ -315,6 +318,16 @@ public:
 private:
   MacroExpander &expander;
   NodeId macro_invoc_expect_id;
+
+  /**
+   * Helper to expand all macro invocations in lieu of types within a vector of
+   * fields (StructField or TupleField).
+   */
+  template <typename T> void expand_fields (std::vector<T> &fields)
+  {
+    for (auto &field : fields)
+      maybe_expand_type (field.get_field_type_ptr ());
+  }
 };
 
 } // namespace Rust


### PR DESCRIPTION
This patch refactors  and  in
 to use a common template helper , reducing
code duplication as requested by the FIXME. It also adds missing documentation for .

gcc/rust/ChangeLog:

	* expand/rust-expand-visitor.h (expand_closure_params): Add documentation.
	(expand_fields): New private template helper.
	* expand/rust-expand-visitor.cc (expand_struct_fields): Use helper.
	(expand_tuple_fields): Use helper.