### PR TITLE
nr: Add modules to types NS

### DIFF
--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
@@ -537,6 +537,34 @@ resolve_type_path_like (NameResolutionContext &ctx, bool block_big_self,
 		     "declared identifiers");
     }
 
+  if (Analysis::Mappings::get ().is_module (
+	resolved->definition.get_node_id ()))
+    {
+      if (type.get_segments ().size () == 1)
+	{
+	  if (auto resolved
+	      = Builtins::find_builtin_node_id (type.as_string ()))
+	    {
+	      ctx.map_usage (Usage (type.get_node_id ()),
+			     Definition (*resolved), Namespace::Types);
+
+	      // In that specific case, we also override the segment resolution
+	      // as it causes issues later down the line during typechecking
+	      ctx.map_usage (Usage (unwrap_segment_node_id (
+			       type.get_segments ().front ())),
+			     Definition (*resolved), Namespace::Types);
+	    }
+	  else
+	    {
+	      rust_error_at (type.get_locus (), ErrorCode::E0573,
+			     "expected type, found module %qs",
+			     unwrap_segment_error_string (type).c_str ());
+	    }
+	}
+
+      return;
+    }
+
   ctx.map_usage (Usage (type.get_node_id ()),
 		 Definition (resolved->definition.get_node_id ()),
 		 Namespace::Types);

--- a/gcc/rust/resolve/rust-name-resolution-context.cc
+++ b/gcc/rust/resolve/rust-name-resolution-context.cc
@@ -256,10 +256,10 @@ NameResolutionContext::insert_globbed (Identifier name, NodeId id, Namespace ns)
 void
 NameResolutionContext::map_usage (Usage usage, Definition definition)
 {
-  auto inserted = resolved_nodes.emplace (usage, definition).second;
+  resolved_nodes[usage] = definition;
 
-  // is that valid?
-  rust_assert (inserted);
+  // TODO: Are reinsertions okay?
+  // rust_assert (inserted);
 }
 
 tl::optional<NodeId>

--- a/gcc/rust/resolve/rust-name-resolution-context.hxx
+++ b/gcc/rust/resolve/rust-name-resolution-context.hxx
@@ -160,28 +160,6 @@ NameResolutionContext::resolve_path (
 	      // TODO: does NonShadowable matter?
 	      return Rib::Definition::NonShadowable (id);
 	    }
-	  else
-	    {
-	      // HACK: check for a module after we check the language prelude
-	      for (auto &kv :
-		   stack.find_closest_module (starting_point.get ()).children)
-		{
-		  auto &link = kv.first;
-
-		  if (link.path.map_or (
-			[&seg] (Identifier path) {
-			  auto &path_str = path.as_string ();
-			  return path_str == seg.name;
-			},
-			false))
-		    {
-		      // FIXME: Is the NS to insert_segment_resolution valid?
-		      insert_segment_resolution (Usage (seg.node_id),
-						 Definition (kv.second.id), N);
-		      return Rib::Definition::NonShadowable (kv.second.id);
-		    }
-		}
-	    }
 	}
 
       // FIXME: Is the NS to insert_segment_resolution valid?
@@ -241,27 +219,6 @@ NameResolutionContext::resolve_path (
   // Ok we didn't find it in the rib, Lets try the prelude...
   if (!res)
     res = stack.get_lang_prelude (seg_name);
-
-  if (N == Namespace::Types && !res)
-    {
-      // HACK: check for a module after we check the language prelude
-      for (auto &kv : final_node.children)
-	{
-	  auto &link = kv.first;
-
-	  if (link.path.map_or (
-		[&seg_name] (Identifier path) {
-		  auto &path_str = path.as_string ();
-		  return path_str == seg_name;
-		},
-		false))
-	    {
-	      insert_segment_resolution (Usage (seg.node_id),
-					 Definition (kv.second.id), N);
-	      return Rib::Definition::NonShadowable (kv.second.id);
-	    }
-	}
-    }
 
   if (res && !res->is_ambiguous ())
     insert_segment_resolution (Usage (seg.node_id),

--- a/gcc/rust/resolve/rust-name-resolution.h
+++ b/gcc/rust/resolve/rust-name-resolution.h
@@ -19,6 +19,8 @@
 #ifndef RUST_NAME_RESOLVER_2_0_H
 #define RUST_NAME_RESOLVER_2_0_H
 
+#include "rust-mapping-common.h"
+
 namespace Rust {
 namespace Resolver2_0 {
 
@@ -39,6 +41,7 @@ public:
 class Definition
 {
 public:
+  explicit Definition () : id (UNKNOWN_NODEID) {}
   explicit Definition (NodeId id) : id (id) {}
 
   NodeId id;

--- a/gcc/rust/resolve/rust-resolve-builtins.cc
+++ b/gcc/rust/resolve/rust-resolve-builtins.cc
@@ -120,6 +120,16 @@ setup_type_ctx ()
 			 unit_type);
 }
 
+tl::optional<NodeId>
+find_builtin_node_id (const std::string &name)
+{
+  for (size_t i = 0; i < builtin_count; i++)
+    if (strcmp (name.c_str (), builtin_names[i]) == 0)
+      return builtin_node_ids[i];
+
+  return tl::nullopt;
+}
+
 } // namespace Builtins
 } // namespace Resolver2_0
 } // namespace Rust

--- a/gcc/rust/resolve/rust-resolve-builtins.h
+++ b/gcc/rust/resolve/rust-resolve-builtins.h
@@ -19,6 +19,9 @@
 #ifndef RUST_RESOLVE_BUILTINS_H
 #define RUST_RESOLVE_BUILTINS_H
 
+#include "optional.h"
+#include "rust-ast.h"
+
 namespace Rust {
 namespace Resolver2_0 {
 
@@ -29,6 +32,9 @@ namespace Builtins {
 
 void setup_lang_prelude (NameResolutionContext &ctx);
 void setup_type_ctx ();
+
+// Return the NodeId associated with a builtin type name if it exists
+tl::optional<NodeId> find_builtin_node_id (const std::string &name);
 
 } // namespace Builtins
 } // namespace Resolver2_0

--- a/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
@@ -107,12 +107,16 @@ TopLevel::go (AST::Crate &crate)
 void
 TopLevel::visit (AST::Module &module)
 {
-  DefaultResolver::visit (module);
-
   if (Analysis::Mappings::get ().lookup_glob_container (module.get_node_id ())
       == tl::nullopt)
     Analysis::Mappings::get ().insert_glob_container (module.get_node_id (),
 						      &module);
+
+  insert_or_error_out (module.get_name (), module, Namespace::Types);
+
+  Analysis::Mappings::get ().insert_module_id (module.get_node_id ());
+
+  DefaultResolver::visit (module);
 }
 
 void

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -31,6 +31,7 @@
 #include "rust-type-util.h"
 #include "rust-system.h"
 #include "rust-compile-base.h"
+#include "rust-resolve-builtins.h"
 
 namespace Rust {
 namespace Resolver {
@@ -349,6 +350,14 @@ TypeCheckType::resolve_root_path (HIR::TypePath &path, size_t *offset,
 	  // assign the ref_node_id if we've found something
 	  nr_ctx.lookup (ast_node_id, Resolver2_0::Namespace::Types)
 	    .map ([&ref_node_id] (NodeId resolved) { ref_node_id = resolved; });
+
+	  // TODO: Should we add a special method to the name resolver to handle
+	  // that case? Resolving something in the Types NS when we want to
+	  // prioritize builtin types over modules or other conflicting things?
+	  if (auto builtin_type_id
+	      = Resolver2_0::Builtins::find_builtin_node_id (seg->to_string ()))
+	    if (mappings.is_module (ref_node_id))
+	      ref_node_id = builtin_type_id.value ();
 	}
 
       // ref_node_id is the NodeId that the segments refers to.
@@ -411,7 +420,8 @@ TypeCheckType::resolve_root_path (HIR::TypePath &path, size_t *offset,
 	  // A::B::C::this_is_a_module
 	  //          ^^^^^^^^^^^^^^^^
 	  // This is an error, we are not expecting a module.
-	  rust_error_at (seg->get_locus (), "expected value");
+	  rust_error_at (seg->get_locus (), "expected value, got module");
+
 	  return new TyTy::ErrorType (path.get_mappings ().get_hirid ());
 	}
 

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -1168,6 +1168,18 @@ Mappings::insert_glob_container (NodeId id, AST::GlobContainer *container)
     glob_containers[id] = container;
 }
 
+void
+Mappings::insert_module_id (NodeId id)
+{
+  module_ids.insert (id);
+}
+
+bool
+Mappings::is_module (NodeId id)
+{
+  return module_ids.find (id) != module_ids.end ();
+}
+
 tl::optional<AST::GlobContainer *>
 Mappings::lookup_glob_container (NodeId id)
 {

--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -323,6 +323,10 @@ public:
 
   void insert_glob_container (NodeId, AST::GlobContainer *);
   tl::optional<AST::GlobContainer *> lookup_glob_container (NodeId id);
+
+  void insert_module_id (NodeId);
+  bool is_module (NodeId id);
+
   void insert_module_child (NodeId module, NodeId child);
   tl::optional<std::vector<NodeId> &> lookup_module_children (NodeId module);
 
@@ -441,10 +445,13 @@ private:
   // Module tree maps
 
   // Maps each module's node id to a list of its children
+  // TODO: I think these are only used by the old resolved and can be removed
   std::map<NodeId, std::vector<NodeId>> module_child_map;
   std::map<NodeId, std::vector<Resolver::CanonicalPath>> module_child_items;
   std::map<NodeId, NodeId> child_to_parent_module_map;
+
   std::map<NodeId, AST::GlobContainer *> glob_containers;
+  std::set<NodeId> module_ids;
 
   // AST mappings
   std::map<NodeId, AST::Item *> ast_item_mappings;

--- a/gcc/testsuite/rust/compile/issue-4563.rs
+++ b/gcc/testsuite/rust/compile/issue-4563.rs
@@ -1,0 +1,12 @@
+#![feature(no_core)]
+#![no_core]
+
+mod foo {
+    pub fn foo() {}
+}
+
+use foo::foo;
+
+fn main() {
+    foo();
+}

--- a/gcc/testsuite/rust/compile/mod_in_types_ns.rs
+++ b/gcc/testsuite/rust/compile/mod_in_types_ns.rs
@@ -1,0 +1,8 @@
+#![feature(no_core)]
+#![no_core]
+
+mod foo {
+    mod bar {}
+
+    struct bar; // { dg-error "defined multiple times" }
+}

--- a/gcc/testsuite/rust/compile/mod_in_types_ns2.rs
+++ b/gcc/testsuite/rust/compile/mod_in_types_ns2.rs
@@ -1,0 +1,8 @@
+#![feature(no_core)]
+#![no_core]
+
+mod foo {
+    mod bar {}
+
+    fn baz() -> bar {} // { dg-error "expected type, found module" }
+}

--- a/gcc/testsuite/rust/compile/type-with-builtin-type-name.rs
+++ b/gcc/testsuite/rust/compile/type-with-builtin-type-name.rs
@@ -1,0 +1,8 @@
+#![feature(no_core)]
+#![no_core]
+
+struct i32;
+
+fn main() {
+    let _: i32 = i32;
+}


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* util/rust-hir-map.cc (Mappings::insert_module_id): New function. (Mappings::is_module): Likewise.
	* util/rust-hir-map.h: Store a set of AST modules, declare functions for adding and retrieving them.
	* resolve/rust-toplevel-name-resolver-2.0.cc (TopLevel::visit): Insert modules in the type namespace and store them in mappings.
	* resolve/rust-late-name-resolver-2.0.cc (resolve_type_path_like): Error out when an expected type resolves to a module.

gcc/testsuite/ChangeLog:

	* rust/compile/mod_in_types_ns.rs: New test.
	* rust/compile/mod_in_types_ns2.rs: New test.

Fixes #4403
Fixes #4563 