### PR TITLE
ast: Fix module path resolution for sibling modules in root

### DIFF
--- a/gcc/testsuite/rust/compile/compile.exp
+++ b/gcc/testsuite/rust/compile/compile.exp
@@ -28,7 +28,20 @@ dg-init
 set saved-dg-do-what-default ${dg-do-what-default}
 
 set dg-do-what-default "compile"
-dg-runtest [lsort [glob -nocomplain $srcdir/$subdir/*.rs]] "" ""
+
+set tests [lsort [glob -nocomplain $srcdir/$subdir/*.rs]]
+set ignore_list [list "issue_4402_foo.rs"]
+
+set tests_to_run [list]
+foreach t $tests {
+    set filename [file tail $t]
+    if {[lsearch -exact $ignore_list $filename] == -1} {
+        lappend tests_to_run $t
+    }
+}
+
+dg-runtest $tests_to_run "" ""
+
 set dg-do-what-default ${saved-dg-do-what-default}
 
 # All done.

--- a/gcc/testsuite/rust/compile/issue-4402.rs
+++ b/gcc/testsuite/rust/compile/issue-4402.rs
@@ -1,0 +1,9 @@
+#![feature(no_core)]
+#![no_core]
+use issue_4402_foo::Bar;
+pub mod issue_4402_foo;
+
+fn main() {
+    // use '_a' to silence the unused variable warning
+    let _a = Bar;
+}

--- a/gcc/testsuite/rust/compile/issue_4402_foo.rs
+++ b/gcc/testsuite/rust/compile/issue_4402_foo.rs
@@ -1,0 +1,1 @@
+pub struct Bar;


### PR DESCRIPTION
Currently, the compiler fails to resolve module paths when a file in the root directory (e.g. 'bar.rs') attempts to load a sibling module (e.g. 'foo.rs') if a 'bar/' directory does not exist. The compiler incorrectly assumes that if 'bar.rs' is not 'mod.rs', it must look exclusively in a subdirectory.

This patch adds a fallback mechanism in 'Module::process_file_path'. If the subdirectory search fails, it strips the implicit subdirectory and attempts to resolve the module in the parent directory, consistent with Rust 2018 path rules.

Fixes Rust-GCC/gccrs#4402

gcc/rust/ChangeLog:

	* ast/rust-ast.cc (Module::process_file_path): Add fallback search for sibling modules when subdirectory search fails.

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4402.rs: New test.
	* rust/compile/issue_4402_foo.rs: New test.

Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[ ] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[ ] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[ ] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---

*Please write a comment explaining your change. This is the message
that will be part of the merge commit.
