### PR TITLE
Reduce node id sharing

### DIFF
--- a/gcc/rust/ast/rust-ast-builder.cc
+++ b/gcc/rust/ast/rust-ast-builder.cc
@@ -510,7 +510,7 @@ Builder::loop (std::vector<std::unique_ptr<Stmt>> &&stmts)
 std::unique_ptr<TypeParamBound>
 Builder::trait_bound (TypePath bound)
 {
-  return std::make_unique<TraitBound> (bound, loc);
+  return std::make_unique<TraitBound> (std::move (bound), loc);
 }
 
 std::unique_ptr<Item>
@@ -520,7 +520,7 @@ Builder::trait_impl (TypePath trait_path, std::unique_ptr<Type> target,
 		     WhereClause where_clause, Visibility visibility) const
 {
   return std::unique_ptr<Item> (
-    new TraitImpl (trait_path, /* unsafe */ false,
+    new TraitImpl (std::move (trait_path), /* unsafe */ false,
 		   /* exclam */ false, std::move (trait_items),
 		   std::move (generics), std::move (target), where_clause,
 		   visibility, {}, {}, loc));
@@ -567,7 +567,7 @@ std::unique_ptr<GenericParam>
 Builder::new_const_param (ConstGenericParam &param) const
 {
   return std::make_unique<ConstGenericParam> (param.get_name (),
-					      param.get_type ().clone_type (),
+					      param.get_type ().reconstruct (),
 					      param.get_default_value (),
 					      param.get_outer_attrs (),
 					      param.get_locus ());

--- a/gcc/rust/ast/rust-path.h
+++ b/gcc/rust/ast/rust-path.h
@@ -1216,10 +1216,10 @@ public:
 
   // Copy constructor with vector clone
   TypePath (TypePath const &other)
-    : has_opening_scope_resolution (other.has_opening_scope_resolution),
+    : TypeNoBounds (other),
+      has_opening_scope_resolution (other.has_opening_scope_resolution),
       locus (other.locus)
   {
-    node_id = other.node_id;
     segments.reserve (other.segments.size ());
     for (const auto &e : other.segments)
       segments.push_back (e->clone_type_path_segment ());
@@ -1228,7 +1228,7 @@ public:
   // Overloaded assignment operator with clone
   TypePath &operator= (TypePath const &other)
   {
-    node_id = other.node_id;
+    TypeNoBounds::operator= (other);
     has_opening_scope_resolution = other.has_opening_scope_resolution;
     locus = other.locus;
 

--- a/gcc/rust/expand/rust-derive-clone.cc
+++ b/gcc/rust/expand/rust-derive-clone.cc
@@ -89,17 +89,17 @@ DeriveClone::clone_impl (
   std::unique_ptr<AssociatedItem> &&clone_fn, std::string name,
   const std::vector<std::unique_ptr<GenericParam>> &type_generics)
 {
-  // we should have two of these, so we don't run into issues with
-  // two paths sharing a node id
-  auto clone_bound = builder.type_path (LangItem::Kind::CLONE);
-  auto clone_trait_path = builder.type_path (LangItem::Kind::CLONE);
+  auto clone_trait_path
+    = [this] () { return builder.type_path (LangItem::Kind::CLONE); };
 
   auto trait_items = vec (std::move (clone_fn));
 
-  auto generics = setup_impl_generics (name, type_generics,
-				       builder.trait_bound (clone_bound));
+  auto generics = setup_impl_generics (name, type_generics, [&, this] () {
+    return builder.trait_bound (clone_trait_path ());
+  });
 
-  return builder.trait_impl (clone_trait_path, std::move (generics.self_type),
+  return builder.trait_impl (clone_trait_path (),
+			     std::move (generics.self_type),
 			     std::move (trait_items),
 			     std::move (generics.impl));
 }

--- a/gcc/rust/expand/rust-derive-copy.cc
+++ b/gcc/rust/expand/rust-derive-copy.cc
@@ -42,15 +42,14 @@ DeriveCopy::copy_impl (
   std::string name,
   const std::vector<std::unique_ptr<GenericParam>> &type_generics)
 {
-  // we should have two of these, so we don't run into issues with
-  // two paths sharing a node id
-  auto copy_bound = builder.type_path (LangItem::Kind::COPY);
-  auto copy_trait_path = builder.type_path (LangItem::Kind::COPY);
+  auto copy_trait_path
+    = [this] () { return builder.type_path (LangItem::Kind::COPY); };
 
-  auto generics = setup_impl_generics (name, type_generics,
-				       builder.trait_bound (copy_bound));
+  auto generics = setup_impl_generics (name, type_generics, [&, this] () {
+    return builder.trait_bound (copy_trait_path ());
+  });
 
-  return builder.trait_impl (copy_trait_path, std::move (generics.self_type),
+  return builder.trait_impl (copy_trait_path (), std::move (generics.self_type),
 			     {}, std::move (generics.impl));
 }
 

--- a/gcc/rust/expand/rust-derive-debug.cc
+++ b/gcc/rust/expand/rust-derive-debug.cc
@@ -81,11 +81,14 @@ DeriveDebug::stub_derive_impl (
 {
   auto trait_items = vec (stub_debug_fn ());
 
-  auto debug = builder.type_path ({"core", "fmt", "Debug"}, true);
-  auto generics
-    = setup_impl_generics (name, type_generics, builder.trait_bound (debug));
+  auto debug = [this] () {
+    return builder.type_path ({"core", "fmt", "Debug"}, true);
+  };
+  auto generics = setup_impl_generics (name, type_generics, [&, this] () {
+    return builder.trait_bound (debug ());
+  });
 
-  return builder.trait_impl (debug, std::move (generics.self_type),
+  return builder.trait_impl (debug (), std::move (generics.self_type),
 			     std::move (trait_items),
 			     std::move (generics.impl));
 }

--- a/gcc/rust/expand/rust-derive-default.cc
+++ b/gcc/rust/expand/rust-derive-default.cc
@@ -69,14 +69,17 @@ DeriveDefault::default_impl (
   std::unique_ptr<AssociatedItem> &&default_fn, std::string name,
   const std::vector<std::unique_ptr<GenericParam>> &type_generics)
 {
-  auto default_path = builder.type_path ({"core", "default", "Default"}, true);
+  auto default_path = [this] () {
+    return builder.type_path ({"core", "default", "Default"}, true);
+  };
 
   auto trait_items = vec (std::move (default_fn));
 
-  auto generics = setup_impl_generics (name, type_generics,
-				       builder.trait_bound (default_path));
+  auto generics = setup_impl_generics (name, type_generics, [&, this] () {
+    return builder.trait_bound (default_path ());
+  });
 
-  return builder.trait_impl (default_path, std::move (generics.self_type),
+  return builder.trait_impl (default_path (), std::move (generics.self_type),
 			     std::move (trait_items),
 			     std::move (generics.impl));
 }

--- a/gcc/rust/expand/rust-derive-eq.cc
+++ b/gcc/rust/expand/rust-derive-eq.cc
@@ -118,19 +118,17 @@ DeriveEq::eq_impls (
   std::unique_ptr<AssociatedItem> &&fn, std::string name,
   const std::vector<std::unique_ptr<GenericParam>> &type_generics)
 {
-  // We create two copies of the type-path to avoid duplicate NodeIds
-  auto eq = get_eq_trait_path (builder);
-  auto eq_bound = builder.trait_bound (get_eq_trait_path (builder));
+  auto eq = [this] () { return get_eq_trait_path (builder); };
+  auto eq_bound = [&, this] () { return builder.trait_bound (eq ()); };
 
   auto steq = builder.type_path (LangItem::Kind::STRUCTURAL_TEQ);
 
   auto trait_items = vec (std::move (fn));
 
-  auto eq_generics
-    = setup_impl_generics (name, type_generics, std::move (eq_bound));
+  auto eq_generics = setup_impl_generics (name, type_generics, eq_bound);
   auto steq_generics = setup_impl_generics (name, type_generics);
 
-  auto eq_impl = builder.trait_impl (eq, std::move (eq_generics.self_type),
+  auto eq_impl = builder.trait_impl (eq (), std::move (eq_generics.self_type),
 				     std::move (trait_items),
 				     std::move (eq_generics.impl));
 

--- a/gcc/rust/expand/rust-derive-hash.cc
+++ b/gcc/rust/expand/rust-derive-hash.cc
@@ -77,14 +77,17 @@ DeriveHash::hash_impl (
   std::unique_ptr<AssociatedItem> &&hash_fn, std::string name,
   const std::vector<std::unique_ptr<GenericParam>> &type_generics)
 {
-  auto hash_path = builder.type_path ({"core", "hash", "Hash"}, true);
+  auto hash_path = [this] () {
+    return builder.type_path ({"core", "hash", "Hash"}, true);
+  };
 
   auto trait_items = vec (std::move (hash_fn));
 
-  auto generics = setup_impl_generics (name, type_generics,
-				       builder.trait_bound (hash_path));
+  auto generics = setup_impl_generics (name, type_generics, [&, this] () {
+    return builder.trait_bound (hash_path ());
+  });
 
-  return builder.trait_impl (hash_path, std::move (generics.self_type),
+  return builder.trait_impl (hash_path (), std::move (generics.self_type),
 			     std::move (trait_items),
 			     std::move (generics.impl));
 }

--- a/gcc/rust/expand/rust-derive-ord.cc
+++ b/gcc/rust/expand/rust-derive-ord.cc
@@ -58,18 +58,19 @@ DeriveOrd::cmp_impl (
   auto fn = cmp_fn (std::move (fn_block), type_name);
 
   auto trait = ordering == Ordering::Partial ? "PartialOrd" : "Ord";
-  auto trait_path = builder.type_path ({"core", "cmp", trait}, true);
+  auto trait_path = [&, this] () {
+    return builder.type_path ({"core", "cmp", trait}, true);
+  };
 
   auto trait_bound
-    = builder.trait_bound (builder.type_path ({"core", "cmp", trait}, true));
+    = [&, this] () { return builder.trait_bound (trait_path ()); };
 
   auto trait_items = vec (std::move (fn));
 
   auto cmp_generics
-    = setup_impl_generics (type_name.as_string (), type_generics,
-			   std::move (trait_bound));
+    = setup_impl_generics (type_name.as_string (), type_generics, trait_bound);
 
-  return builder.trait_impl (trait_path, std::move (cmp_generics.self_type),
+  return builder.trait_impl (trait_path (), std::move (cmp_generics.self_type),
 			     std::move (trait_items),
 			     std::move (cmp_generics.impl));
 }

--- a/gcc/rust/expand/rust-derive-partial-eq.cc
+++ b/gcc/rust/expand/rust-derive-partial-eq.cc
@@ -42,17 +42,18 @@ DerivePartialEq::partialeq_impls (
   std::unique_ptr<AssociatedItem> &&eq_fn, std::string name,
   const std::vector<std::unique_ptr<GenericParam>> &type_generics)
 {
-  auto eq = builder.type_path (LangItem::Kind::EQ);
+  auto eq = [this] () { return builder.type_path (LangItem::Kind::EQ); };
   auto speq = builder.type_path (LangItem::Kind::STRUCTURAL_PEQ);
 
   auto trait_items = vec (std::move (eq_fn));
 
   // no extra bound on StructuralPeq
-  auto peq_generics
-    = setup_impl_generics (name, type_generics, builder.trait_bound (eq));
+  auto peq_generics = setup_impl_generics (name, type_generics, [&, this] () {
+    return builder.trait_bound (eq ());
+  });
   auto speq_generics = setup_impl_generics (name, type_generics);
 
-  auto peq = builder.trait_impl (eq, std::move (peq_generics.self_type),
+  auto peq = builder.trait_impl (eq (), std::move (peq_generics.self_type),
 				 std::move (trait_items),
 				 std::move (peq_generics.impl));
 

--- a/gcc/rust/expand/rust-derive.cc
+++ b/gcc/rust/expand/rust-derive.cc
@@ -83,7 +83,8 @@ DeriveVisitor::ImplGenerics
 DeriveVisitor::setup_impl_generics (
   const std::string &type_name,
   const std::vector<std::unique_ptr<GenericParam>> &type_generics,
-  tl::optional<std::unique_ptr<TypeParamBound>> &&extra_bound) const
+  tl::optional<std::function<std::unique_ptr<TypeParamBound> ()>> &&extra_bound)
+  const
 {
   std::vector<Lifetime> lifetime_args;
   std::vector<GenericArg> generic_args;
@@ -119,8 +120,7 @@ DeriveVisitor::setup_impl_generics (
 	    std::vector<std::unique_ptr<TypeParamBound>> extra_bounds;
 
 	    if (extra_bound)
-	      extra_bounds.emplace_back (
-		extra_bound.value ()->clone_type_param_bound ());
+	      extra_bounds.emplace_back (extra_bound.value () ());
 
 	    auto impl_type_param
 	      = builder.new_type_param (type_param, std::move (extra_bounds));

--- a/gcc/rust/expand/rust-derive.h
+++ b/gcc/rust/expand/rust-derive.h
@@ -67,7 +67,8 @@ protected:
   ImplGenerics setup_impl_generics (
     const std::string &type_name,
     const std::vector<std::unique_ptr<GenericParam>> &type_generics,
-    tl::optional<std::unique_ptr<TypeParamBound>> &&extra_bound
+    tl::optional<std::function<std::unique_ptr<TypeParamBound> ()>>
+      &&extra_bound
     = tl::nullopt) const;
 
 private:


### PR DESCRIPTION
Also removes some redundant copies and improves TypePath copying.

This should prevent the compiler from ICE-ing before it hits the lowering phase.