### PR TITLE
gccrs: avoid ICE when canonical path record is missing

### DIFF
--- a/gcc/rust/resolve/rust-name-resolution-context.cc
+++ b/gcc/rust/resolve/rust-name-resolution-context.cc
@@ -184,6 +184,15 @@ CanonicalPathRecordTraitImpl::as_path (const NameResolutionContext &ctx)
       impl_id, trait_path_record.as_path (ctx), type_record.as_path (ctx)));
 }
 
+Resolver::CanonicalPath
+CanonicalPathCtx::get_path (NodeId id) const
+{
+  if (auto rec = get_record_opt (id))
+    return (*rec)->as_path (*nr_ctx);
+
+  return Resolver::CanonicalPath::create_empty ();
+}
+
 NameResolutionContext::NameResolutionContext ()
   : mappings (Analysis::Mappings::get ()), canonical_ctx (*this)
 {}

--- a/gcc/rust/resolve/rust-name-resolution-context.h
+++ b/gcc/rust/resolve/rust-name-resolution-context.h
@@ -359,10 +359,7 @@ public:
     : current_record (nullptr), nr_ctx (&ctx)
   {}
 
-  Resolver::CanonicalPath get_path (NodeId id) const
-  {
-    return get_record (id).as_path (*nr_ctx);
-  }
+  Resolver::CanonicalPath get_path (NodeId id) const;
 
   CanonicalPathRecord &get_record (NodeId id) const
   {
@@ -378,6 +375,14 @@ public:
       return tl::nullopt;
     else
       return it->second.get ();
+  }
+
+  tl::optional<Resolver::CanonicalPath> get_path_opt (NodeId id) const
+  {
+    auto rec = get_record_opt (id);
+    if (!rec)
+      return tl::nullopt;
+    return (*rec)->as_path (*nr_ctx);
   }
 
   void insert_record (NodeId id, const Identifier &ident)

--- a/gcc/testsuite/rust/compile/issue-4143.rs
+++ b/gcc/testsuite/rust/compile/issue-4143.rs
@@ -1,0 +1,19 @@
+// { dg-do compile }
+// { dg-options "-frust-incomplete-and-experimental-compiler-do-not-use" }
+// { dg-prune-output "failed to locate crate" }
+// { dg-prune-output "unknown crate" }
+
+// ICE regression test for canonical path lookup
+// Inline items inside const generic block expressions
+// must not require canonical paths.
+
+struct Expr<const N: u32>;
+
+trait Trait0 {
+    fn required(_: Expr<{
+        struct Type;
+        0
+    }>);
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #4143 

This fixes an Internal Compiler Error (ICE) in canonical path resolution triggered by const-generic expressions containing inline item definitions (e.g. structs inside const blocks).

Previously, CanonicalPathCtx::get_record unconditionally asserted that a canonical path record exists for a NodeId. However, not all AST nodes (e.g. inline items in const expressions) are guaranteed to have canonical paths, leading to an ICE.

Introduce optional canonical path lookup and update callers to handle the absence of a canonical path explicitly, avoiding the assertion failure.

gcc/rust/ChangeLog:

	* resolve/rust-name-resolution-context.h (CanonicalPathCtx::get_path_opt): New helper returning an optional canonical path.
	* resolve/rust-name-resolution-context.cc: Use optional canonical path lookup instead of asserting on missing records.
	* testsuite/rust/compile/issue-4143.rs: New regression test.
