### PR TITLE
ci: fix send email workflow in case of large commit log

### DIFF
--- a/.github/workflows/send-emails.yml
+++ b/.github/workflows/send-emails.yml
@@ -41,7 +41,9 @@ jobs:
         env:
           GH_EVENT: ${{ toJson(github.event) }}
         run: |
-          echo "$GH_EVENT" > /tmp/gh_event.json
+          # GH_EVENT can be very big as it contains the full commit log and
+          # overflow the shell's maximum length.
+          echo '$GH_EVENT' | envsubst '$GH_EVENT' > /tmp/gh_event.json
 
           BEFORE_REF=$(jq -r '.before' /tmp/gh_event.json)
           echo "BEFORE_REF=$BEFORE_REF" >> $GITHUB_ENV


### PR DESCRIPTION
We've had at least one case of mails not being sent because the commit log was so big that the $GH_EVENT var couldn't be expanded by the shell. Using envsubst avoids having the shell do the expansion.