### PR TITLE
parser: Fix segfault in parse_arithmetic_or_logical_expr 

### DIFF
--- a/gcc/rust/parse/rust-parse-impl-expr.hxx
+++ b/gcc/rust/parse/rust-parse-impl-expr.hxx
@@ -1794,7 +1794,9 @@ Parser<ManagedTokenSource>::parse_expr (int right_binding_power,
     = null_denotation ({}, null_denotation_restrictions);
   if (!expr)
     return tl::unexpected<Parse::Error::Expr> (Parse::Error::Expr::CHILD_ERROR);
-
+  if (expr.value () == nullptr)
+    return tl::unexpected<Parse::Error::Expr> (Parse::Error::Expr::CHILD_ERROR);
+  
   return left_denotations (std::move (expr), right_binding_power,
 			   std::move (outer_attrs), restrictions);
 }

--- a/gcc/testsuite/rust/compile/issue-4414.rs
+++ b/gcc/testsuite/rust/compile/issue-4414.rs
@@ -1,0 +1,30 @@
+#![feature(no_core)]
+#![no_core]
+
+trait Speak : Sized {
+    fn say(&self, s:&str) -> String;
+    fn hi(&self) -> String { hello(self) }
+}
+
+fn hello<S:Speak>(s:&S) -> String{
+    s.say("hello")
+}
+
+impl Speak for assert_eq!(Some(3).hi(), "something!hello: 3".to_string()) { 
+    fn say(&self, s:&str) -> String {
+        format!("{}: {}", s, *self)
+    }
+}
+
+impl<T: Speak> Speak for Option<T> {
+    fn say(&self, s:&str) -> String {
+        match something!hello - none { // { dg-error "unexpected token 'identifier'|failed to parse scrutinee" }
+            None => format!("{} - none", s),
+            Some(ref x) => { format!("something!{}", x.say(s)) }
+        }
+    } 
+} // { dg-error "could not parse definition" }
+
+fn hello<S:Speak>(s:&S) -> String{ // { dg-error "failed to parse trait impl item" }
+    s.say("hello")
+}


### PR DESCRIPTION
The compiler previously crashed with a segmentation fault when parsing an arithmetic expression where the left-hand side was invalid (e.g., after a failed macro expansion). This occurred because the parser attempted to access the location of the null 'left' pointer. This patch adds a check to ensure the left operand is valid before proceeding.

Fixes Rust-GCC/gccrs#4414

gcc/rust/ChangeLog:

	* parse/rust-parse-impl-expr.hxx (parse_arithmetic_or_logical_expr): Check for null left operand to prevent segmentation fault.

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4414.rs: New test.

Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[ ] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[ ] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[ ] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---

*Please write a comment explaining your change. This is the message
that will be part of the merge commit.
