### PR TITLE
util/attributes: Fix ICE on bare #[deprecated] attribute

### DIFF
--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -298,6 +298,9 @@ check_doc_attribute (const AST::Attribute &attribute)
 static void
 check_deprecated_attribute (const AST::Attribute &attribute)
 {
+  if (!attribute.has_attr_input ())
+    return;
+
   const auto &input = attribute.get_attr_input ();
 
   if (input.get_attr_input_type () != AST::AttrInput::META_ITEM)

--- a/gcc/testsuite/rust/compile/issue-4410.rs
+++ b/gcc/testsuite/rust/compile/issue-4410.rs
@@ -1,0 +1,11 @@
+// { dg-options "-frust-incomplete-and-experimental-compiler-do-not-use -w" }
+#![feature(no_core)]
+#![no_core]
+
+// The bug was that a bare #[deprecated] (with no arguments) caused a Segfault.
+// This test ensures it compiles without crashing.
+
+#[deprecated]
+pub mod a {}
+
+fn main() {}


### PR DESCRIPTION
The check_deprecated_attribute function previously assumed that the attribute always contained an input (arguments). However, #[deprecated] is valid without arguments. Accessing the input on a bare #[deprecated] attribute resulted in a null pointer dereference and a segmentation fault.

This patch adds a guard clause to check if the attribute has input before attempting to access it, preventing the crash.

Fixes #4410

gcc/rust/ChangeLog:

	* util/rust-attributes.cc (check_deprecated_attribute): Guard against attributes without input.

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4410.rs: New test.
