### PR TITLE
parser: Fix ICE in AnonConst when expression parsing fails

### DIFF
--- a/gcc/rust/parse/rust-parse-impl-expr.hxx
+++ b/gcc/rust/parse/rust-parse-impl-expr.hxx
@@ -1957,9 +1957,15 @@ Parser<ManagedTokenSource>::null_denotation_path (
   switch (t->get_id ())
     {
     case EXCLAM:
-      // macro
-      return parse_macro_invocation_partial (std::move (path),
-					     std::move (outer_attrs));
+      {
+	// macro
+	auto macro = parse_macro_invocation_partial (std::move (path),
+						     std::move (outer_attrs));
+	if (macro == nullptr)
+	  return tl::unexpected<Parse::Error::Expr> (
+	    Parse::Error::Expr::CHILD_ERROR);
+	return std::unique_ptr<AST::Expr> (std::move (macro));
+      }
     case LEFT_CURLY:
       {
 	bool not_a_block = lexer.peek_token (1)->get_id () == IDENTIFIER

--- a/gcc/testsuite/rust/compile/issue-4412.rs
+++ b/gcc/testsuite/rust/compile/issue-4412.rs
@@ -1,0 +1,9 @@
+// { dg-options "-frust-incomplete-and-experimental-compiler-do-not-use" }
+#![feature(no_core)]
+#![no_core]
+struct Bug([u8; panic!"\t"]);
+// { dg-error "unexpected token" "" { target *-*-* } .-1 }
+// { dg-error "failed to parse" "" { target *-*-* } .-2 }
+// { dg-error "could not parse" "" { target *-*-* } .-3 }
+// { dg-error "expecting" "" { target *-*-* } .-4 }
+fn main() {}


### PR DESCRIPTION
The parse_anon_const function calls parse_expr to parse the expression inside an anonymous constant (e.g., array length [T; N]). Previously, it only checked if the Result object indicated success, but did not check if the contained expression pointer was null.

In cases like malformed macro invocations, parse_expr can return a success Result containing a nullptr. Passing this nullptr to the AnonConst constructor triggered an assertion failure (ICE).

This patch adds a check to ensure the parsed expression is not null before constructing the AnonConst object.

Fixes #4412

gcc/rust/ChangeLog:

	* parse/rust-parse-impl-expr.hxx (parse_anon_const): Check for null expression.

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4412.rs: New test.