### PR TITLE
resolve: Fix ICE on ambiguous glob re-exports

### DIFF
--- a/gcc/rust/resolve/rust-early-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver-2.0.cc
@@ -454,8 +454,12 @@ Early::finalize_rebind_import (const Early::ImportPair &mapping)
     }
 
   for (auto &&definition : data.definitions ())
-    toplevel.insert_or_error_out (
-      declared_name, locus, definition.first.get_node_id (), definition.second /* TODO: This isn't clear - it would be better if it was called .ns or something */);
+    {
+      if (definition.first.is_ambiguous ())
+	continue;
+      toplevel.insert_or_error_out (
+	declared_name, locus, definition.first.get_node_id (), definition.second /* TODO: This isn't clear - it would be better if it was called .ns or something */);
+    }
 }
 
 void

--- a/gcc/testsuite/rust/compile/issue-4411.rs
+++ b/gcc/testsuite/rust/compile/issue-4411.rs
@@ -1,0 +1,23 @@
+#![feature(no_core)]
+#![no_core]
+mod framing {
+    mod public_message {
+        use super::super::*;
+
+        #[derive(Debug)]
+        pub struct ConfirmedTranscriptHashInput;
+    }
+
+    mod public_message_in {
+        use super::*;
+
+        #[derive(Debug)]
+        pub struct ConfirmedTranscriptHashInput;
+    }
+
+    pub use self::public_message::*;
+    pub use self::public_message_in::*;
+}
+
+use crate::framing::ConfirmedTranscriptHashInput;
+fn main() { }


### PR DESCRIPTION
When processing glob imports in early name resolution, we were attempting to retrieve the NodeId of ambiguous definitions, which caused an assertion failure (ICE).

This patch adds a check for `is_ambiguous()` in `finalize_rebind_import` to skip these invalid definitions, preventing the crash while still allowing proper ambiguity errors to be reported later.

Fixes #4411

gcc/rust/ChangeLog:

	* resolve/rust-early-name-resolver-2.0.cc (Early::finalize_rebind_import): Check for ambiguity before accessing definition NodeId.

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4411.rs: New test.

Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[ ] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[ ] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[ ] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---

*Please write a comment explaining your change. This is the message
that will be part of the merge commit.
