### PR TITLE
Remove PR122498 "rust-enabled bootstrap is broken after r16-4897" workaround [PR122498]

### DIFF
--- a/gcc/rust/ast/rust-fmt.h
+++ b/gcc/rust/ast/rust-fmt.h
@@ -22,9 +22,6 @@
 #include "rust-system.h"
 #include "optional.h"
 
-// PR122498 "rust-enabled bootstrap is broken after r16-4897"
-#pragma GCC diagnostic warning "-Warray-bounds"
-
 namespace Rust {
 namespace Fmt {
 


### PR DESCRIPTION
Per my testing, commit r16-6191-gb4e3c262f982dd45665ae4b6b7b564d0db5fa958 "gccrs: Add dump option to show node" has the side effect to alter the C++ IR so that the original problem is no longer exposed.  Therefore, remove the workaround, so that we don't inhibit any actual issues to diagnose.  That is, revert commit r16-5202-g0fb3b3ace66c05e64c39e73be3907f8edd3efa55 "gccrs: Fmt: Simplify pragma diagnostic setup", and commit r16-5198-g8af0e3dff44e931e81fa0e3777bffec06ebd8e26 "gccrs: fmt: Skip warnings in Fmt class due to unused devirt method [PR122498]".

(Interestingly, the PR122197 commit r16-7106-g74e0bb3faacfccfdf5633ab7ad3a15549d4a954d "libstdc++: Disable false positive middle end warnings in std::shared_ptr [PR122197]" workaround would *not* cure the issue in the GCC/Rust front end C++ code.)

	PR rust/122498
	gcc/rust/
	* ast/rust-fmt.h: Remove PR122498 "rust-enabled bootstrap is broken after r16-4897" workaround.
