### PR TITLE
parser: Fix rogue null pointer in null_denotation_path

### DIFF
--- a/gcc/rust/parse/rust-parse-impl-expr.hxx
+++ b/gcc/rust/parse/rust-parse-impl-expr.hxx
@@ -1999,20 +1999,36 @@ Parser<ManagedTokenSource>::null_denotation_path (
 	    return std::unique_ptr<AST::PathInExpression> (
 	      new AST::PathInExpression (std::move (path)));
 	  }
-	return parse_struct_expr_struct_partial (std::move (path),
-						 std::move (outer_attrs));
+	auto struct_expr
+	  = parse_struct_expr_struct_partial (std::move (path),
+					      std::move (outer_attrs));
+	if (struct_expr == nullptr)
+	  {
+	    return tl::unexpected<Parse::Error::Expr> (
+	      Parse::Error::Expr::CHILD_ERROR);
+	  }
+	return struct_expr;
       }
     case LEFT_PAREN:
-      // struct/enum expr tuple
-      if (!restrictions.can_be_struct_expr)
-	{
-	  // assume path is returned
-	  // HACK: add outer attributes to path
-	  path.set_outer_attrs (std::move (outer_attrs));
-	  return std::make_unique<AST::PathInExpression> (std::move (path));
-	}
-      return parse_struct_expr_tuple_partial (std::move (path),
-					      std::move (outer_attrs));
+      {
+	// struct/enum expr tuple
+	if (!restrictions.can_be_struct_expr)
+	  {
+	    // assume path is returned
+	    // HACK: add outer attributes to path
+	    path.set_outer_attrs (std::move (outer_attrs));
+	    return std::make_unique<AST::PathInExpression> (std::move (path));
+	  }
+	auto tuple_expr
+	  = parse_struct_expr_tuple_partial (std::move (path),
+					     std::move (outer_attrs));
+	if (tuple_expr == nullptr)
+	  {
+	    return tl::unexpected<Parse::Error::Expr> (
+	      Parse::Error::Expr::CHILD_ERROR);
+	  }
+	return tuple_expr;
+      }
     default:
       // assume path is returned if not single segment
       if (path.is_single_segment ())


### PR DESCRIPTION
The compiler previously crashed with a segmentation fault when parsing a struct or tuple expression that failed to parse correctly (e.g., returning nullptr). This occurred because the parser implicitly wrapped the null pointer result in a successful tl::expected, causing a crash later when the compiler attempted to use the invalid pointer. This patch adds checks in null_denotation_path to ensure that failed struct and tuple parsing results are returned as errors (tl::unexpected) instead of null pointers.

Fixes Rust-GCC/gccrs#4426

gcc/rust/ChangeLog:

	* parse/rust-parse-impl-expr.hxx (null_denotation_path): Check for null struct and tuple expressions to prevent segmentation fault. (parse_arithmetic_or_logical_expr): Remove redundant null check.

Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[ ] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[ ] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[ ] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---

*Please write a comment explaining your change. This is the message
that will be part of the merge commit.
