### PR TITLE
gccrs : TypeCheck : Fix ICE on invalid trait impl during method resol…

### DIFF
--- a/gcc/rust/typecheck/rust-hir-dot-operator.cc
+++ b/gcc/rust/typecheck/rust-hir-dot-operator.cc
@@ -268,7 +268,8 @@ MethodResolver::assemble_trait_impl_candidates (
       }
 
     TraitReference *trait_ref = TraitResolver::Resolve (impl->get_trait_ref ());
-    rust_assert (!trait_ref->is_error ());
+    if (trait_ref->is_error ())
+      return true;
 
     auto item_ref
       = trait_ref->lookup_trait_item (segment_name.to_string (),

--- a/gcc/testsuite/rust/compile/issue-3937.rs
+++ b/gcc/testsuite/rust/compile/issue-3937.rs
@@ -1,0 +1,15 @@
+#![deny(dead_code)]
+#![feature(no_core)]
+#![no_core]
+
+enum Foo {
+    Bar,
+}
+fn main() {
+    let p = [0; 0];
+    p.bar(); // { dg-error "no method named .bar. found in the current scope" }
+}
+
+trait Bar {}
+
+impl Foo for [u32; Foo::Bar as usize] {} // { dg-error "Expected a trait found .Foo." }


### PR DESCRIPTION


This patch fixes an internal compiler error (ICE) that occurred when resolving methods on an impl block for a non-trait type (example: an enum). The compiler now checks if the trait reference is an error before proceeding, preventing a crash.

Fixes Rust-GCC/gccrs#3937

gcc/rust/ChangeLog:

	* typecheck/rust-hir-dot-operator.cc (assemble_trait_impl_candidates): Check for error state in TraitReference to avoid ICE.

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3937.rs: New test.

Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[ ] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[ ] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[ ] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---

*Please write a comment explaining your change. This is the message
that will be part of the merge commit.
