### PR TITLE
ast: Fix missing location info in derive macros

### DIFF
--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -302,8 +302,9 @@ Attribute::get_traits_to_derive ()
 			auto word = static_cast<AST::MetaWord *> (meta_item);
 			// Convert current word to path
 			current = std::make_unique<AST::MetaItemPath> (
-			  AST::MetaItemPath (
-			    AST::SimplePath (word->get_ident ())));
+			  AST::MetaItemPath (AST::SimplePath::from_str (
+			    word->get_ident ().as_string (),
+			    word->get_locus ())));
 			auto path
 			  = static_cast<AST::MetaItemPath *> (current.get ());
 

--- a/gcc/testsuite/rust/compile/issue-4433.rs
+++ b/gcc/testsuite/rust/compile/issue-4433.rs
@@ -1,0 +1,19 @@
+// { dg-options "-frust-incomplete-and-experimental-compiler-do-not-use" }
+#![feature(no_core)]
+#![no_core]
+
+#[derive(Toto)] // { dg-error "macro not found" }
+// { dg-error "could not resolve trait" "" { target *-*-* } .-1 }
+struct Test {}
+
+#[derive(
+    Happy,   // { dg-error "macro not found" }
+    // { dg-error "could not resolve trait" "" { target *-*-* } .-1 }
+    Birthday // { dg-error "macro not found" }
+    // { dg-error "could not resolve trait" "" { target *-*-* } .-1 }
+)]
+struct MultiLine {}
+
+#[derive(One, Two)] // { dg-error "macro not found" }
+// { dg-error "could not resolve trait" "" { target *-*-* } .-1 }
+struct SingleLine {}


### PR DESCRIPTION
Fixes Rust-GCC#4433

gcc/rust/ChangeLog:

	* ast/rust-ast.cc (Attribute::get_traits_to_derive): Propagate location info from MetaWord to SimplePath.

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4433.rs: Update test to expect valid line numbers.
