### PR TITLE
Fix segfault when processing types with unresolved lifetimes in generic arguments

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-path.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-path.cc
@@ -144,12 +144,17 @@ TypeCheckExpr::visit (HIR::QualifiedPathInExpression &expr)
 	  infered = new TyTy::ErrorType (expr.get_mappings ().get_hirid ());
 	  return;
 	}
-      std::vector<TyTy::Region> regions;
+      auto regions
+	= context->regions_from_generic_args (item_seg.get_generic_args ());
+      if (!regions.has_value ())
+	{
+	  infered = new TyTy::ErrorType (expr.get_mappings ().get_hirid ());
+	  return;
+	}
 
       infered = SubstMapper::Resolve (infered, expr.get_locus (),
 				      &item_seg.get_generic_args (),
-				      context->regions_from_generic_args (
-					item_seg.get_generic_args ()));
+				      regions.value ());
     }
 
   // continue on as a path-in-expression
@@ -365,10 +370,14 @@ TypeCheckExpr::resolve_root_path (HIR::PathInExpression &expr, size_t *offset,
       // turbo-fish segment path::<ty>
       if (seg.has_generic_args ())
 	{
-	  lookup = SubstMapper::Resolve (lookup, expr.get_locus (),
-					 &seg.get_generic_args (),
-					 context->regions_from_generic_args (
-					   seg.get_generic_args ()));
+	  auto regions
+	    = context->regions_from_generic_args (seg.get_generic_args ());
+	  if (!regions.has_value ())
+	    return new TyTy::ErrorType (expr.get_mappings ().get_hirid ());
+
+	  lookup
+	    = SubstMapper::Resolve (lookup, expr.get_locus (),
+				    &seg.get_generic_args (), regions.value ());
 	  if (lookup->get_kind () == TyTy::TypeKind::ERROR)
 	    return new TyTy::ErrorType (expr.get_mappings ().get_hirid ());
 	}
@@ -500,10 +509,14 @@ TypeCheckExpr::resolve_segments (NodeId root_resolved_node_id,
 	{
 	  rust_debug_loc (seg.get_locus (), "applying segment generics: %s",
 			  tyseg->as_string ().c_str ());
+	  auto regions
+	    = context->regions_from_generic_args (seg.get_generic_args ());
+	  if (!regions.has_value ())
+	    return;
+
 	  tyseg
 	    = SubstMapper::Resolve (tyseg, expr_locus, &seg.get_generic_args (),
-				    context->regions_from_generic_args (
-				      seg.get_generic_args ()));
+				    regions.value ());
 	  if (tyseg->get_kind () == TyTy::TypeKind::ERROR)
 	    return;
 	}

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -756,6 +756,12 @@ void
 TypeCheckType::visit (HIR::ReferenceType &type)
 {
   TyTy::BaseType *base = TypeCheckType::Resolve (type.get_base_type ());
+  if (base->is<TyTy::ErrorType> ())
+    {
+      translated = new TyTy::ErrorType (type.get_mappings ().get_hirid ());
+      return;
+    }
+
   rust_assert (type.has_lifetime ());
   auto region = context->lookup_and_resolve_lifetime (type.get_lifetime ());
   if (!region.has_value ())

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -266,11 +266,18 @@ TypeCheckType::visit (HIR::QualifiedPathInType &path)
 		= new TyTy::ErrorType (path.get_mappings ().get_hirid ());
 	      return;
 	    }
-	  translated
-	    = SubstMapper::Resolve (translated, path.get_locus (),
-				    &generic_seg.get_generic_args (),
-				    context->regions_from_generic_args (
-				      generic_seg.get_generic_args ()));
+	  auto regions = context->regions_from_generic_args (
+	    generic_seg.get_generic_args ());
+	  if (!regions.has_value ())
+	    {
+	      translated
+		= new TyTy::ErrorType (path.get_mappings ().get_hirid ());
+	      return;
+	    }
+
+	  translated = SubstMapper::Resolve (translated, path.get_locus (),
+					     &generic_seg.get_generic_args (),
+					     regions.value ());
 
 	  // unwrap the sweets
 	  if (auto *proj = translated->try_as<TyTy::ProjectionType> ())
@@ -435,9 +442,12 @@ TypeCheckType::resolve_root_path (HIR::TypePath &path, size_t *offset,
 
 	  auto regions = context->regions_from_generic_args (
 	    generic_segment.get_generic_args ());
+	  if (!regions.has_value ())
+	    return new TyTy::ErrorType (seg->get_mappings ().get_hirid ());
+
 	  lookup = SubstMapper::Resolve (lookup, path.get_locus (),
 					 &generic_segment.get_generic_args (),
-					 regions);
+					 regions.value ());
 	  if (lookup->get_kind () == TyTy::TypeKind::ERROR)
 	    return new TyTy::ErrorType (seg->get_mappings ().get_hirid ());
 	}
@@ -445,9 +455,9 @@ TypeCheckType::resolve_root_path (HIR::TypePath &path, size_t *offset,
 	{
 	  HIR::GenericArgs empty
 	    = HIR::GenericArgs::create_empty (path.get_locus ());
-	  lookup
-	    = SubstMapper::Resolve (lookup, path.get_locus (), &empty,
-				    context->regions_from_generic_args (empty));
+	  lookup = SubstMapper::Resolve (
+	    lookup, path.get_locus (), &empty,
+	    context->regions_from_generic_args (empty).value ());
 	}
 
       *offset = *offset + 1;

--- a/gcc/rust/typecheck/rust-hir-type-check.h
+++ b/gcc/rust/typecheck/rust-hir-type-check.h
@@ -314,7 +314,7 @@ public:
 
   void intern_and_insert_lifetime (const HIR::Lifetime &lifetime);
 
-  WARN_UNUSED_RESULT std::vector<TyTy::Region>
+  WARN_UNUSED_RESULT tl::optional<std::vector<TyTy::Region>>
   regions_from_generic_args (const HIR::GenericArgs &args) const;
 
   void compute_inference_variables (bool emit_error);

--- a/gcc/rust/typecheck/rust-typecheck-context.cc
+++ b/gcc/rust/typecheck/rust-typecheck-context.cc
@@ -666,7 +666,7 @@ TypeCheckContext::intern_and_insert_lifetime (const HIR::Lifetime &lifetime)
   get_lifetime_resolver ().insert_mapping (intern_lifetime (lifetime));
 }
 
-WARN_UNUSED_RESULT std::vector<TyTy::Region>
+WARN_UNUSED_RESULT tl::optional<std::vector<TyTy::Region>>
 TypeCheckContext::regions_from_generic_args (const HIR::GenericArgs &args) const
 {
   std::vector<TyTy::Region> regions;
@@ -676,7 +676,7 @@ TypeCheckContext::regions_from_generic_args (const HIR::GenericArgs &args) const
       if (!resolved)
 	{
 	  rust_error_at (lifetime.get_locus (), "unresolved lifetime");
-	  return {};
+	  return tl::nullopt;
 	}
       regions.push_back (*resolved);
     }

--- a/gcc/rust/typecheck/rust-tyty-bounds.cc
+++ b/gcc/rust/typecheck/rust-tyty-bounds.cc
@@ -568,10 +568,14 @@ TypeBoundPredicate::apply_generic_arguments (HIR::GenericArgs *generic_args,
     }
 
   // now actually perform a substitution
-  auto args = get_mappings_from_generic_args (
-    *generic_args,
-    Resolver::TypeCheckContext::get ()->regions_from_generic_args (
-      *generic_args));
+  auto regions = Resolver::TypeCheckContext::get ()->regions_from_generic_args (
+    *generic_args);
+  if (!regions.has_value ())
+    {
+      error_flag = true;
+      return;
+    }
+  auto args = get_mappings_from_generic_args (*generic_args, regions.value ());
 
   apply_argument_mappings (args, is_super_trait);
 }

--- a/gcc/testsuite/rust/compile/invalid-lifetime-in-generic-arg.rs
+++ b/gcc/testsuite/rust/compile/invalid-lifetime-in-generic-arg.rs
@@ -1,0 +1,14 @@
+#![feature(no_core)]
+#![no_core]
+
+// Test for segfault when processing enum variant with reference to type
+// with unresolved lifetime in generic arguments.
+// The compiler should report an error gracefully instead of crashing.
+
+enum ast<'a> {
+    num(usize),
+    add(&'a ast<'result>) // { dg-error "failed to resolve type path segment" }
+    // { dg-error "unresolved lifetime" "" { target *-*-* } .-1 }
+}
+
+pub fn main() {}


### PR DESCRIPTION

- \[x] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[x] Read contributing guidelines
- \[x] `make check-rust` passes locally
- \[x] Run `clang-format`
- \[x] Added any relevant test cases to `gcc/testsuite/rust/`

---
Fixes Rust-GCC/gccrs#3611

When resolving type paths with generic arguments, if a lifetime fails to resolve, `regions_from_generic_args()` returns an empty vector. Previously, this empty vector was passed to `SubstMapper::Resolve`, creating types with uninitialized Region data. Later, variance analysis would crash when processing these malformed types.

Fix:
- `resolve_root_path()` : check if `regions_from_generic_args()`  failed and return `ErrorType` immediately instead of creating malformed types
- `visit(ReferenceType&)`:  propagate `ErrorType` when encountered