### PR TITLE
expand: Fix ICE on unimplemented RustcEncodable/Decodable derives

### DIFF
--- a/gcc/rust/expand/rust-derive.cc
+++ b/gcc/rust/expand/rust-derive.cc
@@ -74,6 +74,13 @@ DeriveVisitor::derive (Item &item, const Attribute &attr,
       return vec (DeriveOrd (DeriveOrd::Ordering::Total, loc).go (item));
     case BuiltinMacro::PartialOrd:
       return vec (DeriveOrd (DeriveOrd::Ordering::Partial, loc).go (item));
+    case BuiltinMacro::RustcEncodable:
+    case BuiltinMacro::RustcDecodable:
+      rust_sorry_at (loc, "derive(%s) is not yet implemented",
+		     to_derive == BuiltinMacro::RustcEncodable
+		       ? "RustcEncodable"
+		       : "RustcDecodable");
+      return {};
     default:
       rust_unreachable ();
     };

--- a/gcc/testsuite/rust/compile/issue-3951.rs
+++ b/gcc/testsuite/rust/compile/issue-3951.rs
@@ -1,0 +1,13 @@
+// { dg-options "-frust-incomplete-and-experimental-compiler-do-not-use" }
+#![feature(no_core)]
+#![no_core]
+
+#[derive(RustcDecodable)] // { dg-message "is not yet implemented" }
+struct Struct1 {}
+
+#[derive(RustcEncodable)] // { dg-message "is not yet implemented" }
+struct Struct2 {}
+
+// Pinpoint the global errors (errors with no line number are at line 0)
+// { dg-error "could not resolve trait 'RustcDecodable'" "" { target *-*-* } 0 }
+// { dg-error "could not resolve trait 'RustcEncodable'" "" { target *-*-* } 0 }


### PR DESCRIPTION
Fixes Rust-GCC#3951