### PR TITLE
lint: Fix ICE on error_mark_node in unused variable linter

### DIFF
--- a/gcc/rust/backend/rust-compile-implitem.cc
+++ b/gcc/rust/backend/rust-compile-implitem.cc
@@ -44,8 +44,12 @@ CompileTraitItem::visit (HIR::TraitItemConst &constant)
 			     resolved_type, canonical_path, const_value_expr,
 			     constant.get_locus (),
 			     const_value_expr.get_locus ());
-  ctx->push_const (const_expr);
-  ctx->insert_const_decl (constant.get_mappings ().get_hirid (), const_expr);
+  if (const_expr != error_mark_node)
+    {
+      ctx->push_const (const_expr);
+      ctx->insert_const_decl (constant.get_mappings ().get_hirid (),
+			      const_expr);
+    }
 
   reference = const_expr;
 }

--- a/gcc/rust/backend/rust-compile-item.cc
+++ b/gcc/rust/backend/rust-compile-item.cc
@@ -129,8 +129,11 @@ CompileItem::visit (HIR::ConstantItem &constant)
 			     const_value_expr.get_locus ());
   ctx->pop_const_context ();
 
-  ctx->push_const (const_expr);
-  ctx->insert_const_decl (mappings.get_hirid (), const_expr);
+  if (const_expr != error_mark_node)
+    {
+      ctx->push_const (const_expr);
+      ctx->insert_const_decl (mappings.get_hirid (), const_expr);
+    }
   reference = const_expr;
 }
 

--- a/gcc/testsuite/rust/compile/issue-3910.rs
+++ b/gcc/testsuite/rust/compile/issue-3910.rs
@@ -1,0 +1,14 @@
+#![feature(no_core)]
+#![no_core]
+
+struct B<const M: u32> {}
+
+impl<const M: u32> B<M> {
+    const M: u32 = M;
+}
+
+struct C;
+
+impl<const M: u32> C { // { dg-error "unconstrained type parameter" }
+    const USE_M: u32 = M;
+}


### PR DESCRIPTION
Fixes Rust-GCC#3910