### PR TITLE
rust: Explicitly instantiate FFIVec<Piece> template

### DIFF
--- a/gcc/rust/ast/rust-fmt.h
+++ b/gcc/rust/ast/rust-fmt.h
@@ -398,6 +398,10 @@ enum ParseMode
   InlineAsm,
 };
 
+// Required to avoid Clang warning about returning an incomplete FFIVec<Piece>
+// from extern "C" functions.
+template class FFIVec<Piece>;
+
 extern "C" {
 
 FFIVec<Piece> collect_pieces (RustHamster input, bool append_newline,


### PR DESCRIPTION
Address #4441 

rust: Explicitly instantiate FFIVec<Piece> for C-linkage

Clang warns about returning an incomplete templated type from extern "C"
functions. Explicitly instantiating FFIVec<Piece> before the declarations
makes the type complete at the declaration site and silences the warning
without changing behavior.

Signed-off-by: Hritam Shrivastava <hritamstark05@gmail.com>
