### PR TITLE
Add no_std attribute

### DIFF
--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -681,6 +681,12 @@ Session::compile_crate (const char *filename)
 			 std::string (Values::Attributes::NO_CORE)))
     {
       parsed_crate.inject_extern_crate ("core");
+      // #![no_core] implies #![no_std]
+      if (!has_attribute (parsed_crate,
+			  std::string (Values::Attributes::NO_STD)))
+	{
+	  parsed_crate.inject_extern_crate ("std");
+	}
     }
 
   if (last_step == CompileOptions::CompileStep::Expansion)

--- a/gcc/rust/util/rust-attribute-values.h
+++ b/gcc/rust/util/rust-attribute-values.h
@@ -38,6 +38,7 @@ public:
   static constexpr auto &LANG = "lang";
   static constexpr auto &LINK_NAME = "link_name";
   static constexpr auto &NO_CORE = "no_core";
+  static constexpr auto &NO_STD = "no_std";
   static constexpr auto &LINK_SECTION = "link_section";
   static constexpr auto &NO_MANGLE = "no_mangle";
   static constexpr auto &EXPORT_NAME = "export_name";


### PR DESCRIPTION
Add a no_std attribute, when both no_std and no_core attributes are missing, inject an external std crate.