### PR TITLE
resolve: Fix ICE on ambiguous glob re-exports

### DIFF
--- a/gcc/rust/resolve/rust-early-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver-2.0.cc
@@ -123,6 +123,17 @@ Early::resolve_rebind_import (NodeId use_dec_id,
   // if we've found at least one definition, then we're good
   if (definitions.empty ())
     return false;
+  for (const auto &def : definitions)
+    {
+      if (def.first.is_ambiguous ())
+	{
+	  rich_location rich_locus (line_table,
+				    rebind_import.to_resolve.get_locus ());
+	  rust_error_at (rich_locus, ErrorCode::E0659, "%qs is ambiguous",
+			 rebind_import.to_resolve.as_string ().c_str ());
+	  return true;
+	}
+    }
 
   auto &imports = import_mappings.new_or_access (use_dec_id);
 

--- a/gcc/testsuite/rust/compile/issue-4411.rs
+++ b/gcc/testsuite/rust/compile/issue-4411.rs
@@ -1,0 +1,16 @@
+#![feature(no_core)]
+#![no_core]
+mod framing {
+    mod public_message {
+        pub struct ConfirmedTranscriptHashInput;
+    }
+    mod public_message_in {
+        pub struct ConfirmedTranscriptHashInput;
+    }
+    pub use self::public_message::*;
+    pub use self::public_message_in::*;
+}
+
+use crate::framing::ConfirmedTranscriptHashInput; // { dg-error "is ambiguous .E0659." }
+
+fn main() {}


### PR DESCRIPTION
This patch adds an ambiguity check in 'finalize_rebind_import'. If a Definition is ambiguous, it emits a proper error diagnostic instead of crashing, consistent with rustc's behavior(verified)

Fixes Rust-GCC/gccrs#4411

gcc/rust/ChangeLog:

	* resolve/rust-early-name-resolver-2.0.cc (Early::finalize_rebind_import): Add ambiguity check before calling get_node_id() on glob import definitions.

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4411.rs: New test.

Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[ ] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[ ] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[ ] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---

*Please write a comment explaining your change. This is the message
that will be part of the merge commit.
