### PR TITLE
Fix match arm scope

### DIFF
--- a/gcc/rust/resolve/rust-default-resolver.cc
+++ b/gcc/rust/resolve/rust-default-resolver.cc
@@ -390,6 +390,14 @@ DefaultResolver::visit (AST::MatchExpr &expr)
 }
 
 void
+DefaultResolver::visit (AST::MatchCase &cas)
+{
+  auto vis = [this, &cas] () { AST::DefaultASTVisitor::visit (cas); };
+
+  ctx.scoped (Rib::Kind::Normal, cas.get_node_id (), vis);
+}
+
+void
 DefaultResolver::visit (AST::ConstantItem &item)
 {
   auto expr_vis_1 = [this, &item] () { AST::DefaultASTVisitor::visit (item); };

--- a/gcc/rust/resolve/rust-default-resolver.h
+++ b/gcc/rust/resolve/rust-default-resolver.h
@@ -79,6 +79,7 @@ public:
   void visit (AST::ClosureExprInner &) override;
   void visit (AST::ClosureExprInnerTyped &) override;
   void visit (AST::MatchExpr &) override;
+  void visit (AST::MatchCase &) override;
 
   // Leaf visitors, which do nothing by default
   void visit (AST::ConstantItem &) override;

--- a/gcc/testsuite/rust/compile/match-scope.rs
+++ b/gcc/testsuite/rust/compile/match-scope.rs
@@ -1,0 +1,8 @@
+#![no_core]
+
+pub fn main() -> i32 {
+    match 12 {
+        x => {}
+    }
+    x // { dg-error "cannot find value 'x'" }
+}

--- a/gcc/testsuite/rust/execute/torture/match-structpattern-tuplefield.rs
+++ b/gcc/testsuite/rust/execute/torture/match-structpattern-tuplefield.rs
@@ -5,9 +5,10 @@ pub struct TupStruct (i32, i32);
 
 pub fn main() -> i32 {
     let mut t = TupStruct (1, 1);
+    let mut ret = 1;
     match t {
-        TupStruct { 0: 1, 1: b } => { b -= 1 }
+        TupStruct { 0: 1, 1: b } => { b -= 1; ret = b }
         _ => {}
     }
-    b
+    ret
 }


### PR DESCRIPTION
This fixes a bug where bindings introduced by match arms are given the same scope as their match expression.