### PR TITLE
feat: Implement `no_core` feature gate check

### DIFF
--- a/gcc/rust/checks/errors/feature/rust-feature-gate.cc
+++ b/gcc/rust/checks/errors/feature/rust-feature-gate.cc
@@ -63,6 +63,7 @@ FeatureGate::visit (AST::Crate &crate)
       rust_error_at (locus, ErrorCode::E0635, "unknown feature %qs",
 		     feature.c_str ());
     }
+  check_no_core_attribute (crate.inner_attrs);
 }
 
 void
@@ -106,6 +107,18 @@ FeatureGate::visit (AST::ExternBlock &block)
 	      "intrinsics are subject to change");
     }
   AST::DefaultASTVisitor::visit (block);
+}
+
+void
+FeatureGate::check_no_core_attribute (
+  const std::vector<AST::Attribute> &attributes)
+{
+  for (const AST::Attribute &attr : attributes)
+    {
+      if (attr.get_path ().as_string () == Values::Attributes::NO_CORE)
+	gate (Feature::Name::NO_CORE, attr.get_locus (),
+	      "no_core is experimental");
+    }
 }
 
 void

--- a/gcc/rust/checks/errors/feature/rust-feature-gate.h
+++ b/gcc/rust/checks/errors/feature/rust-feature-gate.h
@@ -54,6 +54,7 @@ public:
 
 private:
   void gate (Feature::Name name, location_t loc, const std::string &error_msg);
+  void check_no_core_attribute (const std::vector<AST::Attribute> &attributes);
   void check_rustc_attri (const std::vector<AST::Attribute> &attributes);
   void
   check_may_dangle_attribute (const std::vector<AST::Attribute> &attributes);

--- a/gcc/testsuite/rust/compile/match-scope.rs
+++ b/gcc/testsuite/rust/compile/match-scope.rs
@@ -1,3 +1,4 @@
+#![feature(no_core)]
 #![no_core]
 
 pub fn main() -> i32 {

--- a/gcc/testsuite/rust/compile/no_core_feature_gate.rs
+++ b/gcc/testsuite/rust/compile/no_core_feature_gate.rs
@@ -1,0 +1,3 @@
+#![no_core] // { dg-error "no_core is experimental" }
+
+fn main() {}


### PR DESCRIPTION
The compiler was accepting `#![no_core]` without requiring `#![feature(no_core)]`, silently treating an unstable attribute as stable.  Gate it via check_no_core_attribute, consistent with how other experimental attributes are handled.

Fixes: #4461

gcc/rust/ChangeLog:

	* checks/errors/feature/rust-feature-gate.cc (FeatureGate::visit):
	* checks/errors/feature/rust-feature-gate.h:

gcc/testsuite/ChangeLog:

	* rust/compile/no_core_feature_gate.rs: New test.