### PR TITLE
Add no_std to builtin attributes

### DIFF
--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -98,6 +98,7 @@ static const BuiltinAttrDefinition __definitions[]
      // #![feature(rustc_attrs)]
      {Attrs::FEATURE, STATIC_ANALYSIS},
      {Attrs::NO_CORE, CODE_GENERATION},
+     {Attrs::NO_STD, CODE_GENERATION},
      {Attrs::DOC, EXTERNAL},
      {Attrs::CRATE_NAME, CODE_GENERATION},
      {Attrs::CRATE_TYPE, CODE_GENERATION},


### PR DESCRIPTION
no_std is a builtin attribute required for rust-for-linux but was missing from the builtin attribute list and instead considered an unknown attribute macro invocation.