### PR TITLE
testsuite:Add a testcase for setup_associated_types

### DIFF
--- a/gcc/testsuite/rust/compile/issue-3931.rs
+++ b/gcc/testsuite/rust/compile/issue-3931.rs
@@ -1,0 +1,16 @@
+#![feature(no_core)]
+#![no_core]
+
+trait Foo {
+    fn foo();
+}
+
+impl Foo for [(); 1] { // { dg-error "missing foo in implementation of trait .Foo. " }
+    fn main() {        // { dg-error "method .main. is not a member of trait .Foo." }
+        <[(); 0] as Foo>::foo() 
+    }
+}
+
+fn main() {
+    <[(); 0] as Foo>::foo() 
+}


### PR DESCRIPTION
Fixes Rust-GCC/gccrs#3931
gcc/testsuite/ChangeLog:

	* rust/compile/issue-3931.rs: New test.

Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[ ] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[ ] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[ ] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---

*Please write a comment explaining your change. This is the message
that will be part of the merge commit.
