### PR TITLE
Fix glob import all ICE issue

### DIFF
--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -1074,7 +1074,7 @@ public:
 
   void accept_vis (ASTVisitor &vis) override;
 
-  PathType get_glob_type () { return glob_type; }
+  PathType get_glob_type () const { return glob_type; }
 
   Kind get_kind () const override { return Glob; }
 

--- a/gcc/rust/resolve/rust-forever-stack.hxx
+++ b/gcc/rust/resolve/rust-forever-stack.hxx
@@ -729,21 +729,24 @@ ForeverStack<N>::resolve_path (
     }
   else
     {
-      rust_assert (!path.get_segments ().empty ());
+      switch (mode)
+	{
+	case ResolutionMode::Normal:
+	  break; // default
+	case ResolutionMode::FromRoot:
+	  starting_point = root;
+	  break;
+	case ResolutionMode::FromExtern:
+	  starting_point = extern_prelude;
+	  break;
+	default:
+	  rust_unreachable ();
+	}
     }
 
-  switch (mode)
+  if (path.get_segments ().empty ())
     {
-    case ResolutionMode::Normal:
-      break; // default
-    case ResolutionMode::FromRoot:
-      starting_point = root;
-      break;
-    case ResolutionMode::FromExtern:
-      starting_point = extern_prelude;
-      break;
-    default:
-      rust_unreachable ();
+      return Rib::Definition::NonShadowable (starting_point.get ().id);
     }
 
   auto &segments = path.get_segments ();

--- a/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
@@ -502,7 +502,9 @@ flatten_glob (const AST::UseTreeGlob &glob, std::vector<AST::SimplePath> &paths,
   if (glob.has_path ())
     paths.emplace_back (glob.get_path ());
   else
-    paths.emplace_back (AST::SimplePath ({}, false, glob.get_locus ()));
+    paths.emplace_back (AST::SimplePath (
+      {}, glob.get_glob_type () == AST::UseTreeGlob::PathType::GLOBAL,
+      glob.get_locus ()));
 }
 
 static bool

--- a/gcc/testsuite/rust/compile/glob-import-all.rs
+++ b/gcc/testsuite/rust/compile/glob-import-all.rs
@@ -1,0 +1,9 @@
+// { dg-additional-options "-frust-edition=2015" }
+
+#![feature(no_core)]
+#![no_core]
+
+mod a {
+    #[allow(unused)]
+    use ::*;
+}


### PR DESCRIPTION
Fixes #4475 
This attempts to fix the ICE that happens when you import modules like this:
```
pub use ::*;
``` 
I have noticed that rustc handles this with an error message tailored to this specific case, see [godbolt](https://godbolt.org/z/nj7z7nPTK). I tried to do the same.
This is my first PR, I'm trying to get feedback on my approach. Also, I know I need to fix the format, commit message and add test cases. Please tell me if I missed something.