### PR TITLE
gccrs: Fix ICE caused by TypeCheckBase::parse_repr_options

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-base.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.cc
@@ -421,14 +421,27 @@ TypeCheckBase::parse_repr_options (const AST::AttrVec &attrs, location_t locus)
 	  const AST::AttrInput &input = attr.get_attr_input ();
 	  bool is_token_tree = input.get_attr_input_type ()
 			       == AST::AttrInput::AttrInputType::TOKEN_TREE;
-	  if (!is_token_tree)
+	  bool is_meta_item = input.get_attr_input_type ()
+			      == AST::AttrInput::AttrInputType::META_ITEM;
+	  if (!is_token_tree && !is_meta_item)
 	    {
 	      rust_error_at (attr.get_locus (), "malformed %<repr%> attribute");
 	      continue;
 	    }
-	  const auto &option = static_cast<const AST::DelimTokenTree &> (input);
-	  AST::AttrInputMetaItemContainer *meta_items
-	    = option.parse_to_meta_item ();
+
+	  const AST::AttrInputMetaItemContainer *meta_items = nullptr;
+	  if (is_token_tree)
+	    {
+	      const auto &option
+		= static_cast<const AST::DelimTokenTree &> (input);
+	      meta_items = option.parse_to_meta_item ();
+	    }
+	  else
+	    { // is_meta_item is true
+	      const auto &option
+		= static_cast<const AST::AttrInputMetaItemContainer &> (input);
+	      meta_items = new AST::AttrInputMetaItemContainer (option);
+	    }
 
 	  if (meta_items == nullptr)
 	    {

--- a/gcc/testsuite/rust/compile/issue-3550.rs
+++ b/gcc/testsuite/rust/compile/issue-3550.rs
@@ -1,0 +1,7 @@
+#![feature(no_core)]
+#![no_core]
+
+#[cfg_attr(not(wrong = "32"), repr(i32))]
+enum Eu64 {
+    Au64 = 0,
+}


### PR DESCRIPTION
Closes #3550.

Expansion of `cfg_attr` causes `AttrInput`-s to be all parsed into `AttrInputMetaItemContainer`. `TypeCheckBase::parse_repr_options` assumes that the `AttrInput`-s within the attributes are all raw token trees instead of already-parsed meta items, which caused it to throw the ICE. The fix is simply to update `parse_repr_options` to also accept `AttrInputMetaItemContainer` attribute inputs.