### PR TITLE
rust: Fix ICE in function_set_parameters

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-item.cc
+++ b/gcc/rust/hir/rust-ast-lower-item.cc
@@ -455,6 +455,25 @@ ASTLoweringItem::visit (AST::Function &function)
 
       auto translated_pattern = std::unique_ptr<HIR::Pattern> (
 	ASTLoweringPattern::translate (param.get_pattern ()));
+
+      switch (param.get_pattern ().get_pattern_kind ())
+	{
+	case AST::Pattern::Kind::Identifier:
+	case AST::Pattern::Kind::Wildcard:
+	case AST::Pattern::Kind::Tuple:
+	case AST::Pattern::Kind::Struct:
+	case AST::Pattern::Kind::TupleStruct:
+	case AST::Pattern::Kind::Reference:
+	case AST::Pattern::Kind::Grouped:
+	case AST::Pattern::Kind::Slice:
+	case AST::Pattern::Kind::Rest:
+	  break;
+	default:
+	  rust_error_at (param.get_locus (),
+			 "refutable pattern in function argument");
+	  continue;
+	}
+
       auto translated_type = std::unique_ptr<HIR::Type> (
 	ASTLoweringType::translate (param.get_type ()));
 

--- a/gcc/testsuite/rust/compile/issue-3919-ice-func-parms.rs
+++ b/gcc/testsuite/rust/compile/issue-3919-ice-func-parms.rs
@@ -1,0 +1,4 @@
+#![feature(no_core)]
+#![no_core]
+
+fn func(1: i32) {} // { dg-error "refutable pattern in function argument" }


### PR DESCRIPTION
When lowering a function to HIR with a refutable pattern in its parameter pattern, we were ICE'ing due to a lack of checks for invalid refutable patterns. Fix this by erroring on invalid patterns while lowering a function.

Fixes #3919

gcc/rust/ChangeLog:

    * hir/rust-ast-lower-item.cc (ASTLoweringItem::visit): added refutable pattern checks for function params.

gcc/testsuite/ChangeLog:

    * rust/compile/issue-3919-ice-func-parms.rs: New test.