### PR TITLE
Fix intrinsic error location

### DIFF
--- a/gcc/rust/backend/rust-intrinsic-handlers.cc
+++ b/gcc/rust/backend/rust-intrinsic-handlers.cc
@@ -80,7 +80,7 @@ check_for_basic_integer_type (const std::string &intrinsic_str,
     {
       rust_error_at (
 	locus,
-	"%s intrinsics can only be used with basic integer types (got %qs)",
+	"%s intrinsic can only be used with basic integer types (got %qs)",
 	intrinsic_str.c_str (), type->get_name ().c_str ());
     }
 
@@ -218,7 +218,7 @@ build_atomic_builtin_name (const std::string &prefix, location_t locus,
 
   auto type_size_str = allowed_types.find (type_name);
 
-  if (!check_for_basic_integer_type ("atomic", locus, operand_type))
+  if (!check_for_basic_integer_type ("atomic operation", locus, operand_type))
     return "";
 
   result += type_size_str->second;
@@ -255,7 +255,8 @@ unchecked_op (Context *ctx, TyTy::FnType *fntype, tree_code op)
   auto *monomorphized_type
     = fntype->get_substs ().at (0).get_param_ty ()->resolve ();
 
-  check_for_basic_integer_type ("unchecked operation", fntype->get_locus (),
+  auto call_locus = ctx->get_mappings ().lookup_location (fntype->get_ref ());
+  check_for_basic_integer_type ("unchecked operation", call_locus,
 				monomorphized_type);
 
   auto expr = build2 (op, TREE_TYPE (x), x, y);
@@ -660,9 +661,9 @@ atomic_store (Context *ctx, TyTy::FnType *fntype, int ordering)
   auto monomorphized_type
     = fntype->get_substs ()[0].get_param_ty ()->resolve ();
 
-  auto builtin_name
-    = build_atomic_builtin_name ("atomic_store_", fntype->get_locus (),
-				 monomorphized_type);
+  auto call_locus = ctx->get_mappings ().lookup_location (fntype->get_ref ());
+  auto builtin_name = build_atomic_builtin_name ("atomic_store_", call_locus,
+						 monomorphized_type);
   if (builtin_name.empty ())
     return error_mark_node;
 
@@ -777,8 +778,8 @@ ctlz_handler (Context *ctx, TyTy::FnType *fntype, bool nonzero)
   rust_assert (fntype->get_num_substitutions () == 1);
   auto *monomorphized_type
     = fntype->get_substs ().at (0).get_param_ty ()->resolve ();
-  if (!check_for_basic_integer_type ("ctlz", fntype->get_locus (),
-				     monomorphized_type))
+  auto call_locus = ctx->get_mappings ().lookup_location (fntype->get_ref ());
+  if (!check_for_basic_integer_type ("ctlz", call_locus, monomorphized_type))
     return error_mark_node;
 
   enter_intrinsic_block (ctx, fndecl);
@@ -922,8 +923,8 @@ cttz_handler (Context *ctx, TyTy::FnType *fntype, bool nonzero)
   rust_assert (fntype->get_num_substitutions () == 1);
   auto *monomorphized_type
     = fntype->get_substs ().at (0).get_param_ty ()->resolve ();
-  if (!check_for_basic_integer_type ("cttz", fntype->get_locus (),
-				     monomorphized_type))
+  auto call_locus = ctx->get_mappings ().lookup_location (fntype->get_ref ());
+  if (!check_for_basic_integer_type ("cttz", call_locus, monomorphized_type))
     return error_mark_node;
 
   enter_intrinsic_block (ctx, fndecl);
@@ -1672,8 +1673,8 @@ bswap_handler (Context *ctx, TyTy::FnType *fntype)
   auto *monomorphized_type
     = fntype->get_substs ().at (0).get_param_ty ()->resolve ();
 
-  check_for_basic_integer_type ("bswap", fntype->get_locus (),
-				monomorphized_type);
+  auto call_locus = ctx->get_mappings ().lookup_location (fntype->get_ref ());
+  check_for_basic_integer_type ("bswap", call_locus, monomorphized_type);
 
   tree template_parameter_type
     = TyTyResolveCompile::compile (ctx, monomorphized_type);

--- a/gcc/testsuite/rust/compile/bswap.rs
+++ b/gcc/testsuite/rust/compile/bswap.rs
@@ -9,9 +9,9 @@ pub trait Sized {}
 pub trait Copy {}
 
 extern "rust-intrinsic" {
-    pub fn bswap<T>(x: T) -> T; // { dg-error "bswap intrinsics can only be used with basic integer types .got 'bool'." }
+    pub fn bswap<T>(x: T) -> T; 
 }
 
 fn main() {
-    let _ = bswap(true);
+    let _ = bswap(true); // { dg-error "bswap intrinsic can only be used with basic integer types .got .bool.." }
 }

--- a/gcc/testsuite/rust/compile/ctlz.rs
+++ b/gcc/testsuite/rust/compile/ctlz.rs
@@ -9,9 +9,9 @@ pub trait Sized {}
 pub trait Copy {}
 
 extern "rust-intrinsic" {
-    pub fn ctlz<T>(x: T) -> u32; // { dg-error "ctlz intrinsics can only be used with basic integer types .got 'bool'." }
+    pub fn ctlz<T>(x: T) -> u32;
 }
 
 fn main() {
-    let _ = ctlz(true);
+    let _ = ctlz(true); // { dg-error "ctlz intrinsic can only be used with basic integer types .got .bool.." }
 }

--- a/gcc/testsuite/rust/compile/ctlz_nonzero.rs
+++ b/gcc/testsuite/rust/compile/ctlz_nonzero.rs
@@ -9,11 +9,11 @@ pub trait Sized {}
 pub trait Copy {}
 
 extern "rust-intrinsic" {
-    pub fn ctlz_nonzero<T>(x: T) -> u32; // { dg-error "ctlz intrinsics can only be used with basic integer types .got 'bool'." }
+    pub fn ctlz_nonzero<T>(x: T) -> u32;
 }
 
 fn main() {
     unsafe {
-        let _ = ctlz_nonzero(true);
+        let _ = ctlz_nonzero(true); // { dg-error "ctlz intrinsic can only be used with basic integer types .got .bool.." }
     }
 }

--- a/gcc/testsuite/rust/compile/cttz.rs
+++ b/gcc/testsuite/rust/compile/cttz.rs
@@ -9,9 +9,9 @@ pub trait Sized {}
 pub trait Copy {}
 
 extern "rust-intrinsic" {
-    pub fn cttz<T>(x: T) -> u32; // { dg-error "cttz intrinsics can only be used with basic integer types .got 'bool'." }
+    pub fn cttz<T>(x: T) -> u32;
 }
 
 fn main() {
-    let _ = cttz(true);
+    let _ = cttz(true); // { dg-error "cttz intrinsic can only be used with basic integer types .got 'bool'." }
 }

--- a/gcc/testsuite/rust/compile/cttz_nonzero.rs
+++ b/gcc/testsuite/rust/compile/cttz_nonzero.rs
@@ -9,11 +9,11 @@ pub trait Sized {}
 pub trait Copy {}
 
 extern "rust-intrinsic" {
-    pub fn cttz_nonzero<T>(x: T) -> u32; // { dg-error "cttz intrinsics can only be used with basic integer types .got 'bool'." }
+    pub fn cttz_nonzero<T>(x: T) -> u32;
 }
 
 fn main() {
     unsafe {
-        let _ = cttz_nonzero(true);
+        let _ = cttz_nonzero(true); // { dg-error "cttz intrinsic can only be used with basic integer types .got 'bool'." }
     }
 }

--- a/gcc/testsuite/rust/compile/torture/intrinsics-5.rs
+++ b/gcc/testsuite/rust/compile/torture/intrinsics-5.rs
@@ -65,8 +65,6 @@ mod copy_impls {
 
 extern "rust-intrinsic" {
     pub fn atomic_store_seqcst<T: Copy>(dst: *mut T, value: T);
-    // { dg-error "atomic intrinsics can only be used with basic integer types .got .VeryLargeType.." "" { target *-*-* } .-1 }
-    // { dg-error "atomic intrinsics can only be used with basic integer types .got .bool.." "" { target *-*-* } .-2 }
 }
 
 struct VeryLargeType {
@@ -100,6 +98,8 @@ fn main() {
 
     unsafe {
         atomic_store_seqcst(&mut dst, VeryLargeType::new(1));
+        // { dg-error "atomic operation intrinsic can only be used with basic integer types .got .VeryLargeType.." "" { target *-*-* } .-1 }
         atomic_store_seqcst(&mut b, true);
+        // { dg-error "atomic operation intrinsic can only be used with basic integer types .got .bool.." "" { target *-*-* } .-1 }
     }
 }

--- a/gcc/testsuite/rust/compile/torture/intrinsics-7.rs
+++ b/gcc/testsuite/rust/compile/torture/intrinsics-7.rs
@@ -9,11 +9,11 @@ pub trait Sized {}
 
 extern "rust-intrinsic" {
     pub fn unchecked_add<T>(x: T, y: T) -> T;
-    // { dg-error "unchecked operation intrinsics can only be used with basic integer types .got .NotAdd.." "" { target *-*-* } .-1 }
 }
 
 fn main() {
     struct NotAdd;
 
     unsafe { unchecked_add(NotAdd, NotAdd) };
+    // { dg-error "unchecked operation intrinsic can only be used with basic integer types .got .NotAdd.." "" { target *-*-* } .-1 }
 }


### PR DESCRIPTION
When an intrisic is used with an incorrect type, prin the location of
the call site, not the declaration.

Fixes https://github.com/Rust-GCC/gccrs/issues/4465.

gcc/rust/ChangeLog:

	* backend/rust-intrinsic-handlers.cc: use call site error
	location instead of the declaration location

gcc/testsuite/ChangeLog:

	* rust/compile/bswap.rs: update error location
	* rust/compile/ctlz.rs: update error location
	* rust/compile/ctlz_nonzero.rs: update error location
	* rust/compile/torture/intrinsics-5.rs: update error location
	* rust/compile/torture/intrinsics-7.rs: update error location