### PR TITLE
rust: Fix ICE with infer type used in struct attribute

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-item.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.cc
@@ -248,6 +248,7 @@ void
 TypeCheckItem::visit (HIR::StructStruct &struct_decl)
 {
   auto lifetime_pin = context->push_clean_lifetime_resolver ();
+  auto &mappings = Analysis::Mappings::get ();
 
   std::vector<TyTy::SubstitutionParamMapping> substitutions;
   if (struct_decl.has_generics ())
@@ -266,6 +267,14 @@ TypeCheckItem::visit (HIR::StructStruct &struct_decl)
     {
       TyTy::BaseType *field_type
 	= TypeCheckType::Resolve (field.get_field_type ());
+      auto infer_type = field_type->contains_infer ();
+      if (infer_type)
+	{
+	  rust_error_at (mappings.lookup_location (infer_type->get_ref ()),
+			 "the placeholder %<_%> is not allowed within types on "
+			 "item signatures for structs");
+	  return;
+	}
       auto *ty_field
 	= new TyTy::StructFieldType (field.get_mappings ().get_hirid (),
 				     field.get_field_name ().as_string (),

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -743,7 +743,10 @@ BaseType::contains_infer () const
     }
   else if (auto arr = x->try_as<const ArrayType> ())
     {
-      return arr->get_element_type ()->contains_infer ();
+      auto type_infer = (arr->get_element_type ()->contains_infer ());
+      if (type_infer)
+	return type_infer;
+      return arr->get_capacity ()->contains_infer ();
     }
   else if (auto slice = x->try_as<const SliceType> ())
     {
@@ -777,6 +780,13 @@ BaseType::contains_infer () const
   else if (x->is<InferType> ())
     {
       return x;
+    }
+  else if (x->get_kind () == TyTy::TypeKind::CONST)
+    {
+      if (x->as_const_type ()->const_kind () == BaseConstType::Infer)
+	{
+	  return x;
+	}
     }
 
   return nullptr;

--- a/gcc/testsuite/rust/compile/infer-type-issue-3583.rs
+++ b/gcc/testsuite/rust/compile/infer-type-issue-3583.rs
@@ -1,0 +1,23 @@
+#![feature(no_core)]
+#![no_core]
+
+struct Test10 {
+    a: _, // { dg-error "the placeholder ... is not allowed within types on item" }
+}
+
+struct Test11 {
+    a: _, // { dg-error "the placeholder ... is not allowed within types on item" }
+    b: i32,
+}
+
+struct Test12 {
+    a: (_, _), // { dg-error "the placeholder ... is not allowed within types on item" }
+}
+
+struct Test13 {
+    a: [_; _], // { dg-error "the placeholder ... is not allowed within types on item" }
+}
+
+struct Test14 {
+    a: [i32; _], // { dg-error "the placeholder ... is not allowed within types on item" }
+}


### PR DESCRIPTION
When visiting a struct declaration, add check for when a struct's attribute is declared as an infer type, emitting an error if true.

Fixes #3583