### PR TITLE
Strip down 1.0 resolver

### DIFF
--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -345,9 +345,6 @@ MacroExpander::expand_invoc (AST::MacroInvocation &invoc,
 void
 MacroExpander::expand_crate ()
 {
-  NodeId scope_node_id = crate.get_node_id ();
-  resolver->get_macro_scope ().push (scope_node_id);
-
   /* fill macro/decorator map from init list? not sure where init list comes
    * from? */
 

--- a/gcc/rust/resolve/rust-name-resolver.cc
+++ b/gcc/rust/resolve/rust-name-resolver.cc
@@ -275,14 +275,7 @@ Scope::decl_was_declared_here (NodeId def) const
   return found;
 }
 
-Resolver::Resolver ()
-  : mappings (Analysis::Mappings::get ()), tyctx (TypeCheckContext::get ()),
-    name_scope (Scope (mappings.get_current_crate ())),
-    type_scope (Scope (mappings.get_current_crate ())),
-    label_scope (Scope (mappings.get_current_crate ())),
-    macro_scope (Scope (mappings.get_current_crate ())),
-    global_type_node_id (UNKNOWN_NODEID), unit_ty_node_id (UNKNOWN_NODEID)
-{}
+Resolver::Resolver () {}
 
 Resolver *
 Resolver::get ()
@@ -295,389 +288,39 @@ Resolver::get ()
 }
 
 void
-Resolver::push_new_name_rib (Rib *r)
-{
-  rust_assert (name_ribs.find (r->get_node_id ()) == name_ribs.end ());
-  name_ribs[r->get_node_id ()] = r;
-}
-
-void
-Resolver::push_new_type_rib (Rib *r)
-{
-  if (type_ribs.size () == 0)
-    global_type_node_id = r->get_node_id ();
-
-  rust_assert (type_ribs.find (r->get_node_id ()) == type_ribs.end ());
-  type_ribs[r->get_node_id ()] = r;
-}
-
-void
-Resolver::push_new_label_rib (Rib *r)
-{
-  rust_assert (label_ribs.find (r->get_node_id ()) == label_ribs.end ());
-  label_ribs[r->get_node_id ()] = r;
-}
-
-void
-Resolver::push_new_macro_rib (Rib *r)
-{
-  rust_assert (label_ribs.find (r->get_node_id ()) == label_ribs.end ());
-  macro_ribs[r->get_node_id ()] = r;
-}
-
-bool
-Resolver::find_name_rib (NodeId id, Rib **rib)
-{
-  auto it = name_ribs.find (id);
-  if (it == name_ribs.end ())
-    return false;
-
-  *rib = it->second;
-  return true;
-}
-
-bool
-Resolver::find_type_rib (NodeId id, Rib **rib)
-{
-  auto it = type_ribs.find (id);
-  if (it == type_ribs.end ())
-    return false;
-
-  *rib = it->second;
-  return true;
-}
-
-bool
-Resolver::find_macro_rib (NodeId id, Rib **rib)
-{
-  auto it = macro_ribs.find (id);
-  if (it == macro_ribs.end ())
-    return false;
-
-  *rib = it->second;
-  return true;
-}
-
-void
-Resolver::insert_builtin_types (Rib *r)
-{
-  auto builtins = get_builtin_types ();
-  for (auto &builtin : builtins)
-    {
-      CanonicalPath builtin_path
-	= CanonicalPath::new_seg (builtin->get_node_id (),
-				  builtin->as_string ());
-      r->insert_name (builtin_path, builtin->get_node_id (), BUILTINS_LOCATION,
-		      false, Rib::ItemType::Type,
-		      [] (const CanonicalPath &, NodeId, location_t) -> void {
-		      });
-    }
-}
-
-std::vector<AST::Type *> &
-Resolver::get_builtin_types ()
-{
-  return builtins;
-}
-
-void
-Resolver::generate_builtins ()
-{
-  auto u8
-    = new TyTy::UintType (mappings.get_next_hir_id (), TyTy::UintType::U8);
-  auto u16
-    = new TyTy::UintType (mappings.get_next_hir_id (), TyTy::UintType::U16);
-  auto u32
-    = new TyTy::UintType (mappings.get_next_hir_id (), TyTy::UintType::U32);
-  auto u64
-    = new TyTy::UintType (mappings.get_next_hir_id (), TyTy::UintType::U64);
-  auto u128
-    = new TyTy::UintType (mappings.get_next_hir_id (), TyTy::UintType::U128);
-  auto i8 = new TyTy::IntType (mappings.get_next_hir_id (), TyTy::IntType::I8);
-  auto i16
-    = new TyTy::IntType (mappings.get_next_hir_id (), TyTy::IntType::I16);
-  auto i32
-    = new TyTy::IntType (mappings.get_next_hir_id (), TyTy::IntType::I32);
-  auto i64
-    = new TyTy::IntType (mappings.get_next_hir_id (), TyTy::IntType::I64);
-  auto i128
-    = new TyTy::IntType (mappings.get_next_hir_id (), TyTy::IntType::I128);
-  auto rbool = new TyTy::BoolType (mappings.get_next_hir_id ());
-  auto f32
-    = new TyTy::FloatType (mappings.get_next_hir_id (), TyTy::FloatType::F32);
-  auto f64
-    = new TyTy::FloatType (mappings.get_next_hir_id (), TyTy::FloatType::F64);
-  auto usize = new TyTy::USizeType (mappings.get_next_hir_id ());
-  auto isize = new TyTy::ISizeType (mappings.get_next_hir_id ());
-  auto char_tyty = new TyTy::CharType (mappings.get_next_hir_id ());
-  auto str = new TyTy::StrType (mappings.get_next_hir_id ());
-  auto never = new TyTy::NeverType (mappings.get_next_hir_id ());
-
-  setup_builtin ("u8", u8);
-  setup_builtin ("u16", u16);
-  setup_builtin ("u32", u32);
-  setup_builtin ("u64", u64);
-  setup_builtin ("u128", u128);
-  setup_builtin ("i8", i8);
-  setup_builtin ("i16", i16);
-  setup_builtin ("i32", i32);
-  setup_builtin ("i64", i64);
-  setup_builtin ("i128", i128);
-  setup_builtin ("bool", rbool);
-  setup_builtin ("f32", f32);
-  setup_builtin ("f64", f64);
-  setup_builtin ("usize", usize);
-  setup_builtin ("isize", isize);
-  setup_builtin ("char", char_tyty);
-  setup_builtin ("str", str);
-
-  // never type
-  NodeId never_node_id = setup_builtin ("!", never);
-  set_never_type_node_id (never_node_id);
-
-  // unit type ()
-  TyTy::TupleType *unit_tyty = TyTy::TupleType::get_unit_type ();
-  std::vector<std::unique_ptr<AST::Type> > elems;
-  AST::TupleType *unit_type
-    = new AST::TupleType (std::move (elems), BUILTINS_LOCATION);
-  builtins.push_back (unit_type);
-  tyctx->insert_builtin (unit_tyty->get_ref (), unit_type->get_node_id (),
-			 unit_tyty);
-  set_unit_type_node_id (unit_type->get_node_id ());
-}
-
-NodeId
-Resolver::setup_builtin (const std::string &name, TyTy::BaseType *tyty)
-{
-  AST::PathIdentSegment seg (name, BUILTINS_LOCATION);
-  auto typePath = ::std::unique_ptr<AST::TypePathSegment> (
-    new AST::TypePathSegment (::std::move (seg), false, BUILTINS_LOCATION));
-  ::std::vector< ::std::unique_ptr<AST::TypePathSegment> > segs;
-  segs.push_back (::std::move (typePath));
-  auto builtin_type
-    = new AST::TypePath (::std::move (segs), BUILTINS_LOCATION, false);
-  builtins.push_back (builtin_type);
-  tyctx->insert_builtin (tyty->get_ref (), builtin_type->get_node_id (), tyty);
-  mappings.insert_node_to_hir (builtin_type->get_node_id (), tyty->get_ref ());
-  mappings.insert_canonical_path (
-    builtin_type->get_node_id (),
-    CanonicalPath::new_seg (builtin_type->get_node_id (), name));
-
-  return builtin_type->get_node_id ();
-}
-
-void
 Resolver::insert_resolved_name (NodeId refId, NodeId defId)
 {
-  rust_assert (!flag_name_resolution_2_0);
-  rust_assert (resolved_names.find (refId) == resolved_names.end ());
-
-  resolved_names[refId] = defId;
-  get_name_scope ().append_reference_for_def (refId, defId);
-  insert_captured_item (defId);
+  rust_unreachable ();
 }
 
 bool
 Resolver::lookup_resolved_name (NodeId refId, NodeId *defId)
 {
-  rust_assert (!flag_name_resolution_2_0);
-  auto it = resolved_names.find (refId);
-  if (it == resolved_names.end ())
-    return false;
-
-  *defId = it->second;
-  return true;
+  rust_unreachable ();
 }
 
 void
 Resolver::insert_resolved_type (NodeId refId, NodeId defId)
 {
-  rust_assert (!flag_name_resolution_2_0);
-  rust_assert (resolved_types.find (refId) == resolved_types.end ());
-
-  resolved_types[refId] = defId;
-  get_type_scope ().append_reference_for_def (refId, defId);
+  rust_unreachable ();
 }
 
 bool
 Resolver::lookup_resolved_type (NodeId refId, NodeId *defId)
 {
-  rust_assert (!flag_name_resolution_2_0);
-  auto it = resolved_types.find (refId);
-  if (it == resolved_types.end ())
-    return false;
-
-  *defId = it->second;
-  return true;
-}
-
-void
-Resolver::insert_resolved_label (NodeId refId, NodeId defId)
-{
-  rust_assert (!flag_name_resolution_2_0);
-  auto it = resolved_labels.find (refId);
-  rust_assert (it == resolved_labels.end ());
-
-  resolved_labels[refId] = defId;
-  get_label_scope ().append_reference_for_def (refId, defId);
-}
-
-bool
-Resolver::lookup_resolved_label (NodeId refId, NodeId *defId)
-{
-  rust_assert (!flag_name_resolution_2_0);
-  auto it = resolved_labels.find (refId);
-  if (it == resolved_labels.end ())
-    return false;
-
-  *defId = it->second;
-  return true;
-}
-
-void
-Resolver::insert_resolved_macro (NodeId refId, NodeId defId)
-{
-  rust_assert (!flag_name_resolution_2_0);
-  auto it = resolved_macros.find (refId);
-  rust_assert (it == resolved_macros.end ());
-
-  resolved_labels[refId] = defId;
-  get_label_scope ().append_reference_for_def (refId, defId);
-}
-
-bool
-Resolver::lookup_resolved_macro (NodeId refId, NodeId *defId)
-{
-  rust_assert (!flag_name_resolution_2_0);
-  auto it = resolved_macros.find (refId);
-  if (it == resolved_macros.end ())
-    return false;
-
-  *defId = it->second;
-  return true;
+  rust_unreachable ();
 }
 
 void
 Resolver::insert_resolved_misc (NodeId refId, NodeId defId)
 {
-  rust_assert (!flag_name_resolution_2_0);
-  auto it = misc_resolved_items.find (refId);
-  rust_assert (it == misc_resolved_items.end ());
-
-  misc_resolved_items[refId] = defId;
+  rust_unreachable ();
 }
 
 bool
 Resolver::lookup_resolved_misc (NodeId refId, NodeId *defId)
 {
-  rust_assert (!flag_name_resolution_2_0);
-  auto it = misc_resolved_items.find (refId);
-  if (it == misc_resolved_items.end ())
-    return false;
-
-  *defId = it->second;
-  return true;
-}
-
-void
-Resolver::push_closure_context (NodeId closure_expr_id)
-{
-  auto it = closures_capture_mappings.find (closure_expr_id);
-  rust_assert (it == closures_capture_mappings.end ());
-
-  closures_capture_mappings.insert ({closure_expr_id, {}});
-  closure_context.push_back (closure_expr_id);
-}
-
-void
-Resolver::pop_closure_context ()
-{
-  rust_assert (!closure_context.empty ());
-  closure_context.pop_back ();
-}
-
-void
-Resolver::insert_captured_item (NodeId id)
-{
-  // nothing to do unless we are in a closure context
-  if (closure_context.empty ())
-    return;
-
-  // check that this is a VAR_DECL?
-  Scope &name_scope = get_name_scope ();
-  Rib::ItemType type = Rib::ItemType::Unknown;
-  bool found = name_scope.lookup_decl_type (id, &type);
-  if (!found)
-    return;
-
-  // RIB Function { let a, let b } id = 1;
-  //   RIB Closure { let c } id = 2;
-  //     RIB IfStmt { <bind a>} id = 3;
-  //   RIB ... { ... } id = 4
-  //
-  // if we have a resolved_node_id of 'a' and the current rib is '3' we know
-  // this is binding exists in a rib with id < the closure rib id, other wise
-  // its just a normal binding and we don't care
-  //
-  // Problem the node id's dont work like this because the inner most items are
-  // created first so this means the root will have a larger id and a simple
-  // less than or greater than check wont work for more complex scoping cases
-  // but we can use our current rib context to figure this out by checking if
-  // the rib id the decl we care about exists prior to the rib for the closure
-  // id
-
-  const Rib *r = nullptr;
-  bool ok = name_scope.lookup_rib_for_decl (id, &r);
-  rust_assert (ok);
-  NodeId decl_rib_node_id = r->get_node_id ();
-
-  // iterate the closure context and add in the mapping for all to handle the
-  // case of nested closures
-  for (auto &closure_expr_id : closure_context)
-    {
-      if (!decl_needs_capture (decl_rib_node_id, closure_expr_id, name_scope))
-	continue;
-
-      // is this a valid binding to take
-      bool is_var_decl_p = type == Rib::ItemType::Var;
-      if (!is_var_decl_p)
-	{
-	  // FIXME is this an error case?
-	  return;
-	}
-
-      // append it to the context info
-      auto it = closures_capture_mappings.find (closure_expr_id);
-      rust_assert (it != closures_capture_mappings.end ());
-
-      it->second.insert (id);
-    }
-}
-
-bool
-Resolver::decl_needs_capture (NodeId decl_rib_node_id,
-			      NodeId closure_rib_node_id, const Scope &scope)
-{
-  for (const auto &rib : scope.get_context ())
-    {
-      bool rib_is_closure = rib->get_node_id () == closure_rib_node_id;
-      bool rib_is_decl = rib->get_node_id () == decl_rib_node_id;
-      if (rib_is_closure)
-	return false;
-      else if (rib_is_decl)
-	return true;
-    }
-  return false;
-}
-
-const std::set<NodeId> &
-Resolver::get_captures (NodeId id) const
-{
-  rust_assert (!flag_name_resolution_2_0);
-
-  auto it = closures_capture_mappings.find (id);
-  rust_assert (it != closures_capture_mappings.end ());
-  return it->second;
+  rust_unreachable ();
 }
 
 } // namespace Resolver

--- a/gcc/rust/resolve/rust-name-resolver.h
+++ b/gcc/rust/resolve/rust-name-resolver.h
@@ -124,173 +124,17 @@ public:
   static Resolver *get ();
   ~Resolver () {}
 
-  // these builtin types
-  void insert_builtin_types (Rib *r);
-
-  // these will be required for type resolution passes to
-  // map back to tyty nodes
-  std::vector<AST::Type *> &get_builtin_types ();
-
-  void push_new_name_rib (Rib *r);
-  void push_new_type_rib (Rib *r);
-  void push_new_label_rib (Rib *r);
-  void push_new_macro_rib (Rib *r);
-
-  bool find_name_rib (NodeId id, Rib **rib);
-  bool find_type_rib (NodeId id, Rib **rib);
-  bool find_label_rib (NodeId id, Rib **rib);
-  bool find_macro_rib (NodeId id, Rib **rib);
-
   void insert_resolved_name (NodeId refId, NodeId defId);
   bool lookup_resolved_name (NodeId refId, NodeId *defId);
 
   void insert_resolved_type (NodeId refId, NodeId defId);
   bool lookup_resolved_type (NodeId refId, NodeId *defId);
 
-  void insert_resolved_label (NodeId refId, NodeId defId);
-  bool lookup_resolved_label (NodeId refId, NodeId *defId);
-
-  void insert_resolved_macro (NodeId refId, NodeId defId);
-  bool lookup_resolved_macro (NodeId refId, NodeId *defId);
-
   void insert_resolved_misc (NodeId refId, NodeId defId);
   bool lookup_resolved_misc (NodeId refId, NodeId *defId);
 
-  // proxy for scoping
-  Scope &get_name_scope () { return name_scope; }
-  Scope &get_type_scope () { return type_scope; }
-  Scope &get_label_scope () { return label_scope; }
-  Scope &get_macro_scope () { return macro_scope; }
-
-  NodeId get_global_type_node_id () { return global_type_node_id; }
-
-  void set_unit_type_node_id (NodeId id) { unit_ty_node_id = id; }
-  NodeId get_unit_type_node_id () { return unit_ty_node_id; }
-
-  void set_never_type_node_id (NodeId id) { never_ty_node_id = id; }
-  NodeId get_never_type_node_id () { return never_ty_node_id; }
-
-  void push_new_module_scope (NodeId module_id)
-  {
-    current_module_stack.push_back (module_id);
-  }
-
-  void pop_module_scope ()
-  {
-    rust_assert (!current_module_stack.empty ());
-    current_module_stack.pop_back ();
-  }
-
-  NodeId peek_current_module_scope () const
-  {
-    rust_assert (!current_module_stack.empty ());
-    return current_module_stack.back ();
-  }
-
-  NodeId peek_crate_module_scope () const
-  {
-    rust_assert (!current_module_stack.empty ());
-    return current_module_stack.front ();
-  }
-
-  NodeId peek_parent_module_scope () const
-  {
-    rust_assert (current_module_stack.size () > 1);
-    return current_module_stack.at (current_module_stack.size () - 2);
-  }
-
-  void push_closure_context (NodeId closure_expr_id);
-  void pop_closure_context ();
-  void insert_captured_item (NodeId id);
-  const std::set<NodeId> &get_captures (NodeId id) const;
-
-  std::string as_debug_string () const
-  {
-    std::stringstream ss;
-
-    ss << "Names:\n";
-    for (auto &n : name_ribs)
-      {
-	ss << "\tNodeID: " << n.first << " Rib: " << n.second->debug_str ()
-	   << "\n";
-      }
-    ss << "Types:\n";
-    for (auto &n : type_ribs)
-      {
-	ss << "\tNodeID: " << n.first << " Rib: " << n.second->debug_str ()
-	   << "\n";
-      }
-    ss << "Macros:\n";
-
-    for (auto &n : macro_ribs)
-      {
-	ss << "\tNodeID: " << n.first << " Rib: " << n.second->debug_str ()
-	   << "\n";
-      }
-
-    ss << "Labels:\n";
-
-    for (auto &n : label_ribs)
-      {
-	ss << "\tNodeID: " << n.first << " Rib: " << n.second->debug_str ()
-	   << "\n";
-      }
-
-    return ss.str ();
-  }
-
-protected:
-  bool decl_needs_capture (NodeId decl_rib_node_id, NodeId closure_rib_node_id,
-			   const Scope &scope);
-
 private:
   Resolver ();
-
-  void generate_builtins ();
-  NodeId setup_builtin (const std::string &name, TyTy::BaseType *tyty);
-
-  Analysis::Mappings &mappings;
-  TypeCheckContext *tyctx;
-
-  std::vector<AST::Type *> builtins;
-
-  Scope name_scope;
-  Scope type_scope;
-  Scope label_scope;
-  Scope macro_scope;
-
-  NodeId global_type_node_id;
-  NodeId unit_ty_node_id;
-  NodeId never_ty_node_id;
-
-  // map a AST Node to a Rib
-  std::map<NodeId, Rib *> name_ribs;
-  std::map<NodeId, Rib *> type_ribs;
-  std::map<NodeId, Rib *> label_ribs;
-  std::map<NodeId, Rib *> macro_ribs;
-
-  // Rust uses DefIds to namespace these under a crate_num
-  // but then it uses the def_collector to assign local_defids
-  // to each ast node as well. not sure if this is going to fit
-  // with gcc very well to compile a full crate in one go but we will
-  // see.
-
-  // these are of the form ref->Def-NodeId
-  // we need two namespaces one for names and ones for types
-  std::map<NodeId, NodeId> resolved_names;
-  std::map<NodeId, NodeId> resolved_types;
-  std::map<NodeId, NodeId> resolved_labels;
-  std::map<NodeId, NodeId> resolved_macros;
-
-  // misc
-  std::map<NodeId, NodeId> misc_resolved_items;
-
-  // keep track of the current module scope ids
-  std::vector<NodeId> current_module_stack;
-
-  // captured variables mappings
-  std::vector<NodeId> closure_context;
-  std::map<NodeId, std::set<NodeId>> closures_capture_mappings;
 };
 
 } // namespace Resolver


### PR DESCRIPTION
This removes large chunks of the 1.0 resolver, and should help make sure further PRs (see: #4109, #4130) can't break anything.