### PR TITLE
Clean up of 'flag_name_resolution_2_0' mention, as this is no longer …

### DIFF
--- a/gcc/rust/lang.opt
+++ b/gcc/rust/lang.opt
@@ -208,10 +208,6 @@ Enum(frust_compile_until) String(compilation) Value(12)
 EnumValue
 Enum(frust_compile_until) String(end) Value(13)
 
-frust-name-resolution-2.0
-Rust Var(flag_name_resolution_2_0) Init(1)
-Use the temporary and experimental name resolution pipeline instead of the stable one.
-
 frust-borrowcheck
 Rust Var(flag_borrowcheck)
 Use the WIP borrow checker.

--- a/gcc/rust/resolve/rust-name-resolver.cc
+++ b/gcc/rust/resolve/rust-name-resolver.cc
@@ -19,9 +19,6 @@
 #include "rust-name-resolver.h"
 #include "rust-ast-full.h"
 
-// for flag_name_resolution_2_0
-#include "options.h"
-
 namespace Rust {
 namespace Resolver {
 


### PR DESCRIPTION
Clean up of obsolete nr2 command line option

Fixes: Rust-GCC/gccrs#4503

gcc/rust/ChangeLog:

        * lang.opt (flag_name_resolution_2_0): Remove.
        * resolve/rust-name-resolver.cc: Remove include.

