### PR TITLE
rust: avoid ICE on attributed struct base parsing

### DIFF
--- a/gcc/rust/parse/rust-parse-error.h
+++ b/gcc/rust/parse/rust-parse-error.h
@@ -358,6 +358,7 @@ enum class StructExprField
 {
   MALFORMED,
   CHILD_ERROR,
+  STRUCT_BASE_ATTRIBUTES,
   // Not a hard error
   STRUCT_BASE,
 };

--- a/gcc/rust/parse/rust-parse-impl-expr.hxx
+++ b/gcc/rust/parse/rust-parse-impl-expr.hxx
@@ -1748,6 +1748,16 @@ Parser<ManagedTokenSource>::parse_struct_expr_field ()
     case DOT_DOT:
       /* this is a struct base and can't be parsed here, so just return
        * nothing without erroring */
+      if (!outer_attrs.empty ())
+	{
+	  add_error (
+	    Error (t->get_locus (),
+		   "attributes are not allowed before %<..%> in a struct "
+		   "expression"));
+
+	  return tl::unexpected<Parse::Error::StructExprField> (
+	    Parse::Error::StructExprField::STRUCT_BASE_ATTRIBUTES);
+	}
 
       return tl::unexpected<Parse::Error::StructExprField> (
 	Parse::Error::StructExprField::STRUCT_BASE);
@@ -4054,9 +4064,15 @@ Parser<ManagedTokenSource>::parse_struct_expr_struct_partial (
 	while (t->get_id () != RIGHT_CURLY && t->get_id () != DOT_DOT)
 	  {
 	    auto field = parse_struct_expr_field ();
-	    if (!field
-		&& field.error () != Parse::Error::StructExprField::STRUCT_BASE)
+	    if (!field)
 	      {
+		if (field.error () == Parse::Error::StructExprField::STRUCT_BASE)
+		  break;
+		if (field.error ()
+		    == Parse::Error::StructExprField::STRUCT_BASE_ATTRIBUTES)
+		  return tl::unexpected<Parse::Error::Expr> (
+		    Parse::Error::Expr::CHILD_ERROR);
+
 		Error error (t->get_locus (),
 			     "failed to parse struct (or enum) expr field");
 		add_error (std::move (error));

--- a/gcc/testsuite/rust/compile/issue-4476.rs
+++ b/gcc/testsuite/rust/compile/issue-4476.rs
@@ -1,0 +1,10 @@
+#![feature(no_core)]
+#![no_core]
+
+struct Foo {}
+struct S {}
+
+fn main() {
+    Foo { #[cfg(feature = -1)] .. } = S {};
+    // { dg-error "attributes are not allowed before .* in a struct expression" "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
Address #4476

rust: avoid ICE on attributed struct base parsing

Parsing a struct expression like `Foo { #[cfg(feature = -1)] .. }`
could ICE because `parse_struct_expr_struct_partial()` unconditionally
called `value()` on an errored `StructExprField` result after
`parse_struct_expr_field()` had already identified `..` as the struct
base.

Handle that case explicitly, emit a normal parser diagnostic when
attributes are attached to the struct-base `..`, and add a regression
test for the reduced reproducer.

Signed-off-by: Hritam Shrivastava <hritamstark05@gmail.com>
