### PR TITLE
Resolve non-final path segments in type namespace

### DIFF
--- a/gcc/rust/resolve/rust-forever-stack.h
+++ b/gcc/rust/resolve/rust-forever-stack.h
@@ -622,6 +622,8 @@ private:
 
 template <Namespace N> class ForeverStack
 {
+  template <Namespace N2> friend class ForeverStack;
+
 public:
   ForeverStack ()
     : root (Node (Rib (Rib::Kind::Normal), UNKNOWN_NODEID)),
@@ -760,11 +762,13 @@ public:
   tl::optional<Rib::Definition> resolve_path (
     const ResolutionPath &path, ResolutionMode mode,
     std::function<void (Usage, Definition)> insert_segment_resolution,
-    std::vector<Error> &collect_errors);
+    std::vector<Error> &collect_errors,
+    ForeverStack<Namespace::Types> &type_stack);
   tl::optional<Rib::Definition> resolve_path (
     const ResolutionPath &path, ResolutionMode mode,
     std::function<void (Usage, Definition)> insert_segment_resolution,
-    std::vector<Error> &collect_errors, NodeId starting_point_id);
+    std::vector<Error> &collect_errors, NodeId starting_point_id,
+    ForeverStack<Namespace::Types> &type_stack);
 
   // FIXME: Documentation
   tl::optional<Rib &> to_rib (NodeId rib_id);
@@ -836,7 +840,8 @@ private:
     const ResolutionPath &path, ResolutionMode mode,
     std::function<void (Usage, Definition)> insert_segment_resolution,
     std::vector<Error> &collect_errors,
-    std::reference_wrapper<Node> starting_point);
+    std::reference_wrapper<Node> starting_point,
+    ForeverStack<Namespace::Types> &type_stack);
 
   /* Should we keep going upon seeing a Rib? */
   enum class KeepGoing
@@ -899,7 +904,8 @@ private:
     Node &starting_point, const std::vector<ResolutionPath::Segment> &segments,
     SegIterator iterator,
     std::function<void (Usage, Definition)> insert_segment_resolution,
-    std::vector<Error> &collect_errors);
+    std::vector<Error> &collect_errors,
+    ForeverStack<Namespace::Types> &type_stack);
 
   tl::optional<Rib::Definition> resolve_final_segment (Node &final_node,
 						       std::string &seg_name,

--- a/gcc/rust/resolve/rust-forever-stack.hxx
+++ b/gcc/rust/resolve/rust-forever-stack.hxx
@@ -526,13 +526,13 @@ ForeverStack<N>::find_starting_point (
   return iterator;
 }
 
-template <Namespace N>
-tl::optional<typename ForeverStack<N>::Node &>
-ForeverStack<N>::resolve_segments (
+template <>
+inline tl::optional<typename ForeverStack<Namespace::Types>::Node &>
+ForeverStack<Namespace::Types>::resolve_segments (
   Node &starting_point, const std::vector<ResolutionPath::Segment> &segments,
   typename std::vector<ResolutionPath::Segment>::const_iterator iterator,
   std::function<void (Usage, Definition)> insert_segment_resolution,
-  std::vector<Error> &collect_errors)
+  std::vector<Error> &collect_errors, ForeverStack<Namespace::Types> &)
 {
   Node *current_node = &starting_point;
   for (; !is_last (iterator, segments); iterator++)
@@ -647,6 +647,28 @@ ForeverStack<N>::resolve_segments (
   return *current_node;
 }
 
+template <Namespace N>
+tl::optional<typename ForeverStack<N>::Node &>
+ForeverStack<N>::resolve_segments (
+  Node &starting_point, const std::vector<ResolutionPath::Segment> &segments,
+  typename std::vector<ResolutionPath::Segment>::const_iterator iterator,
+  std::function<void (Usage, Definition)> insert_segment_resolution,
+  std::vector<Error> &collect_errors,
+  ForeverStack<Namespace::Types> &type_stack)
+{
+  ForeverStack<Namespace::Types>::Node &true_starting_point
+    = type_stack.dfs_node (type_stack.root, starting_point.id).value ();
+
+  auto ret
+    = type_stack.resolve_segments (true_starting_point, segments, iterator,
+				   std::move (insert_segment_resolution),
+				   collect_errors, type_stack);
+  if (!ret.has_value ())
+    return tl::nullopt;
+
+  return dfs_node (root, ret->id).value ();
+}
+
 template <>
 inline tl::optional<Rib::Definition>
 ForeverStack<Namespace::Types>::resolve_final_segment (Node &final_node,
@@ -672,7 +694,8 @@ tl::optional<Rib::Definition>
 ForeverStack<N>::resolve_path (
   const ResolutionPath &path, ResolutionMode mode,
   std::function<void (Usage, Definition)> insert_segment_resolution,
-  std::vector<Error> &collect_errors, NodeId starting_point_id)
+  std::vector<Error> &collect_errors, NodeId starting_point_id,
+  ForeverStack<Namespace::Types> &type_stack)
 {
   auto starting_point = dfs_node (root, starting_point_id);
 
@@ -682,20 +705,7 @@ ForeverStack<N>::resolve_path (
     return tl::nullopt;
 
   return resolve_path (path, mode, insert_segment_resolution, collect_errors,
-		       *starting_point);
-}
-
-template <Namespace N>
-tl::optional<Rib::Definition>
-ForeverStack<N>::resolve_path (
-  const ResolutionPath &path, ResolutionMode mode,
-  std::function<void (Usage, Definition)> insert_segment_resolution,
-  std::vector<Error> &collect_errors)
-{
-  std::reference_wrapper<Node> starting_point = cursor ();
-
-  return resolve_path (path, mode, insert_segment_resolution, collect_errors,
-		       starting_point);
+		       *starting_point, type_stack);
 }
 
 template <Namespace N>
@@ -704,7 +714,22 @@ ForeverStack<N>::resolve_path (
   const ResolutionPath &path, ResolutionMode mode,
   std::function<void (Usage, Definition)> insert_segment_resolution,
   std::vector<Error> &collect_errors,
-  std::reference_wrapper<Node> starting_point)
+  ForeverStack<Namespace::Types> &type_stack)
+{
+  std::reference_wrapper<Node> starting_point = cursor ();
+
+  return resolve_path (path, mode, insert_segment_resolution, collect_errors,
+		       starting_point, type_stack);
+}
+
+template <Namespace N>
+tl::optional<Rib::Definition>
+ForeverStack<N>::resolve_path (
+  const ResolutionPath &path, ResolutionMode mode,
+  std::function<void (Usage, Definition)> insert_segment_resolution,
+  std::vector<Error> &collect_errors,
+  std::reference_wrapper<Node> starting_point,
+  ForeverStack<Namespace::Types> &type_stack)
 {
   bool can_descend = true;
 
@@ -835,7 +860,8 @@ ForeverStack<N>::resolve_path (
     }
 
   return resolve_segments (starting_point.get (), segments, iterator,
-			   insert_segment_resolution, collect_errors)
+			   insert_segment_resolution, collect_errors,
+			   type_stack)
     .and_then ([this, &segments, &insert_segment_resolution] (
 		 Node &final_node) -> tl::optional<Rib::Definition> {
       // leave resolution within impl blocks to type checker

--- a/gcc/rust/resolve/rust-name-resolution-context.h
+++ b/gcc/rust/resolve/rust-name-resolution-context.h
@@ -544,19 +544,19 @@ public:
       {
       case Namespace::Values:
 	resolved = values.resolve_path (path, mode, insert_segment_resolution,
-					collect_errors);
+					collect_errors, types);
 	break;
       case Namespace::Types:
 	resolved = types.resolve_path (path, mode, insert_segment_resolution,
-				       collect_errors);
+				       collect_errors, types);
 	break;
       case Namespace::Macros:
 	resolved = macros.resolve_path (path, mode, insert_segment_resolution,
-					collect_errors);
+					collect_errors, types);
 	break;
       case Namespace::Labels:
 	resolved = labels.resolve_path (path, mode, insert_segment_resolution,
-					collect_errors);
+					collect_errors, types);
 	break;
       default:
 	rust_unreachable ();
@@ -570,16 +570,16 @@ public:
 	  {
 	  case Namespace::Values:
 	    return values.resolve_path (path, mode, insert_segment_resolution,
-					collect_errors, *prelude);
+					collect_errors, *prelude, types);
 	  case Namespace::Types:
 	    return types.resolve_path (path, mode, insert_segment_resolution,
-				       collect_errors, *prelude);
+				       collect_errors, *prelude, types);
 	  case Namespace::Macros:
 	    return macros.resolve_path (path, mode, insert_segment_resolution,
-					collect_errors, *prelude);
+					collect_errors, *prelude, types);
 	  case Namespace::Labels:
 	    return labels.resolve_path (path, mode, insert_segment_resolution,
-					collect_errors, *prelude);
+					collect_errors, *prelude, types);
 	  default:
 	    rust_unreachable ();
 	  }

--- a/gcc/testsuite/rust/compile/name_resolution27.rs
+++ b/gcc/testsuite/rust/compile/name_resolution27.rs
@@ -1,0 +1,13 @@
+#![feature(no_core)]
+#![no_core]
+
+pub mod a {
+    pub mod b {
+        pub const C: i32 = 12;
+    }
+}
+
+pub fn foo() -> i32 {
+    use a::b;
+    b::C
+}


### PR DESCRIPTION
This is very hack-y, and the `ForeverStack`/`NameResolutionContext` boundary is due for some major refactoring, but should be correct. Credit to @CohenArthur for mentioning the idea in DMs
> so I did a quick and dirty implementation where ForeverStack<N>::resolve_path now takes an extra parameter, a ForeverStack<Namespace::Types> &types_stack, and does resolve_segments within the types NS before resolving the last segment.