### PR TITLE
Fix ICE in get_function_expr when cfg'd return type inside macro

### DIFF
--- a/gcc/rust/expand/rust-cfg-strip.cc
+++ b/gcc/rust/expand/rust-cfg-strip.cc
@@ -828,9 +828,13 @@ CfgStrip::visit (AST::ArrayIndexExpr &expr)
 
   const auto &array_expr = expr.get_array_expr ();
   if (array_expr.is_marked_for_strip ())
-    rust_error_at (array_expr.get_locus (),
-		   "cannot strip expression in this position - outer "
-		   "attributes not allowed");
+    {
+      rust_error_at (array_expr.get_locus (),
+		     "cannot strip expression in this position - outer "
+		     "attributes not allowed");
+      expr.mark_for_strip ();
+      return;
+    }
 
   const auto &index_expr = expr.get_index_expr ();
   if (index_expr.is_marked_for_strip ())
@@ -1044,9 +1048,13 @@ CfgStrip::visit (AST::CallExpr &expr)
 
   auto &function = expr.get_function_expr ();
   if (function.is_marked_for_strip ())
-    rust_error_at (function.get_locus (),
-		   "cannot strip expression in this position - outer "
-		   "attributes not allowed");
+    {
+      rust_error_at (function.get_locus (),
+		     "cannot strip expression in this position - outer "
+		     "attributes not allowed");
+      expr.mark_for_strip ();
+      return;
+    }
 
   /* spec says outer attributes are specifically allowed for elements
    * of call expressions, so full stripping possible */

--- a/gcc/testsuite/rust/compile/issue-4167.rs
+++ b/gcc/testsuite/rust/compile/issue-4167.rs
@@ -1,0 +1,15 @@
+#![feature(no_core)]
+#![no_core]
+macro_rules! the_macro {
+    ( $foo:stmt ; $bar:stmt ; ) => {
+        #[cfg(foo)]
+        $foo
+
+        $foo[cfg(bar)]
+        $bar
+    };
+}
+
+fn the_function() {
+    the_macro!( (); (); ); // { dg-error "cannot strip expression in this position" }
+}


### PR DESCRIPTION
the problem is cfg-strip emits an error for unstrippable expressions but doesn't mark the parent for strip, leaving a broken subtree for later passes to ICE on.

gcc/rust/ChangeLog:

	* expand/rust-cfg-strip.cc (CfgStrip::visit): mark CallExpr for strip when function expression fails stripping. (CfgStrip::visit): mark ArrayIndexExpr for strip when array or index expression fails stripping.

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4167.rs: New test.

Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[ ] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[ ] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[ ] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---

*Please write a comment explaining your change. This is the message
that will be part of the merge commit.
