### PR TITLE
Recognize `warn` and `deny` as built in attributes

### DIFF
--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -35,6 +35,8 @@ static const BuiltinAttrDefinition __definitions[]
      {Attrs::DERIVE_ATTR, EXPANSION},
      {Attrs::DEPRECATED, STATIC_ANALYSIS},
      {Attrs::ALLOW, STATIC_ANALYSIS},
+     {Attrs::WARN, STATIC_ANALYSIS},
+     {Attrs::DENY, STATIC_ANALYSIS},
      {Attrs::ALLOW_INTERNAL_UNSTABLE, STATIC_ANALYSIS},
      {Attrs::DOC, HIR_LOWERING},
      {Attrs::MUST_USE, STATIC_ANALYSIS},


### PR DESCRIPTION
Adds just enough more handling of https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes to unblock `libcore`.