### PR TITLE
gccrs: Fix ICE cloning trait functions without return types

### DIFF
--- a/gcc/rust/hir/tree/rust-hir-item.cc
+++ b/gcc/rust/hir/tree/rust-hir-item.cc
@@ -630,7 +630,8 @@ TraitFunctionDecl::TraitFunctionDecl (
 TraitFunctionDecl::TraitFunctionDecl (TraitFunctionDecl const &other)
   : qualifiers (other.qualifiers), function_name (other.function_name),
     function_params (other.function_params),
-    return_type (other.return_type->clone_type ()),
+    return_type (other.return_type != nullptr ? other.return_type->clone_type ()
+					      : nullptr),
     where_clause (other.where_clause), self (other.self)
 {
   generic_params.reserve (other.generic_params.size ());
@@ -644,7 +645,9 @@ TraitFunctionDecl::operator= (TraitFunctionDecl const &other)
   function_name = other.function_name;
   qualifiers = other.qualifiers;
   function_params = other.function_params;
-  return_type = other.return_type->clone_type ();
+  return_type
+    = other.return_type != nullptr ? other.return_type->clone_type () : nullptr;
+
   where_clause = other.where_clause;
   self = other.self;
 

--- a/gcc/testsuite/rust/compile/issue-3972.rs
+++ b/gcc/testsuite/rust/compile/issue-3972.rs
@@ -1,0 +1,19 @@
+// { dg-options "-frust-compile-until=lowering" }
+#![feature(no_core)]
+#![no_core]
+
+struct Expr<const N: u32>;
+
+trait Trait0 {
+    fn required(
+        _: Expr<
+            {
+                trait Trait0 {
+                    fn required();
+                }
+
+                0
+            },
+        >,
+    );
+}


### PR DESCRIPTION
Fixes #3972 

gcc/rust/ChangeLog:
```
	* hir/tree/rust-hir-item.cc (TraitFunctionDecl::TraitFunctionDecl): 
	Handle null return types in copy constructor.
	(TraitFunctionDecl::operator=): Likewise.
```

gcc/testsuite/ChangeLog:
```
	* rust/compile/issue-3972.rs: New test.
```