### PR TITLE
lex: Emit E0768 for empty non-decimal literals

### DIFF
--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -2150,15 +2150,22 @@ Lexer::parse_non_decimal_int_literal (location_t loc, IsDigitFunc is_digit_func,
   raw_str += current_char; // x, o, b
   skip_input ();
 
-  int length = 1;
+  int length = 2;
+  bool has_valid_digit = false;
 
   current_char = peek_input ();
 
-  length++;
-
   // loop through to add entire number to string
-  while (is_digit_func (current_char.value) || current_char == '_')
+  while (true)
     {
+      if (is_digit_func (current_char.value))
+	{
+	  has_valid_digit = true;
+	}
+      else if (current_char != '_')
+	{
+	  break;
+	}
       length++;
 
       raw_str += current_char;
@@ -2175,6 +2182,11 @@ Lexer::parse_non_decimal_int_literal (location_t loc, IsDigitFunc is_digit_func,
   length += suffix_pair.second;
 
   current_column += length;
+
+  if (!has_valid_digit)
+    {
+      rust_error_at (loc, ErrorCode::E0768, "no valid digits found for number");
+    }
 
   loc += length - 1;
 

--- a/gcc/testsuite/rust/compile/empty-non-decimal.rs
+++ b/gcc/testsuite/rust/compile/empty-non-decimal.rs
@@ -1,0 +1,10 @@
+#![feature(no_core)]
+#![no_core]
+
+fn main() {
+    let _a = 0x; // { dg-error "no valid digits found for number" }
+    let _b = 0b; // { dg-error "no valid digits found for number" }
+    let _c = 0o; // { dg-error "no valid digits found for number" }
+    let _d = 0x_; // { dg-error "no valid digits found for number" }
+    let _e = 0x_u32; // { dg-error "no valid digits found for number" }
+}


### PR DESCRIPTION
Previously, the lexer evaluated empty non-decimal literals (like 0x, 0b, 0o) as 0. Now, it emits error E0768 when there are no valid digits.

gcc/rust/ChangeLog:

	* lex/rust-lex.cc (Lexer::parse_non_decimal_int_literal): Emit E0768.

gcc/testsuite/ChangeLog:

	* rust/compile/empty-non-decimal.rs: New test.

Closes #4490