### PR TITLE
Add feature gate for rustc_const_stable attribute

### DIFF
--- a/gcc/rust/checks/errors/feature/rust-feature-gate.cc
+++ b/gcc/rust/checks/errors/feature/rust-feature-gate.cc
@@ -234,6 +234,16 @@ FeatureGate::visit (AST::Function &function)
   if (!function.is_external ())
     check_rustc_attri (function.get_outer_attrs ());
 
+  for (const AST::Attribute &attr : function.get_outer_attrs ())
+    {
+      if (attr.get_path ().as_string () == "rustc_const_stable")
+	{
+	  gate (Feature::Name::STAGED_API, attr.get_locus (),
+		"stability attributes may not be used outside of the standard "
+		"library");
+	}
+    }
+
   check_lang_item_attribute (function.get_outer_attrs ());
 
   note_stability_attribute (function.get_outer_attrs ());

--- a/gcc/testsuite/rust/compile/const-issue1440.rs
+++ b/gcc/testsuite/rust/compile/const-issue1440.rs
@@ -1,9 +1,8 @@
 // { dg-additional-options "-w" }
 #![feature(no_core)]
 #![no_core]
-
 #![feature(intrinsics)]
-
+#![feature(staged_api)]
 #![feature(lang_items)]
 #[lang = "sized"]
 pub trait Sized {}

--- a/gcc/testsuite/rust/compile/for-loop1.rs
+++ b/gcc/testsuite/rust/compile/for-loop1.rs
@@ -1,8 +1,8 @@
 // { dg-output "loop\r*\nloop\r*\n" }
 #![feature(no_core)]
 #![no_core]
-
 #![feature(intrinsics, lang_items)]
+#![feature(staged_api)]
 
 pub use option::Option::{self, None, Some};
 pub use result::Result::{self, Err, Ok};

--- a/gcc/testsuite/rust/compile/for-loop2.rs
+++ b/gcc/testsuite/rust/compile/for-loop2.rs
@@ -1,8 +1,7 @@
 // { dg-output "1\r*\n2\r*\n" }
 #![feature(no_core)]
 #![no_core]
-
-#![feature(intrinsics, lang_items)]
+#![feature(intrinsics, lang_items, staged_api)]
 
 pub use option::Option::{self, None, Some};
 pub use result::Result::{self, Err, Ok};

--- a/gcc/testsuite/rust/compile/issue-1031.rs
+++ b/gcc/testsuite/rust/compile/issue-1031.rs
@@ -1,8 +1,6 @@
 #![feature(no_core)]
 #![no_core]
-
-#![feature(intrinsics)]
-
+#![feature(intrinsics, staged_api)]
 #![feature(lang_items)]
 #[lang = "sized"]
 pub trait Sized {}

--- a/gcc/testsuite/rust/compile/issue-1289.rs
+++ b/gcc/testsuite/rust/compile/issue-1289.rs
@@ -1,8 +1,6 @@
 #![feature(no_core)]
 #![no_core]
-
-#![feature(intrinsics)]
-
+#![feature(intrinsics, staged_api)]
 #![feature(lang_items)]
 #[lang = "sized"]
 pub trait Sized {}

--- a/gcc/testsuite/rust/compile/iterators1.rs
+++ b/gcc/testsuite/rust/compile/iterators1.rs
@@ -1,7 +1,6 @@
 #![feature(no_core)]
 #![no_core]
-
-#![feature(intrinsics, lang_items)]
+#![feature(intrinsics, lang_items, staged_api)]
 
 pub use option::Option::{self, None, Some};
 pub use result::Result::{self, Err, Ok};

--- a/gcc/testsuite/rust/compile/missing_staged_api.rs
+++ b/gcc/testsuite/rust/compile/missing_staged_api.rs
@@ -1,0 +1,12 @@
+#![feature(no_core)]
+#![feature(intrinsics)]
+#![no_core]
+
+pub mod intrinsics {
+
+    extern "rust-intrinsic" {
+        // { dg-error "stability attributes may not be used outside of the standard library" "" { target *-*-* } .+1 }
+        #[rustc_const_stable(feature = "const_size_of", since = "1.40.0")]
+        pub fn size_of<T>() -> usize;
+    }
+}

--- a/gcc/testsuite/rust/compile/rustc_const_stable.rs
+++ b/gcc/testsuite/rust/compile/rustc_const_stable.rs
@@ -1,7 +1,7 @@
 #![feature(no_core)]
 #![no_core]
-
 #![feature(rustc_attrs)]
+#![feature(staged_api)]
 
 #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
 pub fn foo() {}

--- a/gcc/testsuite/rust/compile/torture/issue-1075.rs
+++ b/gcc/testsuite/rust/compile/torture/issue-1075.rs
@@ -1,9 +1,8 @@
 // { dg-additional-options "-w" }
 #![feature(no_core)]
 #![no_core]
-
 #![feature(intrinsics)]
-
+#![feature(staged_api)]
 #![feature(lang_items)]
 #[lang = "sized"]
 pub trait Sized {}

--- a/gcc/testsuite/rust/compile/torture/issue-1432.rs
+++ b/gcc/testsuite/rust/compile/torture/issue-1432.rs
@@ -1,9 +1,8 @@
 // { dg-additional-options "-w" }
 #![feature(no_core)]
 #![no_core]
-
 #![feature(intrinsics)]
-
+#![feature(staged_api)]
 #![feature(lang_items)]
 #[lang = "sized"]
 pub trait Sized {}

--- a/gcc/testsuite/rust/execute/torture/const-generics-7.rs
+++ b/gcc/testsuite/rust/execute/torture/const-generics-7.rs
@@ -1,8 +1,6 @@
 #![feature(no_core)]
 #![no_core]
-
-#![feature(intrinsics)]
-
+#![feature(intrinsics, staged_api)]
 #![feature(lang_items)]
 #[lang = "sized"]
 pub trait Sized {}

--- a/gcc/testsuite/rust/execute/torture/for-loop1.rs
+++ b/gcc/testsuite/rust/execute/torture/for-loop1.rs
@@ -2,7 +2,7 @@
 #![feature(no_core)]
 #![no_core]
 
-#![feature(intrinsics, lang_items)]
+#![feature(intrinsics, lang_items, staged_api)]
 
 pub use option::Option::{self, None, Some};
 pub use result::Result::{self, Err, Ok};

--- a/gcc/testsuite/rust/execute/torture/for-loop2.rs
+++ b/gcc/testsuite/rust/execute/torture/for-loop2.rs
@@ -2,7 +2,7 @@
 #![feature(no_core)]
 #![no_core]
 
-#![feature(intrinsics, lang_items)]
+#![feature(intrinsics, lang_items, staged_api)]
 
 pub use option::Option::{self, None, Some};
 pub use result::Result::{self, Err, Ok};

--- a/gcc/testsuite/rust/execute/torture/issue-1120.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-1120.rs
@@ -1,9 +1,7 @@
 // { dg-additional-options "-w" }
 #![feature(no_core)]
 #![no_core]
-
-#![feature(intrinsics)]
-
+#![feature(intrinsics, staged_api)]
 #![feature(lang_items)]
 #[lang = "sized"]
 pub trait Sized {}

--- a/gcc/testsuite/rust/execute/torture/issue-1133.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-1133.rs
@@ -1,9 +1,7 @@
 // { dg-additional-options "-w" }
 #![feature(no_core)]
 #![no_core]
-
-#![feature(intrinsics)]
-
+#![feature(intrinsics, staged_api)]
 #![feature(lang_items)]
 #[lang = "sized"]
 pub trait Sized {}

--- a/gcc/testsuite/rust/execute/torture/issue-1232.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-1232.rs
@@ -2,9 +2,7 @@
 // { dg-output "slice_access=3\r*\n" }
 #![feature(no_core)]
 #![no_core]
-
-#![feature(intrinsics)]
-
+#![feature(intrinsics, staged_api)]
 #![feature(lang_items)]
 #[lang = "sized"]
 pub trait Sized {}

--- a/gcc/testsuite/rust/execute/torture/issue-1436.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-1436.rs
@@ -1,10 +1,7 @@
 // { dg-options "-w" }
 #![feature(no_core)]
 #![no_core]
-
-
-#![feature(intrinsics)]
-
+#![feature(intrinsics, staged_api)]
 #![feature(lang_items)]
 #[lang = "sized"]
 pub trait Sized {}

--- a/gcc/testsuite/rust/execute/torture/iter1.rs
+++ b/gcc/testsuite/rust/execute/torture/iter1.rs
@@ -1,8 +1,7 @@
 // { dg-output "1\r*\n2\r*\n" }
 #![feature(no_core)]
 #![no_core]
-
-#![feature(intrinsics, lang_items)]
+#![feature(intrinsics, lang_items, staged_api)]
 
 pub use option::Option::{self, None, Some};
 pub use result::Result::{self, Err, Ok};

--- a/gcc/testsuite/rust/execute/torture/slice-magic.rs
+++ b/gcc/testsuite/rust/execute/torture/slice-magic.rs
@@ -1,9 +1,7 @@
 // { dg-additional-options "-w" }
 #![feature(no_core)]
 #![no_core]
-
-#![feature(intrinsics)]
-
+#![feature(intrinsics, staged_api)]
 #![feature(lang_items)]
 #[lang = "sized"]
 pub trait Sized {}

--- a/gcc/testsuite/rust/execute/torture/slice-magic2.rs
+++ b/gcc/testsuite/rust/execute/torture/slice-magic2.rs
@@ -1,9 +1,7 @@
 // { dg-additional-options "-w" }
 #![feature(no_core)]
 #![no_core]
-
-#![feature(intrinsics)]
-
+#![feature(intrinsics, staged_api)]
 #![feature(lang_items)]
 #[lang = "sized"]
 pub trait Sized {}

--- a/gcc/testsuite/rust/execute/torture/str-layout1.rs
+++ b/gcc/testsuite/rust/execute/torture/str-layout1.rs
@@ -2,9 +2,7 @@
 // { dg-output "t1sz=5 t2sz=10\r*" }
 #![feature(no_core)]
 #![no_core]
-
-#![feature(intrinsics)]
-
+#![feature(intrinsics, staged_api)]
 #![feature(lang_items)]
 #[lang = "sized"]
 pub trait Sized {}


### PR DESCRIPTION
rustc_const_stable attributes are used within the core library but were not properly feature gated. The compiler now rejects their usage when the feature has not been explicitly enabled.