### PR TITLE
Nix flake for Reproducible GCC-Rust development environment

### DIFF
--- a/contrib/nix/bash/gccrs-commit-mklog.sh
+++ b/contrib/nix/bash/gccrs-commit-mklog.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+
+ROOT_DIR=$(git rev-parse --show-toplevel 2>/dev/null || true)
+if [ -z "$ROOT_DIR" ]; then
+    echo "Warning: You must be inside a git repository to run this command." >&2
+    exit 1
+fi
+
+if git diff --cached --quiet; then
+    echo "Warning: No staged changes found. Run 'git add' first." >&2
+    exit 1
+fi
+
+TMP_MSG_FILE=$(mktemp -t gccrs-changelog-XXXXXX.txt)
+trap 'rm -f "$TMP_MSG_FILE"' EXIT
+
+if ! gmklog > "$TMP_MSG_FILE" && ! gccrs-mklog > "$TMP_MSG_FILE"; then
+    echo "Warning: Failed to generate ChangeLog template." >&2
+    exit 1
+fi
+
+if [ ! -s "$TMP_MSG_FILE" ]; then
+    echo "Warning: ChangeLog template is empty. Aborting commit." >&2
+    exit 1
+fi
+
+git commit -t "$TMP_MSG_FILE" "$@"

--- a/contrib/nix/bash/gccrs-fix-changelog.sh
+++ b/contrib/nix/bash/gccrs-fix-changelog.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+ROOT_DIR=$(git rev-parse --show-toplevel 2>/dev/null)
+
+if [ -z "$ROOT_DIR" ]; then
+    echo "Warning: You must be inside a git repository to run this command." >&2
+    exit 1
+fi
+
+SCRIPT_PATH="$ROOT_DIR/contrib/git-fix-changelog.py"
+
+if [ ! -f "$SCRIPT_PATH" ]; then
+    echo "Warning: '$SCRIPT_PATH' not found! Are you sure this is the gccrs repository?" >&2
+    exit 1
+fi
+
+python3 "$SCRIPT_PATH" "$@"

--- a/contrib/nix/bash/gccrs-mklog.sh
+++ b/contrib/nix/bash/gccrs-mklog.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+ROOT_DIR=$(git rev-parse --show-toplevel 2>/dev/null)
+
+if [ -z "$ROOT_DIR" ]; then
+    echo "Warning: You must be inside a git repository to run this command." >&2
+    exit 1
+fi
+
+SCRIPT_PATH="$ROOT_DIR/contrib/mklog.py"
+
+if [ ! -f "$SCRIPT_PATH" ]; then
+    echo "Warning: '$SCRIPT_PATH' not found! Are you sure this is the gccrs repository?" >&2
+    exit 1
+fi
+
+git diff --cached | python3 "$SCRIPT_PATH" -

--- a/contrib/nix/bash/gccrs-style.sh
+++ b/contrib/nix/bash/gccrs-style.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+ROOT_DIR=$(git rev-parse --show-toplevel 2>/dev/null)
+
+if [ -z "$ROOT_DIR" ]; then
+    echo "Warning: You must be inside a git repository to run this command." >&2
+    exit 1
+fi
+
+SCRIPT_PATH="$ROOT_DIR/contrib/check_GNU_style.py"
+
+if [ ! -f "$SCRIPT_PATH" ]; then
+    echo "Warning: '$SCRIPT_PATH' not found! Are you sure this is the gccrs repository?" >&2
+    exit 1
+fi
+
+arg=""
+if [ $# -ge 1 ] && [ "$1" != "-f" ]; then
+    arg="$1"
+    shift
+elif [ $# -eq 3 ]; then
+    arg="$3"
+    set -- "$1" "$2"
+fi
+
+TARGET_COMMIT="${arg:-HEAD}"
+
+git show "$TARGET_COMMIT" | python3 "$SCRIPT_PATH" "$@" -

--- a/contrib/nix/bash/gccrs-verify.sh
+++ b/contrib/nix/bash/gccrs-verify.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+ROOT_DIR=$(git rev-parse --show-toplevel 2>/dev/null || true)
+
+if [ -z "$ROOT_DIR" ]; then
+    echo "Warning: You must be inside a git repository to run this command." >&2
+    exit 1
+fi
+
+SCRIPT_PATH="$ROOT_DIR/contrib/gcc-changelog/git_check_commit.py"
+
+if [ ! -f "$SCRIPT_PATH" ]; then
+    echo "Warning: '$SCRIPT_PATH' not found! Are you sure this is the gccrs repository?" >&2
+    exit 1
+fi
+
+cd "$ROOT_DIR"
+
+TARGET_COMMIT="${1:-HEAD}"
+python3 "$SCRIPT_PATH" "$TARGET_COMMIT"

--- a/contrib/nix/flake.lock
+++ b/contrib/nix/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/contrib/nix/flake.nix
+++ b/contrib/nix/flake.nix
@@ -1,0 +1,109 @@
+{
+  description = "Reproducible Nix environment for GCC Rust (gccrs) development";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+      pkgs32 = pkgs.pkgsi686Linux;
+
+
+      mkGccrsEnv =
+        { is32Bit ? false, useShortPrefix ? false }:
+        let
+          targetPkgs = if is32Bit then pkgs32 else pkgs;
+
+          gccrs-env-tools = targetPkgs.callPackage ./packages/gccrs-env-tools.nix {
+            inherit is32Bit useShortPrefix;
+          };
+
+          gccrs-contrib-tools = pkgs.callPackage ./packages/gccrs-contrib-tools.nix {
+            inherit useShortPrefix;
+          };
+        in
+        targetPkgs.mkShell.override { stdenv = targetPkgs.ccacheStdenv; } {
+          name = "gccrs-dev${if is32Bit then "-32" else "-64"}";
+
+          packages = [
+            gccrs-env-tools
+            gccrs-contrib-tools
+          ];
+
+          nativeBuildInputs = with targetPkgs; [
+            # compile dependices
+            gnumake
+            pkg-config
+            autoconf
+            automake
+            m4
+            flex
+            bison
+            texinfo
+            ccache
+            mold
+
+            # test dependencies
+            dejagnu
+            expect
+            tcl
+            autogen
+            check
+
+            # debug dependencies
+            gdb
+            valgrind
+            strace
+            uftrace
+
+            # rust dependencies
+            cargo
+            rustc
+
+            # format dependencies
+            pkgs.bear
+            pkgs.clang-tools
+            pkgs.rustfmt
+          ];
+
+          buildInputs = with targetPkgs; [
+            gmp
+            mpfr
+            libmpc
+            isl
+            zlib
+            zstd
+            gettext
+          ];
+
+          shellHook = ''
+            export NIX_CFLAGS_LINK="-fuse-ld=mold"
+            export GCCRS_INCOMPLETE_AND_EXPERIMENTAL_COMPILER_DO_NOT_USE="1"
+            export NIX_GLIBC_INCLUDE="${targetPkgs.glibc.dev}/include"
+            export LIBRARY_PATH="${targetPkgs.glibc}/lib"
+
+            echo "🦀 GCC Rust (gccrs) ${if is32Bit then "32-bit" else "64-bit"} Development Environment"
+            echo "Run '${if useShortPrefix then "g" else "gccrs-"}help' to see all available commands"
+          '';
+
+        };
+
+    in
+    {
+      devShells.${system} = {
+
+        default = mkGccrsEnv {};
+
+        gcc32 = mkGccrsEnv { is32Bit = true; };
+
+        gprefix = mkGccrsEnv { useShortPrefix = true; };
+
+        gprefix32 = mkGccrsEnv { is32Bit = true; useShortPrefix = true; };
+
+      };
+    };
+}

--- a/contrib/nix/packages/gccrs-contrib-tools.nix
+++ b/contrib/nix/packages/gccrs-contrib-tools.nix
@@ -1,0 +1,76 @@
+{
+  writeShellApplication,
+  symlinkJoin,
+  python3,
+  git,
+  useShortPrefix,
+}:
+
+let
+  prefix = if useShortPrefix then "g" else "gccrs-";
+  
+  pythonEnv = python3.withPackages (
+    ps: with ps; [
+      requests
+      unidiff
+      gitpython
+      termcolor # for gccrs-style
+    ]
+  );
+
+  gccrs-mklog = writeShellApplication {
+    name = "${prefix}mklog";
+    runtimeInputs = [
+      git
+      pythonEnv
+    ];
+    text = builtins.readFile ../bash/gccrs-mklog.sh;
+  };
+
+  gccrs-commit-mklog = writeShellApplication {
+    name = "${prefix}commit-mklog";
+    runtimeInputs = [
+      git
+      pythonEnv
+    ];
+    text = builtins.readFile ../bash/gccrs-commit-mklog.sh;
+  };
+
+  gccrs-verify = writeShellApplication {
+    name = "${prefix}verify";
+    runtimeInputs = [
+      git
+      pythonEnv
+    ];
+    text = builtins.readFile ../bash/gccrs-verify.sh;
+  };
+
+  gccrs-fix-changelog = writeShellApplication {
+    name = "${prefix}fix-changelog";
+    runtimeInputs = [
+      git
+      pythonEnv
+    ];
+    text = builtins.readFile ../bash/gccrs-fix-changelog.sh;
+  };
+
+  gccrs-style = writeShellApplication {
+    name = "${prefix}style";
+    runtimeInputs = [
+      git
+      pythonEnv
+    ];
+    text = builtins.readFile ../bash/gccrs-style.sh;
+  };
+
+in
+symlinkJoin {
+  name = "gccrs-contrib-tools";
+  paths = [
+    gccrs-mklog
+    gccrs-commit-mklog
+    gccrs-verify
+    gccrs-fix-changelog
+    gccrs-style
+  ];
+}

--- a/contrib/nix/packages/gccrs-env-tools.nix
+++ b/contrib/nix/packages/gccrs-env-tools.nix
@@ -1,0 +1,326 @@
+{
+  writeScriptBin,
+  symlinkJoin,
+  is32Bit,
+  useShortPrefix,
+}:
+
+let
+  buildDirName = if is32Bit then "build32" else "build";
+  installDirName = if is32Bit then "install32" else "install";
+  prefix = if useShortPrefix then "g" else "gccrs-";
+  suffix = if is32Bit then "32" else "";
+  setupName = "${prefix}setup${suffix}";
+  buildName = "${prefix}build${suffix}";
+  execName = if useShortPrefix then "gx${suffix}" else "gccrs-exec${suffix}";
+  execHelpSpace = if useShortPrefix then "   " else "";
+  testName = "${prefix}test${suffix}";
+  helpName = "${prefix}help${suffix}";
+  gitName = "${prefix}git";
+
+  gccrs-setup = writeScriptBin setupName ''
+    #!/usr/bin/env bash
+    set -e
+
+    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      SRC_DIR=$(git rev-parse --show-toplevel)
+      ROOT_DIR=$(dirname "$SRC_DIR")
+    elif [ -d "$PWD/gccrs" ]; then
+      ROOT_DIR="$PWD"
+      SRC_DIR="$ROOT_DIR/gccrs"
+    else
+      echo "Warning: Cannot find 'gccrs' directory." >&2
+      echo "Run this command from the workspace root or inside the gccrs repository." >&2
+      exit 1
+    fi
+
+
+    BUILD_DIR="$ROOT_DIR/${buildDirName}"
+    INSTALL_DIR="$ROOT_DIR/${installDirName}"
+
+    SETUP_DIRENV=false
+    FLAKE_TARGET="${if useShortPrefix then "#gprefix${if is32Bit then "32" else ""}" else if is32Bit then "#gcc32" else ""}"
+
+    for arg in "$@"; do
+      case $arg in
+        --use-direnv) SETUP_DIRENV=true ;;
+        --use-gprefix) FLAKE_TARGET="#gprefix${if is32Bit then "32" else""}" ;;
+      esac
+    done
+
+    if [ -f "$BUILD_DIR/Makefile" ]; then
+        echo "Warning: '$BUILD_DIR' is already configured!" >&2
+        echo "If you want to reconfigure, use 'rm -rf $BUILD_DIR/*'" >&2
+        exit 1
+    fi
+
+    mkdir -p "$BUILD_DIR"
+    cd "$BUILD_DIR"
+
+    "$SRC_DIR/configure" \
+        --prefix="$INSTALL_DIR" \
+        --disable-bootstrap \
+        --enable-valgrind-annotations \
+        --enable-languages=rust \
+        --disable-multilib \
+        --with-native-system-header-dir="$NIX_GLIBC_INCLUDE" \
+        --disable-libatomic \
+        --disable-libgomp \
+        --disable-libquadmath \
+        --disable-libssp \
+        --disable-libvtv \
+        --disable-libitm \
+        --disable-libsanitizer \
+        ${if is32Bit then "--host=i686-pc-linux-gnu --build=i686-pc-linux-gnu" else ""}
+
+    bear -- make -j "$(nproc)" \
+         WERROR="" \
+         STRICT_FLAGS="" \
+         CFLAGS="-Wno-error -Wno-format-security" \
+         CXXFLAGS="-Wno-error -Wno-format-security"
+
+    if [ ! -e "$SRC_DIR/compile_commands.json" ] && [ -f "$BUILD_DIR/compile_commands.json" ]; then
+      ln -sf "../${buildDirName}/compile_commands.json" "$SRC_DIR/compile_commands.json"
+    fi
+
+    if [ ! -f "$SRC_DIR/.clang-format" ] && [ -f "$SRC_DIR/contrib/clang-format" ]; then
+      ln -sf "contrib/clang-format" "$SRC_DIR/.clang-format"
+    fi
+
+    if [ "$SETUP_DIRENV" = true ]; then
+      ${
+        if is32Bit then
+          ''
+            echo "use flake \"../$(basename "$SRC_DIR")/contrib/nix$FLAKE_TARGET\"" > "$BUILD_DIR/.envrc"
+            echo "Run 'direnv allow' inside '${buildDirName}' to activate 32-bit direnv."
+          ''
+        else
+          ''
+            echo "use flake \"./$(basename "$SRC_DIR")/contrib/nix$FLAKE_TARGET\"" > "$ROOT_DIR/.envrc"
+            echo "Run 'direnv allow' inside your project root to activate 64-bit direnv."
+          ''
+      }
+    fi
+
+    echo "Your gccrs build is ready!"
+    echo "Use '${buildName}' or 'make' commands to compile it again."
+  '';
+
+  getBuildDirFunc = ''
+    get_build_dir() {
+      local curr="$PWD"
+
+      while [[ "$curr" != "/" ]]; do
+          if [[ "$(basename "$curr")" == "${buildDirName}" ]]; then
+              echo "$curr"
+              return 0
+          fi
+          curr="$(dirname "$curr")"
+      done
+
+      if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+          local git_root
+          git_root=$(git rev-parse --show-toplevel)
+
+          if [ -d "$(dirname "$git_root")/${buildDirName}" ]; then
+            echo "$(dirname "$git_root")/${buildDirName}"
+            return 0
+          fi
+      fi
+
+      if [ -d "$PWD/${buildDirName}" ]; then
+          echo "$PWD/${buildDirName}"
+          return 0
+      fi
+
+      return 1
+    }
+  '';
+
+  gccrs-build = writeScriptBin buildName ''
+    #!/usr/bin/env bash
+    set -e
+
+    ${getBuildDirFunc}
+
+    BUILD_DIR=$(get_build_dir)
+
+    if [ -z "$BUILD_DIR" ] || [ ! -d "$BUILD_DIR" ]; then
+      echo "Warning: '${buildDirName}' not found!" >&2
+      exit 1
+    fi
+
+    cd "$BUILD_DIR" || exit 1
+
+    USE_BEAR=false
+    USE_INSTRUMENT=false
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --bear)
+        USE_BEAR=true
+        shift
+        ;;
+        --instrument)
+        USE_INSTRUMENT=true
+        shift
+        ;;
+      *)
+        break
+        ;;
+      esac
+    done
+
+    CXXFLAGS="-Wno-error -Wno-format-security"
+
+    if [ "$USE_INSTRUMENT" = true ]; then
+      CXXFLAGS="$CXXFLAGS -finstrument-functions -fno-inline"
+    fi
+
+    if [ "$USE_BEAR" = true ]; then
+      bear --append -- make -j "$(nproc)" \
+           WERROR="" \
+           STRICT_FLAGS="" \
+           CFLAGS="-Wno-error -Wno-format-security" \
+           CXXFLAGS="$CXXFLAGS" "$@"
+    else
+      make -j "$(nproc)" \
+           WERROR="" \
+           STRICT_FLAGS="" \
+           CFLAGS="-Wno-error -Wno-format-security" \
+           CXXFLAGS="$CXXFLAGS" "$@"
+    fi
+  '';
+
+  gccrs-exec = writeScriptBin execName ''
+    #!/usr/bin/env bash
+    set -e
+
+    ${getBuildDirFunc}
+
+    BUILD_DIR=$(get_build_dir)
+
+    if [ -z "$BUILD_DIR" ]; then
+        echo "Warning: Build directory '${buildDirName}' not found!" >&2
+        exit 1
+    fi
+
+    if [ -z "$1" ]; then
+        echo "Usage: ${execName} <binary> [args...]" >&2
+        exit 1
+    fi
+
+    BIN_NAME="$1"
+    shift
+
+    TARGET_BIN="$BUILD_DIR/gcc/$BIN_NAME"
+
+    if [ ! -x "$TARGET_BIN" ]; then
+        echo "Warning: Executable '$TARGET_BIN' not found." >&2
+        exit 1
+    fi
+
+    exec "$TARGET_BIN" "$@"
+  '';
+
+  gccrs-test = writeScriptBin testName ''
+    #!/usr/bin/env bash
+    set -e
+
+    ${getBuildDirFunc}
+
+    BUILD_DIR=$(get_build_dir)
+
+    if [ -z "$BUILD_DIR" ]; then
+        echo "Warning: Build directory '${buildDirName}' not found!" >&2
+        exit 1
+    fi
+
+    BUILD_FIRST=false
+    RUNTESTFLAGS=""
+
+    while [[ $# -gt 0 ]]; do
+      case $1 in
+        --build)
+          BUILD_FIRST=true
+          shift
+          ;;
+        *)
+          if [ -z "$RUNTESTFLAGS" ]; then
+            RUNTESTFLAGS="$1"
+          else
+            RUNTESTFLAGS="$RUNTESTFLAGS $1"
+          fi
+          shift
+          ;;
+      esac
+    done
+
+    if [ "$BUILD_FIRST" = true ]; then
+        ${buildName}
+    fi
+
+    cd "$BUILD_DIR" || exit 1
+
+    make -k -j "$(nproc)" check-rust RUNTESTFLAGS="$RUNTESTFLAGS"
+  '';
+
+  gccrs-git = writeScriptBin gitName ''
+    #!/usr/bin/env bash
+    set -e
+
+    ${getBuildDirFunc}
+
+    BUILD_DIR=$(get_build_dir)
+
+    if [ -z "$BUILD_DIR" ]; then
+        echo "Warning: Build directory '${buildDirName}' not found!" >&2
+        exit 1
+    fi
+
+    REPO_NAME="''${GCCRS_REPO:-gccrs}"
+    GIT_DIR="$BUILD_DIR/../$REPO_NAME"
+
+    if [ ! -d "$GIT_DIR" ]; then
+        echo "Warning: Directory '$GIT_DIR' not found." >&2
+        echo "Help: If you are using a custom directory name, override it like this:" >&2
+        echo "      GCCRS_REPO=\"customdir\" ${gitName} <args...>" >&2
+        exit 1
+    fi
+    
+    exec git -C "$GIT_DIR" "$@"
+  '';
+
+  gccrs-help = writeScriptBin helpName ''
+    #!/usr/bin/env bash
+
+    echo "  ${setupName}                   : Start from scratch (configures, builds)."
+    echo "  ${setupName} --use-direnv      : Automatically setup direnv for your build folder."
+    echo "  ${setupName} --use-gprefix     : Use prefix as 'g' instead of 'gccrs-'."
+    echo "  ${buildName}                   : Run incremental build (compiles only changes)."
+    echo "  ${buildName} --bear            : Incremental build and update compile_commands.json."
+    echo "  ${testName} <args...>          : Run gccrs testsuite."
+    echo "  ${testName} --build <args...>  : Build and run gccrs testsuite."
+    echo "  ${execName} <binary> <args...> ${execHelpSpace}: Use built gccrs binaries."
+    echo "  ${gitName} <args...>           : Use git within the gccrs source directory."
+    echo ""
+    echo "  ${prefix}mklog                   : Generate ChangeLog template for STAGED files."
+    echo "  ${prefix}commit-mklog            : Generate ChangeLog and open Git commit editor."
+    echo "  ${prefix}verify                  : Verify your latest commit (HEAD) against GNU std."
+    echo "  ${prefix}verify <hash>           : Verify a specific commit in your history."
+    echo "  ${prefix}fix-changelog           : Attempt to fix minor format typos in HEAD."
+    echo ""
+    echo "  ${prefix}style                   : Check GNU C++ style for modifications in HEAD."
+    echo "  ${prefix}style <hash>            : Check style for modifications in a specific commit."
+  '';
+in
+symlinkJoin {
+  name = "gccrs-env-tools-${if is32Bit then "32" else "64"}";
+  paths = [
+    gccrs-setup
+    gccrs-build
+    gccrs-test
+    gccrs-exec
+    gccrs-git
+    gccrs-help
+  ];
+}


### PR DESCRIPTION
This PR introduces a reproducible Nix development environment
for gccrs. It automatically handles all toolchain, glibc, and dependency
configurations.

Provides completely separate environments for 64-bit and 32-bit targets,
automatically preventing linker conflicts.

Injects useful global scripts (gccrs-setup, gccrs-build, gccrs-test, gx,
gccrs-commit-mklog, gccrs-fix-changelog, gccrs-mklog, gccrs-style,
gccrs-verify and gccrs-help) to automate the build process and ensure
GNU commit standards are met effortlessly.

contrib/ChangeLog:

	* nix/bash/gccrs-commit-mklog.sh: New file.
	* nix/bash/gccrs-fix-changelog.sh: New file.
	* nix/bash/gccrs-mklog.sh: New file.
	* nix/bash/gccrs-style.sh: New file.
	* nix/bash/gccrs-verify.sh: New file.
	* nix/flake.lock: New file.
	* nix/flake.nix: New file.
	* nix/packages/gccrs-contrib-tools.nix: New file.
	* nix/packages/gccrs-env-tools.nix: New file.