### PR TITLE
util: Switch VisType to an enum class and rename variants.

### DIFF
--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -62,7 +62,7 @@ HIRCompileBase::setup_fndecl (tree fndecl, bool is_main_entry_point,
 {
   // if its the main fn or pub visibility mark its as DECL_PUBLIC
   // please see https://github.com/Rust-GCC/gccrs/pull/137
-  bool is_pub = visibility.get_vis_type () == HIR::Visibility::VisType::PUBLIC;
+  bool is_pub = visibility.get_vis_type () == HIR::Visibility::VisType::Public;
   if (is_main_entry_point || (is_pub && !is_generic_fn))
     {
       TREE_PUBLIC (fndecl) = 1;

--- a/gcc/rust/backend/rust-compile-implitem.cc
+++ b/gcc/rust/backend/rust-compile-implitem.cc
@@ -96,7 +96,7 @@ CompileTraitItem::visit (HIR::TraitItemFunc &func)
     = nr_ctx.to_canonical_path (func.get_mappings ().get_nodeid ());
 
   // FIXME: How do we get the proper visibility here?
-  auto vis = HIR::Visibility (HIR::Visibility::VisType::PUBLIC);
+  auto vis = HIR::Visibility (HIR::Visibility::VisType::Public);
   HIR::TraitFunctionDecl &function = func.get_decl ();
   tree fndecl
     = compile_function (false, function.get_function_name ().as_string (),

--- a/gcc/rust/checks/errors/privacy/rust-visibility-resolver.cc
+++ b/gcc/rust/checks/errors/privacy/rust-visibility-resolver.cc
@@ -108,13 +108,13 @@ VisibilityResolver::resolve_visibility (const HIR::Visibility &visibility,
 {
   switch (visibility.get_vis_type ())
     {
-    case HIR::Visibility::PRIVATE:
+    case HIR::Visibility::VisType::Private:
       to_resolve = ModuleVisibility::create_restricted (current_module);
       return true;
-    case HIR::Visibility::PUBLIC:
+    case HIR::Visibility::VisType::Public:
       to_resolve = ModuleVisibility::create_public ();
       return true;
-    case HIR::Visibility::RESTRICTED:
+    case HIR::Visibility::VisType::Restricted:
       {
 	// FIXME: We also need to handle 2015 vs 2018 edition conflicts
 	auto id = UNKNOWN_DEFID;

--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -42,14 +42,14 @@ translate_visibility (const AST::Visibility &vis)
   switch (vis.get_vis_type ())
     {
     case AST::Visibility::PUB:
-      return Visibility (Visibility::VisType::PUBLIC);
+      return Visibility (Visibility::VisType::Public);
     case AST::Visibility::PRIV:
     case AST::Visibility::PUB_SELF:
-      return Visibility (Visibility::VisType::PRIVATE);
+      return Visibility (Visibility::VisType::Private);
     case AST::Visibility::PUB_CRATE:
     case AST::Visibility::PUB_SUPER:
     case AST::Visibility::PUB_IN_PATH:
-      return Visibility (Visibility::VisType::RESTRICTED,
+      return Visibility (Visibility::VisType::Restricted,
 			 ASTLoweringSimplePath::translate (vis.get_path ()),
 			 vis.get_locus ());
       break;

--- a/gcc/rust/hir/tree/rust-hir-visibility.h
+++ b/gcc/rust/hir/tree/rust-hir-visibility.h
@@ -27,12 +27,12 @@ namespace HIR {
 struct Visibility
 {
 public:
-  enum VisType
+  enum class VisType
   {
-    PRIVATE,
-    PUBLIC,
-    RESTRICTED,
-    ERROR,
+    Private,
+    Public,
+    Restricted,
+    Error,
   };
 
 private:
@@ -50,18 +50,18 @@ public:
   {}
 
   // Returns whether visibility is in an error state.
-  bool is_error () const { return vis_type == ERROR; }
+  bool is_error () const { return vis_type == VisType::Error; }
 
   // Does the current visibility refer to a simple `pub <item>` entirely public
-  bool is_public () const { return vis_type == PUBLIC; }
+  bool is_public () const { return vis_type == VisType::Public; }
 
   // Is the current visibility public restricted to a certain path
-  bool is_restricted () const { return vis_type == RESTRICTED; }
+  bool is_restricted () const { return vis_type == VisType::Restricted; }
 
   // Creates an error visibility.
   static Visibility create_error ()
   {
-    return Visibility (ERROR, HIR::SimplePath::create_empty ());
+    return Visibility (VisType::Error, HIR::SimplePath::create_empty ());
   }
 
   VisType get_vis_type () const { return vis_type; }

--- a/gcc/rust/hir/tree/rust-hir.cc
+++ b/gcc/rust/hir/tree/rust-hir.cc
@@ -164,11 +164,11 @@ Visibility::to_string () const
 {
   switch (vis_type)
     {
-    case PRIVATE:
+    case VisType::Private:
       return std::string ("private");
-    case PUBLIC:
+    case VisType::Public:
       return std::string ("pub");
-    case RESTRICTED:
+    case VisType::Restricted:
       return std::string ("pub(in ") + path.get_mappings ().as_string ()
 	     + std::string (")");
     default:

--- a/gcc/rust/metadata/rust-export-metadata.cc
+++ b/gcc/rust/metadata/rust-export-metadata.cc
@@ -344,7 +344,7 @@ PublicInterface::is_crate_public (const HIR::VisItem &item)
   const HIR::Visibility &visibility = item.get_visibility ();
 
   bool is_public
-    = visibility.get_vis_type () == HIR::Visibility::VisType::PUBLIC;
+    = visibility.get_vis_type () == HIR::Visibility::VisType::Public;
   bool has_path = !visibility.get_path ().is_error ();
 
   // FIXME this might be pub(crate)

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -105,7 +105,7 @@ Mappings::Mappings ()
   builtinMarker
     = new HIR::ImplBlock (node, {}, {}, nullptr, nullptr, HIR::WhereClause ({}),
 			  BoundPolarity::RegularBound,
-			  HIR::Visibility (HIR::Visibility::VisType::PUBLIC),
+			  HIR::Visibility (HIR::Visibility::VisType::Public),
 			  {}, {}, UNDEF_LOCATION);
 }
 


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* hir/tree/rust-hir-visibility.h: Switch Visibility::VisType to an enum class, adapt variants' case.
	* backend/rust-compile-base.cc (HIRCompileBase::setup_fndecl): Use the new enum API.
	* backend/rust-compile-implitem.cc (CompileTraitItem::visit): Likewise.
	* checks/errors/privacy/rust-visibility-resolver.cc (VisibilityResolver::resolve_visibility): Likewise.
	* hir/rust-ast-lower.cc (translate_visibility): Likewise.
	* hir/tree/rust-hir.cc (Visibility::to_string): Likewise.
	* metadata/rust-export-metadata.cc (PublicInterface::is_crate_public): Likewise.
	* util/rust-hir-map.cc (Mappings::Mappings): Likewise.
