### PR TITLE
Add allocator attrs

### DIFF
--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -78,24 +78,19 @@ HIRCompileBase::setup_fndecl (tree fndecl, bool is_main_entry_point,
   // is it inline?
   for (const auto &attr : attrs)
     {
-      bool is_inline
-	= attr.get_path ().as_string () == Values::Attributes::INLINE;
-      bool is_must_use
-	= attr.get_path ().as_string () == Values::Attributes::MUST_USE;
-      bool is_cold = attr.get_path ().as_string () == Values::Attributes::COLD;
-      bool is_link_section
-	= attr.get_path ().as_string () == Values::Attributes::LINK_SECTION;
-      bool no_mangle
-	= attr.get_path ().as_string () == Values::Attributes::NO_MANGLE;
-      bool is_deprecated
-	= attr.get_path ().as_string () == Values::Attributes::DEPRECATED;
-      bool is_proc_macro
-	= attr.get_path ().as_string () == Values::Attributes::PROC_MACRO;
+      std::string attr_str = attr.get_path ().as_string ();
+
+      bool is_inline = attr_str == Values::Attributes::INLINE;
+      bool is_must_use = attr_str == Values::Attributes::MUST_USE;
+      bool is_cold = attr_str == Values::Attributes::COLD;
+      bool is_link_section = attr_str == Values::Attributes::LINK_SECTION;
+      bool no_mangle = attr_str == Values::Attributes::NO_MANGLE;
+      bool is_deprecated = attr_str == Values::Attributes::DEPRECATED;
+      bool is_proc_macro = attr_str == Values::Attributes::PROC_MACRO;
       bool is_proc_macro_attribute
-	= attr.get_path ().as_string ()
-	  == Values::Attributes::PROC_MACRO_ATTRIBUTE;
-      bool is_proc_macro_derive = attr.get_path ().as_string ()
-				  == Values::Attributes::PROC_MACRO_DERIVE;
+	= attr_str == Values::Attributes::PROC_MACRO_ATTRIBUTE;
+      bool is_proc_macro_derive
+	= attr_str == Values::Attributes::PROC_MACRO_DERIVE;
 
       if (is_inline)
 	{

--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -51,7 +51,10 @@ bool inline should_mangle_item (const tree fndecl)
 {
   return lookup_attribute (Values::Attributes::NO_MANGLE,
 			   DECL_ATTRIBUTES (fndecl))
-	 == NULL_TREE;
+	   == NULL_TREE
+	 && lookup_attribute (Values::Attributes::RUSTC_STD_INTERNAL_SYMBOL,
+			      DECL_ATTRIBUTES (fndecl))
+	      == NULL_TREE;
 }
 
 void
@@ -85,6 +88,8 @@ HIRCompileBase::setup_fndecl (tree fndecl, bool is_main_entry_point,
       bool is_cold = attr_str == Values::Attributes::COLD;
       bool is_link_section = attr_str == Values::Attributes::LINK_SECTION;
       bool no_mangle = attr_str == Values::Attributes::NO_MANGLE;
+      bool is_std_internal
+	= attr_str == Values::Attributes::RUSTC_STD_INTERNAL_SYMBOL;
       bool is_deprecated = attr_str == Values::Attributes::DEPRECATED;
       bool is_proc_macro = attr_str == Values::Attributes::PROC_MACRO;
       bool is_proc_macro_attribute
@@ -115,6 +120,10 @@ HIRCompileBase::setup_fndecl (tree fndecl, bool is_main_entry_point,
       else if (no_mangle)
 	{
 	  handle_no_mangle_attribute_on_fndecl (fndecl, attr);
+	}
+      else if (is_std_internal)
+	{
+	  handle_rustc_std_internal_symbol_attribute_on_fndecl (fndecl, attr);
 	}
       else if (is_proc_macro)
 	{
@@ -278,6 +287,15 @@ HIRCompileBase::handle_no_mangle_attribute_on_fndecl (
   DECL_ATTRIBUTES (fndecl)
     = tree_cons (get_identifier (Values::Attributes::NO_MANGLE), NULL_TREE,
 		 DECL_ATTRIBUTES (fndecl));
+}
+
+void
+HIRCompileBase::handle_rustc_std_internal_symbol_attribute_on_fndecl (
+  tree fndecl, const AST::Attribute &attr)
+{
+  DECL_ATTRIBUTES (fndecl)
+    = tree_cons (get_identifier (Values::Attributes::RUSTC_STD_INTERNAL_SYMBOL),
+		 NULL_TREE, DECL_ATTRIBUTES (fndecl));
 }
 
 void

--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -96,6 +96,9 @@ HIRCompileBase::setup_fndecl (tree fndecl, bool is_main_entry_point,
 	= attr_str == Values::Attributes::PROC_MACRO_ATTRIBUTE;
       bool is_proc_macro_derive
 	= attr_str == Values::Attributes::PROC_MACRO_DERIVE;
+      bool is_allocator = attr_str == Values::Attributes::RUSTC_ALLOCATOR;
+      bool is_allocator_nounwind
+	= attr_str == Values::Attributes::RUSTC_ALLOCATOR_NOUNWIND;
 
       if (is_inline)
 	{
@@ -136,6 +139,14 @@ HIRCompileBase::setup_fndecl (tree fndecl, bool is_main_entry_point,
       else if (is_proc_macro_derive)
 	{
 	  handle_derive_proc_macro_attribute_on_fndecl (fndecl, attr);
+	}
+      else if (is_allocator)
+	{
+	  handle_rustc_allocator_on_fndecl (fndecl, attr);
+	}
+      else if (is_allocator_nounwind)
+	{
+	  handle_rustc_allocator_nounwind_on_fndecl (fndecl, attr);
 	}
     }
 }
@@ -296,6 +307,55 @@ HIRCompileBase::handle_rustc_std_internal_symbol_attribute_on_fndecl (
   DECL_ATTRIBUTES (fndecl)
     = tree_cons (get_identifier (Values::Attributes::RUSTC_STD_INTERNAL_SYMBOL),
 		 NULL_TREE, DECL_ATTRIBUTES (fndecl));
+}
+
+void
+HIRCompileBase::handle_rustc_allocator_on_fndecl (tree fndecl,
+						  const AST::Attribute &attr)
+{
+  tree return_type = TREE_TYPE (TREE_TYPE (fndecl));
+  if (!POINTER_TYPE_P (return_type))
+    {
+      rust_error_at (attr.get_locus (),
+		     "%<rustc_allocator%> attribute must be applied to a "
+		     "function returning a pointer");
+      return;
+    }
+
+  // https://github.com/rust-lang/rust/blob/e1884a8e3c3e813aada8254edfa120e85bf5ffca/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs#L49
+  // `#[rustc_allocator]`: a hint to LLVM that the pointer returned from this
+  // function is never null.
+  //
+  // https://github.com/rust-lang/rust/blob/e1884a8e3c3e813aada8254edfa120e85bf5ffca/compiler/rustc_typeck/src/collect.rs#L2482
+  // This attribute sets CodegenFnAttrFlags::ALLOCATOR.
+  //
+  // https://github.com/rust-lang/rust/blob/e1884a8e3c3e813aada8254edfa120e85bf5ffca/compiler/rustc_codegen_llvm/src/attributes.rs#L302
+  // This flag activates LLVM::NoAlias attribute.
+  //
+  // In GCC, setting DECL_IS_MALLOC on a FUNCTION_DECL means this function
+  // should be treated as if it were a malloc, meaning it returns a pointer that
+  // is not an alias.
+  DECL_IS_MALLOC (fndecl) = 1;
+  DECL_ATTRIBUTES (fndecl) = tree_cons (get_identifier ("malloc"), NULL_TREE,
+					DECL_ATTRIBUTES (fndecl));
+}
+
+void
+HIRCompileBase::handle_rustc_allocator_nounwind_on_fndecl (
+  tree fndecl, const AST::Attribute &attr)
+{
+  // https://github.com/rust-lang/rust/blob/e1884a8e3c3e813aada8254edfa120e85bf5ffca/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs#L55
+  // `#[rustc_allocator_nounwind]`: an indicator that an imported FFI
+  // function will never unwind.
+  //
+  // https://github.com/rust-lang/rust/blob/e1884a8e3c3e813aada8254edfa120e85bf5ffca/compiler/rustc_typeck/src/collect.rs#L2484
+  // This attribute sets CodegenFnAttrFlags::NOUNWIND.
+  //
+  // In GCC, setting TREE_NOTHROW on a FUNCTION_DECL means a call to the
+  // function cannot throw an exception, which exactly matches this behavior.
+  TREE_NOTHROW (fndecl) = 1;
+  DECL_ATTRIBUTES (fndecl) = tree_cons (get_identifier ("nothrow"), NULL_TREE,
+					DECL_ATTRIBUTES (fndecl));
 }
 
 void

--- a/gcc/rust/backend/rust-compile-base.h
+++ b/gcc/rust/backend/rust-compile-base.h
@@ -152,6 +152,9 @@ protected:
   static void handle_no_mangle_attribute_on_fndecl (tree fndecl,
 						    const AST::Attribute &attr);
 
+  static void handle_rustc_std_internal_symbol_attribute_on_fndecl (
+    tree fndecl, const AST::Attribute &attr);
+
   static void setup_abi_options (tree fndecl, ABI abi);
 
   static tree indirect_expression (tree expr, location_t locus);

--- a/gcc/rust/backend/rust-compile-base.h
+++ b/gcc/rust/backend/rust-compile-base.h
@@ -155,6 +155,13 @@ protected:
   static void handle_rustc_std_internal_symbol_attribute_on_fndecl (
     tree fndecl, const AST::Attribute &attr);
 
+  static void handle_rustc_allocator_on_fndecl (tree fndecl,
+						const AST::Attribute &attr);
+
+  static void
+  handle_rustc_allocator_nounwind_on_fndecl (tree fndecl,
+					     const AST::Attribute &attr);
+
   static void setup_abi_options (tree fndecl, ABI abi);
 
   static tree indirect_expression (tree expr, location_t locus);

--- a/gcc/rust/checks/errors/rust-builtin-attribute-checker.cc
+++ b/gcc/rust/checks/errors/rust-builtin-attribute-checker.cc
@@ -358,25 +358,38 @@ no_mangle (const AST::Attribute &attribute)
 		   "must be of the form: %<#[no_mangle]%>");
     }
 }
+void
+rustc_std_internal_symbol (const AST::Attribute &attribute)
+{
+  if (attribute.has_attr_input ())
+    {
+      rust_error_at (attribute.get_locus (),
+		     "malformed %<rustc_std_internal_symbol%> attribute input");
+      rust_inform (attribute.get_locus (),
+		   "must be of the form: %<#[rustc_std_internal_symbol]%>");
+    }
+}
 
 } // namespace handlers
 
 const std::unordered_map<std::string, std::function<void (AST::Attribute &)>>
-  attribute_checking_handlers
-  = {{Attrs::DOC, handlers::doc},
-     {Attrs::DEPRECATED, handlers::deprecated},
-     {Attrs::LINK_SECTION, handlers::link_section},
-     {Attrs::EXPORT_NAME, handlers::export_name},
-     {Attrs::NO_MANGLE, handlers::no_mangle},
-     {Attrs::ALLOW, handlers::lint},
-     {Attrs::DENY, handlers::lint},
-     {Attrs::WARN, handlers::lint},
-     {Attrs::FORBID, handlers::lint},
-     {Attrs::LINK_NAME, handlers::link_name},
-     {Attrs::PROC_MACRO_DERIVE, handlers::proc_macro_derive},
-     {Attrs::PROC_MACRO, handlers::proc_macro},
-     {Attrs::PROC_MACRO_ATTRIBUTE, handlers::proc_macro},
-     {Attrs::TARGET_FEATURE, handlers::target_feature}};
+  attribute_checking_handlers = {
+    {Attrs::DOC, handlers::doc},
+    {Attrs::DEPRECATED, handlers::deprecated},
+    {Attrs::LINK_SECTION, handlers::link_section},
+    {Attrs::EXPORT_NAME, handlers::export_name},
+    {Attrs::NO_MANGLE, handlers::no_mangle},
+    {Attrs::ALLOW, handlers::lint},
+    {Attrs::DENY, handlers::lint},
+    {Attrs::WARN, handlers::lint},
+    {Attrs::FORBID, handlers::lint},
+    {Attrs::LINK_NAME, handlers::link_name},
+    {Attrs::PROC_MACRO_DERIVE, handlers::proc_macro_derive},
+    {Attrs::PROC_MACRO, handlers::proc_macro},
+    {Attrs::PROC_MACRO_ATTRIBUTE, handlers::proc_macro},
+    {Attrs::TARGET_FEATURE, handlers::target_feature},
+    {Attrs::RUSTC_STD_INTERNAL_SYMBOL, handlers::rustc_std_internal_symbol},
+};
 
 tl::optional<std::function<void (AST::Attribute &)>>
 lookup_handler (std::string attr_name)

--- a/gcc/rust/checks/errors/rust-builtin-attribute-checker.cc
+++ b/gcc/rust/checks/errors/rust-builtin-attribute-checker.cc
@@ -370,6 +370,30 @@ rustc_std_internal_symbol (const AST::Attribute &attribute)
     }
 }
 
+void
+rustc_allocator (const AST::Attribute &attribute)
+{
+  if (attribute.has_attr_input ())
+    {
+      rust_error_at (attribute.get_locus (),
+		     "malformed %<rustc_allocator%> attribute input");
+      rust_inform (attribute.get_locus (),
+		   "must be of the form: %<#[rustc_allocator]%>");
+    }
+}
+
+void
+rustc_allocator_nounwind (const AST::Attribute &attribute)
+{
+  if (attribute.has_attr_input ())
+    {
+      rust_error_at (attribute.get_locus (),
+		     "malformed %<rustc_allocator_nounwind%> attribute input");
+      rust_inform (attribute.get_locus (),
+		   "must be of the form: %<#[rustc_allocator_nounwind]%>");
+    }
+}
+
 } // namespace handlers
 
 const std::unordered_map<std::string, std::function<void (AST::Attribute &)>>
@@ -389,6 +413,8 @@ const std::unordered_map<std::string, std::function<void (AST::Attribute &)>>
     {Attrs::PROC_MACRO_ATTRIBUTE, handlers::proc_macro},
     {Attrs::TARGET_FEATURE, handlers::target_feature},
     {Attrs::RUSTC_STD_INTERNAL_SYMBOL, handlers::rustc_std_internal_symbol},
+    {Attrs::RUSTC_ALLOCATOR, handlers::rustc_allocator},
+    {Attrs::RUSTC_ALLOCATOR_NOUNWIND, handlers::rustc_allocator_nounwind},
 };
 
 tl::optional<std::function<void (AST::Attribute &)>>

--- a/gcc/rust/util/rust-attribute-values.h
+++ b/gcc/rust/util/rust-attribute-values.h
@@ -107,6 +107,9 @@ public:
 
   static constexpr auto &RUSTC_ARGS_REQUIRED_CONST
     = "rustc_args_required_const";
+
+  static constexpr auto &RUSTC_ALLOCATOR = "rustc_allocator";
+  static constexpr auto &RUSTC_ALLOCATOR_NOUNWIND = "rustc_allocator_nounwind";
 };
 } // namespace Values
 } // namespace Rust

--- a/gcc/rust/util/rust-attribute-values.h
+++ b/gcc/rust/util/rust-attribute-values.h
@@ -44,6 +44,8 @@ public:
   static constexpr auto &NO_STD = "no_std";
   static constexpr auto &LINK_SECTION = "link_section";
   static constexpr auto &NO_MANGLE = "no_mangle";
+  static constexpr auto &RUSTC_STD_INTERNAL_SYMBOL
+    = "rustc_std_internal_symbol";
   static constexpr auto &EXPORT_NAME = "export_name";
   static constexpr auto &REPR = "repr";
   static constexpr auto &RUSTC_BUILTIN_MACRO = "rustc_builtin_macro";

--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -94,7 +94,9 @@ static const BuiltinAttrDefinition __definitions[]
      {Attrs::FUNDAMENTAL, TYPE_CHECK},
      {Attrs::NON_EXHAUSTIVE, TYPE_CHECK},
      {Attrs::RUSTFMT, EXTERNAL},
-     {Attrs::TEST, CODE_GENERATION}};
+     {Attrs::TEST, CODE_GENERATION},
+     {Attrs::RUSTC_ALLOCATOR, CODE_GENERATION},
+     {Attrs::RUSTC_ALLOCATOR_NOUNWIND, CODE_GENERATION}};
 
 static const std::set<std::string> __outer_attributes
   = {Attrs::INLINE,

--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -44,6 +44,7 @@ static const BuiltinAttrDefinition __definitions[]
      {Attrs::LINK_NAME, CODE_GENERATION},
      {Attrs::LINK_SECTION, CODE_GENERATION},
      {Attrs::NO_MANGLE, CODE_GENERATION},
+     {Attrs::RUSTC_STD_INTERNAL_SYMBOL, CODE_GENERATION},
      {Attrs::EXPORT_NAME, CODE_GENERATION},
      {Attrs::REPR, CODE_GENERATION},
      {Attrs::RUSTC_BUILTIN_MACRO, EXPANSION},

--- a/gcc/testsuite/rust/compile/attr-allocator1.rs
+++ b/gcc/testsuite/rust/compile/attr-allocator1.rs
@@ -1,0 +1,12 @@
+// { dg-additional-options "-fdump-tree-gimple" }
+#![feature(no_core, rustc_attrs)]
+#![no_core]
+
+#[rustc_allocator]
+#[rustc_allocator_nounwind]
+fn _foo() -> *mut u8 {
+    0 as *mut u8
+}
+
+// { dg-final { scan-tree-dump "malloc" "gimple" } }
+// { dg-final { scan-tree-dump "nothrow" "gimple" } }

--- a/gcc/testsuite/rust/compile/attr-allocator2.rs
+++ b/gcc/testsuite/rust/compile/attr-allocator2.rs
@@ -1,0 +1,10 @@
+#![feature(no_core, rustc_attrs)]
+#![no_core]
+
+#[rustc_allocator(invalid)] // { dg-error "malformed .rustc_allocator. attribute input" }
+pub fn _foo() -> *mut u8 {
+    0 as *mut u8
+}
+
+#[rustc_allocator_nounwind(invalid)] // { dg-error "malformed .rustc_allocator_nounwind. attribute input" }
+pub fn _bar() {}

--- a/gcc/testsuite/rust/compile/attr-allocator3.rs
+++ b/gcc/testsuite/rust/compile/attr-allocator3.rs
@@ -1,0 +1,6 @@
+#![feature(no_core, rustc_attrs)]
+#![no_core]
+
+#[rustc_allocator] // { dg-error ".rustc_allocator. attribute must be applied to a function returning a pointer" }
+pub fn _foo() {}
+

--- a/gcc/testsuite/rust/compile/rustc_std_internal_symbol1.rs
+++ b/gcc/testsuite/rust/compile/rustc_std_internal_symbol1.rs
@@ -1,0 +1,10 @@
+// { dg-additional-options "-fdump-tree-gimple" }
+#![feature(no_core, rustc_attrs)]
+#![no_core]
+
+#[rustc_std_internal_symbol]
+pub fn _foo() -> i32 {
+    0
+}
+
+// { dg-final { scan-tree-dump "_foo" "gimple" } }

--- a/gcc/testsuite/rust/compile/rustc_std_internal_symbol2.rs
+++ b/gcc/testsuite/rust/compile/rustc_std_internal_symbol2.rs
@@ -1,0 +1,7 @@
+#![feature(no_core, rustc_attrs)]
+#![no_core]
+
+#[rustc_std_internal_symbol(invalid_argument)] // { dg-error "malformed .rustc_std_internal_symbol. attribute input" }
+pub fn _bar() -> i32 {
+    0
+}


### PR DESCRIPTION
This PR introduces three new compiler attributes required for `alloc` crate integration and memory allocation support.

 `rustc_std_internal_symbol`: Prevents name mangling for internal runtime symbols.

 `rustc_allocator` and `rustc_allocator_nounwind`: Instruct the GCC backend to apply `malloc` and `nothrow`.