### PR TITLE
Add lang item exchange_malloc

### DIFF
--- a/gcc/rust/util/rust-lang-item.cc
+++ b/gcc/rust/util/rust-lang-item.cc
@@ -119,6 +119,8 @@ const BiMap<std::string, LangItem::Kind> Rust::LangItem::lang_items = {{
   {"discriminant_kind", Kind::DISCRIMINANT_KIND},
   {"discriminant_type", Kind::DISCRIMINANT_TYPE},
   {"manually_drop", Kind::MANUALLY_DROP},
+
+  {"exchange_malloc", Kind::EXCHANGE_MALLOC},
 }};
 
 tl::optional<LangItem::Kind>

--- a/gcc/rust/util/rust-lang-item.h
+++ b/gcc/rust/util/rust-lang-item.h
@@ -155,6 +155,8 @@ public:
     DISCRIMINANT_KIND,
 
     MANUALLY_DROP,
+
+    EXCHANGE_MALLOC
   };
 
   static const BiMap<std::string, Kind> lang_items;

--- a/gcc/testsuite/rust/compile/exchange_malloc.rs
+++ b/gcc/testsuite/rust/compile/exchange_malloc.rs
@@ -1,0 +1,7 @@
+#![feature(no_core,lang_items)]
+#![no_core]
+
+#[lang = "exchange_malloc"]
+unsafe fn _allocate(_size: usize, _align: usize) -> *mut u8 {
+    0 as *mut u8
+}


### PR DESCRIPTION
This patch introduces the `exchange_malloc` lang item to compiler. This lang item is a strict prerequisite for the `owned_box` lang item and box expressions.

gcc/rust/ChangeLog:

	* util/rust-lang-item.cc: Register exchange_malloc to BiMap.
	* util/rust-lang-item.h: Add EXCHANGE_MALLOC to LangItem class.

gcc/testsuite/ChangeLog:

	* rust/compile/exchange_malloc.rs: New test.