### PR TITLE
gccrs: Fix ICE when parsing empty path expression

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.hxx
+++ b/gcc/rust/parse/rust-parse-impl.hxx
@@ -7284,6 +7284,15 @@ Parser<ManagedTokenSource>::parse_stmt_or_expr ()
     case DOLLAR_SIGN:
       {
 	AST::PathInExpression path = parse_path_in_expression ();
+	if (path.is_error ())
+	  {
+	    Error error (t->get_locus (), "expected identifier");
+	    add_error (std::move (error));
+	    skip_after_semicolon ();
+	    return tl::unexpected<Parse::Error::Node> (
+	      Parse::Error::Node::CHILD_ERROR);
+	  }
+
 	tl::expected<std::unique_ptr<AST::Expr>, Parse::Error::Expr>
 	  null_denotation;
 

--- a/gcc/testsuite/rust/compile/empty_path.rs
+++ b/gcc/testsuite/rust/compile/empty_path.rs
@@ -1,0 +1,7 @@
+#![feature(no_core)]
+#![no_core]
+
+fn main() {
+    ::;
+    // { dg-error "expected identifier" "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
This PR is basically a revival of #3286, that PR can be closed when this gets merged.