### PR TITLE
gccrs: Register the Drop lang item

### DIFF
--- a/gcc/rust/util/rust-lang-item.cc
+++ b/gcc/rust/util/rust-lang-item.cc
@@ -62,6 +62,7 @@ const BiMap<std::string, LangItem::Kind> Rust::LangItem::lang_items = {{
   {"fn_once_output", Kind::FN_ONCE_OUTPUT},
   {"copy", Kind::COPY},
   {"clone", Kind::CLONE},
+  {"drop", Kind::DROP},
   {"sized", Kind::SIZED},
   {"sync", Kind::SYNC},
   {"slice_alloc", Kind::SLICE_ALLOC},

--- a/gcc/rust/util/rust-lang-item.h
+++ b/gcc/rust/util/rust-lang-item.h
@@ -90,6 +90,7 @@ public:
     // markers
     COPY,
     CLONE,
+    DROP,
     SIZED,
     SYNC,
 

--- a/gcc/testsuite/rust/compile/drop-lang-item.rs
+++ b/gcc/testsuite/rust/compile/drop-lang-item.rs
@@ -1,0 +1,14 @@
+#![feature(no_core)]
+#![no_core]
+
+#![feature(lang_items)]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "drop"]
+pub trait Drop {
+    fn drop(&mut self);
+}
+
+fn main() {}


### PR DESCRIPTION
Add and register the drop lang item.

gcc/rust/ChangeLog:

	* util/rust-lang-item.h (Rust::LangItem::Kind): Add DROP.
	* util/rust-lang-item.cc (Rust::LangItem::lang_items): Add drop lang item.

gcc/testsuite/ChangeLog:

	* rust/compile/drop-lang-item.rs: New test.


