### PR TITLE
gccrs: Add Drop support for block-local variable

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -225,6 +225,7 @@ GRS_OBJS = \
     rust/rust-compile-struct-field-expr.o \
     rust/rust-constexpr.o \
     rust/rust-compile-base.o \
+    rust/rust-compile-drop.o \
     rust/rust-tree.o \
     rust/rust-compile-context.o \
     rust/rust-export-metadata.o \

--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -20,6 +20,7 @@
 #include "rust-abi.h"
 #include "rust-compile-stmt.h"
 #include "rust-compile-expr.h"
+#include "rust-compile-drop.h"
 #include "rust-compile-fnparam.h"
 #include "rust-compile-var-decl.h"
 #include "rust-compile-type.h"
@@ -634,6 +635,8 @@ HIRCompileBase::compile_function_body (tree fndecl,
 	  return_value = coercion_site (id, return_value, actual, expected,
 					lvalue_locus, rvalue_locus);
 
+	  CompileDrop::emit_current_scope_drop_calls (ctx);
+
 	  tree return_stmt
 	    = Backend::return_statement (fndecl, return_value, locus);
 	  ctx->add_statement (return_stmt);
@@ -656,6 +659,7 @@ HIRCompileBase::compile_function_body (tree fndecl,
       // errors should have occurred
       location_t locus = function_body.get_locus ();
       tree return_value = unit_expression (locus);
+      CompileDrop::emit_current_scope_drop_calls (ctx);
       tree return_stmt
 	= Backend::return_statement (fndecl, return_value, locus);
       ctx->add_statement (return_stmt);

--- a/gcc/rust/backend/rust-compile-block.cc
+++ b/gcc/rust/backend/rust-compile-block.cc
@@ -17,52 +17,13 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-compile-block.h"
-#include "rust-compile-stmt.h"
+#include "rust-compile-drop.h"
 #include "rust-compile-expr.h"
-#include "rust-compile-implitem.h"
+#include "rust-compile-stmt.h"
 #include "rust-hir-expr.h"
-#include "rust-hir-path-probe.h"
-#include "rust-lang-item.h"
 
 namespace Rust {
 namespace Compile {
-
-static tree
-compile_drop_call (Context *ctx, Bvariable *var, TyTy::BaseType *ty,
-		   location_t locus)
-{
-  auto drop_lang = ctx->get_mappings ().lookup_lang_item (LangItem::Kind::DROP);
-  if (!drop_lang.has_value ())
-    return NULL_TREE;
-
-  Resolver::TraitReference *drop_ref = nullptr;
-  bool ok
-    = ctx->get_tyctx ()->lookup_trait_reference (drop_lang.value (), &drop_ref);
-  if (!ok)
-    return NULL_TREE;
-
-  HIR::PathIdentSegment segment ("drop");
-  auto candidates
-    = Resolver::PathProbeImplTrait::Probe (ty->get_root (), segment, drop_ref);
-
-  for (auto &candidate : candidates)
-    {
-      if (!candidate.is_impl_candidate ()
-	  || candidate.ty->get_kind () != TyTy::TypeKind::FNDEF)
-	continue;
-
-      auto *fn_type = static_cast<TyTy::FnType *> (candidate.ty);
-      tree fn_addr
-	= CompileInherentImplItem::Compile (candidate.item.impl.impl_item, ctx,
-					    fn_type, locus);
-
-      tree var_expr = Backend::var_expression (var, locus);
-      tree var_addr = HIRCompileBase::address_expression (var_expr, locus);
-
-      return Backend::call_expression (fn_addr, {var_addr}, nullptr, locus);
-    }
-  return NULL_TREE;
-}
 
 CompileBlock::CompileBlock (Context *ctx, Bvariable *result)
   : HIRCompileBase (ctx), translated (nullptr), result (result)
@@ -124,24 +85,7 @@ CompileBlock::visit (HIR::BlockExpr &expr)
 					 expr.get_locus ());
       ctx->add_statement (assignment);
     }
-
-  auto &drop_candidates = ctx->peek_block_drop_candidates ();
-
-  for (auto it = drop_candidates.rbegin (); it != drop_candidates.rend (); ++it)
-    {
-      TyTy::BaseType *ty = nullptr;
-      Bvariable *var = nullptr;
-
-      bool ok = ctx->get_tyctx ()->lookup_type (it->hirid, &ty);
-      rust_assert (ok);
-
-      ok = ctx->lookup_var_decl (it->hirid, &var);
-      rust_assert (ok);
-
-      tree drop_call = compile_drop_call (ctx, var, ty, it->locus);
-      if (drop_call != NULL_TREE)
-	ctx->add_statement (convert_to_void (drop_call, ICV_STATEMENT));
-    }
+  CompileDrop::emit_current_scope_drop_calls (ctx);
 
   ctx->pop_block ();
   translated = new_block;

--- a/gcc/rust/backend/rust-compile-block.cc
+++ b/gcc/rust/backend/rust-compile-block.cc
@@ -19,10 +19,50 @@
 #include "rust-compile-block.h"
 #include "rust-compile-stmt.h"
 #include "rust-compile-expr.h"
+#include "rust-compile-implitem.h"
 #include "rust-hir-expr.h"
+#include "rust-hir-path-probe.h"
+#include "rust-lang-item.h"
 
 namespace Rust {
 namespace Compile {
+
+static tree
+compile_drop_call (Context *ctx, Bvariable *var, TyTy::BaseType *ty,
+		   location_t locus)
+{
+  auto drop_lang = ctx->get_mappings ().lookup_lang_item (LangItem::Kind::DROP);
+  if (!drop_lang.has_value ())
+    return NULL_TREE;
+
+  Resolver::TraitReference *drop_ref = nullptr;
+  bool ok
+    = ctx->get_tyctx ()->lookup_trait_reference (drop_lang.value (), &drop_ref);
+  if (!ok)
+    return NULL_TREE;
+
+  HIR::PathIdentSegment segment ("drop");
+  auto candidates
+    = Resolver::PathProbeImplTrait::Probe (ty->get_root (), segment, drop_ref);
+
+  for (auto &candidate : candidates)
+    {
+      if (!candidate.is_impl_candidate ()
+	  || candidate.ty->get_kind () != TyTy::TypeKind::FNDEF)
+	continue;
+
+      auto *fn_type = static_cast<TyTy::FnType *> (candidate.ty);
+      tree fn_addr
+	= CompileInherentImplItem::Compile (candidate.item.impl.impl_item, ctx,
+					    fn_type, locus);
+
+      tree var_expr = Backend::var_expression (var, locus);
+      tree var_addr = HIRCompileBase::address_expression (var_expr, locus);
+
+      return Backend::call_expression (fn_addr, {var_addr}, nullptr, locus);
+    }
+  return NULL_TREE;
+}
 
 CompileBlock::CompileBlock (Context *ctx, Bvariable *result)
   : HIRCompileBase (ctx), translated (nullptr), result (result)
@@ -83,6 +123,24 @@ CompileBlock::visit (HIR::BlockExpr &expr)
 	= Backend::assignment_statement (result_reference, compiled_expr,
 					 expr.get_locus ());
       ctx->add_statement (assignment);
+    }
+
+  auto &drop_candidates = ctx->peek_block_drop_candidates ();
+
+  for (auto it = drop_candidates.rbegin (); it != drop_candidates.rend (); ++it)
+    {
+      TyTy::BaseType *ty = nullptr;
+      Bvariable *var = nullptr;
+
+      bool ok = ctx->get_tyctx ()->lookup_type (it->hirid, &ty);
+      rust_assert (ok);
+
+      ok = ctx->lookup_var_decl (it->hirid, &var);
+      rust_assert (ok);
+
+      tree drop_call = compile_drop_call (ctx, var, ty, it->locus);
+      if (drop_call != NULL_TREE)
+	ctx->add_statement (convert_to_void (drop_call, ICV_STATEMENT));
     }
 
   ctx->pop_block ();

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -50,6 +50,12 @@ struct CustomDeriveInfo
   std::vector<std::string> attributes;
 };
 
+struct DropCandidate
+{
+  HirId hirid;
+  location_t locus;
+};
+
 class Context
 {
 public:
@@ -101,6 +107,7 @@ public:
   {
     scope_stack.push_back (scope);
     statements.push_back ({});
+    block_drop_candidates.emplace_back ();
   }
 
   tree pop_block ()
@@ -110,6 +117,9 @@ public:
 
     auto stmts = statements.back ();
     statements.pop_back ();
+
+    rust_assert (!block_drop_candidates.empty ());
+    block_drop_candidates.pop_back ();
 
     Backend::block_add_statements (block, stmts);
 
@@ -130,6 +140,18 @@ public:
   }
 
   void add_statement (tree stmt) { statements.back ().push_back (stmt); }
+
+  std::vector<DropCandidate> &peek_block_drop_candidates ()
+  {
+    rust_assert (!block_drop_candidates.empty ());
+    return block_drop_candidates.back ();
+  }
+
+  void note_simple_drop_candidate (HirId hirid, location_t locus)
+  {
+    rust_assert (!block_drop_candidates.empty ());
+    block_drop_candidates.back ().push_back ({hirid, locus});
+  }
 
   void insert_var_decl (HirId id, ::Bvariable *decl)
   {
@@ -419,6 +441,7 @@ private:
   std::map<HirId, tree> compiled_labels;
   std::vector<::std::vector<tree>> statements;
   std::vector<tree> scope_stack;
+  std::vector<::std::vector<DropCandidate>> block_drop_candidates;
   std::vector<::Bvariable *> loop_value_stack;
   std::vector<tree> loop_begin_labels;
   std::map<DefId, std::vector<std::pair<const TyTy::BaseType *, tree>>>

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -20,6 +20,7 @@
 #define RUST_COMPILE_CONTEXT
 
 #include "rust-system.h"
+#include "rust-compile-drop.h"
 #include "rust-hir-map.h"
 #include "rust-name-resolver.h"
 #include "rust-hir-type-check.h"
@@ -48,12 +49,6 @@ struct CustomDeriveInfo
   tree fndecl;
   std::string trait_name;
   std::vector<std::string> attributes;
-};
-
-struct DropCandidate
-{
-  HirId hirid;
-  location_t locus;
 };
 
 class Context
@@ -150,7 +145,7 @@ public:
   void note_simple_drop_candidate (HirId hirid, location_t locus)
   {
     rust_assert (!block_drop_candidates.empty ());
-    block_drop_candidates.back ().push_back ({hirid, locus});
+    block_drop_candidates.back ().emplace_back (hirid, locus);
   }
 
   void insert_var_decl (HirId id, ::Bvariable *decl)

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -20,7 +20,7 @@
 #define RUST_COMPILE_CONTEXT
 
 #include "rust-system.h"
-#include "rust-compile-drop.h"
+#include "rust-compile-drop-candidate.h"
 #include "rust-hir-map.h"
 #include "rust-name-resolver.h"
 #include "rust-hir-type-check.h"

--- a/gcc/rust/backend/rust-compile-drop-candidate.h
+++ b/gcc/rust/backend/rust-compile-drop-candidate.h
@@ -16,26 +16,25 @@
 // along with GCC; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef RUST_COMPILE_DROP_H
-#define RUST_COMPILE_DROP_H
+#ifndef RUST_COMPILE_DROP_CANDIDATE_H
+#define RUST_COMPILE_DROP_CANDIDATE_H
 
-#include "rust-compile-context.h"
+#include "rust-system.h"
+#include "rust-hir-map.h"
 
 namespace Rust {
 namespace Compile {
 
-class CompileDrop
+struct DropCandidate
 {
-public:
-  static bool type_has_drop_impl (Context *ctx, TyTy::BaseType *ty);
+  DropCandidate (HirId hirid, location_t locus) : hirid (hirid), locus (locus)
+  {}
 
-  static tree compile_drop_call (Context *ctx, Bvariable *var,
-				 TyTy::BaseType *ty, location_t locus);
-
-  static void emit_current_scope_drop_calls (Context *ctx);
+  HirId hirid;
+  location_t locus;
 };
 
 } // namespace Compile
 } // namespace Rust
 
-#endif // RUST_COMPILE_DROP_H
+#endif // RUST_COMPILE_DROP_CANDIDATE_H

--- a/gcc/rust/backend/rust-compile-drop.cc
+++ b/gcc/rust/backend/rust-compile-drop.cc
@@ -1,3 +1,21 @@
+// Copyright (C) 2026 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
 #include "rust-compile-drop.h"
 #include "rust-compile-base.h"
 #include "rust-compile-context.h"
@@ -52,23 +70,21 @@ CompileDrop::compile_drop_call (Context *ctx, Bvariable *var,
   auto candidates
     = Resolver::PathProbeImplTrait::Probe (ty->get_root (), segment, drop_ref);
 
-  for (auto &candidate : candidates)
-    {
-      if (!candidate.is_impl_candidate ()
-	  || candidate.ty->get_kind () != TyTy::TypeKind::FNDEF)
-	continue;
+  rust_assert (candidates.size () == 1);
 
-      auto *fn_type = static_cast<TyTy::FnType *> (candidate.ty);
-      tree fn_addr
-	= CompileInherentImplItem::Compile (candidate.item.impl.impl_item, ctx,
-					    fn_type, locus);
+  auto &candidate = *candidates.begin ();
+  rust_assert (candidate.is_impl_candidate ());
+  rust_assert (candidate.ty->get_kind () == TyTy::TypeKind::FNDEF);
 
-      tree var_expr = Backend::var_expression (var, locus);
-      tree var_addr = HIRCompileBase::address_expression (var_expr, locus);
+  auto *fn_type = static_cast<TyTy::FnType *> (candidate.ty);
+  tree fn_addr
+    = CompileInherentImplItem::Compile (candidate.item.impl.impl_item, ctx,
+					fn_type, locus);
 
-      return Backend::call_expression (fn_addr, {var_addr}, nullptr, locus);
-    }
-  return NULL_TREE;
+  tree var_expr = Backend::var_expression (var, locus);
+  tree var_addr = HIRCompileBase::address_expression (var_expr, locus);
+
+  return Backend::call_expression (fn_addr, {var_addr}, nullptr, locus);
 }
 
 void

--- a/gcc/rust/backend/rust-compile-drop.cc
+++ b/gcc/rust/backend/rust-compile-drop.cc
@@ -1,0 +1,97 @@
+#include "rust-compile-drop.h"
+#include "rust-compile-base.h"
+#include "rust-compile-context.h"
+#include "rust-compile-implitem.h"
+#include "rust-hir-path-probe.h"
+#include "rust-hir-trait-reference.h"
+#include "rust-hir-type-bounds.h"
+#include "rust-lang-item.h"
+#include "rust-tyty.h"
+
+namespace Rust {
+namespace Compile {
+
+bool
+CompileDrop::type_has_drop_impl (Context *ctx, TyTy::BaseType *ty)
+{
+  auto drop_lang_item
+    = ctx->get_mappings ().lookup_lang_item (LangItem::Kind::DROP);
+
+  if (!drop_lang_item.has_value ())
+    return false;
+
+  DefId drop_id = drop_lang_item.value ();
+
+  auto candidates = Resolver::TypeBoundsProbe::Probe (ty);
+  for (auto &candidate : candidates)
+    {
+      Resolver::TraitReference *trait_ref = candidate.first;
+      if (trait_ref != nullptr && trait_ref->get_defid () == drop_id)
+	return true;
+    }
+
+  return false;
+}
+
+// Find the Drop trait, look for the drop method, and build the function call.
+tree
+CompileDrop::compile_drop_call (Context *ctx, Bvariable *var,
+				TyTy::BaseType *ty, location_t locus)
+{
+  auto drop_lang = ctx->get_mappings ().lookup_lang_item (LangItem::Kind::DROP);
+  if (!drop_lang.has_value ())
+    return NULL_TREE;
+
+  Resolver::TraitReference *drop_ref = nullptr;
+  bool ok
+    = ctx->get_tyctx ()->lookup_trait_reference (drop_lang.value (), &drop_ref);
+  if (!ok)
+    return NULL_TREE;
+
+  HIR::PathIdentSegment segment ("drop");
+  auto candidates
+    = Resolver::PathProbeImplTrait::Probe (ty->get_root (), segment, drop_ref);
+
+  for (auto &candidate : candidates)
+    {
+      if (!candidate.is_impl_candidate ()
+	  || candidate.ty->get_kind () != TyTy::TypeKind::FNDEF)
+	continue;
+
+      auto *fn_type = static_cast<TyTy::FnType *> (candidate.ty);
+      tree fn_addr
+	= CompileInherentImplItem::Compile (candidate.item.impl.impl_item, ctx,
+					    fn_type, locus);
+
+      tree var_expr = Backend::var_expression (var, locus);
+      tree var_addr = HIRCompileBase::address_expression (var_expr, locus);
+
+      return Backend::call_expression (fn_addr, {var_addr}, nullptr, locus);
+    }
+  return NULL_TREE;
+}
+
+void
+CompileDrop::emit_current_scope_drop_calls (Context *ctx)
+{
+  auto &drop_candidates = ctx->peek_block_drop_candidates ();
+
+  for (auto it = drop_candidates.rbegin (); it != drop_candidates.rend (); ++it)
+    {
+      TyTy::BaseType *ty = nullptr;
+      Bvariable *var = nullptr;
+
+      bool ok = ctx->get_tyctx ()->lookup_type (it->hirid, &ty);
+      rust_assert (ok);
+
+      ok = ctx->lookup_var_decl (it->hirid, &var);
+      rust_assert (ok);
+
+      tree drop_call = CompileDrop::compile_drop_call (ctx, var, ty, it->locus);
+      if (drop_call != NULL_TREE)
+	ctx->add_statement (convert_to_void (drop_call, ICV_STATEMENT));
+    }
+}
+
+} // namespace Compile
+} // namespace Rust

--- a/gcc/rust/backend/rust-compile-drop.h
+++ b/gcc/rust/backend/rust-compile-drop.h
@@ -1,0 +1,42 @@
+#ifndef RUST_COMPILE_DROP
+#define RUST_COMPILE_DROP
+
+#include "rust-system.h"
+#include "rust-hir-map.h"
+
+class Bvariable;
+
+namespace Rust {
+
+namespace TyTy {
+class BaseType;
+}
+
+namespace Compile {
+
+class Context;
+
+struct DropCandidate
+{
+  DropCandidate (HirId hirid, location_t locus) : hirid (hirid), locus (locus)
+  {}
+
+  HirId hirid;
+  location_t locus;
+};
+
+class CompileDrop
+{
+public:
+  static bool type_has_drop_impl (Context *ctx, TyTy::BaseType *ty);
+
+  static tree compile_drop_call (Context *ctx, Bvariable *var,
+				 TyTy::BaseType *ty, location_t locus);
+
+  static void emit_current_scope_drop_calls (Context *ctx);
+};
+
+} // namespace Compile
+} // namespace Rust
+
+#endif // RUST_COMPILE_DROP

--- a/gcc/rust/backend/rust-compile-pattern.cc
+++ b/gcc/rust/backend/rust-compile-pattern.cc
@@ -1369,10 +1369,23 @@ CompilePatternLet::visit (HIR::IdentifierPattern &pattern)
       ctx->add_statement (s);
     }
 
-  if (!pattern.has_subpattern () && !pattern.get_is_ref ()
-      && type_has_drop_impl (ctx, ty))
+  TyTy::BaseType *drop_ty = ty;
+  if (pattern.get_is_ref ())
+    {
+      auto ref_ty = ty->try_as<TyTy::ReferenceType> ();
+      rust_assert (ref_ty != nullptr);
+      drop_ty = ref_ty->get_base ();
+    }
+
+  if (!type_has_drop_impl (ctx, drop_ty))
+    return;
+
+  if (!pattern.has_subpattern () && !pattern.get_is_ref ())
     ctx->note_simple_drop_candidate (pattern.get_mappings ().get_hirid (),
 				     pattern.get_locus ());
+  else
+    rust_sorry_at (pattern.get_locus (),
+		   "drop trait not supported for subpatterns and ref patterns");
 }
 
 void

--- a/gcc/rust/backend/rust-compile-pattern.cc
+++ b/gcc/rust/backend/rust-compile-pattern.cc
@@ -27,10 +27,35 @@
 #include "rust-hir-pattern.h"
 #include "rust-system.h"
 #include "rust-tyty.h"
+#include "rust-hir-type-bounds.h"
+#include "rust-hir-trait-reference.h"
+#include "rust-lang-item.h"
 #include "tree.h"
 
 namespace Rust {
 namespace Compile {
+
+static bool
+type_has_drop_impl (Context *ctx, TyTy::BaseType *ty)
+{
+  auto drop_lang_item
+    = ctx->get_mappings ().lookup_lang_item (LangItem::Kind::DROP);
+
+  if (!drop_lang_item.has_value ())
+    return false;
+
+  DefId drop_id = drop_lang_item.value ();
+
+  auto candidates = Resolver::TypeBoundsProbe::Probe (ty);
+  for (auto &candidate : candidates)
+    {
+      Resolver::TraitReference *trait_ref = candidate.first;
+      if (trait_ref != nullptr && trait_ref->get_defid () == drop_id)
+	return true;
+    }
+
+  return false;
+}
 
 void
 CompilePatternCheckExpr::visit (HIR::PathInExpression &pattern)
@@ -1343,6 +1368,11 @@ CompilePatternLet::visit (HIR::IdentifierPattern &pattern)
       auto s = Backend::init_statement (fnctx.fndecl, var, init_expr);
       ctx->add_statement (s);
     }
+
+  if (!pattern.has_subpattern () && !pattern.get_is_ref ()
+      && type_has_drop_impl (ctx, ty))
+    ctx->note_simple_drop_candidate (pattern.get_mappings ().get_hirid (),
+				     pattern.get_locus ());
 }
 
 void

--- a/gcc/rust/backend/rust-compile-pattern.cc
+++ b/gcc/rust/backend/rust-compile-pattern.cc
@@ -17,45 +17,24 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-compile-pattern.h"
+#include "print-tree.h"
+#include "rust-compile-drop.h"
 #include "rust-compile-expr.h"
 #include "rust-compile-resolve-path.h"
-#include "rust-constexpr.h"
 #include "rust-compile-type.h"
-#include "print-tree.h"
+#include "rust-constexpr.h"
 #include "rust-diagnostics.h"
 #include "rust-hir-pattern-abstract.h"
 #include "rust-hir-pattern.h"
+#include "rust-hir-trait-reference.h"
+#include "rust-hir-type-bounds.h"
+#include "rust-lang-item.h"
 #include "rust-system.h"
 #include "rust-tyty.h"
-#include "rust-hir-type-bounds.h"
-#include "rust-hir-trait-reference.h"
-#include "rust-lang-item.h"
 #include "tree.h"
 
 namespace Rust {
 namespace Compile {
-
-static bool
-type_has_drop_impl (Context *ctx, TyTy::BaseType *ty)
-{
-  auto drop_lang_item
-    = ctx->get_mappings ().lookup_lang_item (LangItem::Kind::DROP);
-
-  if (!drop_lang_item.has_value ())
-    return false;
-
-  DefId drop_id = drop_lang_item.value ();
-
-  auto candidates = Resolver::TypeBoundsProbe::Probe (ty);
-  for (auto &candidate : candidates)
-    {
-      Resolver::TraitReference *trait_ref = candidate.first;
-      if (trait_ref != nullptr && trait_ref->get_defid () == drop_id)
-	return true;
-    }
-
-  return false;
-}
 
 void
 CompilePatternCheckExpr::visit (HIR::PathInExpression &pattern)
@@ -1377,7 +1356,7 @@ CompilePatternLet::visit (HIR::IdentifierPattern &pattern)
       drop_ty = ref_ty->get_base ();
     }
 
-  if (!type_has_drop_impl (ctx, drop_ty))
+  if (!CompileDrop::type_has_drop_impl (ctx, drop_ty))
     return;
 
   if (!pattern.has_subpattern () && !pattern.get_is_ref ())

--- a/gcc/testsuite/rust/compile/drop-ref-pattern.rs
+++ b/gcc/testsuite/rust/compile/drop-ref-pattern.rs
@@ -1,0 +1,23 @@
+#![feature(no_core)]
+#![feature(lang_items)]
+#![no_core]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "drop"]
+pub trait Drop {
+    fn drop (&mut self);
+}
+
+struct Droppable;
+
+impl Drop for Droppable {
+    fn drop(&mut self) {}
+}
+
+fn main() {
+    {
+        let ref _x = Droppable; // { dg-message "sorry, unimplemented: drop trait not supported for subpatterns and ref patterns" }
+    }
+}

--- a/gcc/testsuite/rust/execute/drop-block-scope.rs
+++ b/gcc/testsuite/rust/execute/drop-block-scope.rs
@@ -1,4 +1,5 @@
-// { dg-output "d\r*\n" }
+// { dg-output "d\r*\nd\r*\nd\r*\n" }
+// { dg-additional-options "-w" }
 #![feature(no_core)]
 #![feature(lang_items)]
 #![no_core]
@@ -29,6 +30,12 @@ impl Drop for Droppable {
 fn main() -> i32 {
     {
         let _x = Droppable;
+    }
+    {
+        let x = Droppable;
+    }
+    {
+        let mut x = Droppable;
     }
     0
 }

--- a/gcc/testsuite/rust/execute/drop-block-scope.rs
+++ b/gcc/testsuite/rust/execute/drop-block-scope.rs
@@ -1,0 +1,34 @@
+// { dg-output "d\r*\n" }
+#![feature(no_core)]
+#![feature(lang_items)]
+#![no_core]
+
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "drop"]
+pub trait Drop {
+    fn drop(&mut self);
+}
+
+struct Droppable;
+
+impl Drop for Droppable {
+    fn drop(&mut self) {
+        let msg = "d\n\0" as *const str as *const i8;
+        unsafe {
+            printf(msg); 
+        }
+    }
+}
+
+fn main() -> i32 {
+    {
+        let _x = Droppable;
+    }
+    0
+}

--- a/gcc/testsuite/rust/execute/drop-function-scope-unit.rs
+++ b/gcc/testsuite/rust/execute/drop-function-scope-unit.rs
@@ -1,0 +1,37 @@
+// { dg-output "d\r*\n" }
+// { dg-additional-options "-w" }
+#![feature(no_core)]
+#![feature(lang_items)]
+#![no_core]
+
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "drop"]
+pub trait Drop {
+    fn drop(&mut self);
+}
+
+struct Droppable;
+
+impl Drop for Droppable {
+    fn drop(&mut self) {
+        let msg = "d\n\0" as *const str as *const i8;
+        unsafe {
+            printf(msg);
+        }
+    }
+}
+
+fn f() {
+    let _x = Droppable;
+}
+
+fn main() -> i32 {
+    f();
+    0
+}

--- a/gcc/testsuite/rust/execute/drop-function-scope.rs
+++ b/gcc/testsuite/rust/execute/drop-function-scope.rs
@@ -1,0 +1,33 @@
+// { dg-output "d\r*\n" }
+// { dg-additional-options "-w" }
+#![feature(no_core)]
+#![feature(lang_items)]
+#![no_core]
+
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "drop"]
+pub trait Drop {
+    fn drop(&mut self);
+}
+
+struct Droppable;
+
+impl Drop for Droppable {
+    fn drop(&mut self) {
+        let msg = "d\n\0" as *const str as *const i8;
+        unsafe {
+            printf(msg);
+        }
+    }
+}
+
+fn main() -> i32 {
+    let _x = Droppable;
+    0
+}


### PR DESCRIPTION
This PR consists of 4 commits:

For now, it handles cases like:

```rust
fn main() -> i32 {
    {
        let _x = Droppable;
    }

    0
}
```
It also emits a temporary rust_sorry_at for unsupported Drop ref/subpatterns.

----

**commit 1**
 gccrs: add block drop candidate tracking infrastructure
    
    gcc/rust/ChangeLog:
    
          * backend/rust-compile-context.h (struct DropCandidate): New struct
            for tracking block-local drop candidates.
---

**commit 2**
gccrs: add block-exit Drop calls
    
    gcc/rust/ChangeLog:
    
            * backend/rust-compile-block.cc (compile_drop_call): New helper to
            build a drop call.
            (CompileBlock::visit): Add drop calls for candidates.
            * backend/rust-compile-pattern.cc (type_has_drop_impl): New helper to
            check whether a type implements Drop.
            (CompilePatternLet::visit): Save initialized simple drop candidates.
    
    gcc/testsuite/ChangeLog:
    
            * rust/execute/drop-block-scope.rs: New test.

---

**commit 3**
gccrs: report unsupported Drop ref patterns
    
    gcc/rust/ChangeLog:
    
            * backend/rust-compile-pattern.cc (CompilePatternLet::visit): Check ref
            pattern base types and emit a sorry for unsupported Drop ref/subpatterns.
    
    gcc/testsuite/ChangeLog:
    
            * rust/execute/drop-block-scope.rs: Extend test coverage for simple
            immutable and mutable bindings.
            * rust/compile/drop-ref-pattern.rs: New test.

---

**commit 4**
gccrs: move Drop helpers to separate files

gcc/rust/ChangeLog:

            * Make-lang.in: Add rust-compile-drop.o.
            * backend/rust-compile-block.cc (compile_drop_call): Move to CompileDrop.
            (CompileBlock::visit): Use CompileDrop to emit scope drop calls.
            * backend/rust-compile-context.h (struct DropCandidate): Move to rust-compile-drop.h.
            * backend/rust-compile-pattern.cc (type_has_drop_impl): Move to CompileDrop.
            (CompilePatternLet::visit): Use CompileDrop to check Drop impls.
            * backend/rust-compile-drop.cc: New file.
            * backend/rust-compile-drop.h: New file.
        
---
Tested with:

```bash
        make all-gcc
        make check-rust RUNTESTFLAGS="--all compile.exp=drop-ref-pattern.rs"
        make check-rust RUNTESTFLAGS="--all compile.exp=drop-lang-item.rs"
        make check-rust RUNTESTFLAGS="--all execute.exp=drop-block-scope.rs"