### PR TITLE
Limit globbing visitor

### DIFF
--- a/gcc/rust/resolve/rust-finalize-imports-2.0.cc
+++ b/gcc/rust/resolve/rust-finalize-imports-2.0.cc
@@ -143,6 +143,28 @@ GlobbingVisitor::visit (AST::ConstantItem &const_item)
 }
 
 void
+GlobbingVisitor::visit (AST::TypeAlias &type)
+{
+  ctx.insert_globbed (type.get_new_type_name (), type.get_node_id (),
+		      Namespace::Types);
+}
+
+void
+GlobbingVisitor::visit (AST::Trait &trait)
+{
+  ctx.insert_globbed (trait.get_identifier (), trait.get_node_id (),
+		      Namespace::Types);
+}
+
+void
+GlobbingVisitor::visit (AST::InherentImpl &impl)
+{}
+
+void
+GlobbingVisitor::visit (AST::TraitImpl &impl)
+{}
+
+void
 GlobbingVisitor::visit (AST::ExternCrate &crate)
 {}
 

--- a/gcc/rust/resolve/rust-finalize-imports-2.0.h
+++ b/gcc/rust/resolve/rust-finalize-imports-2.0.h
@@ -48,6 +48,10 @@ public:
   void visit (AST::Enum &enum_item) override;
   void visit (AST::Union &union_item) override;
   void visit (AST::ConstantItem &const_item) override;
+  void visit (AST::TypeAlias &type) override;
+  void visit (AST::Trait &trait) override;
+  void visit (AST::InherentImpl &impl) override;
+  void visit (AST::TraitImpl &impl) override;
   void visit (AST::ExternCrate &crate) override;
   void visit (AST::UseDeclaration &use) override;
 

--- a/gcc/testsuite/rust/compile/name_resolution27.rs
+++ b/gcc/testsuite/rust/compile/name_resolution27.rs
@@ -1,0 +1,20 @@
+#![feature(no_core)]
+#![no_core]
+
+mod a {
+    trait A {
+        fn foo();
+    }
+
+    struct B;
+
+    impl A for B {
+        fn foo() {}
+    }
+}
+
+use a::*;
+
+pub fn bar() {
+    foo() // { dg-error "Cannot find path" }
+}


### PR DESCRIPTION
The globbing visitor would previously descend into some kinds of rust item, instead of registering them as glob imports or ignoring them. This would cause items nested in those items to be glob imported, despite them not being top level items inside the glob container.

Kudos to @CohenArthur for finding this bug.