### PR TITLE
Workaround bugzilla PR 125600

### DIFF
--- a/gcc/testsuite/rust/compile/torture/utf8_identifiers.rs
+++ b/gcc/testsuite/rust/compile/torture/utf8_identifiers.rs
@@ -12,7 +12,7 @@ pub fn f<'かに>() {
     // { dg-warning "unused name" "" { target *-*-* } .-1 }
     let 게 = "";
     // { dg-warning "unused name" "" { target *-*-* } .-1 }
-    let سلطعون = 0.;
+    let سلطعون = 0.15;
     // { dg-warning "unused name" "" { target *-*-* } .-1 }
 
     let _: &'かに () = &crab;
@@ -21,5 +21,5 @@ pub fn f<'かに>() {
 pub fn g<'β, γ>() {}
 
 struct _S {
-    δ: i32
+    δ: i32,
 }


### PR DESCRIPTION
Commit 2e6d90ba (Defer literal suffix validation) caused a regression on
aarch64 with an invalid error on one of our testcases.

Since the testcase only concerns the parsing of UTF-8 identifiers, work
around the regression by modifying the testcase itself.

We opened Rust-GCC#4575 to address the issue later on, but let's restore
the aarch64 build in the meantime.

gcc/testsuite/ChangeLog:

        * rust/compile/torture/utf8_identifiers.rs: Use a more classical
        looking float value to test our UTF-8 identifier.
