### PR TITLE
Fix use after move in lexer

### DIFF
--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -2306,7 +2306,8 @@ Lexer::parse_decimal_int_or_float (location_t loc)
       loc += length - 1;
 
       str.shrink_to_fit ();
-      return Token::make_float (loc, std::move (str), str.length (),
+      auto suffix_start = str.length ();
+      return Token::make_float (loc, std::move (str), suffix_start,
 				CORETYPE_UNKNOWN);
     }
   else if (current_char == 'E' || current_char == 'e')

--- a/gcc/testsuite/rust/compile/float_literals.rs
+++ b/gcc/testsuite/rust/compile/float_literals.rs
@@ -1,0 +1,13 @@
+#![feature(no_core)]
+#![no_core]
+
+pub fn f() {
+    let _ = 0.;
+    let _ = 159.;
+    let _ = 0.0;
+    let _ = 159.0;
+    let _ = 0.0f32;
+    let _ = 159.0f32;
+    let _ = 0_0.0f32;
+    let _ = 0_159.0f32;
+}


### PR DESCRIPTION
The str variable was left in an unspecified but valid state after the prior move on the same line. This lead to a value of zero on some platforms and the prefix was considered empty.