### PR TITLE
gccrs: Search lang_prelude when reaching module boundary during name resolution

### DIFF
--- a/gcc/rust/resolve/rust-name-resolution-context.h
+++ b/gcc/rust/resolve/rust-name-resolution-context.h
@@ -872,6 +872,12 @@ public:
   tl::optional<NodeId> prelude;
 
 private:
+  template <Namespace N>
+  bool
+  should_search_prelude (const typename ForeverStack<N>::Node *current_node,
+			 const typename ForeverStack<N>::SegIterator &iterator,
+			 const std::vector<ResolutionPath::Segment> &segments);
+
   /**
    * Resolve a path to its definition
    *

--- a/gcc/rust/resolve/rust-name-resolution-context.hxx
+++ b/gcc/rust/resolve/rust-name-resolution-context.hxx
@@ -29,6 +29,26 @@ namespace Rust {
 namespace Resolver2_0 {
 
 template <Namespace N>
+bool
+NameResolutionContext::should_search_prelude (
+  const typename ForeverStack<N>::Node *current_node,
+  const typename ForeverStack<N>::SegIterator &iterator,
+  const std::vector<ResolutionPath::Segment> &segments)
+{
+  // Check whether the current_node is a root node
+  if (current_node->is_root ())
+    return true;
+
+  // Check whether we're at the start of a module (we can't travel elsewhere
+  // from the start of a module)
+  if (is_start (iterator, segments)
+      && current_node->rib.kind == Rib::Kind::Module)
+    return true;
+
+  return false;
+}
+
+template <Namespace N>
 tl::optional<Rib::Definition>
 NameResolutionContext::resolve_path (
   ForeverStack<N> &stack, const ResolutionPath &path, ResolutionMode mode,
@@ -383,7 +403,8 @@ NameResolutionContext::resolve_segments (
 		}
 	    }
 
-	  if (current_node->is_root () && !searched_prelude)
+	  if (!searched_prelude
+	      && should_search_prelude<N> (current_node, iterator, segments))
 	    {
 	      searched_prelude = true;
 	      current_node = &stack.lang_prelude;

--- a/gcc/testsuite/rust/compile/name_resolution28.rs
+++ b/gcc/testsuite/rust/compile/name_resolution28.rs
@@ -1,0 +1,11 @@
+#![feature(no_core, lang_items)]
+#![no_core]
+
+pub mod lateresolve {
+    #![lang = "f32"]
+    impl f32 {
+        pub const RADIX: u32 = 2;
+    }
+
+    pub const _: u32 = f32::RADIX;
+}


### PR DESCRIPTION
Name resolution does not resolve language preludes properly within a module. This PR fixes that.