### PR TITLE
gccrs: Refactor CompileDrop and add DropBuilder

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -225,6 +225,7 @@ GRS_OBJS = \
     rust/rust-compile-struct-field-expr.o \
     rust/rust-constexpr.o \
     rust/rust-compile-base.o \
+    rust/rust-compile-drop-builder.o \
     rust/rust-compile-drop.o \
     rust/rust-tree.o \
     rust/rust-compile-context.o \

--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -708,7 +708,7 @@ HIRCompileBase::compile_function_body (tree fndecl,
 	  return_value = coercion_site (id, return_value, actual, expected,
 					lvalue_locus, rvalue_locus);
 
-	  CompileDrop::emit_current_scope_drop_calls (ctx);
+	  CompileDrop (ctx).emit_current_scope_drop_calls ();
 
 	  tree return_stmt
 	    = Backend::return_statement (fndecl, return_value, locus);
@@ -732,7 +732,7 @@ HIRCompileBase::compile_function_body (tree fndecl,
       // errors should have occurred
       location_t locus = function_body.get_locus ();
       tree return_value = unit_expression (locus);
-      CompileDrop::emit_current_scope_drop_calls (ctx);
+      CompileDrop (ctx).emit_current_scope_drop_calls ();
       tree return_stmt
 	= Backend::return_statement (fndecl, return_value, locus);
       ctx->add_statement (return_stmt);

--- a/gcc/rust/backend/rust-compile-block.cc
+++ b/gcc/rust/backend/rust-compile-block.cc
@@ -85,7 +85,7 @@ CompileBlock::visit (HIR::BlockExpr &expr)
 					 expr.get_locus ());
       ctx->add_statement (assignment);
     }
-  CompileDrop::emit_current_scope_drop_calls (ctx);
+  CompileDrop (ctx).emit_current_scope_drop_calls ();
 
   ctx->pop_block ();
   translated = new_block;

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -51,6 +51,8 @@ struct CustomDeriveInfo
   std::vector<std::string> attributes;
 };
 
+class DropBuilder;
+
 class Context
 {
 public:
@@ -135,18 +137,6 @@ public:
   }
 
   void add_statement (tree stmt) { statements.back ().push_back (stmt); }
-
-  std::vector<DropCandidate> &peek_block_drop_candidates ()
-  {
-    rust_assert (!block_drop_candidates.empty ());
-    return block_drop_candidates.back ();
-  }
-
-  void note_simple_drop_candidate (HirId hirid, location_t locus)
-  {
-    rust_assert (!block_drop_candidates.empty ());
-    block_drop_candidates.back ().emplace_back (hirid, locus);
-  }
 
   void insert_var_decl (HirId id, ::Bvariable *decl)
   {
@@ -421,6 +411,7 @@ public:
   }
 
 private:
+  friend class DropBuilder;
   Context ();
 
   Resolver::TypeCheckContext *tyctx;

--- a/gcc/rust/backend/rust-compile-drop-builder.cc
+++ b/gcc/rust/backend/rust-compile-drop-builder.cc
@@ -16,30 +16,27 @@
 // along with GCC; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef RUST_COMPILE_DROP_H
-#define RUST_COMPILE_DROP_H
-
+#include "rust-compile-drop-builder.h"
 #include "rust-compile-context.h"
 
 namespace Rust {
 namespace Compile {
 
-class CompileDrop
+DropBuilder::DropBuilder (Context &ctx) : ctx (ctx) {}
+
+void
+DropBuilder::note_simple_drop_candidate (HirId hirid, location_t locus)
 {
-public:
-  CompileDrop (Context *ctx);
+  rust_assert (!ctx.block_drop_candidates.empty ());
+  ctx.block_drop_candidates.back ().emplace_back (hirid, locus);
+}
 
-  bool type_has_drop_impl (TyTy::BaseType *ty);
-
-  void emit_current_scope_drop_calls ();
-
-private:
-  tree compile_drop_call (Bvariable *var, TyTy::BaseType *ty, location_t locus);
-
-  Context *ctx;
-};
+std::vector<DropCandidate> &
+DropBuilder::peek_block_drop_candidates ()
+{
+  rust_assert (!ctx.block_drop_candidates.empty ());
+  return ctx.block_drop_candidates.back ();
+}
 
 } // namespace Compile
 } // namespace Rust
-
-#endif // RUST_COMPILE_DROP_H

--- a/gcc/rust/backend/rust-compile-drop-builder.h
+++ b/gcc/rust/backend/rust-compile-drop-builder.h
@@ -16,30 +16,29 @@
 // along with GCC; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef RUST_COMPILE_DROP_H
-#define RUST_COMPILE_DROP_H
+#ifndef RUST_COMPILE_DROP_BUILDER_H
+#define RUST_COMPILE_DROP_BUILDER_H
 
-#include "rust-compile-context.h"
+#include "rust-compile-drop-candidate.h"
 
 namespace Rust {
 namespace Compile {
 
-class CompileDrop
+class Context;
+
+class DropBuilder
 {
 public:
-  CompileDrop (Context *ctx);
+  DropBuilder (Context &ctx);
 
-  bool type_has_drop_impl (TyTy::BaseType *ty);
-
-  void emit_current_scope_drop_calls ();
+  void note_simple_drop_candidate (HirId hirid, location_t locus);
+  std::vector<DropCandidate> &peek_block_drop_candidates ();
 
 private:
-  tree compile_drop_call (Bvariable *var, TyTy::BaseType *ty, location_t locus);
-
-  Context *ctx;
+  Context &ctx;
 };
 
 } // namespace Compile
 } // namespace Rust
 
-#endif // RUST_COMPILE_DROP_H
+#endif // RUST_COMPILE_DROP_BUILDER_H

--- a/gcc/rust/backend/rust-compile-drop.cc
+++ b/gcc/rust/backend/rust-compile-drop.cc
@@ -17,6 +17,7 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-compile-drop.h"
+#include "rust-compile-drop-builder.h"
 #include "rust-compile-base.h"
 #include "rust-compile-context.h"
 #include "rust-compile-implitem.h"
@@ -29,8 +30,10 @@
 namespace Rust {
 namespace Compile {
 
+CompileDrop::CompileDrop (Context *ctx) : ctx (ctx) {}
+
 bool
-CompileDrop::type_has_drop_impl (Context *ctx, TyTy::BaseType *ty)
+CompileDrop::type_has_drop_impl (TyTy::BaseType *ty)
 {
   auto drop_lang_item
     = ctx->get_mappings ().lookup_lang_item (LangItem::Kind::DROP);
@@ -53,8 +56,8 @@ CompileDrop::type_has_drop_impl (Context *ctx, TyTy::BaseType *ty)
 
 // Find the Drop trait, look for the drop method, and build the function call.
 tree
-CompileDrop::compile_drop_call (Context *ctx, Bvariable *var,
-				TyTy::BaseType *ty, location_t locus)
+CompileDrop::compile_drop_call (Bvariable *var, TyTy::BaseType *ty,
+				location_t locus)
 {
   auto drop_lang = ctx->get_mappings ().lookup_lang_item (LangItem::Kind::DROP);
   if (!drop_lang.has_value ())
@@ -88,9 +91,10 @@ CompileDrop::compile_drop_call (Context *ctx, Bvariable *var,
 }
 
 void
-CompileDrop::emit_current_scope_drop_calls (Context *ctx)
+CompileDrop::emit_current_scope_drop_calls ()
 {
-  auto &drop_candidates = ctx->peek_block_drop_candidates ();
+  DropBuilder drop_builder (*ctx);
+  auto &drop_candidates = drop_builder.peek_block_drop_candidates ();
 
   for (auto it = drop_candidates.rbegin (); it != drop_candidates.rend (); ++it)
     {
@@ -103,7 +107,7 @@ CompileDrop::emit_current_scope_drop_calls (Context *ctx)
       ok = ctx->lookup_var_decl (it->hirid, &var);
       rust_assert (ok);
 
-      tree drop_call = CompileDrop::compile_drop_call (ctx, var, ty, it->locus);
+      tree drop_call = compile_drop_call (var, ty, it->locus);
       if (drop_call != NULL_TREE)
 	ctx->add_statement (convert_to_void (drop_call, ICV_STATEMENT));
     }

--- a/gcc/rust/backend/rust-compile-pattern.cc
+++ b/gcc/rust/backend/rust-compile-pattern.cc
@@ -17,6 +17,7 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-compile-pattern.h"
+#include "rust-compile-drop-builder.h"
 #include "print-tree.h"
 #include "rust-compile-drop.h"
 #include "rust-compile-expr.h"
@@ -1356,12 +1357,15 @@ CompilePatternLet::visit (HIR::IdentifierPattern &pattern)
       drop_ty = ref_ty->get_base ();
     }
 
-  if (!CompileDrop::type_has_drop_impl (ctx, drop_ty))
+  if (!CompileDrop (ctx).type_has_drop_impl (drop_ty))
     return;
 
   if (!pattern.has_subpattern () && !pattern.get_is_ref ())
-    ctx->note_simple_drop_candidate (pattern.get_mappings ().get_hirid (),
-				     pattern.get_locus ());
+    {
+      DropBuilder drop_builder (*ctx);
+      drop_builder.note_simple_drop_candidate (
+	pattern.get_mappings ().get_hirid (), pattern.get_locus ());
+    }
   else
     rust_sorry_at (pattern.get_locus (),
 		   "drop trait not supported for subpatterns and ref patterns");


### PR DESCRIPTION
This PR refactors the Drop helper API without changing behavior.

- `CompileDrop` now keeps the compile `Context` as a member instead of passing it to each method. 
- The drop candidate note/peek operations were moved from `Context` to `DropBuilder`, 
keeping the drop-specific API off the compile `Context`.

----

This is intended as a first step toward a dedicated Drop API. 
Future work can decide whether higher-level APIs such as `compile_drop_calls()` should live on `DropBuilder`.


gcc/rust/ChangeLog:

	* Make-lang.in: Add rust-compile-drop-builder.o.
	* backend/rust-compile-base.cc (HIRCompileBase::compile_function_body): Update CompileDrop calls.
	* backend/rust-compile-block.cc (CompileBlock::visit): Update CompileDrop calls.
	* backend/rust-compile-context.h (Context): Allow DropBuilder to access drop candidate storage and move drop candidate APIs to DropBuilder.
	* backend/rust-compile-drop.cc (CompileDrop::CompileDrop): Add constructor. (CompileDrop::type_has_drop_impl): Use stored Context member. (CompileDrop::compile_drop_call): Likewise. (CompileDrop::emit_current_scope_drop_calls): Use stored Context member and get drop candidates from DropBuilder.
	* backend/rust-compile-drop.h: Store Context as a member.
	* backend/rust-compile-pattern.cc (CompilePatternLet::visit): Use DropBuilder and update CompileDrop calls.
	* backend/rust-compile-drop-builder.cc: New file.
	* backend/rust-compile-drop-builder.h: New file.

