### PR TITLE
gccrs: Support function-scope drops on normal function exit

### DIFF
--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -21,6 +21,7 @@
 #include "rust-compile-stmt.h"
 #include "rust-compile-expr.h"
 #include "rust-compile-drop.h"
+#include "rust-compile-drop-builder.h"
 #include "rust-compile-fnparam.h"
 #include "rust-compile-var-decl.h"
 #include "rust-compile-type.h"
@@ -719,7 +720,7 @@ HIRCompileBase::compile_function_body (tree fndecl,
 	  // just add the stmt expression
 	  ctx->add_statement (return_value);
 
-	  CompileDrop::emit_current_scope_drop_calls (ctx);
+	  CompileDrop (ctx).emit_current_scope_drop_calls ();
 
 	  // now just return unit expression
 	  tree unit_expr = unit_expression (locus);
@@ -825,6 +826,7 @@ HIRCompileBase::compile_function (
   // setup the params
   TyTy::BaseType *tyret = fntype->get_return_type ();
   std::vector<Bvariable *> param_vars;
+  std::vector<DropCandidate> param_drop_candidates;
   if (self_param)
     {
       rust_assert (fntype->is_method ());
@@ -860,6 +862,11 @@ HIRCompileBase::compile_function (
       const HIR::Pattern &param_pattern = referenced_param.get_param_name ();
       ctx->insert_var_decl (param_pattern.get_mappings ().get_hirid (),
 			    compiled_param_var);
+
+      if (CompileDrop (ctx).type_has_drop_impl (param_tyty))
+	param_drop_candidates.emplace_back (
+	  param_pattern.get_mappings ().get_hirid (),
+	  param_pattern.get_locus ());
     }
 
   if (!Backend::function_set_parameters (fndecl, param_vars))
@@ -872,6 +879,10 @@ HIRCompileBase::compile_function (
   tree code_block = Backend::block (fndecl, enclosing_scope, {} /*locals*/,
 				    start_location, end_location);
   ctx->push_block (code_block);
+
+  DropBuilder drop_builder (*ctx);
+  for (auto &candidate : param_drop_candidates)
+    drop_builder.note_simple_drop_candidate (candidate.hirid, candidate.locus);
 
   Bvariable *return_address = nullptr;
   tree return_type = TyTyResolveCompile::compile (ctx, tyret);

--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -719,6 +719,8 @@ HIRCompileBase::compile_function_body (tree fndecl,
 	  // just add the stmt expression
 	  ctx->add_statement (return_value);
 
+	  CompileDrop::emit_current_scope_drop_calls (ctx);
+
 	  // now just return unit expression
 	  tree unit_expr = unit_expression (locus);
 	  tree return_stmt

--- a/gcc/testsuite/rust/execute/drop-function-params.rs
+++ b/gcc/testsuite/rust/execute/drop-function-params.rs
@@ -1,0 +1,52 @@
+// { dg-output "l\r*\np\r*\nl\r*\np\r*\n" }
+// { dg-additional-options "-w" }
+#![feature(no_core)]
+#![feature(lang_items)]
+#![no_core]
+
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "drop"]
+pub trait Drop {
+    fn drop(&mut self);
+}
+
+struct ParamDroppable;
+struct LocalDroppable;
+
+impl Drop for ParamDroppable {
+    fn drop(&mut self) {
+        let msg = "p\n\0" as *const str as *const i8;
+        unsafe {
+            printf(msg);
+        }
+    }
+}
+
+impl Drop for LocalDroppable {
+    fn drop(&mut self) {
+        let msg = "l\n\0" as *const str as *const i8;
+        unsafe {
+            printf(msg);
+        }
+    }
+}
+
+fn named_param(_p: ParamDroppable) {
+    let _l = LocalDroppable;
+}
+
+fn wildcard_param(_: ParamDroppable) {
+    let _l = LocalDroppable;
+}
+
+fn main() -> i32 {
+    named_param(ParamDroppable);
+    wildcard_param(ParamDroppable);
+    0
+}

--- a/gcc/testsuite/rust/execute/drop-function-scope-unit-tail.rs
+++ b/gcc/testsuite/rust/execute/drop-function-scope-unit-tail.rs
@@ -1,0 +1,46 @@
+// { dg-output "d\r*\nd\r*\n" }
+// { dg-additional-options "-w" }
+#![feature(no_core)]
+#![feature(lang_items)]
+#![no_core]
+
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "drop"]
+pub trait Drop {
+    fn drop(&mut self);
+}
+
+struct Droppable;
+
+impl Drop for Droppable {
+    fn drop(&mut self) {
+        let msg = "d\n\0" as *const str as *const i8;
+        unsafe {
+            printf(msg);
+        }
+    }
+}
+
+fn foo() {}
+
+fn unit_tail_call() {
+    let _x = Droppable;
+    foo()
+}
+
+fn unit_tail_literal() {
+    let _x = Droppable;
+    ()
+}
+
+fn main() -> i32 {
+    unit_tail_call();
+    unit_tail_literal();
+    0
+}


### PR DESCRIPTION
This PR adds function-scope drop handling for normal function exits only.
Early exits such as `return`, `break`, and `continue` are left for follow-up work.

It covers two missing cases:

1. Unit tail expressions
```rust
fn foo() {}

fn f() {
    let _x = Droppable;
    foo()
}
```

2. Function parameters
```rust
fn f(x: Droppable) {}
```