### PR TITLE
gccrs: Evaluate non-unit tail expressions before drops

### DIFF
--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -708,10 +708,30 @@ HIRCompileBase::compile_function_body (tree fndecl,
 	  return_value = coercion_site (id, return_value, actual, expected,
 					lvalue_locus, rvalue_locus);
 
+	  /* Save the non-unit tail expression result before emitting scope
+	    drops, so a tail call like foo() is evaluated before locals are
+	    dropped.  Conceptually, this changes lowering from:
+
+	      drop (_x);
+	      return foo ();
+
+	    to:
+
+	      ret_slot = foo ();
+	      drop (_x);
+	      return ret_slot; */
+	  fncontext fnctx = ctx->peek_fn ();
+	  tree result_reference
+	    = Backend::var_expression (fnctx.ret_addr, lvalue_locus);
+	  tree assignment = Backend::assignment_statement (result_reference,
+							   return_value, locus);
+	  ctx->add_statement (assignment);
+
 	  CompileDrop (ctx).emit_current_scope_drop_calls ();
 
+	  result_reference = Backend::var_expression (fnctx.ret_addr, locus);
 	  tree return_stmt
-	    = Backend::return_statement (fndecl, return_value, locus);
+	    = Backend::return_statement (fndecl, result_reference, locus);
 	  ctx->add_statement (return_stmt);
 	}
       else

--- a/gcc/testsuite/rust/execute/drop-function-scope-non-unit-tail.rs
+++ b/gcc/testsuite/rust/execute/drop-function-scope-non-unit-tail.rs
@@ -1,0 +1,46 @@
+// { dg-output "f\r*\nd\r*\n" }
+// { dg-additional-options "-w" }
+#![feature(no_core)]
+#![feature(lang_items)]
+#![no_core]
+
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "drop"]
+pub trait Drop {
+    fn drop(&mut self);
+}
+
+struct Droppable;
+
+impl Drop for Droppable {
+    fn drop(&mut self) {
+        let msg = "d\n\0" as *const str as *const i8;
+        unsafe {
+            printf(msg);
+        }
+    }
+}
+
+fn foo() -> i32 {
+    let msg = "f\n\0" as *const str as *const i8;
+    unsafe {
+        printf(msg);
+    }
+
+    0
+}
+
+fn f() -> i32 {
+    let _x = Droppable;
+    foo()
+}
+
+fn main() -> i32 {
+    f()
+}


### PR DESCRIPTION
I initially opened this branch to add coverage for non-unit tail expression testcase.

The new test exposed that a non-unit tail call could be evaluated after local drops, so this PR also includes the fix to store the tail expression result before emitting drops.

For example:
```rust
fn foo() -> i32 {
    0
}

fn f() -> i32 {
    let _x = Droppable;
    foo()
}
```
The expected order is to evaluate `foo()` first, then drop `_x`, then return the stored result.

---
gcc/rust/ChangeLog:

	* backend/rust-compile-base.cc (HIRCompileBase::compile_function_body): Store non-unit tail expression results before emitting current scope drops.

gcc/testsuite/ChangeLog:

	* rust/execute/drop-function-scope-non-unit-tail.rs: New test.


