### PR TITLE
gccrs: Fix ICE when handling invalid results during monomprhization

### DIFF
--- a/gcc/rust/backend/rust-compile-item.cc
+++ b/gcc/rust/backend/rust-compile-item.cc
@@ -180,7 +180,9 @@ CompileItem::visit (HIR::Function &function)
 				    TyTy::TyWithLocation (concrete),
 				    function.get_locus ());
 
-	  rust_assert (resolved->is<TyTy::FnType> ());
+	  if (!resolved->is<TyTy::FnType> ())
+	    return;
+
 	  fntype = resolved->as<TyTy::FnType> ();
 	}
 

--- a/gcc/testsuite/rust/compile/issue-4486-1.rs
+++ b/gcc/testsuite/rust/compile/issue-4486-1.rs
@@ -1,0 +1,15 @@
+#![feature(no_core, intrinsics, staged_api, lang_items)]
+#![no_core]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+trait Number {
+    fn from<T>(n: T) -> Self;
+}
+
+trait NumConv {}
+
+fn main() {
+    let _: f64 = Number::from(0.0f64); // { dg-error {bounds not satisfied for f64 .Number. is not satisfied \[E0277\]} }
+}

--- a/gcc/testsuite/rust/compile/issue-4486-2.rs
+++ b/gcc/testsuite/rust/compile/issue-4486-2.rs
@@ -1,0 +1,41 @@
+#![feature(no_core, intrinsics, staged_api, lang_items)]
+#![no_core]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+pub trait Number: NumConv {
+    fn from<T: Number>(n: T) -> Self;
+}
+
+trait NumberExt: Number {
+    fn to_double(&self) -> f64 {
+        self.to_float() * 2.0
+    }
+}
+
+impl<T: Number> NumberExt for T {}
+
+impl Number for f64 {
+    fn from<T: Number + NewTrait>(n: T) -> f64 { // { dg-error {bounds not satisfied for f64 .NewTrait. is not satisfied \[E0277\]} }
+        n.to_float()
+    }
+}
+
+pub trait NumConv {
+    fn to_float(&self) -> f64;
+}
+
+impl NumConv for f64 {
+    fn to_float(&self) -> f64 {
+        *self
+    }
+}
+
+pub fn main() {
+    let _: f64 = Number::from(0.0f64);
+}
+
+trait NewTrait {
+    type Assoc;
+}


### PR DESCRIPTION
Fixes Rust-GCC#4486

gcc/rust/ChangeLog:

	* backend/rust-compile-item.cc (CompileItem::visit): check instead of assert

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4486-1.rs: New test.
	* rust/compile/issue-4486-2.rs: New test.

