### PR TITLE
gccrs: Fix ICE when trying to resolve const expr

### DIFF
--- a/gcc/rust/backend/rust-compile-resolve-path.cc
+++ b/gcc/rust/backend/rust-compile-resolve-path.cc
@@ -194,7 +194,9 @@ ResolvePathRef::resolve_with_node_id (
       auto d = lookup->destructure ();
       rust_assert (d->get_kind () == TyTy::TypeKind::CONST);
       auto c = d->as_const_type ();
-      rust_assert (c->const_kind () == TyTy::BaseConstType::ConstKind::Value);
+      if (c->const_kind () != TyTy::BaseConstType::ConstKind::Value)
+	return error_mark_node;
+
       auto val = static_cast<TyTy::ConstValueType *> (c);
       return val->get_value ();
     }

--- a/gcc/rust/typecheck/rust-hir-type-check-item.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.cc
@@ -723,11 +723,7 @@ TypeCheckItem::visit (HIR::Function &function)
     {
       auto resolved = TypeCheckType::Resolve (function.get_return_type ());
       if (resolved->get_kind () == TyTy::TypeKind::ERROR)
-	{
-	  rust_error_at (function.get_locus (),
-			 "failed to resolve return type");
-	  return;
-	}
+	return;
 
       ret_type = resolved->clone ();
       ret_type->set_ref (

--- a/gcc/testsuite/rust/compile/issue-2479.rs
+++ b/gcc/testsuite/rust/compile/issue-2479.rs
@@ -9,7 +9,6 @@ enum Dragon {
 
 fn oblivion() -> Dragon::Born {
 // { dg-error "expected type, found variant of .Dragon::Born." "" { target *-*-* } .-1 }
-// { dg-error "failed to resolve return type" "" { target *-*-* } .-2 }
     Dragon::Born
 }
 

--- a/gcc/testsuite/rust/compile/issue-4302.rs
+++ b/gcc/testsuite/rust/compile/issue-4302.rs
@@ -1,0 +1,12 @@
+#![feature(no_core, intrinsics, staged_api, lang_items)]
+#![no_core]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+pub struct Foo<const N: usize>;
+
+pub fn foo<const N: usize>() -> Foo<{ N + 1 }> {
+    // { dg-error "failed to resolve const expression" "" { target *-*-* } .-1 }
+    Foo
+}


### PR DESCRIPTION
We cannot resolve N + 1 a this stage since N has no default and is const
generic, rustc makes a more precise error diag here but our one is
completely fine for now.
    
Fixes Rust-GCC#4302
    
gcc/rust/ChangeLog:
    
        * backend/rust-compile-resolve-path.cc: use error_mark_node
    
gcc/testsuite/ChangeLog:
    
        * rust/compile/issue-4302.rs: New test.
