### PR TITLE
Add write_bytes and arith_offset

### DIFF
--- a/gcc/rust/backend/rust-compile-intrinsic.cc
+++ b/gcc/rust/backend/rust-compile-intrinsic.cc
@@ -29,6 +29,7 @@ using IValue = Values::Intrinsics;
 
 static const std::map<std::string, handlers::HandlerBuilder> generic_intrinsics
   = {{IValue::OFFSET, handlers::offset},
+     {IValue::ARITH_OFFSET, handlers::arith_offset_handler},
      {IValue::WRITE_BYTES, handlers::write_bytes_handler},
      {IValue::SIZE_OF, handlers::sizeof_handler},
      {IValue::MIN_ALIGN_OF, handlers::min_align_of_handler},

--- a/gcc/rust/backend/rust-compile-intrinsic.cc
+++ b/gcc/rust/backend/rust-compile-intrinsic.cc
@@ -29,6 +29,7 @@ using IValue = Values::Intrinsics;
 
 static const std::map<std::string, handlers::HandlerBuilder> generic_intrinsics
   = {{IValue::OFFSET, handlers::offset},
+     {IValue::WRITE_BYTES, handlers::write_bytes_handler},
      {IValue::SIZE_OF, handlers::sizeof_handler},
      {IValue::MIN_ALIGN_OF, handlers::min_align_of_handler},
      {IValue::TRANSMUTE, handlers::transmute},

--- a/gcc/rust/backend/rust-intrinsic-handlers.cc
+++ b/gcc/rust/backend/rust-intrinsic-handlers.cc
@@ -1935,6 +1935,45 @@ write_bytes_handler (Context *ctx, TyTy::FnType *fntype, location_t)
   return fndecl;
 }
 
+/**
+ * pub fn arith_offset<T>(dst: *const T, offset: isize) -> *const T;
+ */
+tree
+arith_offset_handler (Context *ctx, TyTy::FnType *fntype, location_t expr_locus)
+{
+  rust_assert (fntype->get_params ().size () == 2);
+
+  auto fndecl = compile_intrinsic_function (ctx, fntype);
+
+  auto locus = fntype->get_locus ();
+
+  std::vector<Bvariable *> param_vars;
+  compile_fn_params (ctx, fntype, fndecl, &param_vars);
+
+  auto &dst_param = param_vars.at (0);
+  auto &size_param = param_vars.at (1);
+  rust_assert (param_vars.size () == 2);
+  if (!Backend::function_set_parameters (fndecl, param_vars))
+    return error_mark_node;
+
+  enter_intrinsic_block (ctx, fndecl);
+
+  // BUILTIN arith_offset FN BODY BEGIN
+
+  tree dst = Backend::var_expression (dst_param, locus);
+  tree size = Backend::var_expression (size_param, locus);
+  tree pointer_offset_expr = pointer_offset_expression (dst, size, expr_locus);
+  auto return_statement
+    = Backend::return_statement (fndecl, pointer_offset_expr, locus);
+  ctx->add_statement (return_statement);
+
+  // BUILTIN arith_offset FN BODY END
+
+  finalize_intrinsic_block (ctx, fndecl);
+
+  return fndecl;
+}
+
 } // namespace handlers
 } // namespace Compile
 } // namespace Rust

--- a/gcc/rust/backend/rust-intrinsic-handlers.cc
+++ b/gcc/rust/backend/rust-intrinsic-handlers.cc
@@ -1865,6 +1865,76 @@ cttz_nonzero_handler (Context *ctx, TyTy::FnType *fntype, location_t)
   return inner::cttz_handler (ctx, fntype, true);
 }
 
+/**
+ * pub unsafe fn write_bytes<T>(dst: *mut T, val: u8, count: usize);
+ */
+tree
+write_bytes_handler (Context *ctx, TyTy::FnType *fntype, location_t)
+{
+  rust_assert (fntype->get_params ().size () == 3);
+
+  tree lookup = NULL_TREE;
+  if (check_for_cached_intrinsic (ctx, fntype, &lookup))
+    return lookup;
+
+  tree fndecl = compile_intrinsic_function (ctx, fntype);
+
+  auto locus = fntype->get_locus ();
+
+  std::vector<Bvariable *> param_vars;
+  compile_fn_params (ctx, fntype, fndecl, &param_vars);
+
+  auto &dst_param = param_vars.at (0);
+  auto &val_param = param_vars.at (1);
+  auto &count_param = param_vars.at (2);
+  rust_assert (param_vars.size () == 3);
+  if (!Backend::function_set_parameters (fndecl, param_vars))
+    return error_mark_node;
+
+  auto *monomorphized_type
+    = fntype->get_substs ().at (0).get_param_ty ()->resolve ();
+
+  tree template_parameter_type
+    = TyTyResolveCompile::compile (ctx, monomorphized_type);
+  tree dst_size_expr = TYPE_SIZE_UNIT (template_parameter_type);
+  rust_assert (dst_size_expr != NULL_TREE);
+
+  enter_intrinsic_block (ctx, fndecl);
+
+  // BUILTIN WRITE_BYTES FN BODY START
+
+  tree expr_dst = Backend::var_expression (dst_param, locus);
+  tree expr_val = Backend::var_expression (val_param, locus);
+  tree expr_count = Backend::var_expression (count_param, locus);
+
+  tree expr_count_final
+    = fold_build2_loc (locus, MULT_EXPR, size_type_node,
+		       fold_convert_loc (locus, size_type_node, expr_count),
+		       fold_convert_loc (locus, size_type_node, dst_size_expr));
+
+  tree write_bytes_raw = nullptr;
+  // void* memset( void* dest, int ch, size_t count );
+  bool ok = BuiltinsContext::get ().lookup_simple_builtin ("__builtin_memset",
+							   &write_bytes_raw);
+  rust_assert (ok);
+
+  tree write_bytes_fn = build_fold_addr_expr_loc (locus, write_bytes_raw);
+  tree write_bytes_call
+    = Backend::call_expression (write_bytes_fn,
+				{expr_dst, expr_val, expr_count_final},
+				NULL_TREE, locus);
+
+  ctx->add_statement (write_bytes_call);
+
+  // BUILTIN WRITE_BYTES FN BODY END
+
+  finalize_intrinsic_block (ctx, fndecl);
+
+  TREE_READONLY (fndecl) = 0;
+
+  return fndecl;
+}
+
 } // namespace handlers
 } // namespace Compile
 } // namespace Rust

--- a/gcc/rust/backend/rust-intrinsic-handlers.h
+++ b/gcc/rust/backend/rust-intrinsic-handlers.h
@@ -96,6 +96,9 @@ tree prefetch_write_data (Context *ctx, TyTy::FnType *fntype,
 			  location_t expr_locus);
 tree sorry (Context *ctx, TyTy::FnType *fntype, location_t expr_locus);
 
+tree write_bytes_handler (Context *ctx, TyTy::FnType *fntype,
+			  location_t expr_locus);
+
 } // namespace handlers
 
 } // namespace Compile

--- a/gcc/rust/backend/rust-intrinsic-handlers.h
+++ b/gcc/rust/backend/rust-intrinsic-handlers.h
@@ -98,6 +98,8 @@ tree sorry (Context *ctx, TyTy::FnType *fntype, location_t expr_locus);
 
 tree write_bytes_handler (Context *ctx, TyTy::FnType *fntype,
 			  location_t expr_locus);
+tree arith_offset_handler (Context *ctx, TyTy::FnType *fntype,
+			   location_t expr_locus);
 
 } // namespace handlers
 

--- a/gcc/rust/typecheck/rust-hir-type-check-intrinsic.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-intrinsic.cc
@@ -300,6 +300,11 @@ const std::unordered_map<std::string, IntrinsicRules>
     {IValue::FORGET, {1, {IRT::FirstGeneric}, IRT::Unit}},
     // pub fn black_box<T>(mut dummy: T) -> T
     {IValue::BLACK_BOX, {1, {IRT::FirstGeneric}, IRT::FirstGeneric}},
+
+    // fn write_bytes<T>(dst: *mut T, val: u8, count: usize)
+    {IValue::WRITE_BYTES,
+     {1, {IRT::MutPtrFirstGeneric, IRT::U8, IRT::Usize}, IRT::Unit}},
+
 };
 
 IntrinsicCheckResult

--- a/gcc/rust/typecheck/rust-hir-type-check-intrinsic.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-intrinsic.cc
@@ -301,6 +301,9 @@ const std::unordered_map<std::string, IntrinsicRules>
     // pub fn black_box<T>(mut dummy: T) -> T
     {IValue::BLACK_BOX, {1, {IRT::FirstGeneric}, IRT::FirstGeneric}},
 
+    // pub fn arith_offset<T>(dst: *const T, offset: isize) -> *const T;
+    {IValue::ARITH_OFFSET,
+     {1, {IRT::ConstPtrFirstGeneric, IRT::Isize}, IRT::ConstPtrFirstGeneric}},
     // fn write_bytes<T>(dst: *mut T, val: u8, count: usize)
     {IValue::WRITE_BYTES,
      {1, {IRT::MutPtrFirstGeneric, IRT::U8, IRT::Usize}, IRT::Unit}},

--- a/gcc/rust/util/rust-intrinsic-values.h
+++ b/gcc/rust/util/rust-intrinsic-values.h
@@ -157,6 +157,7 @@ public:
   static constexpr auto &TYPE_NAME = "type_name";
   static constexpr auto &FORGET = "forget";
   static constexpr auto &BLACK_BOX = "black_box";
+  static constexpr auto &ARITH_OFFSET = "arith_offset";
   static constexpr auto &WRITE_BYTES = "write_bytes";
 };
 } // namespace Values

--- a/gcc/rust/util/rust-intrinsic-values.h
+++ b/gcc/rust/util/rust-intrinsic-values.h
@@ -157,6 +157,7 @@ public:
   static constexpr auto &TYPE_NAME = "type_name";
   static constexpr auto &FORGET = "forget";
   static constexpr auto &BLACK_BOX = "black_box";
+  static constexpr auto &WRITE_BYTES = "write_bytes";
 };
 } // namespace Values
 } // namespace Rust

--- a/gcc/testsuite/rust/execute/arith-offset.rs
+++ b/gcc/testsuite/rust/execute/arith-offset.rs
@@ -1,0 +1,23 @@
+#![feature(no_core, intrinsics, lang_items)]
+#![no_core]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+extern "rust-intrinsic" {
+    fn arith_offset<T>(dst: *const T, offset: isize) -> *const T;
+}
+
+fn main() -> i32 {
+    let base_addr: usize = 0;
+    let ptr = base_addr as *const u64;
+
+    unsafe {
+        let wrap_ptr = arith_offset(ptr, -1);
+        if wrap_ptr as isize == -8_isize {
+            0 
+        } else {
+            1 
+        }
+    }
+}

--- a/gcc/testsuite/rust/execute/write-bytes.rs
+++ b/gcc/testsuite/rust/execute/write-bytes.rs
@@ -1,0 +1,17 @@
+#![feature(no_core, intrinsics, lang_items)]
+#![no_core]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+extern "rust-intrinsic" {
+    fn write_bytes<T>(dst: *mut T, val: u8, count: usize);
+}
+
+fn main() -> i32 {
+    let mut x: u32 = 0;
+    unsafe { 
+        write_bytes(&mut x as *mut u32, 0xEC_u8, 1); 
+    }
+    if x == 0xECECECEC_u32 { 0 } else { 1 }
+}


### PR DESCRIPTION
This patch implements `arith_offset` and `write_bytes` compiler intrinsics.

* `write_bytes`: Lowered to `__builtin_memset`.
* `arith_offset`: Lowered using `POINTER_PLUS_EXPR`.

`rustc` behavior:
- `arith_offset` -> https://godbolt.org/z/j631bMbT7
- `write_bytes` -> https://godbolt.org/z/q1K1Txc5v