### PR TITLE
gccrs: add while true lint

### DIFF
--- a/gcc/rust/checks/lints/unused/rust-unused-checker.cc
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.cc
@@ -347,5 +347,70 @@ UnusedChecker::visit (HIR::LetStmt &stmt)
   walk (stmt);
 }
 
+namespace {
+
+// Collects the value of a boolean literal expression, if the visited
+// expression is one.
+class BoolLiteral : public HIR::HIRFullVisitorBase
+{
+public:
+  bool found = false;
+  bool value = false;
+
+  using HIR::HIRFullVisitorBase::visit;
+  void visit (HIR::LiteralExpr &lit) override
+  {
+    if (lit.get_literal ().get_lit_type () == HIR::Literal::LitType::BOOL)
+      {
+	found = true;
+	value
+	  = lit.get_literal ().as_string () == Values::Keywords::TRUE_LITERAL;
+      }
+  }
+};
+
+// Detects a predicate that is constantly true: the `true` literal, or a
+// comparison of two boolean literals that always holds.
+class ConstantTruth : public HIR::HIRFullVisitorBase
+{
+public:
+  bool is_true = false;
+
+  using HIR::HIRFullVisitorBase::visit;
+  void visit (HIR::LiteralExpr &lit) override
+  {
+    if (lit.get_literal ().get_lit_type () == HIR::Literal::LitType::BOOL)
+      is_true
+	= lit.get_literal ().as_string () == Values::Keywords::TRUE_LITERAL;
+  }
+
+  void visit (HIR::ComparisonExpr &cmp) override
+  {
+    BoolLiteral lhs, rhs;
+    cmp.get_lhs ().accept_vis (lhs);
+    cmp.get_rhs ().accept_vis (rhs);
+    if (lhs.found && rhs.found)
+      {
+	if (cmp.get_kind () == ComparisonOperator::EQUAL)
+	  is_true = lhs.value == rhs.value;
+	else if (cmp.get_kind () == ComparisonOperator::NOT_EQUAL)
+	  is_true = lhs.value != rhs.value;
+      }
+  }
+};
+
+} // namespace
+
+void
+UnusedChecker::visit (HIR::WhileLoopExpr &expr)
+{
+  ConstantTruth predicate;
+  expr.get_predicate_expr ().accept_vis (predicate);
+  if (predicate.is_true)
+    rust_warning_at (expr.get_locus (), OPT_Wunused,
+		     "denote infinite loops with %<loop { ... }%>");
+  walk (expr);
+}
+
 } // namespace Analysis
 } // namespace Rust

--- a/gcc/rust/checks/lints/unused/rust-unused-checker.cc
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.cc
@@ -413,5 +413,70 @@ UnusedChecker::visit (HIR::BreakExpr &expr)
   walk (expr);
 }
 
+namespace {
+
+// Collects the value of a boolean literal expression, if the visited
+// expression is one.
+class BoolLiteral : public HIR::HIRFullVisitorBase
+{
+public:
+  bool found = false;
+  bool value = false;
+
+  using HIR::HIRFullVisitorBase::visit;
+  void visit (HIR::LiteralExpr &lit) override
+  {
+    if (lit.get_literal ().get_lit_type () == HIR::Literal::LitType::BOOL)
+      {
+	found = true;
+	value
+	  = lit.get_literal ().as_string () == Values::Keywords::TRUE_LITERAL;
+      }
+  }
+};
+
+// Detects a predicate that is constantly true: the `true` literal, or a
+// comparison of two boolean literals that always holds.
+class ConstantTruth : public HIR::HIRFullVisitorBase
+{
+public:
+  bool is_true = false;
+
+  using HIR::HIRFullVisitorBase::visit;
+  void visit (HIR::LiteralExpr &lit) override
+  {
+    if (lit.get_literal ().get_lit_type () == HIR::Literal::LitType::BOOL)
+      is_true
+	= lit.get_literal ().as_string () == Values::Keywords::TRUE_LITERAL;
+  }
+
+  void visit (HIR::ComparisonExpr &cmp) override
+  {
+    BoolLiteral lhs, rhs;
+    cmp.get_lhs ().accept_vis (lhs);
+    cmp.get_rhs ().accept_vis (rhs);
+    if (lhs.found && rhs.found)
+      {
+	if (cmp.get_kind () == ComparisonOperator::EQUAL)
+	  is_true = lhs.value == rhs.value;
+	else if (cmp.get_kind () == ComparisonOperator::NOT_EQUAL)
+	  is_true = lhs.value != rhs.value;
+      }
+  }
+};
+
+} // namespace
+
+void
+UnusedChecker::visit (HIR::WhileLoopExpr &expr)
+{
+  ConstantTruth predicate;
+  expr.get_predicate_expr ().accept_vis (predicate);
+  if (predicate.is_true)
+    rust_warning_at (expr.get_locus (), OPT_Wunused,
+		     "denote infinite loops with %<loop { ... }%>");
+  walk (expr);
+}
+
 } // namespace Analysis
 } // namespace Rust

--- a/gcc/rust/checks/lints/unused/rust-unused-checker.h
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.h
@@ -52,6 +52,7 @@ private:
   virtual void visit (HIR::MatchExpr &expr) override;
   virtual void visit (HIR::ExternBlock &block) override;
   virtual void visit (HIR::LetStmt &stmt) override;
+  virtual void visit (HIR::WhileLoopExpr &expr) override;
   virtual void visit_loop_label (HIR::LoopLabel &label) override;
 };
 } // namespace Analysis

--- a/gcc/rust/checks/lints/unused/rust-unused-checker.h
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.h
@@ -55,6 +55,7 @@ private:
   virtual void visit (HIR::BorrowExpr &expr) override;
   virtual void visit (HIR::NegationExpr &expr) override;
   virtual void visit (HIR::BreakExpr &expr) override;
+  virtual void visit (HIR::WhileLoopExpr &expr) override;
   virtual void visit_loop_label (HIR::LoopLabel &label) override;
 };
 } // namespace Analysis

--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -136,6 +136,8 @@ grs_langhook_init_options_struct (struct gcc_options *opts)
 
   /* We need to warn on unused variables by default */
   opts->x_warn_unused_variable = 1;
+  /* Experimental lints under -frust-unused-check-2.0 warn by default */
+  opts->x_warn_unused = 1;
   /* For const variables too */
   opts->x_warn_unused_const_variable = 1;
   /* And finally unused result for #[must_use] */

--- a/gcc/testsuite/rust/compile/while-true_0.rs
+++ b/gcc/testsuite/rust/compile/while-true_0.rs
@@ -1,0 +1,13 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+#![feature(no_core)]
+#![no_core]
+
+pub fn foo() {
+    while true {}
+// { dg-warning "denote infinite loops with" "" { target *-*-* } .-1 }
+    while true == true {}
+// { dg-warning "denote infinite loops with" "" { target *-*-* } .-1 }
+    while false != true {}
+// { dg-warning "denote infinite loops with" "" { target *-*-* } .-1 }
+    while true == false {}
+}


### PR DESCRIPTION
This patch adds the while true lint, which warns when a while loop uses the literal `true` as its condition and suggests using `loop` instead.

gcc/testsuite/ChangeLog:

	* rust/compile/while-true_0.rs: New test.