### PR TITLE
gccrs: add path statement lint

### DIFF
--- a/gcc/rust/checks/lints/unused/rust-unused-checker.cc
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.cc
@@ -400,5 +400,14 @@ UnusedChecker::visit (HIR::NegationExpr &expr)
   walk (expr);
 }
 
+void
+UnusedChecker::visit (HIR::ExprStmt &stmt)
+{
+  if (stmt.get_expr ().get_expression_type () == HIR::Expr::ExprType::Path)
+    rust_warning_at (stmt.get_locus (), OPT_Wunused_value,
+		     "path statement with no effect");
+  walk (stmt);
+}
+
 } // namespace Analysis
 } // namespace Rust

--- a/gcc/rust/checks/lints/unused/rust-unused-checker.h
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.h
@@ -54,6 +54,7 @@ private:
   virtual void visit (HIR::LetStmt &stmt) override;
   virtual void visit (HIR::BorrowExpr &expr) override;
   virtual void visit (HIR::NegationExpr &expr) override;
+  virtual void visit (HIR::ExprStmt &stmt) override;
   virtual void visit_loop_label (HIR::LoopLabel &label) override;
 };
 } // namespace Analysis

--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -138,6 +138,7 @@ grs_langhook_init_options_struct (struct gcc_options *opts)
   opts->x_warn_unused_variable = 1;
   /* Experimental lints under -frust-unused-check-2.0 warn by default */
   opts->x_warn_unused = 1;
+  opts->x_warn_unused_value = 1;
   /* For const variables too */
   opts->x_warn_unused_const_variable = 1;
   /* And finally unused result for #[must_use] */

--- a/gcc/testsuite/rust/compile/path-statements_0.rs
+++ b/gcc/testsuite/rust/compile/path-statements_0.rs
@@ -1,0 +1,13 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+#![feature(no_core)]
+#![no_core]
+
+pub fn foo() {
+    let x = 5;
+    x;
+// { dg-warning "path statement with no effect" "" { target *-*-* } .-1 }
+}
+
+pub fn bar(y: i32) -> i32 {
+    y
+}


### PR DESCRIPTION
This patch adds the path statement lint, which warns on a statement made of a single path expression, as it has no effect.

gcc/testsuite/ChangeLog:

	* rust/compile/path-statements_0.rs: New test.