### PR TITLE
gccrs: add unreachable pattern lint

### DIFF
--- a/gcc/rust/checks/lints/unused/rust-unused-checker.cc
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.cc
@@ -331,6 +331,26 @@ UnusedChecker::visit (HIR::MatchExpr &expr)
 			 "multiple ranges are one apart");
     }
 
+  // Every arm after an unguarded wildcard can never match. A bare identifier
+  // is not treated as irrefutable: the resolver does not yet disambiguate a
+  // unit-variant path (e.g. None) from a fresh binding.
+  bool seen_irrefutable = false;
+  for (auto &match_case : expr.get_match_cases ())
+    {
+      auto &arm = match_case.get_arm ();
+      if (seen_irrefutable)
+	{
+	  rust_warning_at (arm.get_pattern ()->get_locus (), OPT_Wunused,
+			   "unreachable pattern");
+	  continue;
+	}
+
+      if (!arm.has_match_arm_guard ()
+	  && arm.get_pattern ()->get_pattern_type ()
+	       == HIR::Pattern::PatternType::WILDCARD)
+	seen_irrefutable = true;
+    }
+
   walk (expr);
 }
 

--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -136,6 +136,8 @@ grs_langhook_init_options_struct (struct gcc_options *opts)
 
   /* We need to warn on unused variables by default */
   opts->x_warn_unused_variable = 1;
+  /* Experimental lints under -frust-unused-check-2.0 warn by default */
+  opts->x_warn_unused = 1;
   /* For const variables too */
   opts->x_warn_unused_const_variable = 1;
   /* And finally unused result for #[must_use] */

--- a/gcc/testsuite/rust/compile/unreachable-patterns_0.rs
+++ b/gcc/testsuite/rust/compile/unreachable-patterns_0.rs
@@ -1,0 +1,35 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+#![feature(no_core)]
+#![no_core]
+
+pub fn foo() {
+    match 1 {
+        _ => {}
+        1 => {}
+// { dg-warning "unreachable pattern" "" { target *-*-* } .-1 }
+    }
+}
+
+// A bare identifier pattern is not treated as irrefutable, so the following
+// arm must not be reported as unreachable.
+pub fn ident_binding(x: i32) {
+    match x {
+        _a => {}
+        1 => {}
+    }
+}
+
+enum E {
+    A,
+    B,
+}
+use E::{A, B};
+
+// A bare unit-variant pattern (parsed as an identifier) is refutable, so the
+// second arm is reachable and must not be flagged.
+pub fn variant(e: E) {
+    match e {
+        A => {}
+        B => {}
+    }
+}


### PR DESCRIPTION
This patch adds the unreachable pattern lint, which warns on match arms that can never be reached because an earlier arm is irrefutable.

gcc/testsuite/ChangeLog:

	* rust/compile/unreachable-patterns_0.rs: New test.