### PR TITLE
gccrs: add unused braces lint

### DIFF
--- a/gcc/rust/checks/lints/unused/rust-unused-checker.cc
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.cc
@@ -344,6 +344,15 @@ UnusedChecker::visit (HIR::LetStmt &stmt)
 			 "unused doc comment");
 	break;
       }
+  if (stmt.has_init_expr ()
+      && stmt.get_init_expr ().get_expression_type ()
+	   == HIR::Expr::ExprType::Block)
+    {
+      auto &block = static_cast<HIR::BlockExpr &> (stmt.get_init_expr ());
+      if (block.get_statements ().empty () && block.has_expr ())
+	rust_warning_at (block.get_locus (), OPT_Wunused,
+			 "unnecessary braces around assigned value");
+    }
   walk (stmt);
 }
 

--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -136,6 +136,8 @@ grs_langhook_init_options_struct (struct gcc_options *opts)
 
   /* We need to warn on unused variables by default */
   opts->x_warn_unused_variable = 1;
+  /* Experimental lints under -frust-unused-check-2.0 warn by default */
+  opts->x_warn_unused = 1;
   /* For const variables too */
   opts->x_warn_unused_const_variable = 1;
   /* And finally unused result for #[must_use] */

--- a/gcc/testsuite/rust/compile/unused-braces_0.rs
+++ b/gcc/testsuite/rust/compile/unused-braces_0.rs
@@ -1,0 +1,8 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+#![feature(no_core)]
+#![no_core]
+
+pub fn foo() {
+    let _x = { 5 };
+// { dg-warning "unnecessary braces around assigned value" "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
This patch adds the unused braces lint, which warns on unnecessary braces around the value of a let binding.

gcc/testsuite/ChangeLog:

	* rust/compile/unused-braces_0.rs: New test.