### PR TITLE
gccrs: add unused comparisons lint

### DIFF
--- a/gcc/rust/checks/lints/unused/rust-unused-checker.cc
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.cc
@@ -26,12 +26,15 @@
 #include "rust-keyword-values.h"
 #include "rust-attribute-values.h"
 #include "rust-rib.h"
+#include "rust-tyty.h"
 
 namespace Rust {
 namespace Analysis {
 UnusedChecker::UnusedChecker ()
   : nr_context (Resolver2_0::FinalizedNameResolutionContext::get ()),
-    mappings (Analysis::Mappings::get ()), unused_context (UnusedContext ())
+    mappings (Analysis::Mappings::get ()),
+    context (*Resolver::TypeCheckContext::get ()),
+    unused_context (UnusedContext ())
 {}
 void
 UnusedChecker::go (HIR::Crate &crate)
@@ -345,6 +348,34 @@ UnusedChecker::visit (HIR::LetStmt &stmt)
 	break;
       }
   walk (stmt);
+}
+
+void
+UnusedChecker::visit (HIR::ComparisonExpr &expr)
+{
+  auto is_zero = [] (HIR::Expr &e) {
+    return e.get_expression_type () == HIR::Expr::ExprType::Lit
+	   && static_cast<HIR::LiteralExpr &> (e).get_literal ().as_string ()
+		== "0";
+  };
+  auto is_unsigned = [this] (HIR::Expr &e) {
+    TyTy::BaseType *type;
+    if (!context.lookup_type (e.get_mappings ().get_hirid (), &type))
+      return false;
+    return type->get_kind () == TyTy::UINT || type->get_kind () == TyTy::USIZE;
+  };
+
+  auto op = expr.get_expr_type ();
+  bool useless = (is_zero (expr.get_rhs ()) && is_unsigned (expr.get_lhs ())
+		  && (op == ComparisonOperator::LESS_THAN
+		      || op == ComparisonOperator::GREATER_OR_EQUAL))
+		 || (is_zero (expr.get_lhs ()) && is_unsigned (expr.get_rhs ())
+		     && (op == ComparisonOperator::GREATER_THAN
+			 || op == ComparisonOperator::LESS_OR_EQUAL));
+  if (useless)
+    rust_warning_at (expr.get_locus (), OPT_Wtype_limits,
+		     "comparison is useless due to type limits");
+  walk (expr);
 }
 
 } // namespace Analysis

--- a/gcc/rust/checks/lints/unused/rust-unused-checker.h
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.h
@@ -23,6 +23,7 @@
 #include "rust-hir-visitor.h"
 #include "rust-unused-collector.h"
 #include "rust-finalized-name-resolution-context.h"
+#include "rust-hir-type-check.h"
 
 namespace Rust {
 namespace Analysis {
@@ -35,6 +36,7 @@ public:
 private:
   const Resolver2_0::FinalizedNameResolutionContext &nr_context;
   Analysis::Mappings &mappings;
+  Resolver::TypeCheckContext &context;
   UnusedContext unused_context;
 
   using HIR::DefaultHIRVisitor::visit;
@@ -52,6 +54,7 @@ private:
   virtual void visit (HIR::MatchExpr &expr) override;
   virtual void visit (HIR::ExternBlock &block) override;
   virtual void visit (HIR::LetStmt &stmt) override;
+  virtual void visit (HIR::ComparisonExpr &expr) override;
   virtual void visit_loop_label (HIR::LoopLabel &label) override;
 };
 } // namespace Analysis

--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -136,6 +136,8 @@ grs_langhook_init_options_struct (struct gcc_options *opts)
 
   /* We need to warn on unused variables by default */
   opts->x_warn_unused_variable = 1;
+  /* Experimental lints under -frust-unused-check-2.0 warn by default */
+  opts->x_warn_type_limits = 1;
   /* For const variables too */
   opts->x_warn_unused_const_variable = 1;
   /* And finally unused result for #[must_use] */

--- a/gcc/testsuite/rust/compile/unused-comparisons_0.rs
+++ b/gcc/testsuite/rust/compile/unused-comparisons_0.rs
@@ -1,0 +1,9 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+#![feature(no_core)]
+#![no_core]
+
+pub fn foo() {
+    let x: u32 = 1;
+    let _b = x < 0;
+// { dg-warning "comparison is useless due to type limits" "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
This patch adds the unused comparisons lint, which warns on comparisons that are always true or false due to the type limits of an unsigned integer.

gcc/testsuite/ChangeLog:

	* rust/compile/unused-comparisons_0.rs: New test.