### PR TITLE
gccrs: add unused doc comment lint

### DIFF
--- a/gcc/rust/checks/lints/unused/rust-unused-checker.cc
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.cc
@@ -24,6 +24,7 @@
 
 #include "options.h"
 #include "rust-keyword-values.h"
+#include "rust-attribute-values.h"
 #include "rust-rib.h"
 
 namespace Rust {
@@ -331,6 +332,19 @@ UnusedChecker::visit (HIR::MatchExpr &expr)
     }
 
   walk (expr);
+}
+
+void
+UnusedChecker::visit (HIR::LetStmt &stmt)
+{
+  for (auto &attr : stmt.get_outer_attrs ())
+    if (attr.get_path ().as_string () == Values::Attributes::DOC)
+      {
+	rust_warning_at (stmt.get_locus (), OPT_Wunused_variable,
+			 "unused doc comment");
+	break;
+      }
+  walk (stmt);
 }
 
 } // namespace Analysis

--- a/gcc/rust/checks/lints/unused/rust-unused-checker.h
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.h
@@ -51,6 +51,7 @@ private:
   virtual void visit (HIR::StructPatternFieldIdentPat &field) override;
   virtual void visit (HIR::MatchExpr &expr) override;
   virtual void visit (HIR::ExternBlock &block) override;
+  virtual void visit (HIR::LetStmt &stmt) override;
   virtual void visit_loop_label (HIR::LoopLabel &label) override;
 };
 } // namespace Analysis

--- a/gcc/testsuite/rust/compile/unused-doc-comment_0.rs
+++ b/gcc/testsuite/rust/compile/unused-doc-comment_0.rs
@@ -1,0 +1,10 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+#![feature(no_core)]
+#![no_core]
+
+pub fn foo() {
+    /// useless
+    let _x = 5;
+// { dg-warning "unused doc comment" "" { target *-*-* } .-1 }
+    let _y = _x;
+}


### PR DESCRIPTION
This patch adds the unused doc comment lint, which warns on a doc comment attached to a statement, where it has no effect.

gcc/testsuite/ChangeLog:

	* rust/compile/unused-doc-comment_0.rs: New test.