### PR TITLE
gccrs: add non shorthand field patterns lint

### DIFF
--- a/gcc/rust/checks/lints/unused/rust-unused-checker.cc
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.cc
@@ -192,5 +192,22 @@ UnusedChecker::visit_loop_label (HIR::LoopLabel &label)
 		     "unused label %qs", lifetime.to_string ().c_str ());
 }
 
+void
+UnusedChecker::visit (HIR::StructPatternFieldIdentPat &field)
+{
+  auto &pattern = field.get_pattern ();
+  if (pattern.get_pattern_type () == HIR::Pattern::PatternType::IDENTIFIER)
+    {
+      auto &ident = static_cast<HIR::IdentifierPattern &> (pattern);
+      if (!ident.has_subpattern ()
+	  && ident.get_identifier ().as_string ()
+	       == field.get_identifier ().as_string ())
+	rust_warning_at (field.get_locus (), OPT_Wunused_variable,
+			 "the %qs in this pattern is redundant",
+			 (field.get_identifier ().as_string () + ":").c_str ());
+    }
+  walk (field);
+}
+
 } // namespace Analysis
 } // namespace Rust

--- a/gcc/rust/checks/lints/unused/rust-unused-checker.h
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.h
@@ -48,6 +48,7 @@ private:
   virtual void visit (HIR::Function &fct) override;
   virtual void visit (HIR::Module &mod) override;
   virtual void visit (HIR::LifetimeParam &lft) override;
+  virtual void visit (HIR::StructPatternFieldIdentPat &field) override;
   virtual void visit_loop_label (HIR::LoopLabel &label) override;
 };
 } // namespace Analysis

--- a/gcc/testsuite/rust/compile/non-shorthand-field-patterns_0.rs
+++ b/gcc/testsuite/rust/compile/non-shorthand-field-patterns_0.rs
@@ -1,0 +1,15 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+#![feature(no_core)]
+#![no_core]
+
+pub struct Point {
+    pub x: i32,
+    pub y: i32,
+}
+
+pub fn foo(p: Point) -> i32 {
+    match p {
+	Point { x: x, y: _y } => x,
+// { dg-warning "in this pattern is redundant" "" { target *-*-* } .-1 }
+    }
+}


### PR DESCRIPTION
This patch adds the non shorthand field patterns lint, which warns when a struct pattern field binds to a variable of the same name, e.g. `Point { x: x }`, where the shorthand `Point { x }` should be used.

gcc/testsuite/ChangeLog:

	* rust/compile/non-shorthand-field-patterns_0.rs: New test.