### PR TITLE
gccrs: add trivial numeric casts lint

### DIFF
--- a/gcc/rust/checks/lints/unused/rust-unused-checker.cc
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.cc
@@ -26,13 +26,24 @@
 #include "rust-keyword-values.h"
 #include "rust-attribute-values.h"
 #include "rust-rib.h"
+#include "rust-tyty.h"
 
 namespace Rust {
 namespace Analysis {
 UnusedChecker::UnusedChecker ()
   : nr_context (Resolver2_0::FinalizedNameResolutionContext::get ()),
-    mappings (Analysis::Mappings::get ()), unused_context (UnusedContext ())
+    mappings (Analysis::Mappings::get ()),
+    context (*Resolver::TypeCheckContext::get ()),
+    unused_context (UnusedContext ())
 {}
+
+static bool
+is_numeric (TyTy::BaseType *type)
+{
+  auto kind = type->get_kind ();
+  return kind == TyTy::INT || kind == TyTy::UINT || kind == TyTy::FLOAT
+	 || kind == TyTy::USIZE || kind == TyTy::ISIZE;
+}
 void
 UnusedChecker::go (HIR::Crate &crate)
 {
@@ -345,6 +356,31 @@ UnusedChecker::visit (HIR::LetStmt &stmt)
 	break;
       }
   walk (stmt);
+}
+
+void
+UnusedChecker::visit (HIR::TypeCastExpr &expr)
+{
+  TyTy::BaseType *from;
+  TyTy::BaseType *to;
+  bool found_from
+    = context.lookup_type (expr.get_casted_expr ().get_mappings ().get_hirid (),
+			   &from);
+  bool found_to = context.lookup_type (expr.get_mappings ().get_hirid (), &to);
+
+  if (found_from && found_to)
+    {
+      bool is_numeric_cast = is_numeric (from) && is_numeric (to);
+      bool type_names_match = from->as_string () == to->as_string ();
+
+      if (is_numeric_cast && type_names_match)
+	rust_warning_at (expr.get_locus (), OPT_Wunused,
+			 "trivial numeric cast: %qs as %qs",
+			 from->as_string ().c_str (),
+			 to->as_string ().c_str ());
+    }
+
+  walk (expr);
 }
 
 } // namespace Analysis

--- a/gcc/rust/checks/lints/unused/rust-unused-checker.h
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.h
@@ -23,6 +23,7 @@
 #include "rust-hir-visitor.h"
 #include "rust-unused-collector.h"
 #include "rust-finalized-name-resolution-context.h"
+#include "rust-hir-type-check.h"
 
 namespace Rust {
 namespace Analysis {
@@ -35,6 +36,7 @@ public:
 private:
   const Resolver2_0::FinalizedNameResolutionContext &nr_context;
   Analysis::Mappings &mappings;
+  Resolver::TypeCheckContext &context;
   UnusedContext unused_context;
 
   using HIR::DefaultHIRVisitor::visit;
@@ -52,6 +54,7 @@ private:
   virtual void visit (HIR::MatchExpr &expr) override;
   virtual void visit (HIR::ExternBlock &block) override;
   virtual void visit (HIR::LetStmt &stmt) override;
+  virtual void visit (HIR::TypeCastExpr &expr) override;
   virtual void visit_loop_label (HIR::LoopLabel &label) override;
 };
 } // namespace Analysis

--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -136,6 +136,8 @@ grs_langhook_init_options_struct (struct gcc_options *opts)
 
   /* We need to warn on unused variables by default */
   opts->x_warn_unused_variable = 1;
+  /* Experimental lints under -frust-unused-check-2.0 warn by default */
+  opts->x_warn_unused = 1;
   /* For const variables too */
   opts->x_warn_unused_const_variable = 1;
   /* And finally unused result for #[must_use] */

--- a/gcc/testsuite/rust/compile/trivial-numeric-casts_0.rs
+++ b/gcc/testsuite/rust/compile/trivial-numeric-casts_0.rs
@@ -1,0 +1,9 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+#![feature(no_core)]
+#![no_core]
+
+pub fn foo() -> i32 {
+    let _x = 0i32 as i32;
+// { dg-warning "trivial numeric cast" "" { target *-*-* } .-1 }
+    _x
+}


### PR DESCRIPTION
This patch adds the trivial numeric casts lint, which warns on a numeric cast where the source and target types are the same, e.g. `x as i32` when `x` is already an `i32`.

gcc/testsuite/ChangeLog:

	* rust/compile/trivial-numeric-casts_0.rs: New test.