### PR TITLE
gccrs: Add tests for local binding LIFO and nested block scopes

### DIFF
--- a/gcc/testsuite/rust/execute/drop-local-binding-lifo.rs
+++ b/gcc/testsuite/rust/execute/drop-local-binding-lifo.rs
@@ -1,0 +1,56 @@
+// { dg-output "C\r*\nB\r*\nA\r*\n" }
+// { dg-additional-options "-w" }
+#![feature(no_core)]
+#![feature(lang_items)]
+#![no_core]
+
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "drop"]
+pub trait Drop {
+    fn drop(&mut self);
+}
+
+struct A;
+struct B;
+struct C;
+
+impl Drop for A {
+    fn drop(&mut self) {
+        let msg = "A\n\0" as *const str as *const i8;
+        unsafe {
+            printf(msg);
+        }
+    }
+}
+
+impl Drop for B {
+    fn drop(&mut self) {
+        let msg = "B\n\0" as *const str as *const i8;
+        unsafe {
+            printf(msg);
+        }
+    }
+}
+
+impl Drop for C {
+    fn drop(&mut self) {
+        let msg = "C\n\0" as *const str as *const i8;
+        unsafe {
+            printf(msg);
+        }
+    }
+}
+
+fn main() -> i32 {
+    let _a = A;
+    let _b = B;
+    let _c = C;
+
+    0
+}

--- a/gcc/testsuite/rust/execute/drop-nested-block-scope.rs
+++ b/gcc/testsuite/rust/execute/drop-nested-block-scope.rs
@@ -1,0 +1,86 @@
+// { dg-output "inner\r*\nmiddle2\r*\nmiddle\r*\nouter2\r*\nouter\r*\n" }
+// { dg-additional-options "-w" }
+#![feature(no_core)]
+#![feature(lang_items)]
+#![no_core]
+
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "drop"]
+pub trait Drop {
+    fn drop(&mut self);
+}
+
+struct Outer;
+struct Outer2;
+struct Middle;
+struct Middle2;
+struct Inner;
+
+impl Drop for Outer {
+    fn drop(&mut self) {
+        let msg = "outer\n\0" as *const str as *const i8;
+        unsafe {
+            printf(msg);
+        }
+    }
+}
+
+impl Drop for Outer2 {
+    fn drop(&mut self) {
+        let msg = "outer2\n\0" as *const str as *const i8;
+        unsafe {
+            printf(msg);
+        }
+    }
+}
+
+impl Drop for Middle {
+    fn drop(&mut self) {
+        let msg = "middle\n\0" as *const str as *const i8;
+        unsafe {
+            printf(msg);
+        }
+    }
+}
+
+impl Drop for Middle2 {
+    fn drop(&mut self) {
+        let msg = "middle2\n\0" as *const str as *const i8;
+        unsafe {
+            printf(msg);
+        }
+    }
+}
+
+impl Drop for Inner {
+    fn drop(&mut self) {
+        let msg = "inner\n\0" as *const str as *const i8;
+        unsafe {
+            printf(msg);
+        }
+    }
+}
+
+fn main() -> i32 {
+    let _outer = Outer;
+
+    {
+        let _middle = Middle;
+
+        {
+            let _inner = Inner;
+        }
+
+        let _middle2 = Middle2;
+    }
+
+    let _outer2 = Outer2;
+
+    0
+}


### PR DESCRIPTION
This PR adds two execute tests for local Drop ordering.

It covers:
- multiple local bindings in the same scope being dropped in LIFO order

```rust
fn f() {
    let _a = A;
    let _b = B;
    let _c = C;
}
```
- nested block scopes dropping inner bindings before outer bindings

```rust
fn f() {
    let _outer = Outer;
    {
        let _middle = Middle;
        {
            let _inner = Inner;
        }
        let _middle2 = Middle2;
    }
    let _outer2 = Outer2;
}
```

These cases are already supported by the current Drop implementation, and
this PR adds tests to make the expected order explicit.

-------
gcc/testsuite/ChangeLog:

	* rust/execute/drop-local-binding-lifo.rs: New test.
	* rust/execute/drop-nested-block-scope.rs: New test.

