### PR TITLE
gccrs: add ellipsis inclusive range patterns lint

### DIFF
--- a/gcc/rust/checks/lints/unused/rust-unused-checker.cc
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.cc
@@ -347,5 +347,14 @@ UnusedChecker::visit (HIR::LetStmt &stmt)
   walk (stmt);
 }
 
+void
+UnusedChecker::visit (HIR::RangePattern &pattern)
+{
+  if (pattern.get_has_ellipsis_syntax ())
+    rust_warning_at (pattern.get_locus (), OPT_Wdeprecated,
+		     "%<...%> range patterns are deprecated");
+  walk (pattern);
+}
+
 } // namespace Analysis
 } // namespace Rust

--- a/gcc/rust/checks/lints/unused/rust-unused-checker.h
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.h
@@ -52,6 +52,7 @@ private:
   virtual void visit (HIR::MatchExpr &expr) override;
   virtual void visit (HIR::ExternBlock &block) override;
   virtual void visit (HIR::LetStmt &stmt) override;
+  virtual void visit (HIR::RangePattern &pattern) override;
   virtual void visit_loop_label (HIR::LoopLabel &label) override;
 };
 } // namespace Analysis

--- a/gcc/rust/hir/rust-ast-lower-pattern.cc
+++ b/gcc/rust/hir/rust-ast-lower-pattern.cc
@@ -297,9 +297,10 @@ ASTLoweringPattern::visit (AST::RangePattern &pattern)
 
   bool is_inclusive = (pattern.get_range_kind () == AST::RangeKind::INCLUDED);
 
-  translated = new HIR::RangePattern (mapping, std::move (lower_bound),
-				      std::move (upper_bound),
-				      pattern.get_locus (), is_inclusive);
+  translated
+    = new HIR::RangePattern (mapping, std::move (lower_bound),
+			     std::move (upper_bound), pattern.get_locus (),
+			     is_inclusive, pattern.get_has_ellipsis_syntax ());
 }
 
 void

--- a/gcc/testsuite/rust/compile/ellipsis-inclusive-range-patterns_0.rs
+++ b/gcc/testsuite/rust/compile/ellipsis-inclusive-range-patterns_0.rs
@@ -1,0 +1,11 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+#![feature(no_core)]
+#![no_core]
+
+pub fn foo(x: i32) {
+    match x {
+        1...5 => {}
+// { dg-warning "range patterns are deprecated" "" { target *-*-* } .-1 }
+        _ => {}
+    }
+}


### PR DESCRIPTION
This patch adds the ellipsis inclusive range patterns lint, which warns on the deprecated `...` range pattern syntax and suggests using `..=` instead.

It also propagates the ellipsis syntax flag when lowering range patterns to HIR, so the deprecated `...` form can be distinguished from `..=`.

gcc/testsuite/ChangeLog:

	* rust/compile/ellipsis-inclusive-range-patterns_0.rs: New test.