### PR TITLE
gccrs: add bare trait objects lint

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -407,6 +407,11 @@ TypeCheckType::resolve_root_path (HIR::TypePath &path, size_t *offset,
 	  return root_tyty;
 	}
 
+      if (flag_unused_check_2_0 && lookup->is<TyTy::DynamicObjectType> ())
+	rust_warning_at (
+	  seg->get_locus (), OPT_Wdeprecated,
+	  "trait objects without an explicit %<dyn%> are deprecated");
+
       // if we have a previous segment type
       if (root_tyty != nullptr)
 	{
@@ -625,6 +630,14 @@ TypeCheckType::resolve_segments (
 void
 TypeCheckType::visit (HIR::TraitObjectType &type)
 {
+  // The bare_trait_objects lint: a trait object with more than one bound
+  // written without an explicit %<dyn%> (a single bare trait is a type-path,
+  // handled in resolve_root_path).
+  if (flag_unused_check_2_0 && !type.get_has_dyn ())
+    rust_warning_at (
+      type.get_locus (), OPT_Wdeprecated,
+      "trait objects without an explicit %<dyn%> are deprecated");
+
   std::vector<TyTy::TypeBoundPredicate> specified_bounds;
   for (auto &bound : type.get_type_param_bounds ())
     {

--- a/gcc/testsuite/rust/compile/bare-trait-objects_0.rs
+++ b/gcc/testsuite/rust/compile/bare-trait-objects_0.rs
@@ -1,0 +1,14 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+#![feature(no_core)]
+#![no_core]
+
+pub trait Foo {}
+pub trait Bar {}
+
+pub fn a(_x: &Foo) {}
+// { dg-warning "trait objects without an explicit .dyn. are deprecated" "" { target *-*-* } .-1 }
+
+pub fn b(_x: &dyn Foo) {}
+
+pub fn c(_x: &(Foo + Bar)) {}
+// { dg-warning "trait objects without an explicit .dyn. are deprecated" "" { target *-*-* } .-1 }


### PR DESCRIPTION
This patch adds the bare trait objects lint, which warns on trait objects written without an explicit `dyn`.

A single bare trait (e.g. `&Foo`) is lowered to a type-path that resolves to a trait definition, handled in `visit (HIR::TypePath)`; a bare trait object with several bounds (e.g. `&(Foo + Bar)`) is a `TraitObjectType` without the `dyn` keyword.

gcc/testsuite/ChangeLog:

	* rust/compile/bare-trait-objects_0.rs: New test.