### PR TITLE
gccrs: add drop bounds lint

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-base.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.cc
@@ -17,6 +17,7 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-hir-type-check-base.h"
+#include "options.h"
 #include "rust-compile-base.h"
 #include "rust-hir-item.h"
 #include "rust-hir-type-check-expr.h"
@@ -679,6 +680,18 @@ TypeCheckBase::resolve_generic_params (
       auto pty = static_cast<TyTy::ParamType *> (bpty);
 
       TypeResolveGenericParam::ApplyAnyTraitBounds (type_param, pty);
+
+      // The drop_bounds lint: a `T: Drop` bound is most likely a mistake, as
+      // `Drop` bounds do not constrain a generic parameter in a useful way.
+      if (flag_unused_check_2_0)
+	if (auto drop = mappings.lookup_lang_item (LangItem::Kind::DROP))
+	  for (auto &bound : pty->get_specified_bounds ())
+	    if (bound.get_id () == drop.value ())
+	      rust_warning_at (
+		type_param.get_locus (), OPT_Wunused_variable,
+		"bounds on %<Drop%> are most likely incorrect, "
+		"use %<core::mem::needs_drop%> to detect whether "
+		"a type has a destructor");
     }
 }
 

--- a/gcc/testsuite/rust/compile/drop-bounds_0.rs
+++ b/gcc/testsuite/rust/compile/drop-bounds_0.rs
@@ -1,0 +1,14 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+#![feature(no_core, lang_items)]
+#![no_core]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "drop"]
+pub trait Drop {
+    fn drop(&mut self);
+}
+
+pub fn f<T: Drop>(_x: T) {}
+// { dg-warning "bounds on .Drop. are most likely incorrect" "" { target *-*-* } .-1 }


### PR DESCRIPTION
This patch adds the drop bounds lint, which warns when a generic parameter has an explicit `Drop` bound. Such a bound is most likely a mistake, as it does not constrain the parameter in a useful way.

gcc/testsuite/ChangeLog:

	* rust/compile/drop-bounds_0.rs: New test.