### PR TITLE
gccrs: fix ICE on generic type aliases

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-item.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.cc
@@ -228,6 +228,13 @@ TypeCheckItem::validate_trait_impl_block (
 void
 TypeCheckItem::visit (HIR::TypeAlias &alias)
 {
+  auto lifetime_pin = context->push_clean_lifetime_resolver ();
+
+  std::vector<TyTy::SubstitutionParamMapping> substitutions;
+  if (alias.has_generics ())
+    resolve_generic_params (HIR::Item::ItemKind::TypeAlias, alias.get_locus (),
+			    alias.get_generic_params (), substitutions);
+
   TyTy::BaseType *actual_type
     = TypeCheckType::Resolve (alias.get_type_aliased ());
 

--- a/gcc/testsuite/rust/compile/type-alias-generic-params.rs
+++ b/gcc/testsuite/rust/compile/type-alias-generic-params.rs
@@ -1,0 +1,9 @@
+// Generic type aliases used to ICE in the reachability pass because their
+// generic parameters were never resolved into the type context.
+#![feature(no_core, lang_items)]
+#![no_core]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+pub type Alias<T> = T;


### PR DESCRIPTION
A type alias with generic parameters never resolved those parameters into the type context, so the reachability pass asserted (`rust_assert` in `visit_generic_predicates`) when looking up their types. This resolves the generic parameters as the other items do.

gcc/testsuite/ChangeLog:

	* rust/compile/type-alias-generic-params.rs: New test.