### PR TITLE
gccrs: fix ICE on break with a label and a value

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -779,6 +779,10 @@ CompileExpr::visit (HIR::LoopExpr &expr)
       ctx->add_statement (label_decl);
       ctx->insert_label_decl (
 	loop_label.get_lifetime ().get_mappings ().get_hirid (), label);
+      // Associate the loop's result temporary with the label so that a
+      // `break 'label value` can locate it (see visit (HIR::BreakExpr)).
+      ctx->insert_var_decl (
+	loop_label.get_lifetime ().get_mappings ().get_hirid (), tmp);
     }
 
   tree loop_begin_label

--- a/gcc/testsuite/rust/compile/break-label-loop.rs
+++ b/gcc/testsuite/rust/compile/break-label-loop.rs
@@ -1,0 +1,10 @@
+// `break 'label loop {}` used to ICE in the code generator because the
+// labeled loop never registered its result temporary against the label.
+#![feature(no_core)]
+#![no_core]
+
+pub fn foo() {
+    'a: loop {
+        break 'a loop {};
+    }
+}


### PR DESCRIPTION
A `break 'label value` expression looks up a temporary variable associated with the labeled loop to hold the broken value, but labeled loops never registered that temporary, causing an ICE in the code generator (`lookup_label_temp_var`). This registers the loop result temporary against the label.

gcc/testsuite/ChangeLog:

	* rust/compile/break-label-loop.rs: New test.