### PR TITLE
gccrs: add type alias bounds lint

### DIFF
--- a/gcc/rust/checks/lints/unused/rust-unused-checker.cc
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.cc
@@ -347,5 +347,24 @@ UnusedChecker::visit (HIR::LetStmt &stmt)
   walk (stmt);
 }
 
+void
+UnusedChecker::visit (HIR::TypeAlias &type_alias)
+{
+  bool has_bounds = type_alias.has_where_clause ();
+  for (auto &param : type_alias.get_generic_params ())
+    if (param->get_kind () == HIR::GenericParam::GenericKind::TYPE)
+      {
+	auto &type_param = static_cast<HIR::TypeParam &> (*param);
+	if (type_param.has_type_param_bounds ())
+	  has_bounds = true;
+      }
+
+  if (has_bounds)
+    rust_warning_at (type_alias.get_locus (), OPT_Wunused,
+		     "bounds on generic parameters in type aliases are not "
+		     "enforced");
+  walk (type_alias);
+}
+
 } // namespace Analysis
 } // namespace Rust

--- a/gcc/rust/checks/lints/unused/rust-unused-checker.h
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.h
@@ -52,6 +52,7 @@ private:
   virtual void visit (HIR::MatchExpr &expr) override;
   virtual void visit (HIR::ExternBlock &block) override;
   virtual void visit (HIR::LetStmt &stmt) override;
+  virtual void visit (HIR::TypeAlias &type_alias) override;
   virtual void visit_loop_label (HIR::LoopLabel &label) override;
 };
 } // namespace Analysis

--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -136,6 +136,8 @@ grs_langhook_init_options_struct (struct gcc_options *opts)
 
   /* We need to warn on unused variables by default */
   opts->x_warn_unused_variable = 1;
+  /* Experimental lints under -frust-unused-check-2.0 warn by default */
+  opts->x_warn_unused = 1;
   /* For const variables too */
   opts->x_warn_unused_const_variable = 1;
   /* And finally unused result for #[must_use] */

--- a/gcc/testsuite/rust/compile/type-alias-bounds_0.rs
+++ b/gcc/testsuite/rust/compile/type-alias-bounds_0.rs
@@ -1,0 +1,11 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+#![feature(no_core, lang_items)]
+#![no_core]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+pub trait Foo {}
+
+pub type Alias<T: Foo> = T;
+// { dg-warning "bounds on generic parameters in type aliases are not enforced" "" { target *-*-* } .-1 }


### PR DESCRIPTION
This patch adds the type alias bounds lint, which warns on bounds applied to the generic parameters of a type alias, since those bounds are not enforced.

Note: this branch is based on #4637 (fix ICE on generic type aliases); the first commit is that fix, without which the construct cannot be compiled. It can be rebased once #4637 lands.

gcc/testsuite/ChangeLog:

	* rust/compile/type-alias-bounds_0.rs: New test.