### PR TITLE
gccrs: add break with label and loop lint

### DIFF
--- a/gcc/rust/checks/lints/unused/rust-unused-checker.cc
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.cc
@@ -400,5 +400,18 @@ UnusedChecker::visit (HIR::NegationExpr &expr)
   walk (expr);
 }
 
+void
+UnusedChecker::visit (HIR::BreakExpr &expr)
+{
+  if (expr.has_label () && expr.has_break_expr ()
+      && expr.get_expr ().get_expression_type ()
+	   == HIR::Expr::ExprType::BaseLoop)
+    rust_warning_at (
+      expr.get_locus (), OPT_Wunused,
+      "this labeled %<break%> expression is easy to confuse with "
+      "an unlabeled %<break%> with a labeled value expression");
+  walk (expr);
+}
+
 } // namespace Analysis
 } // namespace Rust

--- a/gcc/rust/checks/lints/unused/rust-unused-checker.h
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.h
@@ -54,6 +54,7 @@ private:
   virtual void visit (HIR::LetStmt &stmt) override;
   virtual void visit (HIR::BorrowExpr &expr) override;
   virtual void visit (HIR::NegationExpr &expr) override;
+  virtual void visit (HIR::BreakExpr &expr) override;
   virtual void visit_loop_label (HIR::LoopLabel &label) override;
 };
 } // namespace Analysis

--- a/gcc/testsuite/rust/compile/break-with-label-and-loop_0.rs
+++ b/gcc/testsuite/rust/compile/break-with-label-and-loop_0.rs
@@ -1,0 +1,10 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+#![feature(no_core)]
+#![no_core]
+
+pub fn foo() {
+    'a: loop {
+        break 'a loop {};
+// { dg-warning "easy to confuse" "" { target *-*-* } .-1 }
+    }
+}


### PR DESCRIPTION
This patch adds the break with label and loop lint, which warns on a labeled `break` whose value is a loop expression, as it is easy to confuse with an unlabeled `break` of a labeled value.

Note: this branch is based on #4638 (fix ICE on break with a label and a value); the first commit is that fix, without which the construct cannot be compiled. It can be rebased once #4638 lands.

gcc/testsuite/ChangeLog:

	* rust/compile/break-with-label-and-loop_0.rs: New test.