### PR TITLE
gccrs: add dyn drop lint

### DIFF
--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -136,6 +136,8 @@ grs_langhook_init_options_struct (struct gcc_options *opts)
 
   /* We need to warn on unused variables by default */
   opts->x_warn_unused_variable = 1;
+  /* Experimental lints under -frust-unused-check-2.0 warn by default */
+  opts->x_warn_unused = 1;
   /* For const variables too */
   opts->x_warn_unused_const_variable = 1;
   /* And finally unused result for #[must_use] */

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -655,6 +655,16 @@ TypeCheckType::visit (HIR::TraitObjectType &type)
 	specified_bounds.push_back (std::move (predicate));
     }
 
+  // The dyn_drop lint: a trait object with a `Drop` bound is pointless, as
+  // values are dropped automatically regardless of the bound.
+  if (flag_unused_check_2_0)
+    if (auto drop = mappings.lookup_lang_item (LangItem::Kind::DROP))
+      for (auto &bound : specified_bounds)
+	if (bound.get_id () == drop.value ())
+	  rust_warning_at (type.get_locus (), OPT_Wunused,
+			   "this trait object has a %<Drop%> bound, which has "
+			   "no effect");
+
   RustIdent ident{CanonicalPath::create_empty (), type.get_locus ()};
   translated
     = new TyTy::DynamicObjectType (type.get_mappings ().get_hirid (), ident,

--- a/gcc/testsuite/rust/compile/dyn-drop_0.rs
+++ b/gcc/testsuite/rust/compile/dyn-drop_0.rs
@@ -1,0 +1,14 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+#![feature(no_core, lang_items)]
+#![no_core]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "drop"]
+pub trait Drop {
+    fn drop(&mut self);
+}
+
+pub fn f(_x: &dyn Drop) {}
+// { dg-warning "trait object has a .Drop. bound" "" { target *-*-* } .-1 }


### PR DESCRIPTION
This patch adds the dyn drop lint, which warns on a trait object carrying a `Drop` bound, since values are dropped automatically and the bound has no effect.

gcc/testsuite/ChangeLog:

	* rust/compile/dyn-drop_0.rs: New test.