### PR TITLE
gccrs: add overlapping range endpoints lint

### DIFF
--- a/gcc/rust/checks/lints/unused/rust-unused-checker.cc
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.cc
@@ -331,6 +331,21 @@ UnusedChecker::visit (HIR::MatchExpr &expr)
 			 "multiple ranges are one apart");
     }
 
+  // An inclusive range whose upper endpoint equals another range's lower
+  // endpoint overlaps it on that single point.
+  for (size_t i = 0; i < ranges.size (); i++)
+    {
+      if (!ranges[i].inclusive)
+	continue;
+      for (size_t j = 0; j < ranges.size (); j++)
+	if (i != j && ranges[i].hi == ranges[j].lo)
+	  {
+	    rust_warning_at (ranges[i].locus, OPT_Wunused,
+			     "multiple patterns overlap on their endpoints");
+	    break;
+	  }
+    }
+
   walk (expr);
 }
 

--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -136,6 +136,8 @@ grs_langhook_init_options_struct (struct gcc_options *opts)
 
   /* We need to warn on unused variables by default */
   opts->x_warn_unused_variable = 1;
+  /* Experimental lints under -frust-unused-check-2.0 warn by default */
+  opts->x_warn_unused = 1;
   /* For const variables too */
   opts->x_warn_unused_const_variable = 1;
   /* And finally unused result for #[must_use] */

--- a/gcc/testsuite/rust/compile/overlapping-range-endpoints_0.rs
+++ b/gcc/testsuite/rust/compile/overlapping-range-endpoints_0.rs
@@ -1,0 +1,15 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+#![feature(no_core, lang_items)]
+#![no_core]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+pub fn f(x: i32) {
+    match x {
+        0..=5 => {}
+// { dg-warning "multiple patterns overlap on their endpoints" "" { target *-*-* } .-1 }
+        5..=10 => {}
+        _ => {}
+    }
+}


### PR DESCRIPTION
This patch adds the overlapping range endpoints lint, which warns when two range patterns in a match overlap on a single endpoint, for example `0..=5` and `5..=10` (both match `5`).

gcc/testsuite/ChangeLog:

	* rust/compile/overlapping-range-endpoints_0.rs: New test.