### PR TITLE
gccrs: add double negations lint

### DIFF
--- a/gcc/rust/checks/lints/unused/rust-unused-checker.cc
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.cc
@@ -367,5 +367,36 @@ UnusedChecker::visit (HIR::BorrowExpr &expr)
   walk (expr);
 }
 
+namespace {
+// Probe whether an expression is itself an arithmetic negation, without
+// recursing (so it only inspects the node it is dispatched on). Used to detect
+// `- -x` for the double_negations lint, since gccrs builds with -fno-rtti and
+// HIR has no down-cast helper.
+class NegationProbe : public HIR::HIRFullVisitorBase
+{
+public:
+  bool is_negation = false;
+  using HIR::HIRFullVisitorBase::visit;
+  void visit (HIR::NegationExpr &expr) override
+  {
+    is_negation = expr.get_expr_type () == HIR::NegationExpr::ExprType::NEGATE;
+  }
+};
+} // namespace
+
+void
+UnusedChecker::visit (HIR::NegationExpr &expr)
+{
+  if (expr.get_expr_type () == HIR::NegationExpr::ExprType::NEGATE)
+    {
+      NegationProbe probe;
+      expr.get_expr ().accept_vis (probe);
+      if (probe.is_negation)
+	rust_warning_at (expr.get_locus (), OPT_Wunused,
+			 "use of a double negation");
+    }
+  walk (expr);
+}
+
 } // namespace Analysis
 } // namespace Rust

--- a/gcc/rust/checks/lints/unused/rust-unused-checker.h
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.h
@@ -53,6 +53,7 @@ private:
   virtual void visit (HIR::ExternBlock &block) override;
   virtual void visit (HIR::LetStmt &stmt) override;
   virtual void visit (HIR::BorrowExpr &expr) override;
+  virtual void visit (HIR::NegationExpr &expr) override;
   virtual void visit_loop_label (HIR::LoopLabel &label) override;
 };
 } // namespace Analysis

--- a/gcc/testsuite/rust/compile/double-negations_0.rs
+++ b/gcc/testsuite/rust/compile/double-negations_0.rs
@@ -1,0 +1,17 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+#![feature(no_core, lang_items)]
+#![no_core]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "neg"]
+pub trait Neg {
+    type Output;
+    fn neg(self) -> Self::Output;
+}
+
+pub fn f(x: i32) -> i32 {
+    - -x
+// { dg-warning "double negation" "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
This patch adds the double negations lint, which warns on a double arithmetic negation such as `- -x` (Rust has no `--` operator, so this is likely a mistake).

gcc/testsuite/ChangeLog:

	* rust/compile/double-negations_0.rs: New test.