### PR TITLE
gccrs: add unused visibilities lint

### DIFF
--- a/gcc/rust/checks/lints/unused/rust-unused-checker.cc
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.cc
@@ -58,6 +58,12 @@ UnusedChecker::visit (HIR::ConstantItem &item)
     rust_warning_at (item.get_locus (), OPT_Wunused_variable,
 		     "unused variable %qs",
 		     item.get_identifier ().as_string ().c_str ());
+
+  // The unused_visibilities lint: a visibility qualifier on a `const _` item
+  // has no effect.
+  if (var_name == "_" && item.get_visibility ().is_public ())
+    rust_warning_at (item.get_locus (), OPT_Wunused_variable,
+		     "visibility qualifier on a %<const _%> item is unused");
 }
 
 void

--- a/gcc/testsuite/rust/compile/unused-visibilities_0.rs
+++ b/gcc/testsuite/rust/compile/unused-visibilities_0.rs
@@ -1,0 +1,6 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+#![feature(no_core)]
+#![no_core]
+
+pub const _: i32 = 0;
+// { dg-warning "visibility qualifier on a .const _. item is unused" "" { target *-*-* } .-1 }


### PR DESCRIPTION
This patch adds the unused visibilities lint, which warns on a visibility qualifier applied to a `const _` item, as it has no effect.

gcc/testsuite/ChangeLog:

	* rust/compile/unused-visibilities_0.rs: New test.