### PR TITLE
gccrs: add no mangle generic items lint

### DIFF
--- a/gcc/rust/checks/lints/unused/rust-unused-checker.cc
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.cc
@@ -166,6 +166,22 @@ UnusedChecker::visit (HIR::Function &fct)
     rust_warning_at (fct.get_locus (), OPT_Wunused_variable,
 		     "function %qs should have a snake case name",
 		     fct.get_function_name ().as_string ().c_str ());
+
+  // The no_mangle_generic_items lint: a generic function cannot be exported
+  // with a fixed symbol, so `#[no_mangle]`/`#[export_name]` has no effect.
+  if (fct.has_generics ())
+    for (auto &attr : fct.get_outer_attrs ())
+      {
+	auto name = attr.get_path ().as_string ();
+	if (name == "no_mangle" || name == "export_name")
+	  {
+	    rust_warning_at (fct.get_locus (), OPT_Wattributes,
+			     "generic functions must be mangled, %qs has no "
+			     "effect",
+			     name.c_str ());
+	    break;
+	  }
+      }
   walk (fct);
 }
 

--- a/gcc/testsuite/rust/compile/no-mangle-generic-items_0.rs
+++ b/gcc/testsuite/rust/compile/no-mangle-generic-items_0.rs
@@ -1,0 +1,10 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+#![feature(no_core, lang_items)]
+#![no_core]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[no_mangle]
+pub fn f<T>(_x: T) {}
+// { dg-warning "generic functions must be mangled" "" { target *-*-* } .-1 }


### PR DESCRIPTION
This patch adds the no mangle generic items lint, which warns when `#[no_mangle]` or `#[export_name]` is applied to a generic function, since generic items must be mangled and the attribute has no effect.

gcc/testsuite/ChangeLog:

	* rust/compile/no-mangle-generic-items_0.rs: New test.