### PR TITLE
gccrs: add static mut refs lint

### DIFF
--- a/gcc/rust/checks/lints/unused/rust-unused-checker.cc
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.cc
@@ -347,5 +347,25 @@ UnusedChecker::visit (HIR::LetStmt &stmt)
   walk (stmt);
 }
 
+void
+UnusedChecker::visit (HIR::BorrowExpr &expr)
+{
+  // The static_mut_refs lint: taking a reference to a mutable static is
+  // discouraged as it can easily lead to undefined behaviour.
+  NodeId ast_node_id = expr.get_expr ().get_mappings ().get_nodeid ();
+  if (auto def
+      = nr_context.lookup (ast_node_id, Resolver2_0::Namespace::Values))
+    if (auto id = mappings.lookup_node_to_hir (*def))
+      if (auto item = mappings.lookup_hir_item (*id))
+	if (item.value ()->get_item_kind () == HIR::Item::ItemKind::Static)
+	  {
+	    auto &static_item = static_cast<HIR::StaticItem &> (*item.value ());
+	    if (static_item.is_mut ())
+	      rust_warning_at (expr.get_locus (), OPT_Wunused,
+			       "creating a reference to a mutable static");
+	  }
+  walk (expr);
+}
+
 } // namespace Analysis
 } // namespace Rust

--- a/gcc/rust/checks/lints/unused/rust-unused-checker.h
+++ b/gcc/rust/checks/lints/unused/rust-unused-checker.h
@@ -52,6 +52,7 @@ private:
   virtual void visit (HIR::MatchExpr &expr) override;
   virtual void visit (HIR::ExternBlock &block) override;
   virtual void visit (HIR::LetStmt &stmt) override;
+  virtual void visit (HIR::BorrowExpr &expr) override;
   virtual void visit_loop_label (HIR::LoopLabel &label) override;
 };
 } // namespace Analysis

--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -136,6 +136,8 @@ grs_langhook_init_options_struct (struct gcc_options *opts)
 
   /* We need to warn on unused variables by default */
   opts->x_warn_unused_variable = 1;
+  /* Experimental lints under -frust-unused-check-2.0 warn by default */
+  opts->x_warn_unused = 1;
   /* For const variables too */
   opts->x_warn_unused_const_variable = 1;
   /* And finally unused result for #[must_use] */

--- a/gcc/testsuite/rust/compile/static-mut-refs_0.rs
+++ b/gcc/testsuite/rust/compile/static-mut-refs_0.rs
@@ -1,0 +1,13 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+#![feature(no_core, lang_items)]
+#![no_core]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+static mut S: i32 = 0;
+
+pub unsafe fn f() {
+    let _y = &S;
+// { dg-warning "reference to a mutable static" "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
This patch adds the static mut refs lint, which warns on taking a reference to a mutable static, as it can easily lead to undefined behaviour.

gcc/testsuite/ChangeLog:

	* rust/compile/static-mut-refs_0.rs: New test.