### PR TITLE
gccrs: add self_constructor_from_outer_item lint

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -207,6 +207,7 @@ GRS_OBJS = \
     rust/rust-unused-collector.o \
     rust/rust-unused-context.o \
     rust/rust-readonly-check.o \
+    rust/rust-hir-self-constructor.o \
     rust/rust-hir-type-check-path.o \
     rust/rust-unsafe-checker.o \
     rust/rust-hir-pattern-analysis.o \

--- a/gcc/rust/checks/errors/rust-hir-self-constructor.cc
+++ b/gcc/rust/checks/errors/rust-hir-self-constructor.cc
@@ -1,0 +1,82 @@
+// Copyright (C) 2025-2026 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-hir-self-constructor.h"
+#include "rust-hir-item.h"
+#include "rust-hir-path.h"
+#include "rust-keyword-values.h"
+#include "rust-diagnostics.h"
+
+namespace Rust {
+namespace HIR {
+
+void
+SelfConstructorChecker::go (Crate &crate)
+{
+  for (auto &item : crate.get_items ())
+    item->accept_vis (*this);
+}
+
+void
+SelfConstructorChecker::visit (Function &fct)
+{
+  bool is_associated = in_associated_scope;
+  bool saved_associated = in_associated_scope;
+  bool saved_self_ctor = self_ctor_from_outer;
+  in_associated_scope = false;
+  self_ctor_from_outer = impl_trait_nesting > 0 && !is_associated;
+  walk (fct);
+  in_associated_scope = saved_associated;
+  self_ctor_from_outer = saved_self_ctor;
+}
+
+void
+SelfConstructorChecker::visit (ImplBlock &impl)
+{
+  impl_trait_nesting++;
+  bool saved_associated = in_associated_scope;
+  in_associated_scope = true;
+  walk (impl);
+  in_associated_scope = saved_associated;
+  impl_trait_nesting--;
+}
+
+void
+SelfConstructorChecker::visit (Trait &trait)
+{
+  impl_trait_nesting++;
+  bool saved_associated = in_associated_scope;
+  in_associated_scope = true;
+  walk (trait);
+  in_associated_scope = saved_associated;
+  impl_trait_nesting--;
+}
+
+void
+SelfConstructorChecker::visit (PathInExpression &path)
+{
+  if (self_ctor_from_outer && path.get_segments ().size () == 1
+      && path.get_segments ()[0].get_segment ().to_string ()
+	   == Values::Keywords::SELF_ALIAS)
+    rust_error_at (path.get_locus (),
+		   "cannot reference %<Self%> constructor from outer item");
+  walk (path);
+}
+
+} // namespace HIR
+} // namespace Rust

--- a/gcc/rust/checks/errors/rust-hir-self-constructor.h
+++ b/gcc/rust/checks/errors/rust-hir-self-constructor.h
@@ -1,0 +1,50 @@
+// Copyright (C) 2025-2026 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_HIR_SELF_CONSTRUCTOR_H
+#define RUST_HIR_SELF_CONSTRUCTOR_H
+
+#include "rust-hir.h"
+#include "rust-hir-visitor.h"
+
+namespace Rust {
+namespace HIR {
+
+// A function nested inside an associated item cannot capture the outer item's
+// `Self`, so referencing the `Self` constructor from it is an error.
+class SelfConstructorChecker : public DefaultHIRVisitor
+{
+public:
+  void go (Crate &crate);
+
+  using DefaultHIRVisitor::visit;
+  virtual void visit (Function &fct) override;
+  virtual void visit (ImplBlock &impl) override;
+  virtual void visit (Trait &trait) override;
+  virtual void visit (PathInExpression &path) override;
+
+private:
+  bool in_associated_scope = false;
+  int impl_trait_nesting = 0;
+  bool self_ctor_from_outer = false;
+};
+
+} // namespace HIR
+} // namespace Rust
+
+#endif // RUST_HIR_SELF_CONSTRUCTOR_H

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -42,6 +42,7 @@
 #include "rust-lint-unused-var.h"
 #include "rust-unused-checker.h"
 #include "rust-readonly-check.h"
+#include "rust-hir-self-constructor.h"
 #include "rust-hir-dump.h"
 #include "rust-ast-dump.h"
 #include "rust-export-metadata.h"
@@ -859,6 +860,8 @@ Session::compile_crate (const char *filename)
     {
       // lints
       Analysis::ScanDeadcode::Scan (hir);
+
+      HIR::SelfConstructorChecker ().go (hir);
 
       if (flag_unused_check_2_0)
 	Analysis::UnusedChecker ().go (hir);

--- a/gcc/testsuite/rust/compile/self-constructor-from-outer-item_0.rs
+++ b/gcc/testsuite/rust/compile/self-constructor-from-outer-item_0.rs
@@ -1,0 +1,18 @@
+#![feature(no_core)]
+#![no_core]
+
+pub struct S0(usize);
+
+impl S0 {
+    pub fn foo() -> S0 {
+        fn bar() -> S0 {
+            Self(0)
+// { dg-error "cannot reference .Self. constructor from outer item" "" { target *-*-* } .-1 }
+        }
+        bar()
+    }
+
+    pub fn direct() -> S0 {
+        Self(0)
+    }
+}


### PR DESCRIPTION
Warn when the `Self` constructor is used from an item nested inside an impl or trait, such as a function defined in a method body. Nested items do not inherit the `Self` of the surrounding impl. Gated behind `-frust-unused-check-2.0`.