### PR TITLE
gccrs: Fix crash when resolving invalid enum item

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-item.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.cc
@@ -412,9 +412,11 @@ TypeCheckItem::visit (HIR::Enum &enum_decl)
     {
       TyTy::VariantDef *field_type
 	= TypeCheckEnumItem::Resolve (*variant, discriminant_value);
-
-      discriminant_value++;
-      variants.push_back (field_type);
+      if (field_type)
+	{
+	  discriminant_value++;
+	  variants.push_back (field_type);
+	}
     }
 
   // Check for zero-variant enum compatibility

--- a/gcc/testsuite/rust/compile/issue-4617.rs
+++ b/gcc/testsuite/rust/compile/issue-4617.rs
@@ -1,0 +1,8 @@
+#![feature(no_core)]
+#![no_core]
+
+struct Apple;
+
+enum Delicious {
+    ApplePie = Apple::PIE, // { dg-error "failed to resolve path segment using an impl Probe" }
+}


### PR DESCRIPTION
Fixes Rust-GCC#1617

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-item.cc (TypeCheckItem::visit): check valid

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4617.rs: New test.
