### PR TITLE
gccrs: Fix unify code on ADT's to check defid

### DIFF
--- a/gcc/rust/typecheck/rust-unify.cc
+++ b/gcc/rust/typecheck/rust-unify.cc
@@ -591,6 +591,11 @@ UnifyRules::expect_adt (TyTy::ADTType *ltype, TyTy::BaseType *rtype)
 	    return unify_error_type_node ();
 	  }
 
+	if (ltype->get_id () != type.get_id ())
+	  {
+	    return unify_error_type_node ();
+	  }
+
 	if (ltype->get_identifier ().compare (type.get_identifier ()) != 0)
 	  {
 	    return unify_error_type_node ();


### PR DESCRIPTION
There is a simple upfront check on ADT's we can check that def-id's match before continuing to unify them.

gcc/rust/ChangeLog:

	* typecheck/rust-unify.cc (UnifyRules::expect_adt): check defid
