### PR TITLE
core: Detect whether we are compiling core or any other crate

### DIFF
--- a/gcc/rust/ast/rust-ast-builder.cc
+++ b/gcc/rust/ast/rust-ast-builder.cc
@@ -547,7 +547,8 @@ std::unique_ptr<Stmt>
 Builder::discriminant_value (std::string binding_name, std::string instance)
 {
   auto intrinsic = ptrify (
-    path_in_expression ({"core", "intrinsics", "discriminant_value"}, true));
+    path_in_expression ({get_path_start (), "intrinsics", "discriminant_value"},
+			true));
 
   return let (identifier_pattern (binding_name), nullptr,
 	      call (std::move (intrinsic), identifier (instance)));

--- a/gcc/rust/ast/rust-ast-builder.h
+++ b/gcc/rust/ast/rust-ast-builder.h
@@ -24,7 +24,8 @@
 #include "rust-ast.h"
 #include "rust-item.h"
 #include "rust-operators.h"
-#include <initializer_list>
+#include "options.h"
+#include "rust-system.h"
 
 namespace Rust {
 namespace AST {
@@ -80,7 +81,20 @@ ptrify (T value)
 class Builder
 {
 public:
-  Builder (location_t loc) : loc (loc) {}
+  /**
+   * Are we building AST nodes for paths within `core`, or any other crate? This
+   * affects the leading path segment when constructing canonical paths, and is
+   * especially important when deriving items.
+   */
+  enum class Source
+  {
+    InCore,
+    Any,
+  };
+
+  Builder (location_t loc, Source item_source)
+    : loc (loc), item_source (item_source)
+  {}
 
   /* Create an expression statement from an expression */
   std::unique_ptr<Stmt> statementify (std::unique_ptr<Expr> &&value,
@@ -336,10 +350,30 @@ public:
   /* Location of the generated AST nodes */
   location_t loc;
 
-private:
-  /* Some constexpr helpers for some of the builders */
-  static constexpr std::initializer_list<const char *> discriminant_value_path
-    = {"core", "intrinsics", "discriminant_value"};
+  /* The source in which we are creating AST nodes */
+  Builder::Source item_source;
+
+  static Builder::Source get_item_source (const AST::Crate &crate)
+  {
+    for (const auto &attr : crate.inner_attrs)
+      if (attr.as_string () == "no_core")
+	return Source::InCore;
+
+    return Source::Any;
+  }
+
+  const char *get_path_start () const
+  {
+    switch (item_source)
+      {
+      case Builder::Source::InCore:
+	return "crate";
+      case Builder::Source::Any:
+	return "core";
+      default:
+	rust_unreachable ();
+      }
+  }
 };
 
 } // namespace AST

--- a/gcc/rust/ast/rust-desugar-for-loops.cc
+++ b/gcc/rust/ast/rust-desugar-for-loops.cc
@@ -69,9 +69,9 @@ DesugarForLoops::DesugarCtx::make_continue_arm ()
 }
 
 std::unique_ptr<Expr>
-DesugarForLoops::desugar (ForLoopExpr &expr)
+DesugarForLoops::desugar (ForLoopExpr &expr, Builder::Source node_source)
 {
-  auto ctx = DesugarCtx (expr.get_locus ());
+  auto ctx = DesugarCtx (expr.get_locus (), node_source);
 
   auto into_iter = std::make_unique<PathInExpression> (
     ctx.builder.path_in_expression (LangItem::Kind::INTOITER_INTOITER));
@@ -141,7 +141,7 @@ DesugarForLoops::desugar (ForLoopExpr &expr)
 }
 
 void
-DesugarForLoops::go (std::unique_ptr<Expr> &ptr)
+DesugarForLoops::go (std::unique_ptr<Expr> &ptr, Builder::Source node_source)
 {
   rust_assert (ptr->get_expr_kind () == Expr::Kind::Loop);
 
@@ -150,7 +150,7 @@ DesugarForLoops::go (std::unique_ptr<Expr> &ptr)
   rust_assert (loop.get_loop_kind () == BaseLoopExpr::Kind::For);
 
   auto &for_loop = static_cast<ForLoopExpr &> (loop);
-  auto desugared = DesugarForLoops ().desugar (for_loop);
+  auto desugared = DesugarForLoops ().desugar (for_loop, node_source);
 
   ptr = std::move (desugared);
 }

--- a/gcc/rust/ast/rust-desugar-for-loops.h
+++ b/gcc/rust/ast/rust-desugar-for-loops.h
@@ -71,14 +71,16 @@ namespace AST {
 class DesugarForLoops
 {
 public:
-  static void go (std::unique_ptr<Expr> &ptr);
+  static void go (std::unique_ptr<Expr> &ptr, Builder::Source node_source);
 
 private:
   DesugarForLoops ();
 
   struct DesugarCtx
   {
-    DesugarCtx (location_t loc) : builder (Builder (loc)), loc (loc) {}
+    DesugarCtx (location_t loc, Builder::Source node_source)
+      : builder (Builder (loc, node_source)), loc (loc)
+    {}
 
     Builder builder;
     location_t loc;
@@ -92,7 +94,8 @@ private:
     constexpr static const char *result_id = "#result";
   };
 
-  std::unique_ptr<Expr> desugar (ForLoopExpr &expr);
+  std::unique_ptr<Expr> desugar (ForLoopExpr &expr,
+				 Builder::Source node_source);
 };
 
 } // namespace AST

--- a/gcc/rust/ast/rust-desugar-question-mark.cc
+++ b/gcc/rust/ast/rust-desugar-question-mark.cc
@@ -17,7 +17,6 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-desugar-question-mark.h"
-#include "rust-ast-builder.h"
 
 namespace Rust {
 namespace AST {
@@ -25,12 +24,13 @@ namespace AST {
 DesugarQuestionMark::DesugarQuestionMark () {}
 
 void
-DesugarQuestionMark::go (std::unique_ptr<Expr> &ptr)
+DesugarQuestionMark::go (std::unique_ptr<Expr> &ptr,
+			 Builder::Source node_source)
 {
   rust_assert (ptr->get_expr_kind () == Expr::Kind::ErrorPropagation);
 
   auto original = static_cast<ErrorPropagationExpr &> (*ptr);
-  auto desugared = DesugarQuestionMark ().desugar (original);
+  auto desugared = DesugarQuestionMark ().desugar (original, node_source);
 
   ptr = std::move (desugared);
 }
@@ -99,9 +99,10 @@ err_case (Builder &builder)
 }
 
 std::unique_ptr<Expr>
-DesugarQuestionMark::desugar (ErrorPropagationExpr &expr)
+DesugarQuestionMark::desugar (ErrorPropagationExpr &expr,
+			      Builder::Source node_source)
 {
-  auto builder = Builder (expr.get_locus ());
+  auto builder = Builder (expr.get_locus (), node_source);
 
   // Try::into_result(<expr>)
   auto try_into = std::make_unique<PathInExpression> (

--- a/gcc/rust/ast/rust-desugar-question-mark.h
+++ b/gcc/rust/ast/rust-desugar-question-mark.h
@@ -20,6 +20,7 @@
 #define RUST_DESUGAR_QUESTION_MARK
 
 #include "rust-expr.h"
+#include "rust-ast-builder.h"
 
 namespace Rust {
 namespace AST {
@@ -57,12 +58,13 @@ namespace AST {
 class DesugarQuestionMark
 {
 public:
-  static void go (std::unique_ptr<Expr> &ptr);
+  static void go (std::unique_ptr<Expr> &ptr, Builder::Source node_source);
 
 private:
   DesugarQuestionMark ();
 
-  std::unique_ptr<Expr> desugar (ErrorPropagationExpr &);
+  std::unique_ptr<Expr> desugar (ErrorPropagationExpr &,
+				 Builder::Source node_source);
 };
 
 } // namespace AST

--- a/gcc/rust/ast/rust-desugar-try-block.cc
+++ b/gcc/rust/ast/rust-desugar-try-block.cc
@@ -17,7 +17,6 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-desugar-try-block.h"
-#include "rust-ast-builder.h"
 #include "rust-expr.h"
 
 namespace Rust {
@@ -26,20 +25,20 @@ namespace AST {
 DesugarTryBlock::DesugarTryBlock () {}
 
 void
-DesugarTryBlock::go (std::unique_ptr<Expr> &ptr)
+DesugarTryBlock::go (std::unique_ptr<Expr> &ptr, Builder::Source node_source)
 {
   rust_assert (ptr->get_expr_kind () == Expr::Kind::Try);
 
   auto original = static_cast<TryExpr &> (*ptr);
-  auto desugared = DesugarTryBlock ().desugar (original);
+  auto desugared = DesugarTryBlock ().desugar (original, node_source);
 
   ptr = std::move (desugared);
 }
 
 std::unique_ptr<Expr>
-DesugarTryBlock::desugar (TryExpr &expr)
+DesugarTryBlock::desugar (TryExpr &expr, Builder::Source node_source)
 {
-  auto builder = Builder (expr.get_locus ());
+  auto builder = Builder (expr.get_locus (), node_source);
   auto &block = expr.get_block_expr ();
 
   if (block.has_statements ())

--- a/gcc/rust/ast/rust-desugar-try-block.h
+++ b/gcc/rust/ast/rust-desugar-try-block.h
@@ -20,6 +20,7 @@
 #define RUST_DESUGAR_TRY_BLOCK
 
 #include "rust-expr.h"
+#include "rust-ast-builder.h"
 
 namespace Rust {
 namespace AST {
@@ -28,12 +29,12 @@ namespace AST {
 class DesugarTryBlock
 {
 public:
-  static void go (std::unique_ptr<Expr> &ptr);
+  static void go (std::unique_ptr<Expr> &ptr, Builder::Source node_source);
 
 private:
   DesugarTryBlock ();
 
-  std::unique_ptr<Expr> desugar (TryExpr &);
+  std::unique_ptr<Expr> desugar (TryExpr &, Builder::Source node_source);
 };
 
 } // namespace AST

--- a/gcc/rust/ast/rust-desugar-while-let.cc
+++ b/gcc/rust/ast/rust-desugar-while-let.cc
@@ -51,7 +51,7 @@ DesugarWhileLet::DesugarCtx::make_continue_arm (
 }
 
 std::unique_ptr<Expr>
-DesugarWhileLet::desugar (WhileLetLoopExpr &expr)
+DesugarWhileLet::desugar (WhileLetLoopExpr &expr, Builder::Source node_source)
 {
   rust_assert (expr.get_pattern () != nullptr);
 
@@ -59,7 +59,7 @@ DesugarWhileLet::desugar (WhileLetLoopExpr &expr)
   auto body = expr.get_loop_block ().clone_block_expr ();
   auto scrutinee = expr.get_scrutinee_expr ().clone_expr ();
 
-  auto ctx = DesugarCtx (expr.get_locus ());
+  auto ctx = DesugarCtx (expr.get_locus (), node_source);
 
   // _ => break,
   auto break_arm = ctx.make_break_arm ();
@@ -86,7 +86,7 @@ DesugarWhileLet::desugar (WhileLetLoopExpr &expr)
 }
 
 void
-DesugarWhileLet::go (std::unique_ptr<Expr> &ptr)
+DesugarWhileLet::go (std::unique_ptr<Expr> &ptr, Builder::Source node_source)
 {
   rust_assert (ptr->get_expr_kind () == Expr::Kind::Loop);
 
@@ -95,7 +95,7 @@ DesugarWhileLet::go (std::unique_ptr<Expr> &ptr)
   rust_assert (loop.get_loop_kind () == BaseLoopExpr::Kind::WhileLet);
 
   auto &while_let = static_cast<WhileLetLoopExpr &> (loop);
-  auto desugared = DesugarWhileLet ().desugar (while_let);
+  auto desugared = DesugarWhileLet ().desugar (while_let, node_source);
 
   ptr = std::move (desugared);
 }

--- a/gcc/rust/ast/rust-desugar-while-let.h
+++ b/gcc/rust/ast/rust-desugar-while-let.h
@@ -45,14 +45,16 @@ namespace AST {
 class DesugarWhileLet
 {
 public:
-  static void go (std::unique_ptr<Expr> &ptr);
+  static void go (std::unique_ptr<Expr> &ptr, Builder::Source node_source);
 
 private:
   DesugarWhileLet ();
 
   struct DesugarCtx
   {
-    DesugarCtx (location_t loc) : builder (Builder (loc)), loc (loc) {}
+    DesugarCtx (location_t loc, Builder::Source node_source)
+      : builder (Builder (loc, node_source)), loc (loc)
+    {}
 
     Builder builder;
     location_t loc;
@@ -62,7 +64,8 @@ private:
 				 std::unique_ptr<BlockExpr> &&body);
   };
 
-  std::unique_ptr<Expr> desugar (WhileLetLoopExpr &expr);
+  std::unique_ptr<Expr> desugar (WhileLetLoopExpr &expr,
+				 Builder::Source node_source);
 };
 
 } // namespace AST

--- a/gcc/rust/ast/rust-expression-yeast.cc
+++ b/gcc/rust/ast/rust-expression-yeast.cc
@@ -17,6 +17,7 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-expression-yeast.h"
+#include "rust-ast-builder.h"
 #include "rust-ast-visitor.h"
 #include "rust-desugar-question-mark.h"
 #include "rust-desugar-try-block.h"
@@ -30,6 +31,8 @@ namespace AST {
 void
 ExpressionYeast::go (AST::Crate &crate)
 {
+  current_crate = crate;
+
   PointerVisitor::visit (crate);
 }
 
@@ -37,14 +40,15 @@ void
 ExpressionYeast::dispatch_loops (std::unique_ptr<Expr> &loop_expr)
 {
   auto &loop = static_cast<BaseLoopExpr &> (*loop_expr.get ());
+  auto node_source = Builder::get_item_source (current_crate.value ());
 
   switch (loop.get_loop_kind ())
     {
     case BaseLoopExpr::Kind::For:
-      DesugarForLoops::go (loop_expr);
+      DesugarForLoops::go (loop_expr, node_source);
       break;
     case BaseLoopExpr::Kind::WhileLet:
-      DesugarWhileLet::go (loop_expr);
+      DesugarWhileLet::go (loop_expr, node_source);
       break;
     default:
       break;
@@ -54,13 +58,15 @@ ExpressionYeast::dispatch_loops (std::unique_ptr<Expr> &loop_expr)
 void
 ExpressionYeast::reseat (std::unique_ptr<Expr> &expr)
 {
+  auto node_source = Builder::get_item_source (current_crate.value ());
+
   switch (expr->get_expr_kind ())
     {
     case Expr::Kind::ErrorPropagation:
-      DesugarQuestionMark::go (expr);
+      DesugarQuestionMark::go (expr, node_source);
       break;
     case Expr::Kind::Try:
-      DesugarTryBlock::go (expr);
+      DesugarTryBlock::go (expr, node_source);
       break;
     case Expr::Kind::Loop:
       dispatch_loops (expr);

--- a/gcc/rust/ast/rust-expression-yeast.h
+++ b/gcc/rust/ast/rust-expression-yeast.h
@@ -19,6 +19,7 @@
 #ifndef RUST_EXPRESSION_YEAST
 #define RUST_EXPRESSION_YEAST
 
+#include "optional.h"
 #include "rust-ast-pointer-visitor.h"
 #include "rust-ast.h"
 #include "rust-desugar-question-mark.h"
@@ -37,6 +38,12 @@ public:
   void go (AST::Crate &);
 
 private:
+  /**
+   * Keep track of the crate we are currently desugaring. This is important for
+   * forming paths when generating AST nodes
+   */
+  tl::optional<AST::Crate &> current_crate = tl::nullopt;
+
   // Dispatch to the proper desugar
   void reseat (std::unique_ptr<Expr> &expr) override;
 

--- a/gcc/rust/expand/rust-derive-clone.cc
+++ b/gcc/rust/expand/rust-derive-clone.cc
@@ -101,8 +101,8 @@ DeriveClone::clone_impl (
 			     std::move (generics.impl));
 }
 
-DeriveClone::DeriveClone (location_t loc)
-  : DeriveVisitor (loc), expanded (nullptr)
+DeriveClone::DeriveClone (location_t loc, Builder::Source item_source)
+  : DeriveVisitor (loc, item_source), expanded (nullptr)
 {}
 
 std::unique_ptr<AST::Item>

--- a/gcc/rust/expand/rust-derive-clone.h
+++ b/gcc/rust/expand/rust-derive-clone.h
@@ -27,7 +27,7 @@ namespace AST {
 class DeriveClone : DeriveVisitor
 {
 public:
-  DeriveClone (location_t loc);
+  DeriveClone (location_t loc, Builder::Source item_source);
 
   std::unique_ptr<Item> go (Item &item);
 

--- a/gcc/rust/expand/rust-derive-copy.cc
+++ b/gcc/rust/expand/rust-derive-copy.cc
@@ -23,8 +23,8 @@
 namespace Rust {
 namespace AST {
 
-DeriveCopy::DeriveCopy (location_t loc)
-  : DeriveVisitor (loc), expanded (nullptr)
+DeriveCopy::DeriveCopy (location_t loc, Builder::Source item_source)
+  : DeriveVisitor (loc, item_source), expanded (nullptr)
 {}
 
 std::unique_ptr<AST::Item>

--- a/gcc/rust/expand/rust-derive-copy.h
+++ b/gcc/rust/expand/rust-derive-copy.h
@@ -27,7 +27,7 @@ namespace AST {
 class DeriveCopy : DeriveVisitor
 {
 public:
-  DeriveCopy (location_t loc);
+  DeriveCopy (location_t loc, Builder::Source item_source);
 
   std::unique_ptr<Item> go (Item &);
 

--- a/gcc/rust/expand/rust-derive-debug.cc
+++ b/gcc/rust/expand/rust-derive-debug.cc
@@ -24,8 +24,8 @@
 namespace Rust {
 namespace AST {
 
-DeriveDebug::DeriveDebug (location_t loc)
-  : DeriveVisitor (loc), expanded (nullptr)
+DeriveDebug::DeriveDebug (location_t loc, Builder::Source item_source)
+  : DeriveVisitor (loc, item_source), expanded (nullptr)
 {}
 
 std::unique_ptr<Item>
@@ -54,11 +54,11 @@ DeriveDebug::stub_debug_fn ()
 
   auto self = builder.self_ref_param ();
 
-  auto return_type
-    = ptrify (builder.type_path ({"core", "fmt", "Result"}, true));
+  auto return_type = ptrify (
+    builder.type_path ({builder.get_path_start (), "fmt", "Result"}, true));
 
-  auto mut_fmt_type_inner
-    = ptrify (builder.type_path ({"core", "fmt", "Formatter"}, true));
+  auto mut_fmt_type_inner = ptrify (
+    builder.type_path ({builder.get_path_start (), "fmt", "Formatter"}, true));
 
   auto mut_fmt_type
     = builder.reference_type (std::move (mut_fmt_type_inner), true);
@@ -82,7 +82,8 @@ DeriveDebug::stub_derive_impl (
   auto trait_items = vec (stub_debug_fn ());
 
   auto debug = [this] () {
-    return builder.type_path ({"core", "fmt", "Debug"}, true);
+    return builder.type_path ({builder.get_path_start (), "fmt", "Debug"},
+			      true);
   };
   auto generics = setup_impl_generics (name, type_generics, [&, this] () {
     return builder.trait_bound (debug ());

--- a/gcc/rust/expand/rust-derive-debug.h
+++ b/gcc/rust/expand/rust-derive-debug.h
@@ -30,7 +30,7 @@ namespace AST {
 class DeriveDebug : DeriveVisitor
 {
 public:
-  DeriveDebug (location_t loc);
+  DeriveDebug (location_t loc, Builder::Source item_source);
 
   std::unique_ptr<Item> go (Item &);
 

--- a/gcc/rust/expand/rust-derive-default.cc
+++ b/gcc/rust/expand/rust-derive-default.cc
@@ -25,8 +25,8 @@
 namespace Rust {
 namespace AST {
 
-DeriveDefault::DeriveDefault (location_t loc)
-  : DeriveVisitor (loc), expanded (nullptr)
+DeriveDefault::DeriveDefault (location_t loc, Builder::Source item_source)
+  : DeriveVisitor (loc, item_source), expanded (nullptr)
 {}
 
 std::unique_ptr<Item>
@@ -42,7 +42,9 @@ DeriveDefault::go (Item &item)
 std::unique_ptr<Expr>
 DeriveDefault::default_call (std::unique_ptr<Type> &&type)
 {
-  auto default_trait = builder.type_path ({"core", "default", "Default"}, true);
+  auto default_trait
+    = builder.type_path ({builder.get_path_start (), "default", "Default"},
+			 true);
 
   auto default_fn
     = builder.qualified_path_in_expression (std::move (type), default_trait,
@@ -70,7 +72,8 @@ DeriveDefault::default_impl (
   const std::vector<std::unique_ptr<GenericParam>> &type_generics)
 {
   auto default_path = [this] () {
-    return builder.type_path ({"core", "default", "Default"}, true);
+    return builder.type_path ({builder.get_path_start (), "default", "Default"},
+			      true);
   };
 
   auto trait_items = vec (std::move (default_fn));

--- a/gcc/rust/expand/rust-derive-default.h
+++ b/gcc/rust/expand/rust-derive-default.h
@@ -30,7 +30,7 @@ namespace AST {
 class DeriveDefault : DeriveVisitor
 {
 public:
-  DeriveDefault (location_t loc);
+  DeriveDefault (location_t loc, Builder::Source item_source);
 
   std::unique_ptr<Item> go (Item &);
 

--- a/gcc/rust/expand/rust-derive-eq.cc
+++ b/gcc/rust/expand/rust-derive-eq.cc
@@ -30,10 +30,12 @@ namespace AST {
 static TypePath
 get_eq_trait_path (Builder &builder)
 {
-  return builder.type_path ({"core", "cmp", "Eq"}, true);
+  return builder.type_path ({builder.get_path_start (), "cmp", "Eq"}, true);
 }
 
-DeriveEq::DeriveEq (location_t loc) : DeriveVisitor (loc) {}
+DeriveEq::DeriveEq (location_t loc, Builder::Source item_source)
+  : DeriveVisitor (loc, item_source)
+{}
 
 std::vector<std::unique_ptr<AST::Item>>
 DeriveEq::go (Item &item)

--- a/gcc/rust/expand/rust-derive-eq.h
+++ b/gcc/rust/expand/rust-derive-eq.h
@@ -29,7 +29,7 @@ namespace AST {
 class DeriveEq : DeriveVisitor
 {
 public:
-  DeriveEq (location_t loc);
+  DeriveEq (location_t loc, Builder::Source item_source);
 
   std::vector<std::unique_ptr<Item>> go (Item &item);
 

--- a/gcc/rust/expand/rust-derive-hash.cc
+++ b/gcc/rust/expand/rust-derive-hash.cc
@@ -28,7 +28,9 @@
 namespace Rust {
 namespace AST {
 
-DeriveHash::DeriveHash (location_t loc) : DeriveVisitor (loc) {}
+DeriveHash::DeriveHash (location_t loc, Builder::Source item_source)
+  : DeriveVisitor (loc, item_source)
+{}
 
 std::unique_ptr<AST::Item>
 DeriveHash::go (Item &item)
@@ -41,8 +43,9 @@ DeriveHash::go (Item &item)
 std::unique_ptr<Expr>
 DeriveHash::hash_call (std::unique_ptr<Expr> &&value)
 {
-  auto hash
-    = builder.path_in_expression ({"core", "hash", "Hash", "hash"}, true);
+  auto hash = builder.path_in_expression ({builder.get_path_start (), "hash",
+					   "Hash", "hash"},
+					  true);
 
   return builder.call (ptrify (hash),
 		       vec (std::move (value),
@@ -63,8 +66,8 @@ DeriveHash::hash_fn (std::unique_ptr<BlockExpr> &&block)
 						    true));
 
   auto params = vec (builder.self_ref_param (), std::move (state_param));
-  auto bounds = vec (
-    builder.trait_bound (builder.type_path ({"core", "hash", "Hasher"}, true)));
+  auto bounds = vec (builder.trait_bound (
+    builder.type_path ({builder.get_path_start (), "hash", "Hasher"}, true)));
   auto generics = vec (
     builder.generic_type_param (DeriveHash::state_type, std::move (bounds)));
 
@@ -78,7 +81,8 @@ DeriveHash::hash_impl (
   const std::vector<std::unique_ptr<GenericParam>> &type_generics)
 {
   auto hash_path = [this] () {
-    return builder.type_path ({"core", "hash", "Hash"}, true);
+    return builder.type_path ({builder.get_path_start (), "hash", "Hash"},
+			      true);
   };
 
   auto trait_items = vec (std::move (hash_fn));

--- a/gcc/rust/expand/rust-derive-hash.h
+++ b/gcc/rust/expand/rust-derive-hash.h
@@ -27,7 +27,7 @@ namespace AST {
 class DeriveHash : DeriveVisitor
 {
 public:
-  DeriveHash (location_t loc);
+  DeriveHash (location_t loc, Builder::Source item_source);
 
   std::unique_ptr<Item> go (Item &item);
 

--- a/gcc/rust/expand/rust-derive-ord.cc
+++ b/gcc/rust/expand/rust-derive-ord.cc
@@ -26,8 +26,9 @@
 namespace Rust {
 namespace AST {
 
-DeriveOrd::DeriveOrd (Ordering ordering, location_t loc)
-  : DeriveVisitor (loc), ordering (ordering)
+DeriveOrd::DeriveOrd (Ordering ordering, location_t loc,
+		      Builder::Source item_source)
+  : DeriveVisitor (loc, item_source), ordering (ordering)
 {}
 
 std::unique_ptr<Item>
@@ -43,7 +44,7 @@ DeriveOrd::cmp_call (std::unique_ptr<Expr> &&self_expr,
 		     std::unique_ptr<Expr> &&other_expr)
 {
   auto cmp_fn_path = builder.path_in_expression (
-    {"core", "cmp", trait (ordering), fn (ordering)}, true);
+    {builder.get_path_start (), "cmp", trait (ordering), fn (ordering)}, true);
 
   return builder.call (ptrify (cmp_fn_path),
 		       vec (builder.ref (std::move (self_expr)),
@@ -59,7 +60,7 @@ DeriveOrd::cmp_impl (
 
   auto trait = ordering == Ordering::Partial ? "PartialOrd" : "Ord";
   auto trait_path = [&, this] () {
-    return builder.type_path ({"core", "cmp", trait}, true);
+    return builder.type_path ({builder.get_path_start (), "cmp", trait}, true);
   };
 
   auto trait_bound
@@ -79,7 +80,8 @@ std::unique_ptr<AssociatedItem>
 DeriveOrd::cmp_fn (std::unique_ptr<BlockExpr> &&block, Identifier type_name)
 {
   // Ordering
-  auto return_type = builder.type_path ({"core", "cmp", "Ordering"}, true);
+  auto return_type
+    = builder.type_path ({builder.get_path_start (), "cmp", "Ordering"}, true);
 
   // In the case of PartialOrd, we return an Option<Ordering>
   if (ordering == Ordering::Partial)
@@ -88,7 +90,7 @@ DeriveOrd::cmp_fn (std::unique_ptr<BlockExpr> &&block, Identifier type_name)
 
       auto generic_seg = builder.type_path_segment_generic (
 	"Option", GenericArgs ({}, {generic}, {}, loc));
-      auto core = builder.type_path_segment ("core");
+      auto core = builder.type_path_segment (builder.get_path_start ());
       auto option = builder.type_path_segment ("option");
 
       return_type
@@ -113,8 +115,8 @@ DeriveOrd::cmp_fn (std::unique_ptr<BlockExpr> &&block, Identifier type_name)
 std::unique_ptr<Pattern>
 DeriveOrd::make_equal ()
 {
-  std::unique_ptr<Pattern> equal = ptrify (
-    builder.path_in_expression ({"core", "cmp", "Ordering", "Equal"}, true));
+  std::unique_ptr<Pattern> equal = ptrify (builder.path_in_expression (
+    {builder.get_path_start (), "cmp", "Ordering", "Equal"}, true));
 
   // We need to wrap the pattern in Option::Some if we are doing partial
   // ordering
@@ -148,9 +150,8 @@ DeriveOrd::recursive_match (std::vector<SelfOther> &&members)
 {
   if (members.empty ())
     {
-      std::unique_ptr<Expr> value = ptrify (
-	builder.path_in_expression ({"core", "cmp", "Ordering", "Equal"},
-				    true));
+      std::unique_ptr<Expr> value = ptrify (builder.path_in_expression (
+	{builder.get_path_start (), "cmp", "Ordering", "Equal"}, true));
 
       if (ordering == Ordering::Partial)
 	value = builder.call (ptrify (builder.path_in_expression (

--- a/gcc/rust/expand/rust-derive-ord.h
+++ b/gcc/rust/expand/rust-derive-ord.h
@@ -59,7 +59,7 @@ public:
       return "PartialOrd";
   }
 
-  DeriveOrd (Ordering ordering, location_t loc);
+  DeriveOrd (Ordering ordering, location_t loc, Builder::Source item_source);
 
   std::unique_ptr<Item> go (Item &item);
 

--- a/gcc/rust/expand/rust-derive-partial-eq.cc
+++ b/gcc/rust/expand/rust-derive-partial-eq.cc
@@ -27,7 +27,9 @@
 
 namespace Rust {
 namespace AST {
-DerivePartialEq::DerivePartialEq (location_t loc) : DeriveVisitor (loc) {}
+DerivePartialEq::DerivePartialEq (location_t loc, Builder::Source item_source)
+  : DeriveVisitor (loc, item_source)
+{}
 
 std::vector<std::unique_ptr<AST::Item>>
 DerivePartialEq::go (Item &item)

--- a/gcc/rust/expand/rust-derive-partial-eq.h
+++ b/gcc/rust/expand/rust-derive-partial-eq.h
@@ -29,7 +29,7 @@ namespace AST {
 class DerivePartialEq : DeriveVisitor
 {
 public:
-  DerivePartialEq (location_t loc);
+  DerivePartialEq (location_t loc, Builder::Source item_source);
 
   std::vector<std::unique_ptr<Item>> go (Item &item);
 

--- a/gcc/rust/expand/rust-derive.cc
+++ b/gcc/rust/expand/rust-derive.cc
@@ -30,13 +30,13 @@
 namespace Rust {
 namespace AST {
 
-DeriveVisitor::DeriveVisitor (location_t loc)
-  : loc (loc), builder (Builder (loc))
+DeriveVisitor::DeriveVisitor (location_t loc, Builder::Source item_source)
+  : loc (loc), builder (Builder (loc, item_source))
 {}
 
 std::vector<std::unique_ptr<Item>>
 DeriveVisitor::derive (Item &item, const Attribute &attr,
-		       BuiltinMacro to_derive)
+		       BuiltinMacro to_derive, Builder::Source item_source)
 {
   auto loc = attr.get_locus ();
 
@@ -53,27 +53,29 @@ DeriveVisitor::derive (Item &item, const Attribute &attr,
   switch (to_derive)
     {
     case BuiltinMacro::Clone:
-      return vec (DeriveClone (loc).go (item));
+      return vec (DeriveClone (loc, item_source).go (item));
     case BuiltinMacro::Copy:
-      return vec (DeriveCopy (loc).go (item));
+      return vec (DeriveCopy (loc, item_source).go (item));
     case BuiltinMacro::Debug:
       rust_warning_at (
 	loc, 0,
 	"derive(Debug) is not fully implemented yet and has no effect - only a "
 	"stub implementation will be generated");
-      return vec (DeriveDebug (loc).go (item));
+      return vec (DeriveDebug (loc, item_source).go (item));
     case BuiltinMacro::Default:
-      return vec (DeriveDefault (loc).go (item));
+      return vec (DeriveDefault (loc, item_source).go (item));
     case BuiltinMacro::Eq:
-      return DeriveEq (loc).go (item);
+      return DeriveEq (loc, item_source).go (item);
     case BuiltinMacro::PartialEq:
-      return DerivePartialEq (loc).go (item);
+      return DerivePartialEq (loc, item_source).go (item);
     case BuiltinMacro::Hash:
-      return vec (DeriveHash (loc).go (item));
+      return vec (DeriveHash (loc, item_source).go (item));
     case BuiltinMacro::Ord:
-      return vec (DeriveOrd (DeriveOrd::Ordering::Total, loc).go (item));
+      return vec (
+	DeriveOrd (DeriveOrd::Ordering::Total, loc, item_source).go (item));
     case BuiltinMacro::PartialOrd:
-      return vec (DeriveOrd (DeriveOrd::Ordering::Partial, loc).go (item));
+      return vec (
+	DeriveOrd (DeriveOrd::Ordering::Partial, loc, item_source).go (item));
     case BuiltinMacro::RustcEncodable:
     case BuiltinMacro::RustcDecodable:
       rust_sorry_at (loc, "derive(%s) is not yet implemented",

--- a/gcc/rust/expand/rust-derive.h
+++ b/gcc/rust/expand/rust-derive.h
@@ -39,10 +39,11 @@ public:
    * which all need to be integrated to the existing AST
    */
   static std::vector<std::unique_ptr<Item>>
-  derive (Item &item, const Attribute &derive, BuiltinMacro to_derive);
+  derive (Item &item, const Attribute &derive, BuiltinMacro to_derive,
+	  Builder::Source item_source);
 
 protected:
-  DeriveVisitor (location_t loc);
+  DeriveVisitor (location_t loc, Builder::Source item_source);
 
   location_t loc;
   Builder builder;

--- a/gcc/rust/expand/rust-expand-format-args.cc
+++ b/gcc/rust/expand/rust-expand-format-args.cc
@@ -35,11 +35,13 @@ static std::unique_ptr<AST::Expr>
 format_arg (const AST::Builder &builder, std::unique_ptr<AST::Expr> &&to_format,
 	    const std::string &trait)
 {
-  auto formatter_fn = std::unique_ptr<AST::Expr> (new AST::PathInExpression (
-    builder.path_in_expression ({"core", "fmt", trait, "fmt"})));
+  auto formatter_fn = std::unique_ptr<AST::Expr> (
+    new AST::PathInExpression (builder.path_in_expression (
+      {builder.get_path_start (), "fmt", trait, "fmt"})));
 
-  auto path = std::unique_ptr<AST::Expr> (new AST::PathInExpression (
-    builder.path_in_expression ({"core", "fmt", "ArgumentV1", "new"})));
+  auto path = std::unique_ptr<AST::Expr> (
+    new AST::PathInExpression (builder.path_in_expression (
+      {builder.get_path_start (), "fmt", "ArgumentV1", "new"})));
 
   auto args = std::vector<std::unique_ptr<AST::Expr>> ();
   args.emplace_back (std::move (to_format));
@@ -70,7 +72,10 @@ expand_format_args (AST::FormatArgs &fmt,
 		    std::vector<std::unique_ptr<AST::Token>> &&tokens)
 {
   auto loc = fmt.get_locus ();
-  auto builder = AST::Builder (loc);
+  // FIXME: This needs to be aware of the crate in which we are expanding it.
+  // Expanding format_args!() within core needs to use paths that start with
+  // `crate::`, not `core::`
+  auto builder = AST::Builder (loc, AST::Builder::Source::InCore);
   auto &arguments = fmt.get_arguments ();
 
   auto static_pieces = std::vector<std::unique_ptr<AST::Expr>> ();
@@ -122,8 +127,9 @@ expand_format_args (AST::FormatArgs &fmt,
   auto pieces = builder.ref (builder.array (std::move (static_pieces)));
   auto args_slice = builder.ref (builder.array (std::move (args_array)));
 
-  auto final_path = std::make_unique<AST::PathInExpression> (
-    builder.path_in_expression ({"core", "fmt", "Arguments", "new_v1"}));
+  auto final_path
+    = std::make_unique<AST::PathInExpression> (builder.path_in_expression (
+      {builder.get_path_start (), "fmt", "Arguments", "new_v1"}));
   auto final_args = std::vector<std::unique_ptr<AST::Expr>> ();
   final_args.emplace_back (std::move (pieces));
   final_args.emplace_back (std::move (args_slice));

--- a/gcc/rust/expand/rust-expand-visitor.cc
+++ b/gcc/rust/expand/rust-expand-visitor.cc
@@ -47,11 +47,16 @@ ExpandVisitor::go (AST::Crate &crate)
 
 static std::vector<std::unique_ptr<AST::Item>>
 builtin_derive_item (AST::Item &item, const AST::Attribute &derive,
-		     BuiltinMacro to_derive)
+		     BuiltinMacro to_derive, MacroExpander &expander)
 {
-  auto items = AST::DeriveVisitor::derive (item, derive, to_derive);
+  auto item_source = AST::Builder::get_item_source (expander.crate);
+
+  auto items
+    = AST::DeriveVisitor::derive (item, derive, to_derive, item_source);
+
   for (auto &item : items)
     Analysis::Mappings::get ().add_derived_node (item->get_node_id ());
+
   return items;
 }
 
@@ -198,7 +203,8 @@ ExpandVisitor::expand_inner_items (
 			{
 			  auto new_items
 			    = builtin_derive_item (item, current,
-						   maybe_builtin.value ());
+						   maybe_builtin.value (),
+						   expander);
 
 			  for (auto &&new_item : new_items)
 			    it = items.insert (it, std::move (new_item));
@@ -284,7 +290,8 @@ ExpandVisitor::expand_inner_stmts (AST::BlockExpr &expr)
 			{
 			  auto new_items
 			    = builtin_derive_item (item, current,
-						   maybe_builtin.value ());
+						   maybe_builtin.value (),
+						   expander);
 
 			  // this inserts the derive *before* the item - is it a
 			  // problem?

--- a/gcc/rust/expand/rust-macro-builtins-log-debug.cc
+++ b/gcc/rust/expand/rust-macro-builtins-log-debug.cc
@@ -47,7 +47,7 @@ MacroBuiltin::assert_handler (location_t invoc_locus,
 
   // don't need to expand macros -- panic! will handle it
 
-  AST::Builder b (invoc_locus);
+  AST::Builder b (invoc_locus, AST::Builder::Source::Any);
 
   std::vector<std::unique_ptr<AST::TokenTree>> panic_tree;
   const_TokenPtr open = Token::make (TokenId::LEFT_PAREN, invoc_locus);

--- a/gcc/rust/expand/rust-macro-builtins-utility.cc
+++ b/gcc/rust/expand/rust-macro-builtins-utility.cc
@@ -274,7 +274,7 @@ MacroBuiltin::option_env_handler (location_t invoc_locus,
   parser.skip_token (last_token_id);
 
   auto env_value = getenv (lit_expr->as_string ().c_str ());
-  AST::Builder b (invoc_locus);
+  AST::Builder b (invoc_locus, AST::Builder::Source::Any);
 
   if (env_value == nullptr)
     {

--- a/gcc/rust/expand/rust-macro-expand.h
+++ b/gcc/rust/expand/rust-macro-expand.h
@@ -296,10 +296,9 @@ struct MacroExpander
   unsigned int expansion_depth = 0;
 
   MacroExpander (AST::Crate &crate, ExpansionCfg cfg, Session &session)
-    : cfg (cfg), crate (crate), session (session),
-      sub_stack (SubstitutionScope ()),
+    : cfg (cfg), session (session), sub_stack (SubstitutionScope ()),
       expanded_fragment (AST::Fragment::create_error ()),
-      has_changed_flag (false), had_duplicate_error (false),
+      has_changed_flag (false), had_duplicate_error (false), crate (crate),
       resolver (Resolver::Resolver::get ()),
       mappings (Analysis::Mappings::get ())
   {}
@@ -502,7 +501,6 @@ struct MacroExpander
 private:
   AST::Fragment parse_proc_macro_output (ProcMacro::TokenStream ts);
 
-  AST::Crate &crate;
   Session &session;
   SubstitutionScope sub_stack;
   std::vector<ContextType> context;
@@ -516,6 +514,9 @@ private:
   bool had_duplicate_error;
 
 public:
+  /* The current crate we are expanding within */
+  AST::Crate &crate;
+
   Resolver::Resolver *resolver;
   Analysis::Mappings &mappings;
 };

--- a/gcc/testsuite/rust/compile/derive-debug1.rs
+++ b/gcc/testsuite/rust/compile/derive-debug1.rs
@@ -1,35 +1,35 @@
 #![feature(no_core)]
 #![no_core]
-
 #![feature(lang_items)]
 #[lang = "sized"]
 trait Sized {}
 
-mod core {
-    pub mod result {
-        pub enum Result<T, E> {
-            #[lang = "Ok"]
-            Ok(T),
-            #[lang = "Err"]
-            Err(E),
-        }
+pub mod result {
+    pub enum Result<T, E> {
+        #[lang = "Ok"]
+        Ok(T),
+        #[lang = "Err"]
+        Err(E),
     }
+}
 
-    mod fmt {
-        struct Formatter; // { dg-warning "is never constructed" }
-        struct Error; // { dg-warning "is never constructed" }
+mod fmt {
+    struct Formatter; // { dg-warning "is never constructed" }
+    struct Error; // { dg-warning "is never constructed" }
 
-        type Result = crate::core::result::Result<(), Error>;
+    type Result = crate::result::Result<(), Error>;
 
-        trait Debug {
-            fn fmt(&self, fmt: &mut Formatter) -> Result;
-        }
+    trait Debug {
+        fn fmt(&self, fmt: &mut Formatter) -> Result;
     }
 }
 
 #[derive(Debug)]
 // { dg-warning "stub implementation" "" { target *-*-* } .-1 }
-struct Foo { a: i32, b: i64 } // { dg-warning "is never constructed" }
+pub struct Foo {
+    pub a: i32,
+    pub b: i64,
+}
 
 #[derive(Debug)]
 // { dg-warning "stub implementation" "" { target *-*-* } .-1 }
@@ -40,6 +40,5 @@ struct Bar(i32, i32); // { dg-warning "is never constructed" }
 enum Baz {
     A,
     B(i32),
-    C { a: i32 }
+    C { a: i32 },
 }
-

--- a/gcc/testsuite/rust/compile/derive-default1.rs
+++ b/gcc/testsuite/rust/compile/derive-default1.rs
@@ -3,29 +3,37 @@
 #![no_core]
 
 #[derive(Default)]
-struct Foo { _a: i32, _b: i64, _c: u8 }
+struct Foo {
+    _a: i32,
+    _b: i64,
+    _c: u8,
+}
 
 #[lang = "sized"]
 pub trait Sized {}
 
-mod core {
-    mod default {
-        use crate::Sized;
+mod default {
+    use crate::Sized;
 
-        trait Default: Sized {
-            fn default() -> Self;
+    trait Default: Sized {
+        fn default() -> Self;
+    }
+
+    impl Default for i32 {
+        fn default() -> Self {
+            0
         }
+    }
 
-        impl Default for i32 {
-            fn default() -> Self { 0 }
+    impl Default for i64 {
+        fn default() -> Self {
+            27
         }
+    }
 
-        impl Default for i64 {
-            fn default() -> Self { 27 }
-        }
-
-        impl Default for u8 {
-            fn default() -> Self { 18 }
+    impl Default for u8 {
+        fn default() -> Self {
+            18
         }
     }
 }

--- a/gcc/testsuite/rust/compile/derive-eq-invalid.rs
+++ b/gcc/testsuite/rust/compile/derive-eq-invalid.rs
@@ -2,22 +2,20 @@
 #![feature(lang_items)]
 #![no_core]
 
-mod core {
-    mod cmp {
-        use crate::Sized;
+mod cmp {
+    use crate::Sized;
 
-        #[lang = "eq"]
-        pub trait PartialEq<Rhs: ?Sized = Self> {
-            fn eq(&self, other: &Rhs) -> bool;
+    #[lang = "eq"]
+    pub trait PartialEq<Rhs: ?Sized = Self> {
+        fn eq(&self, other: &Rhs) -> bool;
 
-            fn ne(&self, other: &Rhs) -> bool {
-                !self.eq(other)
-            }
+        fn ne(&self, other: &Rhs) -> bool {
+            !self.eq(other)
         }
+    }
 
-        pub trait Eq: PartialEq<Self> {
-            fn assert_receiver_is_total_eq(&self) {}
-        }
+    pub trait Eq: PartialEq<Self> {
+        fn assert_receiver_is_total_eq(&self) {}
     }
 }
 

--- a/gcc/testsuite/rust/compile/derive-hash1.rs
+++ b/gcc/testsuite/rust/compile/derive-hash1.rs
@@ -5,77 +5,75 @@
 #[lang = "sized"]
 trait Sized {}
 
-pub mod core {
-    pub mod intrinsics {
-        #[lang = "discriminant_kind"]
-        pub trait DiscriminantKind {
-            #[lang = "discriminant_type"]
-            type Discriminant;
-        }
-
-        extern "rust-intrinsic" {
-            pub fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discriminant;
-        }
+pub mod intrinsics {
+    #[lang = "discriminant_kind"]
+    pub trait DiscriminantKind {
+        #[lang = "discriminant_type"]
+        type Discriminant;
     }
 
-    pub mod hash {
-        use crate::Sized;
+    extern "rust-intrinsic" {
+        pub fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discriminant;
+    }
+}
 
-        pub trait Hasher {}
+pub mod hash {
+    use crate::Sized;
 
-        pub trait Hash {
-            /// Feeds this value into the given [`Hasher`].
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// use std::collections::hash_map::DefaultHasher;
-            /// use std::hash::{Hash, Hasher};
-            ///
-            /// let mut hasher = DefaultHasher::new();
-            /// 7920.hash(&mut hasher);
-            /// println!("Hash is {:x}!", hasher.finish());
-            /// ```
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn hash<H: Hasher>(&self, state: &mut H);
+    pub trait Hasher {}
 
-            /// Feeds a slice of this type into the given [`Hasher`].
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// use std::collections::hash_map::DefaultHasher;
-            /// use std::hash::{Hash, Hasher};
-            ///
-            /// let mut hasher = DefaultHasher::new();
-            /// let numbers = [6, 28, 496, 8128];
-            /// Hash::hash_slice(&numbers, &mut hasher);
-            /// println!("Hash is {:x}!", hasher.finish());
-            /// ```
-            #[stable(feature = "hash_slice", since = "1.3.0")]
-            fn hash_slice<H: Hasher>(data: &[Self], state: &mut H)
-            where
-                Self: Sized,
-            {
-                // for piece in data {
-                //     piece.hash(state);
-                // }
-            }
+    pub trait Hash {
+        /// Feeds this value into the given [`Hasher`].
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use std::collections::hash_map::DefaultHasher;
+        /// use std::hash::{Hash, Hasher};
+        ///
+        /// let mut hasher = DefaultHasher::new();
+        /// 7920.hash(&mut hasher);
+        /// println!("Hash is {:x}!", hasher.finish());
+        /// ```
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn hash<H: Hasher>(&self, state: &mut H);
+
+        /// Feeds a slice of this type into the given [`Hasher`].
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use std::collections::hash_map::DefaultHasher;
+        /// use std::hash::{Hash, Hasher};
+        ///
+        /// let mut hasher = DefaultHasher::new();
+        /// let numbers = [6, 28, 496, 8128];
+        /// Hash::hash_slice(&numbers, &mut hasher);
+        /// println!("Hash is {:x}!", hasher.finish());
+        /// ```
+        #[stable(feature = "hash_slice", since = "1.3.0")]
+        fn hash_slice<H: Hasher>(data: &[Self], state: &mut H)
+        where
+            Self: Sized,
+        {
+            // for piece in data {
+            //     piece.hash(state);
+            // }
         }
     }
 }
 
-impl core::hash::Hash for i32 {
-    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {}
+impl crate::hash::Hash for i32 {
+    fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {}
 }
 
-impl core::hash::Hash for i64 {
-    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {}
+impl crate::hash::Hash for i64 {
+    fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {}
 }
 
 // for the discriminant value
-impl core::hash::Hash for isize {
-    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {}
+impl crate::hash::Hash for isize {
+    fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {}
 }
 
 #[derive(Hash)]
@@ -91,5 +89,5 @@ struct Bar(i32, i64); // { dg-warning "never constructed" }
 enum Baz {
     A,
     B(i32),
-    C { a: i64 }
+    C { a: i64 },
 }

--- a/gcc/testsuite/rust/compile/derive_partial_ord1.rs
+++ b/gcc/testsuite/rust/compile/derive_partial_ord1.rs
@@ -1,350 +1,346 @@
 // { dg-additional-options "-w" }
 #![feature(no_core)]
 #![no_core]
-
-
 #![feature(intrinsics, lang_items)]
 
-mod core {
-    mod option {
-        // #[rustc_diagnostic_item = "option_type"]
+mod option {
+    // #[rustc_diagnostic_item = "option_type"]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub enum Option<T> {
+        /// No value
+        #[lang = "None"]
         #[stable(feature = "rust1", since = "1.0.0")]
-        pub enum Option<T> {
-            /// No value
-            #[lang = "None"]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            None,
-            /// Some value `T`
-            #[lang = "Some"]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+        None,
+        /// Some value `T`
+        #[lang = "Some"]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+    }
+}
+
+mod marker {
+    #[lang = "phantom_data"]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub struct PhantomData<T: ?Sized>;
+
+    #[unstable(feature = "structural_match", issue = "31434")]
+    // #[rustc_on_unimplemented(message = "the type `{Self}` does not `#[derive(PartialEq)]`")]
+    #[lang = "structural_peq"]
+    pub trait StructuralPartialEq {
+        // Empty.
+    }
+
+    #[unstable(feature = "structural_match", issue = "31434")]
+    // #[rustc_on_unimplemented(message = "the type `{Self}` does not `#[derive(Eq)]`")]
+    #[lang = "structural_teq"]
+    pub trait StructuralEq {
+        // Empty.
+    }
+
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[lang = "sized"]
+    // #[rustc_on_unimplemented(
+    //     message = "the size for values of type `{Self}` cannot be known at compilation time",
+    //     label = "doesn't have a size known at compile-time"
+    // )]
+    // #[fundamental] // for Default, for example, which requires that `[T]: !Default` be evaluatable
+    // #[rustc_specialization_trait]
+    pub trait Sized {
+        // Empty.
+    }
+}
+
+mod cmp {
+    use super::marker::Sized;
+    use super::option::Option;
+
+    // #[derive(Clone, Copy, PartialEq, Debug, Hash)]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub enum Ordering {
+        /// An ordering where a compared value is less than another.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        Less = -1,
+        /// An ordering where a compared value is equal to another.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        Equal = 0,
+        /// An ordering where a compared value is greater than another.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        Greater = 1,
+    }
+
+    #[lang = "eq"]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(alias = "==")]
+    #[doc(alias = "!=")]
+    // #[rustc_on_unimplemented(
+    //     message = "can't compare `{Self}` with `{Rhs}`",
+    //     label = "no implementation for `{Self} == {Rhs}`"
+    // )]
+    pub trait PartialEq<Rhs: ?Sized = Self> {
+        /// This method tests for `self` and `other` values to be equal, and is used
+        /// by `==`.
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn eq(&self, other: &Rhs) -> bool;
+
+        fn ne(&self, other: &Rhs) -> bool {
+            !self.eq(other)
         }
     }
 
-    mod marker {
-        #[lang = "phantom_data"]
+    #[doc(alias = "==")]
+    #[doc(alias = "!=")]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub trait Eq: PartialEq<Self> {
+        // this method is used solely by #[deriving] to assert
+        // that every component of a type implements #[deriving]
+        // itself, the current deriving infrastructure means doing this
+        // assertion without using a method on this trait is nearly
+        // impossible.
+        //
+        // This should never be implemented by hand.
+        #[doc(hidden)]
         #[stable(feature = "rust1", since = "1.0.0")]
-        pub struct PhantomData<T: ?Sized>;
+        fn assert_receiver_is_total_eq(&self) {}
+    }
 
-        #[unstable(feature = "structural_match", issue = "31434")]
-        // #[rustc_on_unimplemented(message = "the type `{Self}` does not `#[derive(PartialEq)]`")]
-        #[lang = "structural_peq"]
-        pub trait StructuralPartialEq {
-            // Empty.
+    #[lang = "partial_ord"]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(alias = ">")]
+    #[doc(alias = "<")]
+    #[doc(alias = "<=")]
+    #[doc(alias = ">=")]
+    // #[rustc_on_unimplemented(
+    //     message = "can't compare `{Self}` with `{Rhs}`",
+    //     label = "no implementation for `{Self} < {Rhs}` and `{Self} > {Rhs}`"
+    // )]
+    pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
+        /// This method returns an ordering between `self` and `other` values if one exists.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use std::cmp::Ordering;
+        ///
+        /// let result = 1.0.partial_cmp(&2.0);
+        /// assert_eq!(result, Some(Ordering::Less));
+        ///
+        /// let result = 1.0.partial_cmp(&1.0);
+        /// assert_eq!(result, Some(Ordering::Equal));
+        ///
+        /// let result = 2.0.partial_cmp(&1.0);
+        /// assert_eq!(result, Some(Ordering::Greater));
+        /// ```
+        ///
+        /// When comparison is impossible:
+        ///
+        /// ```
+        /// let result = f64::NAN.partial_cmp(&1.0);
+        /// assert_eq!(result, None);
+        /// ```
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn partial_cmp(&self, other: &Rhs) -> Option<Ordering>;
+
+        /// This method tests less than (for `self` and `other`) and is used by the `<` operator.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// let result = 1.0 < 2.0;
+        /// assert_eq!(result, true);
+        ///
+        /// let result = 2.0 < 1.0;
+        /// assert_eq!(result, false);
+        /// ```
+        #[inline]
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn lt(&self, other: &Rhs) -> bool {
+            match self.partial_cmp(other) {
+                Option::Some(Ordering::Less) => true,
+                _ => false,
+            }
         }
 
-        #[unstable(feature = "structural_match", issue = "31434")]
-        // #[rustc_on_unimplemented(message = "the type `{Self}` does not `#[derive(Eq)]`")]
-        #[lang = "structural_teq"]
-        pub trait StructuralEq {
-            // Empty.
+        /// This method tests less than or equal to (for `self` and `other`) and is used by the `<=`
+        /// operator.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// let result = 1.0 <= 2.0;
+        /// assert_eq!(result, true);
+        ///
+        /// let result = 2.0 <= 2.0;
+        /// assert_eq!(result, true);
+        /// ```
+        #[inline]
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn le(&self, other: &Rhs) -> bool {
+            match self.partial_cmp(other) {
+                Option::Some(Ordering::Less | Ordering::Equal) => true,
+                _ => false,
+            }
         }
 
+        /// This method tests greater than (for `self` and `other`) and is used by the `>` operator.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// let result = 1.0 > 2.0;
+        /// assert_eq!(result, false);
+        ///
+        /// let result = 2.0 > 2.0;
+        /// assert_eq!(result, false);
+        /// ```
+        #[inline]
+        #[must_use]
         #[stable(feature = "rust1", since = "1.0.0")]
-        #[lang = "sized"]
-        // #[rustc_on_unimplemented(
-        //     message = "the size for values of type `{Self}` cannot be known at compilation time",
-        //     label = "doesn't have a size known at compile-time"
-        // )]
-        // #[fundamental] // for Default, for example, which requires that `[T]: !Default` be evaluatable
-        // #[rustc_specialization_trait]
-        pub trait Sized {
-            // Empty.
+        fn gt(&self, other: &Rhs) -> bool {
+            match self.partial_cmp(other) {
+                Option::Some(Ordering::Greater) => true,
+                _ => false,
+            }
+        }
+
+        /// This method tests greater than or equal to (for `self` and `other`) and is used by the `>=`
+        /// operator.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// let result = 2.0 >= 1.0;
+        /// assert_eq!(result, true);
+        ///
+        /// let result = 2.0 >= 2.0;
+        /// assert_eq!(result, true);
+        /// ```
+        #[inline]
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn ge(&self, other: &Rhs) -> bool {
+            match self.partial_cmp(other) {
+                Option::Some(Ordering::Greater | Ordering::Equal) => true,
+                _ => false,
+            }
         }
     }
 
-    mod cmp {
-        use super::marker::Sized;
-        use super::option::Option;
-
-        // #[derive(Clone, Copy, PartialEq, Debug, Hash)]
+    #[doc(alias = "<")]
+    #[doc(alias = ">")]
+    #[doc(alias = "<=")]
+    #[doc(alias = ">=")]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub trait Ord: Eq + PartialOrd<Self> {
+        /// This method returns an [`Ordering`] between `self` and `other`.
+        ///
+        /// By convention, `self.cmp(&other)` returns the ordering matching the expression
+        /// `self <operator> other` if true.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use std::cmp::Ordering;
+        ///
+        /// assert_eq!(5.cmp(&10), Ordering::Less);
+        /// assert_eq!(10.cmp(&5), Ordering::Greater);
+        /// assert_eq!(5.cmp(&5), Ordering::Equal);
+        /// ```
+        #[must_use]
         #[stable(feature = "rust1", since = "1.0.0")]
-        pub enum Ordering {
-            /// An ordering where a compared value is less than another.
-            #[stable(feature = "rust1", since = "1.0.0")]
-            Less = -1,
-            /// An ordering where a compared value is equal to another.
-            #[stable(feature = "rust1", since = "1.0.0")]
-            Equal = 0,
-            /// An ordering where a compared value is greater than another.
-            #[stable(feature = "rust1", since = "1.0.0")]
-            Greater = 1,
+        fn cmp(&self, other: &Self) -> Ordering;
+
+        /// Compares and returns the maximum of two values.
+        ///
+        /// Returns the second argument if the comparison determines them to be equal.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// assert_eq!(2, 1.max(2));
+        /// assert_eq!(2, 2.max(2));
+        /// ```
+        #[stable(feature = "ord_max_min", since = "1.21.0")]
+        #[must_use]
+        fn max(self, other: Self) -> Self
+        where
+            Self: Sized,
+        {
+            self
         }
 
-        #[lang = "eq"]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[doc(alias = "==")]
-        #[doc(alias = "!=")]
-        // #[rustc_on_unimplemented(
-        //     message = "can't compare `{Self}` with `{Rhs}`",
-        //     label = "no implementation for `{Self} == {Rhs}`"
-        // )]
-        pub trait PartialEq<Rhs: ?Sized = Self> {
-            /// This method tests for `self` and `other` values to be equal, and is used
-            /// by `==`.
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn eq(&self, other: &Rhs) -> bool;
-
-            fn ne(&self, other: &Rhs) -> bool {
-                !self.eq(other)
-            }
+        /// Compares and returns the minimum of two values.
+        ///
+        /// Returns the first argument if the comparison determines them to be equal.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// assert_eq!(1, 1.min(2));
+        /// assert_eq!(2, 2.min(2));
+        /// ```
+        #[stable(feature = "ord_max_min", since = "1.21.0")]
+        #[must_use]
+        fn min(self, other: Self) -> Self
+        where
+            Self: Sized,
+        {
+            self
         }
 
-        #[doc(alias = "==")]
-        #[doc(alias = "!=")]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        pub trait Eq: PartialEq<Self> {
-            // this method is used solely by #[deriving] to assert
-            // that every component of a type implements #[deriving]
-            // itself, the current deriving infrastructure means doing this
-            // assertion without using a method on this trait is nearly
-            // impossible.
-            //
-            // This should never be implemented by hand.
-            #[doc(hidden)]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn assert_receiver_is_total_eq(&self) {}
-        }
-
-        #[lang = "partial_ord"]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[doc(alias = ">")]
-        #[doc(alias = "<")]
-        #[doc(alias = "<=")]
-        #[doc(alias = ">=")]
-        // #[rustc_on_unimplemented(
-        //     message = "can't compare `{Self}` with `{Rhs}`",
-        //     label = "no implementation for `{Self} < {Rhs}` and `{Self} > {Rhs}`"
-        // )]
-        pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
-            /// This method returns an ordering between `self` and `other` values if one exists.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// use std::cmp::Ordering;
-            ///
-            /// let result = 1.0.partial_cmp(&2.0);
-            /// assert_eq!(result, Some(Ordering::Less));
-            ///
-            /// let result = 1.0.partial_cmp(&1.0);
-            /// assert_eq!(result, Some(Ordering::Equal));
-            ///
-            /// let result = 2.0.partial_cmp(&1.0);
-            /// assert_eq!(result, Some(Ordering::Greater));
-            /// ```
-            ///
-            /// When comparison is impossible:
-            ///
-            /// ```
-            /// let result = f64::NAN.partial_cmp(&1.0);
-            /// assert_eq!(result, None);
-            /// ```
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn partial_cmp(&self, other: &Rhs) -> Option<Ordering>;
-
-            /// This method tests less than (for `self` and `other`) and is used by the `<` operator.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// let result = 1.0 < 2.0;
-            /// assert_eq!(result, true);
-            ///
-            /// let result = 2.0 < 1.0;
-            /// assert_eq!(result, false);
-            /// ```
-            #[inline]
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn lt(&self, other: &Rhs) -> bool {
-                match self.partial_cmp(other) {
-                    Option::Some(Ordering::Less) => true,
-                    _ => false,
-                }
-            }
-
-            /// This method tests less than or equal to (for `self` and `other`) and is used by the `<=`
-            /// operator.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// let result = 1.0 <= 2.0;
-            /// assert_eq!(result, true);
-            ///
-            /// let result = 2.0 <= 2.0;
-            /// assert_eq!(result, true);
-            /// ```
-            #[inline]
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn le(&self, other: &Rhs) -> bool {
-                match self.partial_cmp(other) {
-                    Option::Some(Ordering::Less | Ordering::Equal) => true,
-                    _ => false,
-                }
-            }
-
-            /// This method tests greater than (for `self` and `other`) and is used by the `>` operator.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// let result = 1.0 > 2.0;
-            /// assert_eq!(result, false);
-            ///
-            /// let result = 2.0 > 2.0;
-            /// assert_eq!(result, false);
-            /// ```
-            #[inline]
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn gt(&self, other: &Rhs) -> bool {
-                match self.partial_cmp(other) {
-                    Option::Some(Ordering::Greater) => true,
-                    _ => false,
-                }
-            }
-
-            /// This method tests greater than or equal to (for `self` and `other`) and is used by the `>=`
-            /// operator.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// let result = 2.0 >= 1.0;
-            /// assert_eq!(result, true);
-            ///
-            /// let result = 2.0 >= 2.0;
-            /// assert_eq!(result, true);
-            /// ```
-            #[inline]
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn ge(&self, other: &Rhs) -> bool {
-                match self.partial_cmp(other) {
-                    Option::Some(Ordering::Greater | Ordering::Equal) => true,
-                    _ => false,
-                }
-            }
-        }
-
-        #[doc(alias = "<")]
-        #[doc(alias = ">")]
-        #[doc(alias = "<=")]
-        #[doc(alias = ">=")]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        pub trait Ord: Eq + PartialOrd<Self> {
-            /// This method returns an [`Ordering`] between `self` and `other`.
-            ///
-            /// By convention, `self.cmp(&other)` returns the ordering matching the expression
-            /// `self <operator> other` if true.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// use std::cmp::Ordering;
-            ///
-            /// assert_eq!(5.cmp(&10), Ordering::Less);
-            /// assert_eq!(10.cmp(&5), Ordering::Greater);
-            /// assert_eq!(5.cmp(&5), Ordering::Equal);
-            /// ```
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn cmp(&self, other: &Self) -> Ordering;
-
-            /// Compares and returns the maximum of two values.
-            ///
-            /// Returns the second argument if the comparison determines them to be equal.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// assert_eq!(2, 1.max(2));
-            /// assert_eq!(2, 2.max(2));
-            /// ```
-            #[stable(feature = "ord_max_min", since = "1.21.0")]
-            #[must_use]
-            fn max(self, other: Self) -> Self
-            where
-                Self: Sized,
-            {
+        /// Restrict a value to a certain interval.
+        ///
+        /// Returns `max` if `self` is greater than `max`, and `min` if `self` is
+        /// less than `min`. Otherwise this returns `self`.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `min > max`.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(clamp)]
+        ///
+        /// assert!((-3).clamp(-2, 1) == -2);
+        /// assert!(0.clamp(-2, 1) == 0);
+        /// assert!(2.clamp(-2, 1) == 1);
+        /// ```
+        #[must_use]
+        #[unstable(feature = "clamp", issue = "44095")]
+        fn clamp(self, min: Self, max: Self) -> Self
+        where
+            Self: Sized,
+        {
+            if self < min {
+                min
+            } else if self > max {
+                max
+            } else {
                 self
             }
-
-            /// Compares and returns the minimum of two values.
-            ///
-            /// Returns the first argument if the comparison determines them to be equal.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// assert_eq!(1, 1.min(2));
-            /// assert_eq!(2, 2.min(2));
-            /// ```
-            #[stable(feature = "ord_max_min", since = "1.21.0")]
-            #[must_use]
-            fn min(self, other: Self) -> Self
-            where
-                Self: Sized,
-            {
-                self
-            }
-
-            /// Restrict a value to a certain interval.
-            ///
-            /// Returns `max` if `self` is greater than `max`, and `min` if `self` is
-            /// less than `min`. Otherwise this returns `self`.
-            ///
-            /// # Panics
-            ///
-            /// Panics if `min > max`.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// #![feature(clamp)]
-            ///
-            /// assert!((-3).clamp(-2, 1) == -2);
-            /// assert!(0.clamp(-2, 1) == 0);
-            /// assert!(2.clamp(-2, 1) == 1);
-            /// ```
-            #[must_use]
-            #[unstable(feature = "clamp", issue = "44095")]
-            fn clamp(self, min: Self, max: Self) -> Self
-            where
-                Self: Sized,
-            {
-                if self < min {
-                    min
-                } else if self > max {
-                    max
-                } else {
-                    self
-                }
-            }
-        }
-    }
-
-    pub mod intrinsics {
-        #[lang = "discriminant_kind"]
-        pub trait DiscriminantKind {
-            #[lang = "discriminant_type"]
-            type Discriminant;
-        }
-
-        extern "rust-intrinsic" {
-            pub fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discriminant;
         }
     }
 }
 
-use core::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
-use core::marker::Sized;
-use core::option::Option;
+pub mod intrinsics {
+    #[lang = "discriminant_kind"]
+    pub trait DiscriminantKind {
+        #[lang = "discriminant_type"]
+        type Discriminant;
+    }
+
+    extern "rust-intrinsic" {
+        pub fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discriminant;
+    }
+}
+
+use crate::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
+use crate::marker::Sized;
+use crate::option::Option;
 
 // for comparing discriminant_value
 impl PartialEq for isize {

--- a/gcc/testsuite/rust/compile/format_args_basic_expansion.rs
+++ b/gcc/testsuite/rust/compile/format_args_basic_expansion.rs
@@ -1,6 +1,5 @@
 #![feature(no_core)]
 #![no_core]
-
 #![feature(rustc_attrs, lang_items)]
 
 #[rustc_builtin_macro]
@@ -11,35 +10,33 @@ macro_rules! format_args {
 #[lang = "sized"]
 trait Sized {}
 
-pub mod core {
-    pub mod fmt {
-        pub struct Formatter;
-        pub struct Result;
+pub mod fmt {
+    pub struct Formatter;
+    pub struct Result;
 
-        pub struct Arguments<'a>;
+    pub struct Arguments<'a>;
 
-        impl<'a> Arguments<'a> {
-            pub fn new_v1(_: &'a [&'static str], _: &'a [ArgumentV1<'a>]) -> Arguments<'a> {
-                Arguments
-            }
+    impl<'a> Arguments<'a> {
+        pub fn new_v1(_: &'a [&'static str], _: &'a [ArgumentV1<'a>]) -> Arguments<'a> {
+            Arguments
         }
+    }
 
-        pub struct ArgumentV1<'a>;
+    pub struct ArgumentV1<'a>;
 
-        impl<'a> ArgumentV1<'a> {
-            pub fn new<'b, T>(_: &'b T, _: fn(&T, &mut Formatter) -> Result) -> ArgumentV1 {
-                ArgumentV1
-            }
+    impl<'a> ArgumentV1<'a> {
+        pub fn new<'b, T>(_: &'b T, _: fn(&T, &mut Formatter) -> Result) -> ArgumentV1 {
+            ArgumentV1
         }
+    }
 
-        pub trait Display {
-            fn fmt(&self, _: &mut Formatter) -> Result;
-        }
+    pub trait Display {
+        fn fmt(&self, _: &mut Formatter) -> Result;
+    }
 
-        impl Display for i32 {
-            fn fmt(&self, _: &mut Formatter) -> Result {
-                Result
-            }
+    impl Display for i32 {
+        fn fmt(&self, _: &mut Formatter) -> Result {
+            Result
         }
     }
 }

--- a/gcc/testsuite/rust/compile/format_args_concat.rs
+++ b/gcc/testsuite/rust/compile/format_args_concat.rs
@@ -1,6 +1,5 @@
 #![feature(no_core)]
 #![no_core]
-
 #![feature(rustc_attrs, lang_items)]
 
 #[rustc_builtin_macro]
@@ -16,35 +15,33 @@ macro_rules! concat {
 #[lang = "sized"]
 trait Sized {}
 
-pub mod core {
-    pub mod fmt {
-        pub struct Formatter;
-        pub struct Result;
+pub mod fmt {
+    pub struct Formatter;
+    pub struct Result;
 
-        pub struct Arguments<'a>;
+    pub struct Arguments<'a>;
 
-        impl<'a> Arguments<'a> {
-            pub fn new_v1(_: &'a [&'static str], _: &'a [ArgumentV1<'a>]) -> Arguments<'a> {
-                Arguments
-            }
+    impl<'a> Arguments<'a> {
+        pub fn new_v1(_: &'a [&'static str], _: &'a [ArgumentV1<'a>]) -> Arguments<'a> {
+            Arguments
         }
+    }
 
-        pub struct ArgumentV1<'a>;
+    pub struct ArgumentV1<'a>;
 
-        impl<'a> ArgumentV1<'a> {
-            pub fn new<'b, T>(_: &'b T, _: fn(&T, &mut Formatter) -> Result) -> ArgumentV1 {
-                ArgumentV1
-            }
+    impl<'a> ArgumentV1<'a> {
+        pub fn new<'b, T>(_: &'b T, _: fn(&T, &mut Formatter) -> Result) -> ArgumentV1 {
+            ArgumentV1
         }
+    }
 
-        pub trait Display {
-            fn fmt(&self, _: &mut Formatter) -> Result;
-        }
+    pub trait Display {
+        fn fmt(&self, _: &mut Formatter) -> Result;
+    }
 
-        impl Display for i32 {
-            fn fmt(&self, _: &mut Formatter) -> Result {
-                Result
-            }
+    impl Display for i32 {
+        fn fmt(&self, _: &mut Formatter) -> Result {
+            Result
         }
     }
 }

--- a/gcc/testsuite/rust/compile/format_args_extra_comma.rs
+++ b/gcc/testsuite/rust/compile/format_args_extra_comma.rs
@@ -1,6 +1,5 @@
 #![feature(no_core)]
 #![no_core]
-
 #![feature(rustc_attrs, lang_items)]
 
 #[rustc_builtin_macro]
@@ -11,35 +10,33 @@ macro_rules! format_args {
 #[lang = "sized"]
 trait Sized {}
 
-pub mod core {
-    pub mod fmt {
-        pub struct Formatter;
-        pub struct Result;
+pub mod fmt {
+    pub struct Formatter;
+    pub struct Result;
 
-        pub struct Arguments<'a>;
+    pub struct Arguments<'a>;
 
-        impl<'a> Arguments<'a> {
-            pub fn new_v1(_: &'a [&'static str], _: &'a [ArgumentV1<'a>]) -> Arguments<'a> {
-                Arguments
-            }
+    impl<'a> Arguments<'a> {
+        pub fn new_v1(_: &'a [&'static str], _: &'a [ArgumentV1<'a>]) -> Arguments<'a> {
+            Arguments
         }
+    }
 
-        pub struct ArgumentV1<'a>;
+    pub struct ArgumentV1<'a>;
 
-        impl<'a> ArgumentV1<'a> {
-            pub fn new<'b, T>(_: &'b T, _: fn(&T, &mut Formatter) -> Result) -> ArgumentV1 {
-                ArgumentV1
-            }
+    impl<'a> ArgumentV1<'a> {
+        pub fn new<'b, T>(_: &'b T, _: fn(&T, &mut Formatter) -> Result) -> ArgumentV1 {
+            ArgumentV1
         }
+    }
 
-        pub trait Display {
-            fn fmt(&self, _: &mut Formatter) -> Result;
-        }
+    pub trait Display {
+        fn fmt(&self, _: &mut Formatter) -> Result;
+    }
 
-        impl Display for i32 {
-            fn fmt(&self, _: &mut Formatter) -> Result {
-                Result
-            }
+    impl Display for i32 {
+        fn fmt(&self, _: &mut Formatter) -> Result {
+            Result
         }
     }
 }

--- a/gcc/testsuite/rust/compile/issue-4090-1.rs
+++ b/gcc/testsuite/rust/compile/issue-4090-1.rs
@@ -1,52 +1,50 @@
 #![feature(no_core)]
 #![no_core]
-
 #![feature(lang_items)]
 
-mod core {
-    mod marker {
-        #[lang = "sized"]
-        pub trait Sized {}
+mod marker {
+    #[lang = "sized"]
+    pub trait Sized {}
 
-        #[lang = "phantom_data"]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        pub struct PhantomData<T: ?Sized>;
+    #[lang = "phantom_data"]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub struct PhantomData<T: ?Sized>;
 
-        #[unstable(feature = "structural_match", issue = "31434")]
-        #[lang = "structural_teq"]
-        pub trait StructuralEq {
-            // Empty.
-        }
+    #[unstable(feature = "structural_match", issue = "31434")]
+    #[lang = "structural_teq"]
+    pub trait StructuralEq {
+        // Empty.
+    }
 
-        #[unstable(feature = "structural_match", issue = "31434")]
-        #[lang = "structural_peq"]
-        pub trait StructuralPartialEq {
-            // Empty.
+    #[unstable(feature = "structural_match", issue = "31434")]
+    #[lang = "structural_peq"]
+    pub trait StructuralPartialEq {
+        // Empty.
+    }
+}
+
+pub mod cmp {
+    use super::marker::Sized;
+
+    #[lang = "eq"]
+    pub trait PartialEq<Rhs: ?Sized = Self> {
+        fn eq(&self, other: &Rhs) -> bool;
+
+        fn ne(&self, other: &Rhs) -> bool {
+            !self.eq(other)
         }
     }
 
-    pub mod cmp {
-        use super::marker::Sized;
-
-        #[lang = "eq"]
-        pub trait PartialEq<Rhs: ?Sized = Self> {
-            fn eq(&self, other: &Rhs) -> bool;
-
-            fn ne(&self, other: &Rhs) -> bool {
-                !self.eq(other)
-            }
-        }
-
-        pub trait Eq: PartialEq<Self> {
-            fn assert_receiver_is_total_eq(&self) {}
-        }
+    pub trait Eq: PartialEq<Self> {
+        fn assert_receiver_is_total_eq(&self) {}
     }
+}
 
-    pub mod ptr {
+pub mod ptr {
 
-        use super::cmp::{Eq, PartialEq};
+    use super::cmp::{Eq, PartialEq};
 
-        macro_rules! fnptr_impls_safety_abi {
+    macro_rules! fnptr_impls_safety_abi {
             ($FnTy: ty, $($Arg: ident),*) => {
                 #[stable(feature = "fnptr_impls", since = "1.4.0")]
                 impl<Ret, $($Arg),*> PartialEq for $FnTy {
@@ -62,8 +60,7 @@ mod core {
             }
         }
 
-        fnptr_impls_safety_abi! { extern "Rust" fn() -> Ret, }
-    }
+    fnptr_impls_safety_abi! { extern "Rust" fn() -> Ret, }
 }
 
 #[derive(PartialEq, Eq)]

--- a/gcc/testsuite/rust/compile/issue-4090-2.rs
+++ b/gcc/testsuite/rust/compile/issue-4090-2.rs
@@ -1,52 +1,50 @@
 #![feature(no_core)]
 #![no_core]
-
 #![feature(lang_items)]
 
-mod core {
-    mod marker {
-        #[lang = "sized"]
-        pub trait Sized {}
+mod marker {
+    #[lang = "sized"]
+    pub trait Sized {}
 
-        #[lang = "phantom_data"]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        pub struct PhantomData<T: ?Sized>;
+    #[lang = "phantom_data"]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub struct PhantomData<T: ?Sized>;
 
-        #[unstable(feature = "structural_match", issue = "31434")]
-        #[lang = "structural_teq"]
-        pub trait StructuralEq {
-            // Empty.
-        }
+    #[unstable(feature = "structural_match", issue = "31434")]
+    #[lang = "structural_teq"]
+    pub trait StructuralEq {
+        // Empty.
+    }
 
-        #[unstable(feature = "structural_match", issue = "31434")]
-        #[lang = "structural_peq"]
-        pub trait StructuralPartialEq {
-            // Empty.
+    #[unstable(feature = "structural_match", issue = "31434")]
+    #[lang = "structural_peq"]
+    pub trait StructuralPartialEq {
+        // Empty.
+    }
+}
+
+pub mod cmp {
+    use super::marker::Sized;
+
+    #[lang = "eq"]
+    pub trait PartialEq<Rhs: ?Sized = Self> {
+        fn eq(&self, other: &Rhs) -> bool;
+
+        fn ne(&self, other: &Rhs) -> bool {
+            !self.eq(other)
         }
     }
 
-    pub mod cmp {
-        use super::marker::Sized;
-
-        #[lang = "eq"]
-        pub trait PartialEq<Rhs: ?Sized = Self> {
-            fn eq(&self, other: &Rhs) -> bool;
-
-            fn ne(&self, other: &Rhs) -> bool {
-                !self.eq(other)
-            }
-        }
-
-        pub trait Eq: PartialEq<Self> {
-            fn assert_receiver_is_total_eq(&self) {}
-        }
+    pub trait Eq: PartialEq<Self> {
+        fn assert_receiver_is_total_eq(&self) {}
     }
+}
 
-    pub mod ptr {
+pub mod ptr {
 
-        use super::cmp::{Eq, PartialEq};
+    use super::cmp::{Eq, PartialEq};
 
-        macro_rules! fnptr_impls_safety_abi {
+    macro_rules! fnptr_impls_safety_abi {
             ($FnTy: ty, $($Arg: ident),*) => {
                 #[stable(feature = "fnptr_impls", since = "1.4.0")]
                 impl<Ret, $($Arg),*> PartialEq for $FnTy {
@@ -62,11 +60,10 @@ mod core {
             }
         }
 
-        fnptr_impls_safety_abi! { extern "Rust" fn() -> Ret, }
-        fnptr_impls_safety_abi! { extern "C" fn() -> Ret, }
-        fnptr_impls_safety_abi! { unsafe extern "Rust" fn() -> Ret, }
-        fnptr_impls_safety_abi! { unsafe extern "C" fn() -> Ret, }
-    }
+    fnptr_impls_safety_abi! { extern "Rust" fn() -> Ret, }
+    fnptr_impls_safety_abi! { extern "C" fn() -> Ret, }
+    fnptr_impls_safety_abi! { unsafe extern "Rust" fn() -> Ret, }
+    fnptr_impls_safety_abi! { unsafe extern "C" fn() -> Ret, }
 }
 
 #[derive(PartialEq, Eq)]

--- a/gcc/testsuite/rust/execute/torture/derive-default1.rs
+++ b/gcc/testsuite/rust/execute/torture/derive-default1.rs
@@ -1,26 +1,28 @@
 #![feature(no_core)]
 #![no_core]
-
 #![feature(lang_items)]
 
 #[derive(Default)]
-struct Foo { a: i32  }
+struct Foo {
+    a: i32,
+}
+
 #[derive(Default)]
 struct Bar(i32);
 
 #[lang = "sized"]
 trait Sized {}
 
-mod core {
-    mod default {
-        use crate::Sized;
+mod default {
+    use crate::Sized;
 
-        trait Default: Sized {
-            fn default() -> Self;
-        }
+    trait Default: Sized {
+        fn default() -> Self;
+    }
 
-        impl Default for i32 {
-            fn default() -> Self { 1 }
+    impl Default for i32 {
+        fn default() -> Self {
+            1
         }
     }
 }

--- a/gcc/testsuite/rust/execute/torture/derive-partialeq2.rs
+++ b/gcc/testsuite/rust/execute/torture/derive-partialeq2.rs
@@ -1,21 +1,17 @@
 // { dg-output "true\r*\nfalse\r*\nfalse\r*\nfalse\r*\nfalse\r*\n" }
 #![feature(no_core)]
 #![no_core]
-
-
 #![feature(intrinsics, lang_items)]
 
-pub mod core {
-    pub mod intrinsics {
-        #[lang = "discriminant_kind"]
-        pub trait DiscriminantKind {
-            #[lang = "discriminant_type"]
-            type Discriminant;
-        }
+pub mod intrinsics {
+    #[lang = "discriminant_kind"]
+    pub trait DiscriminantKind {
+        #[lang = "discriminant_type"]
+        type Discriminant;
+    }
 
-        extern "rust-intrinsic" {
-            pub fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discriminant;
-        }
+    extern "rust-intrinsic" {
+        pub fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discriminant;
     }
 }
 

--- a/gcc/testsuite/rust/execute/torture/issue-2005.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-2005.rs
@@ -2,349 +2,346 @@
 /* { dg-output "WORKS\r?\n" } */
 #![feature(no_core)]
 #![no_core]
-
 #![feature(intrinsics, lang_items)]
 
-mod core {
-    mod option {
-        // #[rustc_diagnostic_item = "option_type"]
+mod option {
+    // #[rustc_diagnostic_item = "option_type"]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub enum Option<T> {
+        /// No value
+        #[lang = "None"]
         #[stable(feature = "rust1", since = "1.0.0")]
-        pub enum Option<T> {
-            /// No value
-            #[lang = "None"]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            None,
-            /// Some value `T`
-            #[lang = "Some"]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+        None,
+        /// Some value `T`
+        #[lang = "Some"]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+    }
+}
+
+mod marker {
+    #[lang = "phantom_data"]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub struct PhantomData<T: ?Sized>;
+
+    #[unstable(feature = "structural_match", issue = "31434")]
+    // #[rustc_on_unimplemented(message = "the type `{Self}` does not `#[derive(PartialEq)]`")]
+    #[lang = "structural_peq"]
+    pub trait StructuralPartialEq {
+        // Empty.
+    }
+
+    #[unstable(feature = "structural_match", issue = "31434")]
+    // #[rustc_on_unimplemented(message = "the type `{Self}` does not `#[derive(Eq)]`")]
+    #[lang = "structural_teq"]
+    pub trait StructuralEq {
+        // Empty.
+    }
+
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[lang = "sized"]
+    // #[rustc_on_unimplemented(
+    //     message = "the size for values of type `{Self}` cannot be known at compilation time",
+    //     label = "doesn't have a size known at compile-time"
+    // )]
+    // #[fundamental] // for Default, for example, which requires that `[T]: !Default` be evaluatable
+    // #[rustc_specialization_trait]
+    pub trait Sized {
+        // Empty.
+    }
+}
+
+mod cmp {
+    use super::marker::Sized;
+    use super::option::Option;
+
+    // #[derive(Clone, Copy, PartialEq, Debug, Hash)]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub enum Ordering {
+        /// An ordering where a compared value is less than another.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        Less = -1,
+        /// An ordering where a compared value is equal to another.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        Equal = 0,
+        /// An ordering where a compared value is greater than another.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        Greater = 1,
+    }
+
+    #[lang = "eq"]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(alias = "==")]
+    #[doc(alias = "!=")]
+    // #[rustc_on_unimplemented(
+    //     message = "can't compare `{Self}` with `{Rhs}`",
+    //     label = "no implementation for `{Self} == {Rhs}`"
+    // )]
+    pub trait PartialEq<Rhs: ?Sized = Self> {
+        /// This method tests for `self` and `other` values to be equal, and is used
+        /// by `==`.
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn eq(&self, other: &Rhs) -> bool;
+
+        fn ne(&self, other: &Rhs) -> bool {
+            !self.eq(other)
         }
     }
 
-    mod marker {
-        #[lang = "phantom_data"]
+    #[doc(alias = "==")]
+    #[doc(alias = "!=")]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub trait Eq: PartialEq<Self> {
+        // this method is used solely by #[deriving] to assert
+        // that every component of a type implements #[deriving]
+        // itself, the current deriving infrastructure means doing this
+        // assertion without using a method on this trait is nearly
+        // impossible.
+        //
+        // This should never be implemented by hand.
+        #[doc(hidden)]
         #[stable(feature = "rust1", since = "1.0.0")]
-        pub struct PhantomData<T: ?Sized>;
+        fn assert_receiver_is_total_eq(&self) {}
+    }
 
-        #[unstable(feature = "structural_match", issue = "31434")]
-        // #[rustc_on_unimplemented(message = "the type `{Self}` does not `#[derive(PartialEq)]`")]
-        #[lang = "structural_peq"]
-        pub trait StructuralPartialEq {
-            // Empty.
+    #[lang = "partial_ord"]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(alias = ">")]
+    #[doc(alias = "<")]
+    #[doc(alias = "<=")]
+    #[doc(alias = ">=")]
+    // #[rustc_on_unimplemented(
+    //     message = "can't compare `{Self}` with `{Rhs}`",
+    //     label = "no implementation for `{Self} < {Rhs}` and `{Self} > {Rhs}`"
+    // )]
+    pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
+        /// This method returns an ordering between `self` and `other` values if one exists.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use std::cmp::Ordering;
+        ///
+        /// let result = 1.0.partial_cmp(&2.0);
+        /// assert_eq!(result, Some(Ordering::Less));
+        ///
+        /// let result = 1.0.partial_cmp(&1.0);
+        /// assert_eq!(result, Some(Ordering::Equal));
+        ///
+        /// let result = 2.0.partial_cmp(&1.0);
+        /// assert_eq!(result, Some(Ordering::Greater));
+        /// ```
+        ///
+        /// When comparison is impossible:
+        ///
+        /// ```
+        /// let result = f64::NAN.partial_cmp(&1.0);
+        /// assert_eq!(result, None);
+        /// ```
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn partial_cmp(&self, other: &Rhs) -> Option<Ordering>;
+
+        /// This method tests less than (for `self` and `other`) and is used by the `<` operator.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// let result = 1.0 < 2.0;
+        /// assert_eq!(result, true);
+        ///
+        /// let result = 2.0 < 1.0;
+        /// assert_eq!(result, false);
+        /// ```
+        #[inline]
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn lt(&self, other: &Rhs) -> bool {
+            match self.partial_cmp(other) {
+                Option::Some(Ordering::Less) => true,
+                _ => false,
+            }
         }
 
-        #[unstable(feature = "structural_match", issue = "31434")]
-        // #[rustc_on_unimplemented(message = "the type `{Self}` does not `#[derive(Eq)]`")]
-        #[lang = "structural_teq"]
-        pub trait StructuralEq {
-            // Empty.
+        /// This method tests less than or equal to (for `self` and `other`) and is used by the `<=`
+        /// operator.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// let result = 1.0 <= 2.0;
+        /// assert_eq!(result, true);
+        ///
+        /// let result = 2.0 <= 2.0;
+        /// assert_eq!(result, true);
+        /// ```
+        #[inline]
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn le(&self, other: &Rhs) -> bool {
+            match self.partial_cmp(other) {
+                Option::Some(Ordering::Less | Ordering::Equal) => true,
+                _ => false,
+            }
         }
 
+        /// This method tests greater than (for `self` and `other`) and is used by the `>` operator.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// let result = 1.0 > 2.0;
+        /// assert_eq!(result, false);
+        ///
+        /// let result = 2.0 > 2.0;
+        /// assert_eq!(result, false);
+        /// ```
+        #[inline]
+        #[must_use]
         #[stable(feature = "rust1", since = "1.0.0")]
-        #[lang = "sized"]
-        // #[rustc_on_unimplemented(
-        //     message = "the size for values of type `{Self}` cannot be known at compilation time",
-        //     label = "doesn't have a size known at compile-time"
-        // )]
-        // #[fundamental] // for Default, for example, which requires that `[T]: !Default` be evaluatable
-        // #[rustc_specialization_trait]
-        pub trait Sized {
-            // Empty.
+        fn gt(&self, other: &Rhs) -> bool {
+            match self.partial_cmp(other) {
+                Option::Some(Ordering::Greater) => true,
+                _ => false,
+            }
+        }
+
+        /// This method tests greater than or equal to (for `self` and `other`) and is used by the `>=`
+        /// operator.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// let result = 2.0 >= 1.0;
+        /// assert_eq!(result, true);
+        ///
+        /// let result = 2.0 >= 2.0;
+        /// assert_eq!(result, true);
+        /// ```
+        #[inline]
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn ge(&self, other: &Rhs) -> bool {
+            match self.partial_cmp(other) {
+                Option::Some(Ordering::Greater | Ordering::Equal) => true,
+                _ => false,
+            }
         }
     }
 
-    mod cmp {
-        use super::marker::Sized;
-        use super::option::Option;
-
-        // #[derive(Clone, Copy, PartialEq, Debug, Hash)]
+    #[doc(alias = "<")]
+    #[doc(alias = ">")]
+    #[doc(alias = "<=")]
+    #[doc(alias = ">=")]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub trait Ord: Eq + PartialOrd<Self> {
+        /// This method returns an [`Ordering`] between `self` and `other`.
+        ///
+        /// By convention, `self.cmp(&other)` returns the ordering matching the expression
+        /// `self <operator> other` if true.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use std::cmp::Ordering;
+        ///
+        /// assert_eq!(5.cmp(&10), Ordering::Less);
+        /// assert_eq!(10.cmp(&5), Ordering::Greater);
+        /// assert_eq!(5.cmp(&5), Ordering::Equal);
+        /// ```
+        #[must_use]
         #[stable(feature = "rust1", since = "1.0.0")]
-        pub enum Ordering {
-            /// An ordering where a compared value is less than another.
-            #[stable(feature = "rust1", since = "1.0.0")]
-            Less = -1,
-            /// An ordering where a compared value is equal to another.
-            #[stable(feature = "rust1", since = "1.0.0")]
-            Equal = 0,
-            /// An ordering where a compared value is greater than another.
-            #[stable(feature = "rust1", since = "1.0.0")]
-            Greater = 1,
+        fn cmp(&self, other: &Self) -> Ordering;
+
+        /// Compares and returns the maximum of two values.
+        ///
+        /// Returns the second argument if the comparison determines them to be equal.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// assert_eq!(2, 1.max(2));
+        /// assert_eq!(2, 2.max(2));
+        /// ```
+        #[stable(feature = "ord_max_min", since = "1.21.0")]
+        #[must_use]
+        fn max(self, other: Self) -> Self
+        where
+            Self: Sized,
+        {
+            self
         }
 
-        #[lang = "eq"]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[doc(alias = "==")]
-        #[doc(alias = "!=")]
-        // #[rustc_on_unimplemented(
-        //     message = "can't compare `{Self}` with `{Rhs}`",
-        //     label = "no implementation for `{Self} == {Rhs}`"
-        // )]
-        pub trait PartialEq<Rhs: ?Sized = Self> {
-            /// This method tests for `self` and `other` values to be equal, and is used
-            /// by `==`.
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn eq(&self, other: &Rhs) -> bool;
-
-            fn ne(&self, other: &Rhs) -> bool {
-                !self.eq(other)
-            }
+        /// Compares and returns the minimum of two values.
+        ///
+        /// Returns the first argument if the comparison determines them to be equal.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// assert_eq!(1, 1.min(2));
+        /// assert_eq!(2, 2.min(2));
+        /// ```
+        #[stable(feature = "ord_max_min", since = "1.21.0")]
+        #[must_use]
+        fn min(self, other: Self) -> Self
+        where
+            Self: Sized,
+        {
+            self
         }
 
-        #[doc(alias = "==")]
-        #[doc(alias = "!=")]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        pub trait Eq: PartialEq<Self> {
-            // this method is used solely by #[deriving] to assert
-            // that every component of a type implements #[deriving]
-            // itself, the current deriving infrastructure means doing this
-            // assertion without using a method on this trait is nearly
-            // impossible.
-            //
-            // This should never be implemented by hand.
-            #[doc(hidden)]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn assert_receiver_is_total_eq(&self) {}
-        }
-
-        #[lang = "partial_ord"]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[doc(alias = ">")]
-        #[doc(alias = "<")]
-        #[doc(alias = "<=")]
-        #[doc(alias = ">=")]
-        // #[rustc_on_unimplemented(
-        //     message = "can't compare `{Self}` with `{Rhs}`",
-        //     label = "no implementation for `{Self} < {Rhs}` and `{Self} > {Rhs}`"
-        // )]
-        pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
-            /// This method returns an ordering between `self` and `other` values if one exists.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// use std::cmp::Ordering;
-            ///
-            /// let result = 1.0.partial_cmp(&2.0);
-            /// assert_eq!(result, Some(Ordering::Less));
-            ///
-            /// let result = 1.0.partial_cmp(&1.0);
-            /// assert_eq!(result, Some(Ordering::Equal));
-            ///
-            /// let result = 2.0.partial_cmp(&1.0);
-            /// assert_eq!(result, Some(Ordering::Greater));
-            /// ```
-            ///
-            /// When comparison is impossible:
-            ///
-            /// ```
-            /// let result = f64::NAN.partial_cmp(&1.0);
-            /// assert_eq!(result, None);
-            /// ```
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn partial_cmp(&self, other: &Rhs) -> Option<Ordering>;
-
-            /// This method tests less than (for `self` and `other`) and is used by the `<` operator.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// let result = 1.0 < 2.0;
-            /// assert_eq!(result, true);
-            ///
-            /// let result = 2.0 < 1.0;
-            /// assert_eq!(result, false);
-            /// ```
-            #[inline]
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn lt(&self, other: &Rhs) -> bool {
-                match self.partial_cmp(other) {
-                    Option::Some(Ordering::Less) => true,
-                    _ => false,
-                }
-            }
-
-            /// This method tests less than or equal to (for `self` and `other`) and is used by the `<=`
-            /// operator.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// let result = 1.0 <= 2.0;
-            /// assert_eq!(result, true);
-            ///
-            /// let result = 2.0 <= 2.0;
-            /// assert_eq!(result, true);
-            /// ```
-            #[inline]
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn le(&self, other: &Rhs) -> bool {
-                match self.partial_cmp(other) {
-                    Option::Some(Ordering::Less | Ordering::Equal) => true,
-                    _ => false,
-                }
-            }
-
-            /// This method tests greater than (for `self` and `other`) and is used by the `>` operator.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// let result = 1.0 > 2.0;
-            /// assert_eq!(result, false);
-            ///
-            /// let result = 2.0 > 2.0;
-            /// assert_eq!(result, false);
-            /// ```
-            #[inline]
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn gt(&self, other: &Rhs) -> bool {
-                match self.partial_cmp(other) {
-                    Option::Some(Ordering::Greater) => true,
-                    _ => false,
-                }
-            }
-
-            /// This method tests greater than or equal to (for `self` and `other`) and is used by the `>=`
-            /// operator.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// let result = 2.0 >= 1.0;
-            /// assert_eq!(result, true);
-            ///
-            /// let result = 2.0 >= 2.0;
-            /// assert_eq!(result, true);
-            /// ```
-            #[inline]
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn ge(&self, other: &Rhs) -> bool {
-                match self.partial_cmp(other) {
-                    Option::Some(Ordering::Greater | Ordering::Equal) => true,
-                    _ => false,
-                }
-            }
-        }
-
-        #[doc(alias = "<")]
-        #[doc(alias = ">")]
-        #[doc(alias = "<=")]
-        #[doc(alias = ">=")]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        pub trait Ord: Eq + PartialOrd<Self> {
-            /// This method returns an [`Ordering`] between `self` and `other`.
-            ///
-            /// By convention, `self.cmp(&other)` returns the ordering matching the expression
-            /// `self <operator> other` if true.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// use std::cmp::Ordering;
-            ///
-            /// assert_eq!(5.cmp(&10), Ordering::Less);
-            /// assert_eq!(10.cmp(&5), Ordering::Greater);
-            /// assert_eq!(5.cmp(&5), Ordering::Equal);
-            /// ```
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn cmp(&self, other: &Self) -> Ordering;
-
-            /// Compares and returns the maximum of two values.
-            ///
-            /// Returns the second argument if the comparison determines them to be equal.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// assert_eq!(2, 1.max(2));
-            /// assert_eq!(2, 2.max(2));
-            /// ```
-            #[stable(feature = "ord_max_min", since = "1.21.0")]
-            #[must_use]
-            fn max(self, other: Self) -> Self
-            where
-                Self: Sized,
-            {
+        /// Restrict a value to a certain interval.
+        ///
+        /// Returns `max` if `self` is greater than `max`, and `min` if `self` is
+        /// less than `min`. Otherwise this returns `self`.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `min > max`.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(clamp)]
+        ///
+        /// assert!((-3).clamp(-2, 1) == -2);
+        /// assert!(0.clamp(-2, 1) == 0);
+        /// assert!(2.clamp(-2, 1) == 1);
+        /// ```
+        #[must_use]
+        #[unstable(feature = "clamp", issue = "44095")]
+        fn clamp(self, min: Self, max: Self) -> Self
+        where
+            Self: Sized,
+        {
+            if self < min {
+                min
+            } else if self > max {
+                max
+            } else {
                 self
             }
-
-            /// Compares and returns the minimum of two values.
-            ///
-            /// Returns the first argument if the comparison determines them to be equal.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// assert_eq!(1, 1.min(2));
-            /// assert_eq!(2, 2.min(2));
-            /// ```
-            #[stable(feature = "ord_max_min", since = "1.21.0")]
-            #[must_use]
-            fn min(self, other: Self) -> Self
-            where
-                Self: Sized,
-            {
-                self
-            }
-
-            /// Restrict a value to a certain interval.
-            ///
-            /// Returns `max` if `self` is greater than `max`, and `min` if `self` is
-            /// less than `min`. Otherwise this returns `self`.
-            ///
-            /// # Panics
-            ///
-            /// Panics if `min > max`.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// #![feature(clamp)]
-            ///
-            /// assert!((-3).clamp(-2, 1) == -2);
-            /// assert!(0.clamp(-2, 1) == 0);
-            /// assert!(2.clamp(-2, 1) == 1);
-            /// ```
-            #[must_use]
-            #[unstable(feature = "clamp", issue = "44095")]
-            fn clamp(self, min: Self, max: Self) -> Self
-            where
-                Self: Sized,
-            {
-                if self < min {
-                    min
-                } else if self > max {
-                    max
-                } else {
-                    self
-                }
-            }
-        }
-    }
-
-    pub mod intrinsics {
-        #[lang = "discriminant_kind"]
-        pub trait DiscriminantKind {
-            #[lang = "discriminant_type"]
-            type Discriminant;
-        }
-
-        extern "rust-intrinsic" {
-            pub fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discriminant;
         }
     }
 }
 
-use core::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
-use core::marker::Sized;
-use core::option::Option;
+pub mod intrinsics {
+    #[lang = "discriminant_kind"]
+    pub trait DiscriminantKind {
+        #[lang = "discriminant_type"]
+        type Discriminant;
+    }
+
+    extern "rust-intrinsic" {
+        pub fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discriminant;
+    }
+}
+
+use crate::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
+use crate::marker::Sized;
+use crate::option::Option;
 
 // --------------
 

--- a/gcc/testsuite/rust/execute/torture/issue-3836.rs
+++ b/gcc/testsuite/rust/execute/torture/issue-3836.rs
@@ -2,350 +2,346 @@
 // { dg-output "less\r*\n" }
 #![feature(no_core)]
 #![no_core]
-
-
 #![feature(intrinsics, lang_items)]
 
-mod core {
-    mod option {
-        // #[rustc_diagnostic_item = "option_type"]
+mod option {
+    // #[rustc_diagnostic_item = "option_type"]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub enum Option<T> {
+        /// No value
+        #[lang = "None"]
         #[stable(feature = "rust1", since = "1.0.0")]
-        pub enum Option<T> {
-            /// No value
-            #[lang = "None"]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            None,
-            /// Some value `T`
-            #[lang = "Some"]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+        None,
+        /// Some value `T`
+        #[lang = "Some"]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+    }
+}
+
+mod marker {
+    #[lang = "phantom_data"]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub struct PhantomData<T: ?Sized>;
+
+    #[unstable(feature = "structural_match", issue = "31434")]
+    // #[rustc_on_unimplemented(message = "the type `{Self}` does not `#[derive(PartialEq)]`")]
+    #[lang = "structural_peq"]
+    pub trait StructuralPartialEq {
+        // Empty.
+    }
+
+    #[unstable(feature = "structural_match", issue = "31434")]
+    // #[rustc_on_unimplemented(message = "the type `{Self}` does not `#[derive(Eq)]`")]
+    #[lang = "structural_teq"]
+    pub trait StructuralEq {
+        // Empty.
+    }
+
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[lang = "sized"]
+    // #[rustc_on_unimplemented(
+    //     message = "the size for values of type `{Self}` cannot be known at compilation time",
+    //     label = "doesn't have a size known at compile-time"
+    // )]
+    // #[fundamental] // for Default, for example, which requires that `[T]: !Default` be evaluatable
+    // #[rustc_specialization_trait]
+    pub trait Sized {
+        // Empty.
+    }
+}
+
+mod cmp {
+    use super::marker::Sized;
+    use super::option::Option;
+
+    // #[derive(Clone, Copy, PartialEq, Debug, Hash)]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub enum Ordering {
+        /// An ordering where a compared value is less than another.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        Less = -1,
+        /// An ordering where a compared value is equal to another.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        Equal = 0,
+        /// An ordering where a compared value is greater than another.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        Greater = 1,
+    }
+
+    #[lang = "eq"]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(alias = "==")]
+    #[doc(alias = "!=")]
+    // #[rustc_on_unimplemented(
+    //     message = "can't compare `{Self}` with `{Rhs}`",
+    //     label = "no implementation for `{Self} == {Rhs}`"
+    // )]
+    pub trait PartialEq<Rhs: ?Sized = Self> {
+        /// This method tests for `self` and `other` values to be equal, and is used
+        /// by `==`.
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn eq(&self, other: &Rhs) -> bool;
+
+        fn ne(&self, other: &Rhs) -> bool {
+            !self.eq(other)
         }
     }
 
-    mod marker {
-        #[lang = "phantom_data"]
+    #[doc(alias = "==")]
+    #[doc(alias = "!=")]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub trait Eq: PartialEq<Self> {
+        // this method is used solely by #[deriving] to assert
+        // that every component of a type implements #[deriving]
+        // itself, the current deriving infrastructure means doing this
+        // assertion without using a method on this trait is nearly
+        // impossible.
+        //
+        // This should never be implemented by hand.
+        #[doc(hidden)]
         #[stable(feature = "rust1", since = "1.0.0")]
-        pub struct PhantomData<T: ?Sized>;
+        fn assert_receiver_is_total_eq(&self) {}
+    }
 
-        #[unstable(feature = "structural_match", issue = "31434")]
-        // #[rustc_on_unimplemented(message = "the type `{Self}` does not `#[derive(PartialEq)]`")]
-        #[lang = "structural_peq"]
-        pub trait StructuralPartialEq {
-            // Empty.
+    #[lang = "partial_ord"]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(alias = ">")]
+    #[doc(alias = "<")]
+    #[doc(alias = "<=")]
+    #[doc(alias = ">=")]
+    // #[rustc_on_unimplemented(
+    //     message = "can't compare `{Self}` with `{Rhs}`",
+    //     label = "no implementation for `{Self} < {Rhs}` and `{Self} > {Rhs}`"
+    // )]
+    pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
+        /// This method returns an ordering between `self` and `other` values if one exists.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use std::cmp::Ordering;
+        ///
+        /// let result = 1.0.partial_cmp(&2.0);
+        /// assert_eq!(result, Some(Ordering::Less));
+        ///
+        /// let result = 1.0.partial_cmp(&1.0);
+        /// assert_eq!(result, Some(Ordering::Equal));
+        ///
+        /// let result = 2.0.partial_cmp(&1.0);
+        /// assert_eq!(result, Some(Ordering::Greater));
+        /// ```
+        ///
+        /// When comparison is impossible:
+        ///
+        /// ```
+        /// let result = f64::NAN.partial_cmp(&1.0);
+        /// assert_eq!(result, None);
+        /// ```
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn partial_cmp(&self, other: &Rhs) -> Option<Ordering>;
+
+        /// This method tests less than (for `self` and `other`) and is used by the `<` operator.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// let result = 1.0 < 2.0;
+        /// assert_eq!(result, true);
+        ///
+        /// let result = 2.0 < 1.0;
+        /// assert_eq!(result, false);
+        /// ```
+        #[inline]
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn lt(&self, other: &Rhs) -> bool {
+            match self.partial_cmp(other) {
+                Option::Some(Ordering::Less) => true,
+                _ => false,
+            }
         }
 
-        #[unstable(feature = "structural_match", issue = "31434")]
-        // #[rustc_on_unimplemented(message = "the type `{Self}` does not `#[derive(Eq)]`")]
-        #[lang = "structural_teq"]
-        pub trait StructuralEq {
-            // Empty.
+        /// This method tests less than or equal to (for `self` and `other`) and is used by the `<=`
+        /// operator.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// let result = 1.0 <= 2.0;
+        /// assert_eq!(result, true);
+        ///
+        /// let result = 2.0 <= 2.0;
+        /// assert_eq!(result, true);
+        /// ```
+        #[inline]
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn le(&self, other: &Rhs) -> bool {
+            match self.partial_cmp(other) {
+                Option::Some(Ordering::Less | Ordering::Equal) => true,
+                _ => false,
+            }
         }
 
+        /// This method tests greater than (for `self` and `other`) and is used by the `>` operator.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// let result = 1.0 > 2.0;
+        /// assert_eq!(result, false);
+        ///
+        /// let result = 2.0 > 2.0;
+        /// assert_eq!(result, false);
+        /// ```
+        #[inline]
+        #[must_use]
         #[stable(feature = "rust1", since = "1.0.0")]
-        #[lang = "sized"]
-        // #[rustc_on_unimplemented(
-        //     message = "the size for values of type `{Self}` cannot be known at compilation time",
-        //     label = "doesn't have a size known at compile-time"
-        // )]
-        // #[fundamental] // for Default, for example, which requires that `[T]: !Default` be evaluatable
-        // #[rustc_specialization_trait]
-        pub trait Sized {
-            // Empty.
+        fn gt(&self, other: &Rhs) -> bool {
+            match self.partial_cmp(other) {
+                Option::Some(Ordering::Greater) => true,
+                _ => false,
+            }
+        }
+
+        /// This method tests greater than or equal to (for `self` and `other`) and is used by the `>=`
+        /// operator.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// let result = 2.0 >= 1.0;
+        /// assert_eq!(result, true);
+        ///
+        /// let result = 2.0 >= 2.0;
+        /// assert_eq!(result, true);
+        /// ```
+        #[inline]
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn ge(&self, other: &Rhs) -> bool {
+            match self.partial_cmp(other) {
+                Option::Some(Ordering::Greater | Ordering::Equal) => true,
+                _ => false,
+            }
         }
     }
 
-    mod cmp {
-        use super::marker::Sized;
-        use super::option::Option;
-
-        // #[derive(Clone, Copy, PartialEq, Debug, Hash)]
+    #[doc(alias = "<")]
+    #[doc(alias = ">")]
+    #[doc(alias = "<=")]
+    #[doc(alias = ">=")]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub trait Ord: Eq + PartialOrd<Self> {
+        /// This method returns an [`Ordering`] between `self` and `other`.
+        ///
+        /// By convention, `self.cmp(&other)` returns the ordering matching the expression
+        /// `self <operator> other` if true.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use std::cmp::Ordering;
+        ///
+        /// assert_eq!(5.cmp(&10), Ordering::Less);
+        /// assert_eq!(10.cmp(&5), Ordering::Greater);
+        /// assert_eq!(5.cmp(&5), Ordering::Equal);
+        /// ```
+        #[must_use]
         #[stable(feature = "rust1", since = "1.0.0")]
-        pub enum Ordering {
-            /// An ordering where a compared value is less than another.
-            #[stable(feature = "rust1", since = "1.0.0")]
-            Less = -1,
-            /// An ordering where a compared value is equal to another.
-            #[stable(feature = "rust1", since = "1.0.0")]
-            Equal = 0,
-            /// An ordering where a compared value is greater than another.
-            #[stable(feature = "rust1", since = "1.0.0")]
-            Greater = 1,
+        fn cmp(&self, other: &Self) -> Ordering;
+
+        /// Compares and returns the maximum of two values.
+        ///
+        /// Returns the second argument if the comparison determines them to be equal.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// assert_eq!(2, 1.max(2));
+        /// assert_eq!(2, 2.max(2));
+        /// ```
+        #[stable(feature = "ord_max_min", since = "1.21.0")]
+        #[must_use]
+        fn max(self, other: Self) -> Self
+        where
+            Self: Sized,
+        {
+            self
         }
 
-        #[lang = "eq"]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[doc(alias = "==")]
-        #[doc(alias = "!=")]
-        // #[rustc_on_unimplemented(
-        //     message = "can't compare `{Self}` with `{Rhs}`",
-        //     label = "no implementation for `{Self} == {Rhs}`"
-        // )]
-        pub trait PartialEq<Rhs: ?Sized = Self> {
-            /// This method tests for `self` and `other` values to be equal, and is used
-            /// by `==`.
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn eq(&self, other: &Rhs) -> bool;
-
-            fn ne(&self, other: &Rhs) -> bool {
-                !self.eq(other)
-            }
+        /// Compares and returns the minimum of two values.
+        ///
+        /// Returns the first argument if the comparison determines them to be equal.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// assert_eq!(1, 1.min(2));
+        /// assert_eq!(2, 2.min(2));
+        /// ```
+        #[stable(feature = "ord_max_min", since = "1.21.0")]
+        #[must_use]
+        fn min(self, other: Self) -> Self
+        where
+            Self: Sized,
+        {
+            self
         }
 
-        #[doc(alias = "==")]
-        #[doc(alias = "!=")]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        pub trait Eq: PartialEq<Self> {
-            // this method is used solely by #[deriving] to assert
-            // that every component of a type implements #[deriving]
-            // itself, the current deriving infrastructure means doing this
-            // assertion without using a method on this trait is nearly
-            // impossible.
-            //
-            // This should never be implemented by hand.
-            #[doc(hidden)]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn assert_receiver_is_total_eq(&self) {}
-        }
-
-        #[lang = "partial_ord"]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[doc(alias = ">")]
-        #[doc(alias = "<")]
-        #[doc(alias = "<=")]
-        #[doc(alias = ">=")]
-        // #[rustc_on_unimplemented(
-        //     message = "can't compare `{Self}` with `{Rhs}`",
-        //     label = "no implementation for `{Self} < {Rhs}` and `{Self} > {Rhs}`"
-        // )]
-        pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
-            /// This method returns an ordering between `self` and `other` values if one exists.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// use std::cmp::Ordering;
-            ///
-            /// let result = 1.0.partial_cmp(&2.0);
-            /// assert_eq!(result, Some(Ordering::Less));
-            ///
-            /// let result = 1.0.partial_cmp(&1.0);
-            /// assert_eq!(result, Some(Ordering::Equal));
-            ///
-            /// let result = 2.0.partial_cmp(&1.0);
-            /// assert_eq!(result, Some(Ordering::Greater));
-            /// ```
-            ///
-            /// When comparison is impossible:
-            ///
-            /// ```
-            /// let result = f64::NAN.partial_cmp(&1.0);
-            /// assert_eq!(result, None);
-            /// ```
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn partial_cmp(&self, other: &Rhs) -> Option<Ordering>;
-
-            /// This method tests less than (for `self` and `other`) and is used by the `<` operator.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// let result = 1.0 < 2.0;
-            /// assert_eq!(result, true);
-            ///
-            /// let result = 2.0 < 1.0;
-            /// assert_eq!(result, false);
-            /// ```
-            #[inline]
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn lt(&self, other: &Rhs) -> bool {
-                match self.partial_cmp(other) {
-                    Option::Some(Ordering::Less) => true,
-                    _ => false,
-                }
-            }
-
-            /// This method tests less than or equal to (for `self` and `other`) and is used by the `<=`
-            /// operator.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// let result = 1.0 <= 2.0;
-            /// assert_eq!(result, true);
-            ///
-            /// let result = 2.0 <= 2.0;
-            /// assert_eq!(result, true);
-            /// ```
-            #[inline]
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn le(&self, other: &Rhs) -> bool {
-                match self.partial_cmp(other) {
-                    Option::Some(Ordering::Less | Ordering::Equal) => true,
-                    _ => false,
-                }
-            }
-
-            /// This method tests greater than (for `self` and `other`) and is used by the `>` operator.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// let result = 1.0 > 2.0;
-            /// assert_eq!(result, false);
-            ///
-            /// let result = 2.0 > 2.0;
-            /// assert_eq!(result, false);
-            /// ```
-            #[inline]
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn gt(&self, other: &Rhs) -> bool {
-                match self.partial_cmp(other) {
-                    Option::Some(Ordering::Greater) => true,
-                    _ => false,
-                }
-            }
-
-            /// This method tests greater than or equal to (for `self` and `other`) and is used by the `>=`
-            /// operator.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// let result = 2.0 >= 1.0;
-            /// assert_eq!(result, true);
-            ///
-            /// let result = 2.0 >= 2.0;
-            /// assert_eq!(result, true);
-            /// ```
-            #[inline]
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn ge(&self, other: &Rhs) -> bool {
-                match self.partial_cmp(other) {
-                    Option::Some(Ordering::Greater | Ordering::Equal) => true,
-                    _ => false,
-                }
-            }
-        }
-
-        #[doc(alias = "<")]
-        #[doc(alias = ">")]
-        #[doc(alias = "<=")]
-        #[doc(alias = ">=")]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        pub trait Ord: Eq + PartialOrd<Self> {
-            /// This method returns an [`Ordering`] between `self` and `other`.
-            ///
-            /// By convention, `self.cmp(&other)` returns the ordering matching the expression
-            /// `self <operator> other` if true.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// use std::cmp::Ordering;
-            ///
-            /// assert_eq!(5.cmp(&10), Ordering::Less);
-            /// assert_eq!(10.cmp(&5), Ordering::Greater);
-            /// assert_eq!(5.cmp(&5), Ordering::Equal);
-            /// ```
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn cmp(&self, other: &Self) -> Ordering;
-
-            /// Compares and returns the maximum of two values.
-            ///
-            /// Returns the second argument if the comparison determines them to be equal.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// assert_eq!(2, 1.max(2));
-            /// assert_eq!(2, 2.max(2));
-            /// ```
-            #[stable(feature = "ord_max_min", since = "1.21.0")]
-            #[must_use]
-            fn max(self, other: Self) -> Self
-            where
-                Self: Sized,
-            {
+        /// Restrict a value to a certain interval.
+        ///
+        /// Returns `max` if `self` is greater than `max`, and `min` if `self` is
+        /// less than `min`. Otherwise this returns `self`.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `min > max`.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(clamp)]
+        ///
+        /// assert!((-3).clamp(-2, 1) == -2);
+        /// assert!(0.clamp(-2, 1) == 0);
+        /// assert!(2.clamp(-2, 1) == 1);
+        /// ```
+        #[must_use]
+        #[unstable(feature = "clamp", issue = "44095")]
+        fn clamp(self, min: Self, max: Self) -> Self
+        where
+            Self: Sized,
+        {
+            if self < min {
+                min
+            } else if self > max {
+                max
+            } else {
                 self
             }
-
-            /// Compares and returns the minimum of two values.
-            ///
-            /// Returns the first argument if the comparison determines them to be equal.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// assert_eq!(1, 1.min(2));
-            /// assert_eq!(2, 2.min(2));
-            /// ```
-            #[stable(feature = "ord_max_min", since = "1.21.0")]
-            #[must_use]
-            fn min(self, other: Self) -> Self
-            where
-                Self: Sized,
-            {
-                self
-            }
-
-            /// Restrict a value to a certain interval.
-            ///
-            /// Returns `max` if `self` is greater than `max`, and `min` if `self` is
-            /// less than `min`. Otherwise this returns `self`.
-            ///
-            /// # Panics
-            ///
-            /// Panics if `min > max`.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// #![feature(clamp)]
-            ///
-            /// assert!((-3).clamp(-2, 1) == -2);
-            /// assert!(0.clamp(-2, 1) == 0);
-            /// assert!(2.clamp(-2, 1) == 1);
-            /// ```
-            #[must_use]
-            #[unstable(feature = "clamp", issue = "44095")]
-            fn clamp(self, min: Self, max: Self) -> Self
-            where
-                Self: Sized,
-            {
-                if self < min {
-                    min
-                } else if self > max {
-                    max
-                } else {
-                    self
-                }
-            }
-        }
-    }
-
-    pub mod intrinsics {
-        #[lang = "discriminant_kind"]
-        pub trait DiscriminantKind {
-            #[lang = "discriminant_type"]
-            type Discriminant;
-        }
-
-        extern "rust-intrinsic" {
-            pub fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discriminant;
         }
     }
 }
 
-use core::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
-use core::marker::Sized;
-use core::option::Option;
+pub mod intrinsics {
+    #[lang = "discriminant_kind"]
+    pub trait DiscriminantKind {
+        #[lang = "discriminant_type"]
+        type Discriminant;
+    }
+
+    extern "rust-intrinsic" {
+        pub fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discriminant;
+    }
+}
+
+use crate::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
+use crate::marker::Sized;
+use crate::option::Option;
 
 // for comparing discriminant_value
 impl PartialEq for isize {

--- a/gcc/testsuite/rust/execute/torture/partial-eq-4.rs
+++ b/gcc/testsuite/rust/execute/torture/partial-eq-4.rs
@@ -2,350 +2,346 @@
 /* { dg-options "-w" } */
 #![feature(no_core)]
 #![no_core]
-
-
 #![feature(intrinsics, lang_items)]
 
-mod core {
-    mod option {
-        // #[rustc_diagnostic_item = "option_type"]
+mod option {
+    // #[rustc_diagnostic_item = "option_type"]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub enum Option<T> {
+        /// No value
+        #[lang = "None"]
         #[stable(feature = "rust1", since = "1.0.0")]
-        pub enum Option<T> {
-            /// No value
-            #[lang = "None"]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            None,
-            /// Some value `T`
-            #[lang = "Some"]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+        None,
+        /// Some value `T`
+        #[lang = "Some"]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+    }
+}
+
+mod marker {
+    #[lang = "phantom_data"]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub struct PhantomData<T: ?Sized>;
+
+    #[unstable(feature = "structural_match", issue = "31434")]
+    // #[rustc_on_unimplemented(message = "the type `{Self}` does not `#[derive(PartialEq)]`")]
+    #[lang = "structural_peq"]
+    pub trait StructuralPartialEq {
+        // Empty.
+    }
+
+    #[unstable(feature = "structural_match", issue = "31434")]
+    // #[rustc_on_unimplemented(message = "the type `{Self}` does not `#[derive(Eq)]`")]
+    #[lang = "structural_teq"]
+    pub trait StructuralEq {
+        // Empty.
+    }
+
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[lang = "sized"]
+    // #[rustc_on_unimplemented(
+    //     message = "the size for values of type `{Self}` cannot be known at compilation time",
+    //     label = "doesn't have a size known at compile-time"
+    // )]
+    // #[fundamental] // for Default, for example, which requires that `[T]: !Default` be evaluatable
+    // #[rustc_specialization_trait]
+    pub trait Sized {
+        // Empty.
+    }
+}
+
+mod cmp {
+    use super::marker::Sized;
+    use super::option::Option;
+
+    // #[derive(Clone, Copy, PartialEq, Debug, Hash)]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub enum Ordering {
+        /// An ordering where a compared value is less than another.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        Less = -1,
+        /// An ordering where a compared value is equal to another.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        Equal = 0,
+        /// An ordering where a compared value is greater than another.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        Greater = 1,
+    }
+
+    #[lang = "eq"]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(alias = "==")]
+    #[doc(alias = "!=")]
+    // #[rustc_on_unimplemented(
+    //     message = "can't compare `{Self}` with `{Rhs}`",
+    //     label = "no implementation for `{Self} == {Rhs}`"
+    // )]
+    pub trait PartialEq<Rhs: ?Sized = Self> {
+        /// This method tests for `self` and `other` values to be equal, and is used
+        /// by `==`.
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn eq(&self, other: &Rhs) -> bool;
+
+        fn ne(&self, other: &Rhs) -> bool {
+            !self.eq(other)
         }
     }
 
-    mod marker {
-        #[lang = "phantom_data"]
+    #[doc(alias = "==")]
+    #[doc(alias = "!=")]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub trait Eq: PartialEq<Self> {
+        // this method is used solely by #[deriving] to assert
+        // that every component of a type implements #[deriving]
+        // itself, the current deriving infrastructure means doing this
+        // assertion without using a method on this trait is nearly
+        // impossible.
+        //
+        // This should never be implemented by hand.
+        #[doc(hidden)]
         #[stable(feature = "rust1", since = "1.0.0")]
-        pub struct PhantomData<T: ?Sized>;
+        fn assert_receiver_is_total_eq(&self) {}
+    }
 
-        #[unstable(feature = "structural_match", issue = "31434")]
-        // #[rustc_on_unimplemented(message = "the type `{Self}` does not `#[derive(PartialEq)]`")]
-        #[lang = "structural_peq"]
-        pub trait StructuralPartialEq {
-            // Empty.
+    #[lang = "partial_ord"]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(alias = ">")]
+    #[doc(alias = "<")]
+    #[doc(alias = "<=")]
+    #[doc(alias = ">=")]
+    // #[rustc_on_unimplemented(
+    //     message = "can't compare `{Self}` with `{Rhs}`",
+    //     label = "no implementation for `{Self} < {Rhs}` and `{Self} > {Rhs}`"
+    // )]
+    pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
+        /// This method returns an ordering between `self` and `other` values if one exists.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use std::cmp::Ordering;
+        ///
+        /// let result = 1.0.partial_cmp(&2.0);
+        /// assert_eq!(result, Some(Ordering::Less));
+        ///
+        /// let result = 1.0.partial_cmp(&1.0);
+        /// assert_eq!(result, Some(Ordering::Equal));
+        ///
+        /// let result = 2.0.partial_cmp(&1.0);
+        /// assert_eq!(result, Some(Ordering::Greater));
+        /// ```
+        ///
+        /// When comparison is impossible:
+        ///
+        /// ```
+        /// let result = f64::NAN.partial_cmp(&1.0);
+        /// assert_eq!(result, None);
+        /// ```
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn partial_cmp(&self, other: &Rhs) -> Option<Ordering>;
+
+        /// This method tests less than (for `self` and `other`) and is used by the `<` operator.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// let result = 1.0 < 2.0;
+        /// assert_eq!(result, true);
+        ///
+        /// let result = 2.0 < 1.0;
+        /// assert_eq!(result, false);
+        /// ```
+        #[inline]
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn lt(&self, other: &Rhs) -> bool {
+            match self.partial_cmp(other) {
+                Option::Some(Ordering::Less) => true,
+                _ => false,
+            }
         }
 
-        #[unstable(feature = "structural_match", issue = "31434")]
-        // #[rustc_on_unimplemented(message = "the type `{Self}` does not `#[derive(Eq)]`")]
-        #[lang = "structural_teq"]
-        pub trait StructuralEq {
-            // Empty.
+        /// This method tests less than or equal to (for `self` and `other`) and is used by the `<=`
+        /// operator.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// let result = 1.0 <= 2.0;
+        /// assert_eq!(result, true);
+        ///
+        /// let result = 2.0 <= 2.0;
+        /// assert_eq!(result, true);
+        /// ```
+        #[inline]
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn le(&self, other: &Rhs) -> bool {
+            match self.partial_cmp(other) {
+                Option::Some(Ordering::Less | Ordering::Equal) => true,
+                _ => false,
+            }
         }
 
+        /// This method tests greater than (for `self` and `other`) and is used by the `>` operator.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// let result = 1.0 > 2.0;
+        /// assert_eq!(result, false);
+        ///
+        /// let result = 2.0 > 2.0;
+        /// assert_eq!(result, false);
+        /// ```
+        #[inline]
+        #[must_use]
         #[stable(feature = "rust1", since = "1.0.0")]
-        #[lang = "sized"]
-        // #[rustc_on_unimplemented(
-        //     message = "the size for values of type `{Self}` cannot be known at compilation time",
-        //     label = "doesn't have a size known at compile-time"
-        // )]
-        // #[fundamental] // for Default, for example, which requires that `[T]: !Default` be evaluatable
-        // #[rustc_specialization_trait]
-        pub trait Sized {
-            // Empty.
+        fn gt(&self, other: &Rhs) -> bool {
+            match self.partial_cmp(other) {
+                Option::Some(Ordering::Greater) => true,
+                _ => false,
+            }
+        }
+
+        /// This method tests greater than or equal to (for `self` and `other`) and is used by the `>=`
+        /// operator.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// let result = 2.0 >= 1.0;
+        /// assert_eq!(result, true);
+        ///
+        /// let result = 2.0 >= 2.0;
+        /// assert_eq!(result, true);
+        /// ```
+        #[inline]
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn ge(&self, other: &Rhs) -> bool {
+            match self.partial_cmp(other) {
+                Option::Some(Ordering::Greater | Ordering::Equal) => true,
+                _ => false,
+            }
         }
     }
 
-    mod cmp {
-        use super::marker::Sized;
-        use super::option::Option;
-
-        // #[derive(Clone, Copy, PartialEq, Debug, Hash)]
+    #[doc(alias = "<")]
+    #[doc(alias = ">")]
+    #[doc(alias = "<=")]
+    #[doc(alias = ">=")]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub trait Ord: Eq + PartialOrd<Self> {
+        /// This method returns an [`Ordering`] between `self` and `other`.
+        ///
+        /// By convention, `self.cmp(&other)` returns the ordering matching the expression
+        /// `self <operator> other` if true.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use std::cmp::Ordering;
+        ///
+        /// assert_eq!(5.cmp(&10), Ordering::Less);
+        /// assert_eq!(10.cmp(&5), Ordering::Greater);
+        /// assert_eq!(5.cmp(&5), Ordering::Equal);
+        /// ```
+        #[must_use]
         #[stable(feature = "rust1", since = "1.0.0")]
-        pub enum Ordering {
-            /// An ordering where a compared value is less than another.
-            #[stable(feature = "rust1", since = "1.0.0")]
-            Less = -1,
-            /// An ordering where a compared value is equal to another.
-            #[stable(feature = "rust1", since = "1.0.0")]
-            Equal = 0,
-            /// An ordering where a compared value is greater than another.
-            #[stable(feature = "rust1", since = "1.0.0")]
-            Greater = 1,
+        fn cmp(&self, other: &Self) -> Ordering;
+
+        /// Compares and returns the maximum of two values.
+        ///
+        /// Returns the second argument if the comparison determines them to be equal.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// assert_eq!(2, 1.max(2));
+        /// assert_eq!(2, 2.max(2));
+        /// ```
+        #[stable(feature = "ord_max_min", since = "1.21.0")]
+        #[must_use]
+        fn max(self, other: Self) -> Self
+        where
+            Self: Sized,
+        {
+            self
         }
 
-        #[lang = "eq"]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[doc(alias = "==")]
-        #[doc(alias = "!=")]
-        // #[rustc_on_unimplemented(
-        //     message = "can't compare `{Self}` with `{Rhs}`",
-        //     label = "no implementation for `{Self} == {Rhs}`"
-        // )]
-        pub trait PartialEq<Rhs: ?Sized = Self> {
-            /// This method tests for `self` and `other` values to be equal, and is used
-            /// by `==`.
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn eq(&self, other: &Rhs) -> bool;
-
-            fn ne(&self, other: &Rhs) -> bool {
-                !self.eq(other)
-            }
+        /// Compares and returns the minimum of two values.
+        ///
+        /// Returns the first argument if the comparison determines them to be equal.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// assert_eq!(1, 1.min(2));
+        /// assert_eq!(2, 2.min(2));
+        /// ```
+        #[stable(feature = "ord_max_min", since = "1.21.0")]
+        #[must_use]
+        fn min(self, other: Self) -> Self
+        where
+            Self: Sized,
+        {
+            self
         }
 
-        #[doc(alias = "==")]
-        #[doc(alias = "!=")]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        pub trait Eq: PartialEq<Self> {
-            // this method is used solely by #[deriving] to assert
-            // that every component of a type implements #[deriving]
-            // itself, the current deriving infrastructure means doing this
-            // assertion without using a method on this trait is nearly
-            // impossible.
-            //
-            // This should never be implemented by hand.
-            #[doc(hidden)]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn assert_receiver_is_total_eq(&self) {}
-        }
-
-        #[lang = "partial_ord"]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[doc(alias = ">")]
-        #[doc(alias = "<")]
-        #[doc(alias = "<=")]
-        #[doc(alias = ">=")]
-        // #[rustc_on_unimplemented(
-        //     message = "can't compare `{Self}` with `{Rhs}`",
-        //     label = "no implementation for `{Self} < {Rhs}` and `{Self} > {Rhs}`"
-        // )]
-        pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
-            /// This method returns an ordering between `self` and `other` values if one exists.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// use std::cmp::Ordering;
-            ///
-            /// let result = 1.0.partial_cmp(&2.0);
-            /// assert_eq!(result, Some(Ordering::Less));
-            ///
-            /// let result = 1.0.partial_cmp(&1.0);
-            /// assert_eq!(result, Some(Ordering::Equal));
-            ///
-            /// let result = 2.0.partial_cmp(&1.0);
-            /// assert_eq!(result, Some(Ordering::Greater));
-            /// ```
-            ///
-            /// When comparison is impossible:
-            ///
-            /// ```
-            /// let result = f64::NAN.partial_cmp(&1.0);
-            /// assert_eq!(result, None);
-            /// ```
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn partial_cmp(&self, other: &Rhs) -> Option<Ordering>;
-
-            /// This method tests less than (for `self` and `other`) and is used by the `<` operator.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// let result = 1.0 < 2.0;
-            /// assert_eq!(result, true);
-            ///
-            /// let result = 2.0 < 1.0;
-            /// assert_eq!(result, false);
-            /// ```
-            #[inline]
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn lt(&self, other: &Rhs) -> bool {
-                match self.partial_cmp(other) {
-                    Option::Some(Ordering::Less) => true,
-                    _ => false,
-                }
-            }
-
-            /// This method tests less than or equal to (for `self` and `other`) and is used by the `<=`
-            /// operator.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// let result = 1.0 <= 2.0;
-            /// assert_eq!(result, true);
-            ///
-            /// let result = 2.0 <= 2.0;
-            /// assert_eq!(result, true);
-            /// ```
-            #[inline]
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn le(&self, other: &Rhs) -> bool {
-                match self.partial_cmp(other) {
-                    Option::Some(Ordering::Less | Ordering::Equal) => true,
-                    _ => false,
-                }
-            }
-
-            /// This method tests greater than (for `self` and `other`) and is used by the `>` operator.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// let result = 1.0 > 2.0;
-            /// assert_eq!(result, false);
-            ///
-            /// let result = 2.0 > 2.0;
-            /// assert_eq!(result, false);
-            /// ```
-            #[inline]
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn gt(&self, other: &Rhs) -> bool {
-                match self.partial_cmp(other) {
-                    Option::Some(Ordering::Greater) => true,
-                    _ => false,
-                }
-            }
-
-            /// This method tests greater than or equal to (for `self` and `other`) and is used by the `>=`
-            /// operator.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// let result = 2.0 >= 1.0;
-            /// assert_eq!(result, true);
-            ///
-            /// let result = 2.0 >= 2.0;
-            /// assert_eq!(result, true);
-            /// ```
-            #[inline]
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn ge(&self, other: &Rhs) -> bool {
-                match self.partial_cmp(other) {
-                    Option::Some(Ordering::Greater | Ordering::Equal) => true,
-                    _ => false,
-                }
-            }
-        }
-
-        #[doc(alias = "<")]
-        #[doc(alias = ">")]
-        #[doc(alias = "<=")]
-        #[doc(alias = ">=")]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        pub trait Ord: Eq + PartialOrd<Self> {
-            /// This method returns an [`Ordering`] between `self` and `other`.
-            ///
-            /// By convention, `self.cmp(&other)` returns the ordering matching the expression
-            /// `self <operator> other` if true.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// use std::cmp::Ordering;
-            ///
-            /// assert_eq!(5.cmp(&10), Ordering::Less);
-            /// assert_eq!(10.cmp(&5), Ordering::Greater);
-            /// assert_eq!(5.cmp(&5), Ordering::Equal);
-            /// ```
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn cmp(&self, other: &Self) -> Ordering;
-
-            /// Compares and returns the maximum of two values.
-            ///
-            /// Returns the second argument if the comparison determines them to be equal.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// assert_eq!(2, 1.max(2));
-            /// assert_eq!(2, 2.max(2));
-            /// ```
-            #[stable(feature = "ord_max_min", since = "1.21.0")]
-            #[must_use]
-            fn max(self, other: Self) -> Self
-            where
-                Self: Sized,
-            {
+        /// Restrict a value to a certain interval.
+        ///
+        /// Returns `max` if `self` is greater than `max`, and `min` if `self` is
+        /// less than `min`. Otherwise this returns `self`.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `min > max`.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(clamp)]
+        ///
+        /// assert!((-3).clamp(-2, 1) == -2);
+        /// assert!(0.clamp(-2, 1) == 0);
+        /// assert!(2.clamp(-2, 1) == 1);
+        /// ```
+        #[must_use]
+        #[unstable(feature = "clamp", issue = "44095")]
+        fn clamp(self, min: Self, max: Self) -> Self
+        where
+            Self: Sized,
+        {
+            if self < min {
+                min
+            } else if self > max {
+                max
+            } else {
                 self
             }
-
-            /// Compares and returns the minimum of two values.
-            ///
-            /// Returns the first argument if the comparison determines them to be equal.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// assert_eq!(1, 1.min(2));
-            /// assert_eq!(2, 2.min(2));
-            /// ```
-            #[stable(feature = "ord_max_min", since = "1.21.0")]
-            #[must_use]
-            fn min(self, other: Self) -> Self
-            where
-                Self: Sized,
-            {
-                self
-            }
-
-            /// Restrict a value to a certain interval.
-            ///
-            /// Returns `max` if `self` is greater than `max`, and `min` if `self` is
-            /// less than `min`. Otherwise this returns `self`.
-            ///
-            /// # Panics
-            ///
-            /// Panics if `min > max`.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// #![feature(clamp)]
-            ///
-            /// assert!((-3).clamp(-2, 1) == -2);
-            /// assert!(0.clamp(-2, 1) == 0);
-            /// assert!(2.clamp(-2, 1) == 1);
-            /// ```
-            #[must_use]
-            #[unstable(feature = "clamp", issue = "44095")]
-            fn clamp(self, min: Self, max: Self) -> Self
-            where
-                Self: Sized,
-            {
-                if self < min {
-                    min
-                } else if self > max {
-                    max
-                } else {
-                    self
-                }
-            }
-        }
-    }
-
-    pub mod intrinsics {
-        #[lang = "discriminant_kind"]
-        pub trait DiscriminantKind {
-            #[lang = "discriminant_type"]
-            type Discriminant;
-        }
-
-        extern "rust-intrinsic" {
-            pub fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discriminant;
         }
     }
 }
 
-use core::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
-use core::marker::Sized;
-use core::option::Option;
+pub mod intrinsics {
+    #[lang = "discriminant_kind"]
+    pub trait DiscriminantKind {
+        #[lang = "discriminant_type"]
+        type Discriminant;
+    }
+
+    extern "rust-intrinsic" {
+        pub fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discriminant;
+    }
+}
+
+use crate::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
+use crate::marker::Sized;
+use crate::option::Option;
 
 // for comparing discriminant_value
 impl PartialEq for isize {

--- a/gcc/testsuite/rust/execute/torture/partial-ord-5.rs
+++ b/gcc/testsuite/rust/execute/torture/partial-ord-5.rs
@@ -2,350 +2,346 @@
 /* { dg-options "-w" } */
 #![feature(no_core)]
 #![no_core]
-
-
 #![feature(intrinsics, lang_items)]
 
-mod core {
-    mod option {
-        // #[rustc_diagnostic_item = "option_type"]
+mod option {
+    // #[rustc_diagnostic_item = "option_type"]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub enum Option<T> {
+        /// No value
+        #[lang = "None"]
         #[stable(feature = "rust1", since = "1.0.0")]
-        pub enum Option<T> {
-            /// No value
-            #[lang = "None"]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            None,
-            /// Some value `T`
-            #[lang = "Some"]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+        None,
+        /// Some value `T`
+        #[lang = "Some"]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+    }
+}
+
+mod marker {
+    #[lang = "phantom_data"]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub struct PhantomData<T: ?Sized>;
+
+    #[unstable(feature = "structural_match", issue = "31434")]
+    // #[rustc_on_unimplemented(message = "the type `{Self}` does not `#[derive(PartialEq)]`")]
+    #[lang = "structural_peq"]
+    pub trait StructuralPartialEq {
+        // Empty.
+    }
+
+    #[unstable(feature = "structural_match", issue = "31434")]
+    // #[rustc_on_unimplemented(message = "the type `{Self}` does not `#[derive(Eq)]`")]
+    #[lang = "structural_teq"]
+    pub trait StructuralEq {
+        // Empty.
+    }
+
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[lang = "sized"]
+    // #[rustc_on_unimplemented(
+    //     message = "the size for values of type `{Self}` cannot be known at compilation time",
+    //     label = "doesn't have a size known at compile-time"
+    // )]
+    // #[fundamental] // for Default, for example, which requires that `[T]: !Default` be evaluatable
+    // #[rustc_specialization_trait]
+    pub trait Sized {
+        // Empty.
+    }
+}
+
+mod cmp {
+    use super::marker::Sized;
+    use super::option::Option;
+
+    // #[derive(Clone, Copy, PartialEq, Debug, Hash)]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub enum Ordering {
+        /// An ordering where a compared value is less than another.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        Less = -1,
+        /// An ordering where a compared value is equal to another.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        Equal = 0,
+        /// An ordering where a compared value is greater than another.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        Greater = 1,
+    }
+
+    #[lang = "eq"]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(alias = "==")]
+    #[doc(alias = "!=")]
+    // #[rustc_on_unimplemented(
+    //     message = "can't compare `{Self}` with `{Rhs}`",
+    //     label = "no implementation for `{Self} == {Rhs}`"
+    // )]
+    pub trait PartialEq<Rhs: ?Sized = Self> {
+        /// This method tests for `self` and `other` values to be equal, and is used
+        /// by `==`.
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn eq(&self, other: &Rhs) -> bool;
+
+        fn ne(&self, other: &Rhs) -> bool {
+            !self.eq(other)
         }
     }
 
-    mod marker {
-        #[lang = "phantom_data"]
+    #[doc(alias = "==")]
+    #[doc(alias = "!=")]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub trait Eq: PartialEq<Self> {
+        // this method is used solely by #[deriving] to assert
+        // that every component of a type implements #[deriving]
+        // itself, the current deriving infrastructure means doing this
+        // assertion without using a method on this trait is nearly
+        // impossible.
+        //
+        // This should never be implemented by hand.
+        #[doc(hidden)]
         #[stable(feature = "rust1", since = "1.0.0")]
-        pub struct PhantomData<T: ?Sized>;
+        fn assert_receiver_is_total_eq(&self) {}
+    }
 
-        #[unstable(feature = "structural_match", issue = "31434")]
-        // #[rustc_on_unimplemented(message = "the type `{Self}` does not `#[derive(PartialEq)]`")]
-        #[lang = "structural_peq"]
-        pub trait StructuralPartialEq {
-            // Empty.
+    #[lang = "partial_ord"]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(alias = ">")]
+    #[doc(alias = "<")]
+    #[doc(alias = "<=")]
+    #[doc(alias = ">=")]
+    // #[rustc_on_unimplemented(
+    //     message = "can't compare `{Self}` with `{Rhs}`",
+    //     label = "no implementation for `{Self} < {Rhs}` and `{Self} > {Rhs}`"
+    // )]
+    pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
+        /// This method returns an ordering between `self` and `other` values if one exists.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use std::cmp::Ordering;
+        ///
+        /// let result = 1.0.partial_cmp(&2.0);
+        /// assert_eq!(result, Some(Ordering::Less));
+        ///
+        /// let result = 1.0.partial_cmp(&1.0);
+        /// assert_eq!(result, Some(Ordering::Equal));
+        ///
+        /// let result = 2.0.partial_cmp(&1.0);
+        /// assert_eq!(result, Some(Ordering::Greater));
+        /// ```
+        ///
+        /// When comparison is impossible:
+        ///
+        /// ```
+        /// let result = f64::NAN.partial_cmp(&1.0);
+        /// assert_eq!(result, None);
+        /// ```
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn partial_cmp(&self, other: &Rhs) -> Option<Ordering>;
+
+        /// This method tests less than (for `self` and `other`) and is used by the `<` operator.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// let result = 1.0 < 2.0;
+        /// assert_eq!(result, true);
+        ///
+        /// let result = 2.0 < 1.0;
+        /// assert_eq!(result, false);
+        /// ```
+        #[inline]
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn lt(&self, other: &Rhs) -> bool {
+            match self.partial_cmp(other) {
+                Option::Some(Ordering::Less) => true,
+                _ => false,
+            }
         }
 
-        #[unstable(feature = "structural_match", issue = "31434")]
-        // #[rustc_on_unimplemented(message = "the type `{Self}` does not `#[derive(Eq)]`")]
-        #[lang = "structural_teq"]
-        pub trait StructuralEq {
-            // Empty.
+        /// This method tests less than or equal to (for `self` and `other`) and is used by the `<=`
+        /// operator.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// let result = 1.0 <= 2.0;
+        /// assert_eq!(result, true);
+        ///
+        /// let result = 2.0 <= 2.0;
+        /// assert_eq!(result, true);
+        /// ```
+        #[inline]
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn le(&self, other: &Rhs) -> bool {
+            match self.partial_cmp(other) {
+                Option::Some(Ordering::Less | Ordering::Equal) => true,
+                _ => false,
+            }
         }
 
+        /// This method tests greater than (for `self` and `other`) and is used by the `>` operator.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// let result = 1.0 > 2.0;
+        /// assert_eq!(result, false);
+        ///
+        /// let result = 2.0 > 2.0;
+        /// assert_eq!(result, false);
+        /// ```
+        #[inline]
+        #[must_use]
         #[stable(feature = "rust1", since = "1.0.0")]
-        #[lang = "sized"]
-        // #[rustc_on_unimplemented(
-        //     message = "the size for values of type `{Self}` cannot be known at compilation time",
-        //     label = "doesn't have a size known at compile-time"
-        // )]
-        // #[fundamental] // for Default, for example, which requires that `[T]: !Default` be evaluatable
-        // #[rustc_specialization_trait]
-        pub trait Sized {
-            // Empty.
+        fn gt(&self, other: &Rhs) -> bool {
+            match self.partial_cmp(other) {
+                Option::Some(Ordering::Greater) => true,
+                _ => false,
+            }
+        }
+
+        /// This method tests greater than or equal to (for `self` and `other`) and is used by the `>=`
+        /// operator.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// let result = 2.0 >= 1.0;
+        /// assert_eq!(result, true);
+        ///
+        /// let result = 2.0 >= 2.0;
+        /// assert_eq!(result, true);
+        /// ```
+        #[inline]
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn ge(&self, other: &Rhs) -> bool {
+            match self.partial_cmp(other) {
+                Option::Some(Ordering::Greater | Ordering::Equal) => true,
+                _ => false,
+            }
         }
     }
 
-    mod cmp {
-        use super::marker::Sized;
-        use super::option::Option;
-
-        // #[derive(Clone, Copy, PartialEq, Debug, Hash)]
+    #[doc(alias = "<")]
+    #[doc(alias = ">")]
+    #[doc(alias = "<=")]
+    #[doc(alias = ">=")]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub trait Ord: Eq + PartialOrd<Self> {
+        /// This method returns an [`Ordering`] between `self` and `other`.
+        ///
+        /// By convention, `self.cmp(&other)` returns the ordering matching the expression
+        /// `self <operator> other` if true.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use std::cmp::Ordering;
+        ///
+        /// assert_eq!(5.cmp(&10), Ordering::Less);
+        /// assert_eq!(10.cmp(&5), Ordering::Greater);
+        /// assert_eq!(5.cmp(&5), Ordering::Equal);
+        /// ```
+        #[must_use]
         #[stable(feature = "rust1", since = "1.0.0")]
-        pub enum Ordering {
-            /// An ordering where a compared value is less than another.
-            #[stable(feature = "rust1", since = "1.0.0")]
-            Less = -1,
-            /// An ordering where a compared value is equal to another.
-            #[stable(feature = "rust1", since = "1.0.0")]
-            Equal = 0,
-            /// An ordering where a compared value is greater than another.
-            #[stable(feature = "rust1", since = "1.0.0")]
-            Greater = 1,
+        fn cmp(&self, other: &Self) -> Ordering;
+
+        /// Compares and returns the maximum of two values.
+        ///
+        /// Returns the second argument if the comparison determines them to be equal.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// assert_eq!(2, 1.max(2));
+        /// assert_eq!(2, 2.max(2));
+        /// ```
+        #[stable(feature = "ord_max_min", since = "1.21.0")]
+        #[must_use]
+        fn max(self, other: Self) -> Self
+        where
+            Self: Sized,
+        {
+            self
         }
 
-        #[lang = "eq"]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[doc(alias = "==")]
-        #[doc(alias = "!=")]
-        // #[rustc_on_unimplemented(
-        //     message = "can't compare `{Self}` with `{Rhs}`",
-        //     label = "no implementation for `{Self} == {Rhs}`"
-        // )]
-        pub trait PartialEq<Rhs: ?Sized = Self> {
-            /// This method tests for `self` and `other` values to be equal, and is used
-            /// by `==`.
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn eq(&self, other: &Rhs) -> bool;
-
-            fn ne(&self, other: &Rhs) -> bool {
-                !self.eq(other)
-            }
+        /// Compares and returns the minimum of two values.
+        ///
+        /// Returns the first argument if the comparison determines them to be equal.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// assert_eq!(1, 1.min(2));
+        /// assert_eq!(2, 2.min(2));
+        /// ```
+        #[stable(feature = "ord_max_min", since = "1.21.0")]
+        #[must_use]
+        fn min(self, other: Self) -> Self
+        where
+            Self: Sized,
+        {
+            self
         }
 
-        #[doc(alias = "==")]
-        #[doc(alias = "!=")]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        pub trait Eq: PartialEq<Self> {
-            // this method is used solely by #[deriving] to assert
-            // that every component of a type implements #[deriving]
-            // itself, the current deriving infrastructure means doing this
-            // assertion without using a method on this trait is nearly
-            // impossible.
-            //
-            // This should never be implemented by hand.
-            #[doc(hidden)]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn assert_receiver_is_total_eq(&self) {}
-        }
-
-        #[lang = "partial_ord"]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[doc(alias = ">")]
-        #[doc(alias = "<")]
-        #[doc(alias = "<=")]
-        #[doc(alias = ">=")]
-        // #[rustc_on_unimplemented(
-        //     message = "can't compare `{Self}` with `{Rhs}`",
-        //     label = "no implementation for `{Self} < {Rhs}` and `{Self} > {Rhs}`"
-        // )]
-        pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
-            /// This method returns an ordering between `self` and `other` values if one exists.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// use std::cmp::Ordering;
-            ///
-            /// let result = 1.0.partial_cmp(&2.0);
-            /// assert_eq!(result, Some(Ordering::Less));
-            ///
-            /// let result = 1.0.partial_cmp(&1.0);
-            /// assert_eq!(result, Some(Ordering::Equal));
-            ///
-            /// let result = 2.0.partial_cmp(&1.0);
-            /// assert_eq!(result, Some(Ordering::Greater));
-            /// ```
-            ///
-            /// When comparison is impossible:
-            ///
-            /// ```
-            /// let result = f64::NAN.partial_cmp(&1.0);
-            /// assert_eq!(result, None);
-            /// ```
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn partial_cmp(&self, other: &Rhs) -> Option<Ordering>;
-
-            /// This method tests less than (for `self` and `other`) and is used by the `<` operator.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// let result = 1.0 < 2.0;
-            /// assert_eq!(result, true);
-            ///
-            /// let result = 2.0 < 1.0;
-            /// assert_eq!(result, false);
-            /// ```
-            #[inline]
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn lt(&self, other: &Rhs) -> bool {
-                match self.partial_cmp(other) {
-                    Option::Some(Ordering::Less) => true,
-                    _ => false,
-                }
-            }
-
-            /// This method tests less than or equal to (for `self` and `other`) and is used by the `<=`
-            /// operator.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// let result = 1.0 <= 2.0;
-            /// assert_eq!(result, true);
-            ///
-            /// let result = 2.0 <= 2.0;
-            /// assert_eq!(result, true);
-            /// ```
-            #[inline]
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn le(&self, other: &Rhs) -> bool {
-                match self.partial_cmp(other) {
-                    Option::Some(Ordering::Less | Ordering::Equal) => true,
-                    _ => false,
-                }
-            }
-
-            /// This method tests greater than (for `self` and `other`) and is used by the `>` operator.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// let result = 1.0 > 2.0;
-            /// assert_eq!(result, false);
-            ///
-            /// let result = 2.0 > 2.0;
-            /// assert_eq!(result, false);
-            /// ```
-            #[inline]
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn gt(&self, other: &Rhs) -> bool {
-                match self.partial_cmp(other) {
-                    Option::Some(Ordering::Greater) => true,
-                    _ => false,
-                }
-            }
-
-            /// This method tests greater than or equal to (for `self` and `other`) and is used by the `>=`
-            /// operator.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// let result = 2.0 >= 1.0;
-            /// assert_eq!(result, true);
-            ///
-            /// let result = 2.0 >= 2.0;
-            /// assert_eq!(result, true);
-            /// ```
-            #[inline]
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn ge(&self, other: &Rhs) -> bool {
-                match self.partial_cmp(other) {
-                    Option::Some(Ordering::Greater | Ordering::Equal) => true,
-                    _ => false,
-                }
-            }
-        }
-
-        #[doc(alias = "<")]
-        #[doc(alias = ">")]
-        #[doc(alias = "<=")]
-        #[doc(alias = ">=")]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        pub trait Ord: Eq + PartialOrd<Self> {
-            /// This method returns an [`Ordering`] between `self` and `other`.
-            ///
-            /// By convention, `self.cmp(&other)` returns the ordering matching the expression
-            /// `self <operator> other` if true.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// use std::cmp::Ordering;
-            ///
-            /// assert_eq!(5.cmp(&10), Ordering::Less);
-            /// assert_eq!(10.cmp(&5), Ordering::Greater);
-            /// assert_eq!(5.cmp(&5), Ordering::Equal);
-            /// ```
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn cmp(&self, other: &Self) -> Ordering;
-
-            /// Compares and returns the maximum of two values.
-            ///
-            /// Returns the second argument if the comparison determines them to be equal.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// assert_eq!(2, 1.max(2));
-            /// assert_eq!(2, 2.max(2));
-            /// ```
-            #[stable(feature = "ord_max_min", since = "1.21.0")]
-            #[must_use]
-            fn max(self, other: Self) -> Self
-            where
-                Self: Sized,
-            {
+        /// Restrict a value to a certain interval.
+        ///
+        /// Returns `max` if `self` is greater than `max`, and `min` if `self` is
+        /// less than `min`. Otherwise this returns `self`.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `min > max`.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(clamp)]
+        ///
+        /// assert!((-3).clamp(-2, 1) == -2);
+        /// assert!(0.clamp(-2, 1) == 0);
+        /// assert!(2.clamp(-2, 1) == 1);
+        /// ```
+        #[must_use]
+        #[unstable(feature = "clamp", issue = "44095")]
+        fn clamp(self, min: Self, max: Self) -> Self
+        where
+            Self: Sized,
+        {
+            if self < min {
+                min
+            } else if self > max {
+                max
+            } else {
                 self
             }
-
-            /// Compares and returns the minimum of two values.
-            ///
-            /// Returns the first argument if the comparison determines them to be equal.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// assert_eq!(1, 1.min(2));
-            /// assert_eq!(2, 2.min(2));
-            /// ```
-            #[stable(feature = "ord_max_min", since = "1.21.0")]
-            #[must_use]
-            fn min(self, other: Self) -> Self
-            where
-                Self: Sized,
-            {
-                self
-            }
-
-            /// Restrict a value to a certain interval.
-            ///
-            /// Returns `max` if `self` is greater than `max`, and `min` if `self` is
-            /// less than `min`. Otherwise this returns `self`.
-            ///
-            /// # Panics
-            ///
-            /// Panics if `min > max`.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// #![feature(clamp)]
-            ///
-            /// assert!((-3).clamp(-2, 1) == -2);
-            /// assert!(0.clamp(-2, 1) == 0);
-            /// assert!(2.clamp(-2, 1) == 1);
-            /// ```
-            #[must_use]
-            #[unstable(feature = "clamp", issue = "44095")]
-            fn clamp(self, min: Self, max: Self) -> Self
-            where
-                Self: Sized,
-            {
-                if self < min {
-                    min
-                } else if self > max {
-                    max
-                } else {
-                    self
-                }
-            }
-        }
-    }
-
-    pub mod intrinsics {
-        #[lang = "discriminant_kind"]
-        pub trait DiscriminantKind {
-            #[lang = "discriminant_type"]
-            type Discriminant;
-        }
-
-        extern "rust-intrinsic" {
-            pub fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discriminant;
         }
     }
 }
 
-use core::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
-use core::marker::Sized;
-use core::option::Option;
+pub mod intrinsics {
+    #[lang = "discriminant_kind"]
+    pub trait DiscriminantKind {
+        #[lang = "discriminant_type"]
+        type Discriminant;
+    }
+
+    extern "rust-intrinsic" {
+        pub fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discriminant;
+    }
+}
+
+use crate::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
+use crate::marker::Sized;
+use crate::option::Option;
 
 // for comparing discriminant_value
 impl PartialEq for isize {
@@ -426,11 +422,11 @@ impl Ord for i32 {
 
 #[derive(PartialEq, Eq, Ord)]
 struct Foo {
-    a: i32,
+    pub a: i32,
 }
 
 impl PartialOrd for Foo {
-    fn partial_cmp(&self, other: &'_ Foo) -> Option<::core::cmp::Ordering> {
+    fn partial_cmp(&self, other: &'_ Foo) -> Option<::crate::cmp::Ordering> {
         self.a.partial_cmp(&other.a)
     }
 }

--- a/gcc/testsuite/rust/execute/torture/partial-ord-6.rs
+++ b/gcc/testsuite/rust/execute/torture/partial-ord-6.rs
@@ -2,350 +2,346 @@
 /* { dg-output "Foo A < B\r?\nFoo B < C\r?\nFoo C == C\r?\nBar x < y\r?\nBarFull s1 < s2\r?\n" } */
 #![feature(no_core)]
 #![no_core]
-
-
 #![feature(intrinsics, lang_items)]
 
-mod core {
-    mod option {
-        // #[rustc_diagnostic_item = "option_type"]
+mod option {
+    // #[rustc_diagnostic_item = "option_type"]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub enum Option<T> {
+        /// No value
+        #[lang = "None"]
         #[stable(feature = "rust1", since = "1.0.0")]
-        pub enum Option<T> {
-            /// No value
-            #[lang = "None"]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            None,
-            /// Some value `T`
-            #[lang = "Some"]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+        None,
+        /// Some value `T`
+        #[lang = "Some"]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+    }
+}
+
+mod marker {
+    #[lang = "phantom_data"]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub struct PhantomData<T: ?Sized>;
+
+    #[unstable(feature = "structural_match", issue = "31434")]
+    // #[rustc_on_unimplemented(message = "the type `{Self}` does not `#[derive(PartialEq)]`")]
+    #[lang = "structural_peq"]
+    pub trait StructuralPartialEq {
+        // Empty.
+    }
+
+    #[unstable(feature = "structural_match", issue = "31434")]
+    // #[rustc_on_unimplemented(message = "the type `{Self}` does not `#[derive(Eq)]`")]
+    #[lang = "structural_teq"]
+    pub trait StructuralEq {
+        // Empty.
+    }
+
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[lang = "sized"]
+    // #[rustc_on_unimplemented(
+    //     message = "the size for values of type `{Self}` cannot be known at compilation time",
+    //     label = "doesn't have a size known at compile-time"
+    // )]
+    // #[fundamental] // for Default, for example, which requires that `[T]: !Default` be evaluatable
+    // #[rustc_specialization_trait]
+    pub trait Sized {
+        // Empty.
+    }
+}
+
+mod cmp {
+    use super::marker::Sized;
+    use super::option::Option;
+
+    // #[derive(Clone, Copy, PartialEq, Debug, Hash)]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub enum Ordering {
+        /// An ordering where a compared value is less than another.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        Less = -1,
+        /// An ordering where a compared value is equal to another.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        Equal = 0,
+        /// An ordering where a compared value is greater than another.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        Greater = 1,
+    }
+
+    #[lang = "eq"]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(alias = "==")]
+    #[doc(alias = "!=")]
+    // #[rustc_on_unimplemented(
+    //     message = "can't compare `{Self}` with `{Rhs}`",
+    //     label = "no implementation for `{Self} == {Rhs}`"
+    // )]
+    pub trait PartialEq<Rhs: ?Sized = Self> {
+        /// This method tests for `self` and `other` values to be equal, and is used
+        /// by `==`.
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn eq(&self, other: &Rhs) -> bool;
+
+        fn ne(&self, other: &Rhs) -> bool {
+            !self.eq(other)
         }
     }
 
-    mod marker {
-        #[lang = "phantom_data"]
+    #[doc(alias = "==")]
+    #[doc(alias = "!=")]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub trait Eq: PartialEq<Self> {
+        // this method is used solely by #[deriving] to assert
+        // that every component of a type implements #[deriving]
+        // itself, the current deriving infrastructure means doing this
+        // assertion without using a method on this trait is nearly
+        // impossible.
+        //
+        // This should never be implemented by hand.
+        #[doc(hidden)]
         #[stable(feature = "rust1", since = "1.0.0")]
-        pub struct PhantomData<T: ?Sized>;
+        fn assert_receiver_is_total_eq(&self) {}
+    }
 
-        #[unstable(feature = "structural_match", issue = "31434")]
-        // #[rustc_on_unimplemented(message = "the type `{Self}` does not `#[derive(PartialEq)]`")]
-        #[lang = "structural_peq"]
-        pub trait StructuralPartialEq {
-            // Empty.
+    #[lang = "partial_ord"]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(alias = ">")]
+    #[doc(alias = "<")]
+    #[doc(alias = "<=")]
+    #[doc(alias = ">=")]
+    // #[rustc_on_unimplemented(
+    //     message = "can't compare `{Self}` with `{Rhs}`",
+    //     label = "no implementation for `{Self} < {Rhs}` and `{Self} > {Rhs}`"
+    // )]
+    pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
+        /// This method returns an ordering between `self` and `other` values if one exists.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use std::cmp::Ordering;
+        ///
+        /// let result = 1.0.partial_cmp(&2.0);
+        /// assert_eq!(result, Some(Ordering::Less));
+        ///
+        /// let result = 1.0.partial_cmp(&1.0);
+        /// assert_eq!(result, Some(Ordering::Equal));
+        ///
+        /// let result = 2.0.partial_cmp(&1.0);
+        /// assert_eq!(result, Some(Ordering::Greater));
+        /// ```
+        ///
+        /// When comparison is impossible:
+        ///
+        /// ```
+        /// let result = f64::NAN.partial_cmp(&1.0);
+        /// assert_eq!(result, None);
+        /// ```
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn partial_cmp(&self, other: &Rhs) -> Option<Ordering>;
+
+        /// This method tests less than (for `self` and `other`) and is used by the `<` operator.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// let result = 1.0 < 2.0;
+        /// assert_eq!(result, true);
+        ///
+        /// let result = 2.0 < 1.0;
+        /// assert_eq!(result, false);
+        /// ```
+        #[inline]
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn lt(&self, other: &Rhs) -> bool {
+            match self.partial_cmp(other) {
+                Option::Some(Ordering::Less) => true,
+                _ => false,
+            }
         }
 
-        #[unstable(feature = "structural_match", issue = "31434")]
-        // #[rustc_on_unimplemented(message = "the type `{Self}` does not `#[derive(Eq)]`")]
-        #[lang = "structural_teq"]
-        pub trait StructuralEq {
-            // Empty.
+        /// This method tests less than or equal to (for `self` and `other`) and is used by the `<=`
+        /// operator.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// let result = 1.0 <= 2.0;
+        /// assert_eq!(result, true);
+        ///
+        /// let result = 2.0 <= 2.0;
+        /// assert_eq!(result, true);
+        /// ```
+        #[inline]
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn le(&self, other: &Rhs) -> bool {
+            match self.partial_cmp(other) {
+                Option::Some(Ordering::Less | Ordering::Equal) => true,
+                _ => false,
+            }
         }
 
+        /// This method tests greater than (for `self` and `other`) and is used by the `>` operator.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// let result = 1.0 > 2.0;
+        /// assert_eq!(result, false);
+        ///
+        /// let result = 2.0 > 2.0;
+        /// assert_eq!(result, false);
+        /// ```
+        #[inline]
+        #[must_use]
         #[stable(feature = "rust1", since = "1.0.0")]
-        #[lang = "sized"]
-        // #[rustc_on_unimplemented(
-        //     message = "the size for values of type `{Self}` cannot be known at compilation time",
-        //     label = "doesn't have a size known at compile-time"
-        // )]
-        // #[fundamental] // for Default, for example, which requires that `[T]: !Default` be evaluatable
-        // #[rustc_specialization_trait]
-        pub trait Sized {
-            // Empty.
+        fn gt(&self, other: &Rhs) -> bool {
+            match self.partial_cmp(other) {
+                Option::Some(Ordering::Greater) => true,
+                _ => false,
+            }
+        }
+
+        /// This method tests greater than or equal to (for `self` and `other`) and is used by the `>=`
+        /// operator.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// let result = 2.0 >= 1.0;
+        /// assert_eq!(result, true);
+        ///
+        /// let result = 2.0 >= 2.0;
+        /// assert_eq!(result, true);
+        /// ```
+        #[inline]
+        #[must_use]
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn ge(&self, other: &Rhs) -> bool {
+            match self.partial_cmp(other) {
+                Option::Some(Ordering::Greater | Ordering::Equal) => true,
+                _ => false,
+            }
         }
     }
 
-    mod cmp {
-        use super::marker::Sized;
-        use super::option::Option;
-
-        // #[derive(Clone, Copy, PartialEq, Debug, Hash)]
+    #[doc(alias = "<")]
+    #[doc(alias = ">")]
+    #[doc(alias = "<=")]
+    #[doc(alias = ">=")]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub trait Ord: Eq + PartialOrd<Self> {
+        /// This method returns an [`Ordering`] between `self` and `other`.
+        ///
+        /// By convention, `self.cmp(&other)` returns the ordering matching the expression
+        /// `self <operator> other` if true.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use std::cmp::Ordering;
+        ///
+        /// assert_eq!(5.cmp(&10), Ordering::Less);
+        /// assert_eq!(10.cmp(&5), Ordering::Greater);
+        /// assert_eq!(5.cmp(&5), Ordering::Equal);
+        /// ```
+        #[must_use]
         #[stable(feature = "rust1", since = "1.0.0")]
-        pub enum Ordering {
-            /// An ordering where a compared value is less than another.
-            #[stable(feature = "rust1", since = "1.0.0")]
-            Less = -1,
-            /// An ordering where a compared value is equal to another.
-            #[stable(feature = "rust1", since = "1.0.0")]
-            Equal = 0,
-            /// An ordering where a compared value is greater than another.
-            #[stable(feature = "rust1", since = "1.0.0")]
-            Greater = 1,
+        fn cmp(&self, other: &Self) -> Ordering;
+
+        /// Compares and returns the maximum of two values.
+        ///
+        /// Returns the second argument if the comparison determines them to be equal.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// assert_eq!(2, 1.max(2));
+        /// assert_eq!(2, 2.max(2));
+        /// ```
+        #[stable(feature = "ord_max_min", since = "1.21.0")]
+        #[must_use]
+        fn max(self, other: Self) -> Self
+        where
+            Self: Sized,
+        {
+            self
         }
 
-        #[lang = "eq"]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[doc(alias = "==")]
-        #[doc(alias = "!=")]
-        // #[rustc_on_unimplemented(
-        //     message = "can't compare `{Self}` with `{Rhs}`",
-        //     label = "no implementation for `{Self} == {Rhs}`"
-        // )]
-        pub trait PartialEq<Rhs: ?Sized = Self> {
-            /// This method tests for `self` and `other` values to be equal, and is used
-            /// by `==`.
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn eq(&self, other: &Rhs) -> bool;
-
-            fn ne(&self, other: &Rhs) -> bool {
-                !self.eq(other)
-            }
+        /// Compares and returns the minimum of two values.
+        ///
+        /// Returns the first argument if the comparison determines them to be equal.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// assert_eq!(1, 1.min(2));
+        /// assert_eq!(2, 2.min(2));
+        /// ```
+        #[stable(feature = "ord_max_min", since = "1.21.0")]
+        #[must_use]
+        fn min(self, other: Self) -> Self
+        where
+            Self: Sized,
+        {
+            self
         }
 
-        #[doc(alias = "==")]
-        #[doc(alias = "!=")]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        pub trait Eq: PartialEq<Self> {
-            // this method is used solely by #[deriving] to assert
-            // that every component of a type implements #[deriving]
-            // itself, the current deriving infrastructure means doing this
-            // assertion without using a method on this trait is nearly
-            // impossible.
-            //
-            // This should never be implemented by hand.
-            #[doc(hidden)]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn assert_receiver_is_total_eq(&self) {}
-        }
-
-        #[lang = "partial_ord"]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[doc(alias = ">")]
-        #[doc(alias = "<")]
-        #[doc(alias = "<=")]
-        #[doc(alias = ">=")]
-        // #[rustc_on_unimplemented(
-        //     message = "can't compare `{Self}` with `{Rhs}`",
-        //     label = "no implementation for `{Self} < {Rhs}` and `{Self} > {Rhs}`"
-        // )]
-        pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
-            /// This method returns an ordering between `self` and `other` values if one exists.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// use std::cmp::Ordering;
-            ///
-            /// let result = 1.0.partial_cmp(&2.0);
-            /// assert_eq!(result, Some(Ordering::Less));
-            ///
-            /// let result = 1.0.partial_cmp(&1.0);
-            /// assert_eq!(result, Some(Ordering::Equal));
-            ///
-            /// let result = 2.0.partial_cmp(&1.0);
-            /// assert_eq!(result, Some(Ordering::Greater));
-            /// ```
-            ///
-            /// When comparison is impossible:
-            ///
-            /// ```
-            /// let result = f64::NAN.partial_cmp(&1.0);
-            /// assert_eq!(result, None);
-            /// ```
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn partial_cmp(&self, other: &Rhs) -> Option<Ordering>;
-
-            /// This method tests less than (for `self` and `other`) and is used by the `<` operator.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// let result = 1.0 < 2.0;
-            /// assert_eq!(result, true);
-            ///
-            /// let result = 2.0 < 1.0;
-            /// assert_eq!(result, false);
-            /// ```
-            #[inline]
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn lt(&self, other: &Rhs) -> bool {
-                match self.partial_cmp(other) {
-                    Option::Some(Ordering::Less) => true,
-                    _ => false,
-                }
-            }
-
-            /// This method tests less than or equal to (for `self` and `other`) and is used by the `<=`
-            /// operator.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// let result = 1.0 <= 2.0;
-            /// assert_eq!(result, true);
-            ///
-            /// let result = 2.0 <= 2.0;
-            /// assert_eq!(result, true);
-            /// ```
-            #[inline]
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn le(&self, other: &Rhs) -> bool {
-                match self.partial_cmp(other) {
-                    Option::Some(Ordering::Less | Ordering::Equal) => true,
-                    _ => false,
-                }
-            }
-
-            /// This method tests greater than (for `self` and `other`) and is used by the `>` operator.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// let result = 1.0 > 2.0;
-            /// assert_eq!(result, false);
-            ///
-            /// let result = 2.0 > 2.0;
-            /// assert_eq!(result, false);
-            /// ```
-            #[inline]
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn gt(&self, other: &Rhs) -> bool {
-                match self.partial_cmp(other) {
-                    Option::Some(Ordering::Greater) => true,
-                    _ => false,
-                }
-            }
-
-            /// This method tests greater than or equal to (for `self` and `other`) and is used by the `>=`
-            /// operator.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// let result = 2.0 >= 1.0;
-            /// assert_eq!(result, true);
-            ///
-            /// let result = 2.0 >= 2.0;
-            /// assert_eq!(result, true);
-            /// ```
-            #[inline]
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn ge(&self, other: &Rhs) -> bool {
-                match self.partial_cmp(other) {
-                    Option::Some(Ordering::Greater | Ordering::Equal) => true,
-                    _ => false,
-                }
-            }
-        }
-
-        #[doc(alias = "<")]
-        #[doc(alias = ">")]
-        #[doc(alias = "<=")]
-        #[doc(alias = ">=")]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        pub trait Ord: Eq + PartialOrd<Self> {
-            /// This method returns an [`Ordering`] between `self` and `other`.
-            ///
-            /// By convention, `self.cmp(&other)` returns the ordering matching the expression
-            /// `self <operator> other` if true.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// use std::cmp::Ordering;
-            ///
-            /// assert_eq!(5.cmp(&10), Ordering::Less);
-            /// assert_eq!(10.cmp(&5), Ordering::Greater);
-            /// assert_eq!(5.cmp(&5), Ordering::Equal);
-            /// ```
-            #[must_use]
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn cmp(&self, other: &Self) -> Ordering;
-
-            /// Compares and returns the maximum of two values.
-            ///
-            /// Returns the second argument if the comparison determines them to be equal.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// assert_eq!(2, 1.max(2));
-            /// assert_eq!(2, 2.max(2));
-            /// ```
-            #[stable(feature = "ord_max_min", since = "1.21.0")]
-            #[must_use]
-            fn max(self, other: Self) -> Self
-            where
-                Self: Sized,
-            {
+        /// Restrict a value to a certain interval.
+        ///
+        /// Returns `max` if `self` is greater than `max`, and `min` if `self` is
+        /// less than `min`. Otherwise this returns `self`.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `min > max`.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(clamp)]
+        ///
+        /// assert!((-3).clamp(-2, 1) == -2);
+        /// assert!(0.clamp(-2, 1) == 0);
+        /// assert!(2.clamp(-2, 1) == 1);
+        /// ```
+        #[must_use]
+        #[unstable(feature = "clamp", issue = "44095")]
+        fn clamp(self, min: Self, max: Self) -> Self
+        where
+            Self: Sized,
+        {
+            if self < min {
+                min
+            } else if self > max {
+                max
+            } else {
                 self
             }
-
-            /// Compares and returns the minimum of two values.
-            ///
-            /// Returns the first argument if the comparison determines them to be equal.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// assert_eq!(1, 1.min(2));
-            /// assert_eq!(2, 2.min(2));
-            /// ```
-            #[stable(feature = "ord_max_min", since = "1.21.0")]
-            #[must_use]
-            fn min(self, other: Self) -> Self
-            where
-                Self: Sized,
-            {
-                self
-            }
-
-            /// Restrict a value to a certain interval.
-            ///
-            /// Returns `max` if `self` is greater than `max`, and `min` if `self` is
-            /// less than `min`. Otherwise this returns `self`.
-            ///
-            /// # Panics
-            ///
-            /// Panics if `min > max`.
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// #![feature(clamp)]
-            ///
-            /// assert!((-3).clamp(-2, 1) == -2);
-            /// assert!(0.clamp(-2, 1) == 0);
-            /// assert!(2.clamp(-2, 1) == 1);
-            /// ```
-            #[must_use]
-            #[unstable(feature = "clamp", issue = "44095")]
-            fn clamp(self, min: Self, max: Self) -> Self
-            where
-                Self: Sized,
-            {
-                if self < min {
-                    min
-                } else if self > max {
-                    max
-                } else {
-                    self
-                }
-            }
-        }
-    }
-
-    pub mod intrinsics {
-        #[lang = "discriminant_kind"]
-        pub trait DiscriminantKind {
-            #[lang = "discriminant_type"]
-            type Discriminant;
-        }
-
-        extern "rust-intrinsic" {
-            pub fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discriminant;
         }
     }
 }
 
-use core::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
-use core::marker::Sized;
-use core::option::Option;
+pub mod intrinsics {
+    #[lang = "discriminant_kind"]
+    pub trait DiscriminantKind {
+        #[lang = "discriminant_type"]
+        type Discriminant;
+    }
+
+    extern "rust-intrinsic" {
+        pub fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discriminant;
+    }
+}
+
+use crate::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
+use crate::marker::Sized;
+use crate::option::Option;
 
 // for comparing discriminant_value
 impl PartialEq for isize {


### PR DESCRIPTION
Replaces #4344

When generating AST nodes for desugaring or deriving builtin traits, the compiler must be
aware of the crate it is currently compiling - and more precisely, whether it is compiling
`core` or any other crate. This is important mainly for the generation of canonicalized path
nodes during macro expansion. For example, when deriving `Copy` for a type in a regular crate,
the compiler should emit paths of the form `core::marker::Copy`. However, when the compiler
is compiling `core` itself, these paths should be of the form `crate::marker::Copy`, as we are
trying to refer to the `Copy` trait present in the current crate. While this isn't a problem
for most builtin derives as they are lang items, it still shows up in a few places and needs
to be handled properly.

gcc/rust/ChangeLog:

	* expand/rust-macro-expand.h (struct MacroExpander): Make `crate` member public for
	sub-expanders to access its inner attributes.
	* ast/rust-ast-builder.h: Add `Source` enum to discriminate between AST node generation
	within `core` and within other crates.
	* ast/rust-ast-builder.cc: Use the new enum for building paths properly.
	* ast/rust-desugar-for-loops.cc (DesugarForLoops::desugar): Likewise.
	(DesugarForLoops::go): Likewise.
	* ast/rust-desugar-for-loops.h: Likewise.
	* ast/rust-desugar-question-mark.cc (DesugarQuestionMark::go): Likewise.
	(DesugarQuestionMark::desugar): Likewise.
	* ast/rust-desugar-question-mark.h: Likewise.
	* ast/rust-desugar-try-block.cc (DesugarTryBlock::go): Likewise.
	(DesugarTryBlock::desugar): Likewise.
	* ast/rust-desugar-try-block.h: Likewise.
	* ast/rust-desugar-while-let.cc (DesugarWhileLet::desugar): Likewise.
	(DesugarWhileLet::go): Likewise.
	* ast/rust-desugar-while-let.h: Likewise.
	* ast/rust-expression-yeast.cc (ExpressionYeast::go): Likewise.
	(ExpressionYeast::dispatch_loops): Likewise.
	(ExpressionYeast::reseat): Likewise.
	* ast/rust-expression-yeast.h (RUST_EXPRESSION_YEAST): Likewise.
	* expand/rust-derive-clone.cc (DeriveClone::DeriveClone): Likewise.
	* expand/rust-derive-clone.h: Likewise.
	* expand/rust-derive-copy.cc (DeriveCopy::DeriveCopy): Likewise.
	* expand/rust-derive-copy.h: Likewise.
	* expand/rust-derive-debug.cc (DeriveDebug::DeriveDebug): Likewise.
	(DeriveDebug::stub_debug_fn): Likewise.
	* expand/rust-derive-debug.h: Likewise.
	* expand/rust-derive-default.cc (DeriveDefault::DeriveDefault): Likewise.
	(DeriveDefault::default_call): Likewise.
	* expand/rust-derive-default.h: Likewise.
	* expand/rust-derive-eq.cc (get_eq_trait_path): Likewise.
	(DeriveEq::DeriveEq): Likewise.
	* expand/rust-derive-eq.h: Likewise.
	* expand/rust-derive-hash.cc (DeriveHash::DeriveHash): Likewise.
	(DeriveHash::hash_call): Likewise.
	(DeriveHash::hash_fn): Likewise.
	* expand/rust-derive-hash.h: Likewise.
	* expand/rust-derive-ord.cc (DeriveOrd::DeriveOrd): Likewise.
	(DeriveOrd::cmp_call): Likewise.
	(DeriveOrd::cmp_fn): Likewise.
	(DeriveOrd::make_equal): Likewise.
	(DeriveOrd::recursive_match): Likewise.
	* expand/rust-derive-ord.h: Likewise.
	* expand/rust-derive-partial-eq.cc (DerivePartialEq::DerivePartialEq): Likewise.
	* expand/rust-derive-partial-eq.h: Likewise.
	* expand/rust-derive.cc (DeriveVisitor::DeriveVisitor): Likewise.
	(DeriveVisitor::derive): Likewise.
	* expand/rust-derive.h: Likewise.
	* expand/rust-expand-format-args.cc (format_arg): Likewise.
	(expand_format_args): Likewise.
	* expand/rust-expand-visitor.cc (builtin_derive_item): Likewise.
	(ExpandVisitor::expand_inner_stmts): Likewise.
	* expand/rust-macro-builtins-log-debug.cc (MacroBuiltin::assert_handler): Likewise.
	* expand/rust-macro-builtins-utility.cc (MacroBuiltin::option_env_handler): Likewise.
