### PR TITLE
gccrs: turn on can_alias_all on build_pointer_type

### DIFF
--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -444,7 +444,7 @@ pointer_type (tree to_type)
 {
   if (error_operand_p (to_type))
     return error_mark_node;
-  tree type = build_pointer_type (to_type);
+  tree type = build_pointer_type_for_mode (to_type, VOIDmode, true);
   return type;
 }
 

--- a/gcc/testsuite/rust/execute/raw-pointer-aliasing.rs
+++ b/gcc/testsuite/rust/execute/raw-pointer-aliasing.rs
@@ -1,0 +1,25 @@
+// { dg-options "-O2" }
+
+#![feature(no_core)]
+#![no_core]
+
+extern "C" {
+    fn malloc(n: u64) -> *mut u8;
+}
+
+fn f() -> i32 {
+    unsafe {
+        let p = malloc(4) as *mut i32;
+        *p = 27;
+        *(p as *mut i16) = 42;
+        *p
+    }
+}
+
+fn main() -> i32 {
+    if f() == 27 {
+        1
+    } else {
+        0
+    }
+}


### PR DESCRIPTION
Rust semantics are that all raw pointers can alias but then we get stronger garentees on reference types.

Fixes Rust-GCC#4536

gcc/rust/ChangeLog:

	* rust-gcc.cc (pointer_type): turn on can alias

gcc/testsuite/ChangeLog:

	* rust/execute/raw-pointer-aliasing.rs: New test.

