### PR TITLE
Add size_of_val and min_align_of_val intrinsics

### DIFF
--- a/gcc/rust/backend/rust-compile-intrinsic.cc
+++ b/gcc/rust/backend/rust-compile-intrinsic.cc
@@ -34,6 +34,7 @@ static const std::map<std::string, handlers::HandlerBuilder> generic_intrinsics
      {IValue::SIZE_OF, handlers::sizeof_handler},
      {IValue::SIZE_OF_VAL, handlers::size_of_val_handler},
      {IValue::MIN_ALIGN_OF, handlers::min_align_of_handler},
+     {IValue::MIN_ALIGN_OF_VAL, handlers::min_align_of_val_handler},
      {IValue::TRANSMUTE, handlers::transmute},
      {IValue::ROTATE_LEFT, handlers::rotate_left},
      {IValue::ROTATE_RIGHT, handlers::rotate_right},

--- a/gcc/rust/backend/rust-compile-intrinsic.cc
+++ b/gcc/rust/backend/rust-compile-intrinsic.cc
@@ -32,6 +32,7 @@ static const std::map<std::string, handlers::HandlerBuilder> generic_intrinsics
      {IValue::ARITH_OFFSET, handlers::arith_offset_handler},
      {IValue::WRITE_BYTES, handlers::write_bytes_handler},
      {IValue::SIZE_OF, handlers::sizeof_handler},
+     {IValue::SIZE_OF_VAL, handlers::size_of_val_handler},
      {IValue::MIN_ALIGN_OF, handlers::min_align_of_handler},
      {IValue::TRANSMUTE, handlers::transmute},
      {IValue::ROTATE_LEFT, handlers::rotate_left},

--- a/gcc/rust/backend/rust-intrinsic-handlers.cc
+++ b/gcc/rust/backend/rust-intrinsic-handlers.cc
@@ -1750,6 +1750,106 @@ min_align_of_handler (Context *ctx, TyTy::FnType *fntype, location_t)
   return fndecl;
 }
 
+/**
+ * pub fn min_align_of_val<T: ?Sized>(_: *const T) -> usize;
+ */
+tree
+min_align_of_val_handler (Context *ctx, TyTy::FnType *fntype, location_t)
+{
+  rust_assert (fntype->get_params ().size () == 1);
+
+  tree lookup = NULL_TREE;
+  if (check_for_cached_intrinsic (ctx, fntype, &lookup))
+    return lookup;
+
+  auto fndecl = compile_intrinsic_function (ctx, fntype);
+
+  auto locus = fntype->get_locus ();
+
+  std::vector<Bvariable *> param_vars;
+  compile_fn_params (ctx, fntype, fndecl, &param_vars);
+
+  auto &__param = param_vars.at (0);
+  rust_assert (param_vars.size () == 1);
+  if (!Backend::function_set_parameters (fndecl, param_vars))
+    return error_mark_node;
+
+  rust_assert (fntype->get_num_substitutions () == 1);
+  auto &param_mapping = fntype->get_substs ().at (0);
+  const auto param_tyty = param_mapping.get_param_ty ();
+  auto resolved_tyty = param_tyty->resolve ();
+  tree template_parameter_type
+    = TyTyResolveCompile::compile (ctx, resolved_tyty);
+
+  enter_intrinsic_block (ctx, fndecl);
+
+  // BUILTIN size_of FN BODY BEGIN
+
+  tree align_expr = NULL_TREE;
+  if (RS_DST_FLAG_P (template_parameter_type))
+    {
+      tree param = Backend::var_expression (__param, UNDEF_LOCATION);
+      tree param_ty = TREE_TYPE (param);
+      tree data_field = TYPE_FIELDS (param_ty);
+      tree meta_field = DECL_CHAIN (data_field);
+      tree meta_field_expr
+	= build3_loc (locus, COMPONENT_REF, TREE_TYPE (meta_field), param,
+		      meta_field, NULL_TREE);
+
+      if (resolved_tyty->get_kind () == TyTy::TypeKind::SLICE
+	  || resolved_tyty->get_kind () == TyTy::TypeKind::STR)
+	{
+	  tree elem_type = NULL_TREE;
+	  if (resolved_tyty->get_kind () == TyTy::TypeKind::SLICE)
+	    {
+	      auto slice_tyty = static_cast<TyTy::SliceType *> (resolved_tyty);
+	      elem_type
+		= TyTyResolveCompile::compile (ctx,
+					       slice_tyty->get_element_type ());
+	    }
+	  else
+	    elem_type = char_type_node;
+
+	  align_expr
+	    = build_int_cst (size_type_node, TYPE_ALIGN_UNIT (elem_type));
+	}
+      else if (resolved_tyty->get_kind () == TyTy::TypeKind::DYNAMIC)
+	{
+	  tree vtable_ptr_ty = TREE_TYPE (meta_field_expr);
+	  tree vtable_ty = TREE_TYPE (vtable_ptr_ty);
+
+	  tree vtable_ref
+	    = build1_loc (locus, INDIRECT_REF, vtable_ty, meta_field_expr);
+
+	  tree vtable_field_0 = TYPE_FIELDS (vtable_ty);
+	  tree vtable_field_1 = DECL_CHAIN (vtable_field_0);
+	  tree vtable_field_align = DECL_CHAIN (vtable_field_1);
+	  rust_assert (vtable_field_align != NULL_TREE);
+
+	  align_expr
+	    = build3_loc (locus, COMPONENT_REF, TREE_TYPE (vtable_field_align),
+			  vtable_ref, vtable_field_align, NULL_TREE);
+	}
+      else
+	{
+	  rust_unreachable ();
+	}
+    }
+  else
+    align_expr = build_int_cst (size_type_node,
+				TYPE_ALIGN_UNIT (template_parameter_type));
+
+  auto return_statement
+    = Backend::return_statement (fndecl, align_expr, UNDEF_LOCATION);
+  ctx->add_statement (return_statement);
+
+  // BUILTIN size_of FN BODY END
+
+  finalize_intrinsic_block (ctx, fndecl);
+
+  return fndecl;
+}
+
 tree
 offset (Context *ctx, TyTy::FnType *fntype, location_t expr_locus)
 {

--- a/gcc/rust/backend/rust-intrinsic-handlers.cc
+++ b/gcc/rust/backend/rust-intrinsic-handlers.cc
@@ -1610,6 +1610,108 @@ sizeof_handler (Context *ctx, TyTy::FnType *fntype, location_t)
 }
 
 /**
+ * pub fn size_of_val<T: ?Sized>(_: *const T) -> usize;
+ */
+tree
+size_of_val_handler (Context *ctx, TyTy::FnType *fntype, location_t)
+{
+  rust_assert (fntype->get_params ().size () == 1);
+
+  tree lookup = NULL_TREE;
+  if (check_for_cached_intrinsic (ctx, fntype, &lookup))
+    return lookup;
+
+  auto fndecl = compile_intrinsic_function (ctx, fntype);
+
+  auto locus = fntype->get_locus ();
+
+  std::vector<Bvariable *> param_vars;
+  compile_fn_params (ctx, fntype, fndecl, &param_vars);
+
+  auto &__param = param_vars.at (0);
+  rust_assert (param_vars.size () == 1);
+  if (!Backend::function_set_parameters (fndecl, param_vars))
+    return error_mark_node;
+
+  rust_assert (fntype->get_num_substitutions () == 1);
+  auto &param_mapping = fntype->get_substs ().at (0);
+  const auto param_tyty = param_mapping.get_param_ty ();
+  auto resolved_tyty = param_tyty->resolve ();
+  tree template_parameter_type
+    = TyTyResolveCompile::compile (ctx, resolved_tyty);
+
+  enter_intrinsic_block (ctx, fndecl);
+
+  // BUILTIN size_of FN BODY BEGIN
+
+  tree size_expr = NULL_TREE;
+  if (RS_DST_FLAG_P (template_parameter_type))
+    {
+      tree param = Backend::var_expression (__param, UNDEF_LOCATION);
+      tree param_ty = TREE_TYPE (param);
+      tree data_field = TYPE_FIELDS (param_ty);
+      tree meta_field = DECL_CHAIN (data_field);
+      tree meta_field_expr
+	= build3_loc (locus, COMPONENT_REF, TREE_TYPE (meta_field), param,
+		      meta_field, NULL_TREE);
+
+      if (resolved_tyty->get_kind () == TyTy::TypeKind::SLICE
+	  || resolved_tyty->get_kind () == TyTy::TypeKind::STR)
+	{
+	  tree elem_type = NULL_TREE;
+	  if (resolved_tyty->get_kind () == TyTy::TypeKind::SLICE)
+	    {
+	      auto slice_tyty = static_cast<TyTy::SliceType *> (resolved_tyty);
+	      elem_type
+		= TyTyResolveCompile::compile (ctx,
+					       slice_tyty->get_element_type ());
+	    }
+	  else
+	    elem_type = char_type_node;
+
+	  tree elem_size = TYPE_SIZE_UNIT (elem_type);
+	  size_expr
+	    = build2_loc (locus, MULT_EXPR, size_type_node,
+			  fold_convert_loc (locus, size_type_node,
+					    meta_field_expr),
+			  fold_convert_loc (locus, size_type_node, elem_size));
+	}
+      else if (resolved_tyty->get_kind () == TyTy::TypeKind::DYNAMIC)
+	{
+	  tree vtable_ptr_ty = TREE_TYPE (meta_field_expr);
+	  tree vtable_ty = TREE_TYPE (vtable_ptr_ty);
+
+	  tree vtable_ref
+	    = build1_loc (locus, INDIRECT_REF, vtable_ty, meta_field_expr);
+
+	  tree vtable_field_0 = TYPE_FIELDS (vtable_ty);
+	  tree vtable_field_size = DECL_CHAIN (vtable_field_0);
+	  rust_assert (vtable_field_size != NULL_TREE);
+
+	  size_expr
+	    = build3_loc (locus, COMPONENT_REF, TREE_TYPE (vtable_field_size),
+			  vtable_ref, vtable_field_size, NULL_TREE);
+	}
+      else
+	{
+	  rust_unreachable ();
+	}
+    }
+  else
+    size_expr = TYPE_SIZE_UNIT (template_parameter_type);
+
+  auto return_statement
+    = Backend::return_statement (fndecl, size_expr, UNDEF_LOCATION);
+  ctx->add_statement (return_statement);
+
+  // BUILTIN size_of FN BODY END
+
+  finalize_intrinsic_block (ctx, fndecl);
+
+  return fndecl;
+}
+
+/**
  * pub fn min_align_of<T>() -> usize;
  */
 tree

--- a/gcc/rust/backend/rust-intrinsic-handlers.h
+++ b/gcc/rust/backend/rust-intrinsic-handlers.h
@@ -62,6 +62,8 @@ tree size_of_val_handler (Context *ctx, TyTy::FnType *fntype,
 			  location_t expr_locus);
 tree min_align_of_handler (Context *ctx, TyTy::FnType *fntype,
 			   location_t expr_locus);
+tree min_align_of_val_handler (Context *ctx, TyTy::FnType *fntype,
+			       location_t expr_locus);
 tree transmute (Context *ctx, TyTy::FnType *fntype, location_t expr_locus);
 tree rotate (Context *ctx, TyTy::FnType *fntype, tree_code op);
 tree uninit (Context *ctx, TyTy::FnType *fntype, location_t expr_locus);

--- a/gcc/rust/backend/rust-intrinsic-handlers.h
+++ b/gcc/rust/backend/rust-intrinsic-handlers.h
@@ -58,6 +58,8 @@ tree rotate_right (Context *ctx, TyTy::FnType *fntype, location_t expr_locus);
 const HandlerBuilder wrapping_op (tree_code op);
 tree offset (Context *ctx, TyTy::FnType *fntype, location_t expr_locus);
 tree sizeof_handler (Context *ctx, TyTy::FnType *fntype, location_t expr_locus);
+tree size_of_val_handler (Context *ctx, TyTy::FnType *fntype,
+			  location_t expr_locus);
 tree min_align_of_handler (Context *ctx, TyTy::FnType *fntype,
 			   location_t expr_locus);
 tree transmute (Context *ctx, TyTy::FnType *fntype, location_t expr_locus);

--- a/gcc/rust/typecheck/rust-hir-type-check-intrinsic.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-intrinsic.cc
@@ -128,6 +128,8 @@ const std::unordered_map<std::string, IntrinsicRules>
      {1, {IRT::ConstPtrFirstGeneric, IRT::Isize}, IRT::ConstPtrFirstGeneric}},
     // pub fn size_of<T>() -> usize;
     {IValue::SIZE_OF, {1, {}, IRT::Usize}},
+    // pub fn size_of_val<T: ?Sized>(_: *const T) -> usize;
+    {IValue::SIZE_OF_VAL, {1, {IRT::ConstPtrFirstGeneric}, IRT::Usize}},
     // pub fn transmute<T, U>(e: T) -> U;
     {IValue::TRANSMUTE, {2, {IRT::FirstGeneric}, IRT::SecondGeneric}},
     // pub fn add_with_overflow<T: Copy>(x: T, y: T) -> (T, bool);

--- a/gcc/rust/typecheck/rust-hir-type-check-intrinsic.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-intrinsic.cc
@@ -267,6 +267,8 @@ const std::unordered_map<std::string, IntrinsicRules>
     {IValue::ASSUME, {0, {IRT::Bool}, IRT::Unit}},
     // pub fn min_align_of<T>() -> usize;
     {IValue::MIN_ALIGN_OF, {1, {}, IRT::Usize}},
+    // pub fn min_align_of_val<T: ?Sized>(_: *const T) -> usize;
+    {IValue::MIN_ALIGN_OF_VAL, {1, {IRT::ConstPtrFirstGeneric}, IRT::Usize}},
     // pub fn needs_drop<T>() -> bool;
     {IValue::NEEDS_DROP, {1, {}, IRT::Bool}},
     // pub fn caller_location() -> &'static crate::panic::Location<'static>;

--- a/gcc/rust/util/rust-intrinsic-values.h
+++ b/gcc/rust/util/rust-intrinsic-values.h
@@ -138,6 +138,7 @@ public:
   static constexpr auto &ASSUME = "assume";
 
   static constexpr auto &MIN_ALIGN_OF = "min_align_of";
+  static constexpr auto &MIN_ALIGN_OF_VAL = "min_align_of_val";
   static constexpr auto &NEEDS_DROP = "needs_drop";
   static constexpr auto &CALLER_LOCATION = "caller_location";
   static constexpr auto &CTPOP = "ctpop";

--- a/gcc/rust/util/rust-intrinsic-values.h
+++ b/gcc/rust/util/rust-intrinsic-values.h
@@ -84,6 +84,7 @@ public:
   static constexpr auto &ABORT = "abort";
   static constexpr auto &OFFSET = "offset";
   static constexpr auto &SIZE_OF = "size_of";
+  static constexpr auto &SIZE_OF_VAL = "size_of_val";
   static constexpr auto &TRANSMUTE = "transmute";
 
   static constexpr auto &ADD_WITH_OVERFLOW = "add_with_overflow";

--- a/gcc/testsuite/rust/execute/min-align-of-val.rs
+++ b/gcc/testsuite/rust/execute/min-align-of-val.rs
@@ -1,0 +1,64 @@
+// { dg-require-effective-target lp64 }
+#![feature(no_core, intrinsics, lang_items)]
+#![no_core]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+extern "rust-intrinsic" {
+    pub fn min_align_of_val<T: ?Sized>(_: *const T) -> usize;
+}
+
+trait TraitA {
+    fn foo(&self) {}
+}
+
+struct StructA {
+    _a: i32,
+    _b: i16,
+}
+
+impl TraitA for StructA {}
+impl TraitA for u8 {}
+
+fn main() -> i32 {
+    let val_i32: i32 = 32;
+    let align_i32 = unsafe { min_align_of_val(&val_i32 as *const i32) };
+
+    let val_struct = StructA { _a: 1, _b: 2 };
+    let align_struct = unsafe { min_align_of_val(&val_struct as *const StructA) };
+
+    let arr: [i32; 3] = [10, 20, 30];
+    let val_slice: &[i32] = &arr;
+    let align_slice = unsafe { min_align_of_val(val_slice as *const [i32]) };
+
+    let val_str: &str = "gccrs";
+    let align_str = unsafe { min_align_of_val(val_str as *const str) };
+
+    let val_dyn_struct = &val_struct as &dyn TraitA;
+    let align_dyn_struct = unsafe { min_align_of_val(val_dyn_struct as *const dyn TraitA) };
+
+    let val_u8: u8 = 7;
+    let align_u8 = unsafe { min_align_of_val(&val_u8 as *const u8) };
+
+    let val_dyn_u8 = &val_u8 as &dyn TraitA;
+    let align_dyn_u8 = unsafe { min_align_of_val(val_dyn_u8 as *const dyn TraitA) };
+
+    if align_i32 != 4 {
+        1
+    } else if align_struct != 4 {
+        2
+    } else if align_slice != 4 {
+        3
+    } else if align_str != 1 {
+        4
+    } else if align_dyn_struct != 4 {
+        5
+    } else if align_u8 != 1 {
+        6
+    } else if align_dyn_u8 != 1 {
+        7
+    } else {
+        0
+    }
+}

--- a/gcc/testsuite/rust/execute/size-of-val.rs
+++ b/gcc/testsuite/rust/execute/size-of-val.rs
@@ -1,0 +1,63 @@
+#![feature(no_core, intrinsics, lang_items)]
+#![no_core]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+extern "rust-intrinsic" {
+    pub fn size_of_val<T: ?Sized>(_: *const T) -> usize;
+}
+
+trait TraitA {
+    fn foo(&self) {}
+}
+
+struct StructA {
+    _a: i32,
+    _b: i32,
+}
+
+impl TraitA for StructA {}
+impl TraitA for u8 {}
+
+fn main() -> i32 {
+    let val_i32: i32 = 32;
+    let size_i32 = unsafe { size_of_val(&val_i32 as *const i32) };
+
+    let val_struct = StructA { _a: 1, _b: 2 };
+    let size_struct = unsafe { size_of_val(&val_struct as *const StructA) };
+
+    let arr: [i32; 3] = [10, 20, 30];
+    let val_slice: &[i32] = &arr;
+    let size_slice = unsafe { size_of_val(val_slice as *const [i32]) };
+
+    let val_str: &str = "gccrs";
+    let size_str = unsafe { size_of_val(val_str as *const str) };
+
+    let val_dyn_struct = &val_struct as &dyn TraitA;
+    let size_dyn_struct = unsafe { size_of_val(val_dyn_struct as *const dyn TraitA) };
+
+    let val_u8: u8 = 7;
+    let size_u8 = unsafe { size_of_val(&val_u8 as *const u8) };
+
+    let val_dyn_u8 = &val_u8 as &dyn TraitA;
+    let size_dyn_u8 = unsafe { size_of_val(val_dyn_u8 as *const dyn TraitA) };
+
+    if size_i32 != 4 {
+        1
+    } else if size_struct != 8 {
+        2
+    } else if size_slice != 12 {
+        3
+    } else if size_str != 5 {
+        4
+    } else if size_dyn_struct != 8 {
+        5
+    } else if size_u8 != 1 {
+        6
+    } else if size_dyn_u8 != 1 {
+        7
+    } else {
+        0
+    }
+}


### PR DESCRIPTION
This patch adds the `size_of_val` and `min_align_of_val` intrinsics to the compiler. This intrinsics evaluates the size/align of a value at runtime, including DSTs.