### PR TITLE
gccrs: Fix `IdentifierPathPass` on sub-patterns

### DIFF
--- a/gcc/rust/resolve/rust-identifier-path.cc
+++ b/gcc/rust/resolve/rust-identifier-path.cc
@@ -39,11 +39,14 @@ IdentifierPathPass::go (AST::Crate &crate, NameResolutionContext &ctx,
 void
 IdentifierPathPass::reseat (std::unique_ptr<AST::Pattern> &ptr)
 {
-  AST::IdentifierPattern *ident_pat;
-  if (ptr->get_pattern_kind () == AST::Pattern::Kind::Identifier)
-    ident_pat = static_cast<AST::IdentifierPattern *> (ptr.get ());
-  else
-    return;
+  if (ptr->get_pattern_kind () != AST::Pattern::Kind::Identifier)
+    {
+      // bail out, but make sure to still visit
+      visit (ptr);
+      return;
+    }
+
+  auto ident_pat = static_cast<AST::IdentifierPattern *> (ptr.get ());
 
   if (ident_path_to_convert.find (ident_pat->get_node_id ())
       != ident_path_to_convert.end ())
@@ -54,6 +57,10 @@ IdentifierPathPass::reseat (std::unique_ptr<AST::Pattern> &ptr)
       ptr = std::make_unique<AST::PathInExpression> (
 	std::move (segments), std::vector<AST::Attribute> (),
 	ident_pat->get_locus ());
+    }
+  else
+    {
+      visit (ptr);
     }
 }
 

--- a/gcc/testsuite/rust/execute/ident_pat_vs_path_3.rs
+++ b/gcc/testsuite/rust/execute/ident_pat_vs_path_3.rs
@@ -1,0 +1,27 @@
+// { dg-additional-options "-w" }
+#![feature(no_core)]
+#![no_core]
+
+enum E {
+    A,
+    B,
+    C
+}
+
+fn main() -> i32 {
+    use E::C;
+
+    let v1 = match (E::A,) {
+        (C,) => 1,
+        (E::A,) => 0,
+        (E::B,) => 1
+    };
+
+    let v2 = match (E::A,) {
+        (B,) => 0,
+        (E::A,) => 1,
+        (C,) => 1
+    };
+
+    v1 + v2
+}


### PR DESCRIPTION
This should address #4116. It will probably fix it, but I want to double check before automatically closing #4116.

Supersedes #4117 and is a follow up to #4455.