### PR TITLE
gccrs: Fix type param forward declare check

### DIFF
--- a/gcc/rust/resolve/rust-default-resolver.cc
+++ b/gcc/rust/resolve/rust-default-resolver.cc
@@ -433,9 +433,17 @@ DefaultResolver::visit (AST::StaticItem &item)
 void
 DefaultResolver::visit (AST::TypeParam &param)
 {
-  auto expr_vis = [this, &param] () { AST::DefaultASTVisitor::visit (param); };
+  auto param_ban_vis = [this, &param] () {
+    visit_outer_attrs (param);
+    if (param.has_type ())
+      visit (param.get_type ());
+  };
 
-  ctx.scoped (Rib::Kind::ForwardTypeParamBan, param.get_node_id (), expr_vis);
+  ctx.scoped (Rib::Kind::ForwardTypeParamBan, param.get_node_id (),
+	      param_ban_vis);
+
+  for (auto &bound : param.get_type_param_bounds ())
+    visit (bound);
 }
 
 void

--- a/gcc/testsuite/rust/compile/generics15.rs
+++ b/gcc/testsuite/rust/compile/generics15.rs
@@ -1,0 +1,9 @@
+#![feature(no_core, lang_items)]
+#![no_core]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+pub trait A<T> {}
+
+pub struct B<T: A<T>> (T);


### PR DESCRIPTION
Type param bounds are allowed to use forward declared generic parameters.