### PR TITLE
gccrs: Emit block scope drops through TRY_FINALLY_EXPR

### DIFF
--- a/gcc/rust/backend/rust-compile-block.cc
+++ b/gcc/rust/backend/rust-compile-block.cc
@@ -85,9 +85,9 @@ CompileBlock::visit (HIR::BlockExpr &expr)
 					 expr.get_locus ());
       ctx->add_statement (assignment);
     }
-  CompileDrop (ctx).emit_current_scope_drop_calls ();
+  tree cleanup = CompileDrop (ctx).build_current_scope_drop_cleanup ();
 
-  ctx->pop_block ();
+  ctx->pop_block_with_cleanup (cleanup, expr.get_locus ());
   translated = new_block;
 }
 

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -107,20 +107,11 @@ public:
     block_drop_candidates.emplace_back ();
   }
 
-  tree pop_block ()
+  tree pop_block () { return pop_block_impl (NULL_TREE, UNKNOWN_LOCATION); }
+
+  tree pop_block_with_cleanup (tree cleanup, location_t cleanup_locus)
   {
-    auto block = scope_stack.back ();
-    scope_stack.pop_back ();
-
-    auto stmts = statements.back ();
-    statements.pop_back ();
-
-    rust_assert (!block_drop_candidates.empty ());
-    block_drop_candidates.pop_back ();
-
-    Backend::block_add_statements (block, stmts);
-
-    return block;
+    return pop_block_impl (cleanup, cleanup_locus);
   }
 
   tree peek_enclosing_scope ()
@@ -428,6 +419,34 @@ public:
 private:
   friend class DropBuilder;
   Context ();
+
+  tree pop_block_impl (tree cleanup, location_t cleanup_locus)
+  {
+    auto block = scope_stack.back ();
+    scope_stack.pop_back ();
+
+    auto stmts = statements.back ();
+    statements.pop_back ();
+
+    rust_assert (!block_drop_candidates.empty ());
+    block_drop_candidates.pop_back ();
+
+    if (cleanup != NULL_TREE)
+      {
+	tree body = Backend::statement_list (stmts);
+	if (body == NULL_TREE)
+	  body = build_empty_stmt (cleanup_locus);
+
+	tree try_finally
+	  = Backend::exception_handler_statement (body, NULL_TREE, cleanup,
+						  cleanup_locus);
+	Backend::block_add_statements (block, {try_finally});
+      }
+    else
+      Backend::block_add_statements (block, stmts);
+
+    return block;
+  }
 
   Resolver::TypeCheckContext *tyctx;
   Analysis::Mappings &mappings;

--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -437,8 +437,14 @@ private:
 	if (body == NULL_TREE)
 	  body = build_empty_stmt (cleanup_locus);
 
+	tree exceptional_cleanup = build_empty_stmt (cleanup_locus);
+	tree cleanup_selector
+	  = build2_loc (cleanup_locus, EH_ELSE_EXPR, void_type_node, cleanup,
+			exceptional_cleanup);
+
 	tree try_finally
-	  = Backend::exception_handler_statement (body, NULL_TREE, cleanup,
+	  = Backend::exception_handler_statement (body, NULL_TREE,
+						  cleanup_selector,
 						  cleanup_locus);
 	Backend::block_add_statements (block, {try_finally});
       }

--- a/gcc/rust/backend/rust-compile-drop.cc
+++ b/gcc/rust/backend/rust-compile-drop.cc
@@ -90,9 +90,11 @@ CompileDrop::compile_drop_call (Bvariable *var, TyTy::BaseType *ty,
   return Backend::call_expression (fn_addr, {var_addr}, nullptr, locus);
 }
 
-void
-CompileDrop::emit_current_scope_drop_calls ()
+tree
+CompileDrop::build_current_scope_drop_cleanup ()
 {
+  std::vector<tree> drop_stmts;
+
   DropBuilder drop_builder (*ctx);
   auto &drop_candidates = drop_builder.peek_block_drop_candidates ();
 
@@ -109,8 +111,21 @@ CompileDrop::emit_current_scope_drop_calls ()
 
       tree drop_call = compile_drop_call (var, ty, it->locus);
       if (drop_call != NULL_TREE)
-	ctx->add_statement (convert_to_void (drop_call, ICV_STATEMENT));
+	drop_stmts.push_back (convert_to_void (drop_call, ICV_STATEMENT));
     }
+
+  if (drop_stmts.empty ())
+    return NULL_TREE;
+
+  return Backend::statement_list (drop_stmts);
+}
+
+void
+CompileDrop::emit_current_scope_drop_calls ()
+{
+  tree cleanup = build_current_scope_drop_cleanup ();
+  if (cleanup != NULL_TREE)
+    ctx->add_statement (cleanup);
 }
 
 } // namespace Compile

--- a/gcc/rust/backend/rust-compile-drop.h
+++ b/gcc/rust/backend/rust-compile-drop.h
@@ -31,6 +31,7 @@ public:
 
   bool type_has_drop_impl (TyTy::BaseType *ty);
 
+  tree build_current_scope_drop_cleanup ();
   void emit_current_scope_drop_calls ();
 
 private:


### PR DESCRIPTION
This PR consists of 3 commits.

It changes block-scope Drop emission to use a TRY_FINALLY_EXPR cleanup instead of 
appending drop calls directly to the block body.

For example, a block like:
```rust
{
    let x = Droppable;
}
```

is lowered as:

```text
try {
    let x = Droppable;
} finally {
    drop(x);
}
```

This follows the same general cleanup/finally shape used by the Go frontend for defer handling.

For now, this PR only covers block-scope drops. Function-scope drops, explicit return cleanup, 
break/continue are left for follow-up work.

---
**commit 1**

gccrs: Add helper to build scope drop cleanup

gcc/rust/ChangeLog:

	* backend/rust-compile-drop.cc
	(CompileDrop::build_current_scope_drop_cleanup): New function to
	build current scope drop calls as a statement tree.
	(CompileDrop::emit_current_scope_drop_calls): Use it.
	* backend/rust-compile-drop.h
	(CompileDrop::build_current_scope_drop_cleanup): Declare.


**commit 2**

gccrs: Emit block scope drops through TRY_FINALLY_EXPR

gcc/rust/ChangeLog:

	* backend/rust-compile-block.cc
	(CompileBlock::visit): Build current scope drop cleanup and pass it
	when popping the block.
	* backend/rust-compile-context.h
	(Context::pop_block): Use pop_block_impl.
	(Context::pop_block_with_cleanup): New function for popping a block
	with cleanup code.
	(Context::pop_block_impl): New helper that adds the block statements
	directly, or wraps them in TRY_FINALLY_EXPR when cleanup is present.
	
**commit 3**

gccrs: Use EH_ELSE_EXPR in block Drop TRY_FINALLY_EXPR

gcc/rust/ChangeLog:

	* backend/rust-compile-context.h
	(Context::pop_block_impl): Wrap Drop cleanup in an EH_ELSE_EXPR.
	
---
**Note:**

`TRY_FINALLY_EXPR` cleanup originally caused `drop-nested-block-scope.rs` to fail
to link with an undefined reference to `__gccrs_personality_v0`.

This version wraps the cleanup operand in `EH_ELSE_EXPR`, using the Drop cleanup
as the normal cleanup and an empty exceptional cleanup for now.
With that, `drop-nested-block-scope.rs` links and passes locally.

