### PR TITLE
gccrs: Fix duplicate "trailing semicolon in macro used" warnings

### DIFF
--- a/gcc/rust/expand/rust-macro-expand.cc
+++ b/gcc/rust/expand/rust-macro-expand.cc
@@ -1011,9 +1011,14 @@ transcribe_expression (Parser<MacroInvocLexer> &parser)
   // FIXME: make this an error for some edititons
   if (parser.peek_current_token ()->get_id () == SEMICOLON)
     {
-      rust_warning_at (
-	parser.peek_current_token ()->get_locus (), 0,
-	"trailing semicolon in macro used in expression context");
+      // TODO bandaid for now, make this a member for MacroExpander instead in
+      // the future
+      static std::unordered_set<location_t> warned_loc;
+      auto locus = parser.peek_current_token ()->get_locus ();
+      if (warned_loc.insert (locus).second)
+	rust_warning_at (
+	  parser.peek_current_token ()->get_locus (), 0,
+	  "trailing semicolon in macro used in expression context");
       parser.skip_token ();
     }
 


### PR DESCRIPTION
Compiling `core` is causing this warning to get spammed, this is just a hot fix to suppress the spam.