### PR TITLE
attr: Register rustc_conversion_suggestion

### DIFF
--- a/gcc/rust/checks/errors/rust-builtin-attribute-checker.cc
+++ b/gcc/rust/checks/errors/rust-builtin-attribute-checker.cc
@@ -382,6 +382,7 @@ const std::unordered_map<std::string, std::function<void (AST::Attribute &)>>
     {Attrs::RUSTC_ALLOCATOR, handlers::expect_no_input},
     {Attrs::RUSTC_ALLOCATOR_NOUNWIND, handlers::expect_no_input},
     {Attrs::GLOBAL_ALLOCATOR, handlers::expect_no_input},
+    {Attrs::RUSTC_CONVERSION_SUGGESTION, handlers::expect_no_input},
 };
 
 tl::optional<std::function<void (AST::Attribute &)>>
@@ -442,6 +443,19 @@ check_valid_attribute_for_item (const AST::Attribute &attr,
 		     "the %<#[%s]%> attribute may only be applied "
 		     "to static items",
 		     attr.get_path ().as_string ().c_str ());
+    }
+  else if (attr.get_path () == Values::Attributes::RUSTC_CONVERSION_SUGGESTION)
+    {
+      auto attr_path = attr.get_path ().as_string ();
+      rust_warning_at (attr.get_locus (), 0,
+		       "%<#[%s]%> is not implemented yet and has no effect",
+		       attr_path.c_str ());
+      if (item.get_item_kind () != AST::Item::Kind::Function)
+	{
+	  rust_error_at (item.get_locus (),
+			 "%<#[%s]%> can only be applied to functions",
+			 attr_path.c_str ());
+	}
     }
 }
 

--- a/gcc/rust/util/rust-attribute-values.h
+++ b/gcc/rust/util/rust-attribute-values.h
@@ -113,6 +113,9 @@ public:
 
   static constexpr auto &RUSTC_ALLOCATOR = "rustc_allocator";
   static constexpr auto &RUSTC_ALLOCATOR_NOUNWIND = "rustc_allocator_nounwind";
+
+  static constexpr auto &RUSTC_CONVERSION_SUGGESTION
+    = "rustc_conversion_suggestion";
 };
 } // namespace Values
 } // namespace Rust

--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -97,7 +97,8 @@ static const BuiltinAttrDefinition __definitions[]
      {Attrs::TEST, CODE_GENERATION},
      {Attrs::RUSTC_ALLOCATOR, CODE_GENERATION},
      {Attrs::RUSTC_ALLOCATOR_NOUNWIND, CODE_GENERATION},
-     {Attrs::GLOBAL_ALLOCATOR, CODE_GENERATION}};
+     {Attrs::GLOBAL_ALLOCATOR, CODE_GENERATION},
+     {Attrs::RUSTC_CONVERSION_SUGGESTION, TYPE_CHECK}};
 
 static const std::set<std::string> __outer_attributes
   = {Attrs::INLINE,

--- a/gcc/testsuite/rust/compile/rustc_conversion_suggestion.rs
+++ b/gcc/testsuite/rust/compile/rustc_conversion_suggestion.rs
@@ -1,0 +1,14 @@
+#![feature(no_core, rustc_attrs)]
+#![no_core]
+
+#[rustc_conversion_suggestion] // { dg-warning "...rustc_conversion_suggestion.. is not implemented yet and has no effect" }
+pub fn to_string() {}
+
+#[rustc_conversion_suggestion] // { dg-warning "...rustc_conversion_suggestion.. is not implemented yet and has no effect" }
+const TO_STRING : i32 = 0; // { dg-error "...rustc_conversion_suggestion.. can only be applied to functions" } 
+
+#[rustc_conversion_suggestion] // { dg-warning "...rustc_conversion_suggestion.. is not implemented yet and has no effect" }
+static TO_STRING2 : i32 = 0; // { dg-error "...rustc_conversion_suggestion.. can only be applied to functions" }
+
+#[rustc_conversion_suggestion] // { dg-warning "...rustc_conversion_suggestion.. is not implemented yet and has no effect" }
+struct TO_STRING3; // { dg-error "...rustc_conversion_suggestion.. can only be applied to functions" }


### PR DESCRIPTION
This patch registers the `rustc_conversion_suggestion` attribute. This attribute is needed for compiling the `alloc` crate, so we register it as a stub and the compiler will emit a warning when it encounters this attribute.

gcc/rust/ChangeLog:

	* checks/errors/rust-builtin-attribute-checker.cc (attribute_checking_handlers): Add rustc_conversion_suggestion attribute to map. (check_valid_attribute_for_item): Add warning for new attribute.
	* util/rust-attribute-values.h (class Attributes): Add RUSTC_CONVERSION_SUGGESTION constexpr.
	* util/rust-attributes.cc (__definitions): Add BuiltinAttrDefinition for new attribute.

gcc/testsuite/ChangeLog:

	* rust/compile/rustc_conversion_suggestion.rs: New test.