### PR TITLE
attr: Register needs_allocator

### DIFF
--- a/gcc/rust/checks/errors/rust-builtin-attribute-checker.cc
+++ b/gcc/rust/checks/errors/rust-builtin-attribute-checker.cc
@@ -38,6 +38,13 @@ check_inner_attribute (const AST::Attribute &attribute)
   if (Attributes::valid_outer_attribute (result.name))
     rust_error_at (attribute.get_locus (),
 		   "attribute cannot be used at crate level");
+
+  if (result.name == Values::Attributes::NEEDS_ALLOCATOR)
+    {
+      rust_warning_at (attribute.get_locus (), 0,
+		       "%<#[%s]%> is not implemented yet and has no effect",
+		       attribute.as_string ().c_str ());
+    }
 }
 
 /**

--- a/gcc/rust/util/rust-attribute-values.h
+++ b/gcc/rust/util/rust-attribute-values.h
@@ -111,6 +111,8 @@ public:
   static constexpr auto &RUSTC_ARGS_REQUIRED_CONST
     = "rustc_args_required_const";
 
+  static constexpr auto &NEEDS_ALLOCATOR = "needs_allocator";
+
   static constexpr auto &RUSTC_ALLOCATOR = "rustc_allocator";
   static constexpr auto &RUSTC_ALLOCATOR_NOUNWIND = "rustc_allocator_nounwind";
 };

--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -95,6 +95,7 @@ static const BuiltinAttrDefinition __definitions[]
      {Attrs::NON_EXHAUSTIVE, TYPE_CHECK},
      {Attrs::RUSTFMT, EXTERNAL},
      {Attrs::TEST, CODE_GENERATION},
+     {Attrs::NEEDS_ALLOCATOR, CODE_GENERATION},
      {Attrs::RUSTC_ALLOCATOR, CODE_GENERATION},
      {Attrs::RUSTC_ALLOCATOR_NOUNWIND, CODE_GENERATION},
      {Attrs::GLOBAL_ALLOCATOR, CODE_GENERATION}};

--- a/gcc/testsuite/rust/compile/needs_allocator.rs
+++ b/gcc/testsuite/rust/compile/needs_allocator.rs
@@ -1,0 +1,4 @@
+#![feature(no_core)]
+#![no_core]
+
+#![needs_allocator] // { dg-warning "...needs_allocator.. is not implemented yet and has no effect" }


### PR DESCRIPTION
This patch registers the 'needs_allocator' attribute, which is required for compiling the 'alloc' crate.

Currently, it is implemented as a stub that emits a compiler warning when encountered. The reoson for this temporary stub is that full handling of 'needs_allocator' strictly depends on the 'global_allocator' infrastructure and the 'core::alloc::GlobalAlloc' trait. Since gccrs does not yet have full support for the 'core' crate, a complete implementation is deferred.

gcc/rust/ChangeLog:

	* checks/errors/rust-builtin-attribute-checker.cc (check_inner_attribute): Add warning for needs_allocator.
	* util/rust-attribute-values.h (class Attributes): Add NEEDS_ALLOCATOR constexpr.
	* util/rust-attributes.cc (__definitions): Add BuiltinAttrDefinition for new attribute.

gcc/testsuite/ChangeLog:

	* rust/compile/needs_allocator.rs: New test.