### PR TITLE
gccrs: Name resolve external types

### DIFF
--- a/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
@@ -391,6 +391,15 @@ TopLevel::visit (AST::TypeAlias &type_item)
   DefaultResolver::visit (type_item);
 }
 
+void
+TopLevel::visit (AST::ExternalTypeItem &type_item)
+{
+  insert_or_error_out (type_item.get_identifier (), type_item,
+		       Namespace::Types);
+
+  DefaultResolver::visit (type_item);
+}
+
 static void flatten_rebind (
   const AST::UseTreeRebind &glob,
   std::vector<std::pair<AST::SimplePath, AST::UseTreeRebind>> &rebind_paths);

--- a/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.h
+++ b/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.h
@@ -183,6 +183,7 @@ private:
   void visit (AST::Union &union_item) override;
   void visit (AST::ConstantItem &const_item) override;
   void visit (AST::TypeAlias &type_item) override;
+  void visit (AST::ExternalTypeItem &type_item) override;
   void visit_extern_crate (AST::ExternCrate &, AST::Crate &, CrateNum) override;
   void visit (AST::TypeParam &type_param) override;
   void visit (AST::ConstGenericParam &const_param) override;

--- a/gcc/testsuite/rust/compile/extern_type_item_resolve.rs
+++ b/gcc/testsuite/rust/compile/extern_type_item_resolve.rs
@@ -1,0 +1,9 @@
+// { dg-additional-options "-frust-compile-until=typecheck" }
+#![feature(no_core, extern_types)]
+#![no_core]
+
+extern "C" {
+    type X;
+}
+
+type Y = X;


### PR DESCRIPTION
This allows us to resolve external types, although they won't pass typechecking.