### PR TITLE
Add range_inclusive_new

### DIFF
--- a/gcc/rust/backend/rust-compile-block.h
+++ b/gcc/rust/backend/rust-compile-block.h
@@ -92,7 +92,6 @@ public:
   void visit (HIR::RangeFromExpr &) override {}
   void visit (HIR::RangeToExpr &) override {}
   void visit (HIR::RangeFullExpr &) override {}
-  void visit (HIR::RangeFromToInclExpr &) override {}
   void visit (HIR::RangeToInclExpr &) override {}
   void visit (HIR::BoxExpr &) override {}
   void visit (HIR::ReturnExpr &) override {}
@@ -183,7 +182,6 @@ public:
   void visit (HIR::RangeFromExpr &) override {}
   void visit (HIR::RangeToExpr &) override {}
   void visit (HIR::RangeFullExpr &) override {}
-  void visit (HIR::RangeFromToInclExpr &) override {}
   void visit (HIR::RangeToInclExpr &) override {}
   void visit (HIR::BoxExpr &) override {}
   void visit (HIR::ReturnExpr &) override {}

--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -2626,29 +2626,6 @@ CompileExpr::visit (HIR::RangeFullExpr &expr)
 }
 
 void
-CompileExpr::visit (HIR::RangeFromToInclExpr &expr)
-{
-  tree from = CompileExpr::Compile (expr.get_from_expr (), ctx);
-  tree to = CompileExpr::Compile (expr.get_to_expr (), ctx);
-  if (from == error_mark_node || to == error_mark_node)
-    {
-      translated = error_mark_node;
-      return;
-    }
-
-  TyTy::BaseType *tyty = nullptr;
-  bool ok
-    = ctx->get_tyctx ()->lookup_type (expr.get_mappings ().get_hirid (), &tyty);
-  rust_assert (ok);
-
-  tree adt = TyTyResolveCompile::compile (ctx, tyty);
-
-  // make the constructor
-  translated = Backend::constructor_expression (adt, false, {from, to}, -1,
-						expr.get_locus ());
-}
-
-void
 CompileExpr::visit (HIR::ArrayIndexExpr &expr)
 {
   tree array_reference = CompileExpr::Compile (expr.get_array_expr (), ctx);

--- a/gcc/rust/backend/rust-compile-expr.h
+++ b/gcc/rust/backend/rust-compile-expr.h
@@ -71,7 +71,6 @@ public:
   void visit (HIR::RangeFromExpr &expr) override;
   void visit (HIR::RangeToExpr &expr) override;
   void visit (HIR::RangeFullExpr &expr) override;
-  void visit (HIR::RangeFromToInclExpr &expr) override;
   void visit (HIR::ClosureExpr &expr) override;
   void visit (HIR::InlineAsm &expr) override;
   void visit (HIR::LlvmInlineAsm &expr) override;

--- a/gcc/rust/checks/errors/borrowck/rust-bir-builder-expr-stmt.cc
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-builder-expr-stmt.cc
@@ -490,15 +490,6 @@ ExprStmtBuilder::visit (HIR::RangeFullExpr &expr)
 }
 
 void
-ExprStmtBuilder::visit (HIR::RangeFromToInclExpr &expr)
-{
-  auto from = visit_expr (expr.get_from_expr ());
-  auto to = visit_expr (expr.get_to_expr ());
-  return_expr (new InitializerExpr ({from, to}), lookup_type (expr),
-	       expr.get_locus ());
-}
-
-void
 ExprStmtBuilder::visit (HIR::RangeToInclExpr &expr)
 {
   auto to = visit_expr (expr.get_to_expr ());

--- a/gcc/rust/checks/errors/borrowck/rust-bir-builder-expr-stmt.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-builder-expr-stmt.h
@@ -93,7 +93,6 @@ protected: // Expr
   void visit (HIR::RangeFromExpr &expr) override;
   void visit (HIR::RangeToExpr &expr) override;
   void visit (HIR::RangeFullExpr &expr) override;
-  void visit (HIR::RangeFromToInclExpr &expr) override;
   void visit (HIR::RangeToInclExpr &expr) override;
   void visit (HIR::BoxExpr &expr) override;
   void visit (HIR::ReturnExpr &ret) override;

--- a/gcc/rust/checks/errors/borrowck/rust-bir-builder-lazyboolexpr.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-builder-lazyboolexpr.h
@@ -237,7 +237,6 @@ protected: // Illegal at this position.
   void visit (HIR::RangeFromExpr &expr) override { rust_unreachable (); }
   void visit (HIR::RangeToExpr &expr) override { rust_unreachable (); }
   void visit (HIR::RangeFullExpr &expr) override { rust_unreachable (); }
-  void visit (HIR::RangeFromToInclExpr &expr) override { rust_unreachable (); }
   void visit (HIR::RangeToInclExpr &expr) override { rust_unreachable (); }
   void visit (HIR::ReturnExpr &expr) override { rust_unreachable (); }
   void visit (HIR::BoxExpr &expr) override { rust_unreachable (); }

--- a/gcc/rust/checks/errors/borrowck/rust-bir-builder-struct.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-builder-struct.h
@@ -143,7 +143,6 @@ protected:
   void visit (HIR::RangeFromExpr &expr) override { rust_unreachable (); }
   void visit (HIR::RangeToExpr &expr) override { rust_unreachable (); }
   void visit (HIR::RangeFullExpr &expr) override { rust_unreachable (); }
-  void visit (HIR::RangeFromToInclExpr &expr) override { rust_unreachable (); }
   void visit (HIR::RangeToInclExpr &expr) override { rust_unreachable (); }
   void visit (HIR::BoxExpr &expr) override { rust_unreachable (); }
   void visit (HIR::ReturnExpr &expr) override { rust_unreachable (); }

--- a/gcc/rust/checks/errors/borrowck/rust-function-collector.h
+++ b/gcc/rust/checks/errors/borrowck/rust-function-collector.h
@@ -113,7 +113,6 @@ public:
   void visit (HIR::RangeFromExpr &expr) override {}
   void visit (HIR::RangeToExpr &expr) override {}
   void visit (HIR::RangeFullExpr &expr) override {}
-  void visit (HIR::RangeFromToInclExpr &expr) override {}
   void visit (HIR::RangeToInclExpr &expr) override {}
   void visit (HIR::BoxExpr &expr) override {}
   void visit (HIR::ReturnExpr &expr) override {}

--- a/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
+++ b/gcc/rust/checks/errors/privacy/rust-privacy-reporter.cc
@@ -576,13 +576,6 @@ PrivacyReporter::visit (HIR::RangeFullExpr &)
 {}
 
 void
-PrivacyReporter::visit (HIR::RangeFromToInclExpr &expr)
-{
-  expr.get_from_expr ().accept_vis (*this);
-  expr.get_to_expr ().accept_vis (*this);
-}
-
-void
 PrivacyReporter::visit (HIR::RangeToInclExpr &)
 {
   // Not handled yet

--- a/gcc/rust/checks/errors/privacy/rust-privacy-reporter.h
+++ b/gcc/rust/checks/errors/privacy/rust-privacy-reporter.h
@@ -125,7 +125,6 @@ types
   virtual void visit (HIR::RangeFromExpr &expr);
   virtual void visit (HIR::RangeToExpr &expr);
   virtual void visit (HIR::RangeFullExpr &expr);
-  virtual void visit (HIR::RangeFromToInclExpr &expr);
   virtual void visit (HIR::RangeToInclExpr &expr);
   virtual void visit (HIR::BoxExpr &expr);
   virtual void visit (HIR::ReturnExpr &expr);

--- a/gcc/rust/checks/errors/rust-const-checker.cc
+++ b/gcc/rust/checks/errors/rust-const-checker.cc
@@ -460,13 +460,6 @@ ConstChecker::visit (RangeFullExpr &)
 {}
 
 void
-ConstChecker::visit (RangeFromToInclExpr &expr)
-{
-  expr.get_from_expr ().accept_vis (*this);
-  expr.get_to_expr ().accept_vis (*this);
-}
-
-void
 ConstChecker::visit (RangeToInclExpr &)
 {
   // FIXME: Visit to_expr

--- a/gcc/rust/checks/errors/rust-const-checker.h
+++ b/gcc/rust/checks/errors/rust-const-checker.h
@@ -121,7 +121,6 @@ private:
   virtual void visit (RangeFromExpr &expr) override;
   virtual void visit (RangeToExpr &expr) override;
   virtual void visit (RangeFullExpr &expr) override;
-  virtual void visit (RangeFromToInclExpr &expr) override;
   virtual void visit (RangeToInclExpr &expr) override;
   virtual void visit (BoxExpr &expr) override;
   virtual void visit (ReturnExpr &expr) override;

--- a/gcc/rust/checks/errors/rust-hir-pattern-analysis.cc
+++ b/gcc/rust/checks/errors/rust-hir-pattern-analysis.cc
@@ -331,13 +331,6 @@ PatternChecker::visit (RangeFullExpr &)
 {}
 
 void
-PatternChecker::visit (RangeFromToInclExpr &expr)
-{
-  expr.get_from_expr ().accept_vis (*this);
-  expr.get_to_expr ().accept_vis (*this);
-}
-
-void
 PatternChecker::visit (RangeToInclExpr &expr)
 {
   expr.get_to_expr ().accept_vis (*this);

--- a/gcc/rust/checks/errors/rust-hir-pattern-analysis.h
+++ b/gcc/rust/checks/errors/rust-hir-pattern-analysis.h
@@ -95,7 +95,6 @@ private:
   virtual void visit (RangeFromExpr &expr) override;
   virtual void visit (RangeToExpr &expr) override;
   virtual void visit (RangeFullExpr &expr) override;
-  virtual void visit (RangeFromToInclExpr &expr) override;
   virtual void visit (RangeToInclExpr &expr) override;
   virtual void visit (BoxExpr &expr) override;
   virtual void visit (ReturnExpr &expr) override;

--- a/gcc/rust/checks/errors/rust-unsafe-checker.cc
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.cc
@@ -561,13 +561,6 @@ UnsafeChecker::visit (RangeFullExpr &)
 {}
 
 void
-UnsafeChecker::visit (RangeFromToInclExpr &expr)
-{
-  expr.get_from_expr ().accept_vis (*this);
-  expr.get_to_expr ().accept_vis (*this);
-}
-
-void
 UnsafeChecker::visit (RangeToInclExpr &expr)
 {
   expr.get_to_expr ().accept_vis (*this);

--- a/gcc/rust/checks/errors/rust-unsafe-checker.h
+++ b/gcc/rust/checks/errors/rust-unsafe-checker.h
@@ -103,7 +103,6 @@ private:
   virtual void visit (RangeFromExpr &expr) override;
   virtual void visit (RangeToExpr &expr) override;
   virtual void visit (RangeFullExpr &expr) override;
-  virtual void visit (RangeFromToInclExpr &expr) override;
   virtual void visit (RangeToInclExpr &expr) override;
   virtual void visit (BoxExpr &expr) override;
   virtual void visit (ReturnExpr &expr) override;

--- a/gcc/rust/hir/rust-ast-lower-expr.cc
+++ b/gcc/rust/hir/rust-ast-lower-expr.cc
@@ -796,18 +796,30 @@ void
 ASTLoweringExpr::visit (AST::RangeFromToInclExpr &expr)
 {
   auto crate_num = mappings.get_current_crate ();
-  Analysis::NodeMapping mapping (crate_num, expr.get_node_id (),
-				 mappings.get_next_hir_id (crate_num),
-				 UNKNOWN_LOCAL_DEFID);
+  Analysis::NodeMapping path_mapping (crate_num, mappings.get_next_node_id (),
+				      mappings.get_next_hir_id (crate_num),
+				      UNKNOWN_LOCAL_DEFID);
+  Analysis::NodeMapping call_mapping (crate_num, expr.get_node_id (),
+				      mappings.get_next_hir_id (crate_num),
+				      UNKNOWN_LOCAL_DEFID);
+
+  HIR::Expr *func
+    = new HIR::PathInExpression (path_mapping,
+				 LangItem::Kind::RANGE_INCLUSIVE_NEW,
+				 expr.get_locus (), false);
 
   HIR::Expr *range_from = ASTLoweringExpr::translate (expr.get_from_expr ());
   HIR::Expr *range_to = ASTLoweringExpr::translate (expr.get_to_expr ());
 
+  std::vector<std::unique_ptr<HIR::Expr>> params;
+  params.reserve (2);
+  params.emplace_back (std::unique_ptr<HIR::Expr> (range_from));
+  params.emplace_back (std::unique_ptr<HIR::Expr> (range_to));
+
   translated
-    = new HIR::RangeFromToInclExpr (mapping,
-				    std::unique_ptr<HIR::Expr> (range_from),
-				    std::unique_ptr<HIR::Expr> (range_to),
-				    expr.get_locus ());
+    = new HIR::CallExpr (call_mapping, std::unique_ptr<HIR::Expr> (func),
+			 std::move (params), expr.get_outer_attrs (),
+			 expr.get_locus ());
 }
 
 void

--- a/gcc/rust/hir/rust-hir-dump.cc
+++ b/gcc/rust/hir/rust-hir-dump.cc
@@ -1392,17 +1392,6 @@ Dump::visit (RangeFullExpr &e)
 }
 
 void
-Dump::visit (RangeFromToInclExpr &e)
-{
-  begin ("RangeFromToInclExpr");
-
-  visit_field ("from", e.get_from_expr ());
-  visit_field ("to", e.get_to_expr ());
-
-  end ("RangeFromToInclExpr");
-}
-
-void
 Dump::visit (RangeToInclExpr &e)
 {
   begin ("RangeToInclExpr");

--- a/gcc/rust/hir/rust-hir-dump.h
+++ b/gcc/rust/hir/rust-hir-dump.h
@@ -154,7 +154,6 @@ private:
   virtual void visit (RangeFromExpr &) override;
   virtual void visit (RangeToExpr &) override;
   virtual void visit (RangeFullExpr &) override;
-  virtual void visit (RangeFromToInclExpr &) override;
   virtual void visit (RangeToInclExpr &) override;
   virtual void visit (BoxExpr &) override;
   virtual void visit (ReturnExpr &) override;

--- a/gcc/rust/hir/tree/rust-hir-expr.cc
+++ b/gcc/rust/hir/tree/rust-hir-expr.cc
@@ -930,29 +930,6 @@ RangeFullExpr::RangeFullExpr (Analysis::NodeMapping mappings, location_t locus)
   : RangeExpr (std::move (mappings), locus)
 {}
 
-RangeFromToInclExpr::RangeFromToInclExpr (Analysis::NodeMapping mappings,
-					  std::unique_ptr<Expr> range_from,
-					  std::unique_ptr<Expr> range_to,
-					  location_t locus)
-  : RangeExpr (std::move (mappings), locus), from (std::move (range_from)),
-    to (std::move (range_to))
-{}
-
-RangeFromToInclExpr::RangeFromToInclExpr (RangeFromToInclExpr const &other)
-  : RangeExpr (other), from (other.from->clone_expr ()),
-    to (other.to->clone_expr ())
-{}
-
-RangeFromToInclExpr &
-RangeFromToInclExpr::operator= (RangeFromToInclExpr const &other)
-{
-  RangeExpr::operator= (other);
-  from = other.from->clone_expr ();
-  to = other.to->clone_expr ();
-
-  return *this;
-}
-
 RangeToInclExpr::RangeToInclExpr (Analysis::NodeMapping mappings,
 				  std::unique_ptr<Expr> range_to,
 				  location_t locus)

--- a/gcc/rust/hir/tree/rust-hir-expr.h
+++ b/gcc/rust/hir/tree/rust-hir-expr.h
@@ -2176,53 +2176,6 @@ protected:
   }
 };
 
-// Range from (inclusive) and to (inclusive) expression HIR node object
-// aka RangeInclusiveExpr; constructs a std::ops::RangeInclusive object
-class RangeFromToInclExpr : public RangeExpr
-{
-  std::unique_ptr<Expr> from;
-  std::unique_ptr<Expr> to;
-
-public:
-  std::string to_string () const override;
-
-  RangeFromToInclExpr (Analysis::NodeMapping mappings,
-		       std::unique_ptr<Expr> range_from,
-		       std::unique_ptr<Expr> range_to, location_t locus);
-  // outer attributes not allowed
-
-  // Copy constructor with clone
-  RangeFromToInclExpr (RangeFromToInclExpr const &other);
-
-  // Overload assignment operator to use clone
-  RangeFromToInclExpr &operator= (RangeFromToInclExpr const &other);
-
-  // move constructors
-  RangeFromToInclExpr (RangeFromToInclExpr &&other) = default;
-  RangeFromToInclExpr &operator= (RangeFromToInclExpr &&other) = default;
-
-  void accept_vis (HIRFullVisitor &vis) override;
-  void accept_vis (HIRExpressionVisitor &vis) override;
-
-  Expr &get_from_expr () { return *from; }
-  Expr &get_to_expr () { return *to; }
-
-protected:
-  /* Use covariance to implement clone function as returning this object rather
-   * than base */
-  RangeFromToInclExpr *clone_expr_impl () const override
-  {
-    return new RangeFromToInclExpr (*this);
-  }
-
-  /* Use covariance to implement clone function as returning this object rather
-   * than base */
-  RangeFromToInclExpr *clone_expr_without_block_impl () const override
-  {
-    return new RangeFromToInclExpr (*this);
-  }
-};
-
 // Range to (inclusive) expression HIR node object
 // aka RangeToInclusiveExpr; constructs a std::ops::RangeToInclusive object
 class RangeToInclExpr : public RangeExpr

--- a/gcc/rust/hir/tree/rust-hir-full-decls.h
+++ b/gcc/rust/hir/tree/rust-hir-full-decls.h
@@ -104,7 +104,6 @@ class RangeFromToExpr;
 class RangeFromExpr;
 class RangeToExpr;
 class RangeFullExpr;
-class RangeFromToInclExpr;
 class RangeToInclExpr;
 class BoxExpr;
 class ReturnExpr;

--- a/gcc/rust/hir/tree/rust-hir-visitor.cc
+++ b/gcc/rust/hir/tree/rust-hir-visitor.cc
@@ -423,13 +423,6 @@ DefaultHIRVisitor::walk (RangeFullExpr &)
 {}
 
 void
-DefaultHIRVisitor::walk (RangeFromToInclExpr &expr)
-{
-  expr.get_from_expr ().accept_vis (*this);
-  expr.get_to_expr ().accept_vis (*this);
-}
-
-void
 DefaultHIRVisitor::walk (RangeToInclExpr &expr)
 {
   expr.get_to_expr ().accept_vis (*this);

--- a/gcc/rust/hir/tree/rust-hir-visitor.h
+++ b/gcc/rust/hir/tree/rust-hir-visitor.h
@@ -74,7 +74,6 @@ public:
   virtual void visit (RangeFromExpr &expr) = 0;
   virtual void visit (RangeToExpr &expr) = 0;
   virtual void visit (RangeFullExpr &expr) = 0;
-  virtual void visit (RangeFromToInclExpr &expr) = 0;
   virtual void visit (RangeToInclExpr &expr) = 0;
   virtual void visit (BoxExpr &expr) = 0;
   virtual void visit (ReturnExpr &expr) = 0;
@@ -244,7 +243,6 @@ public:
   virtual void visit (RangeFromExpr &node) override { walk (node); }
   virtual void visit (RangeToExpr &node) override { walk (node); }
   virtual void visit (RangeFullExpr &node) override { walk (node); }
-  virtual void visit (RangeFromToInclExpr &node) override { walk (node); }
   virtual void visit (RangeToInclExpr &node) override { walk (node); }
   virtual void visit (BoxExpr &node) override { walk (node); }
   virtual void visit (ReturnExpr &node) override { walk (node); }
@@ -386,7 +384,6 @@ protected:
   virtual void walk (RangeFromExpr &) final;
   virtual void walk (RangeToExpr &) final;
   virtual void walk (RangeFullExpr &) final;
-  virtual void walk (RangeFromToInclExpr &) final;
   virtual void walk (RangeToInclExpr &) final;
   virtual void walk (BoxExpr &) final;
   virtual void walk (ReturnExpr &) final;
@@ -528,7 +525,6 @@ public:
   virtual void visit (RangeFromExpr &) override {}
   virtual void visit (RangeToExpr &) override {}
   virtual void visit (RangeFullExpr &) override {}
-  virtual void visit (RangeFromToInclExpr &) override {}
   virtual void visit (RangeToInclExpr &) override {}
   virtual void visit (BoxExpr &) override {}
   virtual void visit (ReturnExpr &) override {}
@@ -761,7 +757,6 @@ public:
   virtual void visit (RangeFromExpr &expr) = 0;
   virtual void visit (RangeToExpr &expr) = 0;
   virtual void visit (RangeFullExpr &expr) = 0;
-  virtual void visit (RangeFromToInclExpr &expr) = 0;
   virtual void visit (RangeToInclExpr &expr) = 0;
   virtual void visit (BoxExpr &expr) = 0;
   virtual void visit (ReturnExpr &expr) = 0;

--- a/gcc/rust/hir/tree/rust-hir.cc
+++ b/gcc/rust/hir/tree/rust-hir.cc
@@ -1657,12 +1657,6 @@ IfExprConseqElse::to_string () const
 }
 
 std::string
-RangeFromToInclExpr::to_string () const
-{
-  return from->to_string () + "..=" + to->to_string ();
-}
-
-std::string
 ErrorPropagationExpr::to_string () const
 {
   return main_or_left_expr->to_string () + "?";
@@ -4247,12 +4241,6 @@ RangeFullExpr::accept_vis (HIRFullVisitor &vis)
 }
 
 void
-RangeFromToInclExpr::accept_vis (HIRFullVisitor &vis)
-{
-  vis.visit (*this);
-}
-
-void
 RangeToInclExpr::accept_vis (HIRFullVisitor &vis)
 {
   vis.visit (*this);
@@ -5046,12 +5034,6 @@ WhileLoopExpr::accept_vis (HIRExpressionVisitor &vis)
 
 void
 CallExpr::accept_vis (HIRExpressionVisitor &vis)
-{
-  vis.visit (*this);
-}
-
-void
-RangeFromToInclExpr::accept_vis (HIRExpressionVisitor &vis)
 {
   vis.visit (*this);
 }

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -1067,56 +1067,6 @@ TypeCheckExpr::visit (HIR::RangeFullExpr &expr)
 }
 
 void
-TypeCheckExpr::visit (HIR::RangeFromToInclExpr &expr)
-{
-  auto lang_item_type = LangItem::Kind::RANGE_INCLUSIVE;
-
-  auto lang_item_defined = mappings.lookup_lang_item (lang_item_type);
-  // we need to have it maybe
-  if (!lang_item_defined)
-    {
-      rust_internal_error_at (expr.get_locus (),
-			      "unable to find relevant lang item: %s",
-			      LangItem::ToString (lang_item_type).c_str ());
-      return;
-    }
-  DefId respective_lang_item_id = lang_item_defined.value ();
-
-  // look it up and it _must_ be a struct definition
-  HIR::Item *item = mappings.lookup_defid (respective_lang_item_id).value ();
-
-  TyTy::BaseType *item_type = nullptr;
-  bool ok
-    = context->lookup_type (item->get_mappings ().get_hirid (), &item_type);
-  rust_assert (ok);
-  rust_assert (item_type->get_kind () == TyTy::TypeKind::ADT);
-  TyTy::ADTType *adt = static_cast<TyTy::ADTType *> (item_type);
-
-  // this is a single generic item lets assert that
-  rust_assert (adt->get_num_substitutions () == 1);
-
-  // resolve the range expressions and these types must unify then we use that
-  // type to substitute into the ADT
-  TyTy::BaseType *from_ty = TypeCheckExpr::Resolve (expr.get_from_expr ());
-  TyTy::BaseType *to_ty = TypeCheckExpr::Resolve (expr.get_to_expr ());
-  TyTy::BaseType *unified = unify_site (
-    expr.get_mappings ().get_hirid (),
-    TyTy::TyWithLocation (from_ty, expr.get_from_expr ().get_locus ()),
-    TyTy::TyWithLocation (to_ty, expr.get_to_expr ().get_locus ()),
-    expr.get_locus ());
-
-  // substitute it in
-  std::vector<TyTy::SubstitutionArg> subst_mappings;
-  const TyTy::SubstitutionParamMapping *param_ref = &adt->get_substs ().at (0);
-  subst_mappings.emplace_back (param_ref, unified);
-
-  TyTy::SubstitutionArgumentMappings subst (
-    subst_mappings, {}, adt->get_substitution_arguments ().get_regions (),
-    expr.get_locus ());
-  infered = SubstMapperInternal::Resolve (adt, subst);
-}
-
-void
 TypeCheckExpr::visit (HIR::ArrayIndexExpr &expr)
 {
   auto array_expr_ty = TypeCheckExpr::Resolve (expr.get_array_expr ());

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.h
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.h
@@ -74,7 +74,6 @@ public:
   void visit (HIR::RangeFromExpr &expr) override;
   void visit (HIR::RangeToExpr &expr) override;
   void visit (HIR::RangeFullExpr &expr) override;
-  void visit (HIR::RangeFromToInclExpr &expr) override;
   void visit (HIR::WhileLoopExpr &expr) override;
   void visit (HIR::ClosureExpr &expr) override;
   void visit (HIR::InlineAsm &expr) override;

--- a/gcc/rust/util/rust-lang-item.cc
+++ b/gcc/rust/util/rust-lang-item.cc
@@ -55,6 +55,7 @@ const BiMap<std::string, LangItem::Kind> Rust::LangItem::lang_items = {{
   {"RangeTo", Kind::RANGE_TO},
   {"RangeInclusive", Kind::RANGE_INCLUSIVE},
   {"RangeToInclusive", Kind::RANGE_TO_INCLUSIVE},
+  {"range_inclusive_new", Kind::RANGE_INCLUSIVE_NEW},
   {"phantom_data", Kind::PHANTOM_DATA},
   {"fn", Kind::FN},
   {"fn_mut", Kind::FN_MUT},

--- a/gcc/rust/util/rust-lang-item.h
+++ b/gcc/rust/util/rust-lang-item.h
@@ -77,6 +77,7 @@ public:
     RANGE_TO,
     RANGE_INCLUSIVE,
     RANGE_TO_INCLUSIVE,
+    RANGE_INCLUSIVE_NEW,
 
     // https://github.com/rust-lang/rust/blob/master/library/core/src/marker.rs
     PHANTOM_DATA,

--- a/gcc/testsuite/rust/compile/torture/range-lang-item1.rs
+++ b/gcc/testsuite/rust/compile/torture/range-lang-item1.rs
@@ -29,6 +29,18 @@ pub struct RangeTo<Idx> {
 pub struct RangeInclusive<Idx> {
     pub start: Idx,
     pub end: Idx,
+    pub exhausted: bool,
+}
+
+impl<Idx> RangeInclusive<Idx> {
+    #[lang = "range_inclusive_new"]
+    pub const fn new(start: Idx, end: Idx) -> Self {
+        Self {
+            start,
+            end,
+            exhausted: false,
+        }
+    }
 }
 
 fn test() {


### PR DESCRIPTION
This patch introduces the 'range_inclusive_new' lang item to the compiler.
When the compiler encounters an inclusive range expression, it now
correctly desugars the operation into a function call targeting this
lang item instead of lowering it directly into a static struct.

gcc/rust/ChangeLog:

	* hir/rust-ast-lower-expr.cc (ASTLoweringExpr::visit): Add
	desugaring for range_inclusive_new lang item.
	* util/rust-lang-item.cc (Rust::LangItem::lang_items): Add
	range_inclusive_new to the BiMap.
	* util/rust-lang-item.h (class LangItem): Add RANGE_INCLUSIVE_NEW
	to the Kind enum.

gcc/testsuite/ChangeLog:

	* rust/compile/torture/range-lang-item1.rs: Update test to use
	the new lang item.

---

This patch removes the unnecessary HIR::RangeFromToInclExpr class and its
associated visitors across the compiler. Since inclusive ranges are now
directly desugared into a CallExpr targeting the 'range_inclusive_new'
lang item during AST-to-HIR lowering, this HIR node and its
codegen/typecheck implementations are dead code.

gcc/rust/ChangeLog:

	* backend/rust-compile-block.h: Remove RangeFromToInclExpr visit.
	* backend/rust-compile-expr.cc (CompileExpr::visit): Likewise.
	* backend/rust-compile-expr.h: Likewise.
	* checks/errors/borrowck/rust-bir-builder-expr-stmt.cc
	(ExprStmtBuilder::visit): Likewise.
	* checks/errors/borrowck/rust-bir-builder-expr-stmt.h: Likewise.
	* checks/errors/borrowck/rust-bir-builder-lazyboolexpr.h:
	Likewise.
	* checks/errors/borrowck/rust-bir-builder-struct.h: Likewise.
	* checks/errors/borrowck/rust-function-collector.h: Likewise.
	* checks/errors/privacy/rust-privacy-reporter.cc
	(PrivacyReporter::visit): Likewise.
	* checks/errors/privacy/rust-privacy-reporter.h: Likewise.
	* checks/errors/rust-const-checker.cc (ConstChecker::visit):
	Likewise.
	* checks/errors/rust-const-checker.h: Likewise.
	* checks/errors/rust-hir-pattern-analysis.cc
	(PatternChecker::visit): Likewise.
	* checks/errors/rust-hir-pattern-analysis.h: Likewise.
	* checks/errors/rust-unsafe-checker.cc (UnsafeChecker::visit):
	Likewise.
	* checks/errors/rust-unsafe-checker.h: Likewise.
	* hir/rust-hir-dump.cc (Dump::visit): Likewise.
	* hir/rust-hir-dump.h: Likewise.
	* hir/tree/rust-hir-expr.cc
	(RangeFromToInclExpr::RangeFromToInclExpr): Likewise.
	(RangeFromToInclExpr::operator=): Likewise.
	* hir/tree/rust-hir-expr.h (class RangeFromToInclExpr): Remove
	class.
	* hir/tree/rust-hir-full-decls.h (class RangeFromToInclExpr):
	Remove forward declaration.
	* hir/tree/rust-hir-visitor.cc (DefaultHIRVisitor::walk): Remove
	RangeFromToInclExpr visit.
	* hir/tree/rust-hir-visitor.h: Likewise.
	* hir/tree/rust-hir.cc (RangeFromToInclExpr::to_string): Remove.
	(RangeFromToInclExpr::accept_vis): Remove.
	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::visit):
	Remove.
	* typecheck/rust-hir-type-check-expr.h: Remove
	RangeFromToInclExpr visit.