### PR TITLE
gccrs: Define constructor for LoadedCrate struct

### DIFF
--- a/gcc/rust/rust-session-manager.h
+++ b/gcc/rust/rust-session-manager.h
@@ -461,6 +461,11 @@ public:
 
   struct LoadedCrate
   {
+    LoadedCrate (std::string name, NodeId node_id,
+		 Resolver2_0::NameResolutionContext ctx)
+      : name (std::move (name)), node_id (node_id), ctx (std::move (ctx))
+    {}
+
     LoadedCrate (const LoadedCrate &) = delete;
     LoadedCrate &operator= (const LoadedCrate &) = delete;
     LoadedCrate (LoadedCrate &&other) = default;


### PR DESCRIPTION
Discovered that gccrs fails to compile after I upgraded to Fedora 44 with my same `configure` config, probably due to the system's `gcc` defaulting to C++20 or something:

```
../../gccrs/gcc/rust/rust-session-manager.cc: In member function ‘tl::expected<Rust::Session::LoadedCrate, Rust::Session::LoadingError> Rust::Session::load_extern_crate(const std::string&, location_t)’:
../../gccrs/gcc/rust/rust-session-manager.cc:1363:78: error: no matching function for call to ‘Rust::Session::LoadedCrate::LoadedCrate(<brace-enclosed initializer list>)’
 1363 |   return LoadedCrate{crate_name, parsed_crate.get_node_id (), std::move (ctx)};
      |                                                                              ^
  • there is 1 candidate
In file included from ../../gccrs/gcc/rust/rust-session-manager.cc:19:
    • candidate 1: ‘Rust::Session::LoadedCrate::LoadedCrate(Rust::Session::LoadedCrate&&)’
      ../../gccrs/gcc/rust/rust-session-manager.h:466:5:
        466 |     LoadedCrate (LoadedCrate &&other) = default;
            |     ^~~~~~~~~~~
      • candidate expects 1 argument, 3 provided
```

This PR fixes it.