### PR TITLE
ci: Avoid trying to send emails on forked repos

### DIFF
--- a/.github/workflows/send-emails.yml
+++ b/.github/workflows/send-emails.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   send_patches:
     runs-on: ubuntu-latest
+    if: ${{ vars.SMTP_SERVER != '' }}
 
     steps:
       - name: Checkout repo with full history


### PR DESCRIPTION
This should prevent `send_patches` from trying to send patches, failing to send patches, and emitting an error notification, on forked repos.