### PR TITLE
gccrs: Fix multiple glob imports in a use decl

### DIFF
--- a/gcc/rust/resolve/rust-early-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver-2.0.cc
@@ -99,14 +99,15 @@ Early::resolve_glob_import (NodeId use_dec_id, TopLevel::ImportKind &&glob)
   if (!result)
     return false;
 
+  auto &imports = import_mappings.new_or_access (use_dec_id);
+
   // here, we insert the module's NodeId into the import_mappings and will look
   // up the module proper in `FinalizeImports`
   // The namespace does not matter here since we are dealing with a glob
   // FIXME: Does the namespace not matter? Is that valid?
   // TODO: Ugly
-  import_mappings.insert (use_dec_id,
-			  ImportPair (std::move (glob),
-				      ImportData::Glob (resolved->definition)));
+  imports.emplace_back (
+    ImportPair (std::move (glob), ImportData::Glob (resolved->definition)));
 
   return true;
 }

--- a/gcc/rust/resolve/rust-early-name-resolver-2.0.h
+++ b/gcc/rust/resolve/rust-early-name-resolver-2.0.h
@@ -157,17 +157,6 @@ public:
       return iter.first->second;
     }
 
-    void insert (NodeId path_id, std::vector<ImportPair> &&pairs)
-    {
-      mappings.insert ({{path_id}, std::move (pairs)});
-    }
-
-    // Same as `insert`, but with just one node
-    void insert (NodeId path_id, ImportPair &&pair)
-    {
-      mappings.insert ({{path_id}, {pair}});
-    }
-
     std::vector<ImportPair> &get (NodeId use_id) { return mappings[use_id]; }
 
   private:

--- a/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
@@ -440,7 +440,6 @@ flatten (
 	flatten_glob (*glob, glob_paths, ctx);
 	break;
       }
-      break;
     }
 }
 

--- a/gcc/testsuite/rust/compile/glob_import_brace.rs
+++ b/gcc/testsuite/rust/compile/glob_import_brace.rs
@@ -1,0 +1,14 @@
+#![feature(no_core)]
+#![no_core]
+
+mod a {}
+
+mod b {
+    pub struct X;
+
+    mod c {
+        use crate::{a::*, b::*};
+
+        type Y = X;
+    }
+}


### PR DESCRIPTION
Also removes some dead code in flatten, since I saw it while working on this PR and it's too small to be its own patch.

Fixes #4702