### PR TITLE
gccrs: Apply try-finally cleanup for function-scope drops

### DIFF
--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -728,8 +728,6 @@ HIRCompileBase::compile_function_body (tree fndecl,
 							   return_value, locus);
 	  ctx->add_statement (assignment);
 
-	  CompileDrop (ctx).emit_current_scope_drop_calls ();
-
 	  result_reference = Backend::var_expression (fnctx.ret_addr, locus);
 	  tree return_stmt
 	    = Backend::return_statement (fndecl, result_reference, locus);
@@ -739,8 +737,6 @@ HIRCompileBase::compile_function_body (tree fndecl,
 	{
 	  // just add the stmt expression
 	  ctx->add_statement (return_value);
-
-	  CompileDrop (ctx).emit_current_scope_drop_calls ();
 
 	  // now just return unit expression
 	  tree unit_expr = unit_expression (locus);
@@ -755,7 +751,7 @@ HIRCompileBase::compile_function_body (tree fndecl,
       // errors should have occurred
       location_t locus = function_body.get_locus ();
       tree return_value = unit_expression (locus);
-      CompileDrop (ctx).emit_current_scope_drop_calls ();
+
       tree return_stmt
 	= Backend::return_statement (fndecl, return_value, locus);
       ctx->add_statement (return_stmt);
@@ -917,7 +913,10 @@ HIRCompileBase::compile_function (
 
   ctx->push_fn (fndecl, return_address, tyret);
   compile_function_body (fndecl, *function_body, tyret);
-  tree bind_tree = ctx->pop_block ();
+
+  tree cleanup = CompileDrop (ctx).build_current_scope_drop_cleanup ();
+  tree bind_tree
+    = ctx->pop_block_with_cleanup (cleanup, function_body->get_locus ());
 
   gcc_assert (TREE_CODE (bind_tree) == BIND_EXPR);
   DECL_SAVED_TREE (fndecl) = bind_tree;
@@ -1002,7 +1001,9 @@ HIRCompileBase::compile_constant_item (
       ctx->add_statement (return_expr);
     }
 
-  tree bind_tree = ctx->pop_block ();
+  tree cleanup = CompileDrop (ctx).build_current_scope_drop_cleanup ();
+  tree bind_tree
+    = ctx->pop_block_with_cleanup (cleanup, const_value_expr.get_locus ());
 
   gcc_assert (TREE_CODE (bind_tree) == BIND_EXPR);
   DECL_SAVED_TREE (fndecl) = bind_tree;

--- a/gcc/rust/backend/rust-compile-drop.cc
+++ b/gcc/rust/backend/rust-compile-drop.cc
@@ -120,13 +120,5 @@ CompileDrop::build_current_scope_drop_cleanup ()
   return Backend::statement_list (drop_stmts);
 }
 
-void
-CompileDrop::emit_current_scope_drop_calls ()
-{
-  tree cleanup = build_current_scope_drop_cleanup ();
-  if (cleanup != NULL_TREE)
-    ctx->add_statement (cleanup);
-}
-
 } // namespace Compile
 } // namespace Rust

--- a/gcc/rust/backend/rust-compile-drop.h
+++ b/gcc/rust/backend/rust-compile-drop.h
@@ -32,7 +32,6 @@ public:
   bool type_has_drop_impl (TyTy::BaseType *ty);
 
   tree build_current_scope_drop_cleanup ();
-  void emit_current_scope_drop_calls ();
 
 private:
   tree compile_drop_call (Bvariable *var, TyTy::BaseType *ty, location_t locus);

--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -24,6 +24,7 @@
 #include "rust-compile-pattern.h"
 #include "rust-compile-resolve-path.h"
 #include "rust-compile-block.h"
+#include "rust-compile-drop.h"
 #include "rust-compile-implitem.h"
 #include "rust-constexpr.h"
 #include "rust-compile-type.h"
@@ -2907,7 +2908,9 @@ CompileExpr::generate_closure_function (HIR::ClosureExpr &expr,
       ctx->add_statement (return_expr);
     }
 
-  tree bind_tree = ctx->pop_block ();
+  tree cleanup = CompileDrop (ctx).build_current_scope_drop_cleanup ();
+  tree bind_tree
+    = ctx->pop_block_with_cleanup (cleanup, function_body.get_locus ());
 
   gcc_assert (TREE_CODE (bind_tree) == BIND_EXPR);
   DECL_SAVED_TREE (fndecl) = bind_tree;


### PR DESCRIPTION
This PR changes function-scope drops to use try-finally cleanup.
It removes the old direct drop calls and uses the try-finally cleanup path for functions, constant items, and closures.

The existing function-scope test still passes with this change.