### PR TITLE
gccrs: Fix deriving with generic const args

### DIFF
--- a/gcc/rust/expand/rust-derive.cc
+++ b/gcc/rust/expand/rust-derive.cc
@@ -143,12 +143,14 @@ DeriveVisitor::setup_impl_generics (
 	    ConstGenericParam &const_param
 	      = (ConstGenericParam &) *generic.get ();
 
-	    std::unique_ptr<Type> associated_type
-	      = builder.single_type_path (const_param.get_name ().as_string ());
+	    auto associated_expr
+	      = std::make_unique<IdentifierExpr> (const_param.get_name (),
+						  std::vector<Attribute> (),
+						  const_param.get_locus ());
 
-	    GenericArg type_arg
-	      = GenericArg::create_type (std::move (associated_type));
-	    generic_args.push_back (std::move (type_arg));
+	    GenericArg const_arg
+	      = GenericArg::create_const (std::move (associated_expr));
+	    generic_args.push_back (std::move (const_arg));
 
 	    auto impl_const_param = builder.new_const_param (const_param);
 	    impl_generics.push_back (std::move (impl_const_param));

--- a/gcc/testsuite/rust/compile/derive_macro9.rs
+++ b/gcc/testsuite/rust/compile/derive_macro9.rs
@@ -1,0 +1,31 @@
+// { dg-additional-options "-frust-compile-until=typecheck" }
+#![feature(no_core)]
+#![no_core]
+
+#![feature(lang_items)]
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "copy"]
+pub trait Copy {}
+
+#[lang = "clone"]
+pub trait Clone {
+    fn clone(&self) -> Self;
+}
+
+#[lang = "phantom_data"]
+pub struct PhantomData<T>;
+
+impl<T: ?Sized> Clone for PhantomData<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T: ?Sized> Copy for PhantomData<T> {}
+
+#[derive(Copy, Clone)]
+struct S<const N: usize> {
+    x: PhantomData<[u8; N]>
+}


### PR DESCRIPTION
This doesn't fix an issue with the typechecker, so the included test only compiles up to the typechecking phase.

@philberty everything look good? This PR shouldn't be causing issues with the typechecker?