### PR TITLE
Add lang pin/unpin

### DIFF
--- a/gcc/rust/typecheck/rust-tyty-bounds.cc
+++ b/gcc/rust/typecheck/rust-tyty-bounds.cc
@@ -181,6 +181,34 @@ TypeBoundsProbe::add_trait_bound (HIR::Trait *trait)
 {
   auto trait_ref = TraitResolver::Resolve (*trait);
 
+  for (const auto &existing : trait_references)
+    if (existing.first->is_equal (*trait_ref))
+      return;
+
+  if (receiver->get_kind () == TyTy::TypeKind::ADT)
+    {
+      TyTy::ADTType *adt = static_cast<TyTy::ADTType *> (receiver);
+      for (auto &variant : adt->get_variants ())
+	{
+	  for (auto &field : variant->get_fields ())
+	    {
+	      TyTy::BaseType *field_ty = field->get_field_type ();
+
+	      // TODO: A loop guard is needed here to prevent infinite
+	      // recursion, but self-referential types currently crash due to
+	      // issue Rust-GCC/gccrs#4709. Therefore, I avoided adding an
+	      // untested guard for now.
+
+	      if (!field_ty->satisfies_bound (
+		    TyTy::TypeBoundPredicate (*trait_ref,
+					      BoundPolarity::RegularBound,
+					      UNDEF_LOCATION),
+		    false))
+		return;
+	    }
+	}
+    }
+
   trait_references.emplace_back (trait_ref, mappings.lookup_builtin_marker ());
 }
 

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -324,10 +324,18 @@ BaseType::satisfies_bound (const TypeBoundPredicate &predicate, bool emit_error)
       if (!bound->is_equal (*query))
 	continue;
 
-      // builtin ones have no impl-block this needs fixed and use a builtin node
-      // of somekind
+      // builtin ones have no impl-block this needs fixed and use a builtin
+      // node of somekind
       if (b.second == nullptr)
-	return true;
+	{
+	  return predicate.get_polarity () == BoundPolarity::RegularBound;
+	}
+      else
+	{
+	  const auto &impl = *(b.second);
+	  if (predicate.get_polarity () != impl.get_polarity ())
+	    continue;
+	}
 
       // need to check that associated types can match as well
       const HIR::ImplBlock &impl = *(b.second);

--- a/gcc/rust/util/rust-lang-item.cc
+++ b/gcc/rust/util/rust-lang-item.cc
@@ -144,6 +144,8 @@ const BiMap<std::string, LangItem::Kind> Rust::LangItem::lang_items = {{
   {"generator_state", Kind::GENERATOR_STATE},
 
   {"va_list", Kind::VA_LIST},
+  {"pin", Kind::PIN},
+  {"unpin", Kind::UNPIN},
 }};
 
 tl::optional<LangItem::Kind>

--- a/gcc/rust/util/rust-lang-item.h
+++ b/gcc/rust/util/rust-lang-item.h
@@ -180,6 +180,8 @@ public:
     GENERATOR_STATE,
 
     VA_LIST,
+    PIN,
+    UNPIN,
   };
 
   static const BiMap<std::string, Kind> lang_items;

--- a/gcc/testsuite/rust/compile/lang-pin-unpin.rs
+++ b/gcc/testsuite/rust/compile/lang-pin-unpin.rs
@@ -1,0 +1,38 @@
+#![feature(no_core, lang_items, optin_builtin_traits, negative_impls)]
+#![no_core]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "unpin"]
+pub auto trait Unpin {}
+
+#[lang = "pin"]
+pub struct Pin<P> {
+    pointer: P,
+}
+
+impl<P> Pin<P> {
+    pub fn new(pointer: P) -> Pin<P>
+    where
+        P: Unpin,
+    {
+        Pin { pointer }
+    }
+}
+
+struct PhantomPinned;
+impl !Unpin for PhantomPinned {}
+
+struct PinnedStruct {
+    _marker: PhantomPinned, 
+}
+
+struct NormalStruct;
+
+fn main() {
+    let _ = Pin::new(NormalStruct); 
+
+    let pinned = PinnedStruct { _marker: PhantomPinned };
+    let _ = Pin::new(pinned); // { dg-error "bounds not satisfied for PinnedStruct .Unpin. is not satisfied .E0277." }
+}


### PR DESCRIPTION
This patch adds pin/unpin lang items to the compiler but not fully tested
due to issues https://github.com/Rust-GCC/gccrs/issues/4709 and https://github.com/Rust-GCC/gccrs/issues/4678 so we tested
auto trait and negative impls behaviors.

gcc/rust/ChangeLog:

	* util/rust-lang-item.cc (Rust::LangItem::lang_items): Add pin
	and unpin lang items to the BiMap.
	* util/rust-lang-item.h (class LangItem): Add PIN and UNPIN to
	the Kind enum.

gcc/testsuite/ChangeLog:

	* rust/compile/lang-pin-unpin.rs: New test.

---

This patch adds support for structural auto-traits and fixes how negative
trait implementations are handled.

gcc/rust/ChangeLog:

	* typecheck/rust-tyty-bounds.cc
	(TypeBoundsProbe::add_trait_bound): Check all fields of an ADT.
	* typecheck/rust-tyty.cc (BaseType::satisfies_bound): Reject
	trait if there is a negative impl.
	
Closes #4760 	