### PR TITLE
lang: Register lang items for alloc crate

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-base.cc
+++ b/gcc/rust/hir/rust-ast-lower-base.cc
@@ -853,6 +853,28 @@ ASTLoweringBase::handle_doc_item_attribute (const ItemWrapper &,
   rust_assert (meta_item);
 }
 
+static void
+warn_if_stub_lang_item (location_t locus, LangItem::Kind kind)
+{
+  switch (kind)
+    {
+    case LangItem::Kind::FUTURE_TRAIT:
+    case LangItem::Kind::POLL:
+    case LangItem::Kind::READY:
+    case LangItem::Kind::PENDING:
+    case LangItem::Kind::GENERATOR:
+    case LangItem::Kind::GENERATOR_STATE:
+    case LangItem::Kind::MAYBE_UNINIT:
+    case LangItem::Kind::BOX_FREE:
+    case LangItem::Kind::DROP_IN_PLACE:
+      rust_warning_at (locus, 0, "%qs is not implemented and has no effect",
+		       LangItem::PrettyString (kind).c_str ());
+      break;
+    default:
+      break;
+    }
+}
+
 void
 ASTLoweringBase::handle_lang_item_attribute (const ItemWrapper &item,
 					     const AST::Attribute &attr)
@@ -863,8 +885,11 @@ ASTLoweringBase::handle_lang_item_attribute (const ItemWrapper &item,
   auto lang_item_type = LangItem::Parse (*lang_item_type_str);
 
   if (lang_item_type)
-    mappings.insert_lang_item (*lang_item_type,
-			       item.get_mappings ().get_defid ());
+    {
+      mappings.insert_lang_item (*lang_item_type,
+				 item.get_mappings ().get_defid ());
+      warn_if_stub_lang_item (attr.get_locus (), *lang_item_type);
+    }
   else
     rust_error_at (attr.get_locus (), "unknown lang item");
 }

--- a/gcc/rust/util/rust-lang-item.cc
+++ b/gcc/rust/util/rust-lang-item.cc
@@ -123,9 +123,21 @@ const BiMap<std::string, LangItem::Kind> Rust::LangItem::lang_items = {{
   {"discriminant_kind", Kind::DISCRIMINANT_KIND},
   {"discriminant_type", Kind::DISCRIMINANT_TYPE},
   {"manually_drop", Kind::MANUALLY_DROP},
+  {"drop_in_place", Kind::DROP_IN_PLACE},
 
   {"exchange_malloc", Kind::EXCHANGE_MALLOC},
   {"owned_box", Kind::OWNED_BOX},
+  {"oom", Kind::OOM},
+  {"alloc_layout", Kind::ALLOC_LAYOUT},
+  {"box_free", Kind::BOX_FREE},
+  {"maybe_uninit", Kind::MAYBE_UNINIT},
+
+  {"future_trait", Kind::FUTURE_TRAIT},
+  {"poll", Kind::POLL},
+  {"Ready", Kind::READY},
+  {"Pending", Kind::PENDING},
+  {"generator", Kind::GENERATOR},
+  {"generator_state", Kind::GENERATOR_STATE},
 }};
 
 tl::optional<LangItem::Kind>

--- a/gcc/rust/util/rust-lang-item.h
+++ b/gcc/rust/util/rust-lang-item.h
@@ -159,9 +159,21 @@ public:
     DISCRIMINANT_KIND,
 
     MANUALLY_DROP,
+    DROP_IN_PLACE,
 
     EXCHANGE_MALLOC,
     OWNED_BOX,
+    OOM,
+    ALLOC_LAYOUT,
+    BOX_FREE,
+    MAYBE_UNINIT,
+
+    FUTURE_TRAIT,
+    POLL,
+    READY,
+    PENDING,
+    GENERATOR,
+    GENERATOR_STATE,
   };
 
   static const BiMap<std::string, Kind> lang_items;

--- a/gcc/testsuite/rust/compile/lang-items-stub.rs
+++ b/gcc/testsuite/rust/compile/lang-items-stub.rs
@@ -1,0 +1,36 @@
+#![feature(no_core, lang_items)]
+#![no_core]
+
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "future_trait"] // { dg-warning "...lang = .future_trait... is not implemented and has no effect" }
+pub trait Future {
+    #[lang = "poll"] // { dg-warning "...lang = .poll... is not implemented and has no effect" }
+    fn poll() {}
+}
+
+#[lang = "generator"] // { dg-warning "...lang = .generator... is not implemented and has no effect" }
+pub trait Generator {}
+
+#[lang = "generator_state"] // { dg-warning "...lang = .generator_state... is not implemented and has no effect" }
+pub enum GeneratorState {}
+
+#[lang = "box_free"] // { dg-warning "...lang = .box_free... is not implemented and has no effect" }
+pub fn _box_free() {}
+
+#[repr(transparent)]
+pub struct ManuallyDrop<T: ?Sized> {
+    _value: T,
+}
+
+#[lang = "maybe_uninit"] // { dg-warning "...lang = .maybe_uninit... is not implemented and has no effect" }
+#[repr(transparent)]
+pub union MaybeUninit<T> {
+    uninit: (),
+    value: ManuallyDrop<T>,
+}
+
+#[lang = "drop_in_place"] // { dg-warning "...lang = .drop_in_place... is not implemented and has no effect" }
+pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T) {}

--- a/gcc/testsuite/rust/compile/lang-items-symbol.rs
+++ b/gcc/testsuite/rust/compile/lang-items-symbol.rs
@@ -1,0 +1,8 @@
+#![feature(no_core, lang_items)]
+#![no_core]
+
+#[lang = "alloc_layout"]
+pub struct Layout;
+
+#[lang = "oom"]
+pub fn _oom() {}


### PR DESCRIPTION
This patch registers several lang items as stubs to progress towards compiling the 'alloc' crate.

- 'oom', 'alloc_layout': Require no specific handling; symbol generation is sufficient.
- 'box_free': Full implementation requires a mature drop infrastructure. Registered as a stub for now.
- 'drop_in_place': Full implementation requires a mature drop infrastructure. Registered as a stub for now.
- 'maybe_uninit': Requires layout engine maturity and niche-filling mechanisms. Registered as a stub.
- 'future_trait', 'poll', 'Ready', 'Pending': Registered as stubs due to lack of async support.
- 'generator', 'generator_state': Registered as stubs due to lack of generator support.

The 'Ready' and 'Pending' lang items are excluded from the new test cases because lang item attributes on enum variants are not currently handled (see Rust-GCC/gccrs#4703).

gcc/rust/ChangeLog:

	* hir/rust-ast-lower-base.cc (warn_if_stub_lang_item): New function. (ASTLoweringBase::handle_lang_item_attribute): Emit a warning if lang item is stub.
	* util/rust-lang-item.cc (Rust::LangItem::lang_items): Add new lang items to the BiMap.
	* util/rust-lang-item.h (class LangItem): Add new lang items to Kind enum.

gcc/testsuite/ChangeLog:

	* rust/compile/lang-items-stub.rs: New test.
	* rust/compile/lang-items-symbol.rs: New test.