### PR TITLE
gccrs: Catch likely compilation error with `None`

### DIFF
--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
@@ -169,6 +169,12 @@ visit_identifier_as_pattern (NameResolutionContext &ctx,
   // but values does not allow shadowing... since functions cannot shadow
   // do we insert functions in labels as well?
 
+  if (ident.as_string () == "None" && !is_ref && !is_mut)
+    {
+      rust_sorry_at (
+	locus, "%<None%> as an identifier pattern is probably a resolver bug");
+    }
+
   if (ctx.bindings.peek ().is_and_bound (ident))
     {
       if (ctx.bindings.peek ().get_source () == BindingSource::Param)


### PR DESCRIPTION
While technically allowed, matching with an irrefutable identifier pattern `None` is almost certainly an in-progress miscompilation of a refutable path pattern `None`.