### PR TITLE
gccrs: Emit E0259 and E0260 for duplicate extern crate names

### DIFF
--- a/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.cc
@@ -50,8 +50,18 @@ TopLevel::check_multiple_insertion_error (
     {
       rich_location rich_loc (line_table, locus);
       rich_loc.add_range (node_locations[result.error ().existing]);
+      auto &mappings = Analysis::Mappings::get ();
+      ErrorCode code;
+      if (mappings.is_extern_crate (node_id)
+	  && mappings.is_extern_crate (result.error ().existing))
+	code = ErrorCode::E0259;
+      else if (mappings.is_extern_crate (node_id)
+	       || mappings.is_extern_crate (result.error ().existing))
+	code = ErrorCode::E0260;
+      else
+	code = ErrorCode::E0428;
 
-      rust_error_at (rich_loc, ErrorCode::E0428, "%qs defined multiple times",
+      rust_error_at (rich_loc, code, "%qs defined multiple times",
 		     identifier.as_string ().c_str ());
     }
 }
@@ -125,6 +135,17 @@ TopLevel::visit (AST::Trait &trait)
   insert_or_error_out (trait.get_identifier (), trait, Namespace::Types);
 
   DefaultResolver::visit (trait);
+}
+
+void
+TopLevel::visit (AST::ExternCrate &crate)
+{
+  auto &name = crate.has_as_clause () ? crate.get_as_clause ()
+				      : crate.get_referenced_crate ();
+  Analysis::Mappings::get ().insert_extern_crate_id (crate.get_node_id ());
+  insert_or_error_out (name, crate, Namespace::Types);
+
+  DefaultResolver::visit (crate);
 }
 
 void

--- a/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.h
+++ b/gcc/rust/resolve/rust-toplevel-name-resolver-2.0.h
@@ -167,6 +167,7 @@ private:
 
   void visit (AST::Module &module) override;
   void visit (AST::Trait &trait) override;
+  void visit (AST::ExternCrate &crate) override;
   void maybe_insert_big_self (AST::Impl &impl) override;
   void visit (AST::TraitItemType &trait_item) override;
   void visit (AST::MacroRulesDefinition &macro) override;

--- a/gcc/rust/util/rust-hir-map.cc
+++ b/gcc/rust/util/rust-hir-map.cc
@@ -1180,6 +1180,18 @@ Mappings::is_module (NodeId id)
   return module_ids.find (id) != module_ids.end ();
 }
 
+void
+Mappings::insert_extern_crate_id (NodeId id)
+{
+  extern_crate_ids.insert (id);
+}
+
+bool
+Mappings::is_extern_crate (NodeId id)
+{
+  return extern_crate_ids.find (id) != extern_crate_ids.end ();
+}
+
 tl::optional<AST::GlobContainer *>
 Mappings::lookup_glob_container (NodeId id)
 {

--- a/gcc/rust/util/rust-hir-map.h
+++ b/gcc/rust/util/rust-hir-map.h
@@ -328,6 +328,9 @@ public:
   void insert_module_id (NodeId);
   bool is_module (NodeId id);
 
+  void insert_extern_crate_id (NodeId);
+  bool is_extern_crate (NodeId id);
+
   void insert_module_child (NodeId module, NodeId child);
   tl::optional<std::vector<NodeId> &> lookup_module_children (NodeId module);
 
@@ -453,6 +456,7 @@ private:
 
   std::map<NodeId, AST::GlobContainer *> glob_containers;
   std::set<NodeId> module_ids;
+  std::set<NodeId> extern_crate_ids;
 
   // AST mappings
   std::map<NodeId, AST::Item *> ast_item_mappings;

--- a/gcc/testsuite/rust/link/extern_crate_alias_0.rs
+++ b/gcc/testsuite/rust/link/extern_crate_alias_0.rs
@@ -1,0 +1,9 @@
+// TODO: this should compile cleanly. It currently ICEs because the same crate
+// gets lowered twice, see Rust-GCC/gccrs#4724.
+// { dg-ice "" }
+
+#![feature(no_core)]
+#![no_core]
+
+extern crate extern_crate_alias_1;
+extern crate extern_crate_alias_1 as other;

--- a/gcc/testsuite/rust/link/extern_crate_alias_1.rs
+++ b/gcc/testsuite/rust/link/extern_crate_alias_1.rs
@@ -1,0 +1,2 @@
+#![feature(no_core)]
+#![no_core]

--- a/gcc/testsuite/rust/link/extern_crate_dup_0.rs
+++ b/gcc/testsuite/rust/link/extern_crate_dup_0.rs
@@ -1,0 +1,5 @@
+#![feature(no_core)]
+#![no_core]
+
+extern crate extern_crate_dup_1;
+extern crate extern_crate_dup_1; // { dg-error ".extern_crate_dup_1. defined multiple times" }

--- a/gcc/testsuite/rust/link/extern_crate_dup_1.rs
+++ b/gcc/testsuite/rust/link/extern_crate_dup_1.rs
@@ -1,0 +1,2 @@
+#![feature(no_core)]
+#![no_core]

--- a/gcc/testsuite/rust/link/extern_crate_item_conflict_0.rs
+++ b/gcc/testsuite/rust/link/extern_crate_item_conflict_0.rs
@@ -1,0 +1,5 @@
+#![feature(no_core)]
+#![no_core]
+
+extern crate extern_crate_item_conflict_1;
+mod extern_crate_item_conflict_1 {} // { dg-error ".extern_crate_item_conflict_1. defined multiple times" }

--- a/gcc/testsuite/rust/link/extern_crate_item_conflict_1.rs
+++ b/gcc/testsuite/rust/link/extern_crate_item_conflict_1.rs
@@ -1,0 +1,2 @@
+#![feature(no_core)]
+#![no_core]


### PR DESCRIPTION
Fixes #4679
Extern crate declarations never inserted their bound name into any namespace, so the existing duplicate-name check could not fire for them and both duplicate extern crates and item/extern crate collisions were accepted silently. Insert the bound name into the type namespace and select the error code based on whether the colliding declarations are extern crates. E0428 is unchanged for every other item kind.

gcc/rust/ChangeLog:

	* resolve/rust-toplevel-name-resolver-2.0.cc (TopLevel::visit (ExternCrate)): New function definition. (TopLevel::check_multiple_insertion_error): Select E0259, E0260 or E0428 based on the colliding declarations. (TopLevel::insert_or_error_out): Record extern crate nodes and forward the new parameter. (TopLevel::insert_enum_variant_or_error_out): Update call.
	* resolve/rust-toplevel-name-resolver-2.0.h (TopLevel::visit (ExternCrate)): New function declaration. (TopLevel::check_multiple_insertion_error) (TopLevel::insert_or_error_out): New parameter. (TopLevel::extern_crate_nodes): New member.

gcc/testsuite/ChangeLog:

	* rust/link/extern_crate_alias_0.rs: New test.
	* rust/link/extern_crate_alias_1.rs: New test.
	* rust/link/extern_crate_dup_0.rs: New test.
	* rust/link/extern_crate_dup_1.rs: New test.
	* rust/link/extern_crate_item_conflict_0.rs: New test.
	* rust/link/extern_crate_item_conflict_1.rs: New test.

Thank you for making Rust GCC better!

If your PR fixes an issue, you can add "Fixes #issue_number" into this
PR description and the git commit message. This way the issue will be
automatically closed when your PR is merged. If your change addresses
an issue but does not fully fix it please mark it as "Addresses #issue_number"
in the git commit message.

Here is a checklist to help you with your PR.

- \[ ] GCC development requires copyright assignment or the Developer's Certificate of Origin sign-off, see https://gcc.gnu.org/contribute.html or https://gcc.gnu.org/dco.html
- \[ ] Read contributing guidlines
- \[ ] `make check-rust` passes locally
- \[ ] Run `clang-format`
- \[ ] Added any relevant test cases to `gcc/testsuite/rust/`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.
---

*Please write a comment explaining your change. This is the message
that will be part of the merge commit.
