### PR TITLE
gccrs: Generalize prelude import handling

### DIFF
--- a/gcc/rust/resolve/rust-default-resolver.cc
+++ b/gcc/rust/resolve/rust-default-resolver.cc
@@ -36,7 +36,10 @@ DefaultResolver::visit (AST::Crate &crate)
   if (!visited_crates.insert (crate.get_node_id ()).second)
     return;
 
-  auto inner_fn = [this, &crate] () { AST::DefaultASTVisitor::visit (crate); };
+  auto inner_fn = [this, &crate] () {
+    maybe_prelude_import ();
+    AST::DefaultASTVisitor::visit (crate);
+  };
 
   auto &mappings = Analysis::Mappings::get ();
 
@@ -62,8 +65,10 @@ DefaultResolver::visit (AST::BlockExpr &expr)
 void
 DefaultResolver::visit (AST::Module &module)
 {
-  auto item_fn_1
-    = [this, &module] () { AST::DefaultASTVisitor::visit (module); };
+  auto item_fn_1 = [this, &module] () {
+    maybe_prelude_import ();
+    AST::DefaultASTVisitor::visit (module);
+  };
 
   auto item_fn_2 = [this, &module, &item_fn_1] () {
     ctx.canonical_ctx.scope (module.get_node_id (), module.get_name (),

--- a/gcc/rust/resolve/rust-default-resolver.h
+++ b/gcc/rust/resolve/rust-default-resolver.h
@@ -45,6 +45,7 @@ public:
   // these nodes create new scopes and ribs - they are often used to declare new
   // variables, such as a for loop's iterator, or a function's arguments
   void visit (AST::BlockExpr &) override;
+  virtual void maybe_prelude_import () {}
   void visit (AST::Module &) override;
   void visit (AST::Function &) override;
   void visit (AST::LoopExpr &expr) override;

--- a/gcc/rust/resolve/rust-early-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver-2.0.cc
@@ -313,6 +313,22 @@ Early::visit (AST::Module &module)
 }
 
 void
+Early::maybe_prelude_import ()
+{
+  // handle prelude import
+  if (ctx.prelude)
+    {
+      auto container = Analysis::Mappings::get ().lookup_glob_container (
+	ctx.prelude.value ());
+      rust_assert (container);
+
+      GlobbingVisitor glob_visit (ctx);
+      glob_visit.go (container.value ());
+      dirty |= glob_visit.is_dirty ();
+    }
+}
+
+void
 Early::visit (AST::MacroInvocation &invoc)
 {
   auto &path = invoc.get_invoc_data ().get_path ();
@@ -487,6 +503,10 @@ Early::finalize_glob_import (NameResolutionContext &ctx,
     {
       rust_assert (container.value ()->get_glob_container_kind ()
 		   == AST::GlobContainer::Kind::Module);
+
+      // TODO: catch multiple attempted prelude imports
+      if (!ctx.prelude)
+	dirty = true;
 
       ctx.prelude = mapping.data.container ().get_node_id ();
     }

--- a/gcc/rust/resolve/rust-early-name-resolver-2.0.h
+++ b/gcc/rust/resolve/rust-early-name-resolver-2.0.h
@@ -59,6 +59,7 @@ public:
 
   // as well as lexical scopes
   void visit (AST::BlockExpr &) override;
+  void maybe_prelude_import () override;
   void visit (AST::Module &) override;
 
   void visit (AST::MacroInvocation &) override;

--- a/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-late-name-resolver-2.0.cc
@@ -369,17 +369,6 @@ Late::visit (AST::IdentifierExpr &expr)
 	  resolved = type;
 	  ns = Namespace::Types;
 	}
-      else if (!resolved && ctx.prelude)
-	{
-	  resolved
-	    = ctx.values.get_from_prelude (*ctx.prelude, expr.get_ident ());
-	  ns = Namespace::Values;
-
-	  if (!resolved)
-	    resolved
-	      = ctx.types.get_from_prelude (*ctx.prelude, expr.get_ident ());
-	  ns = Namespace::Types;
-	}
 
       if (!resolved)
 	{


### PR DESCRIPTION
Replace some ad-hoc handling of prelude imports with a glob import in every module/crate.