### PR TITLE
gccrs: Mark types used as generic arguments as live

### DIFF
--- a/gcc/rust/checks/lints/rust-lint-marklive.cc
+++ b/gcc/rust/checks/lints/rust-lint-marklive.cc
@@ -154,6 +154,21 @@ MarkLive::visit (HIR::MethodCallExpr &expr)
 bool
 MarkLive::visit_path_segment (HIR::PathExprSegment seg)
 {
+  if (seg.has_generic_args ())
+    {
+      for (auto &type : seg.get_generic_args ().get_type_args ())
+	{
+	  NodeId node_id = type->get_mappings ().get_nodeid ();
+
+	  if (auto resolved
+	      = resolver.lookup (node_id, Resolver2_0::Namespace::Types))
+	    {
+	      if (auto hid = mappings.lookup_node_to_hir (*resolved))
+		mark_hir_id (*hid);
+	    }
+	}
+    }
+
   NodeId ast_node_id = seg.get_mappings ().get_nodeid ();
   NodeId ref_node_id = UNKNOWN_NODEID;
 

--- a/gcc/testsuite/rust/compile/generic_args_deadcode.rs
+++ b/gcc/testsuite/rust/compile/generic_args_deadcode.rs
@@ -1,0 +1,14 @@
+// Test for issue #4585.
+// A type used only as a generic argument must not trigger the
+// "struct is never constructed" warning.
+#![feature(no_core)]
+#![feature(lang_items)]
+#![no_core]
+#[lang = "sized"]
+trait Sized {}
+struct GenericArgType;
+fn anything<T>() {}
+fn main() {
+    anything::<GenericArgType>();
+}
+struct NeverUsed; // { dg-warning "struct is never constructed" }

--- a/gcc/testsuite/rust/compile/torture/traits8.rs
+++ b/gcc/testsuite/rust/compile/torture/traits8.rs
@@ -10,7 +10,6 @@ trait Foo {
 }
 
 struct Bar(i32);
-// { dg-warning "struct is never constructed" "" { target *-*-* } .-1 }
 
 impl Foo for Bar {
     fn default() -> i32 {

--- a/gcc/testsuite/rust/compile/v0-mangle1.rs
+++ b/gcc/testsuite/rust/compile/v0-mangle1.rs
@@ -16,7 +16,7 @@ pub mod module_a {
     }
 }
 
-struct S; // { dg-warning "struct is never constructed" }
+struct S;
 
 // name starting with underscore.
 pub fn _uc() {}

--- a/gcc/testsuite/rust/execute/torture/impl_desugar.rs
+++ b/gcc/testsuite/rust/execute/torture/impl_desugar.rs
@@ -12,7 +12,7 @@ pub trait Bar {
     type Baz;
 }
 
-struct MyBaz; // { dg-warning "struct is never constructed" }
+struct MyBaz;
 impl Foo for MyBaz {}
 
 struct MyBar;


### PR DESCRIPTION
Fixes #4585

Types appearing only as generic arguments in a path expression were never
marked live, so scan-deadcode reported them as never constructed.
`MarkLive::visit_path_segment` resolved only the segment's own name and never
looked at its generic arguments. Mark the generic argument types of each path
segment, following the same shape as `visit (TypeAlias&)`.

Three existing tests asserted the false positive and have had those directives
removed: `compile/torture/traits8.rs`, `compile/v0-mangle1.rs`, and
`execute/torture/impl_desugar.rs`. In each, the struct is passed as a generic
argument, so the warning they asserted was the bug rather than correct
behaviour.

Full testsuite is clean against the branch base with no unexpected failures.