### PR TITLE
gccrs: Test `libcore` compilation until lowering

### DIFF
--- a/gcc/testsuite/rust/core/core.exp
+++ b/gcc/testsuite/rust/core/core.exp
@@ -28,9 +28,9 @@ dg-init
 set saved-dg-do-what-default ${dg-do-what-default}
 
 set dg-do-what-default "compile"
-set individual_timeout 600
+set individual_timeout 1200
 dg-additional-files [lsort [glob -nocomplain $srcdir/../../libgrust/rustc-lib/*]]
-dg-runtest $srcdir/../../libgrust/rustc-lib/core/src/lib.rs "-frust-edition=2018 -frust-crate=core -frust-compile-until=attributecheck -w" ""
+dg-runtest $srcdir/../../libgrust/rustc-lib/core/src/lib.rs "-fno-rust-debug -frust-edition=2018 -frust-crate=core -frust-compile-until=lowering -w" ""
 set dg-do-what-default ${saved-dg-do-what-default}
 
 # All done.


### PR DESCRIPTION
This slows down the testsuite a bit (4 minutes on my PC, without parallelization, about 10 minutes on github CI runners), but we need libcore to compile (and therefore need to be verifying that it does).

Closes #4692