### PR TITLE
gccrs: Fix duplicate unused-assignment removals

### DIFF
--- a/gcc/rust/checks/lints/unused/rust-unused-context.cc
+++ b/gcc/rust/checks/lints/unused/rust-unused-context.cc
@@ -44,7 +44,12 @@ void
 UnusedContext::remove_assign (HirId id_def)
 {
   if (assigned_vars.find (id_def) != assigned_vars.end ())
-    assigned_vars[id_def].pop_back ();
+    {
+      assigned_vars[id_def].pop_back ();
+
+      if (assigned_vars[id_def].empty ())
+	assigned_vars.erase (id_def);
+    }
 }
 
 bool

--- a/gcc/testsuite/rust/compile/issue-4674.rs
+++ b/gcc/testsuite/rust/compile/issue-4674.rs
@@ -1,0 +1,15 @@
+// { dg-additional-options "-frust-unused-check-2.0" }
+#![feature(no_core)]
+#![no_core]
+
+fn foo(mut n: i32) {
+    // { dg-warning "function is never used: .foo." "" { target *-*-* } .-1 }
+    if false {
+        n = 0i32;
+    }
+
+    if n > 0i32 {
+        let _ = 1i32 / n;
+    }
+}
+


### PR DESCRIPTION
Fixes #4674 

Hello! First time contributor here :) 

When all unused-assignments of an IdRef have been consumed already, the compiler will crash on the next assignment usage visit as it attempts to pop off of an empty list. This patch removes the list from the map on last element pop so that the condition check evaluates to false as intended.

I'm still not 100% sure my diagnosis of the bug is correct. I'm marking my patch as draft to receive early feedback

