### PR TITLE
gccrs: Make `ExpandVisitor` visit more attributes

### DIFF
--- a/gcc/rust/expand/rust-expand-visitor.cc
+++ b/gcc/rust/expand/rust-expand-visitor.cc
@@ -431,18 +431,6 @@ ExpandVisitor::maybe_expand_pattern (std::unique_ptr<AST::Pattern> &pattern)
     pattern = final_fragment.take_pattern_fragment ();
 }
 
-void
-ExpandVisitor::expand_struct_fields (std::vector<AST::StructField> &fields)
-{
-  expand_fields (fields);
-}
-
-void
-ExpandVisitor::expand_tuple_fields (std::vector<AST::TupleField> &fields)
-{
-  expand_fields (fields);
-}
-
 // FIXME: This can definitely be refactored with the method above
 void
 ExpandVisitor::expand_function_params (
@@ -742,6 +730,9 @@ ExpandVisitor::visit (AST::UseDeclaration &use_decl)
 void
 ExpandVisitor::visit (AST::Function &function)
 {
+  visit_outer_attrs (function);
+  // TODO: handle body inner attributes more regularly?
+  //       apparently, they should be applied to this function
   if (function.has_body ())
     visit_inner_using_attrs (
       function, function.get_definition ().value ()->get_inner_attrs ());
@@ -761,58 +752,13 @@ ExpandVisitor::visit (AST::Function &function)
 }
 
 void
-ExpandVisitor::visit (AST::StructStruct &struct_item)
-{
-  for (auto &generic : struct_item.get_generic_params ())
-    visit (generic);
-
-  if (struct_item.has_where_clause ())
-    expand_where_clause (struct_item.get_where_clause ());
-
-  expand_struct_fields (struct_item.get_fields ());
-}
-
-void
-ExpandVisitor::visit (AST::TupleStruct &tuple_struct)
-{
-  for (auto &generic : tuple_struct.get_generic_params ())
-    visit (generic);
-
-  if (tuple_struct.has_where_clause ())
-    expand_where_clause (tuple_struct.get_where_clause ());
-
-  expand_tuple_fields (tuple_struct.get_fields ());
-}
-
-void
 ExpandVisitor::visit (AST::EnumItem &item)
 {}
-
-void
-ExpandVisitor::visit (AST::EnumItemTuple &item)
-{
-  expand_tuple_fields (item.get_tuple_fields ());
-}
-
-void
-ExpandVisitor::visit (AST::EnumItemStruct &item)
-{
-  expand_struct_fields (item.get_struct_fields ());
-}
 
 void
 ExpandVisitor::visit (AST::EnumItemDiscriminant &item)
 {
   maybe_expand_expr (item.get_expr_ptr ());
-}
-
-void
-ExpandVisitor::visit (AST::Union &union_item)
-{
-  for (auto &generic : union_item.get_generic_params ())
-    visit (generic);
-
-  expand_struct_fields (union_item.get_variants ());
 }
 
 void
@@ -887,12 +833,6 @@ ExpandVisitor::visit (AST::TraitImpl &impl)
 void
 ExpandVisitor::visit (AST::ExternalTypeItem &item)
 {}
-
-void
-ExpandVisitor::visit (AST::ExternalStaticItem &static_item)
-{
-  maybe_expand_type (static_item.get_type_ptr ());
-}
 
 void
 ExpandVisitor::visit (AST::ExternBlock &block)

--- a/gcc/rust/expand/rust-expand-visitor.h
+++ b/gcc/rust/expand/rust-expand-visitor.h
@@ -257,18 +257,12 @@ public:
   void visit (AST::UseTreeRebind &) override;
   void visit (AST::UseDeclaration &use_decl) override;
   void visit (AST::Function &function) override;
-  void visit (AST::StructStruct &struct_item) override;
-  void visit (AST::TupleStruct &tuple_struct) override;
   void visit (AST::EnumItem &item) override;
-  void visit (AST::EnumItemTuple &item) override;
-  void visit (AST::EnumItemStruct &item) override;
   void visit (AST::EnumItemDiscriminant &item) override;
-  void visit (AST::Union &union_item) override;
   void visit (AST::Trait &trait) override;
   void visit (AST::InherentImpl &impl) override;
   void visit (AST::TraitImpl &impl) override;
   void visit (AST::ExternalTypeItem &item) override;
-  void visit (AST::ExternalStaticItem &item) override;
   void visit (AST::ExternBlock &block) override;
 
   // I don't think it would be possible to strip macros without expansion
@@ -297,16 +291,6 @@ public:
 private:
   MacroExpander &expander;
   NodeId macro_invoc_expect_id;
-
-  /**
-   * Helper to expand all macro invocations in lieu of types within a vector of
-   * fields (StructField or TupleField).
-   */
-  template <typename T> void expand_fields (std::vector<T> &fields)
-  {
-    for (auto &field : fields)
-      maybe_expand_type (field.get_field_type_ptr ());
-  }
 };
 
 } // namespace Rust

--- a/gcc/testsuite/rust/compile/doc_macro_2.rs
+++ b/gcc/testsuite/rust/compile/doc_macro_2.rs
@@ -1,0 +1,24 @@
+// { dg-additional-options "-w" }
+#![feature(no_core)]
+#![no_core]
+
+macro_rules! foo {
+    ($e:expr, $($t:tt)*) => {
+        #[doc = $e]
+        $($t)*
+    }
+}
+
+macro_rules! bar {
+    () => { "bar" }
+}
+
+struct S;
+
+trait T {
+    fn f();
+}
+
+impl T for S {
+    foo!(bar!(), fn f() {});
+}


### PR DESCRIPTION
Makes `ExpandVisitor` rely more on functions provided by `PointerVisitor`. More can be done in this area, but this is enough for now to fix an issue compiling core.