### PR TITLE
gccrs: Use BIR Drop analysis in backend cleanup

### DIFF
--- a/gcc/rust/backend/rust-compile-drop.cc
+++ b/gcc/rust/backend/rust-compile-drop.cc
@@ -21,6 +21,7 @@
 #include "rust-compile-base.h"
 #include "rust-compile-context.h"
 #include "rust-compile-implitem.h"
+#include "rust-bir-drop-analysis.h"
 #include "rust-hir-path-probe.h"
 #include "rust-hir-trait-reference.h"
 #include "rust-hir-type-bounds.h"
@@ -100,6 +101,9 @@ CompileDrop::build_current_scope_drop_cleanup ()
 
   for (auto it = drop_candidates.rbegin (); it != drop_candidates.rend (); ++it)
     {
+      if (BIR::DropAnalysis::get ().is_definitely_dead (it->hirid))
+	continue;
+
       TyTy::BaseType *ty = nullptr;
       Bvariable *var = nullptr;
 

--- a/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.cc
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.cc
@@ -18,6 +18,7 @@
 
 #include "rust-bir-drop-analysis.h"
 #include "rust-bir.h"
+#include "rust-hir-map.h"
 
 #include <unordered_set>
 
@@ -35,6 +36,25 @@ struct BasicBlockIdHash
 };
 
 } // namespace
+
+DropAnalysis &
+DropAnalysis::get ()
+{
+  static DropAnalysis instance;
+  return instance;
+}
+
+void
+DropAnalysis::clear ()
+{
+  definitely_dead.clear ();
+}
+
+bool
+DropAnalysis::is_definitely_dead (HirId id) const
+{
+  return definitely_dead.find (id) != definitely_dead.end ();
+}
 
 void
 DropAnalysis::analyze (Function &function)
@@ -105,6 +125,22 @@ DropAnalysis::analyze (Function &function)
 	      statement.set_drop_style (initialized[place.value]
 					  ? Statement::DropStyle::STATIC
 					  : Statement::DropStyle::DEAD);
+
+	      if (statement.get_drop_style () == Statement::DropStyle::DEAD)
+		{
+		  const Place &dropped_place = function.place_db[place];
+
+		  if (dropped_place.kind == Place::VARIABLE)
+		    {
+		      auto hir_id
+			= Analysis::Mappings::get ().lookup_node_to_hir (
+			  static_cast<NodeId> (
+			    dropped_place.variable_or_field_index));
+
+		      if (hir_id.has_value ())
+			definitely_dead.insert (hir_id.value ());
+		    }
+		}
 
 	      initialized[place.value] = false;
 	      break;

--- a/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.h
@@ -20,6 +20,7 @@
 #define RUST_BIR_DROP_ANALYSIS_H
 
 #include "rust-bir.h"
+
 namespace Rust {
 namespace BIR {
 
@@ -32,7 +33,15 @@ namespace BIR {
 class DropAnalysis
 {
 public:
-  static void analyze (Function &function);
+  static DropAnalysis &get ();
+
+  void clear ();
+  void analyze (Function &function);
+
+  bool is_definitely_dead (HirId id) const;
+
+private:
+  std::set<HirId> definitely_dead;
 };
 
 } // namespace BIR

--- a/gcc/rust/checks/errors/borrowck/rust-borrow-checker.cc
+++ b/gcc/rust/checks/errors/borrowck/rust-borrow-checker.cc
@@ -49,6 +49,8 @@ BorrowChecker::go (HIR::Crate &crate)
 {
   std::string crate_name;
 
+  BIR::DropAnalysis::get ().clear ();
+
   if (enable_dump_bir)
     {
       mkdir ("bir_dump", 0755);
@@ -70,7 +72,7 @@ BorrowChecker::go (HIR::Crate &crate)
       BIR::Builder builder (ctx);
       auto bir = builder.build (*func);
 
-      BIR::DropAnalysis::analyze (bir);
+      BIR::DropAnalysis::get ().analyze (bir);
 
       if (enable_dump_bir)
 	{

--- a/gcc/testsuite/rust/execute/drop-whole-local-move.rs
+++ b/gcc/testsuite/rust/execute/drop-whole-local-move.rs
@@ -1,0 +1,59 @@
+// { dg-output "^moved\r*\nstatic\r*\n$" }
+// { dg-additional-options "-frust-borrowcheck -w" }
+
+#![feature(no_core)]
+#![feature(lang_items)]
+#![no_core]
+
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "drop"]
+pub trait Drop {
+    fn drop(&mut self);
+}
+
+struct Moved {
+    value: i32,
+}
+
+struct Static {
+    value: i32,
+}
+
+impl Drop for Moved {
+    fn drop(&mut self) {
+        let msg = "moved\n\0" as *const str as *const i8;
+        unsafe {
+            printf(msg);
+        }
+    }
+}
+
+impl Drop for Static {
+    fn drop(&mut self) {
+        let msg = "static\n\0" as *const str as *const i8;
+        unsafe {
+            printf(msg);
+        }
+    }
+}
+
+fn whole_move() {
+    let x = Moved { value: 1 };
+    let _y = x;
+}
+
+fn static_local() {
+    let _x = Static { value: 2 };
+}
+
+fn main() -> i32 {
+    whole_move();
+    static_local();
+    0
+}


### PR DESCRIPTION
This patch connects the straight-line BIR Drop analysis to the existing backend cleanup.

It uses the BIR analysis result to skip backend Drops classified as `Dead`.
`Static` and unclassified Drops keep the existing cleanup behavior.

---
So now, for a basic move case like:

```rust
fn whole_move() {
    let x = Droppable;
    let y = x;
}
```

The backend uses the results `Drop(y): Static` and `Drop(x): Dead` to
skip `Drop(x)` while keeping `Drop(y)`.

A normal initialized local is still dropped.