### PR TITLE
resolve: Fix ignored self in grouped glob imports

### DIFF
--- a/gcc/rust/resolve/rust-early-name-resolver-2.0.cc
+++ b/gcc/rust/resolve/rust-early-name-resolver-2.0.cc
@@ -144,22 +144,8 @@ Early::resolve_rebind_import (NodeId use_dec_id,
       import_id = rebind.get_node_id ();
       break;
     case AST::UseTreeRebind::NewBindType::NONE:
-      {
-	const auto &segments = path.get_segments ();
-	// We don't want to insert `self` with `use module::self`
-	if (path.get_final_segment ().is_lower_self_seg ())
-	  {
-	    // Erroneous `self` or `{self}` use declaration
-	    if (segments.size () == 1)
-	      break;
-	    import_id = segments[segments.size () - 2].get_node_id ();
-	  }
-	else
-	  {
-	    import_id = path.get_final_segment ().get_node_id ();
-	  }
-	break;
-      }
+      import_id = path.get_final_segment ().get_node_id ();
+      break;
     case AST::UseTreeRebind::NewBindType::WILDCARD:
       // nothing
       break;

--- a/gcc/testsuite/rust/compile/issue-4689-1.rs
+++ b/gcc/testsuite/rust/compile/issue-4689-1.rs
@@ -1,0 +1,23 @@
+#![feature(no_core)]
+#![no_core]
+
+pub mod collections {
+    pub enum TryReserveError {
+        AllocError,
+        CapacityOverflow,
+    }
+}
+
+pub mod test_working {
+    use crate::collections::TryReserveError::{self, AllocError, CapacityOverflow};
+    fn _test_function() -> TryReserveError {
+        AllocError
+    }
+}
+
+pub mod test_failing {
+    use crate::collections::TryReserveError::{self, *};
+    fn _test_function() -> TryReserveError {
+        CapacityOverflow
+    }
+}

--- a/gcc/testsuite/rust/compile/issue-4689-2.rs
+++ b/gcc/testsuite/rust/compile/issue-4689-2.rs
@@ -1,0 +1,27 @@
+#![feature(no_core)]
+#![no_core]
+
+pub mod my_module {
+    pub const MY_CONST: i32 = 42;
+    pub fn my_func() {}
+}
+
+pub mod test_working {
+    use crate::my_module::{self, MY_CONST};
+
+    pub fn check() {
+        let _ = MY_CONST;
+        my_module::my_func(); 
+    }
+}
+
+pub mod test_failing {
+    use crate::my_module::{self, *};
+
+    pub fn check() {
+        let _ = MY_CONST; 
+        my_func();        
+        
+        my_module::my_func(); 
+    }
+}


### PR DESCRIPTION
Previously, when using a grouped import that combines `self` and a glob (e.g., `use path::module::{self, *};`), the compiler successfully imported the inner items via the glob, but failed to import the base module (or enum) itself.

This patch ensures `self` imports use their own unique NodeId, preventing them from being dropped during early resolution.

Fixes Rust-GCC/gccrs#4689

gcc/rust/ChangeLog:

	* resolve/rust-early-name-resolver-2.0.cc (Early::resolve_rebind_import): Use the final segment's NodeId for 'self' imports instead of the parent's to avoid clashing with glob imports.

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4689-1.rs: New test.
	* rust/compile/issue-4689-2.rs: New test.

