### PR TITLE
Improve box

### DIFF
--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -101,12 +101,6 @@ compile_box (Context *ctx, TyTy::BaseType *box_tyty, TyTy::BaseType *inner_tyty,
 {
   tree inner_type_tree = TyTyResolveCompile::compile (ctx, inner_tyty);
 
-  if (!COMPLETE_TYPE_P (inner_type_tree))
-    {
-      rust_sorry_at (locus,
-		     "dynamically sized types in boxes are not supported yet");
-      return error_mark_node;
-    }
   tree size_tree = TYPE_SIZE_UNIT (inner_type_tree);
   tree align_tree
     = build_int_cst (size_type_node, TYPE_ALIGN_UNIT (inner_type_tree));
@@ -145,6 +139,9 @@ build_box_inner_ptr (tree main_expr, location_t locus)
   // custom allocator is placed as the first field in the RECORD_TYPE.
   while (TREE_CODE (TREE_TYPE (main_expr)) == RECORD_TYPE)
     {
+      if (RS_DST_FLAG_P (TREE_TYPE (main_expr)))
+	break;
+
       tree first_field = TYPE_FIELDS (TREE_TYPE (main_expr));
       if (first_field == NULL_TREE)
 	break;
@@ -186,6 +183,13 @@ CompileExpr::visit (HIR::TupleIndexExpr &expr)
     {
       tree indirect = indirect_expression (receiver_ref, expr.get_locus ());
       receiver_ref = indirect;
+    }
+  else if (auto inner_expr_ty = TyTy::try_get_box_inner_type (tuple_expr_ty))
+    {
+      rust_assert (inner_expr_ty.value ()->get_kind ()
+		   == TyTy::TypeKind::TUPLE);
+      receiver_ref = build_box_inner_ptr (receiver_ref, expr.get_locus ());
+      receiver_ref = indirect_expression (receiver_ref, expr.get_locus ());
     }
 
   translated
@@ -1781,6 +1785,21 @@ CompileExpr::visit (HIR::MethodCallExpr &expr)
     expr.get_receiver ().get_mappings ().get_hirid (), &receiver);
   rust_assert (ok);
 
+  // lookup the autoderef mappings
+  HirId autoderef_mappings_id
+    = expr.get_receiver ().get_mappings ().get_hirid ();
+  std::vector<Resolver::Adjustment> *adjustments = nullptr;
+  ok = ctx->get_tyctx ()->lookup_autoderef_mappings (autoderef_mappings_id,
+						     &adjustments);
+  rust_assert (ok);
+
+  // apply adjustments for the fn call
+  self = resolve_adjustments (*adjustments, self,
+			      expr.get_receiver ().get_locus ());
+
+  if (adjustments != nullptr && !adjustments->empty ())
+    receiver = adjustments->back ().get_expected ();
+
   bool is_dyn_dispatch
     = receiver->get_root ()->get_kind () == TyTy::TypeKind::DYNAMIC;
   bool is_generic_receiver = receiver->get_kind () == TyTy::TypeKind::PARAM;
@@ -1803,18 +1822,6 @@ CompileExpr::visit (HIR::MethodCallExpr &expr)
   else
     // lookup compiled functions since it may have already been compiled
     fn_expr = resolve_method_address (fntype, receiver, expr.get_locus ());
-
-  // lookup the autoderef mappings
-  HirId autoderef_mappings_id
-    = expr.get_receiver ().get_mappings ().get_hirid ();
-  std::vector<Resolver::Adjustment> *adjustments = nullptr;
-  ok = ctx->get_tyctx ()->lookup_autoderef_mappings (autoderef_mappings_id,
-						     &adjustments);
-  rust_assert (ok);
-
-  // apply adjustments for the fn call
-  self = resolve_adjustments (*adjustments, self,
-			      expr.get_receiver ().get_locus ());
 
   std::vector<tree> args;
   args.push_back (self); // adjusted self
@@ -2501,12 +2508,14 @@ HIRCompileBase::resolve_deref_adjustment (Resolver::Adjustment &adjustment,
 	       || adjustment.is_deref_mut_adjustment ());
   if (!adjustment.has_operator_overload ())
     {
-      TyTy::BaseType *receiver = adjustment.get_actual ();
-      if (TyTy::try_get_box_inner_type (receiver))
+      if (TyTy::try_get_box_inner_type (adjustment.get_actual ()))
 	{
-	  tree receiver_ref = expression;
-	  receiver_ref = build_box_inner_ptr (receiver_ref, locus);
-	  return indirect_expression (receiver_ref, locus);
+	  expression = build_box_inner_ptr (expression, locus);
+	  if (TREE_CODE (TREE_TYPE (expression)) == POINTER_TYPE
+	      || TREE_CODE (TREE_TYPE (expression)) == REFERENCE_TYPE)
+	    expression = indirect_expression (expression, locus);
+	  return expression;
+	  ;
 	}
       rust_assert (false);
     }
@@ -2928,6 +2937,13 @@ CompileExpr::visit (HIR::ArrayIndexExpr &expr)
   // do we need to add an indirect reference
   if (array_expr_ty->get_kind () == TyTy::TypeKind::REF)
     {
+      array_reference
+	= indirect_expression (array_reference, expr.get_locus ());
+    }
+  else if (TyTy::try_get_box_inner_type (array_expr_ty))
+    {
+      array_reference
+	= build_box_inner_ptr (array_reference, expr.get_locus ());
       array_reference
 	= indirect_expression (array_reference, expr.get_locus ());
     }

--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -1800,8 +1800,30 @@ CompileExpr::visit (HIR::MethodCallExpr &expr)
   if (adjustments != nullptr && !adjustments->empty ())
     receiver = adjustments->back ().get_expected ();
 
-  bool is_dyn_dispatch
-    = receiver->get_root ()->get_kind () == TyTy::TypeKind::DYNAMIC;
+  enum
+  {
+    DYN,
+    DYN_BOX,
+    NOT_DYN,
+  } is_dyn_dispatch
+    = NOT_DYN;
+  const TyTy::DynamicObjectType *dyn = nullptr;
+  if (receiver->get_root ()->get_kind () == TyTy::TypeKind::DYNAMIC)
+    {
+      is_dyn_dispatch = DYN;
+      dyn
+	= static_cast<const TyTy::DynamicObjectType *> (receiver->get_root ());
+    }
+  else if (auto inner = TyTy::try_get_box_inner_type (receiver->get_root ()))
+    {
+      if ((*inner)->get_root ()->get_kind () == TyTy::TypeKind::DYNAMIC)
+	{
+	  is_dyn_dispatch = DYN_BOX;
+	  dyn = static_cast<const TyTy::DynamicObjectType *> (
+	    (*inner)->get_root ());
+	}
+    }
+
   bool is_generic_receiver = receiver->get_kind () == TyTy::TypeKind::PARAM;
   if (is_generic_receiver)
     {
@@ -1810,18 +1832,22 @@ CompileExpr::visit (HIR::MethodCallExpr &expr)
     }
 
   tree fn_expr = error_mark_node;
-  if (is_dyn_dispatch)
-    {
-      const TyTy::DynamicObjectType *dyn
-	= static_cast<const TyTy::DynamicObjectType *> (receiver->get_root ());
-      fn_expr
-	= get_fn_addr_from_dyn (dyn, receiver, fntype, self, expr.get_locus ());
-      self = get_receiver_from_dyn (dyn, receiver, fntype, self,
-				    expr.get_locus ());
-    }
-  else
+  if (is_dyn_dispatch == NOT_DYN)
     // lookup compiled functions since it may have already been compiled
     fn_expr = resolve_method_address (fntype, receiver, expr.get_locus ());
+  else
+    {
+      tree target_self
+	= is_dyn_dispatch == DYN
+	    ? self
+	    : build_box_inner_ptr (self, expr.get_receiver ().get_locus ());
+
+      fn_expr = get_fn_addr_from_dyn (dyn, receiver, fntype, target_self,
+				      expr.get_locus ());
+
+      self = get_receiver_from_dyn (dyn, receiver, fntype, target_self,
+				    expr.get_locus ());
+    }
 
   std::vector<tree> args;
   args.push_back (self); // adjusted self

--- a/gcc/rust/typecheck/rust-hir-dot-operator.cc
+++ b/gcc/rust/typecheck/rust-hir-dot-operator.cc
@@ -103,6 +103,13 @@ MethodResolver::try_hook (const TyTy::BaseType &r)
       predicate_items
 	= get_predicate_items (segment_name, element_ty, specified_bounds);
     }
+  else if (auto inner
+	   = TyTy::try_get_box_inner_type (const_cast<TyTy::BaseType *> (&r)))
+    {
+      const auto &specified_bounds = (*inner)->get_specified_bounds ();
+      predicate_items
+	= get_predicate_items (segment_name, **inner, specified_bounds);
+    }
 }
 
 std::vector<MethodResolver::impl_item_candidate>

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -95,6 +95,12 @@ TypeCheckExpr::visit (HIR::TupleIndexExpr &expr)
       return;
     }
 
+  // Box<T> autoderef
+  if (auto resolved_base = TyTy::try_get_box_inner_type (resolved))
+    {
+      resolved = *resolved_base;
+    }
+
   // FIXME does this require autoderef here?
   if (resolved->get_kind () == TyTy::TypeKind::REF)
     {
@@ -1086,6 +1092,11 @@ TypeCheckExpr::visit (HIR::ArrayIndexExpr &expr)
       auto base = ref->get_base ();
       if (base->get_kind () == TyTy::TypeKind::ARRAY)
 	direct_array_expr_ty = base;
+    }
+  // Box<T> autoderef
+  else if (auto base = TyTy::try_get_box_inner_type (direct_array_expr_ty))
+    {
+      direct_array_expr_ty = *base;
     }
 
   TyTy::BaseType *size_ty;

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -2186,6 +2186,15 @@ ADTType::is_unsized () const
   return last_field_type->is_unsized ();
 }
 
+bool
+ADTType::is_box () const
+{
+  if (auto owned_box = mappings.lookup_lang_item (LangItem::Kind::OWNED_BOX))
+    if (get_id () == owned_box)
+      return true;
+  return false;
+}
+
 // TupleType
 
 TupleType::TupleType (HirId ref, location_t locus, std::vector<TyVar> fields,

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -363,6 +363,8 @@ public:
   // is_unsized returns true if the type is a DST
   virtual bool is_unsized () const { return false; }
 
+  virtual bool is_box () const { return false; }
+
 protected:
   BaseType (HirId ref, HirId ty_ref, TypeKind kind, RustIdent ident,
 	    std::set<HirId> refs = std::set<HirId> ());
@@ -1046,6 +1048,7 @@ public:
 
   bool contains_unsafe_cell () const override;
   virtual bool is_unsized () const override;
+  virtual bool is_box () const override;
 
 private:
   DefId id;

--- a/gcc/rust/util/rust-lang-item.cc
+++ b/gcc/rust/util/rust-lang-item.cc
@@ -57,6 +57,7 @@ const BiMap<std::string, LangItem::Kind> Rust::LangItem::lang_items = {{
   {"RangeToInclusive", Kind::RANGE_TO_INCLUSIVE},
   {"range_inclusive_new", Kind::RANGE_INCLUSIVE_NEW},
   {"coerce_unsized", Kind::COERCE_UNSIZED},
+  {"dispatch_from_dyn", Kind::DISPATCH_FROM_DYN},
   {"phantom_data", Kind::PHANTOM_DATA},
   {"fn", Kind::FN},
   {"fn_mut", Kind::FN_MUT},

--- a/gcc/rust/util/rust-lang-item.h
+++ b/gcc/rust/util/rust-lang-item.h
@@ -81,6 +81,7 @@ public:
 
     // https://github.com/rust-lang/rust/blob/master/library/core/src/ops/unsize.rs
     COERCE_UNSIZED,
+    DISPATCH_FROM_DYN,
 
     // https://github.com/rust-lang/rust/blob/master/library/core/src/marker.rs
     PHANTOM_DATA,

--- a/gcc/testsuite/rust/execute/box-dispatch-1.rs
+++ b/gcc/testsuite/rust/execute/box-dispatch-1.rs
@@ -1,0 +1,47 @@
+#![feature(no_core, lang_items, box_syntax)]
+#![no_core]
+
+extern "C" {
+    fn malloc(size: usize) -> *mut u8;
+}
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "owned_box"]
+pub struct Box<T: ?Sized>(*mut T);
+
+#[lang = "exchange_malloc"]
+pub unsafe fn exchange_malloc(size: usize, _align: usize) -> *mut u8 {
+    malloc(size)
+}
+
+impl<T> Box<T> {
+    pub fn new(x: T) -> Box<T> {
+        box x
+    }
+}
+
+pub trait Animal {
+    fn speak(&self) -> i32;
+}
+
+pub struct Dog {
+    pub code: i32,
+}
+
+impl Animal for Dog {
+    fn speak(&self) -> i32 {
+        self.code
+    }
+}
+
+fn main() -> i32 {
+    let dog1 = Dog { code: 111 };
+
+    let animal_ref: &dyn Animal = &dog1;
+
+    let box_of_ref: Box<&dyn Animal> = Box::new(animal_ref);
+
+    box_of_ref.speak() - 111
+}

--- a/gcc/testsuite/rust/execute/box-dispatch-2.rs
+++ b/gcc/testsuite/rust/execute/box-dispatch-2.rs
@@ -1,0 +1,76 @@
+#![feature(no_core, lang_items, box_syntax, intrinsics)]
+#![no_core]
+
+extern "C" {
+    fn malloc(size: usize) -> *mut u8;
+}
+
+extern "rust-intrinsic" {
+    fn offset<T>(dst: *const T, offset: isize) -> *const T;
+}
+
+#[lang = "index"]
+pub trait Index<Idx> {
+    type Output: ?Sized;
+    fn index(&self, index: Idx) -> &Self::Output;
+}
+
+impl Index<usize> for [i32] {
+    type Output = i32;
+
+    fn index(&self, index: usize) -> &i32 {
+        unsafe {
+            let ptr = self as *const [i32] as *const i32;
+            &*offset(ptr, index as isize)
+        }
+    }
+}
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "owned_box"]
+pub struct Box<T: ?Sized>(*mut T);
+
+#[lang = "exchange_malloc"]
+pub unsafe fn em(size: usize, _align: usize) -> *mut u8 {
+    malloc(size)
+}
+
+impl<T> Box<T> {
+    pub fn new(x: T) -> Box<T> {
+        box x
+    }
+}
+
+pub struct X { data: i32 }
+
+pub trait A {
+    fn a(&self) -> i32;
+}
+
+impl A for X {
+    fn a(&self) -> i32 {
+        self.data
+    }
+}
+pub fn main() -> i32 {
+    let x = X { data: 44 };
+    let y = X { data: 22 };
+    let z : [i32; 3] = [1, 2, 3];
+    let w : (i32, i32) = (10, 20);
+
+    let a : Box<dyn A> = Box::new(x);
+    let b : Box<X> = Box::new(y);
+    let c : Box<[i32; 3]> = Box::new(z);
+    let d : Box<(i32, i32)> = Box::new(w);
+    let e : Box<[i32]> = Box::new(z);
+
+    a.a() - 2 * b.data // 44 - 2 * 22
+    +
+    c[0] + c[1] - c[2] // 1 + 2 - 3
+    +
+    2 * d.0 - d.1 // 2 * 10 - 20
+    +
+    e[0] + e[1] - e[2] // 1 + 2 - 3
+}

--- a/gcc/testsuite/rust/execute/box-dispatch-from-dyn.rs
+++ b/gcc/testsuite/rust/execute/box-dispatch-from-dyn.rs
@@ -1,0 +1,78 @@
+#![feature(no_core, lang_items, box_syntax)]
+#![no_core]
+
+extern "C" {
+    fn malloc(size: usize) -> *mut u8;
+}
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "unsize"]
+pub trait Unsize<T: ?Sized> {}
+
+#[lang = "coerce_unsized"]
+pub trait CoerceUnsized<T: ?Sized> {}
+
+#[lang = "dispatch_from_dyn"]
+pub trait DispatchFromDyn<T> {}
+
+#[lang = "phantom_data"]
+pub struct PhantomData<T: ?Sized>;
+
+#[lang = "exchange_malloc"]
+pub unsafe fn exchange_malloc(size: usize, _align: usize) -> *mut u8 {
+    malloc(size)
+}
+
+pub struct NonNull<T: ?Sized> {
+    pub ptr: *const T,
+}
+
+pub struct Unique<T: ?Sized> {
+    pub pointer: NonNull<T>,
+    pub _marker: PhantomData<T>,
+}
+
+#[lang = "owned_box"]
+pub struct Box<T: ?Sized> {
+    pub inner: Unique<T>,
+}
+
+impl<T: ?Sized> Box<T> {
+    pub fn new(x: T) -> Box<T> {
+        box x
+    }
+}
+
+#[lang = "receiver"]
+pub trait Receiver {}
+
+trait Animal {
+    fn get_age(self: Box<Self>) -> i32;
+}
+
+struct Dog {
+    age: i32,
+}
+
+impl Animal for Dog {
+    fn get_age(self: Box<Self>) -> i32 {
+        self.age
+    }
+}
+
+pub fn main() -> i32 {
+    let dog = Dog { age: 42 };
+    let _ = dog.age;
+
+    let coerced_box: Box<dyn Animal> = Box::new(dog);
+
+    let result = coerced_box.get_age();
+
+    if result == 42 {
+        0
+    } else {
+        1
+    }
+}

--- a/gcc/testsuite/rust/execute/unsized-adt-size.rs
+++ b/gcc/testsuite/rust/execute/unsized-adt-size.rs
@@ -59,15 +59,12 @@ pub fn sov3(s: &TailStruct<TailStruct<[i32]>>) -> usize {
 fn main() -> i32 {
     let t = [1, 2, 3];
     let t1 = &t as &[i32];
-    let s1 : TailStruct<[i32; 3]> = TailStruct {
-        a: 10,
-        tail: t,
+    let s1: TailStruct<[i32; 3]> = TailStruct { a: 10, tail: t };
+    let s2_tail: TailStruct<[i32; 3]> = TailStruct { a: 10, tail: t };
+    let s2: TailStruct<TailStruct<[i32; 3]>> = TailStruct {
+        a: 20,
+        tail: s2_tail,
     };
-    let s2_tail: TailStruct<[i32; 3]> = TailStruct {
-        a: 10,
-        tail: t,
-    };
-    let s2 : TailStruct<TailStruct<[i32; 3]>> = TailStruct { a: 20, tail: s2_tail };
 
     let a = sov1(t1);
     let b = sov2(&s1);


### PR DESCRIPTION
This patch introduces DST support for box, allowing it to correctly
handle unsized types.

It also implements the auto-deref mechanism for box. This ensures that
method dispatch, indexing, and tuple field access work correctly.

gcc/rust/ChangeLog:

	* backend/rust-compile-expr.cc (compile_box): Remove DST guard.
	(build_box_inner_ptr): Add fat pointer control.
	(CompileExpr::visit): Add auto-deref for box.
	(HIRCompileBase::resolve_deref_adjustment): Return fat or thin
	pointer.
	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::visit):
	Add auto-deref for box.
	* typecheck/rust-tyty.cc (ADTType::is_box): New function.
	* typecheck/rust-tyty.h (class BaseType): New declaration.

gcc/testsuite/ChangeLog:

	* rust/execute/box-dispatch-1.rs: New test.
	* rust/execute/box-dispatch-2.rs: New test.
	* rust/execute/unsized-adt-size.rs: Format test.

---

This patch implements the 'dispatch_from_dyn' lang item specifically for
'Box'. While there are other smart pointers and types that require this
lang item for dynamic dispatch, they are omitted in this patch as they
are not yet fully supported by the compiler.

gcc/rust/ChangeLog:

	* backend/rust-compile-expr.cc (CompileExpr::visit): Handle Box
	receivers correctly during dynamic dispatch.
	* typecheck/rust-hir-dot-operator.cc (MethodResolver::try_hook):
	Extract the inner type of a Box to resolve trait methods.
	* util/rust-lang-item.cc (Rust::LangItem::lang_items): Register
	dispatch_from_dyn to the BiMap.
	* util/rust-lang-item.h (class LangItem): Add DISPATCH_FROM_DYN
	to the Kind enum.

gcc/testsuite/ChangeLog:

	* rust/execute/box-dispatch-from-dyn.rs: New test.
