### PR TITLE
Desugar APITs on function items

### DIFF
--- a/gcc/rust/ast/rust-desugar-apit.cc
+++ b/gcc/rust/ast/rust-desugar-apit.cc
@@ -17,6 +17,7 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "rust-desugar-apit.h"
+#include "rust-ast-visitor.h"
 #include "rust-ast.h"
 #include "rust-type.h"
 
@@ -524,6 +525,8 @@ DesugarApit::visit (AST::Function &function)
 				    function.get_generic_params ());
       processor.go (implicit_generics);
     }
+
+  DefaultASTVisitor::visit (function);
 }
 
 } // namespace AST

--- a/gcc/rust/hir/rust-ast-lower-implitem.cc
+++ b/gcc/rust/hir/rust-ast-lower-implitem.cc
@@ -139,7 +139,7 @@ ASTLowerImplItem::visit (AST::Function &function)
   std::unique_ptr<HIR::Type> return_type
     = function.has_return_type () ? std::unique_ptr<HIR::Type> (
 	ASTLoweringType::translate (function.get_return_type (), false,
-				    true /* impl trait is allowed here*/))
+				    ASTLoweringType::ImplTrait::Allow))
 				  : nullptr;
 
   Defaultness defaultness

--- a/gcc/rust/hir/rust-ast-lower-item.cc
+++ b/gcc/rust/hir/rust-ast-lower-item.cc
@@ -412,7 +412,7 @@ ASTLoweringItem::visit (AST::Function &function)
   std::unique_ptr<HIR::Type> return_type
     = function.has_return_type () ? std::unique_ptr<HIR::Type> (
 	ASTLoweringType::translate (function.get_return_type (), false,
-				    true /* impl trait is allowed here*/))
+				    ASTLoweringType::ImplTrait::Allow))
 				  : nullptr;
 
   std::vector<HIR::FunctionParam> function_params;

--- a/gcc/rust/hir/rust-ast-lower-type.cc
+++ b/gcc/rust/hir/rust-ast-lower-type.cc
@@ -210,14 +210,14 @@ ASTLowerQualifiedPathInType::visit (AST::QualifiedPathInType &path)
 }
 
 ASTLoweringType::ASTLoweringType (bool default_to_static_lifetime,
-				  bool impl_trait_allowed)
+				  ImplTrait impl_trait_allowed)
   : ASTLoweringBase (), default_to_static_lifetime (default_to_static_lifetime),
     impl_trait_allowed (impl_trait_allowed), translated (nullptr)
 {}
 
 HIR::Type *
 ASTLoweringType::translate (AST::Type &type, bool default_to_static_lifetime,
-			    bool impl_trait_allowed)
+			    ImplTrait impl_trait_allowed)
 {
   ASTLoweringType resolver (default_to_static_lifetime, impl_trait_allowed);
   type.accept_vis (resolver);
@@ -492,7 +492,7 @@ ASTLoweringType::visit (AST::ParenthesisedType &type)
 void
 ASTLoweringType::visit (AST::ImplTraitType &type)
 {
-  if (!impl_trait_allowed)
+  if (impl_trait_allowed == ImplTrait::Forbid)
     emit_impl_trait_error (type.get_locus ());
 
   std::vector<std::unique_ptr<HIR::TypeParamBound>> bounds;
@@ -514,7 +514,7 @@ ASTLoweringType::visit (AST::ImplTraitType &type)
 void
 ASTLoweringType::visit (AST::ImplTraitTypeOneBound &type)
 {
-  if (!impl_trait_allowed)
+  if (impl_trait_allowed == ImplTrait::Forbid)
     emit_impl_trait_error (type.get_locus ());
 
   std::vector<std::unique_ptr<HIR::TypeParamBound>> bounds;

--- a/gcc/rust/hir/rust-ast-lower-type.h
+++ b/gcc/rust/hir/rust-ast-lower-type.h
@@ -65,9 +65,18 @@ class ASTLoweringType : public ASTLoweringBase
   using Rust::HIR::ASTLoweringBase::visit;
 
 public:
-  static HIR::Type *translate (AST::Type &type,
-			       bool default_to_static_lifetime = false,
-			       bool impl_trait_allowed = false);
+  /**
+   * Allow `arg: impl Trait` types or error out on them
+   */
+  enum class ImplTrait
+  {
+    Allow,
+    Forbid,
+  };
+
+  static HIR::Type *
+  translate (AST::Type &type, bool default_to_static_lifetime = false,
+	     ImplTrait impl_trait_allowed = ImplTrait::Forbid);
 
   void visit (AST::BareFunctionType &fntype) override;
   void visit (AST::TupleType &tuple) override;
@@ -88,11 +97,12 @@ public:
   void emit_impl_trait_error (location_t locus);
 
 private:
-  ASTLoweringType (bool default_to_static_lifetime, bool impl_trait_allowed);
+  ASTLoweringType (bool default_to_static_lifetime,
+		   ImplTrait impl_trait_allowed);
 
   /** Used when compiling const and static items. */
   bool default_to_static_lifetime;
-  bool impl_trait_allowed;
+  ImplTrait impl_trait_allowed;
 
   HIR::Type *translated;
 };

--- a/gcc/testsuite/rust/compile/apit-in-inner-fn.rs
+++ b/gcc/testsuite/rust/compile/apit-in-inner-fn.rs
@@ -1,0 +1,17 @@
+#![feature(no_core)]
+#![feature(lang_items)]
+#![feature(rustc_attrs)]
+#![no_core]
+
+#[lang = "sized"]
+trait Sized {}
+
+trait Foo {}
+
+pub struct Bar;
+
+impl Bar {
+    pub fn foo(b: impl Foo) {
+        fn inner(a: impl Foo) {}
+    }
+}


### PR DESCRIPTION
desugar-apit: Add missing visit to function sub items

When desugaring the Argument Position Impl Traits of a function, we still need to visit that
function's block and its items as it may contain other inner functions with other APITs.

gcc/rust/ChangeLog:

	* ast/rust-desugar-apit.cc (DesugarApit::visit): Call DefaultASTVisitor::visit
	on the function we're currently visiting.

gcc/testsuite/ChangeLog:

	* rust/compile/apit-in-inner-fn.rs: New test.

Fixes #4768