### PR TITLE
Add `freeze` lang item

### DIFF
--- a/gcc/rust/util/rust-lang-item.cc
+++ b/gcc/rust/util/rust-lang-item.cc
@@ -65,6 +65,7 @@ const BiMap<std::string, LangItem::Kind> Rust::LangItem::lang_items = {{
   {"clone", Kind::CLONE},
   {"drop", Kind::DROP},
   {"sized", Kind::SIZED},
+  {"freeze", Kind::FREEZE},
   {"sync", Kind::SYNC},
   {"slice_alloc", Kind::SLICE_ALLOC},
   {"slice_u8_alloc", Kind::SLICE_U8_ALLOC},

--- a/gcc/rust/util/rust-lang-item.h
+++ b/gcc/rust/util/rust-lang-item.h
@@ -93,6 +93,7 @@ public:
     CLONE,
     DROP,
     SIZED,
+    FREEZE,
     SYNC,
 
     // https://github.com/Rust-GCC/gccrs/issues/1896

--- a/gcc/testsuite/rust/compile/freeze-lang-item.rs
+++ b/gcc/testsuite/rust/compile/freeze-lang-item.rs
@@ -1,0 +1,25 @@
+#![feature(no_core)]
+#![feature(optin_builtin_traits)]
+#![feature(negative_impls)]
+#![feature(lang_items)]
+#![feature(rustc_attrs)]
+#![no_core]
+
+#[lang = "sized"]
+trait Sized {}
+
+#[lang = "freeze"]
+pub(crate) unsafe auto trait Freeze {}
+
+#[lang = "phantom_data"]
+pub struct PhantomData<T>;
+
+pub struct UnsafeCell<T>(T);
+
+impl<T: ?Sized> !Freeze for UnsafeCell<T> {}
+unsafe impl<T: ?Sized> Freeze for PhantomData<T> {}
+unsafe impl<T: ?Sized> Freeze for *const T {}
+unsafe impl<T: ?Sized> Freeze for *mut T {}
+unsafe impl<T: ?Sized> Freeze for &T {}
+unsafe impl<T: ?Sized> Freeze for &mut T {}
+


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* util/rust-lang-item.h: Add enum value for Freeze.
	* util/rust-lang-item.cc: Register it.

gcc/testsuite/ChangeLog:

	* rust/compile/freeze-lang-item.rs: New test.

I believe we will just need to check whether something is `Freeze` later on during the compilation to check whether it's actually immutable or fake-immutable. This ties in with the work done by @Polygonalr recently on the checks for `UnsafeCell`.

Closes #4762 