### PR TITLE
Add `va_list` lang item

### DIFF
--- a/gcc/rust/util/rust-lang-item.cc
+++ b/gcc/rust/util/rust-lang-item.cc
@@ -141,6 +141,8 @@ const BiMap<std::string, LangItem::Kind> Rust::LangItem::lang_items = {{
   {"Pending", Kind::PENDING},
   {"generator", Kind::GENERATOR},
   {"generator_state", Kind::GENERATOR_STATE},
+
+  {"va_list", Kind::VA_LIST},
 }};
 
 tl::optional<LangItem::Kind>

--- a/gcc/rust/util/rust-lang-item.h
+++ b/gcc/rust/util/rust-lang-item.h
@@ -177,6 +177,8 @@ public:
     PENDING,
     GENERATOR,
     GENERATOR_STATE,
+
+    VA_LIST,
   };
 
   static const BiMap<std::string, Kind> lang_items;

--- a/gcc/testsuite/rust/compile/va_list-lang-item.rs
+++ b/gcc/testsuite/rust/compile/va_list-lang-item.rs
@@ -1,0 +1,33 @@
+#![feature(no_core)]
+#![feature(optin_builtin_traits)]
+#![feature(negative_impls)]
+#![feature(lang_items)]
+#![feature(rustc_attrs)]
+#![no_core]
+
+#[lang = "sized"]
+trait Sized {}
+
+#[lang = "phantom_data"]
+pub struct PhantomData<T>;
+
+type c_void = ();
+
+/// x86_64 ABI implementation of a `va_list`.
+// #[cfg(all(target_arch = "x86_64", not(windows)))]
+#[repr(C)]
+// #[derive(Debug)]
+#[unstable(
+    feature = "c_variadic",
+    reason = "the `c_variadic` feature has not been properly tested on \
+              all supported platforms",
+    issue = "44930"
+)]
+#[lang = "va_list"]
+pub struct VaListImpl<'f> {
+    pub gp_offset: i32,
+    pub fp_offset: i32,
+    pub overflow_arg_area: *mut c_void,
+    pub reg_save_area: *mut c_void,
+    pub _marker: PhantomData<&'f mut &'f c_void>,
+}


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* util/rust-lang-item.h: Add enum value for VaListImpl.
	* util/rust-lang-item.cc: Register it.

gcc/testsuite/ChangeLog:

	* rust/compile/va_list-lang-item.rs: New test.

Closes #4765