### PR TITLE
gccrs: Handle conditional moves in BIR drop analysis

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -182,6 +182,7 @@ GRS_OBJS = \
     rust/rust-borrow-checker-diagnostics.o\
     rust/rust-bir-builder-expr-stmt.o \
     rust/rust-bir-builder-pattern.o \
+    rust/rust-bir-drop-analysis.o \
     rust/rust-bir-dump.o \
     rust/rust-polonius.o\
     rust/rust-hir-dot-operator.o \

--- a/gcc/rust/backend/rust-compile-drop.cc
+++ b/gcc/rust/backend/rust-compile-drop.cc
@@ -21,6 +21,7 @@
 #include "rust-compile-base.h"
 #include "rust-compile-context.h"
 #include "rust-compile-implitem.h"
+#include "rust-bir-drop-analysis.h"
 #include "rust-hir-path-probe.h"
 #include "rust-hir-trait-reference.h"
 #include "rust-hir-type-bounds.h"
@@ -100,6 +101,9 @@ CompileDrop::build_current_scope_drop_cleanup ()
 
   for (auto it = drop_candidates.rbegin (); it != drop_candidates.rend (); ++it)
     {
+      if (BIR::DropAnalysis::get ().is_definitely_dead (it->hirid))
+	continue;
+
       TyTy::BaseType *ty = nullptr;
       Bvariable *var = nullptr;
 

--- a/gcc/rust/checks/errors/borrowck/rust-bir-builder-internal.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-builder-internal.h
@@ -167,7 +167,29 @@ protected:
     return place_id;
   }
 
+  PlaceId declare_argument (const Analysis::NodeMapping &node,
+			    TyTy::BaseType *ty)
+  {
+    const NodeId nodeid = node.get_nodeid ();
+
+    // In debug mode, check that the argument is not already declared.
+    rust_assert (ctx.place_db.lookup_variable (nodeid) == INVALID_PLACE);
+
+    return ctx.place_db.add_variable (nodeid, ty);
+  }
+
   void push_new_scope () { ctx.place_db.push_new_scope (); }
+
+  void push_drop (PlaceId place)
+  {
+    ctx.get_current_bb ().statements.push_back (Statement::make_drop (place));
+  }
+
+  void push_function_argument_drops ()
+  {
+    std::for_each (ctx.arguments.rbegin (), ctx.arguments.rend (),
+		   [&] (PlaceId argument) { push_drop (argument); });
+  }
 
   void pop_scope ()
   {
@@ -175,7 +197,10 @@ protected:
     if (ctx.place_db.get_current_scope_id () != INVALID_SCOPE)
       {
 	std::for_each (scope.locals.rbegin (), scope.locals.rend (),
-		       [&] (PlaceId place) { push_storage_dead (place); });
+		       [&] (PlaceId place) {
+			 push_drop (place);
+			 push_storage_dead (place);
+		       });
       }
     ctx.place_db.pop_scope ();
   }
@@ -200,7 +225,10 @@ protected:
 	// TODO: Perform stable toposort based on `borrowed_by`.
 
 	std::for_each (scope.locals.rbegin (), scope.locals.rend (),
-		       [&] (PlaceId place) { push_storage_dead (place); });
+		       [&] (PlaceId place) {
+			 push_drop (place);
+			 push_storage_dead (place);
+		       });
 	current_scope_id = scope.parent;
       }
   }
@@ -305,6 +333,8 @@ protected: // Helpers to add BIR statements
 
   void push_return (location_t location)
   {
+    push_function_argument_drops ();
+
     ctx.get_current_bb ().statements.push_back (
       Statement::make_return (location));
   }

--- a/gcc/rust/checks/errors/borrowck/rust-bir-builder.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-builder.h
@@ -125,7 +125,7 @@ private:
 	&& !static_cast<HIR::IdentifierPattern &> (pattern).get_is_ref ())
       {
 	// Avoid useless temporary variable for parameter to look like MIR.
-	translated = declare_variable (pattern.get_mappings ());
+	translated = declare_argument (pattern.get_mappings (), param_type);
 	ctx.arguments.push_back (translated);
       }
     else

--- a/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.cc
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.cc
@@ -1,0 +1,114 @@
+// Copyright (C) 2026 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rust-bir-drop-analysis.h"
+#include "rust-bir.h"
+
+namespace Rust {
+namespace BIR {
+
+void
+DropAnalysis::analyze (Function &function)
+{
+  std::vector<BasicBlockId> block_order;
+  std::set<BasicBlockId> visited;
+
+  BasicBlockId current = ENTRY_BASIC_BLOCK;
+
+  while (current != INVALID_BB)
+    {
+      // A repeated block indicates a cycle in straight-line control flow.
+      if (!visited.insert (current).second)
+	return;
+
+      block_order.push_back (current);
+
+      const BasicBlock &block = function.basic_blocks[current];
+
+      if (block.successors.empty ())
+	break;
+
+      if (block.successors.size () != 1)
+	return;
+
+      current = block.successors.front ();
+    }
+
+  std::vector<bool> initialized (function.place_db.size (), false);
+
+  for (PlaceId argument : function.arguments)
+    initialized[argument.value] = true;
+
+  for (BasicBlockId block_id : block_order)
+    {
+      BasicBlock &block = function.basic_blocks[block_id];
+
+      for (Statement &statement : block.statements)
+	{
+	  PlaceId place = statement.get_place ();
+
+	  switch (statement.get_kind ())
+	    {
+	    case Statement::Kind::STORAGE_LIVE:
+	      initialized[place.value] = false;
+	      break;
+
+	    case Statement::Kind::ASSIGNMENT:
+	      {
+		PlaceId lhs = place;
+		AbstractExpr &expr = statement.get_expr ();
+
+		if (expr.get_kind () == ExprKind::ASSIGNMENT)
+		  {
+		    PlaceId rhs = static_cast<Assignment &> (expr).get_rhs ();
+		    const Place &rhs_place = function.place_db[rhs];
+
+		    if (rhs_place.kind == Place::VARIABLE
+			&& rhs_place.should_be_moved ())
+		      initialized[rhs.value] = false;
+		  }
+
+		initialized[lhs.value] = true;
+		break;
+	      }
+
+	    case Statement::Kind::DROP:
+	      statement.set_drop_style (initialized[place.value]
+					  ? Statement::DropStyle::STATIC
+					  : Statement::DropStyle::DEAD);
+
+	      initialized[place.value] = false;
+	      break;
+
+	    case Statement::Kind::STORAGE_DEAD:
+	      initialized[place.value] = false;
+	      break;
+
+	    case Statement::Kind::SWITCH:
+	    case Statement::Kind::RETURN:
+	    case Statement::Kind::GOTO:
+	    case Statement::Kind::USER_TYPE_ASCRIPTION:
+	    case Statement::Kind::FAKE_READ:
+	      break;
+	    }
+	}
+    }
+}
+
+} // namespace BIR
+} // namespace Rust

--- a/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.cc
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.cc
@@ -22,6 +22,276 @@
 
 namespace Rust {
 namespace BIR {
+namespace {
+
+struct BlockInitializationState
+{
+  explicit BlockInitializationState (size_t place_count)
+    : maybe_initialized (place_count, false),
+      maybe_uninitialized (place_count, false), reachable (false)
+  {}
+
+  std::vector<bool> maybe_initialized;
+  std::vector<bool> maybe_uninitialized;
+
+  // Whether this block can be reached from the function entry.
+  bool reachable;
+};
+
+static bool
+is_straight_line (const Function &function)
+{
+  std::set<BasicBlockId> visited;
+  BasicBlockId current = ENTRY_BASIC_BLOCK;
+
+  while (current != INVALID_BB)
+    {
+      // Revisiting a block means that the CFG contains a cycle.
+      if (!visited.insert (current).second)
+	return false;
+
+      const BasicBlock &block = function.basic_blocks[current];
+
+      if (block.successors.empty ())
+	return true;
+
+      if (block.successors.size () != 1)
+	return false;
+
+      current = block.successors.front ();
+    }
+
+  return true;
+}
+
+static void
+set_initialized (BlockInitializationState &state, PlaceId place)
+{
+  state.maybe_initialized[place.value] = true;
+  state.maybe_uninitialized[place.value] = false;
+}
+
+static void
+set_uninitialized (BlockInitializationState &state, PlaceId place)
+{
+  state.maybe_initialized[place.value] = false;
+  state.maybe_uninitialized[place.value] = true;
+}
+
+static bool
+merge_state (BlockInitializationState &into,
+	     const BlockInitializationState &from)
+{
+  if (!into.reachable)
+    {
+      into = from;
+      return true;
+    }
+
+  bool changed = false;
+
+  for (size_t i = 0; i < into.maybe_initialized.size (); i++)
+    {
+      bool maybe_initialized
+	= into.maybe_initialized[i] || from.maybe_initialized[i];
+
+      bool maybe_uninitialized
+	= into.maybe_uninitialized[i] || from.maybe_uninitialized[i];
+
+      changed |= maybe_initialized != into.maybe_initialized[i];
+      changed |= maybe_uninitialized != into.maybe_uninitialized[i];
+
+      into.maybe_initialized[i] = maybe_initialized;
+      into.maybe_uninitialized[i] = maybe_uninitialized;
+    }
+
+  return changed;
+}
+
+static void
+apply_statement (Function &function, Statement &statement,
+		 BlockInitializationState &state)
+{
+  PlaceId place = statement.get_place ();
+
+  switch (statement.get_kind ())
+    {
+    case Statement::Kind::STORAGE_LIVE:
+      set_uninitialized (state, place);
+      break;
+
+    case Statement::Kind::ASSIGNMENT:
+      {
+	PlaceId lhs = place;
+	AbstractExpr &expr = statement.get_expr ();
+
+	if (expr.get_kind () == ExprKind::ASSIGNMENT)
+	  {
+	    PlaceId rhs = static_cast<Assignment &> (expr).get_rhs ();
+	    const Place &rhs_place = function.place_db[rhs];
+
+	    if (rhs_place.kind == Place::VARIABLE
+		&& rhs_place.should_be_moved ())
+	      set_uninitialized (state, rhs);
+	  }
+
+	set_initialized (state, lhs);
+	break;
+      }
+
+    case Statement::Kind::DROP:
+    case Statement::Kind::STORAGE_DEAD:
+      set_uninitialized (state, place);
+      break;
+
+    case Statement::Kind::SWITCH:
+    case Statement::Kind::RETURN:
+    case Statement::Kind::GOTO:
+    case Statement::Kind::USER_TYPE_ASCRIPTION:
+    case Statement::Kind::FAKE_READ:
+      break;
+    }
+}
+
+static Statement::DropStyle
+classify_drop (const BlockInitializationState &state, PlaceId place)
+{
+  bool maybe_initialized = state.maybe_initialized[place.value];
+  bool maybe_uninitialized = state.maybe_uninitialized[place.value];
+
+  if (!maybe_initialized)
+    return Statement::DropStyle::DEAD;
+
+  if (!maybe_uninitialized)
+    return Statement::DropStyle::STATIC;
+
+  return Statement::DropStyle::CONDITIONAL;
+}
+
+// Compute the initialization state at the entry of every reachable block.
+static std::vector<BlockInitializationState>
+compute_entry_states (Function &function)
+{
+  size_t place_count = function.place_db.size ();
+  size_t block_count = function.basic_blocks.size ();
+
+  std::vector<BlockInitializationState> entry_states;
+  entry_states.reserve (block_count);
+
+  for (size_t i = 0; i < block_count; i++)
+    entry_states.emplace_back (place_count);
+
+  BlockInitializationState &entry_state = entry_states[ENTRY_BASIC_BLOCK.value];
+
+  entry_state.reachable = true;
+
+  // All places start uninitialized, except function arguments.
+  for (size_t i = 0; i < place_count; i++)
+    entry_state.maybe_uninitialized[i] = true;
+
+  for (PlaceId argument : function.arguments)
+    set_initialized (entry_state, argument);
+
+  std::vector<BasicBlockId> worklist;
+  std::vector<bool> queued (block_count, false);
+
+  worklist.push_back (ENTRY_BASIC_BLOCK);
+  queued[ENTRY_BASIC_BLOCK.value] = true;
+
+  // Propagate block states until the last block.
+  while (!worklist.empty ())
+    {
+      BasicBlockId block_id = worklist.back ();
+      worklist.pop_back ();
+      queued[block_id.value] = false;
+
+      BlockInitializationState state = entry_states[block_id.value];
+      BasicBlock &block = function.basic_blocks[block_id];
+
+      for (Statement &statement : block.statements)
+	apply_statement (function, statement, state);
+
+      for (BasicBlockId successor : block.successors)
+	{
+	  bool changed = merge_state (entry_states[successor.value], state);
+
+	  if (changed && !queued[successor.value])
+	    {
+	      worklist.push_back (successor);
+	      queued[successor.value] = true;
+	    }
+	}
+    }
+  return entry_states;
+}
+
+static void
+record_drop_for_straight_line_backend (const Function &function, PlaceId place,
+				       Statement::DropStyle drop_style,
+				       std::set<HirId> &dead_drop_hir_ids,
+				       std::set<HirId> &non_dead_drop_hir_ids)
+{
+  const Place &dropped_place = function.place_db[place];
+
+  if (dropped_place.kind != Place::VARIABLE)
+    return;
+
+  auto hir_id = Analysis::Mappings::get ().lookup_node_to_hir (
+    static_cast<NodeId> (dropped_place.variable_or_field_index));
+
+  if (!hir_id.has_value ())
+    return;
+
+  if (drop_style == Statement::DropStyle::DEAD)
+    dead_drop_hir_ids.insert (hir_id.value ());
+  else
+    non_dead_drop_hir_ids.insert (hir_id.value ());
+}
+
+// Walk each reachable block forward from its stable entry state and classify
+// its Drop statements.
+static void
+annotate_drop_statements (
+  Function &function, const std::vector<BlockInitializationState> &entry_states,
+  bool record_straight_line_backend_drops, std::set<HirId> &dead_drop_hir_ids,
+  std::set<HirId> &non_dead_drop_hir_ids)
+{
+  const size_t block_count = function.basic_blocks.size ();
+
+  for (size_t i = 0; i < block_count; i++)
+    {
+      BlockInitializationState state = entry_states[i];
+
+      if (!state.reachable)
+	continue;
+
+      BasicBlockId block_id = {static_cast<uint32_t> (i)};
+      BasicBlock &block = function.basic_blocks[block_id];
+
+      for (Statement &statement : block.statements)
+	{
+	  // A Drop is classified using the state before it executes.
+	  if (statement.get_kind () == Statement::Kind::DROP)
+	    {
+	      PlaceId place = statement.get_place ();
+	      Statement::DropStyle drop_style = classify_drop (state, place);
+
+	      statement.set_drop_style (drop_style);
+
+	      if (record_straight_line_backend_drops)
+		record_drop_for_straight_line_backend (function, place,
+						       drop_style,
+						       dead_drop_hir_ids,
+						       non_dead_drop_hir_ids);
+	    }
+
+	  // Update the state for the following statement.
+	  apply_statement (function, statement, state);
+	}
+    }
+}
+
+} // namespace
 
 DropAnalysis &
 DropAnalysis::get ()
@@ -45,105 +315,23 @@ DropAnalysis::is_definitely_dead (HirId id) const
 void
 DropAnalysis::analyze (Function &function)
 {
-  std::vector<BasicBlockId> block_order;
-  std::set<BasicBlockId> visited;
+  std::vector<BlockInitializationState> entry_states
+    = compute_entry_states (function);
 
-  BasicBlockId current = ENTRY_BASIC_BLOCK;
+  // Keep the existing backend handling for straight-line CFGs.
+  const bool record_straight_line_backend_drops = is_straight_line (function);
 
-  while (current != INVALID_BB)
-    {
-      // A repeated block indicates a cycle in straight-line control flow.
-      if (!visited.insert (current).second)
-	return;
+  std::set<HirId> dead_drop_hir_ids;
+  std::set<HirId> non_dead_drop_hir_ids;
 
-      block_order.push_back (current);
+  annotate_drop_statements (function, entry_states,
+			    record_straight_line_backend_drops,
+			    dead_drop_hir_ids, non_dead_drop_hir_ids);
 
-      const BasicBlock &block = function.basic_blocks[current];
-
-      if (block.successors.empty ())
-	break;
-
-      if (block.successors.size () != 1)
-	return;
-
-      current = block.successors.front ();
-    }
-
-  std::vector<bool> initialized (function.place_db.size (), false);
-
-  for (PlaceId argument : function.arguments)
-    initialized[argument.value] = true;
-
-  for (BasicBlockId block_id : block_order)
-    {
-      BasicBlock &block = function.basic_blocks[block_id];
-
-      for (Statement &statement : block.statements)
-	{
-	  PlaceId place = statement.get_place ();
-
-	  switch (statement.get_kind ())
-	    {
-	    case Statement::Kind::STORAGE_LIVE:
-	      initialized[place.value] = false;
-	      break;
-
-	    case Statement::Kind::ASSIGNMENT:
-	      {
-		PlaceId lhs = place;
-		AbstractExpr &expr = statement.get_expr ();
-
-		if (expr.get_kind () == ExprKind::ASSIGNMENT)
-		  {
-		    PlaceId rhs = static_cast<Assignment &> (expr).get_rhs ();
-		    const Place &rhs_place = function.place_db[rhs];
-
-		    if (rhs_place.kind == Place::VARIABLE
-			&& rhs_place.should_be_moved ())
-		      initialized[rhs.value] = false;
-		  }
-
-		initialized[lhs.value] = true;
-		break;
-	      }
-
-	    case Statement::Kind::DROP:
-	      statement.set_drop_style (initialized[place.value]
-					  ? Statement::DropStyle::STATIC
-					  : Statement::DropStyle::DEAD);
-
-	      if (statement.get_drop_style () == Statement::DropStyle::DEAD)
-		{
-		  const Place &dropped_place = function.place_db[place];
-
-		  if (dropped_place.kind == Place::VARIABLE)
-		    {
-		      auto hir_id
-			= Analysis::Mappings::get ().lookup_node_to_hir (
-			  static_cast<NodeId> (
-			    dropped_place.variable_or_field_index));
-
-		      if (hir_id.has_value ())
-			definitely_dead.insert (hir_id.value ());
-		    }
-		}
-
-	      initialized[place.value] = false;
-	      break;
-
-	    case Statement::Kind::STORAGE_DEAD:
-	      initialized[place.value] = false;
-	      break;
-
-	    case Statement::Kind::SWITCH:
-	    case Statement::Kind::RETURN:
-	    case Statement::Kind::GOTO:
-	    case Statement::Kind::USER_TYPE_ASCRIPTION:
-	    case Statement::Kind::FAKE_READ:
-	      break;
-	    }
-	}
-    }
+  // A local is definitely dead only when all of its Drops are dead.
+  for (HirId hir_id : dead_drop_hir_ids)
+    if (non_dead_drop_hir_ids.find (hir_id) == non_dead_drop_hir_ids.end ())
+      definitely_dead.insert (hir_id);
 }
 
 } // namespace BIR

--- a/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.cc
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.cc
@@ -18,9 +18,29 @@
 
 #include "rust-bir-drop-analysis.h"
 #include "rust-bir.h"
+#include "rust-hir-map.h"
 
 namespace Rust {
 namespace BIR {
+
+DropAnalysis &
+DropAnalysis::get ()
+{
+  static DropAnalysis instance;
+  return instance;
+}
+
+void
+DropAnalysis::clear ()
+{
+  definitely_dead.clear ();
+}
+
+bool
+DropAnalysis::is_definitely_dead (HirId id) const
+{
+  return definitely_dead.find (id) != definitely_dead.end ();
+}
 
 void
 DropAnalysis::analyze (Function &function)
@@ -91,6 +111,22 @@ DropAnalysis::analyze (Function &function)
 	      statement.set_drop_style (initialized[place.value]
 					  ? Statement::DropStyle::STATIC
 					  : Statement::DropStyle::DEAD);
+
+	      if (statement.get_drop_style () == Statement::DropStyle::DEAD)
+		{
+		  const Place &dropped_place = function.place_db[place];
+
+		  if (dropped_place.kind == Place::VARIABLE)
+		    {
+		      auto hir_id
+			= Analysis::Mappings::get ().lookup_node_to_hir (
+			  static_cast<NodeId> (
+			    dropped_place.variable_or_field_index));
+
+		      if (hir_id.has_value ())
+			definitely_dead.insert (hir_id.value ());
+		    }
+		}
 
 	      initialized[place.value] = false;
 	      break;

--- a/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.h
@@ -19,6 +19,8 @@
 #ifndef RUST_BIR_DROP_ANALYSIS_H
 #define RUST_BIR_DROP_ANALYSIS_H
 
+#include "rust-mapping-common.h"
+
 namespace Rust {
 namespace BIR {
 
@@ -33,7 +35,15 @@ struct Function;
 class DropAnalysis
 {
 public:
-  static void analyze (Function &function);
+  static DropAnalysis &get ();
+
+  void clear ();
+  void analyze (Function &function);
+
+  bool is_definitely_dead (HirId id) const;
+
+private:
+  std::set<HirId> definitely_dead;
 };
 
 } // namespace BIR

--- a/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.h
@@ -1,0 +1,42 @@
+// Copyright (C) 2026 Free Software Foundation, Inc.
+
+// This file is part of GCC.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef RUST_BIR_DROP_ANALYSIS_H
+#define RUST_BIR_DROP_ANALYSIS_H
+
+namespace Rust {
+namespace BIR {
+
+struct Function;
+
+/*
+  Classifies scheduled whole-local BIR Drop statements according to
+  whether their place is initialized at the drop point.
+
+  This initial implementation only handles straight-line control flow.
+*/
+class DropAnalysis
+{
+public:
+  static void analyze (Function &function);
+};
+
+} // namespace BIR
+} // namespace Rust
+
+#endif // RUST_BIR_DROP_ANALYSIS_H

--- a/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.h
@@ -30,7 +30,7 @@ struct Function;
   Classifies scheduled whole-local BIR Drop statements according to
   whether their place is initialized at the drop point.
 
-  This initial implementation only handles straight-line control flow.
+  This analysis tracks initialization state across the BIR control-flow graph.
 */
 class DropAnalysis
 {

--- a/gcc/rust/checks/errors/borrowck/rust-bir-dump.cc
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-dump.cc
@@ -210,6 +210,32 @@ Dump::visit (const Statement &stmt)
 	<< bb_fold_map[func.basic_blocks[statement_bb].successors.at (0)].value;
       bb_terminated = true;
       break;
+
+    case Statement::Kind::DROP:
+      stream << "Drop(";
+      visit_place (stmt.get_place ());
+      stream << "): ";
+
+      switch (stmt.get_drop_style ())
+	{
+	case Statement::DropStyle::UNCLASSIFIED:
+	  stream << "Unclassified";
+	  break;
+
+	case Statement::DropStyle::STATIC:
+	  stream << "Static";
+	  break;
+
+	case Statement::DropStyle::DEAD:
+	  stream << "Dead";
+	  break;
+
+	case Statement::DropStyle::CONDITIONAL:
+	  stream << "Conditional";
+	  break;
+	}
+      break;
+
     case Statement::Kind::STORAGE_DEAD:
       stream << "StorageDead(";
       visit_place (stmt.get_place ());

--- a/gcc/rust/checks/errors/borrowck/rust-bir-fact-collector.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-fact-collector.h
@@ -250,6 +250,13 @@ protected: // Main collection entry points (for different categories).
 	  issue_jumps ();
 	}
 	break;
+
+      case Statement::Kind::DROP:
+	{
+	  // Drop statements are currently used only by BIR drop analysis.
+	  break;
+	}
+
       case Statement::Kind::RETURN:
 	{
 	  issue_place_access (RETURN_VALUE_PLACE);

--- a/gcc/rust/checks/errors/borrowck/rust-bir-place.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-place.h
@@ -209,7 +209,7 @@ template <typename I, typename T> class IndexVec
 
 public:
   IndexVec () = default;
-  IndexVec (size_t size) { internal_vector.reserve (size); }
+  IndexVec (size_t size) : internal_vector (size) {}
 
   T &at (I pid) { return internal_vector[pid.value]; }
   const T &at (I pid) const { return internal_vector[pid.value]; }

--- a/gcc/rust/checks/errors/borrowck/rust-bir.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir.h
@@ -75,12 +75,21 @@ struct Function
 class Statement
 {
 public:
+  enum class DropStyle
+  {
+    UNCLASSIFIED,
+    STATIC,
+    DEAD,
+    CONDITIONAL,
+  };
+
   enum class Kind
   {
     ASSIGNMENT,		  // <place> = <expr>
     SWITCH,		  // switch <place>
     RETURN,		  // return
     GOTO,		  // goto
+    DROP,		  // Drop(<place>)
     STORAGE_DEAD,	  // StorageDead(<place>)
     STORAGE_LIVE,	  // StorageLive(<place>)
     USER_TYPE_ASCRIPTION, // UserTypeAscription(<place>, <tyty>)
@@ -91,9 +100,11 @@ private:
   Kind kind;
   // ASSIGNMENT: lhs
   // SWITCH: switch_val
-  // StorageDead/StorageLive: place
+  // DROP/StorageDead/StorageLive: place
   // otherwise: <unused>
   PlaceId place;
+  // DROP: drop classification
+  DropStyle drop_style = DropStyle::UNCLASSIFIED;
   // ASSIGNMENT: rhs
   // otherwise: <unused>
   std::unique_ptr<AbstractExpr> expr;
@@ -118,6 +129,10 @@ public:
     return Statement (Kind::RETURN, INVALID_PLACE, nullptr, nullptr, location);
   }
   static Statement make_goto () { return Statement (Kind::GOTO); }
+  static Statement make_drop (PlaceId place)
+  {
+    return Statement (Kind::DROP, place);
+  }
   static Statement make_storage_dead (PlaceId place)
   {
     return Statement (Kind::STORAGE_DEAD, place);
@@ -147,6 +162,8 @@ private:
 public:
   WARN_UNUSED_RESULT Kind get_kind () const { return kind; }
   WARN_UNUSED_RESULT PlaceId get_place () const { return place; }
+  WARN_UNUSED_RESULT DropStyle get_drop_style () const { return drop_style; }
+  void set_drop_style (DropStyle style) { drop_style = style; }
   WARN_UNUSED_RESULT AbstractExpr &get_expr () const { return *expr; }
   WARN_UNUSED_RESULT TyTy::BaseType *get_type () const { return type; }
   WARN_UNUSED_RESULT location_t get_location () const { return location; }

--- a/gcc/rust/checks/errors/borrowck/rust-borrow-checker.cc
+++ b/gcc/rust/checks/errors/borrowck/rust-borrow-checker.cc
@@ -21,6 +21,7 @@
 #include "rust-function-collector.h"
 #include "rust-bir-fact-collector.h"
 #include "rust-bir-builder.h"
+#include "rust-bir-drop-analysis.h"
 #include "rust-bir-dump.h"
 #include "polonius/rust-polonius.h"
 
@@ -68,6 +69,8 @@ BorrowChecker::go (HIR::Crate &crate)
       BIR::BuilderContext ctx;
       BIR::Builder builder (ctx);
       auto bir = builder.build (*func);
+
+      BIR::DropAnalysis::analyze (bir);
 
       if (enable_dump_bir)
 	{

--- a/gcc/rust/checks/errors/borrowck/rust-borrow-checker.cc
+++ b/gcc/rust/checks/errors/borrowck/rust-borrow-checker.cc
@@ -49,6 +49,8 @@ BorrowChecker::go (HIR::Crate &crate)
 {
   std::string crate_name;
 
+  BIR::DropAnalysis::get ().clear ();
+
   if (enable_dump_bir)
     {
       mkdir ("bir_dump", 0755);
@@ -70,7 +72,7 @@ BorrowChecker::go (HIR::Crate &crate)
       BIR::Builder builder (ctx);
       auto bir = builder.build (*func);
 
-      BIR::DropAnalysis::analyze (bir);
+      BIR::DropAnalysis::get ().analyze (bir);
 
       if (enable_dump_bir)
 	{

--- a/gcc/testsuite/rust/borrowck/drop_analysis_conditional_move.rs
+++ b/gcc/testsuite/rust/borrowck/drop_analysis_conditional_move.rs
@@ -1,0 +1,46 @@
+// { dg-additional-options "-frust-compile-until=compilation -frust-borrowcheck -frust-dump-bir" }
+// { dg-final { scan-file bir_dump/drop_analysis_conditional_move.conditional_move.bir.dump "Drop\\(_3\\): Conditional" } }
+// { dg-final { scan-file bir_dump/drop_analysis_conditional_move.static_after_join.bir.dump "Drop\\(_3\\): Static" } }
+// { dg-final { scan-file bir_dump/drop_analysis_conditional_move.dead_after_join.bir.dump "Drop\\(_3\\): Dead" } }
+
+#![feature(no_core)]
+#![no_core]
+
+fn conditional_move(condition: bool) {
+    struct A {
+        i: i32,
+    }
+
+    let x = A { i: 1 };
+
+    if condition {
+        let y = x;
+    }
+}
+
+
+fn static_after_join(condition: bool) {
+    struct A {
+        i: i32,
+    }
+
+    let x = A { i: 1 };
+
+    if condition {
+        let y = 1;
+    }
+}
+
+fn dead_after_join(condition: bool) {
+    struct A {
+        i: i32,
+    }
+
+    let x = A { i: 1 };
+
+    if condition {
+        let y = x;
+    } else {
+        let z = x;
+    }
+}

--- a/gcc/testsuite/rust/borrowck/drop_analysis_whole_move.rs
+++ b/gcc/testsuite/rust/borrowck/drop_analysis_whole_move.rs
@@ -1,0 +1,34 @@
+// { dg-additional-options "-frust-compile-until=compilation -frust-borrowcheck -frust-dump-bir" }
+// { dg-final { scan-file bir_dump/drop_analysis_whole_move.static_local.bir.dump "Drop\\(_2\\): Static" } }
+// { dg-final { scan-file bir_dump/drop_analysis_whole_move.whole_move.bir.dump "Drop\\(_4\\): Static" } }
+// { dg-final { scan-file bir_dump/drop_analysis_whole_move.whole_move.bir.dump "Drop\\(_2\\): Dead" } }
+// { dg-final { scan-file bir_dump/drop_analysis_whole_move.copy.bir.dump "Drop\\(_4\\): Static" } }
+// { dg-final { scan-file bir_dump/drop_analysis_whole_move.copy.bir.dump "Drop\\(_2\\): Static" } }
+// { dg-final { scan-file bir_dump/drop_analysis_whole_move.function_argument.bir.dump "Drop\\(_2\\): Static" } }
+
+#![feature(no_core)]
+#![no_core]
+
+fn static_local() {
+    struct A {
+        i: i32,
+    }
+
+    let x = A { i: 1 };
+}
+
+fn whole_move() {
+    struct A {
+        i: i32,
+    }
+
+    let x = A { i: 1 };
+    let y = x;
+}
+
+fn copy() {
+    let x = 1;
+    let y = x;
+}
+
+fn function_argument(x: i32) {}

--- a/gcc/testsuite/rust/execute/drop-whole-local-move.rs
+++ b/gcc/testsuite/rust/execute/drop-whole-local-move.rs
@@ -1,0 +1,59 @@
+// { dg-output "^moved\r*\nstatic\r*\n$" }
+// { dg-additional-options "-frust-borrowcheck -w" }
+
+#![feature(no_core)]
+#![feature(lang_items)]
+#![no_core]
+
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "drop"]
+pub trait Drop {
+    fn drop(&mut self);
+}
+
+struct Moved {
+    value: i32,
+}
+
+struct Static {
+    value: i32,
+}
+
+impl Drop for Moved {
+    fn drop(&mut self) {
+        let msg = "moved\n\0" as *const str as *const i8;
+        unsafe {
+            printf(msg);
+        }
+    }
+}
+
+impl Drop for Static {
+    fn drop(&mut self) {
+        let msg = "static\n\0" as *const str as *const i8;
+        unsafe {
+            printf(msg);
+        }
+    }
+}
+
+fn whole_move() {
+    let x = Moved { value: 1 };
+    let _y = x;
+}
+
+fn static_local() {
+    let _x = Static { value: 2 };
+}
+
+fn main() -> i32 {
+    whole_move();
+    static_local();
+    0
+}


### PR DESCRIPTION
This patch extends the BIR Drop state analysis from straight-line control flow to conditional control flow.

It tracks whether each local variable may be `initialized` or `uninitialized` at the entry of each basic block. 

Take conditional move as example, 

              BB0
           initialize x
              /    \
             v      v
         BB1         BB2
        move x      no change
             \      /
              v    v
               BB3
              Drop(x)

For example,
```
BB0 -> BB1:
  (BB0): maybe_initialized(x)   = true
  (BB0): maybe_uninitialized(x) = false

  (BB1): reachable = false -> true
  (BB1): maybe_initialized(x)   = false -> true 
  (BB1): maybe_uninitialized(x) = false -> false 

BB1 -> BB3
  (pass through `let y = x`)
  (BB1): maybe_initialized(x) = true -> false 
  (BB1): maybe_unitialized(x) = false -> true
     
  (Assume BB2 has already reached BB3)
  (BB3): maybe_initialized(x)   = true -> true 
  (BB3): maybe_uninitialized(x) = false -> true 

BB3 -> END
  (BB3): maybe_initialized(x)   = true 
  (BB3): maybe_uninitialized(x) = true  
```
The analysis stops when the `worklist` becomes empty.

---

A Drop is classified as:

1. maybe initialized only:
1.1. Drop(x): Static
2. maybe uninitialized only:
2.1. Drop(x): Dead
3. maybe initialized and maybe uninitialized:
3.1. Drop(x): Conditional

---
It covers the following conditional control-flow cases:

1. conditional move:
```
  let x = A { i: 1 };

  if condition {
      let y = x;
  }
```
```
  Drop(x): Conditional
```
2. remains initialized after the join:
```
  let x = A { i: 1 };

  if condition {
      let y = 1;
  }
```
```
  Drop(x): Static
```

3. moved on both branches:
```
  let x = A { i: 1 };

  if condition {
      let y = x;
  } else {
      let z = x;
  }
```
```
  Drop(x): Dead
```

