### PR TITLE
gccrs: avoid MarkLive ICE on unresolved paths

### DIFF
--- a/gcc/rust/checks/lints/rust-lint-marklive.cc
+++ b/gcc/rust/checks/lints/rust-lint-marklive.cc
@@ -116,8 +116,8 @@ MarkLive::visit (HIR::PathInExpression &expr)
   if (expr.is_lang_item ())
     ref_node_id
       = Analysis::Mappings::get ().get_lang_item_node (expr.get_lang_item ());
-  else
-    find_value_definition (ast_node_id, ref_node_id);
+  else if (!find_value_definition (ast_node_id, ref_node_id))
+    return;
 
   // node back to HIR
   tl::optional<HirId> hid = mappings.lookup_node_to_hir (ref_node_id);
@@ -142,7 +142,8 @@ MarkLive::visit (HIR::MethodCallExpr &expr)
   // Trying to find the method definition and mark it alive.
   NodeId ast_node_id = expr.get_mappings ().get_nodeid ();
   NodeId ref_node_id = UNKNOWN_NODEID;
-  find_value_definition (ast_node_id, ref_node_id);
+  if (!find_value_definition (ast_node_id, ref_node_id))
+    return;
 
   // node back to HIR
   if (auto hid = mappings.lookup_node_to_hir (ref_node_id))
@@ -291,14 +292,16 @@ MarkLive::mark_hir_id (HirId id)
   liveSymbols.emplace (id);
 }
 
-void
+bool
 MarkLive::find_value_definition (NodeId ast_node_id, NodeId &ref_node_id)
 {
   auto resolved = resolver.lookup (ast_node_id, Resolver2_0::Namespace::Values,
 				   Resolver2_0::Namespace::Types);
-  rust_assert (resolved.has_value ());
+  if (!resolved)
+    return false;
 
   ref_node_id = resolved->id;
+  return true;
 }
 
 } // namespace Analysis

--- a/gcc/rust/checks/lints/rust-lint-marklive.cc
+++ b/gcc/rust/checks/lints/rust-lint-marklive.cc
@@ -111,16 +111,19 @@ MarkLive::visit (HIR::PathInExpression &expr)
   // after iterate the path segments, we should mark functions and associated
   // functions alive.
   NodeId ast_node_id = expr.get_mappings ().get_nodeid ();
-  NodeId ref_node_id = UNKNOWN_NODEID;
+  tl::optional<NodeId> ref_node_id;
 
   if (expr.is_lang_item ())
     ref_node_id
       = Analysis::Mappings::get ().get_lang_item_node (expr.get_lang_item ());
-  else if (!find_value_definition (ast_node_id, ref_node_id))
+  else
+    ref_node_id = find_value_definition (ast_node_id);
+
+  if (!ref_node_id)
     return;
 
   // node back to HIR
-  tl::optional<HirId> hid = mappings.lookup_node_to_hir (ref_node_id);
+  tl::optional<HirId> hid = mappings.lookup_node_to_hir (*ref_node_id);
   rust_assert (hid.has_value ());
   auto ref = hid.value ();
 
@@ -141,12 +144,12 @@ MarkLive::visit (HIR::MethodCallExpr &expr)
 
   // Trying to find the method definition and mark it alive.
   NodeId ast_node_id = expr.get_mappings ().get_nodeid ();
-  NodeId ref_node_id = UNKNOWN_NODEID;
-  if (!find_value_definition (ast_node_id, ref_node_id))
+  auto ref_node_id = find_value_definition (ast_node_id);
+  if (!ref_node_id)
     return;
 
   // node back to HIR
-  if (auto hid = mappings.lookup_node_to_hir (ref_node_id))
+  if (auto hid = mappings.lookup_node_to_hir (*ref_node_id))
     mark_hir_id (*hid);
   else
     rust_unreachable ();
@@ -292,16 +295,15 @@ MarkLive::mark_hir_id (HirId id)
   liveSymbols.emplace (id);
 }
 
-bool
-MarkLive::find_value_definition (NodeId ast_node_id, NodeId &ref_node_id)
+tl::optional<NodeId>
+MarkLive::find_value_definition (NodeId ast_node_id)
 {
   auto resolved = resolver.lookup (ast_node_id, Resolver2_0::Namespace::Values,
 				   Resolver2_0::Namespace::Types);
   if (!resolved)
-    return false;
+    return tl::nullopt;
 
-  ref_node_id = resolved->id;
-  return true;
+  return resolved->id;
 }
 
 } // namespace Analysis

--- a/gcc/rust/checks/lints/rust-lint-marklive.h
+++ b/gcc/rust/checks/lints/rust-lint-marklive.h
@@ -292,7 +292,7 @@ private:
 
   void mark_hir_id (HirId);
   bool visit_path_segment (HIR::PathExprSegment);
-  bool find_value_definition (NodeId ast_node_id, NodeId &ref_node_id);
+  tl::optional<NodeId> find_value_definition (NodeId ast_node_id);
 };
 
 } // namespace Analysis

--- a/gcc/rust/checks/lints/rust-lint-marklive.h
+++ b/gcc/rust/checks/lints/rust-lint-marklive.h
@@ -292,7 +292,7 @@ private:
 
   void mark_hir_id (HirId);
   bool visit_path_segment (HIR::PathExprSegment);
-  void find_value_definition (NodeId ast_node_id, NodeId &ref_node_id);
+  bool find_value_definition (NodeId ast_node_id, NodeId &ref_node_id);
 };
 
 } // namespace Analysis

--- a/gcc/testsuite/rust/compile/issue-4670.rs
+++ b/gcc/testsuite/rust/compile/issue-4670.rs
@@ -1,0 +1,16 @@
+// { dg-options "-frust-crate-attr=no_core" }
+
+pub enum Something {
+    Cat(u64),
+    Dog(u64),
+}
+
+fn main() {
+    let my_int: i32 = 1;
+
+    match my_int {
+        x if x == Something::Foo as i32 => {},
+        // { dg-error "Cannot find path .Something::Foo. in this scope" "" { target *-*-* } .-1 }
+        _ => {},
+    }
+}

--- a/gcc/testsuite/rust/compile/issue-4670.rs
+++ b/gcc/testsuite/rust/compile/issue-4670.rs
@@ -9,8 +9,7 @@ fn main() {
     let my_int: i32 = 1;
 
     match my_int {
-        x if x == Something::Foo as i32 => {},
-        // { dg-error "Cannot find path .Something::Foo. in this scope" "" { target *-*-* } .-1 }
+        x if x == Something::Foo as i32 => {}, // { dg-error "" }
         _ => {},
     }
 }


### PR DESCRIPTION
Fixes #4670

Name resolution already diagnoses the unknown enum variant in the match guard, but the lowered unresolved path still reached `MarkLive`, where a successful definition lookup was asserted. This change treats a missing definition as an already-diagnosed path and stops processing that expression instead of triggering an ICE.

I added a compile regression test for the reduced reproducer and its expected E0433 diagnostic.

Validation:
- Focused build of `rust/rust-lint-marklive.o`
- `clang-format` 16 dry-run on both changed C++ files
- `contrib/gcc-changelog/git_check_commit.py origin/master..HEAD`
- `git diff --check origin/master...HEAD`

The complete `make check-rust` suite is deferred to CI; the local compiler build exceeded the bounded run time after the changed translation unit compiled successfully.

Checklist:
- [x] DCO sign-off included
- [x] Read contributing guidelines
- [ ] `make check-rust` passes locally (deferred to CI)
- [x] Ran `clang-format`
- [x] Added a relevant test case to `gcc/testsuite/rust/`
