### PR TITLE
gccrs: Improve `AST::LlvmInlineAsm` handling

### DIFF
--- a/gcc/rust/ast/rust-ast-collector.cc
+++ b/gcc/rust/ast/rust-ast-collector.cc
@@ -1869,37 +1869,66 @@ TokenCollector::visit (LlvmInlineAsm &expr)
   push (Rust::Token::make_identifier (expr.get_locus (), "llvm_asm"));
   push (Rust::Token::make (EXCLAM, expr.get_locus ()));
   push (Rust::Token::make (LEFT_PAREN, expr.get_locus ()));
-  for (auto &template_str : expr.get_templates ())
-    push (Rust::Token::make_string (template_str.get_locus (),
-				    std::move (template_str.symbol)));
+  push (Rust::Token::make_string (expr.get_template ().get_locus (),
+				  std::move (expr.get_template ().symbol)));
 
   push (Rust::Token::make (COLON, expr.get_locus ()));
+
+  bool needs_comma = false;
+
   for (auto output : expr.get_outputs ())
     {
+      if (needs_comma)
+	push (Rust::Token::make (COMMA, expr.get_locus ()));
+      needs_comma = true;
       push (Rust::Token::make_string (expr.get_locus (),
 				      std::move (output.constraint)));
+      push (Rust::Token::make (LEFT_PAREN, expr.get_locus ()));
       visit (output.expr);
-      push (Rust::Token::make (COMMA, expr.get_locus ()));
+      push (Rust::Token::make (RIGHT_PAREN, expr.get_locus ()));
     }
 
   push (Rust::Token::make (COLON, expr.get_locus ()));
+  needs_comma = false;
   for (auto input : expr.get_inputs ())
     {
+      if (needs_comma)
+	push (Rust::Token::make (COMMA, expr.get_locus ()));
+      needs_comma = true;
       push (Rust::Token::make_string (expr.get_locus (),
 				      std::move (input.constraint)));
+      push (Rust::Token::make (LEFT_PAREN, expr.get_locus ()));
       visit (input.expr);
-      push (Rust::Token::make (COMMA, expr.get_locus ()));
+      push (Rust::Token::make (RIGHT_PAREN, expr.get_locus ()));
     }
 
   push (Rust::Token::make (COLON, expr.get_locus ()));
+  needs_comma = false;
   for (auto &clobber : expr.get_clobbers ())
     {
+      if (needs_comma)
+	push (Rust::Token::make (COMMA, expr.get_locus ()));
+      needs_comma = true;
       push (Rust::Token::make_string (expr.get_locus (),
 				      std::move (clobber.symbol)));
-      push (Rust::Token::make (COMMA, expr.get_locus ()));
     }
   push (Rust::Token::make (COLON, expr.get_locus ()));
-  // Dump options
+
+#define X(code, s)                                                             \
+  if (expr.code)                                                               \
+    {                                                                          \
+      if (needs_comma)                                                         \
+	push (Rust::Token::make (COMMA, expr.get_locus ()));                   \
+      needs_comma = true;                                                      \
+      push (Rust::Token::make_string (expr.get_locus (), s));                  \
+    }
+
+  needs_comma = false;
+  X (is_volatile (), "volatile")
+  X (is_stack_aligned (), "alignstack")
+  X (get_dialect () == LlvmInlineAsm::Dialect::Intel, "intel")
+
+#undef X
 
   push (Rust::Token::make (RIGHT_PAREN, expr.get_locus ()));
 }

--- a/gcc/rust/ast/rust-ast-pointer-visitor.cc
+++ b/gcc/rust/ast/rust-ast-pointer-visitor.cc
@@ -627,6 +627,8 @@ PointerVisitor::visit (AST::InlineAsm &expr)
 void
 PointerVisitor::visit (AST::LlvmInlineAsm &expr)
 {
+  visit_outer_attrs (expr);
+
   for (auto &output : expr.get_outputs ())
     reseat (output.expr);
 

--- a/gcc/rust/ast/rust-ast-visitor.cc
+++ b/gcc/rust/ast/rust-ast-visitor.cc
@@ -759,6 +759,8 @@ DefaultASTVisitor::visit (AST::InlineAsm &expr)
 void
 DefaultASTVisitor::visit (AST::LlvmInlineAsm &expr)
 {
+  visit_outer_attrs (expr);
+
   for (auto &output : expr.get_outputs ())
     visit (output.expr);
 

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -5844,14 +5844,16 @@ private:
   std::vector<Attribute> outer_attrs;
   std::vector<LlvmOperand> inputs;
   std::vector<LlvmOperand> outputs;
-  std::vector<TupleTemplateStr> templates;
+  TupleTemplateStr template_str;
   std::vector<TupleClobber> clobbers;
   bool volatility;
   bool align_stack;
   Dialect dialect;
 
 public:
-  LlvmInlineAsm (location_t locus) : locus (locus) {}
+  LlvmInlineAsm (location_t locus)
+    : locus (locus), template_str (UNKNOWN_LOCATION, "")
+  {}
 
   Dialect get_dialect () { return dialect; }
 
@@ -5874,11 +5876,13 @@ public:
     return new LlvmInlineAsm (*this);
   }
 
-  std::vector<TupleTemplateStr> &get_templates () { return templates; }
-  const std::vector<TupleTemplateStr> &get_templates () const
+  void set_template (TupleTemplateStr template_str)
   {
-    return templates;
+    this->template_str = std::move (template_str);
   }
+
+  TupleTemplateStr &get_template () { return template_str; }
+  const TupleTemplateStr &get_template () const { return template_str; }
 
   Expr::Kind get_expr_kind () const override
   {

--- a/gcc/rust/expand/rust-macro-builtins-asm.cc
+++ b/gcc/rust/expand/rust-macro-builtins-asm.cc
@@ -990,7 +990,7 @@ validate (InlineAsmContext inline_asm_ctx)
 }
 
 tl::optional<LlvmAsmContext>
-parse_llvm_templates (LlvmAsmContext ctx)
+parse_llvm_template (LlvmAsmContext ctx)
 {
   auto &parser = ctx.parser;
 
@@ -1002,19 +1002,12 @@ parse_llvm_templates (LlvmAsmContext ctx)
       return tl::nullopt;
     }
 
-  ctx.llvm_asm.get_templates ().emplace_back (token->get_locus (),
-					      strip_double_quotes (
-						token->as_string ()));
-  ctx.parser.skip_token ();
+  // TODO: improve string handling?
+  ctx.llvm_asm.set_template (
+    AST::TupleTemplateStr (token->get_locus (),
+			   strip_double_quotes (token->as_string ())));
 
-  token = parser.peek_current_token ();
-  if (token->get_id () != ctx.last_token_id && token->get_id () != COLON
-      && token->get_id () != SCOPE_RESOLUTION)
-    {
-      // We do not handle multiple template string, we provide minimal support
-      // for the black_box intrinsics.
-      rust_unreachable ();
-    }
+  ctx.parser.skip_token ();
 
   return ctx;
 }
@@ -1184,7 +1177,7 @@ parse_llvm_asm (location_t invoc_locus, AST::MacroInvocData &invoc,
   auto asm_ctx = LlvmAsmContext (llvm_asm, parser, last_token_id);
 
   tl::optional<LlvmAsmContext> resulting_context
-    = parse_llvm_templates (asm_ctx).and_then (parse_llvm_arguments);
+    = parse_llvm_template (asm_ctx).and_then (parse_llvm_arguments);
 
   if (resulting_context)
     {

--- a/gcc/rust/hir/rust-ast-lower-expr.cc
+++ b/gcc/rust/hir/rust-ast-lower-expr.cc
@@ -1024,8 +1024,7 @@ check_llvm_asm_support (const std::vector<LlvmOperand> &inputs,
 {
   return outputs.size () == 0 && inputs.size () <= 1
 	 && expr.get_clobbers ().size () <= 1
-	 && expr.get_templates ().size () == 1
-	 && expr.get_templates ()[0].symbol == "";
+	 && expr.get_template ().symbol == "";
 }
 
 } // namespace
@@ -1074,7 +1073,7 @@ ASTLoweringExpr::visit (AST::LlvmInlineAsm &expr)
 
   translated
     = new HIR::LlvmInlineAsm (expr.get_locus (), inputs, outputs,
-			      expr.get_templates (), expr.get_clobbers (),
+			      {expr.get_template ()}, expr.get_clobbers (),
 			      options, expr.get_outer_attrs (), mapping);
 }
 


### PR DESCRIPTION
Adjusts some visitor functions and makes `AST::LlvmInlineAsm` store only a single template string.