### PR TITLE
gccrs: Add missing context ast walker to check for free fn's

### DIFF
--- a/gcc/rust/ast/rust-ast-visitor.cc
+++ b/gcc/rust/ast/rust-ast-visitor.cc
@@ -1534,5 +1534,13 @@ ContextualASTVisitor::visit (AST::Trait &trait)
   ctx.exit ();
 }
 
+void
+ContextualASTVisitor::visit (AST::Function &function)
+{
+  ctx.enter (Kind::FUNCTION);
+  DefaultASTVisitor::visit (function);
+  ctx.exit ();
+}
+
 } // namespace AST
 } // namespace Rust

--- a/gcc/rust/ast/rust-ast-visitor.h
+++ b/gcc/rust/ast/rust-ast-visitor.h
@@ -479,6 +479,8 @@ protected:
 
   virtual void visit (AST::Trait &trait) override;
 
+  virtual void visit (AST::Function &function) override;
+
   template <typename T> void visit (T &item)
   {
     DefaultASTVisitor::visit (item);

--- a/gcc/testsuite/rust/compile/issue-3585-1.rs
+++ b/gcc/testsuite/rust/compile/issue-3585-1.rs
@@ -1,0 +1,15 @@
+#![feature(no_core)]
+#![no_core]
+
+macro_rules! mac_trait {
+    ($i:item) => {
+        trait T { $i }
+    }
+}
+
+mac_trait! {
+    fn foo() {
+    fn foo();
+    // { dg-error "free function without a body" "" { target *-*-* } .-1 }
+}
+}

--- a/gcc/testsuite/rust/compile/issue-3585-2.rs
+++ b/gcc/testsuite/rust/compile/issue-3585-2.rs
@@ -1,0 +1,42 @@
+#![feature(no_core)]
+#![no_core]
+#![feature(lang_items)]
+
+#[lang = "sized"]
+trait Sized {}
+
+fn main() {}
+
+macro_rules! mac_impl {
+    ($i:item) => {
+        struct S;
+        impl S { $i }
+    }
+}
+
+mac_impl! {
+    fn foo() {}
+}
+
+macro_rules! mac_trait {
+    ($i:item) => {
+        trait T { $i }
+    }
+}
+
+mac_trait! {
+    fn foo() {
+    fn foo();
+    // { dg-error "free function without a body" "" { target *-*-* } .-1 }
+}
+}
+
+macro_rules! mac_extern {
+    ($i:item) => {
+        extern "C" { $i }
+    }
+}
+
+mac_extern! {
+    fn foo();
+}


### PR DESCRIPTION
Fixes Rust-GCC#3585

gcc/rust/ChangeLog:

	* ast/rust-ast-visitor.cc (ContextualASTVisitor::visit): missing visitor
	* ast/rust-ast-visitor.h: prototype

gcc/testsuite/ChangeLog:

	* rust/compile/issue-3585-1.rs: New test.
	* rust/compile/issue-3585-2.rs: New test.

