### PR TITLE
gccrs: Fix missing error diag on const parser and crash in typecheck

### DIFF
--- a/gcc/rust/parse/rust-parse-impl.hxx
+++ b/gcc/rust/parse/rust-parse-impl.hxx
@@ -2021,6 +2021,16 @@ Parser<ManagedTokenSource>::parse_generic_param (EndTokenPred is_end_token)
 	    if (default_expr.value ().get_kind ()
 		== AST::GenericArg::Kind::Either)
 	      default_expr = default_expr.value ().disambiguate_to_const ();
+	    else if (default_expr.value ().get_kind ()
+		     != AST::GenericArg::Kind::Const)
+	      {
+		Error error (
+		  default_expr.value ().get_locus (),
+		  "expressions must be enclosed in braces to be used as const "
+		  "generic arguments");
+		add_error (std::move (error));
+		default_expr = tl::nullopt;
+	      }
 	  }
 
 	param = std::unique_ptr<AST::ConstGenericParam> (

--- a/gcc/rust/typecheck/rust-hir-type-check-base.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.cc
@@ -683,6 +683,10 @@ TypeCheckBase::resolve_generic_params (
 		auto expr_type
 		  = TypeCheckExpr::Resolve (param.get_default_expression ());
 
+		if (specified_type->is<TyTy::ErrorType> ()
+		    || expr_type->is<TyTy::ErrorType> ())
+		  break;
+
 		coercion_site (param.get_mappings ().get_hirid (),
 			       TyTy::TyWithLocation (specified_type),
 			       TyTy::TyWithLocation (

--- a/gcc/testsuite/rust/compile/issue-4173-1.rs
+++ b/gcc/testsuite/rust/compile/issue-4173-1.rs
@@ -1,0 +1,8 @@
+#![feature(no_core)]
+#![no_core]
+#![feature(lang_items)]
+
+#[lang = "sized"]
+trait Sized {}
+
+pub struct S<const N: u32 = { 1 }>;

--- a/gcc/testsuite/rust/compile/issue-4173-2.rs
+++ b/gcc/testsuite/rust/compile/issue-4173-2.rs
@@ -1,0 +1,9 @@
+#![feature(no_core)]
+#![no_core]
+#![feature(lang_items)]
+
+#[lang = "sized"]
+trait Sized {}
+
+pub struct S<const N: u32 = { u32::MAX }>;
+// { dg-error "failed to resolve path segment using an impl Probe" "" { target *-*-* } .-1 }

--- a/gcc/testsuite/rust/compile/issue-4173-3.rs
+++ b/gcc/testsuite/rust/compile/issue-4173-3.rs
@@ -1,0 +1,9 @@
+#![feature(no_core)]
+#![no_core]
+#![feature(lang_items)]
+
+#[lang = "sized"]
+trait Sized {}
+
+pub struct S<const N: u32 = u32::MAX>;
+// { dg-error "expressions must be enclosed in braces to be used as const generic arguments" "" { target *-*-* } .-1 }


### PR DESCRIPTION
We need to force braces on the default expression in the parser but also the typecheck cant const eval when the typecheck fails otherwise it will crash because invalid error mark node.

Fixes Rust-GCC/gccrs#4173

gcc/rust/ChangeLog:

	* parse/rust-parse-impl.hxx:
	* typecheck/rust-hir-type-check-base.cc:

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4173-1.rs: New test.
	* rust/compile/issue-4173-2.rs: New test.
	* rust/compile/issue-4173-3.rs: New test.
