### PR TITLE
gccrs: Improve `rust_debug` formatting

### DIFF
--- a/.github/glibcxx_ubuntu64b_log_expected_warnings
+++ b/.github/glibcxx_ubuntu64b_log_expected_warnings
@@ -1,0 +1,4 @@
+../../gcc/rust/typecheck/rust-coercion.cc:310:15: warning: too many arguments for format [-Wformat-extra-args]
+../../gcc/rust/typecheck/rust-coercion.cc:310:15: warning: unknown conversion type character ‘z’ in format [-Wformat=]
+../../gcc/rust/typecheck/rust-unify.cc:155:23: warning: too many arguments for format [-Wformat-extra-args]
+../../gcc/rust/typecheck/rust-unify.cc:155:23: warning: unknown conversion type character ‘z’ in format [-Wformat=]

--- a/.github/log_expected_warnings
+++ b/.github/log_expected_warnings
@@ -1,0 +1,4 @@
+../../gcc/rust/typecheck/rust-coercion.cc:310:15: warning: too many arguments for format [-Wformat-extra-args]
+../../gcc/rust/typecheck/rust-coercion.cc:310:15: warning: unknown conversion type character ‘z’ in format [-Wformat=]
+../../gcc/rust/typecheck/rust-unify.cc:155:23: warning: too many arguments for format [-Wformat-extra-args]
+../../gcc/rust/typecheck/rust-unify.cc:155:23: warning: unknown conversion type character ‘z’ in format [-Wformat=]

--- a/gcc/rust/ast/rust-ast.cc
+++ b/gcc/rust/ast/rust-ast.cc
@@ -35,6 +35,9 @@ along with GCC; see the file COPYING3.  If not see
 #include "rust-attribute-values.h"
 #include "rust-macro-invoc-lexer.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 /* Compilation unit used for various AST-related functions that would make
  * the headers too long if they were defined inline and don't receive any
  * benefits from being defined inline because they are virtual. Also used

--- a/gcc/rust/backend/rust-compile-base.cc
+++ b/gcc/rust/backend/rust-compile-base.cc
@@ -46,6 +46,9 @@
 // rust-name-resolution-2.0
 #include "options.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 namespace Rust {
 namespace Compile {
 

--- a/gcc/rust/backend/rust-compile-expr.cc
+++ b/gcc/rust/backend/rust-compile-expr.cc
@@ -44,6 +44,9 @@
 #include "rust-tyty.h"
 #include "tree-core.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 namespace Rust {
 namespace Compile {
 

--- a/gcc/rust/backend/rust-compile-stmt.cc
+++ b/gcc/rust/backend/rust-compile-stmt.cc
@@ -22,6 +22,9 @@
 #include "rust-compile-type.h"
 #include "rust-compile-var-decl.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 namespace Rust {
 namespace Compile {
 

--- a/gcc/rust/backend/rust-mangle-v0.cc
+++ b/gcc/rust/backend/rust-mangle-v0.cc
@@ -26,6 +26,9 @@
 #include "rust-punycode.h"
 #include "rust-compile-type.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 namespace Rust {
 namespace Compile {
 

--- a/gcc/rust/checks/errors/borrowck/rust-bir-builder.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-builder.h
@@ -23,6 +23,9 @@
 #include "rust-bir-builder-pattern.h"
 #include "rust-bir-builder-expr-stmt.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 namespace Rust {
 namespace BIR {
 

--- a/gcc/rust/checks/errors/borrowck/rust-bir-fact-collector.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-fact-collector.h
@@ -24,6 +24,9 @@
 #include "rust-bir-place.h"
 #include "polonius/rust-polonius.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 namespace Rust {
 namespace BIR {
 

--- a/gcc/rust/checks/errors/rust-hir-pattern-analysis.cc
+++ b/gcc/rust/checks/errors/rust-hir-pattern-analysis.cc
@@ -29,6 +29,9 @@
 #include "rust-tyty.h"
 #include "rust-finalized-name-resolution-context.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 namespace Rust {
 namespace Analysis {
 

--- a/gcc/rust/expand/rust-cfg-strip.cc
+++ b/gcc/rust/expand/rust-cfg-strip.cc
@@ -24,6 +24,9 @@
 #include "rust-attribute-values.h"
 #include "rust-macro-expand.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 namespace Rust {
 
 /**

--- a/gcc/rust/expand/rust-macro-builtins-asm.cc
+++ b/gcc/rust/expand/rust-macro-builtins-asm.cc
@@ -24,6 +24,9 @@
 #include "rust-stmt.h"
 #include "rust-parse.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 namespace Rust {
 std::set<std::string> potentially_nonpromoted_keywords
   = {"in", "out", "lateout", "inout", "inlateout", "const", "sym", "label"};

--- a/gcc/rust/expand/rust-macro-builtins-log-debug.cc
+++ b/gcc/rust/expand/rust-macro-builtins-log-debug.cc
@@ -23,6 +23,9 @@
 #include "optional.h"
 #include "rust-ast-collector.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 namespace Rust {
 tl::optional<AST::Fragment>
 MacroBuiltin::assert_handler (location_t invoc_locus,

--- a/gcc/rust/hir/tree/rust-hir.cc
+++ b/gcc/rust/hir/tree/rust-hir.cc
@@ -23,6 +23,9 @@
 #include "rust-hir-visitor.h"
 #include "rust-diagnostics.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 /* Compilation unit used for various HIR-related functions that would make
  * the headers too long if they were defined inline and don't receive any
  * benefits from being defined inline because they are virtual. Also used

--- a/gcc/rust/lex/rust-lex.cc
+++ b/gcc/rust/lex/rust-lex.cc
@@ -26,6 +26,9 @@
 #include "cpplib.h"
 #include "rust-keyword-values.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 namespace Rust {
 // TODO: move to separate compilation unit?
 // overload += for uint32_t to allow 32-bit encoded utf-8 to be added

--- a/gcc/rust/parse/rust-parse-impl-lexer.cc
+++ b/gcc/rust/parse/rust-parse-impl-lexer.cc
@@ -16,6 +16,9 @@
 // along with GCC; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 #include "rust-parse-impl.hxx"
 
 namespace Rust {

--- a/gcc/rust/parse/rust-parse-impl-macro.cc
+++ b/gcc/rust/parse/rust-parse-impl-macro.cc
@@ -16,6 +16,9 @@
 // along with GCC; see the file COPYING3.  If not see
 // <http://www.gnu.org/licenses/>.
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 #include "rust-parse-impl.hxx"
 #include "rust-macro-invoc-lexer.h"
 

--- a/gcc/rust/resolve/rust-forever-stack.hxx
+++ b/gcc/rust/resolve/rust-forever-stack.hxx
@@ -63,6 +63,10 @@ ForeverStack<N>::push (Rib::Kind rib_kind, NodeId id,
   push_inner (rib_kind, Link (id, path));
 }
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 template <Namespace N>
 void
 ForeverStack<N>::push_inner (Rib::Kind rib_kind, Link link)
@@ -116,6 +120,9 @@ ForeverStack<N>::pop ()
 
   update_cursor (cursor ().parent.value ());
 }
+
+// TODO: fix warnings and remove
+#pragma GCC diagnostic pop
 
 static tl::expected<NodeId, DuplicateNameError>
 insert_inner (Rib &rib, std::string name, Rib::Definition definition)

--- a/gcc/rust/rust-diagnostics.cc
+++ b/gcc/rust/rust-diagnostics.cc
@@ -406,18 +406,8 @@ rust_debug_loc (const location_t location, const char *fmt, ...)
   va_list ap;
 
   va_start (ap, fmt);
-  char *mbuf = NULL;
-  int nwr = vasprintf (&mbuf, fmt, ap);
+  rust_be_inform (location, expand_message (fmt, ap));
   va_end (ap);
-  if (nwr == -1)
-    {
-      rust_be_error_at (UNKNOWN_LOCATION,
-			"memory allocation failed in vasprintf");
-      rust_assert (0);
-    }
-  std::string rval = std::string (mbuf);
-  free (mbuf);
-  rust_be_inform (location, rval);
 }
 
 namespace Rust {

--- a/gcc/rust/rust-diagnostics.h
+++ b/gcc/rust/rust-diagnostics.h
@@ -299,12 +299,11 @@ struct Error
 };
 } // namespace Rust
 
-// rust_debug uses normal printf formatting, not GCC diagnostic formatting.
 #define rust_debug(...) rust_debug_loc (UNDEF_LOCATION, __VA_ARGS__)
 
 #define rust_sorry_at(location, ...) sorry_at (location, __VA_ARGS__)
 
-void rust_debug_loc (const location_t location, const char *fmt,
-		     ...) ATTRIBUTE_PRINTF_2;
+void rust_debug_loc (const location_t location, const char *fmt, ...)
+  RUST_ATTRIBUTE_GCC_DIAG (2, 3);
 
 #endif // !defined(RUST_DIAGNOSTICS_H)

--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -160,7 +160,7 @@ grs_langhook_init_options_struct (struct gcc_options *opts)
 static void
 grs_langhook_parse_file (void)
 {
-  rust_debug ("Preparing to parse files. ");
+  rust_debug ("preparing to parse files");
 
   Rust::Session::get_instance ().handle_input_files (num_in_fnames, in_fnames);
 }

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -70,6 +70,9 @@
 #include "rust-target.h"
 #include "rust-system.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 extern bool saw_errors (void);
 
 extern Linemap *rust_get_linemap ();

--- a/gcc/rust/typecheck/rust-autoderef.cc
+++ b/gcc/rust/typecheck/rust-autoderef.cc
@@ -23,6 +23,9 @@
 #include "rust-type-util.h"
 #include "rust-substitution-mapper.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 namespace Rust {
 namespace Resolver {
 

--- a/gcc/rust/typecheck/rust-casts.cc
+++ b/gcc/rust/typecheck/rust-casts.cc
@@ -19,6 +19,9 @@
 #include "rust-casts.h"
 #include "rust-tyty-util.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 namespace Rust {
 namespace Resolver {
 

--- a/gcc/rust/typecheck/rust-coercion.cc
+++ b/gcc/rust/typecheck/rust-coercion.cc
@@ -20,6 +20,9 @@
 #include "rust-type-util.h"
 #include "rust-tyty.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 namespace Rust {
 namespace Resolver {
 

--- a/gcc/rust/typecheck/rust-hir-dot-operator.cc
+++ b/gcc/rust/typecheck/rust-hir-dot-operator.cc
@@ -23,6 +23,9 @@
 #include "rust-type-util.h"
 #include "rust-coercion.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 namespace Rust {
 namespace Resolver {
 

--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -39,6 +39,9 @@
 #include "rust-tyty-util.h"
 #include "rust-tyty.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 namespace Rust {
 namespace Resolver {
 

--- a/gcc/rust/typecheck/rust-hir-type-check-path.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-path.cc
@@ -32,6 +32,9 @@
 #include "rust-session-manager.h"
 #include "rust-finalized-name-resolution-context.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 namespace Rust {
 namespace Resolver {
 

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -33,6 +33,9 @@
 #include "rust-compile-base.h"
 #include "rust-resolve-builtins.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 namespace Rust {
 namespace Resolver {
 

--- a/gcc/rust/typecheck/rust-type-util.cc
+++ b/gcc/rust/typecheck/rust-type-util.cc
@@ -33,6 +33,9 @@
 #include "rust-substitution-mapper.h"
 #include "rust-finalized-name-resolution-context.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 namespace Rust {
 namespace Resolver {
 

--- a/gcc/rust/typecheck/rust-tyty-bounds.cc
+++ b/gcc/rust/typecheck/rust-tyty-bounds.cc
@@ -23,6 +23,9 @@
 #include "rust-hir-trait-resolve.h"
 #include "rust-type-util.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 namespace Rust {
 namespace Resolver {
 

--- a/gcc/rust/typecheck/rust-tyty-subst.cc
+++ b/gcc/rust/typecheck/rust-tyty-subst.cc
@@ -29,6 +29,9 @@
 #include "rust-type-util.h"
 #include "tree.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 namespace Rust {
 namespace TyTy {
 

--- a/gcc/rust/typecheck/rust-tyty-variance-analysis.cc
+++ b/gcc/rust/typecheck/rust-tyty-variance-analysis.cc
@@ -1,6 +1,9 @@
 #include "rust-tyty-variance-analysis-private.h"
 #include "rust-hir-type-check.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 namespace Rust {
 namespace TyTy {
 

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -35,6 +35,9 @@
 #include "tree.h"
 #include "fold-const.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 namespace Rust {
 namespace TyTy {
 

--- a/gcc/rust/typecheck/rust-unify.cc
+++ b/gcc/rust/typecheck/rust-unify.cc
@@ -23,6 +23,9 @@
 #include "rust-tyty.h"
 #include "rust-type-util.h"
 
+// TODO: fix warnings and remove
+#pragma GCC diagnostic ignored "-Wformat-diag"
+
 namespace Rust {
 namespace Resolver {
 


### PR DESCRIPTION
This allows `rust_debug` to use (an ad-hoc implementation of) gcc diagnostic formatting. To keep this patch as small as possible, proper fixes for `-Wformat-diag` are mostly left for future patches.