### PR TITLE
gccrs: Prevent warning on "unreachable" items

### DIFF
--- a/gcc/rust/hir/rust-ast-lower.cc
+++ b/gcc/rust/hir/rust-ast-lower.cc
@@ -117,7 +117,7 @@ ASTLoweringBlock::visit (AST::BlockExpr &expr)
 	  "this point in "
 	  "the pipeline, they should all have been expanded");
 
-      if (block_did_terminate)
+      if (s->get_stmt_kind () != AST::Stmt::Kind::Item && block_did_terminate)
 	rust_warning_at (s->get_locus (), 0, "unreachable statement");
 
       bool terminated = false;

--- a/gcc/testsuite/rust/compile/unreachable.rs
+++ b/gcc/testsuite/rust/compile/unreachable.rs
@@ -1,0 +1,21 @@
+#![feature(no_core)]
+#![no_core]
+
+pub fn f1() {
+    return f11();
+
+    // no warning
+    fn f11() {}
+
+    f11() // { dg-warning "unreachable expression" }
+}
+
+pub fn f2() {
+    return;
+    f1(); // { dg-warning "unreachable statement" }
+}
+
+pub fn f3() {
+    return;
+    f1() // { dg-warning "unreachable expression" }
+}


### PR DESCRIPTION
Items declared in a block expression can't be unreachable.