### PR TITLE
gccrs: Add `rust_debug_fmt`

### DIFF
--- a/gcc/rust/rust-diagnostics.cc
+++ b/gcc/rust/rust-diagnostics.cc
@@ -420,6 +420,19 @@ rust_debug_loc (const location_t location, const char *fmt, ...)
   rust_be_inform (location, rval);
 }
 
+void
+rust_debug_fmt_at (const location_t location, const char *fmt, ...)
+{
+  if (!rust_be_debug_p ())
+    return;
+
+  va_list ap;
+
+  va_start (ap, fmt);
+  rust_be_inform (location, expand_message (fmt, ap));
+  va_end (ap);
+}
+
 namespace Rust {
 
 /**

--- a/gcc/rust/rust-diagnostics.h
+++ b/gcc/rust/rust-diagnostics.h
@@ -307,4 +307,10 @@ struct Error
 void rust_debug_loc (const location_t location, const char *fmt,
 		     ...) ATTRIBUTE_PRINTF_2;
 
+// like rust_debug, but has gcc diagnostic formatting
+#define rust_debug_fmt(...) rust_debug_fmt_at (UNDEF_LOCATION, __VA_ARGS__)
+
+void rust_debug_fmt_at (location_t location, const char *fmt, ...)
+  RUST_ATTRIBUTE_GCC_DIAG (2, 3);
+
 #endif // !defined(RUST_DIAGNOSTICS_H)


### PR DESCRIPTION
This should allow the use of gcc diagnostic format specifiers in debug diagnostics, in exchange for stricter diagnostic quality checks.

Similar to #4783, but doesn't impose diagnostic quality checks on every `rust_debug` call.