### PR TITLE
gccrs: Wrap rust_debugs into a do-while wrapper

### DIFF
--- a/gcc/rust/rust-diagnostics.cc
+++ b/gcc/rust/rust-diagnostics.cc
@@ -398,11 +398,8 @@ rust_be_debug_p (void)
 }
 
 void
-rust_debug_loc (const location_t location, const char *fmt, ...)
+rust_debug_loc_internal (const location_t location, const char *fmt, ...)
 {
-  if (!rust_be_debug_p ())
-    return;
-
   va_list ap;
 
   va_start (ap, fmt);

--- a/gcc/rust/rust-diagnostics.h
+++ b/gcc/rust/rust-diagnostics.h
@@ -300,12 +300,26 @@ struct Error
 } // namespace Rust
 
 // rust_debug uses normal printf formatting, not GCC diagnostic formatting.
-#define rust_debug(...) rust_debug_loc (UNDEF_LOCATION, __VA_ARGS__)
+#define rust_debug(...)                                                        \
+  do                                                                           \
+    {                                                                          \
+      if (rust_be_debug_p ())                                                  \
+	rust_debug_loc_internal (UNDEF_LOCATION, __VA_ARGS__);                 \
+    }                                                                          \
+  while (0)
+
+#define rust_debug_loc(location, ...)                                          \
+  do                                                                           \
+    {                                                                          \
+      if (rust_be_debug_p ())                                                  \
+	rust_debug_loc_internal (location, __VA_ARGS__);                       \
+    }                                                                          \
+  while (0)
 
 #define rust_sorry_at(location, ...) sorry_at (location, __VA_ARGS__)
 
-void rust_debug_loc (const location_t location, const char *fmt,
-		     ...) ATTRIBUTE_PRINTF_2;
+void rust_debug_loc_internal (const location_t location, const char *fmt,
+			      ...) ATTRIBUTE_PRINTF_2;
 
 // like rust_debug, but has gcc diagnostic formatting
 #define rust_debug_fmt(...) rust_debug_fmt_at (UNDEF_LOCATION, __VA_ARGS__)


### PR DESCRIPTION
This reduces compile time when debug is turned off due to evaultion of any passed arguments.

gcc/rust/ChangeLog:

	* rust-diagnostics.cc (rust_debug_loc): rename
	(rust_debug_loc_internal): no longer check if debug is enabled
	* rust-diagnostics.h (rust_debug): new wrapper
	(rust_debug_loc): likewise
	(rust_debug_loc_internal): likewise
