### PR TITLE
gccrs: Generate backend drop flags for conditional moves

### DIFF
--- a/gcc/rust/backend/rust-compile-context.h
+++ b/gcc/rust/backend/rust-compile-context.h
@@ -145,6 +145,21 @@ public:
     return true;
   }
 
+  void insert_drop_flag (HirId id, ::Bvariable *flag)
+  {
+    drop_flags[{peek_fn ().fndecl, id}] = flag;
+  }
+
+  bool lookup_drop_flag (HirId id, ::Bvariable **flag)
+  {
+    auto it = drop_flags.find ({peek_fn ().fndecl, id});
+    if (it == drop_flags.end ())
+      return false;
+
+    *flag = it->second;
+    return true;
+  }
+
   void insert_function_decl (const TyTy::FnType *ref, tree fn)
   {
     auto id = ref->get_ty_ref ();
@@ -504,6 +519,7 @@ private:
   // state
   std::vector<fncontext> fn_stack;
   std::map<HirId, ::Bvariable *> compiled_var_decls;
+  std::map<std::pair<tree, HirId>, ::Bvariable *> drop_flags;
   std::map<hashval_t, tree> compiled_type_map;
   std::map<HirId, tree> compiled_fn_map;
   std::map<HirId, tree> compiled_consts;

--- a/gcc/rust/backend/rust-compile-drop-builder.cc
+++ b/gcc/rust/backend/rust-compile-drop-builder.cc
@@ -18,6 +18,7 @@
 
 #include "rust-compile-drop-builder.h"
 #include "rust-compile-context.h"
+#include "rust-bir-drop-analysis.h"
 
 namespace Rust {
 namespace Compile {
@@ -29,6 +30,39 @@ DropBuilder::note_simple_drop_candidate (HirId hirid, location_t locus)
 {
   rust_assert (!ctx.block_drop_candidates.empty ());
   ctx.block_drop_candidates.back ().emplace_back (hirid, locus);
+}
+
+void
+DropBuilder::maybe_create_drop_flag (HirId hirid, location_t locus,
+				     bool initialized)
+{
+  if (!BIR::DropAnalysis::get ().needs_drop_flag (hirid))
+    return;
+
+  Bvariable *existing = nullptr;
+  if (ctx.lookup_drop_flag (hirid, &existing))
+    return;
+
+  tree declaration = nullptr;
+  Bvariable *flag = Backend::temporary_variable (
+    ctx.peek_fn ().fndecl, nullptr, boolean_type_node,
+    Backend::boolean_constant_expression (initialized), false, locus,
+    &declaration);
+  ctx.add_statement (declaration);
+  ctx.insert_drop_flag (hirid, flag);
+}
+
+tree
+DropBuilder::drop_flag_assignment (HirId hirid, bool value, location_t locus)
+{
+  Bvariable *flag = nullptr;
+  if (!ctx.lookup_drop_flag (hirid, &flag))
+    return nullptr;
+
+  return Backend::assignment_statement (Backend::var_expression (flag, locus),
+					Backend::boolean_constant_expression (
+					  value),
+					locus);
 }
 
 std::vector<DropCandidate> &

--- a/gcc/rust/backend/rust-compile-drop-builder.h
+++ b/gcc/rust/backend/rust-compile-drop-builder.h
@@ -32,6 +32,8 @@ public:
   DropBuilder (Context &ctx);
 
   void note_simple_drop_candidate (HirId hirid, location_t locus);
+  void maybe_create_drop_flag (HirId hirid, location_t locus, bool initialized);
+  tree drop_flag_assignment (HirId hirid, bool value, location_t locus);
   std::vector<DropCandidate> &peek_block_drop_candidates ();
 
 private:

--- a/gcc/rust/backend/rust-compile-drop.cc
+++ b/gcc/rust/backend/rust-compile-drop.cc
@@ -115,7 +115,21 @@ CompileDrop::build_current_scope_drop_cleanup ()
 
       tree drop_call = compile_drop_call (var, ty, it->locus);
       if (drop_call != NULL_TREE)
-	drop_stmts.push_back (convert_to_void (drop_call, ICV_STATEMENT));
+	{
+	  tree drop_stmt = convert_to_void (drop_call, ICV_STATEMENT);
+	  Bvariable *flag = nullptr;
+	  if (ctx->lookup_drop_flag (it->hirid, &flag))
+	    {
+	      tree condition = Backend::var_expression (flag, it->locus);
+	      tree clear = drop_builder.drop_flag_assignment (it->hirid, false,
+							      it->locus);
+	      tree guarded_drop = Backend::statement_list ({clear, drop_stmt});
+	      drop_stmt
+		= Backend::if_statement (ctx->peek_fn ().fndecl, condition,
+					 guarded_drop, NULL_TREE, it->locus);
+	    }
+	  drop_stmts.push_back (drop_stmt);
+	}
     }
 
   if (drop_stmts.empty ())

--- a/gcc/rust/backend/rust-compile-pattern.cc
+++ b/gcc/rust/backend/rust-compile-pattern.cc
@@ -1353,6 +1353,13 @@ CompilePatternLet::visit (HIR::IdentifierPattern &pattern)
       ctx->add_statement (s);
     }
 
+  DropBuilder drop_builder (*ctx);
+  tree set_drop_flag
+    = drop_builder.drop_flag_assignment (pattern.get_mappings ().get_hirid (),
+					 true, pattern.get_locus ());
+  if (set_drop_flag != nullptr)
+    ctx->add_statement (set_drop_flag);
+
   TyTy::BaseType *drop_ty = ty;
   if (pattern.get_is_ref ())
     {
@@ -1366,7 +1373,6 @@ CompilePatternLet::visit (HIR::IdentifierPattern &pattern)
 
   if (!pattern.has_subpattern () && !pattern.get_is_ref ())
     {
-      DropBuilder drop_builder (*ctx);
       drop_builder.note_simple_drop_candidate (
 	pattern.get_mappings ().get_hirid (), pattern.get_locus ());
     }

--- a/gcc/rust/backend/rust-compile-stmt.cc
+++ b/gcc/rust/backend/rust-compile-stmt.cc
@@ -21,6 +21,9 @@
 #include "rust-compile-expr.h"
 #include "rust-compile-type.h"
 #include "rust-compile-var-decl.h"
+#include "rust-compile-drop.h"
+#include "rust-compile-drop-builder.h"
+#include "rust-bir-drop-analysis.h"
 
 namespace Rust {
 namespace Compile {
@@ -67,6 +70,11 @@ CompileStmt::visit (HIR::LetStmt &stmt)
   tree translated_type = TyTyResolveCompile::compile (ctx, ty);
   CompileVarDecl::compile (fndecl, translated_type, &stmt_pattern, ctx);
 
+  if (stmt_pattern.get_pattern_type () == HIR::Pattern::IDENTIFIER
+      && CompileDrop (ctx).type_has_drop_impl (ty))
+    DropBuilder (*ctx).maybe_create_drop_flag (stmt_id, stmt.get_locus (),
+					       false);
+
   // nothing to do
   if (!stmt.has_init_expr ())
     return;
@@ -89,6 +97,16 @@ CompileStmt::visit (HIR::LetStmt &stmt)
 			expected, lvalue_locus, rvalue_locus);
 
   CompilePatternLet::Compile (&stmt_pattern, init, ty, rvalue_locus, ctx);
+
+  HirId source = UNKNOWN_HIRID;
+  if (BIR::DropAnalysis::get ().lookup_move_source (
+	stmt.get_init_expr ().get_mappings ().get_hirid (), &source))
+    {
+      tree clear
+	= DropBuilder (*ctx).drop_flag_assignment (source, false, rvalue_locus);
+      if (clear != nullptr)
+	ctx->add_statement (clear);
+    }
 }
 
 } // namespace Compile

--- a/gcc/rust/checks/errors/borrowck/rust-bir-builder-expr-stmt.cc
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-builder-expr-stmt.cc
@@ -703,7 +703,8 @@ ExprStmtBuilder::visit (HIR::PathInExpression &expr)
 {
   // Note: Type is only stored for the expr, not the segment.
   PlaceId result = resolve_variable_or_fn (expr, lookup_type (expr));
-  return_place (result, expr.get_locus ());
+  return_place (result, expr.get_locus (), false,
+		expr.get_mappings ().get_hirid ());
 }
 
 void

--- a/gcc/rust/checks/errors/borrowck/rust-bir-builder-expr-stmt.cc
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-builder-expr-stmt.cc
@@ -111,7 +111,7 @@ ExprStmtBuilder::visit (HIR::StructExprStructFields &fields)
     {
       field_locations.push_back (field->get_locus ());
     }
-  move_all (init_values, field_locations);
+  move_all (init_values, field_locations, fields.get_mappings ().get_hirid ());
   return_expr (new InitializerExpr (std::move (init_values)),
 	       lookup_type (fields), fields.get_locus ());
 }

--- a/gcc/rust/checks/errors/borrowck/rust-bir-builder-internal.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-builder-internal.h
@@ -280,17 +280,19 @@ protected: // Helpers to add BIR statements
   }
 
   void push_tmp_assignment (AbstractExpr *rhs, TyTy::BaseType *tyty,
-			    location_t location)
+			    location_t location,
+			    tl::optional<HirId> move_site = tl::nullopt)
   {
     PlaceId tmp = ctx.place_db.add_temporary (tyty);
     push_storage_live (tmp);
-    push_assignment (tmp, rhs, location);
+    push_assignment (tmp, rhs, location, move_site);
   }
 
-  void push_tmp_assignment (PlaceId rhs, location_t location)
+  void push_tmp_assignment (PlaceId rhs, location_t location,
+			    tl::optional<HirId> move_site = tl::nullopt)
   {
-    push_tmp_assignment (new Assignment (rhs), ctx.place_db[rhs].tyty,
-			 location);
+    push_tmp_assignment (new Assignment (rhs), ctx.place_db[rhs].tyty, location,
+			 move_site);
   }
 
   void push_switch (PlaceId switch_val, location_t location,
@@ -353,7 +355,8 @@ protected: // Helpers to add BIR statements
     return translated;
   }
 
-  PlaceId move_place (PlaceId arg, location_t location)
+  PlaceId move_place (PlaceId arg, location_t location,
+		      tl::optional<HirId> move_site = tl::nullopt)
   {
     auto &place = ctx.place_db[arg];
 
@@ -366,7 +369,7 @@ protected: // Helpers to add BIR statements
     if (place.is_rvalue ())
       return arg;
 
-    push_tmp_assignment (arg, location);
+    push_tmp_assignment (arg, location, move_site);
     return translated;
   }
 
@@ -379,12 +382,14 @@ protected: // Helpers to add BIR statements
   }
 
   template <typename T>
-  void move_all (T &args, std::vector<location_t> locations)
+  void move_all (T &args, std::vector<location_t> locations,
+		 tl::optional<HirId> move_site = tl::nullopt)
   {
     rust_assert (args.size () == locations.size ());
     std::transform (args.begin (), args.end (), locations.begin (),
-		    args.begin (), [this] (PlaceId arg, location_t location) {
-		      return move_place (arg, location);
+		    args.begin (),
+		    [this, move_site] (PlaceId arg, location_t location) {
+		      return move_place (arg, location, move_site);
 		    });
   }
 

--- a/gcc/rust/checks/errors/borrowck/rust-bir-builder-internal.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-builder-internal.h
@@ -265,16 +265,18 @@ protected:
   }
 
 protected: // Helpers to add BIR statements
-  void push_assignment (PlaceId lhs, AbstractExpr *rhs, location_t location)
+  void push_assignment (PlaceId lhs, AbstractExpr *rhs, location_t location,
+			HirId move_site = UNKNOWN_HIRID)
   {
     ctx.get_current_bb ().statements.push_back (
-      Statement::make_assignment (lhs, rhs, location));
+      Statement::make_assignment (lhs, rhs, location, move_site));
     translated = lhs;
   }
 
-  void push_assignment (PlaceId lhs, PlaceId rhs, location_t location)
+  void push_assignment (PlaceId lhs, PlaceId rhs, location_t location,
+			HirId move_site = UNKNOWN_HIRID)
   {
-    push_assignment (lhs, new Assignment (rhs), location);
+    push_assignment (lhs, new Assignment (rhs), location, move_site);
   }
 
   void push_tmp_assignment (AbstractExpr *rhs, TyTy::BaseType *tyty,
@@ -600,12 +602,13 @@ protected:
   }
 
   /** Mark place to be a result of processed subexpression. */
-  void return_place (PlaceId place, location_t location, bool can_panic = false)
+  void return_place (PlaceId place, location_t location, bool can_panic = false,
+		     HirId move_site = UNKNOWN_HIRID)
   {
     if (expr_return_place != INVALID_PLACE)
       {
 	// Return place is already allocated, no need to defer assignment.
-	push_assignment (expr_return_place, place, location);
+	push_assignment (expr_return_place, place, location, move_site);
       }
     else
       {

--- a/gcc/rust/checks/errors/borrowck/rust-bir-builder-internal.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-builder-internal.h
@@ -265,16 +265,18 @@ protected:
   }
 
 protected: // Helpers to add BIR statements
-  void push_assignment (PlaceId lhs, AbstractExpr *rhs, location_t location)
+  void push_assignment (PlaceId lhs, AbstractExpr *rhs, location_t location,
+			tl::optional<HirId> move_site = tl::nullopt)
   {
     ctx.get_current_bb ().statements.push_back (
-      Statement::make_assignment (lhs, rhs, location));
+      Statement::make_assignment (lhs, rhs, location, move_site));
     translated = lhs;
   }
 
-  void push_assignment (PlaceId lhs, PlaceId rhs, location_t location)
+  void push_assignment (PlaceId lhs, PlaceId rhs, location_t location,
+			tl::optional<HirId> move_site = tl::nullopt)
   {
-    push_assignment (lhs, new Assignment (rhs), location);
+    push_assignment (lhs, new Assignment (rhs), location, move_site);
   }
 
   void push_tmp_assignment (AbstractExpr *rhs, TyTy::BaseType *tyty,
@@ -600,12 +602,13 @@ protected:
   }
 
   /** Mark place to be a result of processed subexpression. */
-  void return_place (PlaceId place, location_t location, bool can_panic = false)
+  void return_place (PlaceId place, location_t location, bool can_panic = false,
+		     tl::optional<HirId> move_site = tl::nullopt)
   {
     if (expr_return_place != INVALID_PLACE)
       {
 	// Return place is already allocated, no need to defer assignment.
-	push_assignment (expr_return_place, place, location);
+	push_assignment (expr_return_place, place, location, move_site);
       }
     else
       {

--- a/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.cc
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.cc
@@ -20,20 +20,277 @@
 #include "rust-bir.h"
 #include "rust-hir-map.h"
 
-#include <unordered_set>
-
 namespace Rust {
 namespace BIR {
-
 namespace {
 
-struct BasicBlockIdHash
+struct BlockInitializationState
 {
-  size_t operator() (BasicBlockId id) const
-  {
-    return std::hash<uint32_t> () (id.value);
-  }
+  explicit BlockInitializationState (size_t place_count)
+    : maybe_initialized (place_count, false),
+      maybe_uninitialized (place_count, false), reachable (false)
+  {}
+
+  std::vector<bool> maybe_initialized;
+  std::vector<bool> maybe_uninitialized;
+
+  // Whether this block is reached or not.
+  bool reachable;
 };
+
+static bool
+is_straight_line (const Function &function)
+{
+  std::set<BasicBlockId> visited;
+  BasicBlockId current = ENTRY_BASIC_BLOCK;
+
+  while (current != INVALID_BB)
+    {
+      // Revisiting a block means that the CFG contains a cycle.
+      if (!visited.insert (current).second)
+	return false;
+
+      const BasicBlock &block = function.basic_blocks[current];
+
+      if (block.successors.empty ())
+	return true;
+
+      if (block.successors.size () != 1)
+	return false;
+
+      current = block.successors.front ();
+    }
+
+  return true;
+}
+
+static void
+set_initialized (BlockInitializationState &state, PlaceId place)
+{
+  state.maybe_initialized[place.value] = true;
+  state.maybe_uninitialized[place.value] = false;
+}
+
+static void
+set_uninitialized (BlockInitializationState &state, PlaceId place)
+{
+  state.maybe_initialized[place.value] = false;
+  state.maybe_uninitialized[place.value] = true;
+}
+
+static bool
+merge_state (BlockInitializationState &into,
+	     const BlockInitializationState &from)
+{
+  bool changed = false;
+
+  if (!into.reachable)
+    {
+      into = from;
+      return !changed;
+    }
+
+  for (size_t i = 0; i < into.maybe_initialized.size (); i++)
+    {
+      bool maybe_initialized
+	= into.maybe_initialized[i] || from.maybe_initialized[i];
+
+      bool maybe_uninitialized
+	= into.maybe_uninitialized[i] || from.maybe_uninitialized[i];
+
+      changed |= maybe_initialized != into.maybe_initialized[i];
+      changed |= maybe_uninitialized != into.maybe_uninitialized[i];
+
+      into.maybe_initialized[i] = maybe_initialized;
+      into.maybe_uninitialized[i] = maybe_uninitialized;
+    }
+
+  return changed;
+}
+
+static void
+update_state_for_statement (Function &function, Statement &statement,
+			    BlockInitializationState &state)
+{
+  PlaceId place = statement.get_place ();
+
+  switch (statement.get_kind ())
+    {
+    case Statement::Kind::STORAGE_LIVE:
+      set_uninitialized (state, place);
+      break;
+
+    case Statement::Kind::ASSIGNMENT:
+      {
+	PlaceId lhs = place;
+	AbstractExpr &expr = statement.get_expr ();
+
+	if (expr.get_kind () == ExprKind::ASSIGNMENT)
+	  {
+	    PlaceId rhs = static_cast<Assignment &> (expr).get_rhs ();
+	    const Place &rhs_place = function.place_db[rhs];
+
+	    if (rhs_place.kind == Place::VARIABLE
+		&& rhs_place.should_be_moved ())
+	      set_uninitialized (state, rhs);
+	  }
+
+	set_initialized (state, lhs);
+	break;
+      }
+
+    case Statement::Kind::DROP:
+    case Statement::Kind::STORAGE_DEAD:
+      set_uninitialized (state, place);
+      break;
+
+    case Statement::Kind::SWITCH:
+    case Statement::Kind::RETURN:
+    case Statement::Kind::GOTO:
+    case Statement::Kind::USER_TYPE_ASCRIPTION:
+    case Statement::Kind::FAKE_READ:
+      break;
+    }
+}
+
+static Statement::DropStyle
+classify_drop (const BlockInitializationState &state, PlaceId place)
+{
+  bool maybe_initialized = state.maybe_initialized[place.value];
+  bool maybe_uninitialized = state.maybe_uninitialized[place.value];
+
+  if (!maybe_initialized)
+    return Statement::DropStyle::DEAD;
+
+  if (!maybe_uninitialized)
+    return Statement::DropStyle::STATIC;
+
+  return Statement::DropStyle::CONDITIONAL;
+}
+
+// Compute the initialization state at the entry of every reachable block.
+static std::vector<BlockInitializationState>
+compute_entry_states (Function &function)
+{
+  size_t place_count = function.place_db.size ();
+  size_t block_count = function.basic_blocks.size ();
+
+  std::vector<BlockInitializationState> entry_states;
+  entry_states.reserve (block_count);
+
+  for (size_t i = 0; i < block_count; i++)
+    entry_states.emplace_back (place_count);
+
+  BlockInitializationState &entry_state = entry_states[ENTRY_BASIC_BLOCK.value];
+
+  entry_state.reachable = true;
+
+  // All places start uninitialized, except function arguments.
+  for (size_t i = 0; i < place_count; i++)
+    entry_state.maybe_uninitialized[i] = true;
+
+  for (PlaceId argument : function.arguments)
+    set_initialized (entry_state, argument);
+
+  std::vector<BasicBlockId> worklist;
+  std::vector<bool> queued (block_count, false);
+
+  worklist.push_back (ENTRY_BASIC_BLOCK);
+  queued[ENTRY_BASIC_BLOCK.value] = true;
+
+  // Propagate block states until the last block.
+  while (!worklist.empty ())
+    {
+      BasicBlockId block_id = worklist.back ();
+      worklist.pop_back ();
+      queued[block_id.value] = false;
+
+      BlockInitializationState state = entry_states[block_id.value];
+      BasicBlock &block = function.basic_blocks[block_id];
+
+      for (Statement &statement : block.statements)
+	update_state_for_statement (function, statement, state);
+
+      for (BasicBlockId successor : block.successors)
+	{
+	  bool state_changed
+	    = merge_state (entry_states[successor.value], state);
+
+	  if (state_changed && !queued[successor.value])
+	    {
+	      worklist.push_back (successor);
+	      queued[successor.value] = true;
+	    }
+	}
+    }
+  return entry_states;
+}
+
+static void
+record_drop_for_straight_line_backend (const Function &function, PlaceId place,
+				       Statement::DropStyle drop_style,
+				       std::set<HirId> &dead_drop_hir_ids,
+				       std::set<HirId> &non_dead_drop_hir_ids)
+{
+  const Place &dropped_place = function.place_db[place];
+
+  if (dropped_place.kind != Place::VARIABLE)
+    return;
+
+  auto hir_id = Analysis::Mappings::get ().lookup_node_to_hir (
+    static_cast<NodeId> (dropped_place.variable_or_field_index));
+
+  if (!hir_id.has_value ())
+    return;
+
+  if (drop_style == Statement::DropStyle::DEAD)
+    dead_drop_hir_ids.insert (hir_id.value ());
+  else
+    non_dead_drop_hir_ids.insert (hir_id.value ());
+}
+
+// Walk each reachable block forward from its stable entry state and classify
+// its Drop statements.
+static void
+annotate_drop_statements (
+  Function &function, const std::vector<BlockInitializationState> &entry_states,
+  bool record_straight_line_backend_drops, std::set<HirId> &dead_drop_hir_ids,
+  std::set<HirId> &non_dead_drop_hir_ids)
+{
+  const size_t block_count = function.basic_blocks.size ();
+
+  for (size_t i = 0; i < block_count; i++)
+    {
+      BlockInitializationState state = entry_states[i];
+
+      if (!state.reachable)
+	continue;
+
+      BasicBlockId block_id = {static_cast<uint32_t> (i)};
+      BasicBlock &block = function.basic_blocks[block_id];
+
+      for (Statement &statement : block.statements)
+	{
+	  // A Drop is classified using the state before it executes.
+	  if (statement.get_kind () == Statement::Kind::DROP)
+	    {
+	      PlaceId place = statement.get_place ();
+	      Statement::DropStyle drop_style = classify_drop (state, place);
+
+	      statement.set_drop_style (drop_style);
+
+	      if (record_straight_line_backend_drops)
+		record_drop_for_straight_line_backend (function, place,
+						       drop_style,
+						       dead_drop_hir_ids,
+						       non_dead_drop_hir_ids);
+	    }
+
+	  // Update the state for the following statement.
+	  update_state_for_statement (function, statement, state);
+	}
+    }
+}
 
 } // namespace
 
@@ -59,105 +316,23 @@ DropAnalysis::is_definitely_dead (HirId id) const
 void
 DropAnalysis::analyze (Function &function)
 {
-  std::vector<BasicBlockId> block_order;
-  std::unordered_set<BasicBlockId, BasicBlockIdHash> visited;
+  std::vector<BlockInitializationState> entry_states
+    = compute_entry_states (function);
 
-  BasicBlockId current = ENTRY_BASIC_BLOCK;
+  // Keep the existing backend handling for straight-line CFGs.
+  const bool record_straight_line_backend_drops = is_straight_line (function);
 
-  while (current != INVALID_BB)
-    {
-      // A repeated block indicates a cycle in straight-line control flow.
-      if (!visited.insert (current).second)
-	return;
+  std::set<HirId> dead_drop_hir_ids;
+  std::set<HirId> non_dead_drop_hir_ids;
 
-      block_order.push_back (current);
+  annotate_drop_statements (function, entry_states,
+			    record_straight_line_backend_drops,
+			    dead_drop_hir_ids, non_dead_drop_hir_ids);
 
-      const BasicBlock &block = function.basic_blocks[current];
-
-      if (block.successors.empty ())
-	break;
-
-      if (block.successors.size () != 1)
-	return;
-
-      current = block.successors.front ();
-    }
-
-  std::vector<bool> initialized (function.place_db.size (), false);
-
-  for (PlaceId argument : function.arguments)
-    initialized[argument.value] = true;
-
-  for (BasicBlockId block_id : block_order)
-    {
-      BasicBlock &block = function.basic_blocks[block_id];
-
-      for (Statement &statement : block.statements)
-	{
-	  PlaceId place = statement.get_place ();
-
-	  switch (statement.get_kind ())
-	    {
-	    case Statement::Kind::STORAGE_LIVE:
-	      initialized[place.value] = false;
-	      break;
-
-	    case Statement::Kind::ASSIGNMENT:
-	      {
-		PlaceId lhs = place;
-		AbstractExpr &expr = statement.get_expr ();
-
-		if (expr.get_kind () == ExprKind::ASSIGNMENT)
-		  {
-		    PlaceId rhs = static_cast<Assignment &> (expr).get_rhs ();
-		    const Place &rhs_place = function.place_db[rhs];
-
-		    if (rhs_place.kind == Place::VARIABLE
-			&& rhs_place.should_be_moved ())
-		      initialized[rhs.value] = false;
-		  }
-
-		initialized[lhs.value] = true;
-		break;
-	      }
-
-	    case Statement::Kind::DROP:
-	      statement.set_drop_style (initialized[place.value]
-					  ? Statement::DropStyle::STATIC
-					  : Statement::DropStyle::DEAD);
-
-	      if (statement.get_drop_style () == Statement::DropStyle::DEAD)
-		{
-		  const Place &dropped_place = function.place_db[place];
-
-		  if (dropped_place.kind == Place::VARIABLE)
-		    {
-		      auto hir_id
-			= Analysis::Mappings::get ().lookup_node_to_hir (
-			  static_cast<NodeId> (
-			    dropped_place.variable_or_field_index));
-
-		      if (hir_id.has_value ())
-			definitely_dead.insert (hir_id.value ());
-		    }
-		}
-
-	      initialized[place.value] = false;
-	      break;
-
-	    case Statement::Kind::STORAGE_DEAD:
-	      initialized[place.value] = false;
-	      break;
-
-	    case Statement::Kind::SWITCH:
-	    case Statement::Kind::RETURN:
-	    case Statement::Kind::GOTO:
-	    case Statement::Kind::USER_TYPE_ASCRIPTION:
-	    case Statement::Kind::FAKE_READ:
-	      break;
-	    }
-	}
-    }
+  // A local is definitely dead only when all of its Drops are dead.
+  for (HirId hir_id : dead_drop_hir_ids)
+    if (non_dead_drop_hir_ids.find (hir_id) == non_dead_drop_hir_ids.end ())
+      definitely_dead.insert (hir_id);
 }
 
 } // namespace BIR

--- a/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.cc
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.cc
@@ -38,31 +38,13 @@ struct BlockInitializationState
   bool reachable;
 };
 
-static bool
-is_straight_line (const Function &function)
+struct DropAnalysisResults
 {
-  std::set<BasicBlockId> visited;
-  BasicBlockId current = ENTRY_BASIC_BLOCK;
-
-  while (current != INVALID_BB)
-    {
-      // Revisiting a block means that the CFG contains a cycle.
-      if (!visited.insert (current).second)
-	return false;
-
-      const BasicBlock &block = function.basic_blocks[current];
-
-      if (block.successors.empty ())
-	return true;
-
-      if (block.successors.size () != 1)
-	return false;
-
-      current = block.successors.front ();
-    }
-
-  return true;
-}
+  std::unordered_set<HirId> dead_drop_hir_ids;
+  std::unordered_set<HirId> static_drop_hir_ids;
+  std::unordered_set<HirId> conditional_drop_hir_ids;
+  std::unordered_map<HirId, HirId> move_sources;
+};
 
 static void
 set_initialized (BlockInitializationState &state, PlaceId place)
@@ -247,10 +229,9 @@ compute_entry_states (Function &function)
 }
 
 static void
-record_drop_for_straight_line_backend (const Function &function, PlaceId place,
-				       Statement::DropStyle drop_style,
-				       std::set<HirId> &dead_drop_hir_ids,
-				       std::set<HirId> &non_dead_drop_hir_ids)
+record_drop_for_backend (const Function &function, PlaceId place,
+			 Statement::DropStyle drop_style,
+			 DropAnalysisResults &results)
 {
   const Place &dropped_place = function.place_db[place];
 
@@ -263,10 +244,23 @@ record_drop_for_straight_line_backend (const Function &function, PlaceId place,
   if (!hir_id.has_value ())
     return;
 
-  if (drop_style == Statement::DropStyle::DEAD)
-    dead_drop_hir_ids.insert (hir_id.value ());
-  else
-    non_dead_drop_hir_ids.insert (hir_id.value ());
+  switch (drop_style)
+    {
+    case Statement::DropStyle::UNCLASSIFIED:
+      break;
+
+    case Statement::DropStyle::DEAD:
+      results.dead_drop_hir_ids.insert (hir_id.value ());
+      break;
+
+    case Statement::DropStyle::STATIC:
+      results.static_drop_hir_ids.insert (hir_id.value ());
+      break;
+
+    case Statement::DropStyle::CONDITIONAL:
+      results.conditional_drop_hir_ids.insert (hir_id.value ());
+      break;
+    }
 }
 
 // Walk each reachable block forward from its stable entry state and classify
@@ -274,8 +268,7 @@ record_drop_for_straight_line_backend (const Function &function, PlaceId place,
 static void
 annotate_drop_statements (
   Function &function, const std::vector<BlockInitializationState> &entry_states,
-  bool record_straight_line_backend_drops, std::set<HirId> &dead_drop_hir_ids,
-  std::set<HirId> &non_dead_drop_hir_ids)
+  DropAnalysisResults &results)
 {
   const size_t block_count = function.basic_blocks.size ();
 
@@ -291,6 +284,29 @@ annotate_drop_statements (
 
       for (Statement &statement : block.statements)
 	{
+	  const auto &move_site = statement.get_move_site ();
+	  if (statement.get_kind () == Statement::Kind::ASSIGNMENT
+	      && move_site.has_value ())
+	    {
+	      AbstractExpr &expr = statement.get_expr ();
+	      if (expr.get_kind () == ExprKind::ASSIGNMENT)
+		{
+		  PlaceId rhs = static_cast<Assignment &> (expr).get_rhs ();
+		  const Place &rhs_place = function.place_db[rhs];
+		  if (rhs_place.kind == Place::VARIABLE
+		      && rhs_place.should_be_moved ())
+		    {
+		      auto hirid
+			= Analysis::Mappings::get ().lookup_node_to_hir (
+			  static_cast<NodeId> (
+			    rhs_place.variable_or_field_index));
+		      if (hirid.has_value ())
+			results.move_sources[move_site.value ()]
+			  = hirid.value ();
+		    }
+		}
+	    }
+
 	  // A Drop is classified using the state before it executes.
 	  if (statement.get_kind () == Statement::Kind::DROP)
 	    {
@@ -299,11 +315,7 @@ annotate_drop_statements (
 
 	      statement.set_drop_style (drop_style);
 
-	      if (record_straight_line_backend_drops)
-		record_drop_for_straight_line_backend (function, place,
-						       drop_style,
-						       dead_drop_hir_ids,
-						       non_dead_drop_hir_ids);
+	      record_drop_for_backend (function, place, drop_style, results);
 	    }
 
 	  // Update the state for the following statement.
@@ -325,6 +337,8 @@ void
 DropAnalysis::clear ()
 {
   definitely_dead.clear ();
+  conditionally_dropped.clear ();
+  move_sources.clear ();
 }
 
 bool
@@ -333,26 +347,44 @@ DropAnalysis::is_definitely_dead (HirId id) const
   return definitely_dead.find (id) != definitely_dead.end ();
 }
 
+bool
+DropAnalysis::needs_drop_flag (HirId id) const
+{
+  return conditionally_dropped.find (id) != conditionally_dropped.end ();
+}
+
+bool
+DropAnalysis::lookup_move_source (HirId move_site, HirId *source) const
+{
+  auto it = move_sources.find (move_site);
+  if (it == move_sources.end ())
+    return false;
+
+  *source = it->second;
+  return true;
+}
+
 void
 DropAnalysis::analyze (Function &function)
 {
   std::vector<BlockInitializationState> entry_states
     = compute_entry_states (function);
 
-  // Keep the existing backend handling for straight-line CFGs.
-  const bool record_straight_line_backend_drops = is_straight_line (function);
-
-  std::set<HirId> dead_drop_hir_ids;
-  std::set<HirId> non_dead_drop_hir_ids;
-
-  annotate_drop_statements (function, entry_states,
-			    record_straight_line_backend_drops,
-			    dead_drop_hir_ids, non_dead_drop_hir_ids);
+  DropAnalysisResults results;
+  annotate_drop_statements (function, entry_states, results);
 
   // A local is definitely dead only when all of its Drops are dead.
-  for (HirId hir_id : dead_drop_hir_ids)
-    if (non_dead_drop_hir_ids.find (hir_id) == non_dead_drop_hir_ids.end ())
+  for (HirId hir_id : results.dead_drop_hir_ids)
+    if (results.static_drop_hir_ids.find (hir_id)
+	  == results.static_drop_hir_ids.end ()
+	&& results.conditional_drop_hir_ids.find (hir_id)
+	     == results.conditional_drop_hir_ids.end ())
       definitely_dead.insert (hir_id);
+
+  conditionally_dropped.insert (results.conditional_drop_hir_ids.begin (),
+				results.conditional_drop_hir_ids.end ());
+  move_sources.insert (results.move_sources.begin (),
+		       results.move_sources.end ());
 }
 
 } // namespace BIR

--- a/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.cc
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.cc
@@ -38,32 +38,6 @@ struct BlockInitializationState
   bool reachable;
 };
 
-static bool
-is_straight_line (const Function &function)
-{
-  std::set<BasicBlockId> visited;
-  BasicBlockId current = ENTRY_BASIC_BLOCK;
-
-  while (current != INVALID_BB)
-    {
-      // Revisiting a block means that the CFG contains a cycle.
-      if (!visited.insert (current).second)
-	return false;
-
-      const BasicBlock &block = function.basic_blocks[current];
-
-      if (block.successors.empty ())
-	return true;
-
-      if (block.successors.size () != 1)
-	return false;
-
-      current = block.successors.front ();
-    }
-
-  return true;
-}
-
 static void
 set_initialized (BlockInitializationState &state, PlaceId place)
 {
@@ -227,10 +201,11 @@ compute_entry_states (Function &function)
 }
 
 static void
-record_drop_for_straight_line_backend (const Function &function, PlaceId place,
-				       Statement::DropStyle drop_style,
-				       std::set<HirId> &dead_drop_hir_ids,
-				       std::set<HirId> &non_dead_drop_hir_ids)
+record_drop_for_backend (const Function &function, PlaceId place,
+			 Statement::DropStyle drop_style,
+			 std::set<HirId> &dead_drop_hir_ids,
+			 std::set<HirId> &static_drop_hir_ids,
+			 std::set<HirId> &conditional_drop_hir_ids)
 {
   const Place &dropped_place = function.place_db[place];
 
@@ -243,10 +218,23 @@ record_drop_for_straight_line_backend (const Function &function, PlaceId place,
   if (!hir_id.has_value ())
     return;
 
-  if (drop_style == Statement::DropStyle::DEAD)
-    dead_drop_hir_ids.insert (hir_id.value ());
-  else
-    non_dead_drop_hir_ids.insert (hir_id.value ());
+  switch (drop_style)
+    {
+    case Statement::DropStyle::UNCLASSIFIED:
+      break;
+
+    case Statement::DropStyle::DEAD:
+      dead_drop_hir_ids.insert (hir_id.value ());
+      break;
+
+    case Statement::DropStyle::STATIC:
+      static_drop_hir_ids.insert (hir_id.value ());
+      break;
+
+    case Statement::DropStyle::CONDITIONAL:
+      conditional_drop_hir_ids.insert (hir_id.value ());
+      break;
+    }
 }
 
 // Walk each reachable block forward from its stable entry state and classify
@@ -254,8 +242,9 @@ record_drop_for_straight_line_backend (const Function &function, PlaceId place,
 static void
 annotate_drop_statements (
   Function &function, const std::vector<BlockInitializationState> &entry_states,
-  bool record_straight_line_backend_drops, std::set<HirId> &dead_drop_hir_ids,
-  std::set<HirId> &non_dead_drop_hir_ids)
+  std::set<HirId> &dead_drop_hir_ids, std::set<HirId> &static_drop_hir_ids,
+  std::set<HirId> &conditional_drop_hir_ids,
+  std::map<HirId, HirId> &move_sources)
 {
   const size_t block_count = function.basic_blocks.size ();
 
@@ -271,6 +260,28 @@ annotate_drop_statements (
 
       for (Statement &statement : block.statements)
 	{
+	  if (statement.get_kind () == Statement::Kind::ASSIGNMENT
+	      && statement.get_move_site () != UNKNOWN_HIRID)
+	    {
+	      AbstractExpr &expr = statement.get_expr ();
+	      if (expr.get_kind () == ExprKind::ASSIGNMENT)
+		{
+		  PlaceId rhs = static_cast<Assignment &> (expr).get_rhs ();
+		  const Place &rhs_place = function.place_db[rhs];
+		  if (rhs_place.kind == Place::VARIABLE
+		      && rhs_place.should_be_moved ())
+		    {
+		      auto hirid
+			= Analysis::Mappings::get ().lookup_node_to_hir (
+			  static_cast<NodeId> (
+			    rhs_place.variable_or_field_index));
+		      if (hirid.has_value ())
+			move_sources[statement.get_move_site ()]
+			  = hirid.value ();
+		    }
+		}
+	    }
+
 	  // A Drop is classified using the state before it executes.
 	  if (statement.get_kind () == Statement::Kind::DROP)
 	    {
@@ -279,11 +290,9 @@ annotate_drop_statements (
 
 	      statement.set_drop_style (drop_style);
 
-	      if (record_straight_line_backend_drops)
-		record_drop_for_straight_line_backend (function, place,
-						       drop_style,
-						       dead_drop_hir_ids,
-						       non_dead_drop_hir_ids);
+	      record_drop_for_backend (function, place, drop_style,
+				       dead_drop_hir_ids, static_drop_hir_ids,
+				       conditional_drop_hir_ids);
 	    }
 
 	  // Update the state for the following statement.
@@ -305,6 +314,8 @@ void
 DropAnalysis::clear ()
 {
   definitely_dead.clear ();
+  conditionally_dropped.clear ();
+  move_sources.clear ();
 }
 
 bool
@@ -313,26 +324,45 @@ DropAnalysis::is_definitely_dead (HirId id) const
   return definitely_dead.find (id) != definitely_dead.end ();
 }
 
+bool
+DropAnalysis::needs_drop_flag (HirId id) const
+{
+  return conditionally_dropped.find (id) != conditionally_dropped.end ();
+}
+
+bool
+DropAnalysis::lookup_move_source (HirId move_site, HirId *source) const
+{
+  auto it = move_sources.find (move_site);
+  if (it == move_sources.end ())
+    return false;
+
+  *source = it->second;
+  return true;
+}
+
 void
 DropAnalysis::analyze (Function &function)
 {
   std::vector<BlockInitializationState> entry_states
     = compute_entry_states (function);
 
-  // Keep the existing backend handling for straight-line CFGs.
-  const bool record_straight_line_backend_drops = is_straight_line (function);
-
   std::set<HirId> dead_drop_hir_ids;
-  std::set<HirId> non_dead_drop_hir_ids;
+  std::set<HirId> static_drop_hir_ids;
+  std::set<HirId> conditional_drop_hir_ids;
 
-  annotate_drop_statements (function, entry_states,
-			    record_straight_line_backend_drops,
-			    dead_drop_hir_ids, non_dead_drop_hir_ids);
+  annotate_drop_statements (function, entry_states, dead_drop_hir_ids,
+			    static_drop_hir_ids, conditional_drop_hir_ids,
+			    move_sources);
 
   // A local is definitely dead only when all of its Drops are dead.
   for (HirId hir_id : dead_drop_hir_ids)
-    if (non_dead_drop_hir_ids.find (hir_id) == non_dead_drop_hir_ids.end ())
+    if (static_drop_hir_ids.find (hir_id) == static_drop_hir_ids.end ()
+	&& conditional_drop_hir_ids.find (hir_id)
+	     == conditional_drop_hir_ids.end ())
       definitely_dead.insert (hir_id);
+
+  conditionally_dropped = conditional_drop_hir_ids;
 }
 
 } // namespace BIR

--- a/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.cc
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.cc
@@ -18,6 +18,7 @@
 
 #include "rust-bir-drop-analysis.h"
 #include "rust-bir.h"
+#include "rust-diagnostics.h"
 #include "rust-hir-map.h"
 
 namespace Rust {
@@ -301,8 +302,19 @@ annotate_drop_statements (
 			  static_cast<NodeId> (
 			    rhs_place.variable_or_field_index));
 		      if (hirid.has_value ())
-			results.move_sources[move_site.value ()]
-			  = hirid.value ();
+			{
+			  auto move_source
+			    = results.move_sources.find (move_site.value ());
+			  if (move_source != results.move_sources.end ()
+			      && move_source->second != hirid.value ())
+			    rust_sorry_at (statement.get_location (),
+					   "moving multiple IDs within the "
+					   "same location is not "
+					   "yet supported");
+			  else
+			    results.move_sources.emplace (move_site.value (),
+							  hirid.value ());
+			}
 		    }
 		}
 	    }

--- a/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.h
@@ -19,6 +19,7 @@
 #ifndef RUST_BIR_DROP_ANALYSIS_H
 #define RUST_BIR_DROP_ANALYSIS_H
 
+#include "rust-system.h"
 #include "rust-bir.h"
 
 namespace Rust {
@@ -39,9 +40,16 @@ public:
   void analyze (Function &function);
 
   bool is_definitely_dead (HirId id) const;
+  bool needs_drop_flag (HirId id) const;
+  bool lookup_move_source (HirId move_site, HirId *source) const;
 
 private:
-  std::set<HirId> definitely_dead;
+  std::unordered_set<HirId> definitely_dead;
+  std::unordered_set<HirId> conditionally_dropped;
+  // This may need to be extended to
+  // std::unordered_map<HirId, std::unordered_set<HirId>>
+  // to support product moves in the future.
+  std::unordered_map<HirId, HirId> move_sources;
 };
 
 } // namespace BIR

--- a/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.h
@@ -39,9 +39,13 @@ public:
   void analyze (Function &function);
 
   bool is_definitely_dead (HirId id) const;
+  bool needs_drop_flag (HirId id) const;
+  bool lookup_move_source (HirId move_site, HirId *source) const;
 
 private:
   std::set<HirId> definitely_dead;
+  std::set<HirId> conditionally_dropped;
+  std::map<HirId, HirId> move_sources;
 };
 
 } // namespace BIR

--- a/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir-drop-analysis.h
@@ -28,7 +28,7 @@ namespace BIR {
   Classifies scheduled whole-local BIR Drop statements according to
   whether their place is initialized at the drop point.
 
-  This initial implementation only handles straight-line control flow.
+  This analysis tracks initialization state across the BIR control-flow graph.
 */
 class DropAnalysis
 {

--- a/gcc/rust/checks/errors/borrowck/rust-bir.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir.h
@@ -21,6 +21,7 @@
 
 #include "rust-bir-place.h"
 #include "rust-bir-visitor.h"
+#include "optional.h"
 
 #include "polonius/rust-polonius-ffi.h"
 #include "rust-tyty-variance-analysis.h"
@@ -113,12 +114,17 @@ private:
   // currently only available when kind is ASSIGNMENT | RETURN
   // FIXME: Add location for other statement kinds
   location_t location;
+  // HIR expression which consumes the RHS of an assignment.  This is used to
+  // attach backend drop-flag updates to the corresponding expression.
+  tl::optional<HirId> move_site;
 
 public:
   static Statement make_assignment (PlaceId place, AbstractExpr *rhs,
-				    location_t location)
+				    location_t location,
+				    tl::optional<HirId> move_site = tl::nullopt)
   {
-    return Statement (Kind::ASSIGNMENT, place, rhs, nullptr, location);
+    return Statement (Kind::ASSIGNMENT, place, rhs, nullptr, location,
+		      move_site);
   }
   static Statement make_switch (PlaceId place)
   {
@@ -155,8 +161,10 @@ private:
   // compelete constructor, used by make_* functions
   Statement (Kind kind, PlaceId place = INVALID_PLACE,
 	     AbstractExpr *rhs = nullptr, TyTy::BaseType *type = nullptr,
-	     location_t location = UNKNOWN_LOCATION)
-    : kind (kind), place (place), expr (rhs), type (type), location (location)
+	     location_t location = UNKNOWN_LOCATION,
+	     tl::optional<HirId> move_site = tl::nullopt)
+    : kind (kind), place (place), expr (rhs), type (type), location (location),
+      move_site (move_site)
   {}
 
 public:
@@ -167,6 +175,10 @@ public:
   WARN_UNUSED_RESULT AbstractExpr &get_expr () const { return *expr; }
   WARN_UNUSED_RESULT TyTy::BaseType *get_type () const { return type; }
   WARN_UNUSED_RESULT location_t get_location () const { return location; }
+  WARN_UNUSED_RESULT const tl::optional<HirId> &get_move_site () const
+  {
+    return move_site;
+  }
 };
 
 struct BasicBlock

--- a/gcc/rust/checks/errors/borrowck/rust-bir.h
+++ b/gcc/rust/checks/errors/borrowck/rust-bir.h
@@ -113,12 +113,17 @@ private:
   // currently only available when kind is ASSIGNMENT | RETURN
   // FIXME: Add location for other statement kinds
   location_t location;
+  // HIR expression which consumes the RHS of an assignment.  This is used to
+  // attach backend drop-flag updates to the corresponding expression.
+  HirId move_site;
 
 public:
   static Statement make_assignment (PlaceId place, AbstractExpr *rhs,
-				    location_t location)
+				    location_t location,
+				    HirId move_site = UNKNOWN_HIRID)
   {
-    return Statement (Kind::ASSIGNMENT, place, rhs, nullptr, location);
+    return Statement (Kind::ASSIGNMENT, place, rhs, nullptr, location,
+		      move_site);
   }
   static Statement make_switch (PlaceId place)
   {
@@ -155,8 +160,10 @@ private:
   // compelete constructor, used by make_* functions
   Statement (Kind kind, PlaceId place = INVALID_PLACE,
 	     AbstractExpr *rhs = nullptr, TyTy::BaseType *type = nullptr,
-	     location_t location = UNKNOWN_LOCATION)
-    : kind (kind), place (place), expr (rhs), type (type), location (location)
+	     location_t location = UNKNOWN_LOCATION,
+	     HirId move_site = UNKNOWN_HIRID)
+    : kind (kind), place (place), expr (rhs), type (type), location (location),
+      move_site (move_site)
   {}
 
 public:
@@ -167,6 +174,7 @@ public:
   WARN_UNUSED_RESULT AbstractExpr &get_expr () const { return *expr; }
   WARN_UNUSED_RESULT TyTy::BaseType *get_type () const { return type; }
   WARN_UNUSED_RESULT location_t get_location () const { return location; }
+  WARN_UNUSED_RESULT HirId get_move_site () const { return move_site; }
 };
 
 struct BasicBlock

--- a/gcc/testsuite/rust/borrowck/drop_analysis_conditional_move.rs
+++ b/gcc/testsuite/rust/borrowck/drop_analysis_conditional_move.rs
@@ -1,0 +1,46 @@
+// { dg-additional-options "-frust-compile-until=compilation -frust-borrowcheck -frust-dump-bir" }
+// { dg-final { scan-file bir_dump/drop_analysis_conditional_move.conditional_move.bir.dump "Drop\\(_3\\): Conditional" } }
+// { dg-final { scan-file bir_dump/drop_analysis_conditional_move.static_after_join.bir.dump "Drop\\(_3\\): Static" } }
+// { dg-final { scan-file bir_dump/drop_analysis_conditional_move.dead_after_join.bir.dump "Drop\\(_3\\): Dead" } }
+
+#![feature(no_core)]
+#![no_core]
+
+fn conditional_move(condition: bool) {
+    struct A {
+        i: i32,
+    }
+
+    let x = A { i: 1 };
+
+    if condition {
+        let y = x;
+    }
+}
+
+
+fn static_after_join(condition: bool) {
+    struct A {
+        i: i32,
+    }
+
+    let x = A { i: 1 };
+
+    if condition {
+        let y = 1;
+    }
+}
+
+fn dead_after_join(condition: bool) {
+    struct A {
+        i: i32,
+    }
+
+    let x = A { i: 1 };
+
+    if condition {
+        let y = x;
+    } else {
+        let z = x;
+    }
+}

--- a/gcc/testsuite/rust/compile/drop-conditional-product-move.rs
+++ b/gcc/testsuite/rust/compile/drop-conditional-product-move.rs
@@ -1,0 +1,49 @@
+// { dg-additional-options "-frust-borrowcheck -w" }
+
+#![feature(no_core)]
+#![feature(lang_items)]
+#![no_core]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "drop"]
+pub trait Drop {
+    fn drop(&mut self);
+}
+
+struct Droppable {
+    value: i32,
+}
+
+impl Drop for Droppable {
+    fn drop(&mut self) {}
+}
+
+struct Pair {
+    first: Droppable,
+    second: Droppable,
+}
+
+fn unconditional_product_move() {
+    let first = Droppable { value: 1 };
+    let second = Droppable { value: 2 };
+    let _pair = Pair { first, second }; // { dg-message "sorry, unimplemented: moving multiple IDs within the same location is not yet supported" }
+}
+
+fn conditional_product_move(condition: bool) {
+    let first = Droppable { value: 1 };
+    let second = Droppable { value: 2 };
+
+    if condition {
+        let _pair = Pair {
+            first,
+            second, // { dg-message "sorry, unimplemented: moving multiple IDs within the same location is not yet supported" }
+        };
+    }
+}
+
+fn main() {
+    unconditional_product_move();
+    conditional_product_move(true);
+}

--- a/gcc/testsuite/rust/execute/drop-conditional-move.rs
+++ b/gcc/testsuite/rust/execute/drop-conditional-move.rs
@@ -1,0 +1,100 @@
+// { dg-output "^drop\r*\nafter conditional\r*\nafter conditional\r*\ndrop\r*\nafter static\r*\ndrop\r*\nafter static\r*\ndrop\r*\ndrop\r*\ndrop\r*\n$" }
+// { dg-additional-options "-frust-borrowcheck -w" }
+
+#![feature(no_core)]
+#![feature(lang_items)]
+#![no_core]
+
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "drop"]
+pub trait Drop {
+    fn drop(&mut self);
+}
+
+struct Droppable {
+    value: i32,
+}
+
+struct AfterConditional {
+    value: i32,
+}
+
+struct AfterStatic {
+    value: i32,
+}
+
+impl Drop for Droppable {
+    fn drop(&mut self) {
+        let msg = "drop\n\0" as *const str as *const i8;
+        unsafe {
+            printf(msg);
+        }
+    }
+}
+
+impl Drop for AfterConditional {
+    fn drop(&mut self) {
+        let msg = "after conditional\n\0" as *const str as *const i8;
+        unsafe {
+            printf(msg);
+        }
+    }
+}
+
+impl Drop for AfterStatic {
+    fn drop(&mut self) {
+        let msg = "after static\n\0" as *const str as *const i8;
+        unsafe {
+            printf(msg);
+        }
+    }
+}
+
+fn conditional_move(condition: bool) {
+    let x = Droppable { value: 1 };
+
+    if condition {
+        let _y = x;
+    }
+
+    let _after = AfterConditional { value: 0 };
+}
+
+fn static_after_join(condition: bool) {
+    let _x = Droppable { value: 2 };
+
+    if condition {
+        let _n = 1;
+    }
+
+    let _after = AfterStatic { value: 0 };
+}
+
+fn move_on_both_branches(condition: bool) {
+    let x = Droppable { value: 3 };
+
+    if condition {
+        let _y = x;
+    } else {
+        let _z = x;
+    }
+}
+
+fn main() -> i32 {
+    conditional_move(true);
+    conditional_move(false);
+
+    static_after_join(true);
+    static_after_join(false);
+
+    move_on_both_branches(true);
+    move_on_both_branches(false);
+
+    0
+}

--- a/gcc/testsuite/rust/execute/drop-conditional-move.rs
+++ b/gcc/testsuite/rust/execute/drop-conditional-move.rs
@@ -1,0 +1,100 @@
+// { dg-output "^drop\r*\nafter conditional\r*\ndrop\r*\nafter conditional\r*\ndrop\r*\nafter static\r*\ndrop\r*\nafter static\r*\ndrop\r*\ndrop\r*\ndrop\r*\n$" }
+// { dg-additional-options "-frust-borrowcheck -w" }
+
+#![feature(no_core)]
+#![feature(lang_items)]
+#![no_core]
+
+extern "C" {
+    fn printf(s: *const i8, ...);
+}
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "drop"]
+pub trait Drop {
+    fn drop(&mut self);
+}
+
+struct Droppable {
+    value: i32,
+}
+
+struct AfterConditional {
+    value: i32,
+}
+
+struct AfterStatic {
+    value: i32,
+}
+
+impl Drop for Droppable {
+    fn drop(&mut self) {
+        let msg = "drop\n\0" as *const str as *const i8;
+        unsafe {
+            printf(msg);
+        }
+    }
+}
+
+impl Drop for AfterConditional {
+    fn drop(&mut self) {
+        let msg = "after conditional\n\0" as *const str as *const i8;
+        unsafe {
+            printf(msg);
+        }
+    }
+}
+
+impl Drop for AfterStatic {
+    fn drop(&mut self) {
+        let msg = "after static\n\0" as *const str as *const i8;
+        unsafe {
+            printf(msg);
+        }
+    }
+}
+
+fn conditional_move(condition: bool) {
+    let x = Droppable { value: 1 };
+
+    if condition {
+        let _y = x;
+    }
+
+    let _after = AfterConditional { value: 0 };
+}
+
+fn static_after_join(condition: bool) {
+    let _x = Droppable { value: 2 };
+
+    if condition {
+        let _n = 1;
+    }
+
+    let _after = AfterStatic { value: 0 };
+}
+
+fn move_on_both_branches(condition: bool) {
+    let x = Droppable { value: 3 };
+
+    if condition {
+        let _y = x;
+    } else {
+        let _z = x;
+    }
+}
+
+fn main() -> i32 {
+    conditional_move(true);
+    conditional_move(false);
+
+    static_after_join(true);
+    static_after_join(false);
+
+    move_on_both_branches(true);
+    move_on_both_branches(false);
+
+    0
+}


### PR DESCRIPTION
This patch connects the conditional BIR Drop analysis to the existing backend cleanup.


For now, in a conditional move case like:
```
fn f(cond: bool) {
    let x = Droppable { value: 1 };


    if cond {
        let y = x;
    }
}
```


The BIR Drop analysis classifies the cleanup of x as:


    Drop(x): Conditional


The backend then creates a Drop flag for x.
Conceptually, the generated backend code behaves like:
```
try {
    bool flag = false;
    let x = Droppable { value: 1 };
    flag = true;


    if (cond) {
        let y = x;
        flag = false;
    }
}
finally {
    if (flag) {
        flag = false;
        Drop(x);
    }
}
```

- When x is initialized, the flag is set to true.
- When x is moved, the flag is cleared to false, so Drop(x) is skipped during cleanup.
- When x is not moved, the flag remains true, so Drop(x) is called.
