### PR TITLE
gccrs: Report an error on an empty path expression

### DIFF
--- a/gcc/rust/parse/rust-parse-impl-path.hxx
+++ b/gcc/rust/parse/rust-parse-impl-path.hxx
@@ -389,8 +389,11 @@ Parser<ManagedTokenSource>::parse_path_in_expression ()
   AST::PathExprSegment initial_segment = parse_path_expr_segment ();
   if (initial_segment.is_error ())
     {
-      // skip after somewhere?
-      // don't necessarily throw error but yeah
+      if (has_opening_scope_resolution)
+	{
+	  Error error (locus, "expected identifier");
+	  add_error (std::move (error));
+	}
       return AST::PathInExpression::create_error ();
     }
   segments.push_back (std::move (initial_segment));

--- a/gcc/rust/parse/rust-parse-impl.hxx
+++ b/gcc/rust/parse/rust-parse-impl.hxx
@@ -7294,15 +7294,6 @@ Parser<ManagedTokenSource>::parse_stmt_or_expr ()
     case DOLLAR_SIGN:
       {
 	AST::PathInExpression path = parse_path_in_expression ();
-	if (path.is_error ())
-	  {
-	    Error error (t->get_locus (), "expected identifier");
-	    add_error (std::move (error));
-	    skip_after_semicolon ();
-	    return tl::unexpected<Parse::Error::Node> (
-	      Parse::Error::Node::CHILD_ERROR);
-	  }
-
 	tl::expected<std::unique_ptr<AST::Expr>, Parse::Error::Expr>
 	  null_denotation;
 

--- a/gcc/testsuite/rust/compile/empty_path2.rs
+++ b/gcc/testsuite/rust/compile/empty_path2.rs
@@ -1,0 +1,9 @@
+#![feature(no_core)]
+#![no_core]
+
+// A path expression with no segments in a let initialiser segfaulted
+// during type checking, see Rust-GCC/gccrs#4790.
+fn main() {
+    let x = ::;
+    // { dg-error "expected identifier" "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/compile/empty_path2.rs
+++ b/gcc/testsuite/rust/compile/empty_path2.rs
@@ -1,0 +1,9 @@
+#![feature(no_core)]
+#![no_core]
+
+// A path expression with no segments in a let initialiser segfaulted
+// during type checking, see #4790.
+fn main() {
+    let x = ::;
+    // { dg-error "expected identifier" "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/compile/empty_path3.rs
+++ b/gcc/testsuite/rust/compile/empty_path3.rs
@@ -1,0 +1,12 @@
+#![feature(no_core)]
+#![no_core]
+
+// An empty path `::` in pattern position. The parser returns a path with no
+// segments without reporting anything, so type checking dereferences a null
+// root type and the compiler crashes instead of diagnosing. Same defect as
+// empty_path2.rs, which covers the let initialiser instead of the pattern.
+// See #4790.
+fn main() {
+    let :: = 1;
+    // { dg-error "expected identifier" "" { target *-*-* } .-1 }
+}

--- a/gcc/testsuite/rust/compile/empty_path3.rs
+++ b/gcc/testsuite/rust/compile/empty_path3.rs
@@ -1,0 +1,12 @@
+#![feature(no_core)]
+#![no_core]
+
+// An empty path `::` in pattern position. The parser returned a path with no
+// segments without reporting anything, so type checking dereferenced a null
+// root type and the compiler crashed instead of diagnosing. Same defect as
+// empty_path2.rs, which covers the let initialiser instead of the pattern.
+// See Rust-GCC/gccrs#4790.
+fn main() {
+    let :: = 1;
+    // { dg-error "expected identifier" "" { target *-*-* } .-1 }
+}


### PR DESCRIPTION
Fixes Rust-GCC/gccrs#4790

The path parser previously returned an error node silently when the initial path segment failed to parse. The resulting zero-segment path can reach rust-hir-type-check-path.cc:228 through two routes: let x = ::; reaches TypeCheckStmt::visit (LetStmt&), while let :: = 1; reaches TypeCheckPattern::visit (PathInExpression&). Both eventually dereference the null result from resolve_root_path.

The new diagnostic is therefore gated on has_opening_scope_resolution. An unconditional guard was incorrect because it also catches bare $, which never ICEs and already receives more specific diagnostics downstream. The unconditional version broke issue-2225.rs and both issue-4140-*.rs by adding the less-specific expected identifier diagnostic.

The parse_stmt_or_expr guard from #4558 was also removed because it reports the same error at the same locus. Since add_error does not deduplicate diagnostics, keeping both guards produces duplicate errors and turns empty_path.rs red on excess errors.

Validation passes increased from 11,449 to 11,453 with zero failures. Comparing against the same-commit baseline showed exactly the four new PASS lines corresponding to the added tests.