### PR TITLE
gccrs: Function node links should be unnamed

### DIFF
--- a/gcc/rust/resolve/rust-default-resolver.cc
+++ b/gcc/rust/resolve/rust-default-resolver.cc
@@ -91,8 +91,7 @@ DefaultResolver::visit (AST::Function &function)
 			     std::move (def_fn_1));
   };
 
-  ctx.scoped (Rib::Kind::Function, function.get_node_id (), def_fn_2,
-	      function.get_function_name ());
+  ctx.scoped (Rib::Kind::Function, function.get_node_id (), def_fn_2);
 }
 
 void

--- a/gcc/testsuite/rust/compile/mod_fn_conflict.rs
+++ b/gcc/testsuite/rust/compile/mod_fn_conflict.rs
@@ -1,0 +1,19 @@
+// TODO: allow(unused) should be disabling "function is never used" warnings
+// { dg-additional-options "-w" }
+#![no_core]
+#![feature(no_core)]
+
+mod a {
+    pub mod b {
+        pub struct X;
+    }
+}
+
+use a::*;
+
+#[allow(unused)]
+fn b() {}
+
+trait Y {}
+
+impl Y for b::X {}


### PR DESCRIPTION
Functions shouldn't be usable as named node links.

Fixes #4806