### PR TITLE
gccrs: Add missing unconstrained type parameters walker for const generics

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-base.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.cc
@@ -101,6 +101,7 @@ walk_type_to_constrain (std::set<HirId> &constrained_symbols, TyTy::BaseType &r)
       {
 	auto &arr = static_cast<TyTy::ArrayType &> (r);
 	walk_type_to_constrain (constrained_symbols, *arr.get_element_type ());
+	walk_type_to_constrain (constrained_symbols, *arr.get_capacity ());
       }
       break;
     case TyTy::TypeKind::FNDEF:
@@ -115,6 +116,13 @@ walk_type_to_constrain (std::set<HirId> &constrained_symbols, TyTy::BaseType &r)
       {
 	auto &param = static_cast<TyTy::ParamType &> (r);
 	constrained_symbols.insert (param.get_ty_ref ());
+      }
+      break;
+    case TyTy::TypeKind::CONST:
+      {
+	auto *constant = r.as_const_type ();
+	if (constant->const_kind () == TyTy::BaseConstType::ConstKind::Decl)
+	  constrained_symbols.insert (r.get_ty_ref ());
       }
       break;
     case TyTy::SLICE:

--- a/gcc/testsuite/rust/compile/issue-4805.rs
+++ b/gcc/testsuite/rust/compile/issue-4805.rs
@@ -1,0 +1,7 @@
+#![no_core]
+#![feature(no_core)]
+#![feature(min_const_generics)]
+
+trait A {}
+
+impl<const N: usize> A for [u8; N] {}


### PR DESCRIPTION
Fixes Rust-GCC/gccrs#4805

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-base.cc (walk_type_to_constrain): walk const generics

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4805.rs: New test.
