### PR TITLE
tyty: Fix FN_VARIADIC flag typo

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-implitem.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-implitem.cc
@@ -134,7 +134,7 @@ TypeCheckTopLevelExternItem::visit (HIR::ExternalFunctionItem &function)
   uint8_t flags = TyTy::FnType::FNTYPE_IS_EXTERN_FLAG;
   if (function.is_variadic ())
     {
-      flags |= TyTy::FnType::FNTYPE_IS_VARADIC_FLAG;
+      flags |= TyTy::FnType::FNTYPE_IS_VARIADIC_FLAG;
       if (parent.get_abi () != Rust::ABI::C)
 	{
 	  rust_error_at (

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -1099,7 +1099,7 @@ public:
   static const uint8_t FNTYPE_DEFAULT_FLAGS = 0x00;
   static const uint8_t FNTYPE_IS_METHOD_FLAG = 0x01;
   static const uint8_t FNTYPE_IS_EXTERN_FLAG = 0x02;
-  static const uint8_t FNTYPE_IS_VARADIC_FLAG = 0X04;
+  static const uint8_t FNTYPE_IS_VARIADIC_FLAG = 0X04;
   static const uint8_t FNTYPE_IS_SYN_CONST_FLAG = 0X08;
 
   FnType (HirId ref, DefId id, std::string identifier, RustIdent ident,
@@ -1160,7 +1160,7 @@ public:
 
   bool is_extern () const { return (flags & FNTYPE_IS_EXTERN_FLAG) != 0; }
 
-  bool is_variadic () const { return (flags & FNTYPE_IS_VARADIC_FLAG) != 0; }
+  bool is_variadic () const { return (flags & FNTYPE_IS_VARIADIC_FLAG) != 0; }
 
   bool is_syn_constant () const
   {


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* typecheck/rust-tyty.h: Rename FN_VARADIC_FLAG -> FN_VARIADIC_FLAG.
	* typecheck/rust-hir-type-check-implitem.cc (TypeCheckTopLevelExternItem::visit): Use the new name.

