### PR TITLE
gccrs: Fix missing unconstrained check to look at the full argument

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-base.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.cc
@@ -26,7 +26,6 @@
 #include "rust-type-util.h"
 #include "rust-attribute-values.h"
 #include "rust-tyty.h"
-#include "tree.h"
 
 namespace Rust {
 namespace Resolver {
@@ -58,6 +57,9 @@ TypeCheckBase::ResolvePredicateFromBound (
 				       is_qualified_type, is_super_trait);
 }
 
+static void walk_type_to_constrain (std::set<HirId> &constrained_symbols,
+				    TyTy::BaseType &r);
+
 static void
 walk_types_to_constrain (std::set<HirId> &constrained_symbols,
 			 const TyTy::SubstitutionArgumentMappings &constraints)
@@ -70,6 +72,7 @@ walk_types_to_constrain (std::set<HirId> &constrained_symbols,
 	  const auto p = arg->get_root ();
 	  constrained_symbols.insert (p->get_ref ());
 	  constrained_symbols.insert (p->get_ty_ref ());
+	  walk_type_to_constrain (constrained_symbols, *arg);
 
 	  if (p->has_substitutions_defined ())
 	    {

--- a/gcc/testsuite/rust/compile/issue-4822.rs
+++ b/gcc/testsuite/rust/compile/issue-4822.rs
@@ -1,0 +1,11 @@
+#![feature(lang_items, no_core)]
+#![no_core]
+
+#[lang = "sized"]
+trait Sized {}
+
+trait PartialEq<Rhs> {}
+
+impl<A, B, const N: usize> PartialEq<[B; N]> for [A; N] {}
+
+fn main() {}


### PR DESCRIPTION
Fixes Rust-GCC/gccrs#4822

    gcc/rust/ChangeLog:
    
            * typecheck/rust-hir-type-check-base.cc (walk_type_to_constrain): prototype
            (walk_types_to_constrain): make sure to walk the argument too
    
    gcc/testsuite/ChangeLog:
    
            * rust/compile/issue-4822.rs: New test.
