### PR TITLE
gccrs: Fix ambigious path resolution

### DIFF
--- a/gcc/rust/typecheck/rust-hir-path-probe-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-path-probe-expr.cc
@@ -80,6 +80,21 @@ PathProbeExpr::probe_adt_impls (TyTy::ADTType *adt)
   mappings.iterate_adt_impl_items (
     adt_node_id,
     [this] (HirId id, HIR::ImplItem *item, HIR::ImplBlock *impl) -> bool {
+      if (impl->has_trait_ref ())
+	return true;
+
+      return process_impl_item_candidate (id, item, impl);
+    });
+
+  if (!candidates.empty ())
+    return;
+
+  mappings.iterate_adt_impl_items (
+    adt_node_id,
+    [this] (HirId id, HIR::ImplItem *item, HIR::ImplBlock *impl) -> bool {
+      if (!impl->has_trait_ref ())
+	return true;
+
       return process_impl_item_candidate (id, item, impl);
     });
 }
@@ -89,6 +104,20 @@ PathProbeExpr::probe_fallback_impls ()
 {
   mappings.iterate_impl_items (
     [this] (HirId id, HIR::ImplItem *item, HIR::ImplBlock *impl) -> bool {
+      if (impl->has_trait_ref ())
+	return true;
+
+      return process_impl_item_candidate (id, item, impl);
+    });
+
+  if (!candidates.empty ())
+    return;
+
+  mappings.iterate_impl_items (
+    [this] (HirId id, HIR::ImplItem *item, HIR::ImplBlock *impl) -> bool {
+      if (!impl->has_trait_ref ())
+	return true;
+
       return process_impl_item_candidate (id, item, impl);
     });
 }

--- a/gcc/testsuite/rust/compile/issue-4823.rs
+++ b/gcc/testsuite/rust/compile/issue-4823.rs
@@ -1,0 +1,23 @@
+#![feature(no_core)]
+#![no_core]
+
+pub struct S;
+
+trait T {
+    const VALUE: i32;
+}
+
+impl T for S {
+    const VALUE: i32 = 1;
+    // { dg-warning "unused name" "" { target *-*-* } .-1 }
+}
+
+impl S {
+    const VALUE: i32 = 2;
+}
+
+const RESULT: i32 = S::VALUE;
+
+pub fn test() -> i32 {
+    RESULT
+}


### PR DESCRIPTION
Rust checks regular impls first then only when candidates are empty it should iterate trait impls.

Fixes Rust-GCC/gccrs#4823

gcc/rust/ChangeLog:

	* typecheck/rust-hir-path-probe-expr.cc (PathProbeExpr::probe_adt_impls): check impls first
	(PathProbeExpr::probe_fallback_impls): likewise

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4823.rs: New test.
