### PR TITLE
gccrs: Add hir lowering to trait item where clauses

### DIFF
--- a/gcc/rust/hir/rust-ast-lower-implitem.cc
+++ b/gcc/rust/hir/rust-ast-lower-implitem.cc
@@ -234,6 +234,11 @@ void
 ASTLowerTraitItem::visit (AST::Function &func)
 {
   std::vector<std::unique_ptr<HIR::WhereClauseItem>> where_clause_items;
+  where_clause_items.reserve (func.get_where_clause ().get_items ().size ());
+  for (auto &item : func.get_where_clause ().get_items ())
+    where_clause_items.emplace_back (
+      ASTLowerWhereClauseItem::translate (*item.get ()));
+
   HIR::WhereClause where_clause (std::move (where_clause_items));
   HIR::FunctionQualifiers qualifiers
     = lower_qualifiers (func.get_qualifiers ());

--- a/gcc/testsuite/rust/compile/issue-4828.rs
+++ b/gcc/testsuite/rust/compile/issue-4828.rs
@@ -1,0 +1,18 @@
+#![feature(lang_items, no_core)]
+#![no_core]
+
+#[lang = "sized"]
+trait Sized {}
+
+trait IntoIterator {
+    type IntoIter;
+}
+
+pub struct Chain<A, B>(A, B);
+
+trait Iterator {
+    fn chain<U>(self, other: U) -> Chain<Self, U::IntoIter>
+    where
+        Self: Sized,
+        U: IntoIterator;
+}


### PR DESCRIPTION
Fixes Rust-GCC/gccrs#4828

gcc/rust/ChangeLog:

	* hir/rust-ast-lower-implitem.cc (ASTLowerTraitItem::visit): lower where clauses

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4828.rs: New test.
