### PR TITLE
codegen: Compile extern types as C void

### DIFF
--- a/gcc/rust/backend/rust-compile-type.cc
+++ b/gcc/rust/backend/rust-compile-type.cc
@@ -344,7 +344,10 @@ TyTyResolveCompile::visit (const TyTy::ADTType &type)
     }
   else if (type.get_adt_kind () == TyTy::ADTType::ADTKind::EXTERN)
     {
-      type_record = Backend::struct_type ({});
+      // Extern types are codegen'd as C's void type. They can only be used
+      // through indirection, so they're effectively always codegen'd as
+      // `void *` types.
+      type_record = void_type_node;
     }
   else if (!type.is_enum ())
     {


### PR DESCRIPTION
Per Rust's RFC 1861 (https://rust-lang.github.io/rfcs/1861-extern-types.html), extern types are FFI-safe types that are dynamically sized, and should thus compile down to regular empty types like C's void type. They are to always be used with an indirection, which means they are effectively always a regular pointer (not a pointer + metadata like a lot of pointers in Rust) to C's void type.

Closes Rust-GCC/gccrs#1922. We eventually need to work on adding checks to external types, but as they are currently implemented as types not implementing `Sized`, a lot of their typechecking behavior is covered.

gcc/rust/ChangeLog:

	* backend/rust-compile-type.cc (TyTyResolveCompile::visit): Change extern type codegen from empty struct to the void type node.

