### PR TITLE
gccrs: Remove rust_unreachable from grs_langhook_pushdecl

### DIFF
--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -255,7 +255,7 @@ grs_langhook_global_bindings_p (void)
 static tree
 grs_langhook_pushdecl (tree decl ATTRIBUTE_UNUSED)
 {
-  rust_unreachable ();
+  // rust_unreachable ();
   return NULL;
 }
 


### PR DESCRIPTION
tbh I don't really know the innards of how GCC handles built-ins, but for some reason this was being called on aarch64 targets, which caused [this regression](https://patchwork.sourceware.org/project/gcc/patch/20260826120357.3019-1-gerris.rs@gmail.com/).