### PR TITLE
gccrs: use std::move to reduce copy ctor usage on type-bound-predicate

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -2018,7 +2018,7 @@ TypeCheckExpr::visit (HIR::ClosureExpr &expr)
   predicate.apply_generic_arguments (&args, false, false);
 
   // finally inherit the trait bound
-  infered->inherit_bounds ({predicate});
+  infered->inherit_bound (predicate);
 }
 
 bool

--- a/gcc/rust/typecheck/rust-hir-type-check-item.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-item.cc
@@ -1086,7 +1086,7 @@ TypeCheckItem::resolve_impl_block_substitutions (HIR::ImplBlock &impl_block,
 
   // inherit the bounds
   if (!specified_bound.is_error ())
-    self->inherit_bounds ({specified_bound});
+    self->inherit_bound (specified_bound);
 
   // check for any unconstrained type-params
   const TyTy::SubstitutionArgumentMappings trait_constraints

--- a/gcc/rust/typecheck/rust-hir-type-check-path.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-path.cc
@@ -73,7 +73,7 @@ TypeCheckExpr::visit (HIR::QualifiedPathInExpression &expr)
     return;
 
   // inherit the bound
-  root->inherit_bounds ({specified_bound});
+  root->inherit_bound (specified_bound);
 
   // lookup the associated item from the specified bound
   HIR::PathExprSegment &item_seg = expr.get_segments ().at (0);

--- a/gcc/rust/typecheck/rust-hir-type-check-type.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-type.cc
@@ -221,7 +221,7 @@ TypeCheckType::visit (HIR::QualifiedPathInType &path)
     return;
 
   // inherit the bound
-  root->inherit_bounds ({specified_bound});
+  root->inherit_bound (specified_bound);
 
   // lookup the associated item from the specified bound
   HIR::TypePathSegment &item_seg = path.get_associated_segment ();

--- a/gcc/rust/typecheck/rust-hir-type-check.h
+++ b/gcc/rust/typecheck/rust-hir-type-check.h
@@ -299,7 +299,8 @@ public:
   void insert_unconstrained_check_marker (HirId id, bool status);
   bool have_checked_for_unconstrained (HirId id, bool *result);
 
-  void insert_resolved_predicate (HirId id, TyTy::TypeBoundPredicate predicate);
+  void insert_resolved_predicate (HirId id,
+				  const TyTy::TypeBoundPredicate &predicate);
   bool lookup_predicate (HirId id, TyTy::TypeBoundPredicate *result);
 
   void insert_query (HirId id);

--- a/gcc/rust/typecheck/rust-typecheck-context.cc
+++ b/gcc/rust/typecheck/rust-typecheck-context.cc
@@ -574,13 +574,13 @@ TypeCheckContext::have_checked_for_unconstrained (HirId id, bool *result)
 }
 
 void
-TypeCheckContext::insert_resolved_predicate (HirId id,
-					     TyTy::TypeBoundPredicate predicate)
+TypeCheckContext::insert_resolved_predicate (
+  HirId id, const TyTy::TypeBoundPredicate &predicate)
 {
   // auto it = predicates.find (id);
   // rust_assert (it == predicates.end ());
 
-  predicates.insert ({id, predicate});
+  predicates.emplace (id, predicate);
 }
 
 bool

--- a/gcc/rust/typecheck/rust-tyty-bounds.cc
+++ b/gcc/rust/typecheck/rust-tyty-bounds.cc
@@ -450,14 +450,6 @@ TypeBoundPredicate::TypeBoundPredicate (const TypeBoundPredicate &other)
   for (const auto &p : other.get_substs ())
     substitutions.push_back (p.clone ());
 
-  std::vector<SubstitutionArg> mappings;
-  for (size_t i = 0; i < other.used_arguments.get_mappings ().size (); i++)
-    {
-      const SubstitutionArg &oa = other.used_arguments.get_mappings ().at (i);
-      SubstitutionArg arg (oa);
-      mappings.push_back (std::move (arg));
-    }
-
   // we need to remap the argument mappings based on this copied constructor
   std::vector<SubstitutionArg> copied_arg_mappings;
   size_t i = 0;
@@ -490,14 +482,6 @@ TypeBoundPredicate::operator= (const TypeBoundPredicate &other)
 
   if (other.is_error ())
     return *this;
-
-  std::vector<SubstitutionArg> mappings;
-  for (size_t i = 0; i < other.used_arguments.get_mappings ().size (); i++)
-    {
-      const SubstitutionArg &oa = other.used_arguments.get_mappings ().at (i);
-      SubstitutionArg arg (oa);
-      mappings.push_back (std::move (arg));
-    }
 
   // we need to remap the argument mappings based on this copied constructor
   std::vector<SubstitutionArg> copied_arg_mappings;
@@ -983,7 +967,7 @@ TypeBoundPredicateItem::get_locus () const
 
 TypeBoundsMappings::TypeBoundsMappings (
   std::vector<TypeBoundPredicate> specified_bounds)
-  : specified_bounds (specified_bounds)
+  : specified_bounds (std::move (specified_bounds))
 {}
 
 std::vector<TypeBoundPredicate> &
@@ -1049,7 +1033,7 @@ TypeBoundsMappings::raw_bounds_as_name () const
 }
 
 void
-TypeBoundsMappings::add_bound (TypeBoundPredicate predicate)
+TypeBoundsMappings::add_bound (const TypeBoundPredicate &predicate)
 {
   for (auto &bound : specified_bounds)
     {

--- a/gcc/rust/typecheck/rust-tyty-call.cc
+++ b/gcc/rust/typecheck/rust-tyty-call.cc
@@ -73,7 +73,7 @@ validate_call_argument_associated_impl_bounds (BaseType *param_ty,
       || resolved_argument_ty->get_kind () == TypeKind::PROJECTION)
     return true;
 
-  for (auto bound : param_ty->get_specified_bounds ())
+  for (const auto &bound : param_ty->get_specified_bounds ())
     {
       bool ambigious = false;
       auto associated

--- a/gcc/rust/typecheck/rust-tyty.cc
+++ b/gcc/rust/typecheck/rust-tyty.cc
@@ -156,7 +156,7 @@ BaseType::BaseType (HirId ref, HirId ty_ref, TypeKind kind, RustIdent ident,
 BaseType::BaseType (HirId ref, HirId ty_ref, TypeKind kind, RustIdent ident,
 		    std::vector<TypeBoundPredicate> specified_bounds,
 		    std::set<HirId> refs)
-  : TypeBoundsMappings (specified_bounds), kind (kind), ref (ref),
+  : TypeBoundsMappings (std::move (specified_bounds)), kind (kind), ref (ref),
     ty_ref (ty_ref), orig_ref (ref), combined (refs), ident (ident),
     mappings (Analysis::Mappings::get ())
 {}
@@ -531,6 +531,12 @@ void
 BaseType::inherit_bounds (const BaseType &other)
 {
   inherit_bounds (other.get_specified_bounds ());
+}
+
+void
+BaseType::inherit_bound (const TypeBoundPredicate &bound)
+{
+  add_bound (bound);
 }
 
 void
@@ -3701,7 +3707,7 @@ ParamType::ParamType (std::string symbol, location_t locus, HirId ref,
   : BaseGeneric (ref, ref, KIND,
 		 {Resolver::CanonicalPath::new_seg (UNKNOWN_NODEID, symbol),
 		  locus},
-		 specified_bounds, refs),
+		 std::move (specified_bounds), refs),
     is_trait_self (false), symbol (symbol)
 {}
 
@@ -3712,7 +3718,7 @@ ParamType::ParamType (bool is_trait_self, std::string symbol, location_t locus,
   : BaseGeneric (ref, ty_ref, KIND,
 		 {Resolver::CanonicalPath::new_seg (UNKNOWN_NODEID, symbol),
 		  locus},
-		 specified_bounds, refs),
+		 std::move (specified_bounds), refs),
     is_trait_self (is_trait_self), symbol (symbol)
 {}
 

--- a/gcc/rust/typecheck/rust-tyty.h
+++ b/gcc/rust/typecheck/rust-tyty.h
@@ -207,7 +207,7 @@ public:
   std::string raw_bounds_as_name () const;
 
 protected:
-  void add_bound (TypeBoundPredicate predicate);
+  void add_bound (const TypeBoundPredicate &predicate);
 
   std::vector<TypeBoundPredicate> specified_bounds;
 };
@@ -244,6 +244,8 @@ public:
   bool bounds_compatible (BaseType &other, location_t locus, bool emit_error);
 
   void inherit_bounds (const BaseType &other);
+
+  void inherit_bound (const TypeBoundPredicate &bound);
 
   void inherit_bounds (
     const std::vector<TyTy::TypeBoundPredicate> &specified_bounds);
@@ -500,7 +502,7 @@ protected:
   BaseGeneric (HirId ref, HirId ty_ref, TypeKind kind, RustIdent ident,
 	       std::vector<TypeBoundPredicate> specified_bounds,
 	       std::set<HirId> refs = std::set<HirId> ())
-    : BaseType (ref, ty_ref, kind, ident, specified_bounds, refs)
+    : BaseType (ref, ty_ref, kind, ident, std::move (specified_bounds), refs)
   {}
 };
 


### PR DESCRIPTION
gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::visit): update
	* typecheck/rust-hir-type-check-item.cc (TypeCheckItem::resolve_impl_block_substitutions): likewise
	* typecheck/rust-hir-type-check-path.cc (TypeCheckExpr::visit): likewise
	* typecheck/rust-hir-type-check-type.cc (TypeCheckType::visit): likewise
	* typecheck/rust-hir-type-check.h: likewise
	* typecheck/rust-typecheck-context.cc (TypeCheckContext::insert_resolved_predicate): likewise
	* typecheck/rust-tyty-bounds.cc (TypeBoundPredicate::TypeBoundPredicate): likewise (TypeBoundPredicate::operator=): remove deadcode (TypeBoundsMappings::add_bound): use ref
	* typecheck/rust-tyty-call.cc (validate_call_argument_associated_impl_bounds): use ref
	* typecheck/rust-tyty.cc (BaseType::BaseType): likewise (BaseType::inherit_bound): likewise (ParamType::ParamType): likewiase
	* typecheck/rust-tyty.h: likewise
