### PR TITLE
gccrs: Stop method selection when we hit generic params

### DIFF
--- a/gcc/rust/typecheck/rust-hir-dot-operator.cc
+++ b/gcc/rust/typecheck/rust-hir-dot-operator.cc
@@ -482,6 +482,11 @@ MethodResolver::select (TyTy::BaseType &receiver)
   if (try_select_predicate_candidates (receiver))
     return true;
 
+  // A receiver that is still a bare unresolved generic type parameter can only
+  // ever satisfy a method through its own trait bounds
+  if (receiver.destructure ()->get_kind () == TyTy::TypeKind::PARAM)
+    return false;
+
   // Assemble candidates
   std::vector<impl_item_candidate> inherent_impl_fns;
   if (specified_trait == nullptr)

--- a/gcc/testsuite/rust/compile/issue-4859.rs
+++ b/gcc/testsuite/rust/compile/issue-4859.rs
@@ -1,0 +1,35 @@
+#![feature(no_core, lang_items)]
+#![no_core]
+#[lang = "sized"]
+pub trait Sized {}
+#[lang = "deref"]
+pub trait Deref {
+    type Target: ?Sized;
+    fn deref(&self) -> &Self::Target;
+}
+pub struct VaList {
+    pub inner: i32,
+}
+impl Deref for VaList {
+    type Target = i32;
+    fn deref(&self) -> &i32 {
+        &self.inner
+    }
+}
+pub struct Pin<P> {
+    pub pointer: P,
+}
+impl<P: Deref> Pin<P> {
+    pub const unsafe fn new_unchecked(pointer: P) -> Pin<P> {
+        Pin { pointer }
+    }
+    pub fn as_ref(&self) -> Pin<&P::Target> {
+        unsafe { Pin::new_unchecked(&*self.pointer) }
+    }
+}
+impl<T: ?Sized> Deref for &T {
+    type Target = T;
+    fn deref(&self) -> &T {
+        *self
+    }
+}


### PR DESCRIPTION
Generics like this need to match directly via their associated type bound predicates which will already be checked. Otherwise the unify machinery for types_compatable will wrongly match by injecting infer_vars.

Fixes Rust-GCC/gccrs#4859

gcc/rust/ChangeLog:

	* typecheck/rust-hir-dot-operator.cc (MethodResolver::select): stop on ParamTypes

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4859.rs: New test.

