### PR TITLE
gccrs: Add missing isize and usize as valid options here

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-expr.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-expr.cc
@@ -612,6 +612,8 @@ TypeCheckExpr::visit (HIR::NegationExpr &expr)
 	  = (negated_expr_ty->get_kind () == TyTy::TypeKind::BOOL)
 	    || (negated_expr_ty->get_kind () == TyTy::TypeKind::INT)
 	    || (negated_expr_ty->get_kind () == TyTy::TypeKind::UINT)
+	    || (negated_expr_ty->get_kind () == TyTy::TypeKind::ISIZE)
+	    || (negated_expr_ty->get_kind () == TyTy::TypeKind::USIZE)
 	    || (negated_expr_ty->get_kind () == TyTy::TypeKind::INFER
 		&& (((TyTy::InferType *) negated_expr_ty)->get_infer_kind ()
 		    == TyTy::InferType::INTEGRAL));

--- a/gcc/testsuite/rust/compile/issue-4858.rs
+++ b/gcc/testsuite/rust/compile/issue-4858.rs
@@ -1,0 +1,10 @@
+#![feature(no_core)]
+#![no_core]
+
+pub fn signed(x: isize) -> isize {
+    !x
+}
+
+pub fn unsigned(x: usize) -> usize {
+    !x
+}


### PR DESCRIPTION
Fixes Rust-GCC/gccrs#4858

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-expr.cc (TypeCheckExpr::visit): add missing checks

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4858.rs: New test.
