### PR TITLE
gccrs: Track lifetimes per trait item

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check.cc
@@ -155,6 +155,17 @@ TraitItemReference::get_type_from_fn (/*const*/ HIR::TraitItemFunc &fn) const
 {
   auto binder_pin = context->push_clean_lifetime_resolver ();
 
+  auto &mappings = Analysis::Mappings::get ();
+  auto *trait
+    = mappings.lookup_trait_item_mapping (get_mappings ().get_hirid ());
+  rust_assert (trait != nullptr);
+  for (auto &param : trait->get_generic_params ())
+    if (param->get_kind () == HIR::GenericParam::GenericKind::LIFETIME)
+      {
+	auto &lifetime_param = static_cast<HIR::LifetimeParam &> (*param);
+	context->intern_and_insert_lifetime (lifetime_param.get_lifetime ());
+      }
+
   std::vector<TyTy::SubstitutionParamMapping> substitutions
     = inherited_substitutions;
 

--- a/gcc/testsuite/rust/compile/issue-4861.rs
+++ b/gcc/testsuite/rust/compile/issue-4861.rs
@@ -1,0 +1,17 @@
+#![feature(no_core, lang_items)]
+#![no_core]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+trait Searcher<'a> {
+    fn haystack(&self) -> &'a str;
+    fn with_lifetime<'b>(&self, value: &'b str) -> &'a str;
+    fn borrow(&'a self) -> &'a str;
+}
+
+trait Other<'a, 'b> {
+    fn first(&self) -> &'a str;
+    fn second(&self) -> &'b str;
+    fn method<'c>(&self, value: &'c str) -> &'c str;
+}


### PR DESCRIPTION
Fixes Rust-GCC/gccrs#4861

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check.cc (TraitItemReference::get_type_from_fn): grab lifetimes

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4861.rs: New test.
