### PR TITLE
gccrs: walk the binding generic arguments for unconstrained checks

### DIFF
--- a/gcc/rust/typecheck/rust-hir-type-check-base.cc
+++ b/gcc/rust/typecheck/rust-hir-type-check-base.cc
@@ -197,6 +197,17 @@ TypeCheckBase::check_for_unconstrained (
   walk_types_to_constrain (constrained_symbols, constraint_b);
   walk_type_to_constrain (constrained_symbols, *reference);
 
+  for (const auto &param : params_to_constrain)
+    {
+      auto *ty = param.get_param_ty ();
+      for (const auto &bound : ty->get_specified_bounds ())
+	{
+	  const auto &args = bound.get_substitution_arguments ();
+	  for (const auto &binding : args.get_binding_args ())
+	    walk_type_to_constrain (constrained_symbols, *binding.second);
+	}
+    }
+
   // check for unconstrained
   bool unconstrained = false;
   for (auto &sym : symbols_to_constrain)

--- a/gcc/testsuite/rust/compile/issue-4862.rs
+++ b/gcc/testsuite/rust/compile/issue-4862.rs
@@ -1,0 +1,11 @@
+#![feature(no_core, lang_items)]
+#![no_core]
+#[lang = "sized"]
+pub trait Sized {}
+trait Iterator {
+    type Item;
+}
+pub struct Wrapper<I>(I);
+impl<T, I: Iterator<Item = T>> Iterator for Wrapper<I> {
+    type Item = T;
+}

--- a/gcc/testsuite/rust/compile/issue-4863.rs
+++ b/gcc/testsuite/rust/compile/issue-4863.rs
@@ -1,0 +1,19 @@
+#![feature(no_core, lang_items)]
+#![no_core]
+#[lang = "sized"]
+pub trait Sized {}
+#[lang = "fn_once"]
+trait FnOnce<Args> {
+    #[lang = "fn_once_output"]
+    type Output;
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+}
+trait Iterator {
+    type Item;
+}
+pub struct OnceWith<F> {
+    pub f: F,
+}
+impl<A, F: FnOnce() -> A> Iterator for OnceWith<F> {
+    type Item = A;
+}


### PR DESCRIPTION
Fixes Rust-GCC/gccrs#4862
Fixes Rust-GCC/gccrs#4863

gcc/rust/ChangeLog:

	* typecheck/rust-hir-type-check-base.cc: walk type bindings

gcc/testsuite/ChangeLog:

	* rust/compile/issue-4862.rs: New test.
	* rust/compile/issue-4863.rs: New test.
