### PR TITLE
gccrs: This is an utterly insane rustc shim needed for stdarch

### DIFF
--- a/gcc/rust/typecheck/rust-casts.cc
+++ b/gcc/rust/typecheck/rust-casts.cc
@@ -18,6 +18,7 @@
 
 #include "rust-casts.h"
 #include "rust-tyty-util.h"
+#include "rust-tyty.h"
 
 namespace Rust {
 namespace Resolver {
@@ -70,6 +71,8 @@ TypeCastRules::cast_rules ()
   // https://github.com/rust-lang/rust/blob/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/compiler/rustc_typeck/src/check/cast.rs#L654
 
   TyTy::BaseType *from_type = from.get_ty ()->destructure ();
+  if (auto c = from_type->try_as<TyTy::ConstParamType> ())
+    from_type = c->get_specified_type ();
 
   rust_debug ("cast_rules from={%s} to={%s}", from_type->debug_str ().c_str (),
 	      to.get_ty ()->debug_str ().c_str ());

--- a/gcc/rust/util/rust-attribute-values.h
+++ b/gcc/rust/util/rust-attribute-values.h
@@ -115,6 +115,9 @@ public:
   static constexpr auto &RUSTC_ARGS_REQUIRED_CONST
     = "rustc_args_required_const";
 
+  static constexpr auto &RUSTC_LEGACY_CONST_GENERICS
+    = "rustc_legacy_const_generics";
+
   static constexpr auto &NEEDS_ALLOCATOR = "needs_allocator";
 
   static constexpr auto &RUSTC_ALLOCATOR = "rustc_allocator";

--- a/gcc/rust/util/rust-attributes.cc
+++ b/gcc/rust/util/rust-attributes.cc
@@ -86,6 +86,7 @@ static const BuiltinAttrDefinition __definitions[]
      {Attrs::RUSTC_LAYOUT_SCALAR_VALID_RANGE_START, CODE_GENERATION},
      // TODO: be careful about calling functions marked with this?
      {Attrs::RUSTC_ARGS_REQUIRED_CONST, CODE_GENERATION},
+     {Attrs::RUSTC_LEGACY_CONST_GENERICS, TYPE_CHECK},
      {Attrs::COMPILER_BUILTINS, CODE_GENERATION},
      {Attrs::NO_BUILTINS, CODE_GENERATION},
      {Attrs::PRELUDE_IMPORT, NAME_RESOLUTION},


### PR DESCRIPTION
This doesnt fully implement the legacy const generics attribute but its the starting point.

What we actually need to do is understand:

    #[rustc_legacy_const_generics(1)]
    fn foo<const N: usize>(x: i32) -> i32 {
        x + N as i32
    }

    fn main() {
        let a = foo(10, 3);
    }

So you can see the call to foo has a 2nd param but its not a real 2nd param its meant to be turned into:

    foo::<3>(10)

Honestly this is just silly they probably implemented a bit of const generics wanted to use it in core and put this work around in to get away with it. Dumb.

Addresses #3868

gcc/rust/ChangeLog:

	* typecheck/rust-casts.cc (TypeCastRules::cast_rules): fix bad const cast
	* util/rust-attribute-values.h: add attribute
	* util/rust-attributes.cc: likewise
